### PR TITLE
JDK-8276650: GenGraphs does not produce deterministic output

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/ModuleDotGraph.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/ModuleDotGraph.java
@@ -333,7 +333,7 @@ public class ModuleDotGraph {
 
         private final String name;
         private final Graph<String> graph;
-        private final Set<ModuleDescriptor> descriptors = new TreeSet<>();
+        private final TreeSet<ModuleDescriptor> descriptors = new TreeSet<>();
         private final List<SubGraph> subgraphs = new ArrayList<>();
         private final Attributes attributes;
         public DotGraphBuilder(String name,
@@ -414,7 +414,7 @@ public class ModuleDotGraph {
                 .collect(toSet());
 
             String mn = md.name();
-            edges.forEach(dn -> {
+            edges.stream().sorted().forEach(dn -> {
                 String attr = "";
                 if (dn.equals("java.base")) {
                     attr = "color=\"" + attributes.requiresMandatedColor() + "\"";


### PR DESCRIPTION
The dot graph should print the edges in alphatical order.   A simple fix to sort the edges before printing them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276650](https://bugs.openjdk.java.net/browse/JDK-8276650): GenGraphs does not produce deterministic output


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6266/head:pull/6266` \
`$ git checkout pull/6266`

Update a local copy of the PR: \
`$ git checkout pull/6266` \
`$ git pull https://git.openjdk.java.net/jdk pull/6266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6266`

View PR using the GUI difftool: \
`$ git pr show -t 6266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6266.diff">https://git.openjdk.java.net/jdk/pull/6266.diff</a>

</details>
