### PR TITLE
8276400: openjdk image Jars, Zips and Jmods built from the same source are not reproducible

### DIFF
--- a/make/ToolsJdk.gmk
+++ b/make/ToolsJdk.gmk
@@ -82,6 +82,8 @@ TOOL_GENERATECACERTS = $(JAVA_SMALL) -cp $(BUILDTOOLS_OUTPUTDIR)/jdk_tools_class
 TOOL_GENERATEEMOJIDATA = $(JAVA_SMALL) -cp $(BUILDTOOLS_OUTPUTDIR)/jdk_tools_classes \
     build.tools.generateemojidata.GenerateEmojiData
 
+TOOL_GENERATEZIP = $(JAVA_SMALL) -cp $(BUILDTOOLS_OUTPUTDIR)/jdk_tools_classes \
+    build.tools.generatezip.GenerateZip
 
 # TODO: There are references to the jdwpgen.jar in jdk/make/netbeans/jdwpgen/build.xml
 # and nbproject/project.properties in the same dir. Needs to be looked at.

--- a/make/common/ZipArchive.gmk
+++ b/make/common/ZipArchive.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 ifndef _ZIP_ARCHIVE_GMK
 _ZIP_ARCHIVE_GMK := 1
+
+include ../ToolsJdk.gmk
 
 ifeq (,$(_MAKEBASE_GMK))
   $(error You must include MakeBase.gmk prior to including ZipArchive.gmk)
@@ -134,6 +136,8 @@ define SetupZipArchiveBody
   # dir is very small.
   # If zip has nothing to do, it returns 12 and would fail the build. Check for 12
   # and only fail if it's not.
+  # For reproducible builds the zip does not support SOURCE_DATE_EPOCH and will not
+  # produce determinsitic output, instead use GenerateZip jdk tool to create final zip.
   $$($1_ZIP) : $$($1_ALL_SRCS) $$($1_EXTRA_DEPS)
 	$$(call LogWarn, Updating $$($1_NAME))
 	$$(call MakeTargetDir)
@@ -156,14 +160,22 @@ define SetupZipArchiveBody
 	    ) \
 	  ) \
 	)
+	$(RM) -r $$(SUPPORT_OUTPUTDIR)/ziptmp/$1 && $(MKDIR) -p $$(SUPPORT_OUTPUTDIR)/ziptmp/$1/files
 	$$(foreach s,$$($1_SRC_SLASH), $$(call ExecuteWithLog, \
 	    $$(SUPPORT_OUTPUTDIR)/zip/$$(patsubst $$(OUTPUTDIR)/%,%, $$@), \
-	    (cd $$s && $(ZIPEXE) -qru $$($1_ZIP_OPTIONS) $$@ . \
+	    (cd $$s && $(ZIPEXE) -qru $$($1_ZIP_OPTIONS) $$(SUPPORT_OUTPUTDIR)/ziptmp/$1/tmp.zip . \
 	        $$($1_ZIP_INCLUDES) $$($1_ZIP_EXCLUDES) -x \*_the.\* \
 	        $$($1_ZIP_EXCLUDES_$$s) \
 	        || test "$$$$?" = "12" \
 	    ))$$(NEWLINE) \
-	) true \
+	) true
+	$$(call ExecuteWithLog, \
+	    $$(SUPPORT_OUTPUTDIR)/generatezip/$$(patsubst $$(OUTPUTDIR)/%,%, $$@), \
+	    (cd $$(SUPPORT_OUTPUTDIR)/ziptmp/$1/files && \
+	        $(RM) $$@ && \
+	        $(UNZIP) -q $$(SUPPORT_OUTPUTDIR)/ziptmp/$1/tmp.zip && \
+	        $(TOOL_GENERATEZIP) -f $$@ . \
+	))$$(NEWLINE) \
 	$(TOUCH) $$@
 
   # Add zip to target list

