### PR TITLE
8276641: Use blessed modifier order in jshell

### DIFF
--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/utils/AnsiWriter.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/utils/AnsiWriter.java
@@ -45,7 +45,7 @@ public class AnsiWriter extends FilterWriter {
         super(out);
     }
 
-    private final static int MAX_ESCAPE_SEQUENCE_LENGTH = 100;
+    private static final int MAX_ESCAPE_SEQUENCE_LENGTH = 100;
     private final char[] buffer = new char[MAX_ESCAPE_SEQUENCE_LENGTH];
     private int pos = 0;
     private int startOfValue;

--- a/src/jdk.internal.le/windows/classes/jdk/internal/org/jline/terminal/impl/jna/win/WindowsAnsiWriter.java
+++ b/src/jdk.internal.le/windows/classes/jdk/internal/org/jline/terminal/impl/jna/win/WindowsAnsiWriter.java
@@ -70,7 +70,7 @@ public final class WindowsAnsiWriter extends AnsiWriter {
             BACKGROUND_WHITE,
     };
 
-    private final static int MAX_ESCAPE_SEQUENCE_LENGTH = 100;
+    private static final int MAX_ESCAPE_SEQUENCE_LENGTH = 100;
 
     private final Pointer console;
 

--- a/src/jdk.jshell/share/classes/jdk/jshell/Key.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/Key.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jshell/share/classes/jdk/jshell/Key.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/Key.java
@@ -76,7 +76,7 @@ abstract class Key {
      * They are keyed off at least the name.  They may be Modified/Replaced
      * with new input.
      */
-    static abstract class PersistentKey extends Key {
+    abstract static class PersistentKey extends Key {
 
         private final String name;
 
@@ -95,7 +95,7 @@ abstract class Key {
     /**
      * Grouping for snippets which reference declarations
      */
-    static abstract class DeclarationKey extends PersistentKey {
+    abstract static class DeclarationKey extends PersistentKey {
 
         DeclarationKey(JShell state, String name) {
             super(state, name);
@@ -201,7 +201,7 @@ abstract class Key {
      * exactly same entry is made again. The referenced snippets are thus
      * unmodifiable.
      */
-    static abstract class UniqueKey extends Key {
+    abstract static class UniqueKey extends Key {
 
         UniqueKey(JShell state) {
             super(state);

--- a/src/jdk.jshell/share/classes/jdk/jshell/MemoryFileManager.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/MemoryFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jshell/share/classes/jdk/jshell/MemoryFileManager.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/MemoryFileManager.java
@@ -73,7 +73,7 @@ class MemoryFileManager implements JavaFileManager {
         return this.stdFileManager.getLocationAsPaths(loc);
     }
 
-    static abstract class MemoryJavaFileObject extends SimpleJavaFileObject {
+    abstract static class MemoryJavaFileObject extends SimpleJavaFileObject {
 
         public MemoryJavaFileObject(String name, JavaFileObject.Kind kind) {
             super(URI.create("string:///" + name.replace('.', '/')

--- a/src/jdk.jshell/share/classes/jdk/jshell/spi/ExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/spi/ExecutionControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jshell/share/classes/jdk/jshell/spi/ExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/spi/ExecutionControl.java
@@ -337,7 +337,7 @@ public interface ExecutionControl extends AutoCloseable {
     /**
      * The abstract base of all {@code ExecutionControl} exceptions.
      */
-    public static abstract class ExecutionControlException extends Exception {
+    public abstract static class ExecutionControlException extends Exception {
 
         private static final long serialVersionUID = 1L;
 
@@ -410,7 +410,7 @@ public interface ExecutionControl extends AutoCloseable {
     /**
      * The abstract base of of exceptions specific to running user code.
      */
-    public static abstract class RunException extends ExecutionControlException {
+    public abstract static class RunException extends ExecutionControlException {
 
         private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
I ran bin/blessed-modifier-order.sh on source owned by jshell/project Kulla. This scripts verifies that modifiers are in the "blessed" order, and fixes it otherwise. I have manually checked the changes made by the script to make sure they are sound.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276641](https://bugs.openjdk.java.net/browse/JDK-8276641): Use blessed modifier order in jshell


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6255/head:pull/6255` \
`$ git checkout pull/6255`

Update a local copy of the PR: \
`$ git checkout pull/6255` \
`$ git pull https://git.openjdk.java.net/jdk pull/6255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6255`

View PR using the GUI difftool: \
`$ git pr show -t 6255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6255.diff">https://git.openjdk.java.net/jdk/pull/6255.diff</a>

</details>
