### PR TITLE
8276688: Remove JLinkReproducibleXXXTest from ProblemList.txt

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -755,8 +755,6 @@ sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java 8265770 macosx-all
 
 # core_tools
 
-tools/jlink/JLinkReproducibleTest.java                          8217166 windows-all,linux-aarch64
-tools/jlink/JLinkReproducible3Test.java                         8253688 linux-aarch64
 tools/jlink/plugins/CompressorPluginTest.java                   8247407 generic-all
 
 ############################################################################


### PR DESCRIPTION
Can I please get a review for this change which removes the `JLinkReproducibleTest` and `JLinkReproducible3Test` tests from the `ProblemList.txt`?

With the fix for https://bugs.openjdk.java.net/browse/JDK-8275509 now merged, I expect these tests to stop failing intermittently. I have run these tests on my Linux setup before and after the fix for JDK-8275509. Before the fix, these tests used to fail at least a few times in 50 runs each. After the fix for JDK-8275509, I've run these tests at least a 100 times each and haven't seen any failures.

Having said that, I think it would be good to have someone run these a few times on a linux-aarch64 system and windows too. I don't have access to such setups.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276688](https://bugs.openjdk.java.net/browse/JDK-8276688): Remove JLinkReproducibleXXXTest from ProblemList.txt


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6272/head:pull/6272` \
`$ git checkout pull/6272`

Update a local copy of the PR: \
`$ git checkout pull/6272` \
`$ git pull https://git.openjdk.java.net/jdk pull/6272/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6272`

View PR using the GUI difftool: \
`$ git pr show -t 6272`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6272.diff">https://git.openjdk.java.net/jdk/pull/6272.diff</a>

</details>