--- a/make/jdk/src/classes/build/tools/generatezip/GenerateZip.java
+++ b/make/jdk/src/classes/build/tools/generatezip/GenerateZip.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package build.tools.generatezip;
+
+import java.io.*;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+/**
+ * Generate a zip file in a "reproducible" manner from the input files or directory.
+ * Standard zip tools rely on OS file list querying whose ordering varies by platform architecture,
+ * this class ensures the zip entries are sorted and also supports SOURCE_DATE_EPOCH timestamps.
+ */
+public class GenerateZip {
+    String fname = null;
+    String zname = "";
+    List<String> files = new ArrayList<>();;
+    boolean verbose = false;
+
+    Set<File> entries = new LinkedHashSet<>();
+
+    private boolean ok;
+
+    /* Cache SOURCE_DATE_EPOCH if set for reproducible Jar content */
+    private static long sourceDateEpochMillis = -1;
+    static {
+        String env = System.getenv("SOURCE_DATE_EPOCH");
+        if (env != null) {
+            try {
+                long value = Long.parseLong(env);
+                // SOURCE_DATE_EPOCH is in seconds
+                sourceDateEpochMillis = value*1000;
+            } catch(NumberFormatException e) {
+                sourceDateEpochMillis = -1;
+            }
+        }
+    }
+
+    public GenerateZip() {
+    }
+
+    public synchronized boolean run(String args[]) {
+        ok = true;
+        if (!parseArgs(args)) {
+            return false;
+        }
+        try {
+            zname = fname.replace(File.separatorChar, '/');
+            if (zname.startsWith("./")) {
+                zname = zname.substring(2);
+            }
+
+            if (verbose) System.out.println("Files or directories to zip: "+files);
+
+            File zipFile = new File(fname);
+            // Check archive to create does not exist
+            if (!zipFile.exists()) {
+                // Process Files
+                for(String file : files) {
+                    Path filepath = Paths.get(file);
+                    processFiles(filepath);
+                }
+
+                FileOutputStream out = new FileOutputStream(fname);
+                boolean createOk = create(new BufferedOutputStream(out, 4096));
+                if (ok) {
+                    ok = createOk;
+                }
+                out.close();
+            } else {
+                error("Target zip file "+fname+" already exists.");
+                ok = false;
+            }
+        } catch (IOException e) {
+            fatalError(e);
+            ok = false;
+        } catch (Error ee) {
+            ee.printStackTrace();
+            ok = false;
+        } catch (Throwable t) {
+            t.printStackTrace();
+            ok = false;
+        }
+        return ok;
+    }
+
+    boolean parseArgs(String args[]) {
+        try {
+            boolean parsingIncludes = false;
+            boolean parsingExcludes = false;
+            int count = 0;
+            while(count < args.length) {
+                if (args[count].startsWith("-")) {
+                    String flag = args[count].substring(1);
+                    switch (flag.charAt(0)) {
+                    case 'f':
+                        fname = args[++count];
+                        break;
+                    case 'v':
+                        verbose = true;
+                        break;
+                    default:
+                        error(String.format("Illegal option -%s", String.valueOf(flag.charAt(0))));
+                        usageError();
+                        return false;
+                    }
+                } else {
+                    // file or dir to zip
+                    files.add(args[count]);
+                }
+                count++;
+            }
+        } catch (ArrayIndexOutOfBoundsException e) {
+            usageError();
+            return false;
+        }
+        if (fname == null) {
+            error(String.format("-f <archiveName> must be specified"));
+            usageError();
+            return false;
+        }
+        // If no files specified then default to current directory
+        if (files.size() == 0) {
+            error("No input directory or files were specified");
+            usageError();
+            return false;
+        }
+
+        return true;
+    }
+
+    // Walk tree matching files and adding to entries list
+    void processFiles(Path path) throws IOException {
+        File fpath = path.toFile();
+        boolean pathIsDir = fpath.isDirectory();
+
+        // Keep a sorted Set of files to be processed, so that the Jmod is reproducible
+        // as Files.walkFileTree order is not defined
+        SortedMap<String, Path> filesToProcess  = new TreeMap<String, Path>();
+
+        Files.walkFileTree(path, Set.of(FileVisitOption.FOLLOW_LINKS),
+            Integer.MAX_VALUE, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                    throws IOException
+                {
+                    Path relPath;
+                    String name;
+                    if (pathIsDir) {
+                        relPath = path.relativize(file);
+                        name = relPath.toString();
+                    } else {
+                        relPath = file;
+                        name = file.toString();
+                    }
+                    filesToProcess.put(name, file);
+                    return FileVisitResult.CONTINUE;
+                }
+        });
+
+        // Process files in sorted order
+        Iterator<Map.Entry<String, Path>> itr = filesToProcess.entrySet().iterator();
+        while(itr.hasNext()) {
+            Map.Entry<String, Path> entry = itr.next();
+            String name = entry.getKey();
+            Path   filepath = entry.getValue();
+
+            File f = filepath.toFile();
+            entries.add(f);
+        }
+    }
+
+    // Create new zip from entries
+    boolean create(OutputStream out) throws IOException
+    {
+        try (ZipOutputStream zos = new ZipOutputStream(out)) {
+            for (File file: entries) {
+                addFile(zos, file);
+            }
+        }
+        return true;
+    }
+
+    // Ensure a consistent entry name format
+    String entryName(String name) {
+        name = name.replace(File.separatorChar, '/');
+
+        if (name.startsWith("/")) {
+            name = name.substring(1);
+        } else if (name.startsWith("./")) {
+            name = name.substring(2);
+        }
+        return name;
+    }
+
+    // Add File to Zip
+    void addFile(ZipOutputStream zos, File file) throws IOException {
+        String name = file.getPath();
+        boolean isDir = file.isDirectory();
+        if (isDir) {
+            name = name.endsWith(File.separator) ? name : (name + File.separator);
+        }
+        name = entryName(name);
+
+        if (name.equals("") || name.equals(".") || name.equals(zname)) {
+            return;
+        }
+
+        long size = isDir ? 0 : file.length();
+
+        if (verbose) {
+            System.out.println("Adding: "+name);
+        }
+
+        ZipEntry e = new ZipEntry(name);
+        // If we are adding a new entry and SOURCE_DATE_EPOCH is set then use that time
+        if (sourceDateEpochMillis != -1) {
+            e.setTime(sourceDateEpochMillis);
+        } else {
+            e.setTime(file.lastModified());
+        }
+        if (size == 0) {
+            e.setMethod(ZipEntry.STORED);
+            e.setSize(0);
+            e.setCrc(0);
+        }
+        zos.putNextEntry(e);
+        if (!isDir) {
+            byte[] buf = new byte[8192];
+            int len;
+            InputStream is = new BufferedInputStream(new FileInputStream(file));
+            while ((len = is.read(buf, 0, buf.length)) != -1) {
+                zos.write(buf, 0, len);
+            }
+            is.close();
+        }
+        zos.closeEntry();
+    }
+
+    void usageError() {
+        error(
+        "Usage: GenerateZip [-v] -f <zip_file> <files_or_directories>\n" +
+        "Options:\n" +
+        "   -v  verbose output\n" +
+        "   -f  specify archive file name to create\n" +
+        "If any file is a directory then it is processed recursively.\n");
+    }
+
+    void fatalError(Exception e) {
+        e.printStackTrace();
+    }
+
+    protected void error(String s) {
+        System.err.println(s);
+    }
+
+    public static String[] parse(String[] args)
+    {
+        ArrayList<String> newArgs = new ArrayList<String>(args.length);
+        for (int i = 0; i < args.length; i++) {
+            String arg = args[i];
+            newArgs.add(arg);
+        }
+        return newArgs.toArray(new String[newArgs.size()]);
+    }
+
+    public static void main(String args[]) {
+        GenerateZip z = new GenerateZip();
+        System.exit(z.run(args) ? 0 : 1);
+    }
+}
+

