### PR TITLE
8198626: java/awt/KeyboardFocusmanager/TypeAhead/TestDialogTypeAhead.html fails on mac

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -145,7 +145,6 @@ java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java 8144030 macosx-all
 java/awt/grab/EmbeddedFrameTest1/EmbeddedFrameTest1.java 7080150 macosx-all
 java/awt/event/InputEvent/EventWhenTest/EventWhenTest.java 8168646 generic-all
 java/awt/KeyboardFocusmanager/TypeAhead/SubMenuShowTest/SubMenuShowTest.java 8273520 macosx-all
-java/awt/KeyboardFocusmanager/TypeAhead/TestDialogTypeAhead.java 8198626 macosx-all
 java/awt/Mixing/AWT_Mixing/HierarchyBoundsListenerMixingTest.java 8049405 macosx-all
 java/awt/Mixing/AWT_Mixing/OpaqueOverlappingChoice.java 8048171 generic-all
 java/awt/Mixing/AWT_Mixing/JMenuBarOverlapping.java 8159451 linux-all,windows-all,macosx-all

--- a/test/jdk/java/awt/KeyboardFocusmanager/TypeAhead/TestDialogTypeAhead.java
+++ b/test/jdk/java/awt/KeyboardFocusmanager/TypeAhead/TestDialogTypeAhead.java
@@ -124,6 +124,7 @@ public class TestDialogTypeAhead {
                                 TestDialogTypeAhead.this.moveMouseOver(d);
                             }
                         });
+
                     d.setVisible(true);
                 }
             });

