### PR TITLE
JDK-8276649: MethodHandles.Lookup docs: replace the table in the cross-module access check section with list

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -874,41 +874,21 @@ public class MethodHandles {
      * the intersection of all public types that are accessible to {@code M1}
      * with all public types that are accessible to {@code M0}. {@code M0}
      * reads {@code M1} and hence the set of accessible types includes:
-     *
-     * <table class="striped">
-     * <caption style="display:none">
-     * Public types in the following packages are accessible to the
-     * lookup class and the previous lookup class.
-     * </caption>
-     * <thead>
-     * <tr>
-     * <th scope="col">Equally accessible types to {@code M0} and {@code M1}</th>
-     * </tr>
-     * </thead>
-     * <tbody>
-     * <tr>
-     * <th scope="row" style="text-align:left">unconditional-exported packages from {@code M1}</th>
-     * </tr>
-     * <tr>
-     * <th scope="row" style="text-align:left">unconditional-exported packages from {@code M0} if {@code M1} reads {@code M0}</th>
-     * </tr>
-     * <tr>
-     * <th scope="row" style="text-align:left">unconditional-exported packages from a third module {@code M2}
-     * if both {@code M0} and {@code M1} read {@code M2}</th>
-     * </tr>
-     * <tr>
-     * <th scope="row" style="text-align:left">qualified-exported packages from {@code M1} to {@code M0}</th>
-     * </tr>
-     * <tr>
-     * <th scope="row" style="text-align:left">qualified-exported packages from {@code M0} to {@code M1}
-     * if {@code M1} reads {@code M0}</th>
-     * </tr>
-     * <tr>
-     * <th scope="row" style="text-align:left">qualified-exported packages from a third module {@code M2} to
-     * both {@code M0} and {@code M1} if both {@code M0} and {@code M1} read {@code M2}</th>
-     * </tr>
-     * </tbody>
-     * </table>
+     * 
+     * <ul>
+     * <li>unconditional-exported packages from {@code M1}</li>
+     * <li>unconditional-exported packages from {@code M0} if {@code M1} reads {@code M0}</li>
+     * <li>
+     *     unconditional-exported packages from a third module {@code M2}if both {@code M0} 
+     *     and {@code M1} read {@code M2}
+     * </li>
+     * <li>qualified-exported packages from {@code M1} to {@code M0}</li>
+     * <li>qualified-exported packages from {@code M0} to {@code M1} if {@code M1} reads {@code M0}</li>
+     * <li>
+     *     qualified-exported packages from a third module {@code M2} to both {@code M0} and 
+     *     {@code M1} if both {@code M0} and {@code M1} read {@code M2}
+     * </li>
+     * </ul>
      *
      * <h2><a id="access-modes"></a>Access modes</h2>
      *

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -874,18 +874,18 @@ public class MethodHandles {
      * the intersection of all public types that are accessible to {@code M1}
      * with all public types that are accessible to {@code M0}. {@code M0}
      * reads {@code M1} and hence the set of accessible types includes:
-     * 
+     *
      * <ul>
      * <li>unconditional-exported packages from {@code M1}</li>
      * <li>unconditional-exported packages from {@code M0} if {@code M1} reads {@code M0}</li>
      * <li>
-     *     unconditional-exported packages from a third module {@code M2}if both {@code M0} 
+     *     unconditional-exported packages from a third module {@code M2}if both {@code M0}
      *     and {@code M1} read {@code M2}
      * </li>
      * <li>qualified-exported packages from {@code M1} to {@code M0}</li>
      * <li>qualified-exported packages from {@code M0} to {@code M1} if {@code M1} reads {@code M0}</li>
      * <li>
-     *     qualified-exported packages from a third module {@code M2} to both {@code M0} and 
+     *     qualified-exported packages from a third module {@code M2} to both {@code M0} and
      *     {@code M1} if both {@code M0} and {@code M1} read {@code M2}
      * </li>
      * </ul>


### PR DESCRIPTION
Inferring from the flow of the text, the table should have been a list all along, so I've made it that way. Before and after for comparison:
![image](https://user-images.githubusercontent.com/6298393/140376551-6f8ac0c9-5336-4da0-8504-01af806ecae0.png)
![image](https://user-images.githubusercontent.com/6298393/140376679-54716d82-f431-46f7-b959-022374b6f893.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276649](https://bugs.openjdk.java.net/browse/JDK-8276649): MethodHandles.Lookup docs: replace the table in the cross-module access check section with list


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6260/head:pull/6260` \
`$ git checkout pull/6260`

Update a local copy of the PR: \
`$ git checkout pull/6260` \
`$ git pull https://git.openjdk.java.net/jdk pull/6260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6260`

View PR using the GUI difftool: \
`$ git pr show -t 6260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6260.diff">https://git.openjdk.java.net/jdk/pull/6260.diff</a>

</details>