--- a/test/jdk/java/util/zip/TestZipSourceDateEpoch.sh
+++ b/test/jdk/java/util/zip/TestZipSourceDateEpoch.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+
+# Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+# @test
+# @bug 8276400 
+# @summary Test ZipOutputStream support for SOURCE_DATE_EPOCH 
+# @build ZipSourceDateEpoch 
+# @run shell/timeout=600 TestZipSourceDateEpoch.sh
+
+if [ "${TESTJAVA}" = "" ]
+then
+  echo "TESTJAVA not set.  Test cannot execute.  Failed."
+  exit 1
+fi
+echo "TESTJAVA=${TESTJAVA}"
+if [ "${TESTCLASSES}" = "" ]
+then
+  echo "TESTCLASSES not set.  Test cannot execute.  Failed."
+  exit 1
+fi
+echo "TESTCLASSES=${TESTCLASSES}"
+echo "CLASSPATH=${CLASSPATH}"
+
+# set platform-dependent variables
+OS=`uname -s`
+case "$OS" in
+  Linux | Darwin | AIX )
+    PS=":"
+    FS="/"
+    ;;
+  Windows* )
+    PS=";"
+    FS="/"
+    ;;
+  CYGWIN* )
+    PS=";"
+    FS="/"
+    TESTJAVA=`cygpath -u ${TESTJAVA}`
+    ;;
+  * )
+    echo "Unrecognized system!"
+    exit 1;
+    ;;
+esac
+
+failures=0
+
+run() {
+    echo ''
+    ${TESTJAVA}${FS}bin${FS}java ${TESTVMOPTS} -cp ${TESTCLASSES} $* 2>&1
+    if [ $? != 0 ]; then failures=`expr $failures + 1`; fi
+}
+
+# Run with source date epoch set to 15/03/2022 
+export SOURCE_DATE_EPOCH=1647302400
+run ZipSourceDateEpoch 
+
+# Run with no source date epoch set 
+unset SOURCE_DATE_EPOCH
+run ZipSourceDateEpoch
+
+# Results
+echo ''
+if [ $failures -gt 0 ];
+  then echo "$failures tests failed";
+  else echo "All tests passed"; fi
+exit $failures
+

