### PR TITLE
8276186: Require getAvailableLocales() methods to include Locale.ROOT

### DIFF
--- a/src/java.base/share/classes/java/text/BreakIterator.java
+++ b/src/java.base/share/classes/java/text/BreakIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -576,8 +576,8 @@ public abstract class BreakIterator implements Cloneable
      * The returned array represents the union of locales supported by the Java
      * runtime and by installed
      * {@link java.text.spi.BreakIteratorProvider BreakIteratorProvider} implementations.
-     * It must contain at least a {@code Locale}
-     * instance equal to {@link java.util.Locale#US Locale.US}.
+     * It must contain at least two {@code Locale} instances equal to {@link Locale#ROOT
+     * Locale.ROOT} and {@link Locale#US Locale.US}.
      *
      * @return An array of locales for which localized
      *         {@code BreakIterator} instances are available.

--- a/src/java.base/share/classes/java/text/BreakIterator.java
+++ b/src/java.base/share/classes/java/text/BreakIterator.java
@@ -576,8 +576,9 @@ public abstract class BreakIterator implements Cloneable
      * The returned array represents the union of locales supported by the Java
      * runtime and by installed
      * {@link java.text.spi.BreakIteratorProvider BreakIteratorProvider} implementations.
-     * It must contain at least two {@code Locale} instances equal to {@link Locale#ROOT
-     * Locale.ROOT} and {@link Locale#US Locale.US}.
+     * At a minimum, the returned array must contain a {@code Locale} instance equal to
+     * {@link Locale#ROOT Locale.ROOT} and a {@code Locale} instance equal to
+     * {@link Locale#US Locale.US}.
      *
      * @return An array of locales for which localized
      *         {@code BreakIterator} instances are available.

--- a/src/java.base/share/classes/java/text/Collator.java
+++ b/src/java.base/share/classes/java/text/Collator.java
@@ -421,8 +421,9 @@ public abstract class Collator
      * The returned array represents the union of locales supported
      * by the Java runtime and by installed
      * {@link java.text.spi.CollatorProvider CollatorProvider} implementations.
-     * It must contain at least two {@code Locale} instances equal to {@link Locale#ROOT
-     * Locale.ROOT} and {@link Locale#US Locale.US}.
+     * At a minimum, the returned array must contain a {@code Locale} instance equal to
+     * {@link Locale#ROOT Locale.ROOT} and a {@code Locale} instance equal to
+     * {@link Locale#US Locale.US}.
      *
      * @return An array of locales for which localized
      *         {@code Collator} instances are available.

--- a/src/java.base/share/classes/java/text/Collator.java
+++ b/src/java.base/share/classes/java/text/Collator.java
@@ -421,8 +421,8 @@ public abstract class Collator
      * The returned array represents the union of locales supported
      * by the Java runtime and by installed
      * {@link java.text.spi.CollatorProvider CollatorProvider} implementations.
-     * It must contain at least a Locale instance equal to
-     * {@link java.util.Locale#US Locale.US}.
+     * It must contain at least two {@code Locale} instances equal to {@link Locale#ROOT
+     * Locale.ROOT} and {@link Locale#US Locale.US}.
      *
      * @return An array of locales for which localized
      *         {@code Collator} instances are available.

--- a/src/java.base/share/classes/java/text/DateFormat.java
+++ b/src/java.base/share/classes/java/text/DateFormat.java
@@ -636,8 +636,9 @@ public abstract class DateFormat extends Format {
      * The returned array represents the union of locales supported by the Java
      * runtime and by installed
      * {@link java.text.spi.DateFormatProvider DateFormatProvider} implementations.
-     * It must contain at least two {@code Locale} instances equal to
-     * {@link Locale#ROOT Locale.ROOT} and {@link Locale#US Locale.US}.
+     * At a minimum, the returned array must contain a {@code Locale} instance equal to
+     * {@link Locale#ROOT Locale.ROOT} and a {@code Locale} instance equal to
+     * {@link Locale#US Locale.US}.
      *
      * @return An array of locales for which localized
      *         {@code DateFormat} instances are available.

--- a/src/java.base/share/classes/java/text/DateFormat.java
+++ b/src/java.base/share/classes/java/text/DateFormat.java
@@ -636,8 +636,8 @@ public abstract class DateFormat extends Format {
      * The returned array represents the union of locales supported by the Java
      * runtime and by installed
      * {@link java.text.spi.DateFormatProvider DateFormatProvider} implementations.
-     * It must contain at least a {@code Locale} instance equal to
-     * {@link java.util.Locale#US Locale.US}.
+     * It must contain at least two {@code Locale} instances equal to
+     * {@link Locale#ROOT Locale.ROOT} and {@link Locale#US Locale.US}.
      *
      * @return An array of locales for which localized
      *         {@code DateFormat} instances are available.

--- a/src/java.base/share/classes/java/text/DateFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DateFormatSymbols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -299,8 +299,9 @@ public class DateFormatSymbols implements Serializable, Cloneable {
      * The returned array represents the union of locales supported by the
      * Java runtime and by installed
      * {@link java.text.spi.DateFormatSymbolsProvider DateFormatSymbolsProvider}
-     * implementations.  It must contain at least a {@code Locale}
-     * instance equal to {@link java.util.Locale#US Locale.US}.
+     * implementations. It must contain at least two {@code Locale}
+     * instances equal to {@link Locale#ROOT Locale.ROOT} and
+     * {@link Locale#US Locale.US}.
      *
      * @return An array of locales for which localized
      *         {@code DateFormatSymbols} instances are available.

--- a/src/java.base/share/classes/java/text/DateFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DateFormatSymbols.java
@@ -299,9 +299,9 @@ public class DateFormatSymbols implements Serializable, Cloneable {
      * The returned array represents the union of locales supported by the
      * Java runtime and by installed
      * {@link java.text.spi.DateFormatSymbolsProvider DateFormatSymbolsProvider}
-     * implementations. It must contain at least two {@code Locale}
-     * instances equal to {@link Locale#ROOT Locale.ROOT} and
-     * {@link Locale#US Locale.US}.
+     * implementations. At a minimum, the returned array must contain a
+     * {@code Locale} instance equal to {@link Locale#ROOT Locale.ROOT} and
+     * a {@code Locale} instance equal to {@link Locale#US Locale.US}.
      *
      * @return An array of locales for which localized
      *         {@code DateFormatSymbols} instances are available.

--- a/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,8 +122,9 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
      * The returned array represents the union of locales supported by the Java
      * runtime and by installed
      * {@link java.text.spi.DecimalFormatSymbolsProvider DecimalFormatSymbolsProvider}
-     * implementations.  It must contain at least a {@code Locale}
-     * instance equal to {@link java.util.Locale#US Locale.US}.
+     * implementations. It must contain at least two {@code Locale}
+     * instances equal to {@link Locale#ROOT Locale.ROOT} and
+     * {@link Locale#US Locale.US}.
      *
      * @return an array of locales for which localized
      *         {@code DecimalFormatSymbols} instances are available.

--- a/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
@@ -122,9 +122,9 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
      * The returned array represents the union of locales supported by the Java
      * runtime and by installed
      * {@link java.text.spi.DecimalFormatSymbolsProvider DecimalFormatSymbolsProvider}
-     * implementations. It must contain at least two {@code Locale}
-     * instances equal to {@link Locale#ROOT Locale.ROOT} and
-     * {@link Locale#US Locale.US}.
+     * implementations. At a minimum, the returned array must contain a
+     * {@code Locale} instance equal to {@link Locale#ROOT Locale.ROOT} and
+     * a {@code Locale} instance equal to {@link Locale#US Locale.US}.
      *
      * @return an array of locales for which localized
      *         {@code DecimalFormatSymbols} instances are available.

--- a/src/java.base/share/classes/java/text/NumberFormat.java
+++ b/src/java.base/share/classes/java/text/NumberFormat.java
@@ -682,8 +682,9 @@ public abstract class NumberFormat extends Format  {
      * The returned array represents the union of locales supported by the Java
      * runtime and by installed
      * {@link java.text.spi.NumberFormatProvider NumberFormatProvider} implementations.
-     * It must contain at least two {@code Locale} instances equal to
-     * {@link Locale#ROOT Locale.ROOT} and {@link Locale#US Locale.US}.
+     * At a minimum, the returned array must contain a {@code Locale} instance equal to
+     * {@link Locale#ROOT Locale.ROOT} and a {@code Locale} instance equal to
+     * {@link Locale#US Locale.US}.
      *
      * @return An array of locales for which localized
      *         {@code NumberFormat} instances are available.

--- a/src/java.base/share/classes/java/text/NumberFormat.java
+++ b/src/java.base/share/classes/java/text/NumberFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -682,8 +682,8 @@ public abstract class NumberFormat extends Format  {
      * The returned array represents the union of locales supported by the Java
      * runtime and by installed
      * {@link java.text.spi.NumberFormatProvider NumberFormatProvider} implementations.
-     * It must contain at least a {@code Locale} instance equal to
-     * {@link java.util.Locale#US Locale.US}.
+     * It must contain at least two {@code Locale} instances equal to
+     * {@link Locale#ROOT Locale.ROOT} and {@link Locale#US Locale.US}.
      *
      * @return An array of locales for which localized
      *         {@code NumberFormat} instances are available.

--- a/src/java.base/share/classes/java/time/format/DecimalStyle.java
+++ b/src/java.base/share/classes/java/time/format/DecimalStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,7 +115,7 @@ public final class DecimalStyle {
     /**
      * Lists all the locales that are supported.
      * <p>
-     * The locale 'en_US' will always be present.
+     * The locale 'ROOT' and 'en_US' will always be present.
      *
      * @return a Set of Locales for which localization is supported
      */

--- a/src/java.base/share/classes/java/time/format/DecimalStyle.java
+++ b/src/java.base/share/classes/java/time/format/DecimalStyle.java
@@ -115,7 +115,9 @@ public final class DecimalStyle {
     /**
      * Lists all the locales that are supported.
      * <p>
-     * The locale 'ROOT' and 'en_US' will always be present.
+     * At a minimum, the returned Set must contain a {@code Locale} instance equal to
+     * {@link Locale#ROOT Locale.ROOT} and a {@code Locale} instance equal to
+     * {@link Locale#US Locale.US}.
      *
      * @return a Set of Locales for which localization is supported
      */

--- a/src/java.base/share/classes/java/time/format/DecimalStyle.java
+++ b/src/java.base/share/classes/java/time/format/DecimalStyle.java
@@ -115,7 +115,7 @@ public final class DecimalStyle {
     /**
      * Lists all the locales that are supported.
      * <p>
-     * At a minimum, the returned Set must contain a {@code Locale} instance equal to
+     * At a minimum, the returned {@code Set} must contain a {@code Locale} instance equal to
      * {@link Locale#ROOT Locale.ROOT} and a {@code Locale} instance equal to
      * {@link Locale#US Locale.US}.
      *

--- a/src/java.base/share/classes/java/util/Calendar.java
+++ b/src/java.base/share/classes/java/util/Calendar.java
@@ -1730,8 +1730,8 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
     /**
      * Returns an array of all locales for which the {@code getInstance}
      * methods of this class can return localized instances.
-     * The array returned must contain at least two {@code Locale}
-     * instances equal to {@link Locale#ROOT Locale.ROOT} and
+     * At a minimum, the returned array must contain a {@code Locale} instance equal to
+     * {@link Locale#ROOT Locale.ROOT} and a {@code Locale} instance equal to
      * {@link Locale#US Locale.US}.
      *
      * @return An array of locales for which localized

--- a/src/java.base/share/classes/java/util/Calendar.java
+++ b/src/java.base/share/classes/java/util/Calendar.java
@@ -1730,8 +1730,9 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
     /**
      * Returns an array of all locales for which the {@code getInstance}
      * methods of this class can return localized instances.
-     * The array returned must contain at least a {@code Locale}
-     * instance equal to {@link java.util.Locale#US Locale.US}.
+     * The array returned must contain at least two {@code Locale}
+     * instances equal to {@link Locale#ROOT Locale.ROOT} and
+     * {@link Locale#US Locale.US}.
      *
      * @return An array of locales for which localized
      *         {@code Calendar} instances are available.

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -1126,8 +1126,9 @@ public final class Locale implements Cloneable, Serializable {
      * The returned array represents the union of locales supported
      * by the Java runtime environment and by installed
      * {@link java.util.spi.LocaleServiceProvider LocaleServiceProvider}
-     * implementations.  It must contain at least two {@code Locale}
-     * instances equal to {@link #ROOT Locale.ROOT} and {@link #US Locale.US}.
+     * implementations. At a minimum, the returned array must contain a
+     * {@code Locale} instance equal to {@link Locale#ROOT Locale.ROOT} and
+     * a {@code Locale} instance equal to {@link Locale#US Locale.US}.
      *
      * @return An array of installed locales.
      */

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -1126,8 +1126,8 @@ public final class Locale implements Cloneable, Serializable {
      * The returned array represents the union of locales supported
      * by the Java runtime environment and by installed
      * {@link java.util.spi.LocaleServiceProvider LocaleServiceProvider}
-     * implementations.  It must contain at least a {@code Locale}
-     * instance equal to {@link java.util.Locale#US Locale.US}.
+     * implementations.  It must contain at least two {@code Locale}
+     * instances equal to {@link #ROOT Locale.ROOT} and {@link #US Locale.US}.
      *
      * @return An array of installed locales.
      */

--- a/test/jdk/java/util/Locale/RequiredAvailableLocalesTest.java
+++ b/test/jdk/java/util/Locale/RequiredAvailableLocalesTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/**
+ * @test
+ * @bug 8276186
+ * @summary Checks whether getAvailableLocales() returns at least Locale.ROOT and
+ *      Locale.US instances.
+ * @run testng/othervm -Djava.locale.providers=COMPAT RequiredAvailableLocalesTest
+ * @run testng/othervm -Djava.locale.providers=CLDR RequiredAvailableLocalesTest
+ */
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.text.*;
+import java.time.format.DecimalStyle;
+import java.util.*;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertTrue;
+
+@Test
+public class RequiredAvailableLocalesTest {
+
+    private static final Set<Locale> REQUIRED_LOCALES = Set.of(Locale.ROOT, Locale.US);
+    private static final MethodType ARRAY_RETURN_TYPE = MethodType.methodType(Locale.class.arrayType());
+    private static final MethodType SET_RETURN_TYPE = MethodType.methodType(Set.class);
+
+    @DataProvider
+    public Object[][] availableLocalesClasses() {
+        return new Object[][] {
+            {BreakIterator.class, ARRAY_RETURN_TYPE},
+            {Calendar.class, ARRAY_RETURN_TYPE},
+            {Collator.class, ARRAY_RETURN_TYPE},
+            {DateFormat.class, ARRAY_RETURN_TYPE},
+            {DateFormatSymbols.class, ARRAY_RETURN_TYPE},
+            {DecimalFormatSymbols.class, ARRAY_RETURN_TYPE},
+            {DecimalStyle.class, SET_RETURN_TYPE},
+            {Locale.class, ARRAY_RETURN_TYPE},
+            {NumberFormat.class, ARRAY_RETURN_TYPE},
+        };
+    }
+
+    @Test (dataProvider = "availableLocalesClasses")
+    public void checkRequiredLocales(Class c, MethodType mt) throws Throwable {
+        var ret = MethodHandles.lookup().findStatic(c, "getAvailableLocales", mt).invoke();
+
+        if (ret instanceof Locale[] a) {
+            assertTrue(Arrays.asList(a).containsAll(REQUIRED_LOCALES));
+        } else if (ret instanceof Set s) {
+            assertTrue(s.containsAll(REQUIRED_LOCALES));
+        } else {
+            throw new RuntimeException("return type mismatch");
+        }
+    }
+}

--- a/test/jdk/java/util/Locale/RequiredAvailableLocalesTest.java
+++ b/test/jdk/java/util/Locale/RequiredAvailableLocalesTest.java
@@ -62,12 +62,12 @@ public class RequiredAvailableLocalesTest {
     }
 
     @Test (dataProvider = "availableLocalesClasses")
-    public void checkRequiredLocales(Class c, MethodType mt) throws Throwable {
+    public void checkRequiredLocales(Class<?> c, MethodType mt) throws Throwable {
         var ret = MethodHandles.lookup().findStatic(c, "getAvailableLocales", mt).invoke();
 
         if (ret instanceof Locale[] a) {
             assertTrue(Arrays.asList(a).containsAll(REQUIRED_LOCALES));
-        } else if (ret instanceof Set s) {
+        } else if (ret instanceof Set<?> s) {
             assertTrue(s.containsAll(REQUIRED_LOCALES));
         } else {
             throw new RuntimeException("return type mismatch");


### PR DESCRIPTION
This fix is to require to include `Locale.ROOT` in the returned arrays/set from `getAvailableLocales()` methods in various locale-sensitive classes. The implementation has been including `Locale.ROOT` since its inception, it is simply a doc clarification (+ a test case verifying it). Corresponding CSR has also been drafted: https://bugs.openjdk.java.net/browse/JDK-8276249

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276186](https://bugs.openjdk.java.net/browse/JDK-8276186): Require getAvailableLocales() methods to include Locale.ROOT


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**) ⚠️ Review applies to 1a611bd50a63647d35f50e8cd41d1e58eaaa70c0
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6258/head:pull/6258` \
`$ git checkout pull/6258`

Update a local copy of the PR: \
`$ git checkout pull/6258` \
`$ git pull https://git.openjdk.java.net/jdk pull/6258/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6258`

View PR using the GUI difftool: \
`$ git pr show -t 6258`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6258.diff">https://git.openjdk.java.net/jdk/pull/6258.diff</a>

</details>