--- a/test/jdk/java/awt/KeyboardFocusmanager/TypeAhead/TestDialogTypeAhead.java
+++ b/test/jdk/java/awt/KeyboardFocusmanager/TypeAhead/TestDialogTypeAhead.java
@@ -116,7 +116,7 @@ public class TestDialogTypeAhead {
         b.addActionListener(new ActionListener() {
                 public void actionPerformed(ActionEvent e) {
                     System.err.println("B pressed");
-                    d.setVisible(true);
+
                     EventQueue.invokeLater(new Runnable() {
                             public void run() {
                                 waitTillShown(d);
@@ -124,6 +124,7 @@ public class TestDialogTypeAhead {
                                 TestDialogTypeAhead.this.moveMouseOver(d);
                             }
                         });
+                    d.setVisible(true);
                 }
             });
 
@@ -150,7 +151,6 @@ public class TestDialogTypeAhead {
 
         robot.keyPress(KeyEvent.VK_SPACE);
         robot.keyRelease(KeyEvent.VK_SPACE);
-        waitForIdle();
 
         try {
             robotSema.doWait(1000);

--- a/test/jdk/java/awt/KeyboardFocusmanager/TypeAhead/TestDialogTypeAhead.java
+++ b/test/jdk/java/awt/KeyboardFocusmanager/TypeAhead/TestDialogTypeAhead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,14 +26,29 @@
   @key headful
   @bug 4799136
   @summary Tests that type-ahead for dialog works and doesn't block program
-  @library    ../../regtesthelpers
-  @modules java.desktop/sun.awt
-  @build      Util
   @run main TestDialogTypeAhead
 */
 
-import java.awt.*;
-import java.awt.event.*;
+
+import java.awt.AWTEvent;
+import java.awt.Button;
+import java.awt.Component;
+import java.awt.DefaultKeyboardFocusManager;
+import java.awt.Dialog;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.KeyboardFocusManager;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.event.AWTEventListener;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
 import java.lang.reflect.InvocationTargetException;
 
 public class TestDialogTypeAhead {
@@ -49,8 +64,17 @@ public class TestDialogTypeAhead {
 
     public static void main(final String[] args) {
         TestDialogTypeAhead app = new TestDialogTypeAhead();
-        app.init();
-        app.start();
+        try {
+            app.init();
+            app.start();
+        } finally {
+            if (d != null) {
+                d.dispose();
+            }
+            if (f != null) {
+                f.dispose();
+            }
+        }
     }
 
     public void init()
@@ -73,13 +97,12 @@ public class TestDialogTypeAhead {
         ok.addKeyListener(new KeyAdapter() {
                 public void keyPressed(KeyEvent e) {
                     System.err.println("OK pressed");
-                    d.dispose();
-                    f.dispose();
                     // Typed-ahead key events should only be accepted if
                     // they arrive after FOCUS_GAINED
                     if (gotFocus) {
                         pressSema.raise();
                     }
+
                 }
             });
         ok.addFocusListener(new FocusAdapter() {
@@ -93,7 +116,7 @@ public class TestDialogTypeAhead {
         b.addActionListener(new ActionListener() {
                 public void actionPerformed(ActionEvent e) {
                     System.err.println("B pressed");
-
+                    d.setVisible(true);
                     EventQueue.invokeLater(new Runnable() {
                             public void run() {
                                 waitTillShown(d);
@@ -101,8 +124,6 @@ public class TestDialogTypeAhead {
                                 TestDialogTypeAhead.this.moveMouseOver(d);
                             }
                         });
-
-                    d.setVisible(true);
                 }
             });
 
@@ -112,6 +133,7 @@ public class TestDialogTypeAhead {
     {
         try {
             robot = new Robot();
+            robot.setAutoDelay(100);
         } catch (Exception e) {
             throw new RuntimeException("Can't create robot:" + e);
         }
@@ -128,6 +150,8 @@ public class TestDialogTypeAhead {
 
         robot.keyPress(KeyEvent.VK_SPACE);
         robot.keyRelease(KeyEvent.VK_SPACE);
+        waitForIdle();
+
         try {
             robotSema.doWait(1000);
         } catch (InterruptedException ie) {
@@ -149,13 +173,13 @@ public class TestDialogTypeAhead {
         if (!pressSema.getState()) {
             throw new RuntimeException("Type-ahead doesn't work");
         }
-
     }// start()
 
-    private void moveMouseOver(Container c) {
+    private void moveMouseOver(Component c) {
         Point p = c.getLocationOnScreen();
         Dimension d = c.getSize();
-        robot.mouseMove(p.x + (int)(d.getWidth()/2), p.y + (int)(d.getHeight()/2));
+        robot.mouseMove(p.x + (int)(d.getWidth()/2),
+                p.y + (int)(d.getHeight()/2));
     }
     private void waitForIdle() {
         try {
@@ -209,7 +233,10 @@ public class TestDialogTypeAhead {
         }
         comp.removeFocusListener(fa);
         if (!comp.isFocusOwner()) {
-            throw new RuntimeException("Can't make " + comp + " focused, current owner is " + KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner());
+            throw new RuntimeException("Can't make " + comp + " focused,"
+                    + "current owner is "
+                    + KeyboardFocusManager
+                    .getCurrentKeyboardFocusManager().getFocusOwner());
         }
     }
 
@@ -257,4 +284,3 @@ public class TestDialogTypeAhead {
         }
     }
 }// class TestDialogTypeAhead
-


### PR DESCRIPTION
Test java/awt/KeyboardFocusmanager/TypeAhead/TestDialogTypeAhead.html fails on mac fails on Mac. The test fails on my local machine (macOS BigSur) always and on mach5 also. The test uses Robot for mouse clicks and there is no delay or autoDelay set on Robot.

The fix adds set autoDelay on the robot. Along with this, some other cleanup is done. The test passes after the changes on my local mac and mach5 (Link in the JBS)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8198626](https://bugs.openjdk.java.net/browse/JDK-8198626): java/awt/KeyboardFocusmanager/TypeAhead/TestDialogTypeAhead.html fails on mac


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6273/head:pull/6273` \
`$ git checkout pull/6273`

Update a local copy of the PR: \
`$ git checkout pull/6273` \
`$ git pull https://git.openjdk.java.net/jdk pull/6273/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6273`

View PR using the GUI difftool: \
`$ git pr show -t 6273`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6273.diff">https://git.openjdk.java.net/jdk/pull/6273.diff</a>

</details>