--- a/test/jdk/java/util/zip/ZipSourceDateEpoch.java
+++ b/test/jdk/java/util/zip/ZipSourceDateEpoch.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * Driven by: TestZipSourceDateEpoch.sh
+ */
+
+import java.util.*;
+import java.util.zip.*;
+import java.util.jar.*;
+import java.io.*;
+
+public class ZipSourceDateEpoch {
+
+    public static void main(String[] args) throws Exception {
+
+        String TEST_DATA = "Test data string";
+
+        String env = System.getenv("SOURCE_DATE_EPOCH");
+
+        long sourceDateEpochMillis = -1;
+        if (env != null) {
+            try {
+                long value = Long.parseLong(env);
+                // SOURCE_DATE_EPOCH is in seconds
+                sourceDateEpochMillis = value*1000;
+            } catch(NumberFormatException e) {
+                throw new AssertionError("Invalid SOURCE_DATE_EPOCH long value");
+            }
+        }
+
+        // Write test zip
+        File f = new File("epoch.zip");
+        f.deleteOnExit();
+
+        OutputStream os = new FileOutputStream(f);
+        ZipOutputStream zos = new ZipOutputStream(os);
+        try {
+            zos.putNextEntry(new ZipEntry("Entry1.txt"));
+            zos.write(TEST_DATA.getBytes());
+            zos.closeEntry();
+            zos.putNextEntry(new ZipEntry("Entry2.txt"));
+            zos.write(TEST_DATA.getBytes());
+            zos.closeEntry();
+            zos.putNextEntry(new ZipEntry("Entry3.txt"));
+            zos.write(TEST_DATA.getBytes());
+            zos.closeEntry();
+        } finally {
+            zos.close();
+            os.close();
+        }
+
+        //----------------------------------------------------------------
+        // Verify zip file entries all have SOURCE_DATE_EPOCH time if set
+        //----------------------------------------------------------------
+        FileInputStream fis = new FileInputStream(f);
+        ZipInputStream zis = new ZipInputStream(fis);
+        try {
+            long now = System.currentTimeMillis();
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                if (sourceDateEpochMillis != -1) {
+                    // SOURCE_DATE_EPOCH set, check time correct
+                    if (entry.getTime() != sourceDateEpochMillis) {
+                        throw new AssertionError("ZipEntry getTime() "+entry.getTime()+" not equal to SOURCE_DATE_EPOCH "+sourceDateEpochMillis);
+                    }
+                } else {
+                    // SOURCE_DATE_EPOCH not set, check time is current created within the last 60 seconds
+                    if (entry.getTime() < (now-60000) || entry.getTime() > now) {
+                        throw new AssertionError("ZipEntry getTime() "+entry.getTime()+" is not the current time "+now);
+                    }
+                }
+            }
+        } finally {
+            zis.close();
+            fis.close();
+        }
+
+        if (sourceDateEpochMillis != -1) {
+            System.out.println("ZipOutputStream SOURCE_DATE_EPOCH test passed");
+        } else {
+            System.out.println("ZipOutputStream current time test passed");
+        }
+    }
+}

