### PR TITLE
8276655: Use blessed modifier order in SCTP

### DIFF
--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/AssociationChange.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/AssociationChange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,11 +35,11 @@ public class AssociationChange extends AssociationChangeNotification
     implements SctpNotification
 {
     /* static final ints so that they can be referenced from native */
-    @Native private final static int SCTP_COMM_UP = 1;
-    @Native private final static int SCTP_COMM_LOST = 2;
-    @Native private final static int SCTP_RESTART = 3;
-    @Native private final static int SCTP_SHUTDOWN = 4;
-    @Native private final static int SCTP_CANT_START = 5;
+    @Native private static final int SCTP_COMM_UP = 1;
+    @Native private static final int SCTP_COMM_LOST = 2;
+    @Native private static final int SCTP_RESTART = 3;
+    @Native private static final int SCTP_SHUTDOWN = 4;
+    @Native private static final int SCTP_CANT_START = 5;
 
     private Association association;
 

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/PeerAddrChange.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/PeerAddrChange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,12 +36,12 @@ public class PeerAddrChange extends PeerAddressChangeNotification
     implements SctpNotification
 {
     /* static final ints so that they can be referenced from native */
-    @Native private final static int SCTP_ADDR_AVAILABLE = 1;
-    @Native private final static int SCTP_ADDR_UNREACHABLE = 2;
-    @Native private final static int SCTP_ADDR_REMOVED = 3;
-    @Native private final static int SCTP_ADDR_ADDED = 4;
-    @Native private final static int SCTP_ADDR_MADE_PRIM = 5;
-    @Native private final static int SCTP_ADDR_CONFIRMED =6;
+    @Native private static final int SCTP_ADDR_AVAILABLE = 1;
+    @Native private static final int SCTP_ADDR_UNREACHABLE = 2;
+    @Native private static final int SCTP_ADDR_REMOVED = 3;
+    @Native private static final int SCTP_ADDR_ADDED = 4;
+    @Native private static final int SCTP_ADDR_MADE_PRIM = 5;
+    @Native private static final int SCTP_ADDR_CONFIRMED =6;
 
     private Association association;
 


### PR DESCRIPTION
I ran bin/blessed-modifier-order.sh on source owned by net libs. This scripts verifies that modifiers are in the "blessed" order, and fixes it otherwise. I have manually checked the changes made by the script to make sure they are sound.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276655](https://bugs.openjdk.java.net/browse/JDK-8276655): Use blessed modifier order in SCTP


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6264/head:pull/6264` \
`$ git checkout pull/6264`

Update a local copy of the PR: \
`$ git checkout pull/6264` \
`$ git pull https://git.openjdk.java.net/jdk pull/6264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6264`

View PR using the GUI difftool: \
`$ git pr show -t 6264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6264.diff">https://git.openjdk.java.net/jdk/pull/6264.diff</a>

</details>
