### PR TITLE
8276640: Use blessed modifier order in jfr code

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/FilePurger.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/FilePurger.java
@@ -38,14 +38,14 @@ final class FilePurger {
 
     private static final Set<SafePath> paths = new LinkedHashSet<>();
 
-    public synchronized static void add(SafePath p) {
+    public static synchronized void add(SafePath p) {
         paths.add(p);
         if (paths.size() > 1000) {
             removeOldest();
         }
     }
 
-    public synchronized static void purge() {
+    public static synchronized void purge() {
         if (paths.isEmpty()) {
             return;
         }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
@@ -211,7 +211,7 @@ public final class JVM {
      *
      * @throws IllegalStateException if wrong JVMTI phase.
      */
-    public native synchronized void retransformClasses(Class<?>[] classes);
+    public synchronized native void retransformClasses(Class<?>[] classes);
 
     /**
      * Enable event

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
@@ -143,7 +143,7 @@ public final class PlatformRecorder {
         return Collections.unmodifiableList(new ArrayList<PlatformRecording>(recordings));
     }
 
-    public synchronized static void addListener(FlightRecorderListener changeListener) {
+    public static synchronized void addListener(FlightRecorderListener changeListener) {
         @SuppressWarnings("removal")
         AccessControlContext context = AccessController.getContext();
         SecureRecorderListener sl = new SecureRecorderListener(context, changeListener);
@@ -157,7 +157,7 @@ public final class PlatformRecorder {
         }
     }
 
-    public synchronized static boolean removeListener(FlightRecorderListener changeListener) {
+    public static synchronized boolean removeListener(FlightRecorderListener changeListener) {
         for (SecureRecorderListener s : new ArrayList<>(changeListeners)) {
             if (s.getChangeListener() == changeListener) {
                 changeListeners.remove(s);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PrivateAccess.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PrivateAccess.java
@@ -51,7 +51,7 @@ import jdk.jfr.internal.management.EventSettingsModifier;
  * java.lang.reflect.
  */
 public abstract class PrivateAccess {
-    private volatile static PrivateAccess instance;
+    private static volatile PrivateAccess instance;
 
     public static PrivateAccess getInstance() {
         // Can't be initialized in <clinit> because it may

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/JDKEvents.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/JDKEvents.java
@@ -117,7 +117,7 @@ public final class JDKEvents {
     private static boolean initializationTriggered;
 
     @SuppressWarnings("unchecked")
-    public synchronized static void initialize() {
+    public static synchronized void initialize() {
         try {
             if (initializationTriggered == false) {
                 for (Class<?> mirrorEventClass : mirrorEventClasses) {


### PR DESCRIPTION
I ran bin/blessed-modifier-order.sh on source owned by the JFR team. This scripts verifies that modifiers are in the "blessed" order, and fixes it otherwise. I have manually checked the changes made by the script to make sure they are sound.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276640](https://bugs.openjdk.java.net/browse/JDK-8276640): Use blessed modifier order in jfr code


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6254/head:pull/6254` \
`$ git checkout pull/6254`

Update a local copy of the PR: \
`$ git checkout pull/6254` \
`$ git pull https://git.openjdk.java.net/jdk pull/6254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6254`

View PR using the GUI difftool: \
`$ git pr show -t 6254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6254.diff">https://git.openjdk.java.net/jdk/pull/6254.diff</a>

</details>