--- a/test/jdk/tools/jar/TestReproducibleJar.sh
+++ b/test/jdk/tools/jar/TestReproducibleJar.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+
+# Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+# @test
+# @bug 8276400 
+# @summary Test two jars created with SOURCE_DATE_EPOCH set are identicakl 
+# @run shell/timeout=600 TestReproducibleJar.sh 
+
+if [ "${TESTJAVA}" = "" ]
+then
+  echo "TESTJAVA not set.  Test cannot execute.  Failed."
+  exit 1
+fi
+echo "TESTJAVA=${TESTJAVA}"
+
+# set platform-dependent variables
+OS=`uname -s`
+case "$OS" in
+  Linux | Darwin | AIX )
+    PS=":"
+    FS="/"
+    ;;
+  Windows* )
+    PS=";"
+    FS="/"
+    ;;
+  CYGWIN* )
+    PS=";"
+    FS="/"
+    TESTJAVA=`cygpath -u ${TESTJAVA}`
+    ;;
+  * )
+    echo "Unrecognized system!"
+    exit 1;
+    ;;
+esac
+
+TESTJAR="${TESTJAVA}${FS}bin${FS}jar"
+echo "TESTJAR=${TESTJAR}"
+
+failures=0
+
+run() {
+    echo "Creating $*" 
+    rm -rf reproJarTmp
+    mkdir -p reproJarTmp${FS}inner1
+    mkdir -p reproJarTmp${FS}inner2
+    echo "foo" > reproJarTmp${FS}inner1${FS}foo1.txt
+    echo "bar" > reproJarTmp${FS}inner2${FS}bar1.txt
+ 
+    SOURCE_DATE_EPOCH=1647302400 && ${TESTJAR} -cf $* reproJarTmp
+    if [ $? != 0 ]; then failures=`expr $failures + 1`; fi
+
+    rm -rf reproJarTmp
+}
+
+# Create test jar twice and test for reproducibility
+export SOURCE_DATE_EPOCH=1647302400
+run reproJar1.jar
+# sleep 5 seconds to ensure jar timestamps would be different
+sleep 5
+run reproJar2.jar 
+unset SOURCE_DATE_EPOCH
+
+diff reproJar1.jar reproJar2.jar
+if [ $? != 0 ]; then failures=`expr $failures + 1`; else echo "reproJar1.jar and reproJar2.jar are identical"; fi
+
+rm reproJar1.jar
+rm reproJar2.jar
+
+# Results
+echo ''
+if [ $failures -gt 0 ];
+  then echo "$failures tests failed";
+  else echo "All tests passed"; fi
+exit $failures
+

--- a/test/jdk/tools/jmod/JmodTest.java
+++ b/test/jdk/tools/jmod/JmodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8142968 8166568 8166286 8170618 8168149 8240910
+ * @bug 8142968 8166568 8166286 8170618 8168149 8240910 8276400
  * @summary Basic test for jmod
  * @library /test/lib
  * @modules jdk.compiler
