### PR TITLE
8273235: tools/launcher/HelpFlagsTest.java Fails on Windows 32bit

### DIFF
--- a/test/jdk/tools/launcher/HelpFlagsTest.java
+++ b/test/jdk/tools/launcher/HelpFlagsTest.java
@@ -47,7 +47,9 @@ public class HelpFlagsTest extends TestHelper {
     static final String[] TOOLS_NOT_TO_TEST = {
         "appletviewer",     // deprecated, don't test
         "jaccessinspector", // gui, don't test, win only
+        "jaccessinspector-32", // gui, don't test, win-32 only
         "jaccesswalker",    // gui, don't test, win only
+        "jaccesswalker-32", // gui, don't test, win-32 only
         "jconsole",         // gui, don't test
         "servertool",       // none. Shell, don't test.
         "javaw",            // don't test, win only


### PR DESCRIPTION
This PR implements the fix as suggested by Adam Farley, which reads:

> Note: Looks to be as simple as adding `jaccessinspector-32` and `jaccesswalker-32` to `TOOLS_NOT_TO_TEST` at the top of `HelpFlagsTest.java`, as the non-32bit versions are already there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273235](https://bugs.openjdk.java.net/browse/JDK-8273235): tools/launcher/HelpFlagsTest.java Fails on Windows 32bit


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6256/head:pull/6256` \
`$ git checkout pull/6256`

Update a local copy of the PR: \
`$ git checkout pull/6256` \
`$ git pull https://git.openjdk.java.net/jdk pull/6256/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6256`

View PR using the GUI difftool: \
`$ git pr show -t 6256`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6256.diff">https://git.openjdk.java.net/jdk/pull/6256.diff</a>

</details>
