### PR TITLE
8276663: Cleanup NMT AccessLock

### DIFF
--- a/src/hotspot/share/services/mallocSiteTable.cpp
+++ b/src/hotspot/share/services/mallocSiteTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/services/mallocSiteTable.cpp
+++ b/src/hotspot/share/services/mallocSiteTable.cpp
@@ -231,8 +231,8 @@ void MallocSiteTable::AccessLock::exclusiveLock() {
   // make counter negative to block out shared locks
   do {
     val = *_lock;
-    target = _MAGIC_ + *_lock;
-  } while (Atomic::cmpxchg(_lock, val, target) != val);
+    target = _MAGIC_ + val;
+  } while (Atomic::cmpxchg(_lock, val, target, memory_order_relaxed) != val);
 
   // wait for all readers to exit
   while (*_lock != _MAGIC_) {


### PR DESCRIPTION
Please review this cleanup patch to NMT AccessLock:

* Make LockState enum private, no external use.
* const lock location pointer
* Use memory_order_relaxed for lock counter updates.

Test:
- [x] hotspot_nmt on x86_64 and aarch64