@@ -74,6 +74,8 @@ public class JmodTest {
     static final String CMDS_PREFIX = "bin/";
     static final String LIBS_PREFIX = "lib/";
     static final String CONFIGS_PREFIX = "conf/";
+
+    static final long SOURCE_DATE_EPOCH = 1647302400; // 15/03/2022
 
     @BeforeTest
     public void buildExplodedModules() throws IOException {
@@ -197,7 +199,45 @@ public class JmodTest {
                 assertContains(r.output, CLASSES_PREFIX + "jdk/test/foo/Foo.class");
                 assertContains(r.output, CLASSES_PREFIX + "jdk/test/foo/internal/Message.class");
                 assertContains(r.output, CLASSES_PREFIX + "jdk/test/foo/resources/foo.properties");
+
+                // JDK-8276400: Ensure the sort order is deterministic for reproducible jmod content
+                // module-info, followed by <sorted classes>
+                int mod_info_i = r.output.indexOf(CLASSES_PREFIX + "module-info.class");
+                int foo_cls_i  = r.output.indexOf(CLASSES_PREFIX + "jdk/test/foo/Foo.class");
+                int msg_i      = r.output.indexOf(CLASSES_PREFIX + "jdk/test/foo/internal/Message.class");
+                int res_i      = r.output.indexOf(CLASSES_PREFIX + "jdk/test/foo/resources/foo.properties");
+                System.out.println("jmod classes sort order check:\n"+r.output);
+                assertTrue(mod_info_i < foo_cls_i);
+                assertTrue(foo_cls_i < msg_i);
+                assertTrue(msg_i < res_i);
             });
+    }
+
+    // JDK-8276400: Ensure deterministic reproducible identical jmods
+    @Test
+    public void testReproducible() throws IOException {
+        String cp = EXPLODED_DIR.resolve("foo").resolve("classes").toString();
+        Path jmod1 = MODS_DIR.resolve("foo1.jmod");
+        Path jmod2 = MODS_DIR.resolve("foo2.jmod");
+        FileUtils.deleteFileIfExistsWithRetry(jmod1);
+        FileUtils.deleteFileIfExistsWithRetry(jmod2);
+
+        assertEquals(reproducibleJmod("create", "--class-path", cp, jmod1.toString()), 0);
+        assertTrue(Files.exists(jmod1));
+
+        try {
+            // Sleep 5 seconds to ensure zip timestamps might be different if they could be
+            Thread.sleep(5000);
+        } catch(InterruptedException ex) {}
+
+        assertEquals(reproducibleJmod("create", "--class-path", cp, jmod2.toString()), 0);
+        assertTrue(Files.exists(jmod2));
+
+        // Compare file byte content to see if they are identical
+        assertSameContent(jmod1, jmod2);
+
+        Files.delete(jmod1);
+        Files.delete(jmod2);
     }
 
     @Test
@@ -760,6 +800,31 @@ public class JmodTest {
         System.out.println("jmod " + Arrays.asList(args));
         int ec = JMOD_TOOL.run(ps, ps, args);
         return new JmodResult(ec, new String(baos.toByteArray(), UTF_8));
+    }
+
+    static int reproducibleJmod(String... args) throws IOException {
+        String javaHome = System.getProperty("java.home");
+        String jmodCmd = javaHome + File.separator + "bin" + File.separator + "jmod";
+
+        List<String> argsList = new ArrayList<String>();
+        argsList.add(jmodCmd);
+        argsList.addAll(Arrays.asList(args));
+
+        List<String> envList = new ArrayList<String>();
+        for (Map.Entry<String,String> env : (new ProcessBuilder().environment()).entrySet()) {
+            envList.add(env.getKey()+"="+env.getValue());
+        }
+        envList.add("SOURCE_DATE_EPOCH="+SOURCE_DATE_EPOCH);
+
+        Process p = Runtime.getRuntime().exec(argsList.toArray(new String[0]), envList.toArray(new String[0]));
+        int ec = -1;
+        if (p != null) {
+            try {
+                ec = p.waitFor();
+            } catch(InterruptedException ex) {}
+        }
+
+        return ec;
     }
 
     static class JmodResult {


### PR DESCRIPTION
This PR enables reproducible Jars, Jmods and openjdk image zip files (eg.src.zip).
It provides support for SOURCE_DATE_EPOCH for Jar, Jmod and underlying ZipOutputStream's.
It fixes the following keys issues relating to reproducibility:
- Jar and ZipOutputStream are not SOURCE_DATE_EPOCH aware
  - Jar and ZipOutputStream now detect SOURCE_DATE_EPOCH environment setting
- Jar and Jmod file content ordering was non-determinsitic
  - Fixes to Jar and Jmod main's to ensure sorted classes content ordering
- openjdk image zip file generation used "zip" which is non-determinsitic
  - New openjdk build tool "GenerateZip" which produces the final determinsitic zip files as part of the build and also detects SOURCE_DATE_EPOCH

Signed-off-by: Andrew Leonard <anleonar@redhat.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ The change requires a CSR request to be approved.

### Issue
 * [JDK-8276400](https://bugs.openjdk.java.net/browse/JDK-8276400): openjdk image Jars, Zips and Jmods built from the same source are not reproducible


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6268/head:pull/6268` \
`$ git checkout pull/6268`

Update a local copy of the PR: \
`$ git checkout pull/6268` \
`$ git pull https://git.openjdk.java.net/jdk pull/6268/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6268`

View PR using the GUI difftool: \
`$ git pr show -t 6268`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6268.diff">https://git.openjdk.java.net/jdk/pull/6268.diff</a>

</details>
