### PR TITLE
8276635: Use blessed modifier order in compiler code

### DIFF
--- a/src/java.compiler/share/classes/javax/tools/Diagnostic.java
+++ b/src/java.compiler/share/classes/javax/tools/Diagnostic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/tools/Diagnostic.java
+++ b/src/java.compiler/share/classes/javax/tools/Diagnostic.java
@@ -89,7 +89,7 @@ public interface Diagnostic<S> {
     /**
      * Used to signal that no position is available.
      */
-    public final static long NOPOS = -1;
+    public static final long NOPOS = -1;
 
     /**
      * Returns the kind of this diagnostic, for example, error or

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -794,7 +794,7 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
 
     /** A base class for Symbols representing types.
      */
-    public static abstract class TypeSymbol extends Symbol {
+    public abstract static class TypeSymbol extends Symbol {
         public TypeSymbol(Kind kind, long flags, Name name, Type type, Symbol owner) {
             super(kind, flags, name, type, owner);
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -241,7 +241,7 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
      * of a given type expression. This mapping returns the original type is no changes occurred
      * when recursively mapping the original type's subterms.
      */
-    public static abstract class StructuralTypeMapping<S> extends Types.TypeMapping<S> {
+    public abstract static class StructuralTypeMapping<S> extends Types.TypeMapping<S> {
 
         @Override
         public Type visitClassType(ClassType t, S s) {
@@ -1786,7 +1786,7 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
         }
     }
 
-    public static abstract class DelegatedType extends Type {
+    public abstract static class DelegatedType extends Type {
         public Type qtype;
         public TypeTag tag;
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -4896,7 +4896,7 @@ public class Types {
      * type itself) of the operation implemented by this visitor; use
      * Void if a second argument is not needed.
      */
-    public static abstract class DefaultTypeVisitor<R,S> implements Type.Visitor<R,S> {
+    public abstract static class DefaultTypeVisitor<R,S> implements Type.Visitor<R,S> {
         public final R visit(Type t, S s)               { return t.accept(this, s); }
         public R visitClassType(ClassType t, S s)       { return visitType(t, s); }
         public R visitWildcardType(WildcardType t, S s) { return visitType(t, s); }
@@ -4923,7 +4923,7 @@ public class Types {
      * symbol itself) of the operation implemented by this visitor; use
      * Void if a second argument is not needed.
      */
-    public static abstract class DefaultSymbolVisitor<R,S> implements Symbol.Visitor<R,S> {
+    public abstract static class DefaultSymbolVisitor<R,S> implements Symbol.Visitor<R,S> {
         public final R visit(Symbol s, S arg)                   { return s.accept(this, arg); }
         public R visitClassSymbol(ClassSymbol s, S arg)         { return visitSymbol(s, arg); }
         public R visitMethodSymbol(MethodSymbol s, S arg)       { return visitSymbol(s, arg); }
@@ -4946,7 +4946,7 @@ public class Types {
      * type itself) of the operation implemented by this visitor; use
      * Void if a second argument is not needed.
      */
-    public static abstract class SimpleVisitor<R,S> extends DefaultTypeVisitor<R,S> {
+    public abstract static class SimpleVisitor<R,S> extends DefaultTypeVisitor<R,S> {
         @Override
         public R visitCapturedType(CapturedType t, S s) {
             return visitTypeVar(t, s);
@@ -4966,7 +4966,7 @@ public class Types {
      * form Type&nbsp;&times;&nbsp;Type&nbsp;&rarr;&nbsp;Boolean.
      * <!-- In plain text: Type x Type -> Boolean -->
      */
-    public static abstract class TypeRelation extends SimpleVisitor<Boolean,Type> {}
+    public abstract static class TypeRelation extends SimpleVisitor<Boolean,Type> {}
 
     /**
      * A convenience visitor for implementing operations that only
@@ -4976,7 +4976,7 @@ public class Types {
      * @param <R> the return type of the operation implemented by this
      * visitor; use Void if no return type is needed.
      */
-    public static abstract class UnaryVisitor<R> extends SimpleVisitor<R,Void> {
+    public abstract static class UnaryVisitor<R> extends SimpleVisitor<R,Void> {
         public final R visit(Type t) { return t.accept(this, null); }
     }
 
@@ -5041,7 +5041,7 @@ public class Types {
 
     // <editor-fold defaultstate="collapsed" desc="Signature Generation">
 
-    public static abstract class SignatureGenerator {
+    public abstract static class SignatureGenerator {
 
         public static class InvalidSignatureException extends RuntimeException {
             private static final long serialVersionUID = 0;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -341,7 +341,7 @@ public class Flow {
      * Base visitor class for all visitors implementing dataflow analysis logic.
      * This class define the shared logic for handling jumps (break/continue statements).
      */
-    static abstract class BaseAnalyzer extends TreeScanner {
+    abstract static class BaseAnalyzer extends TreeScanner {
 
         enum JumpKind {
             BREAK(JCTree.Tag.BREAK) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JRTIndex.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JRTIndex.java
@@ -56,7 +56,7 @@ import com.sun.tools.javac.util.Context;
 public class JRTIndex {
     /** Get a shared instance of the cache. */
     private static JRTIndex sharedInstance;
-    public synchronized static JRTIndex getSharedInstance() {
+    public static synchronized JRTIndex getSharedInstance() {
         if (sharedInstance == null) {
             try {
                 sharedInstance = new JRTIndex();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/Locations.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/Locations.java
@@ -444,7 +444,7 @@ public class Locations {
      * @see #initHandlers
      * @see #getHandler
      */
-    protected static abstract class LocationHandler {
+    protected abstract static class LocationHandler {
 
         /**
          * @see JavaFileManager#handleOption
@@ -513,7 +513,7 @@ public class Locations {
     /**
      * A LocationHandler for a given Location, and associated set of options.
      */
-    private static abstract class BasicLocationHandler extends LocationHandler {
+    private abstract static class BasicLocationHandler extends LocationHandler {
 
         final Location location;
         final Set<Option> options;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/StringConcat.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/StringConcat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/StringConcat.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/StringConcat.java
@@ -254,7 +254,7 @@ public abstract class StringConcat {
     /**
      * Base class for indified concatenation bytecode flavors.
      */
-    private static abstract class Indy extends StringConcat {
+    private abstract static class Indy extends StringConcat {
         public Indy(Context context) {
             super(context);
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/model/AnnotationProxyMaker.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/model/AnnotationProxyMaker.java
@@ -259,7 +259,7 @@ public class AnnotationProxyMaker {
         private void typeMismatch(Method method, final Attribute attr) {
             class AnnotationTypeMismatchExceptionProxy extends ExceptionProxy {
                 static final long serialVersionUID = 269;
-                transient final Method method;
+                final transient Method method;
                 AnnotationTypeMismatchExceptionProxy(Method method) {
                     this.method = method;
                 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
@@ -1115,7 +1115,7 @@ public class DocCommentParser {
         return new String(buf, start, end - start);
     }
 
-    private static abstract class TagParser {
+    private abstract static class TagParser {
         enum Kind { INLINE, BLOCK, EITHER }
 
         final Kind kind;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -4988,7 +4988,7 @@ public class JavacParser implements Parser {
 
     }
 
-    protected static abstract class AbstractEndPosTable implements EndPosTable {
+    protected abstract static class AbstractEndPosTable implements EndPosTable {
         /**
          * The current parser.
          */

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DCTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DCTree.java
@@ -294,7 +294,7 @@ public abstract class DCTree implements DocTree {
         };
     }
 
-    public static abstract class DCEndPosTree<T extends DCEndPosTree<T>> extends DCTree {
+    public abstract static class DCEndPosTree<T extends DCEndPosTree<T>> extends DCTree {
 
         private int endPos = NOPOS;
 
@@ -381,14 +381,14 @@ public abstract class DCTree implements DocTree {
         }
     }
 
-    public static abstract class DCBlockTag extends DCTree implements BlockTagTree {
+    public abstract static class DCBlockTag extends DCTree implements BlockTagTree {
         @Override @DefinedBy(Api.COMPILER_TREE)
         public String getTagName() {
             return getKind().tagName;
         }
     }
 
-    public static abstract class DCInlineTag extends DCEndPosTree<DCInlineTag> implements InlineTagTree {
+    public abstract static class DCInlineTag extends DCEndPosTree<DCInlineTag> implements InlineTagTree {
         @Override @DefinedBy(Api.COMPILER_TREE)
         public String getTagName() {
             return getKind().tagName;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
@@ -689,7 +689,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         }
     }
 
-    public static abstract class JCStatement extends JCTree implements StatementTree {
+    public abstract static class JCStatement extends JCTree implements StatementTree {
         @Override
         public JCStatement setType(Type type) {
             super.setType(type);
@@ -702,7 +702,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         }
     }
 
-    public static abstract class JCCaseLabel extends JCTree implements CaseLabelTree {
+    public abstract static class JCCaseLabel extends JCTree implements CaseLabelTree {
         public abstract boolean isExpression();
         public boolean isNullPattern() {
             return isExpression() && TreeInfo.isNull((JCExpression) this);
@@ -710,7 +710,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         public abstract boolean isPattern();
     }
 
-    public static abstract class JCExpression extends JCCaseLabel implements ExpressionTree {
+    public abstract static class JCExpression extends JCCaseLabel implements ExpressionTree {
         @Override
         public JCExpression setType(Type type) {
             super.setType(type);
@@ -740,7 +740,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
      * Common supertype for all poly expression trees (lambda, method references,
      * conditionals, method and constructor calls)
      */
-    public static abstract class JCPolyExpression extends JCExpression {
+    public abstract static class JCPolyExpression extends JCExpression {
 
         /**
          * A poly expression can only be truly 'poly' in certain contexts
@@ -762,7 +762,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
     /**
      * Common supertype for all functional expression trees (lambda and method references)
      */
-    public static abstract class JCFunctionalExpression extends JCPolyExpression {
+    public abstract static class JCFunctionalExpression extends JCPolyExpression {
 
         public JCFunctionalExpression() {
             //a functional expression is always a 'true' poly
@@ -2056,7 +2056,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         }
     }
 
-    public static abstract class JCOperatorExpression extends JCExpression {
+    public abstract static class JCOperatorExpression extends JCExpression {
         public enum OperandPos {
             LEFT,
             RIGHT
@@ -2238,7 +2238,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
     /**
      * Pattern matching forms.
      */
-    public static abstract class JCPattern extends JCCaseLabel
+    public abstract static class JCPattern extends JCCaseLabel
             implements PatternTree {
 
         @Override
@@ -2989,7 +2989,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         }
     }
 
-    public static abstract class JCDirective extends JCTree
+    public abstract static class JCDirective extends JCTree
         implements DirectiveTree {
     }
 
@@ -3401,7 +3401,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
 
     /** A generic visitor class for trees.
      */
-    public static abstract class Visitor {
+    public abstract static class Visitor {
         public void visitTopLevel(JCCompilationUnit that)    { visitTree(that); }
         public void visitPackageDef(JCPackageDecl that)      { visitTree(that); }
         public void visitImport(JCImport that)               { visitTree(that); }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Dependencies.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Dependencies.java
@@ -178,7 +178,7 @@ public abstract class Dependencies {
         /**
          * Class representing a node in the dependency graph.
          */
-        public static abstract class Node extends GraphUtils.AbstractNode<ClassSymbol, Node>
+        public abstract static class Node extends GraphUtils.AbstractNode<ClassSymbol, Node>
                 implements GraphUtils.DottableNode<ClassSymbol, Node> {
             /**
              * dependant nodes grouped by kind

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/GraphUtils.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/GraphUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/GraphUtils.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/GraphUtils.java
@@ -54,7 +54,7 @@ public class GraphUtils {
     /**
      * Visitor for graph nodes.
      */
-    static abstract class NodeVisitor<D, N extends Node<D, N>, A> {
+    abstract static class NodeVisitor<D, N extends Node<D, N>, A> {
         /**
          * Visitor action for nodes.
          */
@@ -92,7 +92,7 @@ public class GraphUtils {
      * This class is a basic abstract class for representing a node.
      * A node is associated with a given data.
      */
-    public static abstract class AbstractNode<D, N extends AbstractNode<D, N>> implements Node<D, N> {
+    public abstract static class AbstractNode<D, N extends AbstractNode<D, N>> implements Node<D, N> {
         public final D data;
 
         public AbstractNode(D data) {
@@ -129,7 +129,7 @@ public class GraphUtils {
      * This class specialized Node, by adding elements that are required in order
      * to perform Tarjan computation of strongly connected components.
      */
-    public static abstract class TarjanNode<D, N extends TarjanNode<D, N>> extends AbstractNode<D, N>
+    public abstract static class TarjanNode<D, N extends TarjanNode<D, N>> extends AbstractNode<D, N>
             implements Comparable<N> {
         int index = -1;
         int lowlink;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/JCDiagnostic.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/JCDiagnostic.java
@@ -479,7 +479,7 @@ public class JCDiagnostic implements Diagnostic<JavaFileObject> {
      * created programmatically (by using the supplied factory method) or obtained through build-time
      * generated factory methods.
      */
-    public static abstract class DiagnosticInfo {
+    public abstract static class DiagnosticInfo {
 
         /** The diagnostic kind (i.e. error). */
         DiagnosticType type;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Log.java
@@ -90,7 +90,7 @@ public class Log extends AbstractLog {
      * Note that javax.tools.DiagnosticListener (if set) is called later in the
      * diagnostic pipeline.
      */
-    public static abstract class DiagnosticHandler {
+    public abstract static class DiagnosticHandler {
         /**
          * The previously installed diagnostic handler.
          */

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Name.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Name.java
@@ -205,7 +205,7 @@ public abstract class Name implements javax.lang.model.element.Name, PoolConstan
 
     /** An abstraction for the hash table used to create unique Name instances.
      */
-    public static abstract class Table {
+    public abstract static class Table {
         /** Standard name table.
          */
         public final Names names;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Name.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Name.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jartool/share/classes/sun/tools/jar/GNUStyleOptions.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/GNUStyleOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jartool/share/classes/sun/tools/jar/GNUStyleOptions.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/GNUStyleOptions.java
@@ -239,7 +239,7 @@ class GNUStyleOptions {
         OptionType(String name) { this.name = name; }
     }
 
-    static abstract class Option {
+    abstract static class Option {
         final boolean hasArg;
         final boolean argIsOptional;
         final String[] aliases;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DeprecatedListWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DeprecatedListWriter.java
@@ -51,7 +51,7 @@ import jdk.javadoc.internal.doclets.toolkit.util.DocPaths;
  */
 public class DeprecatedListWriter extends SummaryListWriter<DeprecatedAPIListBuilder> {
 
-    private final static String TERMINALLY_DEPRECATED_KEY = "doclet.Terminally_Deprecated_Elements";
+    private static final String TERMINALLY_DEPRECATED_KEY = "doclet.Terminally_Deprecated_Elements";
 
     /**
      * Constructor.

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriterImpl.java
@@ -84,8 +84,8 @@ public class PackageWriterImpl extends HtmlDocletWriter
     private final BodyContents bodyContents = new BodyContents();
 
     // Maximum number of subpackages and sibling packages to list in related packages table
-    private final static int MAX_SUBPACKAGES = 20;
-    private final static int MAX_SIBLING_PACKAGES = 5;
+    private static final int MAX_SUBPACKAGES = 20;
+    private static final int MAX_SIBLING_PACKAGES = 5;
 
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/snippet/Attribute.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/snippet/Attribute.java
@@ -83,7 +83,7 @@ public /* sealed */ abstract class Attribute {
      * SinglyQuoted or Unquoted to form a (sealed) hierarchy. In that case,
      * `Valued` should become abstract similarly to `Attribute`.
      */
-    final static class Valued extends Attribute {
+    static final class Valued extends Attribute {
 
         private final String value;
 
@@ -104,7 +104,7 @@ public /* sealed */ abstract class Attribute {
         }
     }
 
-    final static class Valueless extends Attribute {
+    static final class Valueless extends Attribute {
 
         Valueless(String name, int nameStartPosition) {
             super(name, nameStartPosition);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/snippet/MarkupParser.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/snippet/MarkupParser.java
@@ -48,7 +48,7 @@ import jdk.javadoc.internal.doclets.toolkit.Resources;
  */
 public final class MarkupParser {
 
-    private final static int EOI = 0x1A;
+    private static final int EOI = 0x1A;
     private char[] buf;
     private int bp;
     private int buflen;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/DocLint.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/DocLint.java
@@ -378,7 +378,7 @@ public class DocLint extends com.sun.tools.doclint.DocLint {
 
     // <editor-fold defaultstate="collapsed" desc="DeclScanner">
 
-    static abstract class DeclScanner extends TreePathScanner<Void, Void> {
+    abstract static class DeclScanner extends TreePathScanner<Void, Void> {
         final Env env;
 
         public DeclScanner(Env env) {


### PR DESCRIPTION
I ran bin/blessed-modifier-order.sh on source owned by compiler. This scripts verifies that modifiers are in the "blessed" order, and fixes it otherwise. I have manually checked the changes made by the script to make sure they are sound.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276635](https://bugs.openjdk.java.net/browse/JDK-8276635): Use blessed modifier order in compiler code


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to 483213d371b5e0e31206bc0aef157f40b567916e


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6253/head:pull/6253` \
`$ git checkout pull/6253`

Update a local copy of the PR: \
`$ git checkout pull/6253` \
`$ git pull https://git.openjdk.java.net/jdk pull/6253/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6253`

View PR using the GUI difftool: \
`$ git pr show -t 6253`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6253.diff">https://git.openjdk.java.net/jdk/pull/6253.diff</a>

</details>
