### PR TITLE
JDK-8276653: Missing row headers in j.l.Character docs

### DIFF
--- a/src/java.base/share/classes/java/lang/Character.java
+++ b/src/java.base/share/classes/java/lang/Character.java
@@ -75,27 +75,27 @@ import static java.lang.constant.ConstantDescs.DEFAULT_NAME;
  *     <th scope="col">Unicode version</th></tr>
  * </thead>
  * <tbody>
- * <tr><td>Java SE 15</td>
+ * <tr><th scope="row" style="text-align:left">Java SE 15</th>
  *     <td>Unicode 13.0</td></tr>
- * <tr><td>Java SE 13</td>
+ * <tr><th scope="row" style="text-align:left">Java SE 13</th>
  *     <td>Unicode 12.1</td></tr>
- * <tr><td>Java SE 12</td>
+ * <tr><th scope="row" style="text-align:left">Java SE 12</th>
  *     <td>Unicode 11.0</td></tr>
- * <tr><td>Java SE 11</td>
+ * <tr><th scope="row" style="text-align:left">Java SE 11</th>
  *     <td>Unicode 10.0</td></tr>
- * <tr><td>Java SE 9</td>
+ * <tr><th scope="row" style="text-align:left">Java SE 9</th>
  *     <td>Unicode 8.0</td></tr>
- * <tr><td>Java SE 8</td>
+ * <tr><th scope="row" style="text-align:left">Java SE 8</th>
  *     <td>Unicode 6.2</td></tr>
- * <tr><td>Java SE 7</td>
+ * <tr><th scope="row" style="text-align:left">Java SE 7</th>
  *     <td>Unicode 6.0</td></tr>
- * <tr><td>Java SE 5.0</td>
+ * <tr><th scope="row" style="text-align:left">Java SE 5.0</th>
  *     <td>Unicode 4.0</td></tr>
- * <tr><td>Java SE 1.4</td>
+ * <tr><th scope="row" style="text-align:left">Java SE 1.4</th>
  *     <td>Unicode 3.0</td></tr>
- * <tr><td>JDK 1.1</td>
+ * <tr><th scope="row" style="text-align:left">JDK 1.1</th>
  *     <td>Unicode 2.0</td></tr>
- * <tr><td>JDK 1.0.2</td>
+ * <tr><th scope="row" style="text-align:left">JDK 1.0.2</th>
  *     <td>Unicode 1.1.5</td></tr>
  * </tbody>
  * </table>


### PR DESCRIPTION
The first table is missing row headers, adding them to aid screen readers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276653](https://bugs.openjdk.java.net/browse/JDK-8276653): Missing row headers in j.l.Character docs


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6262/head:pull/6262` \
`$ git checkout pull/6262`

Update a local copy of the PR: \
`$ git checkout pull/6262` \
`$ git pull https://git.openjdk.java.net/jdk pull/6262/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6262`

View PR using the GUI difftool: \
`$ git pr show -t 6262`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6262.diff">https://git.openjdk.java.net/jdk/pull/6262.diff</a>

</details>
