### PR TITLE
JDK-8276236: Table headers missing in Formatter api docs

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -874,41 +874,21 @@ public class MethodHandles {
      * the intersection of all public types that are accessible to {@code M1}
      * with all public types that are accessible to {@code M0}. {@code M0}
      * reads {@code M1} and hence the set of accessible types includes:
-     *
-     * <table class="striped">
-     * <caption style="display:none">
-     * Public types in the following packages are accessible to the
-     * lookup class and the previous lookup class.
-     * </caption>
-     * <thead>
-     * <tr>
-     * <th scope="col">Equally accessible types to {@code M0} and {@code M1}</th>
-     * </tr>
-     * </thead>
-     * <tbody>
-     * <tr>
-     * <th scope="row" style="text-align:left">unconditional-exported packages from {@code M1}</th>
-     * </tr>
-     * <tr>
-     * <th scope="row" style="text-align:left">unconditional-exported packages from {@code M0} if {@code M1} reads {@code M0}</th>
-     * </tr>
-     * <tr>
-     * <th scope="row" style="text-align:left">unconditional-exported packages from a third module {@code M2}
-     * if both {@code M0} and {@code M1} read {@code M2}</th>
-     * </tr>
-     * <tr>
-     * <th scope="row" style="text-align:left">qualified-exported packages from {@code M1} to {@code M0}</th>
-     * </tr>
-     * <tr>
-     * <th scope="row" style="text-align:left">qualified-exported packages from {@code M0} to {@code M1}
-     * if {@code M1} reads {@code M0}</th>
-     * </tr>
-     * <tr>
-     * <th scope="row" style="text-align:left">qualified-exported packages from a third module {@code M2} to
-     * both {@code M0} and {@code M1} if both {@code M0} and {@code M1} read {@code M2}</th>
-     * </tr>
-     * </tbody>
-     * </table>
+     * 
+     * <ul>
+     * <li>unconditional-exported packages from {@code M1}</li>
+     * <li>unconditional-exported packages from {@code M0} if {@code M1} reads {@code M0}</li>
+     * <li>
+     *     unconditional-exported packages from a third module {@code M2}if both {@code M0} 
+     *     and {@code M1} read {@code M2}
+     * </li>
+     * <li>qualified-exported packages from {@code M1} to {@code M0}</li>
+     * <li>qualified-exported packages from {@code M0} to {@code M1} if {@code M1} reads {@code M0}</li>
+     * <li>
+     *     qualified-exported packages from a third module {@code M2} to both {@code M0} and 
+     *     {@code M1} if both {@code M0} and {@code M1} read {@code M2}
+     * </li>
+     * </ul>
      *
      * <h2><a id="access-modes"></a>Access modes</h2>
      *

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -874,18 +874,18 @@ public class MethodHandles {
      * the intersection of all public types that are accessible to {@code M1}
      * with all public types that are accessible to {@code M0}. {@code M0}
      * reads {@code M1} and hence the set of accessible types includes:
-     * 
+     *
      * <ul>
      * <li>unconditional-exported packages from {@code M1}</li>
      * <li>unconditional-exported packages from {@code M0} if {@code M1} reads {@code M0}</li>
      * <li>
-     *     unconditional-exported packages from a third module {@code M2}if both {@code M0} 
+     *     unconditional-exported packages from a third module {@code M2}if both {@code M0}
      *     and {@code M1} read {@code M2}
      * </li>
      * <li>qualified-exported packages from {@code M1} to {@code M0}</li>
      * <li>qualified-exported packages from {@code M0} to {@code M1} if {@code M1} reads {@code M0}</li>
      * <li>
-     *     qualified-exported packages from a third module {@code M2} to both {@code M0} and 
+     *     qualified-exported packages from a third module {@code M2} to both {@code M0} and
      *     {@code M1} if both {@code M0} and {@code M1} read {@code M2}
      * </li>
      * </ul>


### PR DESCRIPTION
Inferring from the flow of the text, the table should have been a list all along, so I've made it that way.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8276236](https://bugs.openjdk.java.net/browse/JDK-8276236): Table headers missing in Formatter api docs ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6259/head:pull/6259` \
`$ git checkout pull/6259`

Update a local copy of the PR: \
`$ git checkout pull/6259` \
`$ git pull https://git.openjdk.java.net/jdk pull/6259/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6259`

View PR using the GUI difftool: \
`$ git pr show -t 6259`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6259.diff">https://git.openjdk.java.net/jdk/pull/6259.diff</a>

</details>
