### PR TITLE
JDK-8277095 : Empty streams create too many objects

### DIFF
--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -5444,7 +5444,7 @@ public class Arrays {
      * @since 1.8
      */
     public static <T> Stream<T> stream(T[] array, int startInclusive, int endExclusive) {
-        if (startInclusive == endExclusive) return Stream.empty();
+        if (array != null && startInclusive >= 0 && startInclusive == endExclusive) return Stream.empty();
         return StreamSupport.stream(spliterator(array, startInclusive, endExclusive), false);
     }
 
@@ -5475,7 +5475,7 @@ public class Arrays {
      * @since 1.8
      */
     public static IntStream stream(int[] array, int startInclusive, int endExclusive) {
-        if (startInclusive == endExclusive) return IntStream.empty();
+        if (array != null && startInclusive >= 0 && startInclusive == endExclusive) return IntStream.empty();
         return StreamSupport.intStream(spliterator(array, startInclusive, endExclusive), false);
     }
 
@@ -5506,7 +5506,7 @@ public class Arrays {
      * @since 1.8
      */
     public static LongStream stream(long[] array, int startInclusive, int endExclusive) {
-        if (startInclusive == endExclusive) return LongStream.empty();
+        if (array != null && startInclusive >= 0 && startInclusive == endExclusive) return LongStream.empty();
         return StreamSupport.longStream(spliterator(array, startInclusive, endExclusive), false);
     }
 
@@ -5537,7 +5537,7 @@ public class Arrays {
      * @since 1.8
      */
     public static DoubleStream stream(double[] array, int startInclusive, int endExclusive) {
-        if (startInclusive == endExclusive) return DoubleStream.empty();
+        if (array != null && startInclusive >= 0 && startInclusive == endExclusive) return DoubleStream.empty();
         return StreamSupport.doubleStream(spliterator(array, startInclusive, endExclusive), false);
     }
 

--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -5444,8 +5444,9 @@ public class Arrays {
      * @since 1.8
      */
     public static <T> Stream<T> stream(T[] array, int startInclusive, int endExclusive) {
-        if (array != null && startInclusive >= 0 && startInclusive == endExclusive) return Stream.empty();
-        return StreamSupport.stream(spliterator(array, startInclusive, endExclusive), false);
+        var spliterator = spliterator(array, startInclusive, endExclusive);
+        if (startInclusive == endExclusive) return Stream.empty();
+        return StreamSupport.stream(spliterator, false);
     }
 
     /**
@@ -5475,8 +5476,9 @@ public class Arrays {
      * @since 1.8
      */
     public static IntStream stream(int[] array, int startInclusive, int endExclusive) {
-        if (array != null && startInclusive >= 0 && startInclusive == endExclusive) return IntStream.empty();
-        return StreamSupport.intStream(spliterator(array, startInclusive, endExclusive), false);
+        var spliterator = spliterator(array, startInclusive, endExclusive);
+        if (startInclusive == endExclusive) return IntStream.empty();
+        return StreamSupport.intStream(spliterator, false);
     }
 
     /**
@@ -5506,8 +5508,9 @@ public class Arrays {
      * @since 1.8
      */
     public static LongStream stream(long[] array, int startInclusive, int endExclusive) {
-        if (array != null && startInclusive >= 0 && startInclusive == endExclusive) return LongStream.empty();
-        return StreamSupport.longStream(spliterator(array, startInclusive, endExclusive), false);
+        var spliterator = spliterator(array, startInclusive, endExclusive);
+        if (startInclusive == endExclusive) return LongStream.empty();
+        return StreamSupport.longStream(spliterator, false);
     }
 
     /**
@@ -5537,8 +5540,9 @@ public class Arrays {
      * @since 1.8
      */
     public static DoubleStream stream(double[] array, int startInclusive, int endExclusive) {
-        if (array != null && startInclusive >= 0 && startInclusive == endExclusive) return DoubleStream.empty();
-        return StreamSupport.doubleStream(spliterator(array, startInclusive, endExclusive), false);
+        var spliterator = spliterator(array, startInclusive, endExclusive);
+        if (startInclusive == endExclusive) return DoubleStream.empty();
+        return StreamSupport.doubleStream(spliterator, false);
     }
 
 

--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -5445,7 +5445,7 @@ public class Arrays {
      */
     public static <T> Stream<T> stream(T[] array, int startInclusive, int endExclusive) {
         var spliterator = spliterator(array, startInclusive, endExclusive);
-        if (startInclusive == endExclusive) return Stream.empty();
+        if (startInclusive == endExclusive) return StreamSupport.emptyStream(spliterator);
         return StreamSupport.stream(spliterator, false);
     }
 
@@ -5477,7 +5477,7 @@ public class Arrays {
      */
     public static IntStream stream(int[] array, int startInclusive, int endExclusive) {
         var spliterator = spliterator(array, startInclusive, endExclusive);
-        if (startInclusive == endExclusive) return IntStream.empty();
+        if (startInclusive == endExclusive) return StreamSupport.emptyIntStream(spliterator);
         return StreamSupport.intStream(spliterator, false);
     }
 
@@ -5509,7 +5509,7 @@ public class Arrays {
      */
     public static LongStream stream(long[] array, int startInclusive, int endExclusive) {
         var spliterator = spliterator(array, startInclusive, endExclusive);
-        if (startInclusive == endExclusive) return LongStream.empty();
+        if (startInclusive == endExclusive) return StreamSupport.emptyLongStream(spliterator);
         return StreamSupport.longStream(spliterator, false);
     }
 
@@ -5541,7 +5541,7 @@ public class Arrays {
      */
     public static DoubleStream stream(double[] array, int startInclusive, int endExclusive) {
         var spliterator = spliterator(array, startInclusive, endExclusive);
-        if (startInclusive == endExclusive) return DoubleStream.empty();
+        if (startInclusive == endExclusive) return StreamSupport.emptyDoubleStream(spliterator);
         return StreamSupport.doubleStream(spliterator, false);
     }
 

--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -5444,6 +5444,7 @@ public class Arrays {
      * @since 1.8
      */
     public static <T> Stream<T> stream(T[] array, int startInclusive, int endExclusive) {
+        if (startInclusive == endExclusive) return Stream.empty();
         return StreamSupport.stream(spliterator(array, startInclusive, endExclusive), false);
     }
 
@@ -5474,6 +5475,7 @@ public class Arrays {
      * @since 1.8
      */
     public static IntStream stream(int[] array, int startInclusive, int endExclusive) {
+        if (startInclusive == endExclusive) return IntStream.empty();
         return StreamSupport.intStream(spliterator(array, startInclusive, endExclusive), false);
     }
 
@@ -5504,6 +5506,7 @@ public class Arrays {
      * @since 1.8
      */
     public static LongStream stream(long[] array, int startInclusive, int endExclusive) {
+        if (startInclusive == endExclusive) return LongStream.empty();
         return StreamSupport.longStream(spliterator(array, startInclusive, endExclusive), false);
     }
 
@@ -5534,6 +5537,7 @@ public class Arrays {
      * @since 1.8
      */
     public static DoubleStream stream(double[] array, int startInclusive, int endExclusive) {
+        if (startInclusive == endExclusive) return DoubleStream.empty();
         return StreamSupport.doubleStream(spliterator(array, startInclusive, endExclusive), false);
     }
 

--- a/src/java.base/share/classes/java/util/Collection.java
+++ b/src/java.base/share/classes/java/util/Collection.java
@@ -740,8 +740,9 @@ public interface Collection<E> extends Iterable<E> {
      * @since 1.8
      */
     default Stream<E> stream() {
-        if (isEmpty()) return Stream.empty();
-        return StreamSupport.stream(spliterator(), false);
+        var spliterator = spliterator();
+        if (isEmpty()) return StreamSupport.emptyStream(spliterator);
+        return StreamSupport.stream(spliterator, false);
     }
 
     /**

--- a/src/java.base/share/classes/java/util/Collection.java
+++ b/src/java.base/share/classes/java/util/Collection.java
@@ -740,6 +740,7 @@ public interface Collection<E> extends Iterable<E> {
      * @since 1.8
      */
     default Stream<E> stream() {
+        if (isEmpty()) return Stream.empty();
         return StreamSupport.stream(spliterator(), false);
     }
 

--- a/src/java.base/share/classes/java/util/stream/DoubleStream.java
+++ b/src/java.base/share/classes/java/util/stream/DoubleStream.java
@@ -954,7 +954,7 @@ public interface DoubleStream extends BaseStream<Double, DoubleStream> {
      * @return an empty sequential stream
      */
     public static DoubleStream empty() {
-        return Streams.emptyDoubleStream();
+        return new Streams.EmptyDoubleStream(Spliterators.emptyDoubleSpliterator());
     }
 
     /**

--- a/src/java.base/share/classes/java/util/stream/DoubleStream.java
+++ b/src/java.base/share/classes/java/util/stream/DoubleStream.java
@@ -954,7 +954,7 @@ public interface DoubleStream extends BaseStream<Double, DoubleStream> {
      * @return an empty sequential stream
      */
     public static DoubleStream empty() {
-        return StreamSupport.doubleStream(Spliterators.emptyDoubleSpliterator(), false);
+        return Streams.emptyDoubleStream();
     }
 
     /**

--- a/src/java.base/share/classes/java/util/stream/IntStream.java
+++ b/src/java.base/share/classes/java/util/stream/IntStream.java
@@ -895,7 +895,7 @@ public interface IntStream extends BaseStream<Integer, IntStream> {
      * @return an empty sequential stream
      */
     public static IntStream empty() {
-        return StreamSupport.intStream(Spliterators.emptyIntSpliterator(), false);
+        return Streams.emptyIntStream();
     }
 
     /**

--- a/src/java.base/share/classes/java/util/stream/IntStream.java
+++ b/src/java.base/share/classes/java/util/stream/IntStream.java
@@ -895,7 +895,7 @@ public interface IntStream extends BaseStream<Integer, IntStream> {
      * @return an empty sequential stream
      */
     public static IntStream empty() {
-        return Streams.emptyIntStream();
+        return new Streams.EmptyIntStream(Spliterators.emptyIntSpliterator());
     }
 
     /**

--- a/src/java.base/share/classes/java/util/stream/LongStream.java
+++ b/src/java.base/share/classes/java/util/stream/LongStream.java
@@ -884,7 +884,7 @@ public interface LongStream extends BaseStream<Long, LongStream> {
      * @return an empty sequential stream
      */
     public static LongStream empty() {
-        return StreamSupport.longStream(Spliterators.emptyLongSpliterator(), false);
+        return Streams.emptyLongStream();
     }
 
     /**

--- a/src/java.base/share/classes/java/util/stream/LongStream.java
+++ b/src/java.base/share/classes/java/util/stream/LongStream.java
@@ -884,7 +884,7 @@ public interface LongStream extends BaseStream<Long, LongStream> {
      * @return an empty sequential stream
      */
     public static LongStream empty() {
-        return Streams.emptyLongStream();
+        return new Streams.EmptyLongStream(Spliterators.emptyLongSpliterator());
     }
 
     /**

--- a/src/java.base/share/classes/java/util/stream/Stream.java
+++ b/src/java.base/share/classes/java/util/stream/Stream.java
@@ -1384,7 +1384,7 @@ public interface Stream<T> extends BaseStream<T, Stream<T>> {
      * @return an empty sequential stream
      */
     public static<T> Stream<T> empty() {
-        return Streams.<T>emptyStream();
+        return new Streams.EmptyStream<>(Spliterators.emptySpliterator());
     }
 
     /**

--- a/src/java.base/share/classes/java/util/stream/Stream.java
+++ b/src/java.base/share/classes/java/util/stream/Stream.java
@@ -1384,7 +1384,7 @@ public interface Stream<T> extends BaseStream<T, Stream<T>> {
      * @return an empty sequential stream
      */
     public static<T> Stream<T> empty() {
-        return StreamSupport.stream(Spliterators.<T>emptySpliterator(), false);
+        return Streams.<T>emptyStream();
     }
 
     /**

--- a/src/java.base/share/classes/java/util/stream/StreamSupport.java
+++ b/src/java.base/share/classes/java/util/stream/StreamSupport.java
@@ -328,4 +328,37 @@ public final class StreamSupport {
     public static <T> Stream<T> emptyStream(Spliterator<T> spliterator) {
         return new Streams.EmptyStream<>(spliterator);
     }
+
+    /**
+     * Creates a new sequential empty {@code IntStream} with the
+     * characteristics of the provided {@code Spliterator}.
+     *
+     * @param spliterator a {@code Spliterator.OfInt} describing the stream elements
+     * @return a new sequential empty {@code IntStream}
+     */
+    public static IntStream emptyIntStream(Spliterator.OfInt spliterator) {
+        return new Streams.EmptyIntStream(spliterator);
+    }
+
+    /**
+     * Creates a new sequential empty {@code LongStream} with the
+     * characteristics of the provided {@code Spliterator}.
+     *
+     * @param spliterator a {@code Spliterator.OfLong} describing the stream elements
+     * @return a new sequential empty {@code IntStream}
+     */
+    public static LongStream emptyLongStream(Spliterator.OfLong spliterator) {
+        return new Streams.EmptyLongStream(spliterator);
+    }
+
+    /**
+     * Creates a new sequential empty {@code DoubleStream} with the
+     * characteristics of the provided {@code Spliterator}.
+     *
+     * @param spliterator a {@code Spliterator.OfDouble} describing the stream elements
+     * @return a new sequential empty {@code DoubleStream}
+     */
+    public static DoubleStream emptyDoubleStream(Spliterator.OfDouble spliterator) {
+        return new Streams.EmptyDoubleStream(spliterator);
+    }
 }

--- a/src/java.base/share/classes/java/util/stream/StreamSupport.java
+++ b/src/java.base/share/classes/java/util/stream/StreamSupport.java
@@ -26,6 +26,7 @@ package java.util.stream;
 
 import java.util.Objects;
 import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.function.Supplier;
 
 /**
@@ -314,5 +315,17 @@ public final class StreamSupport {
         return new DoublePipeline.Head<>(supplier,
                                          StreamOpFlag.fromCharacteristics(characteristics),
                                          parallel);
+    }
+
+    /**
+     * Creates a new sequential empty {@code Stream} with the
+     * characteristics of the provided {@code Spliterator}.
+     *
+     * @param <T> the type of stream elements
+     * @param spliterator a {@code Spliterator} describing the stream elements
+     * @return a new sequential empty {@code Stream}
+     */
+    public static <T> Stream<T> emptyStream(Spliterator<T> spliterator) {
+        return new Streams.EmptyStream<>(spliterator);
     }
 }

--- a/src/java.base/share/classes/java/util/stream/Streams.java
+++ b/src/java.base/share/classes/java/util/stream/Streams.java
@@ -24,14 +24,58 @@
  */
 package java.util.stream;
 
-import java.util.Comparator;
-import java.util.Objects;
-import java.util.Spliterator;
-import java.util.function.Consumer;
-import java.util.function.DoubleConsumer;
-import java.util.function.IntConsumer;
-import java.util.function.LongConsumer;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.DoubleSummaryStatistics;
+import java.util.IntSummaryStatistics;
+import java.util.Iterator;
+import java.util.List;
+import java.util.LongSummaryStatistics;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.PrimitiveIterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Consumer;
+import java.util.function.DoubleBinaryOperator;
+import java.util.function.DoubleConsumer;
+import java.util.function.DoubleFunction;
+import java.util.function.DoublePredicate;
+import java.util.function.DoubleToIntFunction;
+import java.util.function.DoubleToLongFunction;
+import java.util.function.DoubleUnaryOperator;
+import java.util.function.Function;
+import java.util.function.IntBinaryOperator;
+import java.util.function.IntConsumer;
+import java.util.function.IntFunction;
+import java.util.function.IntPredicate;
+import java.util.function.IntToDoubleFunction;
+import java.util.function.IntToLongFunction;
+import java.util.function.IntUnaryOperator;
+import java.util.function.LongBinaryOperator;
+import java.util.function.LongConsumer;
+import java.util.function.LongFunction;
+import java.util.function.LongPredicate;
+import java.util.function.LongToDoubleFunction;
+import java.util.function.LongToIntFunction;
+import java.util.function.LongUnaryOperator;
+import java.util.function.ObjDoubleConsumer;
+import java.util.function.ObjIntConsumer;
+import java.util.function.ObjLongConsumer;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToIntFunction;
+import java.util.function.ToLongFunction;
 
 /**
  * Utility methods for operating on and creating streams.
@@ -884,5 +928,1068 @@ final class Streams {
                 b.close();
             }
         };
+    }
+
+
+    private static final Stream<?> emptyStream = new EmptyStream<>();
+    private static final IntStream emptyIntStream = new EmptyIntStream();
+    private static final LongStream emptyLongStream = new EmptyLongStream();
+    private static final DoubleStream emptyDoubleStream = new EmptyDoubleStream();
+
+    static <T> Stream<T> emptyStream() {
+        @SuppressWarnings("unchecked")
+        var stream = (Stream<T>) emptyStream;
+        return stream;
+    }
+
+    static IntStream emptyIntStream() {
+        return emptyIntStream;
+    }
+
+    static LongStream emptyLongStream() {
+        return emptyLongStream;
+    }
+
+    static DoubleStream emptyDoubleStream() {
+        return emptyDoubleStream;
+    }
+
+    /**
+     * EmptyStream is an optimization to reduce object allocation
+     * during stream creation for empty streams. Most of the
+     * methods such as filter() and map() will return "this".
+     * We have tried to mirror the behavior of the previous
+     * Stream.empty() for spliterator characteristics, parallel()
+     * and
+     */
+    private static final class EmptyStream<T> implements Stream<T> {
+        private static <T> Stream<T> createOldEmpty() {
+            return StreamSupport.stream(Spliterators.<T>emptySpliterator(), false);
+        }
+
+        @Override
+        public Stream<T> filter(Predicate<? super T> predicate) {
+            Objects.requireNonNull(predicate);
+            return this;
+        }
+
+        @Override
+        public <R> Stream<R> map(Function<? super T, ? extends R> mapper) {
+            Objects.requireNonNull(mapper);
+            @SuppressWarnings("unchecked")
+            var stream = (Stream<R>) this;
+            return stream;
+        }
+
+        @Override
+        public IntStream mapToInt(ToIntFunction<? super T> mapper) {
+            Objects.requireNonNull(mapper);
+            return emptyIntStream();
+        }
+
+        @Override
+        public LongStream mapToLong(ToLongFunction<? super T> mapper) {
+            Objects.requireNonNull(mapper);
+            return emptyLongStream();
+        }
+
+        @Override
+        public DoubleStream mapToDouble(ToDoubleFunction<? super T> mapper) {
+            Objects.requireNonNull(mapper);
+            return emptyDoubleStream();
+        }
+
+        @Override
+        public <R> Stream<R> flatMap(Function<? super T, ? extends Stream<? extends R>> mapper) {
+            Objects.requireNonNull(mapper);
+            @SuppressWarnings("unchecked")
+            var stream = (Stream<R>) this;
+            return stream;
+        }
+
+        @Override
+        public IntStream flatMapToInt(Function<? super T, ? extends IntStream> mapper) {
+            Objects.requireNonNull(mapper);
+            return emptyIntStream();
+        }
+
+        @Override
+        public LongStream flatMapToLong(Function<? super T, ? extends LongStream> mapper) {
+            Objects.requireNonNull(mapper);
+            return emptyLongStream();
+        }
+
+        @Override
+        public DoubleStream flatMapToDouble(Function<? super T, ? extends DoubleStream> mapper) {
+            Objects.requireNonNull(mapper);
+            return emptyDoubleStream();
+        }
+
+        @Override
+        public <R> Stream<R> mapMulti(BiConsumer<? super T, ? super Consumer<R>> mapper) {
+            Objects.requireNonNull(mapper);
+            @SuppressWarnings("unchecked")
+            var stream = (Stream<R>) this;
+            return stream;
+        }
+
+        @Override
+        public IntStream mapMultiToInt(BiConsumer<? super T, ? super IntConsumer> mapper) {
+            Objects.requireNonNull(mapper);
+            return emptyIntStream();
+        }
+
+        @Override
+        public LongStream mapMultiToLong(BiConsumer<? super T, ? super LongConsumer> mapper) {
+            Objects.requireNonNull(mapper);
+            return emptyLongStream();
+        }
+
+        @Override
+        public DoubleStream mapMultiToDouble(BiConsumer<? super T, ? super DoubleConsumer> mapper) {
+            Objects.requireNonNull(mapper);
+            return emptyDoubleStream();
+        }
+
+        @Override
+        public Stream<T> distinct() {
+            return EmptyStream.<T>createOldEmpty().distinct();
+        }
+
+        @Override
+        public Stream<T> sorted() {
+            return EmptyStream.<T>createOldEmpty().sorted();
+        }
+
+        @Override
+        public Stream<T> sorted(Comparator<? super T> comparator) {
+            Objects.requireNonNull(comparator);
+            return this;
+        }
+
+        @Override
+        public Stream<T> peek(Consumer<? super T> action) {
+            Objects.requireNonNull(action);
+            return this;
+        }
+
+        @Override
+        public Stream<T> limit(long maxSize) {
+            if (maxSize < 0)
+                throw new IllegalArgumentException(Long.toString(maxSize));
+            return this;
+        }
+
+        @Override
+        public Stream<T> skip(long n) {
+            if (n < 0)
+                throw new IllegalArgumentException(Long.toString(n));
+            return this;
+        }
+
+        @Override
+        public Stream<T> takeWhile(Predicate<? super T> predicate) {
+            Objects.requireNonNull(predicate);
+            return this;
+        }
+
+        @Override
+        public Stream<T> dropWhile(Predicate<? super T> predicate) {
+            Objects.requireNonNull(predicate);
+            return this;
+        }
+
+        @Override
+        public void forEach(Consumer<? super T> action) {
+            Objects.requireNonNull(action);
+            // do nothing
+        }
+
+        @Override
+        public void forEachOrdered(Consumer<? super T> action) {
+            Objects.requireNonNull(action);
+            // do nothing
+        }
+
+        private static final Object[] EMPTY_ARRAY = {};
+
+        @Override
+        public Object[] toArray() {
+            return EMPTY_ARRAY;
+        }
+
+        @Override
+        public <A> A[] toArray(IntFunction<A[]> generator) {
+            return generator.apply(0);
+        }
+
+        @Override
+        public T reduce(T identity, BinaryOperator<T> accumulator) {
+            Objects.requireNonNull(accumulator);
+            return identity;
+        }
+
+        @Override
+        public Optional<T> reduce(BinaryOperator<T> accumulator) {
+            Objects.requireNonNull(accumulator);
+            return Optional.empty();
+        }
+
+        @Override
+        public <U> U reduce(U identity, BiFunction<U, ? super T, U> accumulator, BinaryOperator<U> combiner) {
+            Objects.requireNonNull(accumulator);
+            Objects.requireNonNull(combiner);
+            return identity;
+        }
+
+        @Override
+        public <R> R collect(Supplier<R> supplier, BiConsumer<R, ? super T> accumulator, BiConsumer<R, R> combiner) {
+            Objects.requireNonNull(supplier);
+            Objects.requireNonNull(accumulator);
+            Objects.requireNonNull(combiner);
+            return supplier.get();
+        }
+
+        @Override
+        public <R, A> R collect(Collector<? super T, A, R> collector) {
+            Objects.requireNonNull(collector);
+            return collector.finisher().apply(collector.supplier().get());
+        }
+
+        @Override
+        public List<T> toList() {
+            return List.of();
+        }
+
+        @Override
+        public Optional<T> min(Comparator<? super T> comparator) {
+            Objects.requireNonNull(comparator);
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<T> max(Comparator<? super T> comparator) {
+            Objects.requireNonNull(comparator);
+            return Optional.empty();
+        }
+
+        @Override
+        public long count() {
+            return 0L;
+        }
+
+        @Override
+        public boolean anyMatch(Predicate<? super T> predicate) {
+            Objects.requireNonNull(predicate);
+            return false;
+        }
+
+        @Override
+        public boolean allMatch(Predicate<? super T> predicate) {
+            Objects.requireNonNull(predicate);
+            return true;
+        }
+
+        @Override
+        public boolean noneMatch(Predicate<? super T> predicate) {
+            Objects.requireNonNull(predicate);
+            return true;
+        }
+
+        @Override
+        public Optional<T> findFirst() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<T> findAny() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Iterator<T> iterator() {
+            return Collections.emptyIterator();
+        }
+
+        @Override
+        public Spliterator<T> spliterator() {
+            return Spliterators.emptySpliterator();
+        }
+
+        @Override
+        public boolean isParallel() {
+            return false;
+        }
+
+        @Override
+        public Stream<T> sequential() {
+            return this;
+        }
+
+        @Override
+        public Stream<T> parallel() {
+            return EmptyStream.<T>createOldEmpty().parallel();
+        }
+
+        @Override
+        public Stream<T> unordered() {
+            // Since our characteristics are already not ORDERED,
+            // we do not need to change anything.
+            return this;
+        }
+
+        @Override
+        public Stream<T> onClose(Runnable closeHandler) {
+            return EmptyStream.<T>createOldEmpty().onClose(closeHandler);
+        }
+
+        @Override
+        public void close() {
+            // nothing to do
+        }
+    }
+
+    private static final class EmptyIntStream implements IntStream {
+        private static IntStream createOldEmpty() {
+            return StreamSupport.intStream(
+                Spliterators.emptyIntSpliterator(), false);
+        }
+
+        @Override
+        public IntStream filter(IntPredicate predicate) {
+            Objects.requireNonNull(predicate);
+            return this;
+        }
+
+        @Override
+        public IntStream map(IntUnaryOperator mapper) {
+            Objects.requireNonNull(mapper);
+            return this;
+        }
+
+        @Override
+        public <U> Stream<U> mapToObj(IntFunction<? extends U> mapper) {
+            Objects.requireNonNull(mapper);
+            return emptyStream();
+        }
+
+        @Override
+        public LongStream mapToLong(IntToLongFunction mapper) {
+            Objects.requireNonNull(mapper);
+            return emptyLongStream();
+        }
+
+        @Override
+        public DoubleStream mapToDouble(IntToDoubleFunction mapper) {
+            Objects.requireNonNull(mapper);
+            return emptyDoubleStream();
+        }
+
+        @Override
+        public IntStream flatMap(IntFunction<? extends IntStream> mapper) {
+            Objects.requireNonNull(mapper);
+            return this;
+        }
+
+        @Override
+        public IntStream distinct() {
+            return createOldEmpty().distinct();
+        }
+
+        @Override
+        public IntStream sorted() {
+            return createOldEmpty().sorted();
+        }
+
+        @Override
+        public IntStream peek(IntConsumer action) {
+            Objects.requireNonNull(action);
+            return this;
+        }
+
+        @Override
+        public IntStream limit(long maxSize) {
+            if (maxSize < 0)
+                throw new IllegalArgumentException("maxSize < 0");
+            return this;
+        }
+
+        @Override
+        public IntStream skip(long n) {
+            if (n < 0) throw new IllegalArgumentException("n < 0");
+            return this;
+        }
+
+        @Override
+        public void forEach(IntConsumer action) {
+            Objects.requireNonNull(action);
+        }
+
+        @Override
+        public void forEachOrdered(IntConsumer action) {
+            Objects.requireNonNull(action);
+        }
+
+        private static final int[] EMPTY_INT_ARRAY = {};
+
+        @Override
+        public int[] toArray() {
+            return EMPTY_INT_ARRAY;
+        }
+
+        @Override
+        public int reduce(int identity, IntBinaryOperator op) {
+            Objects.requireNonNull(op);
+            return identity;
+        }
+
+        @Override
+        public OptionalInt reduce(IntBinaryOperator op) {
+            Objects.requireNonNull(op);
+            return OptionalInt.empty();
+        }
+
+        @Override
+        public <R> R collect(Supplier<R> supplier, ObjIntConsumer<R> accumulator, BiConsumer<R, R> combiner) {
+            Objects.requireNonNull(supplier);
+            Objects.requireNonNull(accumulator);
+            Objects.requireNonNull(combiner);
+            return supplier.get();
+        }
+
+        @Override
+        public int sum() {
+            return 0;
+        }
+
+        @Override
+        public OptionalInt min() {
+            return OptionalInt.empty();
+        }
+
+        @Override
+        public OptionalInt max() {
+            return OptionalInt.empty();
+        }
+
+        @Override
+        public long count() {
+            return 0L;
+        }
+
+        @Override
+        public OptionalDouble average() {
+            return OptionalDouble.empty();
+        }
+
+        @Override
+        public IntSummaryStatistics summaryStatistics() {
+            return new IntSummaryStatistics();
+        }
+
+        @Override
+        public boolean anyMatch(IntPredicate predicate) {
+            Objects.requireNonNull(predicate);
+            return false;
+        }
+
+        @Override
+        public boolean allMatch(IntPredicate predicate) {
+            Objects.requireNonNull(predicate);
+            return true;
+        }
+
+        @Override
+        public boolean noneMatch(IntPredicate predicate) {
+            Objects.requireNonNull(predicate);
+            return true;
+        }
+
+        @Override
+        public OptionalInt findFirst() {
+            return OptionalInt.empty();
+        }
+
+        @Override
+        public OptionalInt findAny() {
+            return OptionalInt.empty();
+        }
+
+        @Override
+        public LongStream asLongStream() {
+            return emptyLongStream();
+        }
+
+        @Override
+        public DoubleStream asDoubleStream() {
+            return emptyDoubleStream();
+        }
+
+        @Override
+        public Stream<Integer> boxed() {
+            return emptyStream();
+        }
+
+        @Override
+        public IntStream sequential() {
+            return this;
+        }
+
+        @Override
+        public IntStream parallel() {
+            return createOldEmpty().parallel();
+        }
+
+        private static final PrimitiveIterator.OfInt EMPTY_ITERATOR =
+            new PrimitiveIterator.OfInt() {
+                @Override
+                public int nextInt() {
+                    throw new NoSuchElementException();
+                }
+
+                @Override
+                public boolean hasNext() {
+                    return false;
+                }
+            };
+
+        @Override
+        public PrimitiveIterator.OfInt iterator() {
+            return EMPTY_ITERATOR;
+        }
+
+        @Override
+        public Spliterator.OfInt spliterator() {
+            return Spliterators.emptyIntSpliterator();
+        }
+
+        @Override
+        public boolean isParallel() {
+            return false;
+        }
+
+        @Override
+        public IntStream unordered() {
+            return this;
+        }
+
+        @Override
+        public IntStream onClose(Runnable closeHandler) {
+            return createOldEmpty().onClose(closeHandler);
+        }
+
+        @Override
+        public void close() {
+            // do nothing
+        }
+
+        @Override
+        public IntStream mapMulti(IntMapMultiConsumer mapper) {
+            Objects.requireNonNull(mapper);
+            return this;
+        }
+
+        @Override
+        public IntStream takeWhile(IntPredicate predicate) {
+            Objects.requireNonNull(predicate);
+            return this;
+        }
+
+        @Override
+        public IntStream dropWhile(IntPredicate predicate) {
+            Objects.requireNonNull(predicate);
+            return this;
+        }
+    }
+
+    private static final class EmptyLongStream implements LongStream {
+        private static LongStream createOldEmpty() {
+            return StreamSupport.longStream(
+                Spliterators.emptyLongSpliterator(), false);
+        }
+
+        @Override
+        public LongStream filter(LongPredicate predicate) {
+            Objects.requireNonNull(predicate);
+            return this;
+        }
+
+        @Override
+        public LongStream map(LongUnaryOperator mapper) {
+            Objects.requireNonNull(mapper);
+            return this;
+        }
+
+        @Override
+        public <U> Stream<U> mapToObj(LongFunction<? extends U> mapper) {
+            Objects.requireNonNull(mapper);
+            return emptyStream();
+        }
+
+        @Override
+        public IntStream mapToInt(LongToIntFunction mapper) {
+            Objects.requireNonNull(mapper);
+            return emptyIntStream();
+        }
+
+        @Override
+        public DoubleStream mapToDouble(LongToDoubleFunction mapper) {
+            Objects.requireNonNull(mapper);
+            return emptyDoubleStream();
+        }
+
+        @Override
+        public LongStream flatMap(LongFunction<? extends LongStream> mapper) {
+            Objects.requireNonNull(mapper);
+            return this;
+        }
+
+        @Override
+        public LongStream distinct() {
+            return createOldEmpty().distinct();
+        }
+
+        @Override
+        public LongStream sorted() {
+            return createOldEmpty().sorted();
+        }
+
+        @Override
+        public LongStream peek(LongConsumer action) {
+            Objects.requireNonNull(action);
+            return this;
+        }
+
+        @Override
+        public LongStream limit(long maxSize) {
+            if (maxSize < 0)
+                throw new IllegalArgumentException("maxSize < 0");
+            return this;
+        }
+
+        @Override
+        public LongStream skip(long n) {
+            if (n < 0) throw new IllegalArgumentException("n < 0");
+            return this;
+        }
+
+        @Override
+        public void forEach(LongConsumer action) {
+            Objects.requireNonNull(action);
+        }
+
+        @Override
+        public void forEachOrdered(LongConsumer action) {
+            Objects.requireNonNull(action);
+        }
+
+        private static final long[] EMPTY_LONG_ARRAY = {};
+
+        @Override
+        public long[] toArray() {
+            return EMPTY_LONG_ARRAY;
+        }
+
+        @Override
+        public long reduce(long identity, LongBinaryOperator op) {
+            Objects.requireNonNull(op);
+            return identity;
+        }
+
+        @Override
+        public OptionalLong reduce(LongBinaryOperator op) {
+            Objects.requireNonNull(op);
+            return OptionalLong.empty();
+        }
+
+        @Override
+        public <R> R collect(Supplier<R> supplier, ObjLongConsumer<R> accumulator, BiConsumer<R, R> combiner) {
+            Objects.requireNonNull(supplier);
+            Objects.requireNonNull(accumulator);
+            Objects.requireNonNull(combiner);
+            return supplier.get();
+        }
+
+        @Override
+        public long sum() {
+            return 0;
+        }
+
+        @Override
+        public OptionalLong min() {
+            return OptionalLong.empty();
+        }
+
+        @Override
+        public OptionalLong max() {
+            return OptionalLong.empty();
+        }
+
+        @Override
+        public long count() {
+            return 0L;
+        }
+
+        @Override
+        public OptionalDouble average() {
+            return OptionalDouble.empty();
+        }
+
+        @Override
+        public LongSummaryStatistics summaryStatistics() {
+            return new LongSummaryStatistics();
+        }
+
+        @Override
+        public boolean anyMatch(LongPredicate predicate) {
+            Objects.requireNonNull(predicate);
+            return false;
+        }
+
+        @Override
+        public boolean allMatch(LongPredicate predicate) {
+            Objects.requireNonNull(predicate);
+            return true;
+        }
+
+        @Override
+        public boolean noneMatch(LongPredicate predicate) {
+            Objects.requireNonNull(predicate);
+            return true;
+        }
+
+        @Override
+        public OptionalLong findFirst() {
+            return OptionalLong.empty();
+        }
+
+        @Override
+        public OptionalLong findAny() {
+            return OptionalLong.empty();
+        }
+
+        @Override
+        public DoubleStream asDoubleStream() {
+            return emptyDoubleStream();
+        }
+
+        @Override
+        public Stream<Long> boxed() {
+            return emptyStream();
+        }
+
+        @Override
+        public LongStream sequential() {
+            return this;
+        }
+
+        @Override
+        public LongStream parallel() {
+            return createOldEmpty().parallel();
+        }
+
+        private static final PrimitiveIterator.OfLong EMPTY_ITERATOR =
+            new PrimitiveIterator.OfLong() {
+                @Override
+                public long nextLong() {
+                    throw new NoSuchElementException();
+                }
+
+                @Override
+                public boolean hasNext() {
+                    return false;
+                }
+            };
+
+        @Override
+        public PrimitiveIterator.OfLong iterator() {
+            return EMPTY_ITERATOR;
+        }
+
+        @Override
+        public Spliterator.OfLong spliterator() {
+            return Spliterators.emptyLongSpliterator();
+        }
+
+        @Override
+        public boolean isParallel() {
+            return false;
+        }
+
+        @Override
+        public LongStream unordered() {
+            return this;
+        }
+
+        @Override
+        public LongStream onClose(Runnable closeHandler) {
+            return createOldEmpty().onClose(closeHandler);
+        }
+
+        @Override
+        public void close() {
+            // do nothing
+        }
+
+        @Override
+        public LongStream mapMulti(LongMapMultiConsumer mapper) {
+            Objects.requireNonNull(mapper);
+            return this;
+        }
+
+        @Override
+        public LongStream takeWhile(LongPredicate predicate) {
+            Objects.requireNonNull(predicate);
+            return this;
+        }
+
+        @Override
+        public LongStream dropWhile(LongPredicate predicate) {
+            Objects.requireNonNull(predicate);
+            return this;
+        }
+    }
+
+    private static final class EmptyDoubleStream implements DoubleStream {
+        private static DoubleStream createOldEmpty() {
+            return StreamSupport.doubleStream(
+                Spliterators.emptyDoubleSpliterator(), false);
+        }
+
+        @Override
+        public DoubleStream filter(DoublePredicate predicate) {
+            Objects.requireNonNull(predicate);
+            return this;
+        }
+
+        @Override
+        public DoubleStream map(DoubleUnaryOperator mapper) {
+            Objects.requireNonNull(mapper);
+            return this;
+        }
+
+        @Override
+        public <U> Stream<U> mapToObj(DoubleFunction<? extends U> mapper) {
+            Objects.requireNonNull(mapper);
+            return emptyStream();
+        }
+
+        @Override
+        public IntStream mapToInt(DoubleToIntFunction mapper) {
+            Objects.requireNonNull(mapper);
+            return emptyIntStream();
+        }
+
+        @Override
+        public LongStream mapToLong(DoubleToLongFunction mapper) {
+            Objects.requireNonNull(mapper);
+            return emptyLongStream();
+        }
+
+        @Override
+        public DoubleStream flatMap(DoubleFunction<? extends DoubleStream> mapper) {
+            Objects.requireNonNull(mapper);
+            return this;
+        }
+
+        @Override
+        public DoubleStream distinct() {
+            return createOldEmpty().distinct();
+        }
+
+        @Override
+        public DoubleStream sorted() {
+            return createOldEmpty().sorted();
+        }
+
+        @Override
+        public DoubleStream peek(DoubleConsumer action) {
+            Objects.requireNonNull(action);
+            return this;
+        }
+
+        @Override
+        public DoubleStream limit(long maxSize) {
+            if (maxSize < 0)
+                throw new IllegalArgumentException("maxSize < 0");
+            return this;
+        }
+
+        @Override
+        public DoubleStream skip(long n) {
+            if (n < 0) throw new IllegalArgumentException("n < 0");
+            return this;
+        }
+
+        @Override
+        public void forEach(DoubleConsumer action) {
+            Objects.requireNonNull(action);
+        }
+
+        @Override
+        public void forEachOrdered(DoubleConsumer action) {
+            Objects.requireNonNull(action);
+        }
+
+        private static final double[] EMPTY_DOUBLE_ARRAY = {};
+
+        @Override
+        public double[] toArray() {
+            return EMPTY_DOUBLE_ARRAY;
+        }
+
+        @Override
+        public double reduce(double identity, DoubleBinaryOperator op) {
+            Objects.requireNonNull(op);
+            return identity;
+        }
+
+        @Override
+        public OptionalDouble reduce(DoubleBinaryOperator op) {
+            Objects.requireNonNull(op);
+            return OptionalDouble.empty();
+        }
+
+        @Override
+        public <R> R collect(Supplier<R> supplier, ObjDoubleConsumer<R> accumulator, BiConsumer<R, R> combiner) {
+            Objects.requireNonNull(supplier);
+            Objects.requireNonNull(accumulator);
+            Objects.requireNonNull(combiner);
+            return supplier.get();
+        }
+
+        @Override
+        public double sum() {
+            return 0;
+        }
+
+        @Override
+        public OptionalDouble min() {
+            return OptionalDouble.empty();
+        }
+
+        @Override
+        public OptionalDouble max() {
+            return OptionalDouble.empty();
+        }
+
+        @Override
+        public long count() {
+            return 0L;
+        }
+
+        @Override
+        public OptionalDouble average() {
+            return OptionalDouble.empty();
+        }
+
+        @Override
+        public DoubleSummaryStatistics summaryStatistics() {
+            return new DoubleSummaryStatistics();
+        }
+
+        @Override
+        public boolean anyMatch(DoublePredicate predicate) {
+            Objects.requireNonNull(predicate);
+            return false;
+        }
+
+        @Override
+        public boolean allMatch(DoublePredicate predicate) {
+            Objects.requireNonNull(predicate);
+            return true;
+        }
+
+        @Override
+        public boolean noneMatch(DoublePredicate predicate) {
+            Objects.requireNonNull(predicate);
+            return true;
+        }
+
+        @Override
+        public OptionalDouble findFirst() {
+            return OptionalDouble.empty();
+        }
+
+        @Override
+        public OptionalDouble findAny() {
+            return OptionalDouble.empty();
+        }
+
+        @Override
+        public Stream<Double> boxed() {
+            return emptyStream();
+        }
+
+        @Override
+        public DoubleStream sequential() {
+            return this;
+        }
+
+        @Override
+        public DoubleStream parallel() {
+            return createOldEmpty().parallel();
+        }
+
+        private static final PrimitiveIterator.OfDouble EMPTY_ITERATOR =
+            new PrimitiveIterator.OfDouble() {
+                @Override
+                public double nextDouble() {
+                    throw new NoSuchElementException();
+                }
+
+                @Override
+                public boolean hasNext() {
+                    return false;
+                }
+            };
+
+        @Override
+        public PrimitiveIterator.OfDouble iterator() {
+            return EMPTY_ITERATOR;
+        }
+
+        @Override
+        public Spliterator.OfDouble spliterator() {
+            return Spliterators.emptyDoubleSpliterator();
+        }
+
+        @Override
+        public boolean isParallel() {
+            return false;
+        }
+
+        @Override
+        public DoubleStream unordered() {
+            return this;
+        }
+
+        @Override
+        public DoubleStream onClose(Runnable closeHandler) {
+            return createOldEmpty().onClose(closeHandler);
+        }
+
+        @Override
+        public void close() {
+            // do nothing
+        }
+
+        @Override
+        public DoubleStream mapMulti(DoubleMapMultiConsumer mapper) {
+            Objects.requireNonNull(mapper);
+            return this;
+        }
+
+        @Override
+        public DoubleStream takeWhile(DoublePredicate predicate) {
+            Objects.requireNonNull(predicate);
+            return this;
+        }
+
+        @Override
+        public DoubleStream dropWhile(DoublePredicate predicate) {
+            Objects.requireNonNull(predicate);
+            return this;
+        }
     }
 }

--- a/src/java.base/share/classes/java/util/stream/Streams.java
+++ b/src/java.base/share/classes/java/util/stream/Streams.java
@@ -967,11 +967,10 @@ final class Streams {
             state |= OPERATED_ON;
         }
 
-        protected final void stateDistinct(boolean hasComparator) {
+        protected final void stateDistinct() {
             state |= DISTINCT;
             state &= ~(SIZED | SUBSIZED | CONCURRENT | NONNULL | IMMUTABLE);
-            if (hasComparator)
-                state &= ~(SORTED);
+            if (hasComparator()) state &= ~SORTED;
         }
 
         protected final void stateDistinctPrimitiveStream() {
@@ -987,12 +986,14 @@ final class Streams {
             return (state & SORTED) == SORTED;
         }
 
-        protected boolean stateIsUnordered() {
-            return (state & ORDERED) == 0;
-        }
-
-        protected void stateUnordered() {
-            state &= ~ORDERED;
+        protected boolean unorderedSame() {
+            if ((state & ORDERED) == ORDERED) {
+                state &= ~(CONCURRENT | NONNULL | ORDERED | IMMUTABLE);
+                if (hasComparator()) state &= ~SORTED;
+                state |= OPERATED_ON;
+                return false;
+            }
+            return true;
         }
 
         protected final int stateBareCharacteristics() {
@@ -1002,6 +1003,58 @@ final class Streams {
         public final void close() {
             // nothing to do
             state |= CLOSED;
+        }
+
+        public boolean isParallel() {
+            return false;
+        }
+
+        protected final void checkParametersAndThenState(Object parameter) {
+            Objects.requireNonNull(parameter);
+            checkIfOperatedOnOrClosedAndChangeState();
+        }
+
+        protected final void checkParametersAndThenState(Object parameter1, Object parameter2) {
+            Objects.requireNonNull(parameter1);
+            Objects.requireNonNull(parameter2);
+            checkIfOperatedOnOrClosedAndChangeState();
+        }
+
+        protected final void checkParametersAndThenState(Object parameter1, Object parameter2, Object parameter3) {
+            Objects.requireNonNull(parameter1);
+            Objects.requireNonNull(parameter2);
+            Objects.requireNonNull(parameter3);
+            checkIfOperatedOnOrClosedAndChangeState();
+        }
+
+        protected final void checkStateAndThenParameters(Object parameter) {
+            // for some of the methods, we first check the state and then the parameter
+            checkIfOperatedOnOrClosedAndChangeState();
+            Objects.requireNonNull(parameter);
+        }
+
+        protected final <R> EmptyStream<R> nextEmptyStream(Object parameter) {
+            checkParametersAndThenState(parameter);
+            return new EmptyStream<>(this);
+        }
+
+        protected final EmptyIntStream nextEmptyIntStream(Object parameter) {
+            checkParametersAndThenState(parameter);
+            return new EmptyIntStream(this);
+        }
+
+        protected final EmptyLongStream nextEmptyLongStream(Object parameter) {
+            checkParametersAndThenState(parameter);
+            return new EmptyLongStream(this);
+        }
+
+        protected final EmptyDoubleStream nextEmptyDoubleStream(Object parameter) {
+            checkParametersAndThenState(parameter);
+            return new EmptyDoubleStream(this);
+        }
+
+        protected boolean hasComparator() {
+            return false;
         }
     }
 
@@ -1032,100 +1085,79 @@ final class Streams {
 
         @Override
         public Stream<T> filter(Predicate<? super T> predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyStream<>(this);
+            return nextEmptyStream(predicate);
         }
 
         @Override
         public <R> Stream<R> map(Function<? super T, ? extends R> mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyStream<>(this);
+            return nextEmptyStream(mapper);
         }
 
         @Override
         public IntStream mapToInt(ToIntFunction<? super T> mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyIntStream(this);
+            return nextEmptyIntStream(mapper);
         }
 
         @Override
         public LongStream mapToLong(ToLongFunction<? super T> mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyLongStream(this);
+            return nextEmptyLongStream(mapper);
         }
 
         @Override
         public DoubleStream mapToDouble(ToDoubleFunction<? super T> mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyDoubleStream(this);
+            return nextEmptyDoubleStream(mapper);
         }
 
         @Override
         public <R> Stream<R> flatMap(Function<? super T, ? extends Stream<? extends R>> mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyStream<>(this);
+            return nextEmptyStream(mapper);
         }
 
         @Override
         public IntStream flatMapToInt(Function<? super T, ? extends IntStream> mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyIntStream(this);
+            return nextEmptyIntStream(mapper);
         }
 
         @Override
         public LongStream flatMapToLong(Function<? super T, ? extends LongStream> mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyLongStream(this);
+            return nextEmptyLongStream(mapper);
         }
 
         @Override
         public DoubleStream flatMapToDouble(Function<? super T, ? extends DoubleStream> mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyDoubleStream(this);
+            return nextEmptyDoubleStream(mapper);
         }
 
         @Override
         public <R> Stream<R> mapMulti(BiConsumer<? super T, ? super Consumer<R>> mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyStream<>(this);
+            return nextEmptyStream(mapper);
         }
 
         @Override
         public IntStream mapMultiToInt(BiConsumer<? super T, ? super IntConsumer> mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyIntStream(this);
+            return nextEmptyIntStream(mapper);
         }
 
         @Override
         public LongStream mapMultiToLong(BiConsumer<? super T, ? super LongConsumer> mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyLongStream(this);
+            return nextEmptyLongStream(mapper);
         }
 
         @Override
         public DoubleStream mapMultiToDouble(BiConsumer<? super T, ? super DoubleConsumer> mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyDoubleStream(this);
+            return nextEmptyDoubleStream(mapper);
         }
 
         @Override
         public Stream<T> distinct() {
             checkIfOperatedOnOrClosedAndChangeState();
-            super.stateDistinct(comparator != null);
+            super.stateDistinct();
             return new EmptyStream<>(this);
+        }
+
+        @Override
+        protected boolean hasComparator() {
+            return comparator != null;
         }
 
         @Override
@@ -1137,17 +1169,13 @@ final class Streams {
 
         @Override
         public Stream<T> sorted(Comparator<? super T> comparator) {
-            // the check is the other way round to normal
-            checkIfOperatedOnOrClosedAndChangeState();
-            Objects.requireNonNull(comparator);
+            checkStateAndThenParameters(comparator);
             return new EmptyStream<>(this);
         }
 
         @Override
         public Stream<T> peek(Consumer<? super T> action) {
-            Objects.requireNonNull(action);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyStream<>(this);
+            return nextEmptyStream(action);
         }
 
         @Override
@@ -1169,29 +1197,23 @@ final class Streams {
 
         @Override
         public Stream<T> takeWhile(Predicate<? super T> predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyStream<>(this);
+            return nextEmptyStream(predicate);
         }
 
         @Override
         public Stream<T> dropWhile(Predicate<? super T> predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyStream<>(this);
+            return nextEmptyStream(predicate);
         }
 
         @Override
         public void forEach(Consumer<? super T> action) {
-            checkIfOperatedOnOrClosedAndChangeState();
-            Objects.requireNonNull(action);
+            checkStateAndThenParameters(action);
             // do nothing
         }
 
         @Override
         public void forEachOrdered(Consumer<? super T> action) {
-            checkIfOperatedOnOrClosedAndChangeState();
-            Objects.requireNonNull(action);
+            checkStateAndThenParameters(action);
             // do nothing
         }
 
@@ -1205,46 +1227,37 @@ final class Streams {
 
         @Override
         public <A> A[] toArray(IntFunction<A[]> generator) {
-            checkIfOperatedOnOrClosedAndChangeState();
-            Objects.requireNonNull(generator);
+            checkStateAndThenParameters(generator);
             return Objects.requireNonNull(generator.apply(0));
         }
 
         @Override
         public T reduce(T identity, BinaryOperator<T> accumulator) {
-            Objects.requireNonNull(accumulator);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(accumulator);
             return identity;
         }
 
         @Override
         public Optional<T> reduce(BinaryOperator<T> accumulator) {
-            Objects.requireNonNull(accumulator);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(accumulator);
             return Optional.empty();
         }
 
         @Override
         public <U> U reduce(U identity, BiFunction<U, ? super T, U> accumulator, BinaryOperator<U> combiner) {
-            Objects.requireNonNull(accumulator);
-            Objects.requireNonNull(combiner);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(accumulator, combiner);
             return identity;
         }
 
         @Override
         public <R> R collect(Supplier<R> supplier, BiConsumer<R, ? super T> accumulator, BiConsumer<R, R> combiner) {
-            Objects.requireNonNull(supplier);
-            Objects.requireNonNull(accumulator);
-            Objects.requireNonNull(combiner);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(supplier, accumulator, combiner);
             return supplier.get();
         }
 
         @Override
         public <R, A> R collect(Collector<? super T, A, R> collector) {
-            Objects.requireNonNull(collector);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(collector);
             return collector.finisher().apply(collector.supplier().get());
         }
 
@@ -1256,15 +1269,13 @@ final class Streams {
 
         @Override
         public Optional<T> min(Comparator<? super T> comparator) {
-            Objects.requireNonNull(comparator);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(comparator);
             return Optional.empty();
         }
 
         @Override
         public Optional<T> max(Comparator<? super T> comparator) {
-            Objects.requireNonNull(comparator);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(comparator);
             return Optional.empty();
         }
 
@@ -1276,22 +1287,19 @@ final class Streams {
 
         @Override
         public boolean anyMatch(Predicate<? super T> predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(predicate);
             return false;
         }
 
         @Override
         public boolean allMatch(Predicate<? super T> predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(predicate);
             return true;
         }
 
         @Override
         public boolean noneMatch(Predicate<? super T> predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(predicate);
             return true;
         }
 
@@ -1322,12 +1330,6 @@ final class Streams {
                 return new EmptySpliterator.OfRef<>(stateBareCharacteristics());
         }
 
-
-        @Override
-        public boolean isParallel() {
-            return false;
-        }
-
         @Override
         public Stream<T> sequential() {
             return this;
@@ -1341,10 +1343,8 @@ final class Streams {
         @Override
         public Stream<T> unordered() {
             checkIfOperatedOnOrClosed();
-            if (super.stateIsUnordered()) return this;
-            checkIfOperatedOnOrClosedAndChangeState();
-            super.stateUnordered();
-            return new EmptyStream<>(this);
+            if (super.unorderedSame()) return this;
+            else return new EmptyStream<>(this);
         }
 
         @Override
@@ -1366,51 +1366,37 @@ final class Streams {
 
         @Override
         public IntStream filter(IntPredicate predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyIntStream(this);
+            return nextEmptyIntStream(predicate);
         }
 
         @Override
         public IntStream map(IntUnaryOperator mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyIntStream(this);
+            return nextEmptyIntStream(mapper);
         }
 
         @Override
         public <U> Stream<U> mapToObj(IntFunction<? extends U> mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyStream<>(this);
+            return nextEmptyStream(mapper);
         }
 
         @Override
         public LongStream mapToLong(IntToLongFunction mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyLongStream(this);
+            return nextEmptyLongStream(mapper);
         }
 
         @Override
         public DoubleStream mapToDouble(IntToDoubleFunction mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyDoubleStream(this);
+            return nextEmptyDoubleStream(mapper);
         }
 
         @Override
         public IntStream flatMap(IntFunction<? extends IntStream> mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyIntStream(this);
+            return nextEmptyIntStream(mapper);
         }
 
         @Override
         public IntStream mapMulti(IntMapMultiConsumer mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyIntStream(this);
+            return nextEmptyIntStream(mapper);
         }
 
         @Override
@@ -1429,9 +1415,7 @@ final class Streams {
 
         @Override
         public IntStream peek(IntConsumer action) {
-            Objects.requireNonNull(action);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyIntStream(this);
+            return nextEmptyIntStream(action);
         }
 
         @Override
@@ -1453,29 +1437,23 @@ final class Streams {
 
         @Override
         public IntStream takeWhile(IntPredicate predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyIntStream(this);
+            return nextEmptyIntStream(predicate);
         }
 
         @Override
         public IntStream dropWhile(IntPredicate predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyIntStream(this);
+            return nextEmptyIntStream(predicate);
         }
 
         @Override
         public void forEach(IntConsumer action) {
-            checkIfOperatedOnOrClosedAndChangeState();
-            Objects.requireNonNull(action);
+            checkStateAndThenParameters(action);
             // do nothing
         }
 
         @Override
         public void forEachOrdered(IntConsumer action) {
-            checkIfOperatedOnOrClosedAndChangeState();
-            Objects.requireNonNull(action);
+            checkStateAndThenParameters(action);
             // do nothing
         }
 
@@ -1489,24 +1467,19 @@ final class Streams {
 
         @Override
         public int reduce(int identity, IntBinaryOperator op) {
-            Objects.requireNonNull(op);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(op);
             return identity;
         }
 
         @Override
         public OptionalInt reduce(IntBinaryOperator op) {
-            Objects.requireNonNull(op);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(op);
             return OptionalInt.empty();
         }
 
         @Override
         public <R> R collect(Supplier<R> supplier, ObjIntConsumer<R> accumulator, BiConsumer<R, R> combiner) {
-            Objects.requireNonNull(supplier);
-            Objects.requireNonNull(accumulator);
-            Objects.requireNonNull(combiner);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(supplier, accumulator, combiner);
             return supplier.get();
         }
 
@@ -1530,22 +1503,19 @@ final class Streams {
 
         @Override
         public boolean anyMatch(IntPredicate predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(predicate);
             return false;
         }
 
         @Override
         public boolean allMatch(IntPredicate predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(predicate);
             return true;
         }
 
         @Override
         public boolean noneMatch(IntPredicate predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(predicate);
             return true;
         }
 
@@ -1588,11 +1558,6 @@ final class Streams {
         }
 
         @Override
-        public boolean isParallel() {
-            return false;
-        }
-
-        @Override
         public IntStream sequential() {
             return this;
         }
@@ -1604,10 +1569,9 @@ final class Streams {
 
         @Override
         public IntStream unordered() {
-            if (super.stateIsUnordered()) return this;
-            checkIfOperatedOnOrClosedAndChangeState();
-            super.stateUnordered();
-            return new EmptyIntStream(this);
+            checkIfOperatedOnOrClosed();
+            if (super.unorderedSame()) return this;
+            else return new EmptyIntStream(this);
         }
 
         @Override
@@ -1665,51 +1629,37 @@ final class Streams {
 
         @Override
         public LongStream filter(LongPredicate predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyLongStream(this);
+            return nextEmptyLongStream(predicate);
         }
 
         @Override
         public LongStream map(LongUnaryOperator mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyLongStream(this);
+            return nextEmptyLongStream(mapper);
         }
 
         @Override
         public <U> Stream<U> mapToObj(LongFunction<? extends U> mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyStream<>(this);
+            return nextEmptyStream(mapper);
         }
 
         @Override
         public IntStream mapToInt(LongToIntFunction mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyIntStream(this);
+            return nextEmptyIntStream(mapper);
         }
 
         @Override
         public DoubleStream mapToDouble(LongToDoubleFunction mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyDoubleStream(this);
+            return nextEmptyDoubleStream(mapper);
         }
 
         @Override
         public LongStream flatMap(LongFunction<? extends LongStream> mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyLongStream(this);
+            return nextEmptyLongStream(mapper);
         }
 
         @Override
         public LongStream mapMulti(LongMapMultiConsumer mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyLongStream(this);
+            return nextEmptyLongStream(mapper);
         }
 
         @Override
@@ -1728,9 +1678,7 @@ final class Streams {
 
         @Override
         public LongStream peek(LongConsumer action) {
-            Objects.requireNonNull(action);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyLongStream(this);
+            return nextEmptyLongStream(action);
         }
 
         @Override
@@ -1752,29 +1700,23 @@ final class Streams {
 
         @Override
         public LongStream takeWhile(LongPredicate predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyLongStream(this);
+            return nextEmptyLongStream(predicate);
         }
 
         @Override
         public LongStream dropWhile(LongPredicate predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyLongStream(this);
+            return nextEmptyLongStream(predicate);
         }
 
         @Override
         public void forEach(LongConsumer action) {
-            checkIfOperatedOnOrClosedAndChangeState();
-            Objects.requireNonNull(action);
+            checkStateAndThenParameters(action);
             // do nothing
         }
 
         @Override
         public void forEachOrdered(LongConsumer action) {
-            checkIfOperatedOnOrClosedAndChangeState();
-            Objects.requireNonNull(action);
+            checkStateAndThenParameters(action);
             // do nothing
         }
 
@@ -1788,24 +1730,19 @@ final class Streams {
 
         @Override
         public long reduce(long identity, LongBinaryOperator op) {
-            Objects.requireNonNull(op);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(op);
             return identity;
         }
 
         @Override
         public OptionalLong reduce(LongBinaryOperator op) {
-            Objects.requireNonNull(op);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(op);
             return OptionalLong.empty();
         }
 
         @Override
         public <R> R collect(Supplier<R> supplier, ObjLongConsumer<R> accumulator, BiConsumer<R, R> combiner) {
-            Objects.requireNonNull(supplier);
-            Objects.requireNonNull(accumulator);
-            Objects.requireNonNull(combiner);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(supplier, accumulator, combiner);
             return supplier.get();
         }
 
@@ -1829,22 +1766,19 @@ final class Streams {
 
         @Override
         public boolean anyMatch(LongPredicate predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(predicate);
             return false;
         }
 
         @Override
         public boolean allMatch(LongPredicate predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(predicate);
             return true;
         }
 
         @Override
         public boolean noneMatch(LongPredicate predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(predicate);
             return true;
         }
 
@@ -1887,11 +1821,6 @@ final class Streams {
         }
 
         @Override
-        public boolean isParallel() {
-            return false;
-        }
-
-        @Override
         public LongStream sequential() {
             return this;
         }
@@ -1903,10 +1832,9 @@ final class Streams {
 
         @Override
         public LongStream unordered() {
-            if (super.stateIsUnordered()) return this;
-            checkIfOperatedOnOrClosedAndChangeState();
-            super.stateUnordered();
-            return new EmptyLongStream(this);
+            checkIfOperatedOnOrClosed();
+            if (super.unorderedSame()) return this;
+            else return new EmptyLongStream(this);
         }
 
         @Override
@@ -1958,51 +1886,37 @@ final class Streams {
 
         @Override
         public DoubleStream filter(DoublePredicate predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyDoubleStream(this);
+            return nextEmptyDoubleStream(predicate);
         }
 
         @Override
         public DoubleStream map(DoubleUnaryOperator mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyDoubleStream(this);
+            return nextEmptyDoubleStream(mapper);
         }
 
         @Override
         public <U> Stream<U> mapToObj(DoubleFunction<? extends U> mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyStream<>(this);
+            return nextEmptyStream(mapper);
         }
 
         @Override
         public IntStream mapToInt(DoubleToIntFunction mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyIntStream(this);
+            return nextEmptyIntStream(mapper);
         }
 
         @Override
         public LongStream mapToLong(DoubleToLongFunction mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyLongStream(this);
+            return nextEmptyLongStream(mapper);
         }
 
         @Override
         public DoubleStream flatMap(DoubleFunction<? extends DoubleStream> mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyDoubleStream(this);
+            return nextEmptyDoubleStream(mapper);
         }
 
         @Override
         public DoubleStream mapMulti(DoubleMapMultiConsumer mapper) {
-            Objects.requireNonNull(mapper);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyDoubleStream(this);
+            return nextEmptyDoubleStream(mapper);
         }
 
         @Override
@@ -2021,8 +1935,7 @@ final class Streams {
 
         @Override
         public DoubleStream peek(DoubleConsumer action) {
-            Objects.requireNonNull(action);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(action);
             return new EmptyDoubleStream(this);
         }
 
@@ -2045,29 +1958,23 @@ final class Streams {
 
         @Override
         public DoubleStream takeWhile(DoublePredicate predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyDoubleStream(this);
+            return nextEmptyDoubleStream(predicate);
         }
 
         @Override
         public DoubleStream dropWhile(DoublePredicate predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
-            return new EmptyDoubleStream(this);
+            return nextEmptyDoubleStream(predicate);
         }
 
         @Override
         public void forEach(DoubleConsumer action) {
-            checkIfOperatedOnOrClosedAndChangeState();
-            Objects.requireNonNull(action);
+            checkStateAndThenParameters(action);
             // do nothing
         }
 
         @Override
         public void forEachOrdered(DoubleConsumer action) {
-            checkIfOperatedOnOrClosedAndChangeState();
-            Objects.requireNonNull(action);
+            checkStateAndThenParameters(action);
             // do nothing
         }
 
@@ -2081,24 +1988,19 @@ final class Streams {
 
         @Override
         public double reduce(double identity, DoubleBinaryOperator op) {
-            Objects.requireNonNull(op);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(op);
             return identity;
         }
 
         @Override
         public OptionalDouble reduce(DoubleBinaryOperator op) {
-            Objects.requireNonNull(op);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(op);
             return OptionalDouble.empty();
         }
 
         @Override
         public <R> R collect(Supplier<R> supplier, ObjDoubleConsumer<R> accumulator, BiConsumer<R, R> combiner) {
-            Objects.requireNonNull(supplier);
-            Objects.requireNonNull(accumulator);
-            Objects.requireNonNull(combiner);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(supplier, accumulator, combiner);
             return supplier.get();
         }
 
@@ -2122,22 +2024,19 @@ final class Streams {
 
         @Override
         public boolean anyMatch(DoublePredicate predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(predicate);
             return false;
         }
 
         @Override
         public boolean allMatch(DoublePredicate predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(predicate);
             return true;
         }
 
         @Override
         public boolean noneMatch(DoublePredicate predicate) {
-            Objects.requireNonNull(predicate);
-            checkIfOperatedOnOrClosedAndChangeState();
+            checkParametersAndThenState(predicate);
             return true;
         }
 
@@ -2180,11 +2079,6 @@ final class Streams {
         }
 
         @Override
-        public boolean isParallel() {
-            return false;
-        }
-
-        @Override
         public DoubleStream sequential() {
             return this;
         }
@@ -2196,10 +2090,9 @@ final class Streams {
 
         @Override
         public DoubleStream unordered() {
-            if (super.stateIsUnordered()) return this;
-            checkIfOperatedOnOrClosedAndChangeState();
-            super.stateUnordered();
-            return new EmptyDoubleStream(this);
+            checkIfOperatedOnOrClosed();
+            if (super.unorderedSame()) return this;
+            else return new EmptyDoubleStream(this);
         }
 
         @Override
@@ -2312,4 +2205,5 @@ final class Streams {
             }
         }
     }
+
 }

--- a/src/java.base/share/classes/java/util/stream/Streams.java
+++ b/src/java.base/share/classes/java/util/stream/Streams.java
@@ -959,8 +959,10 @@ final class Streams {
      * during stream creation for empty streams. Most of the
      * methods such as filter() and map() will return "this".
      * We have tried to mirror the behavior of the previous
-     * Stream.empty() for spliterator characteristics, parallel()
-     * and
+     * Stream.empty() for spliterator characteristics. If someone
+     * calls parallel() or sorted() then we will create a new
+     * empty stream using the old way of StreamSupport.stream(
+     * spliterator(), false).
      */
     private static final class EmptyStream<T> implements Stream<T> {
         private static <T> Stream<T> createOldEmpty() {
@@ -976,9 +978,7 @@ final class Streams {
         @Override
         public <R> Stream<R> map(Function<? super T, ? extends R> mapper) {
             Objects.requireNonNull(mapper);
-            @SuppressWarnings("unchecked")
-            var stream = (Stream<R>) this;
-            return stream;
+            return emptyStream();
         }
 
         @Override
@@ -1002,9 +1002,7 @@ final class Streams {
         @Override
         public <R> Stream<R> flatMap(Function<? super T, ? extends Stream<? extends R>> mapper) {
             Objects.requireNonNull(mapper);
-            @SuppressWarnings("unchecked")
-            var stream = (Stream<R>) this;
-            return stream;
+            return emptyStream();
         }
 
         @Override
@@ -1028,9 +1026,7 @@ final class Streams {
         @Override
         public <R> Stream<R> mapMulti(BiConsumer<? super T, ? super Consumer<R>> mapper) {
             Objects.requireNonNull(mapper);
-            @SuppressWarnings("unchecked")
-            var stream = (Stream<R>) this;
-            return stream;
+            return emptyStream();
         }
 
         @Override
@@ -1249,6 +1245,10 @@ final class Streams {
         }
     }
 
+    /**
+     * The EmptyIntStream is equivalent to the EmptyStream - to
+     * optimize empty stream processing, but for IntStreams.
+     */
     private static final class EmptyIntStream implements IntStream {
         private static IntStream createOldEmpty() {
             return StreamSupport.intStream(
@@ -1502,6 +1502,10 @@ final class Streams {
         }
     }
 
+    /**
+     * The EmptyLongStream is equivalent to the EmptyStream - to
+     * optimize empty stream processing, but for LongStreams.
+     */
     private static final class EmptyLongStream implements LongStream {
         private static LongStream createOldEmpty() {
             return StreamSupport.longStream(
@@ -1750,6 +1754,10 @@ final class Streams {
         }
     }
 
+    /**
+     * The EmptyDoubleStream is equivalent to the EmptyStream - to
+     * optimize empty stream processing, but for DoubleStreams.
+     */
     private static final class EmptyDoubleStream implements DoubleStream {
         private static DoubleStream createOldEmpty() {
             return StreamSupport.doubleStream(

--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyBaseStreamTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyBaseStreamTest.java
@@ -293,6 +293,7 @@ sealed abstract class EmptyBaseStreamTest permits EmptyDoubleStreamTest,
         assertEquals(actualResult.hasCharacteristics(Spliterator.ORDERED),
                 expectedResult.hasCharacteristics(Spliterator.ORDERED));
         assertFalse(actualResult.hasCharacteristics(Spliterator.ORDERED));
+        assertEquals(actualResult.characteristics(), expectedResult.characteristics());
     }
 
     public final void testUnorderedExceptions(BaseStream<?, ?> actual, BaseStream<?, ?> expected) {

--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyBaseStreamTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyBaseStreamTest.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.tests.java.util.stream;
+
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.Spliterator;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.BaseStream;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static org.testng.Assert.*;
+
+/**
+ * The new EmptyStream, EmptyIntStream, etc. are supposed to
+ * be drop-in replacements for the previous Stream.empty(),
+ * IntStream.empty(), etc. factory methods, which used to be
+ * generated using {@link
+ * StreamSupport#stream(Spliterator, boolean)}. In our tests,
+ * we thus compare all the behavior of the empty streams, to
+ * ensure that they are exactly the same as before.
+ * <p>
+ * Implementations of this class have to implement the testAll()
+ * method, in which we would call {@link BaseStreamTest#compare(Class, Supplier, Supplier)}
+ * The BaseStreamTest checks the methods in the BaseStream,
+ * such as parallel(), unordered(), spliterator(), iterator(),
+ * onClose(), etc. Subclasses implement the testAll() method
+ * and then call compare() with the type that we are
+ *
+ * @author Heinz Kabutz heinz@javaspecialists.eu
+ */
+sealed abstract class EmptyBaseStreamTest permits
+        EmptyStreamTest, EmptyIntStreamTest,
+        EmptyLongStreamTest, EmptyDoubleStreamTest {
+    @Test
+    public abstract void testAll();
+
+    protected final <T> T failing(Class<T> clazz) {
+        return clazz.cast(
+                Proxy.newProxyInstance(
+                        clazz.getClassLoader(),
+                        new Class<?>[]{clazz},
+                        (proxy, method, args) -> {
+                            throw new AssertionError();
+                        }));
+    }
+
+    /**
+     * Helper function that uses reflection to call the rest of the
+     * test method, depending on the parameter types. For example,
+     * to test the Stream class, we would search for methods
+     * beginning with "test" and with two Stream.class parameters,
+     * such as {@link testFilter(Stream,Stream)}.
+     *
+     * @param type             the type of parameters to find test
+     *                         methods for
+     * @param expectedSupplier creates the expected stream
+     * @param actualSupplier   creates the actual stream
+     * @throws ReflectiveOperationException
+     */
+    protected final <E> void compare(Class<?> type,
+                                 Supplier<?> expectedSupplier,
+                                 Supplier<?> actualSupplier) {
+        if (type == null) return;
+        for (Class<?> superInterface : type.getInterfaces()) {
+            compare(superInterface, expectedSupplier, actualSupplier);
+        }
+        try {
+            Class<?>[] parameterTypes = {type, type};
+            for (Method method : getClass().getMethods()) {
+                if (method.getName().startsWith("test") &&
+                        method.getParameterCount() == 2 &&
+                        Arrays.equals(parameterTypes,
+                                method.getParameterTypes())) {
+                    method.invoke(this, expectedSupplier.get(),
+                            actualSupplier.get());
+                }
+            }
+        } catch (InvocationTargetException e) {
+            try {
+                throw e.getCause();
+            } catch (RuntimeException | Error cause) {
+                throw cause;
+            } catch (Throwable other) {
+                throw new AssertionError(other);
+            }
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    protected final void compareResults(Object expected, Object actual) {
+        assertSame(expected.getClass(), actual.getClass());
+        if (expected instanceof List<?> expectedList
+                && actual instanceof List<?> actualList) {
+            assertEquals(expectedList, actualList);
+            assertTrue(actualList.isEmpty());
+        } else if (expected.getClass().isArray() && actual.getClass()
+                .isArray()) {
+            assertEquals(Array.getLength(expected), Array.getLength(actual));
+        } else if (expected instanceof Optional<?> expectedOptional
+                && actual instanceof Optional<?> actualOptional) {
+            assertEquals(expectedOptional, actualOptional);
+            assertTrue(actualOptional.isEmpty());
+        } else if (expected instanceof OptionalInt expectedOptional
+                && actual instanceof OptionalInt actualOptional) {
+            assertEquals(expectedOptional, actualOptional);
+            assertTrue(actualOptional.isEmpty());
+        } else if (expected instanceof OptionalLong expectedOptional
+                && actual instanceof OptionalLong actualOptional) {
+            assertEquals(expectedOptional, actualOptional);
+            assertTrue(actualOptional.isEmpty());
+        } else if (expected instanceof OptionalDouble expectedOptional
+                && actual instanceof OptionalDouble actualOptional) {
+            assertEquals(expectedOptional, actualOptional);
+            assertTrue(actualOptional.isEmpty());
+        } else {
+            throw new IllegalArgumentException("Invalid parameter types");
+        }
+    }
+
+    ///// Methods from BaseStream
+
+    public final void testIterator(BaseStream<?, ?> expected, BaseStream<?, ?> actual) {
+        var expectedResult = expected.iterator();
+        var actualResult = actual.iterator();
+        assertEquals(expectedResult.hasNext(), actualResult.hasNext());
+        assertThrows(NoSuchElementException.class, expectedResult::next);
+        assertThrows(NoSuchElementException.class, actualResult::next);
+        try {
+            expectedResult.remove();
+            fail();
+        } catch (IllegalStateException | UnsupportedOperationException ignore) {
+        }
+        try {
+            actualResult.remove();
+            fail();
+        } catch (IllegalStateException | UnsupportedOperationException ignore) {
+        }
+    }
+
+    public final void testSequential(BaseStream<?, ?> expected, BaseStream<?, ?> actual) {
+        expected = expected.sequential().parallel().sequential();
+        actual = actual.sequential().parallel().sequential();
+        var expectedResult = expected.isParallel();
+        var actualResult = actual.isParallel();
+        assertEquals(expectedResult, actualResult);
+        assertFalse(actualResult);
+    }
+
+    public final void testSequentialIgnoringExpected(BaseStream<?, ?> ignored, BaseStream<?, ?> actual) {
+        assertSame(actual, actual.sequential());
+    }
+
+    public final void testParallelAndIsParallel(BaseStream<?, ?> expected, BaseStream<?, ?> actual) {
+        // The correct way of invoking parallel is to have it inside
+        // a call chain, since we might return a new stream (in our
+        // emptyStream() case we do)
+        expected = expected.parallel();
+        actual = actual.parallel();
+        var expectedResult = expected.isParallel();
+        var actualResult = actual.isParallel();
+        assertEquals(expectedResult, actualResult);
+        assertTrue(actualResult);
+    }
+
+    public final void testUnordered(BaseStream<?, ?> expected, BaseStream<?, ?> actual) {
+        var expectedResult = expected.unordered().spliterator();
+        var actualResult = actual.unordered().spliterator();
+        assertEquals(expectedResult.hasCharacteristics(Spliterator.ORDERED),
+                actualResult.hasCharacteristics(Spliterator.ORDERED));
+        assertFalse(actualResult.hasCharacteristics(Spliterator.ORDERED));
+    }
+
+    public final void testOnCloseAndClose(BaseStream<?, ?> expected, BaseStream<?, ?> actual) {
+        var expectedResult = new AtomicBoolean(false);
+        var actualResult = new AtomicBoolean(false);
+        expected.onClose(() -> expectedResult.set(true)).close();
+        actual.onClose(() -> actualResult.set(true)).close();
+        assertEquals(expectedResult.get(), actualResult.get());
+        assertTrue(actualResult.get());
+    }
+
+    public final void testOnCloseParameters(BaseStream<?, ?> expected, BaseStream<?, ?> actual) {
+        assertThrows(NullPointerException.class, () -> expected.onClose(null));
+        assertThrows(NullPointerException.class, () -> actual.onClose(null));
+    }
+
+
+    public final void testSpliterator(BaseStream<?, ?> expected, BaseStream<?, ?> actual) {
+        var actualResult = actual.spliterator();
+
+        assertTrue(actualResult.hasCharacteristics(Spliterator.SIZED));
+        assertTrue(actualResult.hasCharacteristics(Spliterator.SUBSIZED));
+
+        assertFalse(actualResult.hasCharacteristics(Spliterator.CONCURRENT));
+        assertFalse(actualResult.hasCharacteristics(Spliterator.DISTINCT));
+        assertFalse(actualResult.hasCharacteristics(Spliterator.IMMUTABLE));
+        assertFalse(actualResult.hasCharacteristics(Spliterator.NONNULL));
+        assertFalse(actualResult.hasCharacteristics(Spliterator.ORDERED));
+        assertFalse(actualResult.hasCharacteristics(Spliterator.SORTED));
+
+        assertNull(actualResult.trySplit());
+        actualResult.tryAdvance(failing(Consumer.class));
+        actualResult.forEachRemaining(failing(Consumer.class));
+    }
+
+    private void compareCharacteristics(BaseStream<?, ?> expected, BaseStream<?, ?> actual, String... methodsToCall) {
+        try {
+            for (String method : methodsToCall) {
+                expected = (BaseStream<?, ?>) findMethod(expected, method).invoke(expected);
+                actual = (BaseStream<?, ?>) findMethod(actual, method).invoke(actual);
+            }
+            var actualResult = actual.spliterator().characteristics();
+            var expectedResult = expected.spliterator()
+                    .characteristics();
+            assertEquals(actualResult, expectedResult);
+        } catch (InvocationTargetException e) {
+            try {
+                throw e.getCause();
+            } catch (RuntimeException | Error cause) {
+                throw cause;
+            } catch (Throwable ex) {
+                throw new AssertionError(ex);
+            }
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private Method findMethod(BaseStream<?, ?> stream, String method) throws NoSuchMethodException {
+        if (stream instanceof Stream)
+            return Stream.class.getMethod(method);
+        if (stream instanceof IntStream)
+            return IntStream.class.getMethod(method);
+        if (stream instanceof LongStream)
+            return LongStream.class.getMethod(method);
+        if (stream instanceof DoubleStream)
+            return DoubleStream.class.getMethod(method);
+        throw new AssertionError();
+    }
+
+    private void compareCharacteristics(BaseStream<?, ?> expected, BaseStream<?, ?> actual) {
+        var actualResult = actual.spliterator().characteristics();
+        var expectedResult = expected.spliterator()
+                .characteristics();
+        assertEquals(actualResult, expectedResult);
+    }
+
+    public final void testCharacteristicsDistinct(BaseStream<?, ?> expected, BaseStream<?, ?> actual) {
+        // distinct()
+        compareCharacteristics(expected, actual, "distinct");
+    }
+
+    public final void testCharacteristicsDistinctSorted(BaseStream<?, ?> expected, BaseStream<?, ?> actual) {
+        // sorted().unordered().distinct()
+        compareCharacteristics(expected, actual, "sorted", "unordered", "distinct");
+    }
+
+    public final void testCharacteristicsDistinctOrderedSorted(BaseStream<?, ?> expected, BaseStream<?, ?> actual) {
+        // distinct().sorted()
+        compareCharacteristics(expected, actual, "distinct", "sorted");
+    }
+
+    public final void testCharacteristicsSizedSubsized(BaseStream<?, ?> expected, BaseStream<?, ?> actual) {
+        // String.empty()
+        compareCharacteristics(expected, actual);
+    }
+
+    public final void testCharacteristicsSizedSortedSubsized(BaseStream<?, ?> expected, BaseStream<?, ?> actual) {
+        // sorted().unordered()
+        compareCharacteristics(expected, actual, "sorted", "unordered");
+    }
+
+    public final void testCharacteristicsOrderedSizedSortedSubsized(BaseStream<?, ?> expected, BaseStream<?, ?> actual) {
+        // sorted()
+        compareCharacteristics(expected, actual, "sorted");
+    }
+
+    public final void testCharacteristicsParallelDistinct(BaseStream<?, ?> expected, BaseStream<?, ?> actual) {
+        // parallel().distinct()
+        compareCharacteristics(expected, actual, "parallel", "distinct");
+    }
+
+    public final void testCharacteristicsParallelDistinctSorted(BaseStream<?, ?> expected, BaseStream<?, ?> actual) {
+        // parallel().sorted().unordered().distinct()
+        compareCharacteristics(expected, actual, "sorted", "unordered", "distinct");
+    }
+
+    public final void testCharacteristicsParallelSizedSubsized(BaseStream<?, ?> expected, BaseStream<?, ?> actual) {
+        // parallel()
+        compareCharacteristics(expected, actual, "parallel");
+    }
+
+    public final void testCharacteristicsParallelSizedSortedSubsized(BaseStream<?, ?> expected, BaseStream<?, ?> actual) {
+        // parallel().sorted().unordered()
+        compareCharacteristics(expected, actual, "sorted", "unordered");
+    }
+
+    public final void testCharacteristicsParallelDistinctSizedSortedSubsized(BaseStream<?, ?> expected, BaseStream<?, ?> actual) {
+        // parallel().distinct().sorted().unordered()
+        compareCharacteristics(expected, actual, "distinct", "sorted", "unordered");
+    }
+
+    public final void testCharacteristicsParallelOrderedSizedSortedSubsized(BaseStream<?, ?> expected, BaseStream<?, ?> actual) {
+        // parallel().sorted()
+        compareCharacteristics(expected, actual, "parallel", "sorted");
+    }
+
+    public final void testCharacteristicsParallelDistinctOrderedSizedSortedSubsized(BaseStream<?, ?> expected, BaseStream<?, ?> actual) {
+        //parallel().distinct().sorted()
+        compareCharacteristics(expected, actual, "parallel", "distinct", "sorted");
+    }
+}

--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyDoubleStreamTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyDoubleStreamTest.java
@@ -46,7 +46,7 @@ import static org.testng.Assert.*;
 
 /*
  * @test
- * @summary Checks that the EmptyDoubleStream is equivalent to the
+ * @summary Checks that the EmptyStream is equivalent to the
  * old way of creating it with StreamSupport.
  * @author Heinz Kabutz
  */
@@ -55,340 +55,394 @@ public final class EmptyDoubleStreamTest extends EmptyBaseStreamTest {
     @Test
     public void testAll() {
         this.compare(DoubleStream.class,
-                () -> StreamSupport.doubleStream(Spliterators.emptyDoubleSpliterator(), false),
-                DoubleStream::empty);
+                DoubleStream::empty, () -> StreamSupport.doubleStream(Spliterators.emptyDoubleSpliterator(), false)
+        );
         this.compare(DoubleStream.class,
-                () -> StreamSupport.doubleStream(Spliterators.emptyDoubleSpliterator(), true),
-                () -> DoubleStream.empty().parallel());
+                () -> DoubleStream.empty().parallel(), () -> StreamSupport.doubleStream(Spliterators.emptyDoubleSpliterator(), true)
+        );
     }
 
-    public void testFilter(DoubleStream expected, DoubleStream actual) {
-        expected = expected.filter(failing(DoublePredicate.class));
+    public void testFilter(DoubleStream actual, DoubleStream expected) {
         actual = actual.filter(failing(DoublePredicate.class));
-        var expectedResult = expected.toArray();
+        expected = expected.filter(failing(DoublePredicate.class));
         var actualResult = actual.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testFilterParameters(DoubleStream expected, DoubleStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.filter(null));
-        assertThrows(NullPointerException.class, () -> actual.filter(null));
+    public void testFilterExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "filter", DoublePredicate.class);
     }
 
-    public void testMap(DoubleStream expected, DoubleStream actual) {
-        DoubleStream expectedAsDoubleStream = expected.map(failing(DoubleUnaryOperator.class));
+    public void testMap(DoubleStream actual, DoubleStream expected) {
         DoubleStream actualAsDoubleStream = actual.map(failing(DoubleUnaryOperator.class));
-        var expectedResult = expectedAsDoubleStream.toArray();
+        DoubleStream expectedAsDoubleStream = expected.map(failing(DoubleUnaryOperator.class));
         var actualResult = actualAsDoubleStream.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expectedAsDoubleStream.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMapParameters(DoubleStream expected, DoubleStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.map(null));
-        assertThrows(NullPointerException.class, () -> actual.map(null));
+    public void testMapExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "map", DoubleUnaryOperator.class);
     }
 
-    public void testMapToObj(DoubleStream expected, DoubleStream actual) {
-        Stream<Double> expectedAsStream = expected.mapToObj(failing(DoubleFunction.class));
+    public void testMapToObj(DoubleStream actual, DoubleStream expected) {
         Stream<Double> actualAsStream = actual.mapToObj(failing(DoubleFunction.class));
-        var expectedResult = expectedAsStream.toArray();
+        Stream<Double> expectedAsStream = expected.mapToObj(failing(DoubleFunction.class));
         var actualResult = actualAsStream.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expectedAsStream.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMapToObjParameters(DoubleStream expected, DoubleStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.mapToObj(null));
-        assertThrows(NullPointerException.class, () -> actual.mapToObj(null));
+    public void testMapToObjExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "mapToObj", DoubleFunction.class);
     }
 
-    public void testMapToInt(DoubleStream expected, DoubleStream actual) {
-        IntStream expectedAsDoubleStream = expected.mapToInt(failing(DoubleToIntFunction.class));
-        IntStream actualAsDoubleStream = actual.mapToInt(failing(DoubleToIntFunction.class));
-        var expectedResult = expectedAsDoubleStream.toArray();
-        var actualResult = actualAsDoubleStream.toArray();
-        compareResults(expectedResult, actualResult);
-    }
-
-    public void testMapToIntParameters(DoubleStream expected, DoubleStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.mapToInt(null));
-        assertThrows(NullPointerException.class, () -> actual.mapToInt(null));
-    }
-
-    public void testMapToLong(DoubleStream expected, DoubleStream actual) {
-        LongStream expectedAsDoubleStream = expected.mapToLong(failing(DoubleToLongFunction.class));
-        LongStream actualAsDoubleStream = actual.mapToLong(failing(DoubleToLongFunction.class));
-        var expectedResult = expectedAsDoubleStream.toArray();
-        var actualResult = actualAsDoubleStream.toArray();
-        compareResults(expectedResult, actualResult);
-    }
-
-    public void testMapToDoubleParameters(DoubleStream expected, DoubleStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.mapToLong(null));
-        assertThrows(NullPointerException.class, () -> actual.mapToLong(null));
-    }
-
-    public void testFlatMap(DoubleStream expected, DoubleStream actual) {
-        DoubleStream expectedAsIntStream = expected.flatMap(failing(DoubleFunction.class));
-        DoubleStream actualAsIntStream = actual.flatMap(failing(DoubleFunction.class));
-        var expectedResult = expectedAsIntStream.toArray();
+    public void testMapToInt(DoubleStream actual, DoubleStream expected) {
+        IntStream actualAsIntStream = actual.mapToInt(failing(DoubleToIntFunction.class));
+        IntStream expectedAsIntStream = expected.mapToInt(failing(DoubleToIntFunction.class));
         var actualResult = actualAsIntStream.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expectedAsIntStream.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testFlatMapParameters(DoubleStream expected, DoubleStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.flatMap(null));
-        assertThrows(NullPointerException.class, () -> actual.flatMap(null));
+    public void testMapToIntExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "mapToInt", DoubleToIntFunction.class);
     }
 
-    public void testDistinct(DoubleStream expected, DoubleStream actual) {
-        expected = expected.distinct();
+    public void testMapToDouble(DoubleStream actual, DoubleStream expected) {
+        LongStream actualAsLongStream = actual.mapToLong(failing(DoubleToLongFunction.class));
+        LongStream expectedAsLongStream = expected.mapToLong(failing(DoubleToLongFunction.class));
+        var actualResult = actualAsLongStream.toArray();
+        var expectedResult = expectedAsLongStream.toArray();
+        compareResults(actualResult, expectedResult);
+    }
+
+    public void testMapToDoubleExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "mapToLong", DoubleToLongFunction.class);
+    }
+
+    public void testFlatMap(DoubleStream actual, DoubleStream expected) {
+        DoubleStream actualAsDoubleStream = actual.flatMap(failing(DoubleFunction.class));
+        DoubleStream expectedAsDoubleStream = expected.flatMap(failing(DoubleFunction.class));
+        var actualResult = actualAsDoubleStream.toArray();
+        var expectedResult = expectedAsDoubleStream.toArray();
+        compareResults(actualResult, expectedResult);
+    }
+
+    public void testFlatMapExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "flatMap", DoubleFunction.class);
+    }
+
+    public void testDistinct(DoubleStream actual, DoubleStream expected) {
         actual = actual.distinct();
-        var expectedResult = expected.toArray();
+        expected = expected.distinct();
         var actualResult = actual.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testSorted(DoubleStream expected, DoubleStream actual) {
-        expected = expected.sorted();
+    public void testDistinctExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "distinct");
+    }
+
+    public void testSorted(DoubleStream actual, DoubleStream expected) {
         actual = actual.sorted();
-        var expectedResult = expected.toArray();
+        expected = expected.sorted();
         var actualResult = actual.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testPeek(DoubleStream expected, DoubleStream actual) {
-        expected.peek(failing(DoubleConsumer.class)).toArray();
+    public void testSortedExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "sorted");
+    }
+
+    public void testPeek(DoubleStream actual, DoubleStream expected) {
         actual.peek(failing(DoubleConsumer.class)).toArray();
+        expected.peek(failing(DoubleConsumer.class)).toArray();
     }
 
-    public void testPeekParameters(DoubleStream expected, DoubleStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.peek(null));
-        assertThrows(NullPointerException.class, () -> actual.peek(null));
+    public void testPeekExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "peek", DoubleConsumer.class);
     }
 
-    public void testLimit(DoubleStream expected, DoubleStream actual) {
-        var expectedResult = expected.limit(10).toArray();
+    public void testLimit(DoubleStream actual, DoubleStream expected) {
         var actualResult = actual.limit(10).toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.limit(10).toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testLimitParameters(DoubleStream expected, DoubleStream actual) {
-        assertThrows(IllegalArgumentException.class, () -> expected.limit(-1));
+    public void testLimitExceptions(DoubleStream actual, DoubleStream expected) {
         assertThrows(IllegalArgumentException.class, () -> actual.limit(-1));
+        assertThrows(IllegalArgumentException.class, () -> expected.limit(-1));
+
+        actual.limit(10);
+        expected.limit(10);
+        assertThrows(IllegalStateException.class, () -> actual.limit(10));
+        assertThrows(IllegalStateException.class, () -> expected.limit(10));
     }
 
-    public void testSkip(DoubleStream expected, DoubleStream actual) {
-        var expectedResult = expected.skip(10).toArray();
+    public void testSkip(DoubleStream actual, DoubleStream expected) {
         var actualResult = actual.skip(10).toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.skip(10).toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testSkipParameters(DoubleStream expected, DoubleStream actual) {
-        assertThrows(IllegalArgumentException.class, () -> expected.skip(-1));
+    public void testSkipExceptions(DoubleStream actual, DoubleStream expected) {
         assertThrows(IllegalArgumentException.class, () -> actual.skip(-1));
+        assertThrows(IllegalArgumentException.class, () -> expected.skip(-1));
+
+        actual.skip(0); // should be ok
+        expected.skip(0); // should be ok
+        actual.skip(0); // should be ok
+        expected.skip(0); // should be ok
+
+        actual.skip(10);
+        expected.skip(10);
+        assertThrows(IllegalStateException.class, () -> actual.skip(10));
+        assertThrows(IllegalStateException.class, () -> expected.skip(10));
     }
 
-    public void testForEach(DoubleStream expected, DoubleStream actual) {
-        expected.forEach(failing(DoubleConsumer.class));
+    public void testForEach(DoubleStream actual, DoubleStream expected) {
         actual.forEach(failing(DoubleConsumer.class));
+        expected.forEach(failing(DoubleConsumer.class));
     }
 
-    public void testForEachParameters(DoubleStream expected, DoubleStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.forEach(null));
-        assertThrows(NullPointerException.class, () -> actual.forEach(null));
+    public void testForEachExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "forEach", DoubleConsumer.class);
     }
 
-    public void testForEachOrdered(DoubleStream expected, DoubleStream actual) {
-        expected.forEachOrdered(failing(DoubleConsumer.class));
+    public void testForEachOrdered(DoubleStream actual, DoubleStream expected) {
         actual.forEachOrdered(failing(DoubleConsumer.class));
+        expected.forEachOrdered(failing(DoubleConsumer.class));
     }
 
-    public void testForEachOrderedParameters(DoubleStream expected, DoubleStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.forEachOrdered(null));
-        assertThrows(NullPointerException.class, () -> actual.forEachOrdered(null));
+    public void testForEachOrderedExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "forEachOrdered", DoubleConsumer.class);
     }
 
-    public void testToArray(DoubleStream expected, DoubleStream actual) {
-        var expectedResult = expected.toArray();
+    public void testToArray(DoubleStream actual, DoubleStream expected) {
         var actualResult = actual.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testReduceIntBinaryOperator(DoubleStream expected, DoubleStream actual) {
-        var expectedResult = expected.reduce(failing(DoubleBinaryOperator.class));
+    public void testToArrayExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "toArray");
+    }
+
+    public void testReduceDoubleBinaryOperator(DoubleStream actual, DoubleStream expected) {
         var actualResult = actual.reduce(failing(DoubleBinaryOperator.class));
+        var expectedResult = expected.reduce(failing(DoubleBinaryOperator.class));
 
-        compareResults(expectedResult, actualResult);
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testReduceIntBinaryOperatorParameters(DoubleStream expected, DoubleStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.reduce(null));
-        assertThrows(NullPointerException.class, () -> actual.reduce(null));
+    public void testReduceDoubleBinaryOperatorExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "reduce", DoubleBinaryOperator.class);
     }
 
-    public void testReduceIdentityIntBinaryOperator(DoubleStream expected, DoubleStream actual) {
-        var magicIdentity = 42;
-        var expectedResult = expected.reduce(magicIdentity, failing(DoubleBinaryOperator.class));
+    public void testReduceIdentityDoubleBinaryOperator(DoubleStream actual, DoubleStream expected) {
+        var magicIdentity = 42L;
         var actualResult = actual.reduce(magicIdentity, failing(DoubleBinaryOperator.class));
+        var expectedResult = expected.reduce(magicIdentity, failing(DoubleBinaryOperator.class));
 
-        assertEquals(magicIdentity, expectedResult);
-        assertEquals(magicIdentity, actualResult);
+        assertEquals(actualResult, magicIdentity);
+        assertEquals(expectedResult, magicIdentity);
     }
 
-    public void testReduceIdentityIntBinaryOperatorParameters(DoubleStream expected, DoubleStream actual) {
-        int magicInt = 42;
-        assertThrows(NullPointerException.class, () -> expected.reduce(magicInt, null));
-        assertThrows(NullPointerException.class, () -> actual.reduce(magicInt, null));
+    public void testReduceIdentityDoubleBinaryOperatorExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "reduce", double.class, DoubleBinaryOperator.class);
     }
 
-    public void testCollect(DoubleStream expected, DoubleStream actual) {
+    public void testCollect(DoubleStream actual, DoubleStream expected) {
         var magicIdentity = new Object();
-        Supplier<Object> supplier = () -> magicIdentity;
-        ObjDoubleConsumer<Object> accumulator = failing(ObjDoubleConsumer.class);
-        BiConsumer<Object, Object> combiner = failing(BiConsumer.class);
+        var actualResult = actual.collect(() -> magicIdentity, failing(ObjDoubleConsumer.class), failing(BiConsumer.class));
+        var expectedResult = expected.collect(() -> magicIdentity, failing(ObjDoubleConsumer.class), failing(BiConsumer.class));
 
-        var expectedResult = expected.collect(supplier, accumulator, combiner);
-        var actualResult = actual.collect(supplier, accumulator, combiner);
-
-        assertSame(magicIdentity, expectedResult);
         assertSame(magicIdentity, actualResult);
+        assertSame(magicIdentity, expectedResult);
     }
 
-    public void testCollectParameters(DoubleStream expected, DoubleStream actual) {
+    public void testCollectExceptions(DoubleStream actual, DoubleStream expected) {
         Supplier<Object> supplier = Object::new;
         var accumulator = failing(ObjDoubleConsumer.class);
         var combiner = failing(BiConsumer.class);
-        assertThrows(NullPointerException.class, () -> expected.collect(null, accumulator, combiner));
         assertThrows(NullPointerException.class, () -> actual.collect(null, accumulator, combiner));
-        assertThrows(NullPointerException.class, () -> expected.collect(supplier, null, combiner));
+        assertThrows(NullPointerException.class, () -> expected.collect(null, accumulator, combiner));
         assertThrows(NullPointerException.class, () -> actual.collect(supplier, null, combiner));
-        assertThrows(NullPointerException.class, () -> expected.collect(supplier, accumulator, null));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, null, combiner));
         assertThrows(NullPointerException.class, () -> actual.collect(supplier, accumulator, null));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, accumulator, null));
+
+        actual.collect(supplier, accumulator, combiner);
+        expected.collect(supplier, accumulator, combiner);
+
+        assertThrows(NullPointerException.class, () -> actual.collect(null, accumulator, combiner));
+        assertThrows(NullPointerException.class, () -> expected.collect(null, accumulator, combiner));
+        assertThrows(NullPointerException.class, () -> actual.collect(supplier, null, combiner));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, null, combiner));
+        assertThrows(NullPointerException.class, () -> actual.collect(supplier, accumulator, null));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, accumulator, null));
+
+        assertThrows(IllegalStateException.class, () -> actual.collect(supplier, accumulator, combiner));
+        assertThrows(IllegalStateException.class, () -> expected.collect(supplier, accumulator, combiner));
     }
 
-    public void testSum(DoubleStream expected, DoubleStream actual) {
-        var expectedResult = expected.sum();
+    public void testSum(DoubleStream actual, DoubleStream expected) {
         var actualResult = actual.sum();
+        var expectedResult = expected.sum();
 
-        assertEquals(expectedResult, actualResult);
-        assertEquals(0, actualResult);
+        assertEquals(actualResult, expectedResult);
+        assertEquals(actualResult, 0);
     }
 
-    public void testMin(DoubleStream expected, DoubleStream actual) {
-        var expectedResult = expected.min();
+    public void testSumExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "sum");
+    }
+
+    public void testMin(DoubleStream actual, DoubleStream expected) {
         var actualResult = actual.min();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.min();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMax(DoubleStream expected, DoubleStream actual) {
-        var expectedResult = expected.max();
+    public void testMinExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "min");
+    }
+
+    public void testMax(DoubleStream actual, DoubleStream expected) {
         var actualResult = actual.max();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.max();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testCount(DoubleStream expected, DoubleStream actual) {
-        var expectedResult = expected.count();
+    public void testMaxExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "max");
+    }
+
+    public void testCount(DoubleStream actual, DoubleStream expected) {
         var actualResult = actual.count();
-        assertEquals(expectedResult, actualResult);
-        assertEquals(0L, actualResult);
+        var expectedResult = expected.count();
+        assertEquals(actualResult, expectedResult);
+        assertEquals(actualResult, 0L);
     }
 
-    public void testAverage(DoubleStream expected, DoubleStream actual) {
-        var expectedResult = expected.average();
+    public void testCountExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "count");
+    }
+
+    public void testAverage(DoubleStream actual, DoubleStream expected) {
         var actualResult = actual.average();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.average();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testSummaryStatistics(DoubleStream expected, DoubleStream actual) {
-        var expectedResult = expected.summaryStatistics().toString();
+    public void testAverageExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "average");
+    }
+
+    public void testSummaryStatistics(DoubleStream actual, DoubleStream expected) {
         var actualResult = actual.summaryStatistics().toString();
-        assertEquals(expectedResult, actualResult);
+        var expectedResult = expected.summaryStatistics().toString();
+        assertEquals(actualResult, expectedResult);
     }
 
-    public void testAnyMatch(DoubleStream expected, DoubleStream actual) {
-        var expectedResult = expected.anyMatch(failing(DoublePredicate.class));
+    public void testSummaryStatisticsExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "summaryStatistics");
+    }
+
+    public void testAnyMatch(DoubleStream actual, DoubleStream expected) {
         var actualResult = actual.anyMatch(failing(DoublePredicate.class));
-        assertEquals(expectedResult, actualResult);
+        var expectedResult = expected.anyMatch(failing(DoublePredicate.class));
+        assertEquals(actualResult, expectedResult);
     }
 
-    public void testAnyMatchParameters(DoubleStream expected, DoubleStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.anyMatch(null));
-        assertThrows(NullPointerException.class, () -> actual.anyMatch(null));
+    public void testAnyMatchExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "anyMatch", DoublePredicate.class);
     }
 
-    public void testAllMatch(DoubleStream expected, DoubleStream actual) {
-        var expectedResult = expected.allMatch(failing(DoublePredicate.class));
+    public void testAllMatch(DoubleStream actual, DoubleStream expected) {
         var actualResult = actual.allMatch(failing(DoublePredicate.class));
-        assertEquals(expectedResult, actualResult);
+        var expectedResult = expected.allMatch(failing(DoublePredicate.class));
+        assertEquals(actualResult, expectedResult);
     }
 
-    public void testAllMatchParameters(DoubleStream expected, DoubleStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.allMatch(null));
-        assertThrows(NullPointerException.class, () -> actual.allMatch(null));
+    public void testAllMatchExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "allMatch", DoublePredicate.class);
     }
 
-    public void testNoneMatch(DoubleStream expected, DoubleStream actual) {
-        var expectedResult = expected.noneMatch(failing(DoublePredicate.class));
+    public void testNoneMatch(DoubleStream actual, DoubleStream expected) {
         var actualResult = actual.noneMatch(failing(DoublePredicate.class));
-        assertEquals(expectedResult, actualResult);
+        var expectedResult = expected.noneMatch(failing(DoublePredicate.class));
+        assertEquals(actualResult, expectedResult);
     }
 
-    public void testNoneMatchParameters(DoubleStream expected, DoubleStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.noneMatch(null));
-        assertThrows(NullPointerException.class, () -> actual.noneMatch(null));
+    public void testNoneMatchExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "noneMatch", DoublePredicate.class);
     }
 
-    public void testFindFirst(DoubleStream expected, DoubleStream actual) {
-        var expectedResult = expected.findFirst();
+    public void testFindFirst(DoubleStream actual, DoubleStream expected) {
         var actualResult = actual.findFirst();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.findFirst();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testFindAny(DoubleStream expected, DoubleStream actual) {
-        var expectedResult = expected.findAny();
+    public void testFindFirstExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "findFirst");
+    }
+
+    public void testFindAny(DoubleStream actual, DoubleStream expected) {
         var actualResult = actual.findAny();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.findAny();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testBoxed(DoubleStream expected, DoubleStream actual) {
-        Stream<Double> expectedAsStream = expected.boxed();
+    public void testFindAnyExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "findAny");
+    }
+
+    public void testBoxed(DoubleStream actual, DoubleStream expected) {
         Stream<Double> actualAsStream = actual.boxed();
-        var expectedResult = expectedAsStream.toArray();
+        Stream<Double> expectedAsStream = expected.boxed();
         var actualResult = actualAsStream.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expectedAsStream.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMapMulti(DoubleStream expected, DoubleStream actual) {
-        var expectedResult = expected.mapMulti(failing(DoubleStream.DoubleMapMultiConsumer.class)).toArray();
+    public void testBoxedExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "boxed");
+    }
+
+    public void testMapMulti(DoubleStream actual, DoubleStream expected) {
         var actualResult = actual.mapMulti(failing(DoubleStream.DoubleMapMultiConsumer.class)).toArray();
+        var expectedResult = expected.mapMulti(failing(DoubleStream.DoubleMapMultiConsumer.class)).toArray();
 
-        compareResults(expectedResult, actualResult);
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMapMultiParameters(DoubleStream expected, DoubleStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.mapMulti(null));
-        assertThrows(NullPointerException.class, () -> actual.mapMulti(null));
+    public void testMapMultiExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "mapMulti", DoubleStream.DoubleMapMultiConsumer.class);
     }
 
-    public void testTakeWhile(DoubleStream expected, DoubleStream actual) {
-        var expectedResult = expected.takeWhile(failing(DoublePredicate.class)).toArray();
+    public void testTakeWhile(DoubleStream actual, DoubleStream expected) {
         var actualResult = actual.takeWhile(failing(DoublePredicate.class)).toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.takeWhile(failing(DoublePredicate.class)).toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testTakeWhileParameters(DoubleStream expected, DoubleStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.takeWhile(null));
-        assertThrows(NullPointerException.class, () -> actual.takeWhile(null));
+    public void testTakeWhileExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "takeWhile", DoublePredicate.class);
     }
 
-    public void testDropWhile(DoubleStream expected, DoubleStream actual) {
-        var expectedResult = expected.dropWhile(failing(DoublePredicate.class)).toArray();
+    public void testDropWhile(DoubleStream actual, DoubleStream expected) {
         var actualResult = actual.dropWhile(failing(DoublePredicate.class)).toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.dropWhile(failing(DoublePredicate.class)).toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testDropWhileParameters(DoubleStream expected, DoubleStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.dropWhile(null));
-        assertThrows(NullPointerException.class, () -> actual.dropWhile(null));
+    public void testDropWhileExceptions(DoubleStream actual, DoubleStream expected) {
+        checkExpectedExceptions(actual, expected, "dropWhile", DoublePredicate.class);
     }
 }

--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyDoubleStreamTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyDoubleStreamTest.java
@@ -1,0 +1,394 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.tests.java.util.stream;
+
+import org.testng.annotations.Test;
+
+import java.util.Spliterators;
+import java.util.function.BiConsumer;
+import java.util.function.DoubleBinaryOperator;
+import java.util.function.DoubleConsumer;
+import java.util.function.DoubleFunction;
+import java.util.function.DoublePredicate;
+import java.util.function.DoubleToIntFunction;
+import java.util.function.DoubleToLongFunction;
+import java.util.function.DoubleUnaryOperator;
+import java.util.function.ObjDoubleConsumer;
+import java.util.function.Supplier;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static org.testng.Assert.*;
+
+/*
+ * @test
+ * @summary Checks that the EmptyDoubleStream is equivalent to the
+ * old way of creating it with StreamSupport.
+ * @author Heinz Kabutz
+ */
+
+public final class EmptyDoubleStreamTest extends EmptyBaseStreamTest {
+    @Test
+    public void testAll() {
+        this.compare(DoubleStream.class,
+                () -> StreamSupport.doubleStream(Spliterators.emptyDoubleSpliterator(), false),
+                DoubleStream::empty);
+        this.compare(DoubleStream.class,
+                () -> StreamSupport.doubleStream(Spliterators.emptyDoubleSpliterator(), true),
+                () -> DoubleStream.empty().parallel());
+    }
+
+    public void testFilter(DoubleStream expected, DoubleStream actual) {
+        expected = expected.filter(failing(DoublePredicate.class));
+        actual = actual.filter(failing(DoublePredicate.class));
+        var expectedResult = expected.toArray();
+        var actualResult = actual.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testFilterParameters(DoubleStream expected, DoubleStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.filter(null));
+        assertThrows(NullPointerException.class, () -> actual.filter(null));
+    }
+
+    public void testMap(DoubleStream expected, DoubleStream actual) {
+        DoubleStream expectedAsDoubleStream = expected.map(failing(DoubleUnaryOperator.class));
+        DoubleStream actualAsDoubleStream = actual.map(failing(DoubleUnaryOperator.class));
+        var expectedResult = expectedAsDoubleStream.toArray();
+        var actualResult = actualAsDoubleStream.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMapParameters(DoubleStream expected, DoubleStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.map(null));
+        assertThrows(NullPointerException.class, () -> actual.map(null));
+    }
+
+    public void testMapToObj(DoubleStream expected, DoubleStream actual) {
+        Stream<Double> expectedAsStream = expected.mapToObj(failing(DoubleFunction.class));
+        Stream<Double> actualAsStream = actual.mapToObj(failing(DoubleFunction.class));
+        var expectedResult = expectedAsStream.toArray();
+        var actualResult = actualAsStream.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMapToObjParameters(DoubleStream expected, DoubleStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.mapToObj(null));
+        assertThrows(NullPointerException.class, () -> actual.mapToObj(null));
+    }
+
+    public void testMapToInt(DoubleStream expected, DoubleStream actual) {
+        IntStream expectedAsDoubleStream = expected.mapToInt(failing(DoubleToIntFunction.class));
+        IntStream actualAsDoubleStream = actual.mapToInt(failing(DoubleToIntFunction.class));
+        var expectedResult = expectedAsDoubleStream.toArray();
+        var actualResult = actualAsDoubleStream.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMapToIntParameters(DoubleStream expected, DoubleStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.mapToInt(null));
+        assertThrows(NullPointerException.class, () -> actual.mapToInt(null));
+    }
+
+    public void testMapToLong(DoubleStream expected, DoubleStream actual) {
+        LongStream expectedAsDoubleStream = expected.mapToLong(failing(DoubleToLongFunction.class));
+        LongStream actualAsDoubleStream = actual.mapToLong(failing(DoubleToLongFunction.class));
+        var expectedResult = expectedAsDoubleStream.toArray();
+        var actualResult = actualAsDoubleStream.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMapToDoubleParameters(DoubleStream expected, DoubleStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.mapToLong(null));
+        assertThrows(NullPointerException.class, () -> actual.mapToLong(null));
+    }
+
+    public void testFlatMap(DoubleStream expected, DoubleStream actual) {
+        DoubleStream expectedAsIntStream = expected.flatMap(failing(DoubleFunction.class));
+        DoubleStream actualAsIntStream = actual.flatMap(failing(DoubleFunction.class));
+        var expectedResult = expectedAsIntStream.toArray();
+        var actualResult = actualAsIntStream.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testFlatMapParameters(DoubleStream expected, DoubleStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.flatMap(null));
+        assertThrows(NullPointerException.class, () -> actual.flatMap(null));
+    }
+
+    public void testDistinct(DoubleStream expected, DoubleStream actual) {
+        expected = expected.distinct();
+        actual = actual.distinct();
+        var expectedResult = expected.toArray();
+        var actualResult = actual.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testSorted(DoubleStream expected, DoubleStream actual) {
+        expected = expected.sorted();
+        actual = actual.sorted();
+        var expectedResult = expected.toArray();
+        var actualResult = actual.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testPeek(DoubleStream expected, DoubleStream actual) {
+        expected.peek(failing(DoubleConsumer.class)).toArray();
+        actual.peek(failing(DoubleConsumer.class)).toArray();
+    }
+
+    public void testPeekParameters(DoubleStream expected, DoubleStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.peek(null));
+        assertThrows(NullPointerException.class, () -> actual.peek(null));
+    }
+
+    public void testLimit(DoubleStream expected, DoubleStream actual) {
+        var expectedResult = expected.limit(10).toArray();
+        var actualResult = actual.limit(10).toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testLimitParameters(DoubleStream expected, DoubleStream actual) {
+        assertThrows(IllegalArgumentException.class, () -> expected.limit(-1));
+        assertThrows(IllegalArgumentException.class, () -> actual.limit(-1));
+    }
+
+    public void testSkip(DoubleStream expected, DoubleStream actual) {
+        var expectedResult = expected.skip(10).toArray();
+        var actualResult = actual.skip(10).toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testSkipParameters(DoubleStream expected, DoubleStream actual) {
+        assertThrows(IllegalArgumentException.class, () -> expected.skip(-1));
+        assertThrows(IllegalArgumentException.class, () -> actual.skip(-1));
+    }
+
+    public void testForEach(DoubleStream expected, DoubleStream actual) {
+        expected.forEach(failing(DoubleConsumer.class));
+        actual.forEach(failing(DoubleConsumer.class));
+    }
+
+    public void testForEachParameters(DoubleStream expected, DoubleStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.forEach(null));
+        assertThrows(NullPointerException.class, () -> actual.forEach(null));
+    }
+
+    public void testForEachOrdered(DoubleStream expected, DoubleStream actual) {
+        expected.forEachOrdered(failing(DoubleConsumer.class));
+        actual.forEachOrdered(failing(DoubleConsumer.class));
+    }
+
+    public void testForEachOrderedParameters(DoubleStream expected, DoubleStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.forEachOrdered(null));
+        assertThrows(NullPointerException.class, () -> actual.forEachOrdered(null));
+    }
+
+    public void testToArray(DoubleStream expected, DoubleStream actual) {
+        var expectedResult = expected.toArray();
+        var actualResult = actual.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testReduceIntBinaryOperator(DoubleStream expected, DoubleStream actual) {
+        var expectedResult = expected.reduce(failing(DoubleBinaryOperator.class));
+        var actualResult = actual.reduce(failing(DoubleBinaryOperator.class));
+
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testReduceIntBinaryOperatorParameters(DoubleStream expected, DoubleStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.reduce(null));
+        assertThrows(NullPointerException.class, () -> actual.reduce(null));
+    }
+
+    public void testReduceIdentityIntBinaryOperator(DoubleStream expected, DoubleStream actual) {
+        var magicIdentity = 42;
+        var expectedResult = expected.reduce(magicIdentity, failing(DoubleBinaryOperator.class));
+        var actualResult = actual.reduce(magicIdentity, failing(DoubleBinaryOperator.class));
+
+        assertEquals(magicIdentity, expectedResult);
+        assertEquals(magicIdentity, actualResult);
+    }
+
+    public void testReduceIdentityIntBinaryOperatorParameters(DoubleStream expected, DoubleStream actual) {
+        int magicInt = 42;
+        assertThrows(NullPointerException.class, () -> expected.reduce(magicInt, null));
+        assertThrows(NullPointerException.class, () -> actual.reduce(magicInt, null));
+    }
+
+    public void testCollect(DoubleStream expected, DoubleStream actual) {
+        var magicIdentity = new Object();
+        Supplier<Object> supplier = () -> magicIdentity;
+        ObjDoubleConsumer<Object> accumulator = failing(ObjDoubleConsumer.class);
+        BiConsumer<Object, Object> combiner = failing(BiConsumer.class);
+
+        var expectedResult = expected.collect(supplier, accumulator, combiner);
+        var actualResult = actual.collect(supplier, accumulator, combiner);
+
+        assertSame(magicIdentity, expectedResult);
+        assertSame(magicIdentity, actualResult);
+    }
+
+    public void testCollectParameters(DoubleStream expected, DoubleStream actual) {
+        Supplier<Object> supplier = Object::new;
+        var accumulator = failing(ObjDoubleConsumer.class);
+        var combiner = failing(BiConsumer.class);
+        assertThrows(NullPointerException.class, () -> expected.collect(null, accumulator, combiner));
+        assertThrows(NullPointerException.class, () -> actual.collect(null, accumulator, combiner));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, null, combiner));
+        assertThrows(NullPointerException.class, () -> actual.collect(supplier, null, combiner));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, accumulator, null));
+        assertThrows(NullPointerException.class, () -> actual.collect(supplier, accumulator, null));
+    }
+
+    public void testSum(DoubleStream expected, DoubleStream actual) {
+        var expectedResult = expected.sum();
+        var actualResult = actual.sum();
+
+        assertEquals(expectedResult, actualResult);
+        assertEquals(0, actualResult);
+    }
+
+    public void testMin(DoubleStream expected, DoubleStream actual) {
+        var expectedResult = expected.min();
+        var actualResult = actual.min();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMax(DoubleStream expected, DoubleStream actual) {
+        var expectedResult = expected.max();
+        var actualResult = actual.max();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testCount(DoubleStream expected, DoubleStream actual) {
+        var expectedResult = expected.count();
+        var actualResult = actual.count();
+        assertEquals(expectedResult, actualResult);
+        assertEquals(0L, actualResult);
+    }
+
+    public void testAverage(DoubleStream expected, DoubleStream actual) {
+        var expectedResult = expected.average();
+        var actualResult = actual.average();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testSummaryStatistics(DoubleStream expected, DoubleStream actual) {
+        var expectedResult = expected.summaryStatistics().toString();
+        var actualResult = actual.summaryStatistics().toString();
+        assertEquals(expectedResult, actualResult);
+    }
+
+    public void testAnyMatch(DoubleStream expected, DoubleStream actual) {
+        var expectedResult = expected.anyMatch(failing(DoublePredicate.class));
+        var actualResult = actual.anyMatch(failing(DoublePredicate.class));
+        assertEquals(expectedResult, actualResult);
+    }
+
+    public void testAnyMatchParameters(DoubleStream expected, DoubleStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.anyMatch(null));
+        assertThrows(NullPointerException.class, () -> actual.anyMatch(null));
+    }
+
+    public void testAllMatch(DoubleStream expected, DoubleStream actual) {
+        var expectedResult = expected.allMatch(failing(DoublePredicate.class));
+        var actualResult = actual.allMatch(failing(DoublePredicate.class));
+        assertEquals(expectedResult, actualResult);
+    }
+
+    public void testAllMatchParameters(DoubleStream expected, DoubleStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.allMatch(null));
+        assertThrows(NullPointerException.class, () -> actual.allMatch(null));
+    }
+
+    public void testNoneMatch(DoubleStream expected, DoubleStream actual) {
+        var expectedResult = expected.noneMatch(failing(DoublePredicate.class));
+        var actualResult = actual.noneMatch(failing(DoublePredicate.class));
+        assertEquals(expectedResult, actualResult);
+    }
+
+    public void testNoneMatchParameters(DoubleStream expected, DoubleStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.noneMatch(null));
+        assertThrows(NullPointerException.class, () -> actual.noneMatch(null));
+    }
+
+    public void testFindFirst(DoubleStream expected, DoubleStream actual) {
+        var expectedResult = expected.findFirst();
+        var actualResult = actual.findFirst();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testFindAny(DoubleStream expected, DoubleStream actual) {
+        var expectedResult = expected.findAny();
+        var actualResult = actual.findAny();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testBoxed(DoubleStream expected, DoubleStream actual) {
+        Stream<Double> expectedAsStream = expected.boxed();
+        Stream<Double> actualAsStream = actual.boxed();
+        var expectedResult = expectedAsStream.toArray();
+        var actualResult = actualAsStream.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMapMulti(DoubleStream expected, DoubleStream actual) {
+        var expectedResult = expected.mapMulti(failing(DoubleStream.DoubleMapMultiConsumer.class)).toArray();
+        var actualResult = actual.mapMulti(failing(DoubleStream.DoubleMapMultiConsumer.class)).toArray();
+
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMapMultiParameters(DoubleStream expected, DoubleStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.mapMulti(null));
+        assertThrows(NullPointerException.class, () -> actual.mapMulti(null));
+    }
+
+    public void testTakeWhile(DoubleStream expected, DoubleStream actual) {
+        var expectedResult = expected.takeWhile(failing(DoublePredicate.class)).toArray();
+        var actualResult = actual.takeWhile(failing(DoublePredicate.class)).toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testTakeWhileParameters(DoubleStream expected, DoubleStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.takeWhile(null));
+        assertThrows(NullPointerException.class, () -> actual.takeWhile(null));
+    }
+
+    public void testDropWhile(DoubleStream expected, DoubleStream actual) {
+        var expectedResult = expected.dropWhile(failing(DoublePredicate.class)).toArray();
+        var actualResult = actual.dropWhile(failing(DoublePredicate.class)).toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testDropWhileParameters(DoubleStream expected, DoubleStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.dropWhile(null));
+        assertThrows(NullPointerException.class, () -> actual.dropWhile(null));
+    }
+}

--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyDoubleStreamTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyDoubleStreamTest.java
@@ -25,6 +25,8 @@ package org.openjdk.tests.java.util.stream;
 
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.function.BiConsumer;
 import java.util.function.DoubleBinaryOperator;
@@ -34,6 +36,7 @@ import java.util.function.DoublePredicate;
 import java.util.function.DoubleToIntFunction;
 import java.util.function.DoubleToLongFunction;
 import java.util.function.DoubleUnaryOperator;
+import java.util.function.Function;
 import java.util.function.ObjDoubleConsumer;
 import java.util.function.Supplier;
 import java.util.stream.DoubleStream;
@@ -54,11 +57,22 @@ import static org.testng.Assert.*;
 public final class EmptyDoubleStreamTest extends EmptyBaseStreamTest {
     @Test
     public void testAll() {
+        Function<Spliterator.OfDouble, DoubleStream> emptyStreamCreator =
+                StreamSupport::emptyDoubleStream;
+        Function<Spliterator.OfDouble, DoubleStream> traditionalStreamCreator =
+                spliterator -> StreamSupport.doubleStream(spliterator, false);
+
         this.compare(DoubleStream.class,
-                DoubleStream::empty, () -> StreamSupport.doubleStream(Spliterators.emptyDoubleSpliterator(), false)
+                () -> emptyStreamCreator.apply(Spliterators.emptyDoubleSpliterator()),
+                () -> traditionalStreamCreator.apply(Spliterators.emptyDoubleSpliterator())
         );
         this.compare(DoubleStream.class,
-                () -> DoubleStream.empty().parallel(), () -> StreamSupport.doubleStream(Spliterators.emptyDoubleSpliterator(), true)
+                () -> emptyStreamCreator.apply(Spliterators.emptyDoubleSpliterator()).parallel(),
+                () -> traditionalStreamCreator.apply(Spliterators.emptyDoubleSpliterator()).parallel()
+        );
+        this.compare(DoubleStream.class,
+                () -> emptyStreamCreator.apply(Arrays.spliterator(new double[0])),
+                () -> traditionalStreamCreator.apply(Arrays.spliterator(new double[0]))
         );
     }
 

--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyIntStreamTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyIntStreamTest.java
@@ -46,7 +46,7 @@ import static org.testng.Assert.*;
 
 /*
  * @test
- * @summary Checks that the EmptyIntStream is equivalent to the
+ * @summary Checks that the EmptyInttream is equivalent to the
  * old way of creating it with StreamSupport.
  * @author Heinz Kabutz
  */
@@ -55,352 +55,418 @@ public final class EmptyIntStreamTest extends EmptyBaseStreamTest {
     @Test
     public void testAll() {
         this.compare(IntStream.class,
-                () -> StreamSupport.intStream(Spliterators.emptyIntSpliterator(), false),
-                IntStream::empty);
+                IntStream::empty, () -> StreamSupport.intStream(Spliterators.emptyIntSpliterator(), false)
+        );
         this.compare(IntStream.class,
-                () -> StreamSupport.intStream(Spliterators.emptyIntSpliterator(), true),
-                () -> IntStream.empty().parallel());
+                () -> IntStream.empty().parallel(), () -> StreamSupport.intStream(Spliterators.emptyIntSpliterator(), true)
+        );
     }
 
-    public void testFilter(IntStream expected, IntStream actual) {
-        expected = expected.filter(failing(IntPredicate.class));
+    public void testFilter(IntStream actual, IntStream expected) {
         actual = actual.filter(failing(IntPredicate.class));
-        var expectedResult = expected.toArray();
+        expected = expected.filter(failing(IntPredicate.class));
         var actualResult = actual.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testFilterParameters(IntStream expected, IntStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.filter(null));
-        assertThrows(NullPointerException.class, () -> actual.filter(null));
+    public void testFilterExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "filter", IntPredicate.class);
     }
 
-    public void testMap(IntStream expected, IntStream actual) {
-        IntStream expectedAsIntStream = expected.map(failing(IntUnaryOperator.class));
+    public void testMap(IntStream actual, IntStream expected) {
         IntStream actualAsIntStream = actual.map(failing(IntUnaryOperator.class));
-        var expectedResult = expectedAsIntStream.toArray();
+        IntStream expectedAsIntStream = expected.map(failing(IntUnaryOperator.class));
         var actualResult = actualAsIntStream.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expectedAsIntStream.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMapParameters(IntStream expected, IntStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.map(null));
-        assertThrows(NullPointerException.class, () -> actual.map(null));
+    public void testMapExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "map", IntUnaryOperator.class);
     }
 
-    public void testMapToObj(IntStream expected, IntStream actual) {
-        Stream<Integer> expectedAsStream = expected.mapToObj(failing(IntFunction.class));
+    public void testMapToObj(IntStream actual, IntStream expected) {
         Stream<Integer> actualAsStream = actual.mapToObj(failing(IntFunction.class));
-        var expectedResult = expectedAsStream.toArray();
+        Stream<Integer> expectedAsStream = expected.mapToObj(failing(IntFunction.class));
         var actualResult = actualAsStream.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expectedAsStream.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMapToObjParameters(IntStream expected, IntStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.mapToObj(null));
-        assertThrows(NullPointerException.class, () -> actual.mapToObj(null));
+    public void testMapToObjExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "mapToObj", IntFunction.class);
     }
 
-    public void testMapToLong(IntStream expected, IntStream actual) {
-        LongStream expectedAsLongStream = expected.mapToLong(failing(IntToLongFunction.class));
+    public void testMapToLong(IntStream actual, IntStream expected) {
         LongStream actualAsLongStream = actual.mapToLong(failing(IntToLongFunction.class));
-        var expectedResult = expectedAsLongStream.toArray();
+        LongStream expectedAsLongStream = expected.mapToLong(failing(IntToLongFunction.class));
         var actualResult = actualAsLongStream.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expectedAsLongStream.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMapToLongParameters(IntStream expected, IntStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.mapToLong(null));
-        assertThrows(NullPointerException.class, () -> actual.mapToLong(null));
+    public void testMapToLongExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "mapToLong", IntToLongFunction.class);
     }
 
-    public void testMapToDouble(IntStream expected, IntStream actual) {
-        DoubleStream expectedAsDoubleStream = expected.mapToDouble(failing(IntToDoubleFunction.class));
+    public void testMapToDouble(IntStream actual, IntStream expected) {
         DoubleStream actualAsDoubleStream = actual.mapToDouble(failing(IntToDoubleFunction.class));
-        var expectedResult = expectedAsDoubleStream.toArray();
+        DoubleStream expectedAsDoubleStream = expected.mapToDouble(failing(IntToDoubleFunction.class));
         var actualResult = actualAsDoubleStream.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expectedAsDoubleStream.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMapToDoubleParameters(IntStream expected, IntStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.mapToDouble(null));
-        assertThrows(NullPointerException.class, () -> actual.mapToDouble(null));
+    public void testMapToDoubleExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "mapToDouble", IntToDoubleFunction.class);
     }
 
-    public void testFlatMap(IntStream expected, IntStream actual) {
-        IntStream expectedAsIntStream = expected.flatMap(failing(IntFunction.class));
+    public void testFlatMap(IntStream actual, IntStream expected) {
         IntStream actualAsIntStream = actual.flatMap(failing(IntFunction.class));
-        var expectedResult = expectedAsIntStream.toArray();
+        IntStream expectedAsIntStream = expected.flatMap(failing(IntFunction.class));
         var actualResult = actualAsIntStream.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expectedAsIntStream.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testFlatMapParameters(IntStream expected, IntStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.flatMap(null));
-        assertThrows(NullPointerException.class, () -> actual.flatMap(null));
+    public void testFlatMapExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "flatMap", IntFunction.class);
     }
 
-    public void testDistinct(IntStream expected, IntStream actual) {
-        expected = expected.distinct();
+    public void testDistinct(IntStream actual, IntStream expected) {
         actual = actual.distinct();
-        var expectedResult = expected.toArray();
+        expected = expected.distinct();
         var actualResult = actual.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testSorted(IntStream expected, IntStream actual) {
-        expected = expected.sorted();
+    public void testDistinctExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "distinct");
+    }
+
+    public void testSorted(IntStream actual, IntStream expected) {
         actual = actual.sorted();
-        var expectedResult = expected.toArray();
+        expected = expected.sorted();
         var actualResult = actual.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testPeek(IntStream expected, IntStream actual) {
-        expected.peek(failing(IntConsumer.class)).toArray();
+    public void testSortedExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "sorted");
+    }
+
+    public void testPeek(IntStream actual, IntStream expected) {
         actual.peek(failing(IntConsumer.class)).toArray();
+        expected.peek(failing(IntConsumer.class)).toArray();
     }
 
-    public void testPeekParameters(IntStream expected, IntStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.peek(null));
-        assertThrows(NullPointerException.class, () -> actual.peek(null));
+    public void testPeekExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "peek", IntConsumer.class);
     }
 
-    public void testLimit(IntStream expected, IntStream actual) {
-        var expectedResult = expected.limit(10).toArray();
+    public void testLimit(IntStream actual, IntStream expected) {
         var actualResult = actual.limit(10).toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.limit(10).toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testLimitParameters(IntStream expected, IntStream actual) {
-        assertThrows(IllegalArgumentException.class, () -> expected.limit(-1));
+    public void testLimitExceptions(IntStream actual, IntStream expected) {
         assertThrows(IllegalArgumentException.class, () -> actual.limit(-1));
+        assertThrows(IllegalArgumentException.class, () -> expected.limit(-1));
+
+        actual.limit(10);
+        expected.limit(10);
+        assertThrows(IllegalStateException.class, () -> actual.limit(10));
+        assertThrows(IllegalStateException.class, () -> expected.limit(10));
     }
 
-    public void testSkip(IntStream expected, IntStream actual) {
-        var expectedResult = expected.skip(10).toArray();
+    public void testSkip(IntStream actual, IntStream expected) {
         var actualResult = actual.skip(10).toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.skip(10).toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testSkipParameters(IntStream expected, IntStream actual) {
-        assertThrows(IllegalArgumentException.class, () -> expected.skip(-1));
+    public void testSkipExceptions(IntStream actual, IntStream expected) {
         assertThrows(IllegalArgumentException.class, () -> actual.skip(-1));
+        assertThrows(IllegalArgumentException.class, () -> expected.skip(-1));
+
+        actual.skip(0); // should be ok
+        expected.skip(0); // should be ok
+        actual.skip(0); // should be ok
+        expected.skip(0); // should be ok
+
+        actual.skip(10);
+        expected.skip(10);
+        assertThrows(IllegalStateException.class, () -> actual.skip(10));
+        assertThrows(IllegalStateException.class, () -> expected.skip(10));
     }
 
-    public void testForEach(IntStream expected, IntStream actual) {
-        expected.forEach(failing(IntConsumer.class));
+    public void testForEach(IntStream actual, IntStream expected) {
         actual.forEach(failing(IntConsumer.class));
+        expected.forEach(failing(IntConsumer.class));
     }
 
-    public void testForEachParameters(IntStream expected, IntStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.forEach(null));
-        assertThrows(NullPointerException.class, () -> actual.forEach(null));
+    public void testForEachExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "forEach", IntConsumer.class);
     }
 
-    public void testForEachOrdered(IntStream expected, IntStream actual) {
-        expected.forEachOrdered(failing(IntConsumer.class));
+    public void testForEachOrdered(IntStream actual, IntStream expected) {
         actual.forEachOrdered(failing(IntConsumer.class));
+        expected.forEachOrdered(failing(IntConsumer.class));
     }
 
-    public void testForEachOrderedParameters(IntStream expected, IntStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.forEachOrdered(null));
-        assertThrows(NullPointerException.class, () -> actual.forEachOrdered(null));
+    public void testForEachOrderedExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "forEachOrdered", IntConsumer.class);
     }
 
-    public void testToArray(IntStream expected, IntStream actual) {
-        var expectedResult = expected.toArray();
+    public void testToArray(IntStream actual, IntStream expected) {
         var actualResult = actual.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testReduceIntBinaryOperator(IntStream expected, IntStream actual) {
-        var expectedResult = expected.reduce(failing(IntBinaryOperator.class));
+    public void testToArrayExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "toArray");
+    }
+
+    public void testReduceIntBinaryOperator(IntStream actual, IntStream expected) {
         var actualResult = actual.reduce(failing(IntBinaryOperator.class));
+        var expectedResult = expected.reduce(failing(IntBinaryOperator.class));
 
-        compareResults(expectedResult, actualResult);
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testReduceIntBinaryOperatorParameters(IntStream expected, IntStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.reduce(null));
-        assertThrows(NullPointerException.class, () -> actual.reduce(null));
+    public void testReduceIntBinaryOperatorExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "reduce", IntBinaryOperator.class);
     }
 
-    public void testReduceIdentityIntBinaryOperator(IntStream expected, IntStream actual) {
+    public void testReduceIdentityIntBinaryOperator(IntStream actual, IntStream expected) {
         var magicIdentity = 42;
-        var expectedResult = expected.reduce(magicIdentity, failing(IntBinaryOperator.class));
         var actualResult = actual.reduce(magicIdentity, failing(IntBinaryOperator.class));
+        var expectedResult = expected.reduce(magicIdentity, failing(IntBinaryOperator.class));
 
-        assertEquals(magicIdentity, expectedResult);
-        assertEquals(magicIdentity, actualResult);
+        assertEquals(actualResult, magicIdentity);
+        assertEquals(expectedResult, magicIdentity);
     }
 
-    public void testReduceIdentityIntBinaryOperatorParameters(IntStream expected, IntStream actual) {
-        int magicInt = 42;
-        assertThrows(NullPointerException.class, () -> expected.reduce(magicInt, null));
-        assertThrows(NullPointerException.class, () -> actual.reduce(magicInt, null));
+    public void testReduceIdentityIntBinaryOperatorExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "reduce", int.class, IntBinaryOperator.class);
     }
 
-    public void testCollect(IntStream expected, IntStream actual) {
+    public void testCollect(IntStream actual, IntStream expected) {
         var magicIdentity = new Object();
-        var expectedResult = expected.collect(() -> magicIdentity, failing(ObjIntConsumer.class), failing(BiConsumer.class));
         var actualResult = actual.collect(() -> magicIdentity, failing(ObjIntConsumer.class), failing(BiConsumer.class));
+        var expectedResult = expected.collect(() -> magicIdentity, failing(ObjIntConsumer.class), failing(BiConsumer.class));
 
-        assertSame(magicIdentity, expectedResult);
         assertSame(magicIdentity, actualResult);
+        assertSame(magicIdentity, expectedResult);
     }
 
-    public void testCollectParameters(IntStream expected, IntStream actual) {
+    public void testCollectExceptions(IntStream actual, IntStream expected) {
         Supplier<Object> supplier = Object::new;
         var accumulator = failing(ObjIntConsumer.class);
         var combiner = failing(BiConsumer.class);
-        assertThrows(NullPointerException.class, () -> expected.collect(null, accumulator, combiner));
         assertThrows(NullPointerException.class, () -> actual.collect(null, accumulator, combiner));
-        assertThrows(NullPointerException.class, () -> expected.collect(supplier, null, combiner));
+        assertThrows(NullPointerException.class, () -> expected.collect(null, accumulator, combiner));
         assertThrows(NullPointerException.class, () -> actual.collect(supplier, null, combiner));
-        assertThrows(NullPointerException.class, () -> expected.collect(supplier, accumulator, null));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, null, combiner));
         assertThrows(NullPointerException.class, () -> actual.collect(supplier, accumulator, null));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, accumulator, null));
+
+        actual.collect(supplier, accumulator, combiner);
+        expected.collect(supplier, accumulator, combiner);
+
+        assertThrows(NullPointerException.class, () -> actual.collect(null, accumulator, combiner));
+        assertThrows(NullPointerException.class, () -> expected.collect(null, accumulator, combiner));
+        assertThrows(NullPointerException.class, () -> actual.collect(supplier, null, combiner));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, null, combiner));
+        assertThrows(NullPointerException.class, () -> actual.collect(supplier, accumulator, null));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, accumulator, null));
+
+        assertThrows(IllegalStateException.class, () -> actual.collect(supplier, accumulator, combiner));
+        assertThrows(IllegalStateException.class, () -> expected.collect(supplier, accumulator, combiner));
     }
 
-    public void testSum(IntStream expected, IntStream actual) {
-        var expectedResult = expected.sum();
+    public void testSum(IntStream actual, IntStream expected) {
         var actualResult = actual.sum();
+        var expectedResult = expected.sum();
 
-        assertEquals(expectedResult, actualResult);
-        assertEquals(0, actualResult);
+        assertEquals(actualResult, expectedResult);
+        assertEquals(actualResult, 0);
     }
 
-    public void testMin(IntStream expected, IntStream actual) {
-        var expectedResult = expected.min();
+    public void testSumExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "sum");
+    }
+
+    public void testMin(IntStream actual, IntStream expected) {
         var actualResult = actual.min();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.min();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMax(IntStream expected, IntStream actual) {
-        var expectedResult = expected.max();
+    public void testMinExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "min");
+    }
+
+    public void testMax(IntStream actual, IntStream expected) {
         var actualResult = actual.max();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.max();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testCount(IntStream expected, IntStream actual) {
-        var expectedResult = expected.count();
+    public void testMaxExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "max");
+    }
+
+    public void testCount(IntStream actual, IntStream expected) {
         var actualResult = actual.count();
-        assertEquals(expectedResult, actualResult);
-        assertEquals(0L, actualResult);
+        var expectedResult = expected.count();
+        assertEquals(actualResult, expectedResult);
+        assertEquals(actualResult, 0L);
     }
 
-    public void testAverage(IntStream expected, IntStream actual) {
-        var expectedResult = expected.average();
+    public void testCountExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "count");
+    }
+
+    public void testAverage(IntStream actual, IntStream expected) {
         var actualResult = actual.average();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.average();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testSummaryStatistics(IntStream expected, IntStream actual) {
-        var expectedResult = expected.summaryStatistics().toString();
+    public void testAverageExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "average");
+    }
+
+    public void testSummaryStatistics(IntStream actual, IntStream expected) {
         var actualResult = actual.summaryStatistics().toString();
-        assertEquals(expectedResult, actualResult);
+        var expectedResult = expected.summaryStatistics().toString();
+        assertEquals(actualResult, expectedResult);
     }
 
-    public void testAnyMatch(IntStream expected, IntStream actual) {
-        var expectedResult = expected.anyMatch(failing(IntPredicate.class));
+    public void testSummaryStatisticsExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "summaryStatistics");
+    }
+
+    public void testAnyMatch(IntStream actual, IntStream expected) {
         var actualResult = actual.anyMatch(failing(IntPredicate.class));
-        assertEquals(expectedResult, actualResult);
+        var expectedResult = expected.anyMatch(failing(IntPredicate.class));
+        assertEquals(actualResult, expectedResult);
     }
 
-    public void testAnyMatchParameters(IntStream expected, IntStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.anyMatch(null));
-        assertThrows(NullPointerException.class, () -> actual.anyMatch(null));
+    public void testAnyMatchExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "anyMatch", IntPredicate.class);
     }
 
-    public void testAllMatch(IntStream expected, IntStream actual) {
-        var expectedResult = expected.allMatch(failing(IntPredicate.class));
+    public void testAllMatch(IntStream actual, IntStream expected) {
         var actualResult = actual.allMatch(failing(IntPredicate.class));
-        assertEquals(expectedResult, actualResult);
+        var expectedResult = expected.allMatch(failing(IntPredicate.class));
+        assertEquals(actualResult, expectedResult);
     }
 
-    public void testAllMatchParameters(IntStream expected, IntStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.allMatch(null));
-        assertThrows(NullPointerException.class, () -> actual.allMatch(null));
+    public void testAllMatchExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "allMatch", IntPredicate.class);
     }
 
-    public void testNoneMatch(IntStream expected, IntStream actual) {
-        var expectedResult = expected.noneMatch(failing(IntPredicate.class));
+    public void testNoneMatch(IntStream actual, IntStream expected) {
         var actualResult = actual.noneMatch(failing(IntPredicate.class));
-        assertEquals(expectedResult, actualResult);
+        var expectedResult = expected.noneMatch(failing(IntPredicate.class));
+        assertEquals(actualResult, expectedResult);
     }
 
-    public void testNoneMatchParameters(IntStream expected, IntStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.noneMatch(null));
-        assertThrows(NullPointerException.class, () -> actual.noneMatch(null));
+    public void testNoneMatchExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "noneMatch", IntPredicate.class);
     }
 
-    public void testFindFirst(IntStream expected, IntStream actual) {
-        var expectedResult = expected.findFirst();
+    public void testFindFirst(IntStream actual, IntStream expected) {
         var actualResult = actual.findFirst();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.findFirst();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testFindAny(IntStream expected, IntStream actual) {
-        var expectedResult = expected.findAny();
+    public void testFindFirstExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "findFirst");
+    }
+
+    public void testFindAny(IntStream actual, IntStream expected) {
         var actualResult = actual.findAny();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.findAny();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testAsLongStream(IntStream expected, IntStream actual) {
-        LongStream expectedAsLongStream = expected.asLongStream();
+    public void testFindAnyExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "findAny");
+    }
+
+    public void testAsLongStream(IntStream actual, IntStream expected) {
         LongStream actualAsLongStream = actual.asLongStream();
-        long[] expectedResult = expectedAsLongStream.toArray();
+        LongStream expectedAsLongStream = expected.asLongStream();
         long[] actualResult = actualAsLongStream.toArray();
-        compareResults(expectedResult, actualResult);
+        long[] expectedResult = expectedAsLongStream.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testAsDoubleStream(IntStream expected, IntStream actual) {
-        DoubleStream expectedAsDoubleStream = expected.asDoubleStream();
+    public void testAsLongStreamExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "asLongStream");
+    }
+
+    public void testAsDoubleStream(IntStream actual, IntStream expected) {
         DoubleStream actualAsDoubleStream = actual.asDoubleStream();
-        double[] expectedResult = expectedAsDoubleStream.toArray();
+        DoubleStream expectedAsDoubleStream = expected.asDoubleStream();
         double[] actualResult = actualAsDoubleStream.toArray();
-        compareResults(expectedResult, actualResult);
+        double[] expectedResult = expectedAsDoubleStream.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testBoxed(IntStream expected, IntStream actual) {
-        Stream<Integer> expectedAsStream = expected.boxed();
+    public void testAsDoubleStreamExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "asDoubleStream");
+    }
+
+    public void testBoxed(IntStream actual, IntStream expected) {
         Stream<Integer> actualAsStream = actual.boxed();
-        var expectedResult = expectedAsStream.toArray();
+        Stream<Integer> expectedAsStream = expected.boxed();
         var actualResult = actualAsStream.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expectedAsStream.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMapMulti(IntStream expected, IntStream actual) {
-        var expectedResult = expected.mapMulti(failing(IntStream.IntMapMultiConsumer.class)).toArray();
+    public void testBoxedExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "boxed");
+    }
+
+    public void testMapMulti(IntStream actual, IntStream expected) {
         var actualResult = actual.mapMulti(failing(IntStream.IntMapMultiConsumer.class)).toArray();
+        var expectedResult = expected.mapMulti(failing(IntStream.IntMapMultiConsumer.class)).toArray();
 
-        compareResults(expectedResult, actualResult);
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMapMultiParameters(IntStream expected, IntStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.mapMulti(null));
-        assertThrows(NullPointerException.class, () -> actual.mapMulti(null));
+    public void testMapMultiExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "mapMulti", IntStream.IntMapMultiConsumer.class);
     }
 
-    public void testTakeWhile(IntStream expected, IntStream actual) {
-        var expectedResult = expected.takeWhile(failing(IntPredicate.class)).toArray();
+    public void testTakeWhile(IntStream actual, IntStream expected) {
         var actualResult = actual.takeWhile(failing(IntPredicate.class)).toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.takeWhile(failing(IntPredicate.class)).toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testTakeWhileParameters(IntStream expected, IntStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.takeWhile(null));
-        assertThrows(NullPointerException.class, () -> actual.takeWhile(null));
+    public void testTakeWhileExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "takeWhile", IntPredicate.class);
     }
 
-    public void testDropWhile(IntStream expected, IntStream actual) {
-        var expectedResult = expected.dropWhile(failing(IntPredicate.class)).toArray();
+    public void testDropWhile(IntStream actual, IntStream expected) {
         var actualResult = actual.dropWhile(failing(IntPredicate.class)).toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.dropWhile(failing(IntPredicate.class)).toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testDropWhileParameters(IntStream expected, IntStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.dropWhile(null));
-        assertThrows(NullPointerException.class, () -> actual.dropWhile(null));
+    public void testDropWhileExceptions(IntStream actual, IntStream expected) {
+        checkExpectedExceptions(actual, expected, "dropWhile", IntPredicate.class);
     }
 }

--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyIntStreamTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyIntStreamTest.java
@@ -1,0 +1,406 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.tests.java.util.stream;
+
+import org.testng.annotations.Test;
+
+import java.util.Spliterators;
+import java.util.function.BiConsumer;
+import java.util.function.IntBinaryOperator;
+import java.util.function.IntConsumer;
+import java.util.function.IntFunction;
+import java.util.function.IntPredicate;
+import java.util.function.IntToDoubleFunction;
+import java.util.function.IntToLongFunction;
+import java.util.function.IntUnaryOperator;
+import java.util.function.ObjIntConsumer;
+import java.util.function.Supplier;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static org.testng.Assert.*;
+
+/*
+ * @test
+ * @summary Checks that the EmptyIntStream is equivalent to the
+ * old way of creating it with StreamSupport.
+ * @author Heinz Kabutz
+ */
+
+public final class EmptyIntStreamTest extends EmptyBaseStreamTest {
+    @Test
+    public void testAll() {
+        this.compare(IntStream.class,
+                () -> StreamSupport.intStream(Spliterators.emptyIntSpliterator(), false),
+                IntStream::empty);
+        this.compare(IntStream.class,
+                () -> StreamSupport.intStream(Spliterators.emptyIntSpliterator(), true),
+                () -> IntStream.empty().parallel());
+    }
+
+    public void testFilter(IntStream expected, IntStream actual) {
+        expected = expected.filter(failing(IntPredicate.class));
+        actual = actual.filter(failing(IntPredicate.class));
+        var expectedResult = expected.toArray();
+        var actualResult = actual.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testFilterParameters(IntStream expected, IntStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.filter(null));
+        assertThrows(NullPointerException.class, () -> actual.filter(null));
+    }
+
+    public void testMap(IntStream expected, IntStream actual) {
+        IntStream expectedAsIntStream = expected.map(failing(IntUnaryOperator.class));
+        IntStream actualAsIntStream = actual.map(failing(IntUnaryOperator.class));
+        var expectedResult = expectedAsIntStream.toArray();
+        var actualResult = actualAsIntStream.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMapParameters(IntStream expected, IntStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.map(null));
+        assertThrows(NullPointerException.class, () -> actual.map(null));
+    }
+
+    public void testMapToObj(IntStream expected, IntStream actual) {
+        Stream<Integer> expectedAsStream = expected.mapToObj(failing(IntFunction.class));
+        Stream<Integer> actualAsStream = actual.mapToObj(failing(IntFunction.class));
+        var expectedResult = expectedAsStream.toArray();
+        var actualResult = actualAsStream.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMapToObjParameters(IntStream expected, IntStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.mapToObj(null));
+        assertThrows(NullPointerException.class, () -> actual.mapToObj(null));
+    }
+
+    public void testMapToLong(IntStream expected, IntStream actual) {
+        LongStream expectedAsLongStream = expected.mapToLong(failing(IntToLongFunction.class));
+        LongStream actualAsLongStream = actual.mapToLong(failing(IntToLongFunction.class));
+        var expectedResult = expectedAsLongStream.toArray();
+        var actualResult = actualAsLongStream.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMapToLongParameters(IntStream expected, IntStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.mapToLong(null));
+        assertThrows(NullPointerException.class, () -> actual.mapToLong(null));
+    }
+
+    public void testMapToDouble(IntStream expected, IntStream actual) {
+        DoubleStream expectedAsDoubleStream = expected.mapToDouble(failing(IntToDoubleFunction.class));
+        DoubleStream actualAsDoubleStream = actual.mapToDouble(failing(IntToDoubleFunction.class));
+        var expectedResult = expectedAsDoubleStream.toArray();
+        var actualResult = actualAsDoubleStream.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMapToDoubleParameters(IntStream expected, IntStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.mapToDouble(null));
+        assertThrows(NullPointerException.class, () -> actual.mapToDouble(null));
+    }
+
+    public void testFlatMap(IntStream expected, IntStream actual) {
+        IntStream expectedAsIntStream = expected.flatMap(failing(IntFunction.class));
+        IntStream actualAsIntStream = actual.flatMap(failing(IntFunction.class));
+        var expectedResult = expectedAsIntStream.toArray();
+        var actualResult = actualAsIntStream.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testFlatMapParameters(IntStream expected, IntStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.flatMap(null));
+        assertThrows(NullPointerException.class, () -> actual.flatMap(null));
+    }
+
+    public void testDistinct(IntStream expected, IntStream actual) {
+        expected = expected.distinct();
+        actual = actual.distinct();
+        var expectedResult = expected.toArray();
+        var actualResult = actual.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testSorted(IntStream expected, IntStream actual) {
+        expected = expected.sorted();
+        actual = actual.sorted();
+        var expectedResult = expected.toArray();
+        var actualResult = actual.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testPeek(IntStream expected, IntStream actual) {
+        expected.peek(failing(IntConsumer.class)).toArray();
+        actual.peek(failing(IntConsumer.class)).toArray();
+    }
+
+    public void testPeekParameters(IntStream expected, IntStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.peek(null));
+        assertThrows(NullPointerException.class, () -> actual.peek(null));
+    }
+
+    public void testLimit(IntStream expected, IntStream actual) {
+        var expectedResult = expected.limit(10).toArray();
+        var actualResult = actual.limit(10).toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testLimitParameters(IntStream expected, IntStream actual) {
+        assertThrows(IllegalArgumentException.class, () -> expected.limit(-1));
+        assertThrows(IllegalArgumentException.class, () -> actual.limit(-1));
+    }
+
+    public void testSkip(IntStream expected, IntStream actual) {
+        var expectedResult = expected.skip(10).toArray();
+        var actualResult = actual.skip(10).toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testSkipParameters(IntStream expected, IntStream actual) {
+        assertThrows(IllegalArgumentException.class, () -> expected.skip(-1));
+        assertThrows(IllegalArgumentException.class, () -> actual.skip(-1));
+    }
+
+    public void testForEach(IntStream expected, IntStream actual) {
+        expected.forEach(failing(IntConsumer.class));
+        actual.forEach(failing(IntConsumer.class));
+    }
+
+    public void testForEachParameters(IntStream expected, IntStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.forEach(null));
+        assertThrows(NullPointerException.class, () -> actual.forEach(null));
+    }
+
+    public void testForEachOrdered(IntStream expected, IntStream actual) {
+        expected.forEachOrdered(failing(IntConsumer.class));
+        actual.forEachOrdered(failing(IntConsumer.class));
+    }
+
+    public void testForEachOrderedParameters(IntStream expected, IntStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.forEachOrdered(null));
+        assertThrows(NullPointerException.class, () -> actual.forEachOrdered(null));
+    }
+
+    public void testToArray(IntStream expected, IntStream actual) {
+        var expectedResult = expected.toArray();
+        var actualResult = actual.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testReduceIntBinaryOperator(IntStream expected, IntStream actual) {
+        var expectedResult = expected.reduce(failing(IntBinaryOperator.class));
+        var actualResult = actual.reduce(failing(IntBinaryOperator.class));
+
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testReduceIntBinaryOperatorParameters(IntStream expected, IntStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.reduce(null));
+        assertThrows(NullPointerException.class, () -> actual.reduce(null));
+    }
+
+    public void testReduceIdentityIntBinaryOperator(IntStream expected, IntStream actual) {
+        var magicIdentity = 42;
+        var expectedResult = expected.reduce(magicIdentity, failing(IntBinaryOperator.class));
+        var actualResult = actual.reduce(magicIdentity, failing(IntBinaryOperator.class));
+
+        assertEquals(magicIdentity, expectedResult);
+        assertEquals(magicIdentity, actualResult);
+    }
+
+    public void testReduceIdentityIntBinaryOperatorParameters(IntStream expected, IntStream actual) {
+        int magicInt = 42;
+        assertThrows(NullPointerException.class, () -> expected.reduce(magicInt, null));
+        assertThrows(NullPointerException.class, () -> actual.reduce(magicInt, null));
+    }
+
+    public void testCollect(IntStream expected, IntStream actual) {
+        var magicIdentity = new Object();
+        var expectedResult = expected.collect(() -> magicIdentity, failing(ObjIntConsumer.class), failing(BiConsumer.class));
+        var actualResult = actual.collect(() -> magicIdentity, failing(ObjIntConsumer.class), failing(BiConsumer.class));
+
+        assertSame(magicIdentity, expectedResult);
+        assertSame(magicIdentity, actualResult);
+    }
+
+    public void testCollectParameters(IntStream expected, IntStream actual) {
+        Supplier<Object> supplier = Object::new;
+        var accumulator = failing(ObjIntConsumer.class);
+        var combiner = failing(BiConsumer.class);
+        assertThrows(NullPointerException.class, () -> expected.collect(null, accumulator, combiner));
+        assertThrows(NullPointerException.class, () -> actual.collect(null, accumulator, combiner));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, null, combiner));
+        assertThrows(NullPointerException.class, () -> actual.collect(supplier, null, combiner));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, accumulator, null));
+        assertThrows(NullPointerException.class, () -> actual.collect(supplier, accumulator, null));
+    }
+
+    public void testSum(IntStream expected, IntStream actual) {
+        var expectedResult = expected.sum();
+        var actualResult = actual.sum();
+
+        assertEquals(expectedResult, actualResult);
+        assertEquals(0, actualResult);
+    }
+
+    public void testMin(IntStream expected, IntStream actual) {
+        var expectedResult = expected.min();
+        var actualResult = actual.min();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMax(IntStream expected, IntStream actual) {
+        var expectedResult = expected.max();
+        var actualResult = actual.max();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testCount(IntStream expected, IntStream actual) {
+        var expectedResult = expected.count();
+        var actualResult = actual.count();
+        assertEquals(expectedResult, actualResult);
+        assertEquals(0L, actualResult);
+    }
+
+    public void testAverage(IntStream expected, IntStream actual) {
+        var expectedResult = expected.average();
+        var actualResult = actual.average();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testSummaryStatistics(IntStream expected, IntStream actual) {
+        var expectedResult = expected.summaryStatistics().toString();
+        var actualResult = actual.summaryStatistics().toString();
+        assertEquals(expectedResult, actualResult);
+    }
+
+    public void testAnyMatch(IntStream expected, IntStream actual) {
+        var expectedResult = expected.anyMatch(failing(IntPredicate.class));
+        var actualResult = actual.anyMatch(failing(IntPredicate.class));
+        assertEquals(expectedResult, actualResult);
+    }
+
+    public void testAnyMatchParameters(IntStream expected, IntStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.anyMatch(null));
+        assertThrows(NullPointerException.class, () -> actual.anyMatch(null));
+    }
+
+    public void testAllMatch(IntStream expected, IntStream actual) {
+        var expectedResult = expected.allMatch(failing(IntPredicate.class));
+        var actualResult = actual.allMatch(failing(IntPredicate.class));
+        assertEquals(expectedResult, actualResult);
+    }
+
+    public void testAllMatchParameters(IntStream expected, IntStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.allMatch(null));
+        assertThrows(NullPointerException.class, () -> actual.allMatch(null));
+    }
+
+    public void testNoneMatch(IntStream expected, IntStream actual) {
+        var expectedResult = expected.noneMatch(failing(IntPredicate.class));
+        var actualResult = actual.noneMatch(failing(IntPredicate.class));
+        assertEquals(expectedResult, actualResult);
+    }
+
+    public void testNoneMatchParameters(IntStream expected, IntStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.noneMatch(null));
+        assertThrows(NullPointerException.class, () -> actual.noneMatch(null));
+    }
+
+    public void testFindFirst(IntStream expected, IntStream actual) {
+        var expectedResult = expected.findFirst();
+        var actualResult = actual.findFirst();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testFindAny(IntStream expected, IntStream actual) {
+        var expectedResult = expected.findAny();
+        var actualResult = actual.findAny();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testAsLongStream(IntStream expected, IntStream actual) {
+        LongStream expectedAsLongStream = expected.asLongStream();
+        LongStream actualAsLongStream = actual.asLongStream();
+        long[] expectedResult = expectedAsLongStream.toArray();
+        long[] actualResult = actualAsLongStream.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testAsDoubleStream(IntStream expected, IntStream actual) {
+        DoubleStream expectedAsDoubleStream = expected.asDoubleStream();
+        DoubleStream actualAsDoubleStream = actual.asDoubleStream();
+        double[] expectedResult = expectedAsDoubleStream.toArray();
+        double[] actualResult = actualAsDoubleStream.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testBoxed(IntStream expected, IntStream actual) {
+        Stream<Integer> expectedAsStream = expected.boxed();
+        Stream<Integer> actualAsStream = actual.boxed();
+        var expectedResult = expectedAsStream.toArray();
+        var actualResult = actualAsStream.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMapMulti(IntStream expected, IntStream actual) {
+        var expectedResult = expected.mapMulti(failing(IntStream.IntMapMultiConsumer.class)).toArray();
+        var actualResult = actual.mapMulti(failing(IntStream.IntMapMultiConsumer.class)).toArray();
+
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMapMultiParameters(IntStream expected, IntStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.mapMulti(null));
+        assertThrows(NullPointerException.class, () -> actual.mapMulti(null));
+    }
+
+    public void testTakeWhile(IntStream expected, IntStream actual) {
+        var expectedResult = expected.takeWhile(failing(IntPredicate.class)).toArray();
+        var actualResult = actual.takeWhile(failing(IntPredicate.class)).toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testTakeWhileParameters(IntStream expected, IntStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.takeWhile(null));
+        assertThrows(NullPointerException.class, () -> actual.takeWhile(null));
+    }
+
+    public void testDropWhile(IntStream expected, IntStream actual) {
+        var expectedResult = expected.dropWhile(failing(IntPredicate.class)).toArray();
+        var actualResult = actual.dropWhile(failing(IntPredicate.class)).toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testDropWhileParameters(IntStream expected, IntStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.dropWhile(null));
+        assertThrows(NullPointerException.class, () -> actual.dropWhile(null));
+    }
+}

--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyIntStreamTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyIntStreamTest.java
@@ -25,8 +25,11 @@ package org.openjdk.tests.java.util.stream;
 
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 import java.util.function.IntBinaryOperator;
 import java.util.function.IntConsumer;
 import java.util.function.IntFunction;
@@ -54,11 +57,22 @@ import static org.testng.Assert.*;
 public final class EmptyIntStreamTest extends EmptyBaseStreamTest {
     @Test
     public void testAll() {
+        Function<Spliterator.OfInt, IntStream> emptyStreamCreator =
+                StreamSupport::emptyIntStream;
+        Function<Spliterator.OfInt, IntStream> traditionalStreamCreator =
+                spliterator -> StreamSupport.intStream(spliterator, false);
+
         this.compare(IntStream.class,
-                IntStream::empty, () -> StreamSupport.intStream(Spliterators.emptyIntSpliterator(), false)
+                () -> emptyStreamCreator.apply(Spliterators.emptyIntSpliterator()),
+                () -> traditionalStreamCreator.apply(Spliterators.emptyIntSpliterator())
         );
         this.compare(IntStream.class,
-                () -> IntStream.empty().parallel(), () -> StreamSupport.intStream(Spliterators.emptyIntSpliterator(), true)
+                () -> emptyStreamCreator.apply(Spliterators.emptyIntSpliterator()).parallel(),
+                () -> traditionalStreamCreator.apply(Spliterators.emptyIntSpliterator()).parallel()
+        );
+        this.compare(IntStream.class,
+                () -> emptyStreamCreator.apply(Arrays.spliterator(new int[0])),
+                () -> traditionalStreamCreator.apply(Arrays.spliterator(new int[0]))
         );
     }
 

--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyLongStreamTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyLongStreamTest.java
@@ -25,8 +25,11 @@ package org.openjdk.tests.java.util.stream;
 
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 import java.util.function.LongBinaryOperator;
 import java.util.function.LongConsumer;
 import java.util.function.LongFunction;
@@ -54,11 +57,22 @@ import static org.testng.Assert.*;
 public final class EmptyLongStreamTest extends EmptyBaseStreamTest {
     @Test
     public void testAll() {
+        Function<Spliterator.OfLong, LongStream> emptyStreamCreator =
+                StreamSupport::emptyLongStream;
+        Function<Spliterator.OfLong, LongStream> traditionalStreamCreator =
+                spliterator -> StreamSupport.longStream(spliterator, false);
+
         this.compare(LongStream.class,
-                LongStream::empty, () -> StreamSupport.longStream(Spliterators.emptyLongSpliterator(), false)
+                () -> emptyStreamCreator.apply(Spliterators.emptyLongSpliterator()),
+                () -> traditionalStreamCreator.apply(Spliterators.emptyLongSpliterator())
         );
         this.compare(LongStream.class,
-                () -> LongStream.empty().parallel(), () -> StreamSupport.longStream(Spliterators.emptyLongSpliterator(), true)
+                () -> emptyStreamCreator.apply(Spliterators.emptyLongSpliterator()).parallel(),
+                () -> traditionalStreamCreator.apply(Spliterators.emptyLongSpliterator()).parallel()
+        );
+        this.compare(LongStream.class,
+                () -> emptyStreamCreator.apply(Arrays.spliterator(new long[0])),
+                () -> traditionalStreamCreator.apply(Arrays.spliterator(new long[0]))
         );
     }
 

--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyLongStreamTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyLongStreamTest.java
@@ -55,346 +55,406 @@ public final class EmptyLongStreamTest extends EmptyBaseStreamTest {
     @Test
     public void testAll() {
         this.compare(LongStream.class,
-                () -> StreamSupport.longStream(Spliterators.emptyLongSpliterator(), false),
-                LongStream::empty);
+                LongStream::empty, () -> StreamSupport.longStream(Spliterators.emptyLongSpliterator(), false)
+        );
         this.compare(LongStream.class,
-                () -> StreamSupport.longStream(Spliterators.emptyLongSpliterator(), true),
-                () -> LongStream.empty().parallel());
+                () -> LongStream.empty().parallel(), () -> StreamSupport.longStream(Spliterators.emptyLongSpliterator(), true)
+        );
     }
 
-    public void testFilter(LongStream expected, LongStream actual) {
-        expected = expected.filter(failing(LongPredicate.class));
+    public void testFilter(LongStream actual, LongStream expected) {
         actual = actual.filter(failing(LongPredicate.class));
-        var expectedResult = expected.toArray();
+        expected = expected.filter(failing(LongPredicate.class));
         var actualResult = actual.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testFilterParameters(LongStream expected, LongStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.filter(null));
-        assertThrows(NullPointerException.class, () -> actual.filter(null));
+    public void testFilterExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "filter", LongPredicate.class);
     }
 
-    public void testMap(LongStream expected, LongStream actual) {
-        LongStream expectedAsLongStream = expected.map(failing(LongUnaryOperator.class));
+    public void testMap(LongStream actual, LongStream expected) {
         LongStream actualAsLongStream = actual.map(failing(LongUnaryOperator.class));
-        var expectedResult = expectedAsLongStream.toArray();
+        LongStream expectedAsLongStream = expected.map(failing(LongUnaryOperator.class));
         var actualResult = actualAsLongStream.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expectedAsLongStream.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMapParameters(LongStream expected, LongStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.map(null));
-        assertThrows(NullPointerException.class, () -> actual.map(null));
+    public void testMapExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "map", LongUnaryOperator.class);
     }
 
-    public void testMapToObj(LongStream expected, LongStream actual) {
-        Stream<Long> expectedAsStream = expected.mapToObj(failing(LongFunction.class));
+    public void testMapToObj(LongStream actual, LongStream expected) {
         Stream<Long> actualAsStream = actual.mapToObj(failing(LongFunction.class));
-        var expectedResult = expectedAsStream.toArray();
+        Stream<Long> expectedAsStream = expected.mapToObj(failing(LongFunction.class));
         var actualResult = actualAsStream.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expectedAsStream.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMapToObjParameters(LongStream expected, LongStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.mapToObj(null));
-        assertThrows(NullPointerException.class, () -> actual.mapToObj(null));
+    public void testMapToObjExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "mapToObj", LongFunction.class);
     }
 
-    public void testMapToInt(LongStream expected, LongStream actual) {
-        IntStream expectedAsLongStream = expected.mapToInt(failing(LongToIntFunction.class));
-        IntStream actualAsLongStream = actual.mapToInt(failing(LongToIntFunction.class));
-        var expectedResult = expectedAsLongStream.toArray();
-        var actualResult = actualAsLongStream.toArray();
-        compareResults(expectedResult, actualResult);
-    }
-
-    public void testMapToIntParameters(LongStream expected, LongStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.mapToInt(null));
-        assertThrows(NullPointerException.class, () -> actual.mapToInt(null));
-    }
-
-    public void testMapToDouble(LongStream expected, LongStream actual) {
-        DoubleStream expectedAsDoubleStream = expected.mapToDouble(failing(LongToDoubleFunction.class));
-        DoubleStream actualAsDoubleStream = actual.mapToDouble(failing(LongToDoubleFunction.class));
-        var expectedResult = expectedAsDoubleStream.toArray();
-        var actualResult = actualAsDoubleStream.toArray();
-        compareResults(expectedResult, actualResult);
-    }
-
-    public void testMapToDoubleParameters(LongStream expected, LongStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.mapToDouble(null));
-        assertThrows(NullPointerException.class, () -> actual.mapToDouble(null));
-    }
-
-    public void testFlatMap(LongStream expected, LongStream actual) {
-        LongStream expectedAsIntStream = expected.flatMap(failing(LongFunction.class));
-        LongStream actualAsIntStream = actual.flatMap(failing(LongFunction.class));
-        var expectedResult = expectedAsIntStream.toArray();
+    public void testMapToInt(LongStream actual, LongStream expected) {
+        IntStream actualAsIntStream = actual.mapToInt(failing(LongToIntFunction.class));
+        IntStream expectedAsIntStream = expected.mapToInt(failing(LongToIntFunction.class));
         var actualResult = actualAsIntStream.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expectedAsIntStream.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testFlatMapParameters(LongStream expected, LongStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.flatMap(null));
-        assertThrows(NullPointerException.class, () -> actual.flatMap(null));
+    public void testMapToIntExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "mapToInt", LongToIntFunction.class);
     }
 
-    public void testDistinct(LongStream expected, LongStream actual) {
-        expected = expected.distinct();
+    public void testMapToDouble(LongStream actual, LongStream expected) {
+        DoubleStream actualAsDoubleStream = actual.mapToDouble(failing(LongToDoubleFunction.class));
+        DoubleStream expectedAsDoubleStream = expected.mapToDouble(failing(LongToDoubleFunction.class));
+        var actualResult = actualAsDoubleStream.toArray();
+        var expectedResult = expectedAsDoubleStream.toArray();
+        compareResults(actualResult, expectedResult);
+    }
+
+    public void testMapToDoubleExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "mapToDouble", LongToDoubleFunction.class);
+    }
+
+    public void testFlatMap(LongStream actual, LongStream expected) {
+        LongStream actualAsLongStream = actual.flatMap(failing(LongFunction.class));
+        LongStream expectedAsLongStream = expected.flatMap(failing(LongFunction.class));
+        var actualResult = actualAsLongStream.toArray();
+        var expectedResult = expectedAsLongStream.toArray();
+        compareResults(actualResult, expectedResult);
+    }
+
+    public void testFlatMapExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "flatMap", LongFunction.class);
+    }
+
+    public void testDistinct(LongStream actual, LongStream expected) {
         actual = actual.distinct();
-        var expectedResult = expected.toArray();
+        expected = expected.distinct();
         var actualResult = actual.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testSorted(LongStream expected, LongStream actual) {
-        expected = expected.sorted();
+    public void testDistinctExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "distinct");
+    }
+
+    public void testSorted(LongStream actual, LongStream expected) {
         actual = actual.sorted();
-        var expectedResult = expected.toArray();
+        expected = expected.sorted();
         var actualResult = actual.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testPeek(LongStream expected, LongStream actual) {
-        expected.peek(failing(LongConsumer.class)).toArray();
+    public void testSortedExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "sorted");
+    }
+
+    public void testPeek(LongStream actual, LongStream expected) {
         actual.peek(failing(LongConsumer.class)).toArray();
+        expected.peek(failing(LongConsumer.class)).toArray();
     }
 
-    public void testPeekParameters(LongStream expected, LongStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.peek(null));
-        assertThrows(NullPointerException.class, () -> actual.peek(null));
+    public void testPeekExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "peek", LongConsumer.class);
     }
 
-    public void testLimit(LongStream expected, LongStream actual) {
-        var expectedResult = expected.limit(10).toArray();
+    public void testLimit(LongStream actual, LongStream expected) {
         var actualResult = actual.limit(10).toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.limit(10).toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testLimitParameters(LongStream expected, LongStream actual) {
-        assertThrows(IllegalArgumentException.class, () -> expected.limit(-1));
+    public void testLimitExceptions(LongStream actual, LongStream expected) {
         assertThrows(IllegalArgumentException.class, () -> actual.limit(-1));
+        assertThrows(IllegalArgumentException.class, () -> expected.limit(-1));
+
+        actual.limit(10);
+        expected.limit(10);
+        assertThrows(IllegalStateException.class, () -> actual.limit(10));
+        assertThrows(IllegalStateException.class, () -> expected.limit(10));
     }
 
-    public void testSkip(LongStream expected, LongStream actual) {
-        var expectedResult = expected.skip(10).toArray();
+    public void testSkip(LongStream actual, LongStream expected) {
         var actualResult = actual.skip(10).toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.skip(10).toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testSkipParameters(LongStream expected, LongStream actual) {
-        assertThrows(IllegalArgumentException.class, () -> expected.skip(-1));
+    public void testSkipExceptions(LongStream actual, LongStream expected) {
         assertThrows(IllegalArgumentException.class, () -> actual.skip(-1));
+        assertThrows(IllegalArgumentException.class, () -> expected.skip(-1));
+
+        actual.skip(0); // should be ok
+        expected.skip(0); // should be ok
+        actual.skip(0); // should be ok
+        expected.skip(0); // should be ok
+
+        actual.skip(10);
+        expected.skip(10);
+        assertThrows(IllegalStateException.class, () -> actual.skip(10));
+        assertThrows(IllegalStateException.class, () -> expected.skip(10));
     }
 
-    public void testForEach(LongStream expected, LongStream actual) {
-        expected.forEach(failing(LongConsumer.class));
+    public void testForEach(LongStream actual, LongStream expected) {
         actual.forEach(failing(LongConsumer.class));
+        expected.forEach(failing(LongConsumer.class));
     }
 
-    public void testForEachParameters(LongStream expected, LongStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.forEach(null));
-        assertThrows(NullPointerException.class, () -> actual.forEach(null));
+    public void testForEachExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "forEach", LongConsumer.class);
     }
 
-    public void testForEachOrdered(LongStream expected, LongStream actual) {
-        expected.forEachOrdered(failing(LongConsumer.class));
+    public void testForEachOrdered(LongStream actual, LongStream expected) {
         actual.forEachOrdered(failing(LongConsumer.class));
+        expected.forEachOrdered(failing(LongConsumer.class));
     }
 
-    public void testForEachOrderedParameters(LongStream expected, LongStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.forEachOrdered(null));
-        assertThrows(NullPointerException.class, () -> actual.forEachOrdered(null));
+    public void testForEachOrderedExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "forEachOrdered", LongConsumer.class);
     }
 
-    public void testToArray(LongStream expected, LongStream actual) {
-        var expectedResult = expected.toArray();
+    public void testToArray(LongStream actual, LongStream expected) {
         var actualResult = actual.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testReduceIntBinaryOperator(LongStream expected, LongStream actual) {
-        var expectedResult = expected.reduce(failing(LongBinaryOperator.class));
+    public void testToArrayExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "toArray");
+    }
+
+    public void testReduceLongBinaryOperator(LongStream actual, LongStream expected) {
         var actualResult = actual.reduce(failing(LongBinaryOperator.class));
+        var expectedResult = expected.reduce(failing(LongBinaryOperator.class));
 
-        compareResults(expectedResult, actualResult);
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testReduceIntBinaryOperatorParameters(LongStream expected, LongStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.reduce(null));
-        assertThrows(NullPointerException.class, () -> actual.reduce(null));
+    public void testReduceLongBinaryOperatorExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "reduce", LongBinaryOperator.class);
     }
 
-    public void testReduceIdentityIntBinaryOperator(LongStream expected, LongStream actual) {
-        var magicIdentity = 42;
-        var expectedResult = expected.reduce(magicIdentity, failing(LongBinaryOperator.class));
+    public void testReduceIdentityLongBinaryOperator(LongStream actual, LongStream expected) {
+        var magicIdentity = 42L;
         var actualResult = actual.reduce(magicIdentity, failing(LongBinaryOperator.class));
+        var expectedResult = expected.reduce(magicIdentity, failing(LongBinaryOperator.class));
 
-        assertEquals(magicIdentity, expectedResult);
-        assertEquals(magicIdentity, actualResult);
+        assertEquals(actualResult, magicIdentity);
+        assertEquals(expectedResult, magicIdentity);
     }
 
-    public void testReduceIdentityIntBinaryOperatorParameters(LongStream expected, LongStream actual) {
-        int magicInt = 42;
-        assertThrows(NullPointerException.class, () -> expected.reduce(magicInt, null));
-        assertThrows(NullPointerException.class, () -> actual.reduce(magicInt, null));
+    public void testReduceIdentityLongBinaryOperatorExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "reduce", long.class, LongBinaryOperator.class);
     }
 
-    public void testCollect(LongStream expected, LongStream actual) {
+    public void testCollect(LongStream actual, LongStream expected) {
         var magicIdentity = new Object();
-        var accumulator = failing(ObjLongConsumer.class);
-        var combiner = failing(BiConsumer.class);
-        var expectedResult = expected.collect(() -> magicIdentity, accumulator, combiner);
-        var actualResult = actual.collect(() -> magicIdentity, accumulator, combiner);
+        var actualResult = actual.collect(() -> magicIdentity, failing(ObjLongConsumer.class), failing(BiConsumer.class));
+        var expectedResult = expected.collect(() -> magicIdentity, failing(ObjLongConsumer.class), failing(BiConsumer.class));
 
-        assertSame(magicIdentity, expectedResult);
         assertSame(magicIdentity, actualResult);
+        assertSame(magicIdentity, expectedResult);
     }
 
-    public void testCollectParameters(LongStream expected, LongStream actual) {
+    public void testCollectExceptions(LongStream actual, LongStream expected) {
         Supplier<Object> supplier = Object::new;
         var accumulator = failing(ObjLongConsumer.class);
         var combiner = failing(BiConsumer.class);
-        assertThrows(NullPointerException.class, () -> expected.collect(null, accumulator, combiner));
         assertThrows(NullPointerException.class, () -> actual.collect(null, accumulator, combiner));
-        assertThrows(NullPointerException.class, () -> expected.collect(supplier, null, combiner));
+        assertThrows(NullPointerException.class, () -> expected.collect(null, accumulator, combiner));
         assertThrows(NullPointerException.class, () -> actual.collect(supplier, null, combiner));
-        assertThrows(NullPointerException.class, () -> expected.collect(supplier, accumulator, null));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, null, combiner));
         assertThrows(NullPointerException.class, () -> actual.collect(supplier, accumulator, null));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, accumulator, null));
+
+        actual.collect(supplier, accumulator, combiner);
+        expected.collect(supplier, accumulator, combiner);
+
+        assertThrows(NullPointerException.class, () -> actual.collect(null, accumulator, combiner));
+        assertThrows(NullPointerException.class, () -> expected.collect(null, accumulator, combiner));
+        assertThrows(NullPointerException.class, () -> actual.collect(supplier, null, combiner));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, null, combiner));
+        assertThrows(NullPointerException.class, () -> actual.collect(supplier, accumulator, null));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, accumulator, null));
+
+        assertThrows(IllegalStateException.class, () -> actual.collect(supplier, accumulator, combiner));
+        assertThrows(IllegalStateException.class, () -> expected.collect(supplier, accumulator, combiner));
     }
 
-    public void testSum(LongStream expected, LongStream actual) {
-        var expectedResult = expected.sum();
+    public void testSum(LongStream actual, LongStream expected) {
         var actualResult = actual.sum();
+        var expectedResult = expected.sum();
 
-        assertEquals(expectedResult, actualResult);
-        assertEquals(0, actualResult);
+        assertEquals(actualResult, expectedResult);
+        assertEquals(actualResult, 0);
     }
 
-    public void testMin(LongStream expected, LongStream actual) {
-        var expectedResult = expected.min();
+    public void testSumExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "sum");
+    }
+
+    public void testMin(LongStream actual, LongStream expected) {
         var actualResult = actual.min();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.min();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMax(LongStream expected, LongStream actual) {
-        var expectedResult = expected.max();
+    public void testMinExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "min");
+    }
+
+    public void testMax(LongStream actual, LongStream expected) {
         var actualResult = actual.max();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.max();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testCount(LongStream expected, LongStream actual) {
-        var expectedResult = expected.count();
+    public void testMaxExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "max");
+    }
+
+    public void testCount(LongStream actual, LongStream expected) {
         var actualResult = actual.count();
-        assertEquals(expectedResult, actualResult);
-        assertEquals(0L, actualResult);
+        var expectedResult = expected.count();
+        assertEquals(actualResult, expectedResult);
+        assertEquals(actualResult, 0L);
     }
 
-    public void testAverage(LongStream expected, LongStream actual) {
-        var expectedResult = expected.average();
+    public void testCountExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "count");
+    }
+
+    public void testAverage(LongStream actual, LongStream expected) {
         var actualResult = actual.average();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.average();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testSummaryStatistics(LongStream expected, LongStream actual) {
-        var expectedResult = expected.summaryStatistics().toString();
+    public void testAverageExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "average");
+    }
+
+    public void testSummaryStatistics(LongStream actual, LongStream expected) {
         var actualResult = actual.summaryStatistics().toString();
-        assertEquals(expectedResult, actualResult);
+        var expectedResult = expected.summaryStatistics().toString();
+        assertEquals(actualResult, expectedResult);
     }
 
-    public void testAnyMatch(LongStream expected, LongStream actual) {
-        var expectedResult = expected.anyMatch(failing(LongPredicate.class));
+    public void testSummaryStatisticsExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "summaryStatistics");
+    }
+
+    public void testAnyMatch(LongStream actual, LongStream expected) {
         var actualResult = actual.anyMatch(failing(LongPredicate.class));
-        assertEquals(expectedResult, actualResult);
+        var expectedResult = expected.anyMatch(failing(LongPredicate.class));
+        assertEquals(actualResult, expectedResult);
     }
 
-    public void testAnyMatchParameters(LongStream expected, LongStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.anyMatch(null));
-        assertThrows(NullPointerException.class, () -> actual.anyMatch(null));
+    public void testAnyMatchExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "anyMatch", LongPredicate.class);
     }
 
-    public void testAllMatch(LongStream expected, LongStream actual) {
-        var expectedResult = expected.allMatch(failing(LongPredicate.class));
+    public void testAllMatch(LongStream actual, LongStream expected) {
         var actualResult = actual.allMatch(failing(LongPredicate.class));
-        assertEquals(expectedResult, actualResult);
+        var expectedResult = expected.allMatch(failing(LongPredicate.class));
+        assertEquals(actualResult, expectedResult);
     }
 
-    public void testAllMatchParameters(LongStream expected, LongStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.allMatch(null));
-        assertThrows(NullPointerException.class, () -> actual.allMatch(null));
+    public void testAllMatchExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "allMatch", LongPredicate.class);
     }
 
-    public void testNoneMatch(LongStream expected, LongStream actual) {
-        var expectedResult = expected.noneMatch(failing(LongPredicate.class));
+    public void testNoneMatch(LongStream actual, LongStream expected) {
         var actualResult = actual.noneMatch(failing(LongPredicate.class));
-        assertEquals(expectedResult, actualResult);
+        var expectedResult = expected.noneMatch(failing(LongPredicate.class));
+        assertEquals(actualResult, expectedResult);
     }
 
-    public void testNoneMatchParameters(LongStream expected, LongStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.noneMatch(null));
-        assertThrows(NullPointerException.class, () -> actual.noneMatch(null));
+    public void testNoneMatchExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "noneMatch", LongPredicate.class);
     }
 
-    public void testFindFirst(LongStream expected, LongStream actual) {
-        var expectedResult = expected.findFirst();
+    public void testFindFirst(LongStream actual, LongStream expected) {
         var actualResult = actual.findFirst();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.findFirst();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testFindAny(LongStream expected, LongStream actual) {
-        var expectedResult = expected.findAny();
+    public void testFindFirstExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "findFirst");
+    }
+
+    public void testFindAny(LongStream actual, LongStream expected) {
         var actualResult = actual.findAny();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.findAny();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testAsDoubleStream(LongStream expected, LongStream actual) {
-        DoubleStream expectedAsDoubleStream = expected.asDoubleStream();
+    public void testFindAnyExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "findAny");
+    }
+
+    public void testAsDoubleStream(LongStream actual, LongStream expected) {
         DoubleStream actualAsDoubleStream = actual.asDoubleStream();
-        double[] expectedResult = expectedAsDoubleStream.toArray();
+        DoubleStream expectedAsDoubleStream = expected.asDoubleStream();
         double[] actualResult = actualAsDoubleStream.toArray();
-        compareResults(expectedResult, actualResult);
+        double[] expectedResult = expectedAsDoubleStream.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testBoxed(LongStream expected, LongStream actual) {
-        Stream<Long> expectedAsStream = expected.boxed();
+    public void testAsDoubleStreamExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "asDoubleStream");
+    }
+
+    public void testBoxed(LongStream actual, LongStream expected) {
         Stream<Long> actualAsStream = actual.boxed();
-        var expectedResult = expectedAsStream.toArray();
+        Stream<Long> expectedAsStream = expected.boxed();
         var actualResult = actualAsStream.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expectedAsStream.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMapMulti(LongStream expected, LongStream actual) {
-        var expectedResult = expected.mapMulti(failing(LongStream.LongMapMultiConsumer.class)).toArray();
+    public void testBoxedExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "boxed");
+    }
+
+    public void testMapMulti(LongStream actual, LongStream expected) {
         var actualResult = actual.mapMulti(failing(LongStream.LongMapMultiConsumer.class)).toArray();
+        var expectedResult = expected.mapMulti(failing(LongStream.LongMapMultiConsumer.class)).toArray();
 
-        compareResults(expectedResult, actualResult);
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMapMultiParameters(LongStream expected, LongStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.mapMulti(null));
-        assertThrows(NullPointerException.class, () -> actual.mapMulti(null));
+    public void testMapMultiExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "mapMulti", LongStream.LongMapMultiConsumer.class);
     }
 
-    public void testTakeWhile(LongStream expected, LongStream actual) {
-        var expectedResult = expected.takeWhile(failing(LongPredicate.class)).toArray();
+    public void testTakeWhile(LongStream actual, LongStream expected) {
         var actualResult = actual.takeWhile(failing(LongPredicate.class)).toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.takeWhile(failing(LongPredicate.class)).toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testTakeWhileParameters(LongStream expected, LongStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.takeWhile(null));
-        assertThrows(NullPointerException.class, () -> actual.takeWhile(null));
+    public void testTakeWhileExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "takeWhile", LongPredicate.class);
     }
 
-    public void testDropWhile(LongStream expected, LongStream actual) {
-        var expectedResult = expected.dropWhile(failing(LongPredicate.class)).toArray();
+    public void testDropWhile(LongStream actual, LongStream expected) {
         var actualResult = actual.dropWhile(failing(LongPredicate.class)).toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.dropWhile(failing(LongPredicate.class)).toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testDropWhileParameters(LongStream expected, LongStream actual) {
-        assertThrows(NullPointerException.class, () -> expected.dropWhile(null));
-        assertThrows(NullPointerException.class, () -> actual.dropWhile(null));
+    public void testDropWhileExceptions(LongStream actual, LongStream expected) {
+        checkExpectedExceptions(actual, expected, "dropWhile", LongPredicate.class);
     }
 }

--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyLongStreamTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyLongStreamTest.java
@@ -1,0 +1,400 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.tests.java.util.stream;
+
+import org.testng.annotations.Test;
+
+import java.util.Spliterators;
+import java.util.function.BiConsumer;
+import java.util.function.LongBinaryOperator;
+import java.util.function.LongConsumer;
+import java.util.function.LongFunction;
+import java.util.function.LongPredicate;
+import java.util.function.LongToDoubleFunction;
+import java.util.function.LongToIntFunction;
+import java.util.function.LongUnaryOperator;
+import java.util.function.ObjLongConsumer;
+import java.util.function.Supplier;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static org.testng.Assert.*;
+
+/*
+ * @test
+ * @summary Checks that the EmptyLongStream is equivalent to the
+ * old way of creating it with StreamSupport.
+ * @author Heinz Kabutz
+ */
+
+public final class EmptyLongStreamTest extends EmptyBaseStreamTest {
+    @Test
+    public void testAll() {
+        this.compare(LongStream.class,
+                () -> StreamSupport.longStream(Spliterators.emptyLongSpliterator(), false),
+                LongStream::empty);
+        this.compare(LongStream.class,
+                () -> StreamSupport.longStream(Spliterators.emptyLongSpliterator(), true),
+                () -> LongStream.empty().parallel());
+    }
+
+    public void testFilter(LongStream expected, LongStream actual) {
+        expected = expected.filter(failing(LongPredicate.class));
+        actual = actual.filter(failing(LongPredicate.class));
+        var expectedResult = expected.toArray();
+        var actualResult = actual.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testFilterParameters(LongStream expected, LongStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.filter(null));
+        assertThrows(NullPointerException.class, () -> actual.filter(null));
+    }
+
+    public void testMap(LongStream expected, LongStream actual) {
+        LongStream expectedAsLongStream = expected.map(failing(LongUnaryOperator.class));
+        LongStream actualAsLongStream = actual.map(failing(LongUnaryOperator.class));
+        var expectedResult = expectedAsLongStream.toArray();
+        var actualResult = actualAsLongStream.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMapParameters(LongStream expected, LongStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.map(null));
+        assertThrows(NullPointerException.class, () -> actual.map(null));
+    }
+
+    public void testMapToObj(LongStream expected, LongStream actual) {
+        Stream<Long> expectedAsStream = expected.mapToObj(failing(LongFunction.class));
+        Stream<Long> actualAsStream = actual.mapToObj(failing(LongFunction.class));
+        var expectedResult = expectedAsStream.toArray();
+        var actualResult = actualAsStream.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMapToObjParameters(LongStream expected, LongStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.mapToObj(null));
+        assertThrows(NullPointerException.class, () -> actual.mapToObj(null));
+    }
+
+    public void testMapToInt(LongStream expected, LongStream actual) {
+        IntStream expectedAsLongStream = expected.mapToInt(failing(LongToIntFunction.class));
+        IntStream actualAsLongStream = actual.mapToInt(failing(LongToIntFunction.class));
+        var expectedResult = expectedAsLongStream.toArray();
+        var actualResult = actualAsLongStream.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMapToIntParameters(LongStream expected, LongStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.mapToInt(null));
+        assertThrows(NullPointerException.class, () -> actual.mapToInt(null));
+    }
+
+    public void testMapToDouble(LongStream expected, LongStream actual) {
+        DoubleStream expectedAsDoubleStream = expected.mapToDouble(failing(LongToDoubleFunction.class));
+        DoubleStream actualAsDoubleStream = actual.mapToDouble(failing(LongToDoubleFunction.class));
+        var expectedResult = expectedAsDoubleStream.toArray();
+        var actualResult = actualAsDoubleStream.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMapToDoubleParameters(LongStream expected, LongStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.mapToDouble(null));
+        assertThrows(NullPointerException.class, () -> actual.mapToDouble(null));
+    }
+
+    public void testFlatMap(LongStream expected, LongStream actual) {
+        LongStream expectedAsIntStream = expected.flatMap(failing(LongFunction.class));
+        LongStream actualAsIntStream = actual.flatMap(failing(LongFunction.class));
+        var expectedResult = expectedAsIntStream.toArray();
+        var actualResult = actualAsIntStream.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testFlatMapParameters(LongStream expected, LongStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.flatMap(null));
+        assertThrows(NullPointerException.class, () -> actual.flatMap(null));
+    }
+
+    public void testDistinct(LongStream expected, LongStream actual) {
+        expected = expected.distinct();
+        actual = actual.distinct();
+        var expectedResult = expected.toArray();
+        var actualResult = actual.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testSorted(LongStream expected, LongStream actual) {
+        expected = expected.sorted();
+        actual = actual.sorted();
+        var expectedResult = expected.toArray();
+        var actualResult = actual.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testPeek(LongStream expected, LongStream actual) {
+        expected.peek(failing(LongConsumer.class)).toArray();
+        actual.peek(failing(LongConsumer.class)).toArray();
+    }
+
+    public void testPeekParameters(LongStream expected, LongStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.peek(null));
+        assertThrows(NullPointerException.class, () -> actual.peek(null));
+    }
+
+    public void testLimit(LongStream expected, LongStream actual) {
+        var expectedResult = expected.limit(10).toArray();
+        var actualResult = actual.limit(10).toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testLimitParameters(LongStream expected, LongStream actual) {
+        assertThrows(IllegalArgumentException.class, () -> expected.limit(-1));
+        assertThrows(IllegalArgumentException.class, () -> actual.limit(-1));
+    }
+
+    public void testSkip(LongStream expected, LongStream actual) {
+        var expectedResult = expected.skip(10).toArray();
+        var actualResult = actual.skip(10).toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testSkipParameters(LongStream expected, LongStream actual) {
+        assertThrows(IllegalArgumentException.class, () -> expected.skip(-1));
+        assertThrows(IllegalArgumentException.class, () -> actual.skip(-1));
+    }
+
+    public void testForEach(LongStream expected, LongStream actual) {
+        expected.forEach(failing(LongConsumer.class));
+        actual.forEach(failing(LongConsumer.class));
+    }
+
+    public void testForEachParameters(LongStream expected, LongStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.forEach(null));
+        assertThrows(NullPointerException.class, () -> actual.forEach(null));
+    }
+
+    public void testForEachOrdered(LongStream expected, LongStream actual) {
+        expected.forEachOrdered(failing(LongConsumer.class));
+        actual.forEachOrdered(failing(LongConsumer.class));
+    }
+
+    public void testForEachOrderedParameters(LongStream expected, LongStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.forEachOrdered(null));
+        assertThrows(NullPointerException.class, () -> actual.forEachOrdered(null));
+    }
+
+    public void testToArray(LongStream expected, LongStream actual) {
+        var expectedResult = expected.toArray();
+        var actualResult = actual.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testReduceIntBinaryOperator(LongStream expected, LongStream actual) {
+        var expectedResult = expected.reduce(failing(LongBinaryOperator.class));
+        var actualResult = actual.reduce(failing(LongBinaryOperator.class));
+
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testReduceIntBinaryOperatorParameters(LongStream expected, LongStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.reduce(null));
+        assertThrows(NullPointerException.class, () -> actual.reduce(null));
+    }
+
+    public void testReduceIdentityIntBinaryOperator(LongStream expected, LongStream actual) {
+        var magicIdentity = 42;
+        var expectedResult = expected.reduce(magicIdentity, failing(LongBinaryOperator.class));
+        var actualResult = actual.reduce(magicIdentity, failing(LongBinaryOperator.class));
+
+        assertEquals(magicIdentity, expectedResult);
+        assertEquals(magicIdentity, actualResult);
+    }
+
+    public void testReduceIdentityIntBinaryOperatorParameters(LongStream expected, LongStream actual) {
+        int magicInt = 42;
+        assertThrows(NullPointerException.class, () -> expected.reduce(magicInt, null));
+        assertThrows(NullPointerException.class, () -> actual.reduce(magicInt, null));
+    }
+
+    public void testCollect(LongStream expected, LongStream actual) {
+        var magicIdentity = new Object();
+        var accumulator = failing(ObjLongConsumer.class);
+        var combiner = failing(BiConsumer.class);
+        var expectedResult = expected.collect(() -> magicIdentity, accumulator, combiner);
+        var actualResult = actual.collect(() -> magicIdentity, accumulator, combiner);
+
+        assertSame(magicIdentity, expectedResult);
+        assertSame(magicIdentity, actualResult);
+    }
+
+    public void testCollectParameters(LongStream expected, LongStream actual) {
+        Supplier<Object> supplier = Object::new;
+        var accumulator = failing(ObjLongConsumer.class);
+        var combiner = failing(BiConsumer.class);
+        assertThrows(NullPointerException.class, () -> expected.collect(null, accumulator, combiner));
+        assertThrows(NullPointerException.class, () -> actual.collect(null, accumulator, combiner));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, null, combiner));
+        assertThrows(NullPointerException.class, () -> actual.collect(supplier, null, combiner));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, accumulator, null));
+        assertThrows(NullPointerException.class, () -> actual.collect(supplier, accumulator, null));
+    }
+
+    public void testSum(LongStream expected, LongStream actual) {
+        var expectedResult = expected.sum();
+        var actualResult = actual.sum();
+
+        assertEquals(expectedResult, actualResult);
+        assertEquals(0, actualResult);
+    }
+
+    public void testMin(LongStream expected, LongStream actual) {
+        var expectedResult = expected.min();
+        var actualResult = actual.min();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMax(LongStream expected, LongStream actual) {
+        var expectedResult = expected.max();
+        var actualResult = actual.max();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testCount(LongStream expected, LongStream actual) {
+        var expectedResult = expected.count();
+        var actualResult = actual.count();
+        assertEquals(expectedResult, actualResult);
+        assertEquals(0L, actualResult);
+    }
+
+    public void testAverage(LongStream expected, LongStream actual) {
+        var expectedResult = expected.average();
+        var actualResult = actual.average();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testSummaryStatistics(LongStream expected, LongStream actual) {
+        var expectedResult = expected.summaryStatistics().toString();
+        var actualResult = actual.summaryStatistics().toString();
+        assertEquals(expectedResult, actualResult);
+    }
+
+    public void testAnyMatch(LongStream expected, LongStream actual) {
+        var expectedResult = expected.anyMatch(failing(LongPredicate.class));
+        var actualResult = actual.anyMatch(failing(LongPredicate.class));
+        assertEquals(expectedResult, actualResult);
+    }
+
+    public void testAnyMatchParameters(LongStream expected, LongStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.anyMatch(null));
+        assertThrows(NullPointerException.class, () -> actual.anyMatch(null));
+    }
+
+    public void testAllMatch(LongStream expected, LongStream actual) {
+        var expectedResult = expected.allMatch(failing(LongPredicate.class));
+        var actualResult = actual.allMatch(failing(LongPredicate.class));
+        assertEquals(expectedResult, actualResult);
+    }
+
+    public void testAllMatchParameters(LongStream expected, LongStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.allMatch(null));
+        assertThrows(NullPointerException.class, () -> actual.allMatch(null));
+    }
+
+    public void testNoneMatch(LongStream expected, LongStream actual) {
+        var expectedResult = expected.noneMatch(failing(LongPredicate.class));
+        var actualResult = actual.noneMatch(failing(LongPredicate.class));
+        assertEquals(expectedResult, actualResult);
+    }
+
+    public void testNoneMatchParameters(LongStream expected, LongStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.noneMatch(null));
+        assertThrows(NullPointerException.class, () -> actual.noneMatch(null));
+    }
+
+    public void testFindFirst(LongStream expected, LongStream actual) {
+        var expectedResult = expected.findFirst();
+        var actualResult = actual.findFirst();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testFindAny(LongStream expected, LongStream actual) {
+        var expectedResult = expected.findAny();
+        var actualResult = actual.findAny();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testAsDoubleStream(LongStream expected, LongStream actual) {
+        DoubleStream expectedAsDoubleStream = expected.asDoubleStream();
+        DoubleStream actualAsDoubleStream = actual.asDoubleStream();
+        double[] expectedResult = expectedAsDoubleStream.toArray();
+        double[] actualResult = actualAsDoubleStream.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testBoxed(LongStream expected, LongStream actual) {
+        Stream<Long> expectedAsStream = expected.boxed();
+        Stream<Long> actualAsStream = actual.boxed();
+        var expectedResult = expectedAsStream.toArray();
+        var actualResult = actualAsStream.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMapMulti(LongStream expected, LongStream actual) {
+        var expectedResult = expected.mapMulti(failing(LongStream.LongMapMultiConsumer.class)).toArray();
+        var actualResult = actual.mapMulti(failing(LongStream.LongMapMultiConsumer.class)).toArray();
+
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMapMultiParameters(LongStream expected, LongStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.mapMulti(null));
+        assertThrows(NullPointerException.class, () -> actual.mapMulti(null));
+    }
+
+    public void testTakeWhile(LongStream expected, LongStream actual) {
+        var expectedResult = expected.takeWhile(failing(LongPredicate.class)).toArray();
+        var actualResult = actual.takeWhile(failing(LongPredicate.class)).toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testTakeWhileParameters(LongStream expected, LongStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.takeWhile(null));
+        assertThrows(NullPointerException.class, () -> actual.takeWhile(null));
+    }
+
+    public void testDropWhile(LongStream expected, LongStream actual) {
+        var expectedResult = expected.dropWhile(failing(LongPredicate.class)).toArray();
+        var actualResult = actual.dropWhile(failing(LongPredicate.class)).toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testDropWhileParameters(LongStream expected, LongStream actual) {
+        assertThrows(NullPointerException.class, () -> expected.dropWhile(null));
+        assertThrows(NullPointerException.class, () -> actual.dropWhile(null));
+    }
+}

--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyStreamTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyStreamTest.java
@@ -1,0 +1,567 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.tests.java.util.stream;
+
+import org.testng.annotations.Test;
+
+import java.util.Comparator;
+import java.util.Set;
+import java.util.Spliterators;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToIntFunction;
+import java.util.function.ToLongFunction;
+import java.util.stream.Collector;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static org.testng.Assert.*;
+
+/*
+ * @test
+ * @summary Checks that the EmptyStream is equivalent to the
+ * old way of creating it with StreamSupport.
+ * @author Heinz Kabutz
+ */
+
+public final class EmptyStreamTest extends EmptyBaseStreamTest {
+    @Test
+    public void testAll() {
+        this.compare(Stream.class,
+                () -> StreamSupport.stream(Spliterators.emptySpliterator(), false),
+                Stream::empty);
+        this.compare(Stream.class,
+                () -> StreamSupport.stream(Spliterators.emptySpliterator(), true),
+                () -> Stream.empty().parallel());
+    }
+
+    public void testFilter(Stream<Integer> expected, Stream<Integer> actual) {
+        expected = expected.filter(failing(Predicate.class));
+        actual = actual.filter(failing(Predicate.class));
+        var expectedResult = expected.toList();
+        var actualResult = actual.toList();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testFilterParameters(Stream<Integer> expected, Stream<Integer> actual) {
+        assertThrows(NullPointerException.class, () -> expected.filter(null));
+        assertThrows(NullPointerException.class, () -> actual.filter(null));
+    }
+
+    public void testMap(Stream<Integer> expected, Stream<Integer> actual) {
+        Stream<String> expectedAsStrings = expected.map(failing(Function.class));
+        Stream<String> actualAsStrings = actual.map(failing(Function.class));
+        var expectedResult = expectedAsStrings.toList();
+        var actualResult = actualAsStrings.toList();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMapParameters(Stream<Integer> expected, Stream<Integer> actual) {
+        assertThrows(NullPointerException.class, () -> expected.map(null));
+        assertThrows(NullPointerException.class, () -> actual.map(null));
+    }
+
+    public void testMapToInt(Stream<Integer> expected, Stream<Integer> actual) {
+        IntStream expectedAsIntStream = expected.mapToInt(failing(ToIntFunction.class));
+        IntStream actualAsIntStream = actual.mapToInt(failing(ToIntFunction.class));
+        var expectedResult = expectedAsIntStream.toArray();
+        var actualResult = actualAsIntStream.toArray();
+        compareResults(expectedResult, actualResult);
+        assertEquals(expected.isParallel(), expectedAsIntStream.isParallel());
+        assertEquals(actual.isParallel(), actualAsIntStream.isParallel());
+    }
+
+    public void testMapToIntParameters(Stream<Integer> expected, Stream<Integer> actual) {
+        assertThrows(NullPointerException.class, () -> expected.mapToInt(null));
+        assertThrows(NullPointerException.class, () -> actual.mapToInt(null));
+    }
+
+    public void testMapToLong(Stream<Integer> expected, Stream<Integer> actual) {
+        LongStream expectedAsLongStream = expected.mapToLong(failing(ToLongFunction.class));
+        LongStream actualAsLongStream = actual.mapToLong(failing(ToLongFunction.class));
+        var expectedResult = expectedAsLongStream.toArray();
+        var actualResult = actualAsLongStream.toArray();
+        compareResults(expectedResult, actualResult);
+        assertEquals(expected.isParallel(), expectedAsLongStream.isParallel());
+        assertEquals(actual.isParallel(), actualAsLongStream.isParallel());
+    }
+
+    public void testMapToLongParameters(Stream<Integer> expected, Stream<Integer> actual) {
+        assertThrows(NullPointerException.class, () -> expected.mapToLong(null));
+        assertThrows(NullPointerException.class, () -> actual.mapToLong(null));
+    }
+
+    public void testMapToDouble(Stream<Integer> expected, Stream<Integer> actual) {
+        DoubleStream expectedAsDoubleStream = expected.mapToDouble(failing(ToDoubleFunction.class));
+        DoubleStream actualAsDoubleStream = actual.mapToDouble(failing(ToDoubleFunction.class));
+        var expectedResult = expectedAsDoubleStream.toArray();
+        var actualResult = actualAsDoubleStream.toArray();
+        compareResults(expectedResult, actualResult);
+        assertEquals(expected.isParallel(), expectedAsDoubleStream.isParallel());
+        assertEquals(actual.isParallel(), actualAsDoubleStream.isParallel());
+    }
+
+    public void testMapToDoubleParameters(Stream<Integer> expected, Stream<Integer> actual) {
+        assertThrows(NullPointerException.class, () -> expected.mapToDouble(null));
+        assertThrows(NullPointerException.class, () -> actual.mapToDouble(null));
+    }
+
+    public void testFlatMap(Stream<Stream<Integer>> expected, Stream<Stream<Integer>> actual) {
+        var expectedResult = expected.flatMap(Function.identity())
+                .toList();
+        var actualResult = actual.flatMap(Function.identity())
+                .toList();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testFlatMapParameters(Stream<Stream<Integer>> expected, Stream<Stream<Integer>> actual) {
+        assertThrows(NullPointerException.class, () -> expected.flatMap(null));
+        assertThrows(NullPointerException.class, () -> actual.flatMap(null));
+    }
+
+    public void testFlatMapToInt(Stream<IntStream> expected, Stream<IntStream> actual) {
+        var expectedResult = expected.flatMapToInt(Function.identity())
+                .toArray();
+        var actualResult = actual.flatMapToInt(Function.identity())
+                .toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testFlatMapToIntParameters(Stream<IntStream> expected, Stream<IntStream> actual) {
+        assertThrows(NullPointerException.class, () -> expected.flatMapToInt(null));
+        assertThrows(NullPointerException.class, () -> actual.flatMapToInt(null));
+    }
+
+    public void testFlatMapToLong(Stream<LongStream> expected, Stream<LongStream> actual) {
+        var expectedResult = expected.flatMapToLong(Function.identity())
+                .toArray();
+        var actualResult = actual.flatMapToLong(Function.identity())
+                .toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testFlatMapToLongParameters(Stream<LongStream> expected, Stream<LongStream> actual) {
+        assertThrows(NullPointerException.class, () -> expected.flatMapToLong(null));
+        assertThrows(NullPointerException.class, () -> actual.flatMapToLong(null));
+    }
+
+    public void testFlatMapToDouble(Stream<DoubleStream> expected, Stream<DoubleStream> actual) {
+        var expectedResult = expected.flatMapToDouble(Function.identity())
+                .toArray();
+        var actualResult = actual.flatMapToDouble(Function.identity())
+                .toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testFlatMapToDoubleParameters(Stream<DoubleStream> expected, Stream<DoubleStream> actual) {
+        assertThrows(NullPointerException.class, () -> expected.flatMapToDouble(null));
+        assertThrows(NullPointerException.class, () -> actual.flatMapToDouble(null));
+    }
+
+    public void testMapMulti(Stream<Number> expected, Stream<Number> actual) {
+        var expectedResult = expected.mapMulti(failing(BiConsumer.class))
+                .toList();
+        var actualResult = actual.mapMulti(failing(BiConsumer.class))
+                .toList();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMapMultiParameters(Stream<Number> expected, Stream<Number> actual) {
+        assertThrows(NullPointerException.class, () -> expected.mapMulti(null));
+        assertThrows(NullPointerException.class, () -> actual.mapMulti(null));
+    }
+
+    public void testMapMultiToInt(Stream<Number> expected, Stream<Number> actual) {
+        var expectedResult = expected.mapMultiToInt(failing(BiConsumer.class))
+                .toArray();
+        var actualResult = actual.mapMultiToInt(failing(BiConsumer.class))
+                .toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMapMultiToIntParameters(Stream<Number> expected, Stream<Number> actual) {
+        assertThrows(NullPointerException.class, () -> expected.mapMultiToInt(null));
+        assertThrows(NullPointerException.class, () -> actual.mapMultiToInt(null));
+    }
+
+    public void testMapMultiToLong(Stream<Number> expected, Stream<Number> actual) {
+        var expectedResult = expected.mapMultiToLong(failing(BiConsumer.class))
+                .toArray();
+        var actualResult = actual.mapMultiToLong(failing(BiConsumer.class))
+                .toArray();
+
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMapMultiToLongParameters(Stream<Number> expected, Stream<Number> actual) {
+        assertThrows(NullPointerException.class, () -> expected.mapMultiToLong(null));
+        assertThrows(NullPointerException.class, () -> actual.mapMultiToLong(null));
+    }
+
+    public void testMapMultiToDouble(Stream<Number> expected, Stream<Number> actual) {
+        var expectedResult = expected.mapMultiToDouble(failing(BiConsumer.class))
+                .toArray();
+        var actualResult = actual.mapMultiToDouble(failing(BiConsumer.class))
+                .toArray();
+
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMapMultiToDoubleParameters(Stream<Number> expected, Stream<Number> actual) {
+        assertThrows(NullPointerException.class, () -> expected.mapMultiToDouble(null));
+        assertThrows(NullPointerException.class, () -> actual.mapMultiToDouble(null));
+    }
+
+    public void testDistinct(Stream<?> expected, Stream<?> actual) {
+        expected = expected.distinct();
+        actual = actual.distinct();
+        var expectedResult = expected.toList();
+        var actualResult = actual.toList();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testSorted(Stream<Integer> expected, Stream<Integer> actual) {
+        expected = expected.sorted();
+        actual = actual.sorted();
+        var expectedResult = expected.toList();
+        var actualResult = actual.toList();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testSortedComparator(Stream<Integer> expected, Stream<Integer> actual) {
+        expected = expected.sorted(Comparator.reverseOrder());
+        actual = actual.sorted(Comparator.reverseOrder());
+        var expectedResult = expected.toList();
+        var actualResult = actual.toList();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testSortedComparatorParameters(Stream<Integer> expected, Stream<Integer> actual) {
+        assertThrows(NullPointerException.class, () -> expected.sorted(null));
+        assertThrows(NullPointerException.class, () -> actual.sorted(null));
+    }
+
+    public void testPeek(Stream<Integer> expected, Stream<Integer> actual) {
+        expected.peek(failing(Consumer.class)).toList();
+        actual.peek(failing(Consumer.class)).toList();
+    }
+
+    public void testPeekParameters(Stream<Integer> expected, Stream<Integer> actual) {
+        assertThrows(NullPointerException.class, () -> expected.peek(null));
+        assertThrows(NullPointerException.class, () -> actual.peek(null));
+    }
+
+    public void testSkip(Stream<Integer> expected, Stream<Integer> actual) {
+        var expectedResult = expected.skip(10).toList();
+        var actualResult = actual.skip(10).toList();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testSkipParameters(Stream<Integer> expected, Stream<Integer> actual) {
+        assertThrows(IllegalArgumentException.class, () -> expected.skip(-1));
+        assertThrows(IllegalArgumentException.class, () -> actual.skip(-1));
+    }
+
+    public void testTakeWhile(Stream<Integer> expected, Stream<Integer> actual) {
+        var expectedResult = expected.takeWhile(failing(Predicate.class))
+                .toList();
+        var actualResult = actual.takeWhile(failing(Predicate.class))
+                .toList();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testTakeWhileParameters(Stream<Integer> expected, Stream<Integer> actual) {
+        assertThrows(NullPointerException.class, () -> expected.takeWhile(null));
+        assertThrows(NullPointerException.class, () -> actual.takeWhile(null));
+    }
+
+    public void testDropWhile(Stream<Integer> expected, Stream<Integer> actual) {
+        var expectedResult = expected.dropWhile(failing(Predicate.class))
+                .toList();
+        var actualResult = actual.dropWhile(failing(Predicate.class))
+                .toList();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testDropWhileParameters(Stream<Integer> expected, Stream<Integer> actual) {
+        assertThrows(NullPointerException.class, () -> expected.dropWhile(null));
+        assertThrows(NullPointerException.class, () -> actual.dropWhile(null));
+    }
+
+    public void testForEach(Stream<Integer> expected, Stream<Integer> actual) {
+        expected.forEach(failing(Consumer.class));
+        actual.forEach(failing(Consumer.class));
+    }
+
+    public void testForEachParameters(Stream<Integer> expected, Stream<Integer> actual) {
+        assertThrows(NullPointerException.class, () -> expected.forEach(null));
+        assertThrows(NullPointerException.class, () -> actual.forEach(null));
+    }
+
+    public void testForEachOrdered(Stream<Integer> expected, Stream<Integer> actual) {
+        expected.forEachOrdered(failing(Consumer.class));
+        actual.forEachOrdered(failing(Consumer.class));
+    }
+
+    public void testForEachOrderedParameters(Stream<Integer> expected, Stream<Integer> actual) {
+        assertThrows(NullPointerException.class, () -> expected.forEachOrdered(null));
+        assertThrows(NullPointerException.class, () -> actual.forEachOrdered(null));
+    }
+
+    public void testToArray(Stream<Integer> expected, Stream<Integer> actual) {
+        var expectedResult = expected.toArray();
+        var actualResult = actual.toArray();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testToArrayFunction(Stream<Integer> expected, Stream<Integer> actual) {
+        var expectedResult = expected.toArray(Integer[]::new);
+        var actualResult = actual.toArray(Integer[]::new);
+        compareResults(expectedResult, actualResult);
+        assertEquals(Integer.class, expectedResult.getClass()
+                .getComponentType());
+    }
+
+    public void testToArrayFunctionParameters(Stream<Integer> expected, Stream<Integer> actual) {
+        assertThrows(NullPointerException.class, () -> expected.toArray(null));
+        assertThrows(NullPointerException.class, () -> actual.toArray(null));
+    }
+
+    public void testReduceIdentityAccumulator(Stream<Object> expected, Stream<Object> actual) {
+        var magicIdentity = new Object();
+        var expectedResult = expected.reduce(magicIdentity, failing(BinaryOperator.class));
+        var actualResult = actual.reduce(magicIdentity, failing(BinaryOperator.class));
+
+        assertSame(magicIdentity, expectedResult);
+        assertSame(magicIdentity, actualResult);
+    }
+
+    public void testReduceIdentityAccumulatorParameters(Stream<Object> expected, Stream<Object> actual) {
+        // null identity should be fine
+        expected.reduce(null, failing(BinaryOperator.class));
+        actual.reduce(null, failing(BinaryOperator.class));
+        var magicIdentity = new Object();
+        assertThrows(NullPointerException.class, () -> expected.reduce(magicIdentity, null));
+        assertThrows(NullPointerException.class, () -> actual.reduce(magicIdentity, null));
+    }
+
+    public void testReduceAccumulator(Stream<Object> expected, Stream<Object> actual) {
+        var expectedResult = expected.reduce(failing(BinaryOperator.class));
+        var actualResult = actual.reduce(failing(BinaryOperator.class));
+
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testReduceAccumulatorParameters(Stream<Object> expected, Stream<Object> actual) {
+        assertThrows(NullPointerException.class, () -> expected.reduce(null));
+        assertThrows(NullPointerException.class, () -> actual.reduce(null));
+    }
+
+    public void testReduceIdentityAccumulatorCombiner(Stream<Object> expected, Stream<Object> actual) {
+        var magicIdentity = new Object();
+        var expectedResult = expected.reduce(magicIdentity, failing(BinaryOperator.class), failing(BinaryOperator.class));
+        var actualResult = actual.reduce(magicIdentity, failing(BinaryOperator.class), failing(BinaryOperator.class));
+
+        assertSame(magicIdentity, expectedResult);
+        assertSame(magicIdentity, actualResult);
+    }
+
+    public void testReduceIdentityAccumulatorCombinerParameters(Stream<Object> expected, Stream<Object> actual) {
+        var accumulator = failing(BinaryOperator.class);
+        var combiner = failing(BinaryOperator.class);
+        // null identity should be fine
+        expected.reduce(null, accumulator, combiner);
+        actual.reduce(null, accumulator, combiner);
+        var magicIdentity = new Object();
+        assertThrows(NullPointerException.class, () -> expected.reduce(magicIdentity, null, combiner));
+        assertThrows(NullPointerException.class, () -> actual.reduce(magicIdentity, null, combiner));
+        assertThrows(NullPointerException.class, () -> expected.reduce(magicIdentity, accumulator, null));
+        assertThrows(NullPointerException.class, () -> actual.reduce(magicIdentity, accumulator, null));
+    }
+
+    public void testCollectSupplierAccumulatorCombiner(Stream<Integer> expected, Stream<Integer> actual) {
+        var magicIdentity = new Object();
+        var expectedResult = expected.collect(() -> magicIdentity, failing(BiConsumer.class), failing(BiConsumer.class));
+        var actualResult = actual.collect(() -> magicIdentity, failing(BiConsumer.class), failing(BiConsumer.class));
+
+        assertSame(magicIdentity, expectedResult);
+        assertSame(magicIdentity, actualResult);
+    }
+
+    public void testCollectSupplierAccumulatorCombinerParameters(Stream<Integer> expected, Stream<Integer> actual) {
+        var magicIdentity = new Object();
+        Supplier<Object> supplier = () -> magicIdentity;
+        var accumulator = failing(BiConsumer.class);
+        var combiner = failing(BiConsumer.class);
+        assertThrows(NullPointerException.class, () -> expected.collect(null, accumulator, combiner));
+        assertThrows(NullPointerException.class, () -> actual.collect(null, accumulator, combiner));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, null, combiner));
+        assertThrows(NullPointerException.class, () -> actual.collect(supplier, null, combiner));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, accumulator, null));
+        assertThrows(NullPointerException.class, () -> actual.collect(supplier, accumulator, null));
+    }
+
+    public void testCollectCollector(Stream<Object> expected, Stream<Object> actual) {
+        var magicIdentity = new Object();
+        var superMagicIdentity = new Object();
+        Collector<Object, Object, Object> collector = new Collector<>() {
+            @Override
+            public Supplier<Object> supplier() {
+                return () -> magicIdentity;
+            }
+
+            @Override
+            public BiConsumer<Object, Object> accumulator() {
+                return failing(BiConsumer.class);
+            }
+
+            @Override
+            public BinaryOperator<Object> combiner() {
+                return failing(BinaryOperator.class);
+            }
+
+            @Override
+            public Function<Object, Object> finisher() {
+                return a -> {
+                    assertSame(magicIdentity, a);
+                    return superMagicIdentity;
+                };
+            }
+
+            @Override
+            public Set<Characteristics> characteristics() {
+                return Set.of();
+            }
+        };
+        var expectedResult = expected.collect(collector);
+        var actualResult = actual.collect(collector);
+
+        assertSame(superMagicIdentity, expectedResult);
+        assertSame(superMagicIdentity, actualResult);
+    }
+
+    public void testCollectCollectorParameters(Stream<Object> expected, Stream<Object> actual) {
+        assertThrows(NullPointerException.class, () -> expected.collect(null));
+        assertThrows(NullPointerException.class, () -> actual.collect(null));
+    }
+
+    public void testToList(Stream<Integer> expected, Stream<Integer> actual) {
+        var expectedResult = expected.toList();
+        var actualResult = actual.toList();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMin(Stream<Integer> expected, Stream<Integer> actual) {
+        var expectedResult = expected.min(Comparator.reverseOrder());
+        var actualResult = actual.min(Comparator.reverseOrder());
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMinParameters(Stream<Integer> expected, Stream<Integer> actual) {
+        assertThrows(NullPointerException.class, () -> expected.min(null));
+        assertThrows(NullPointerException.class, () -> actual.min(null));
+    }
+
+    public void testMax(Stream<Integer> expected, Stream<Integer> actual) {
+        var expectedResult = expected.max(Comparator.reverseOrder());
+        var actualResult = actual.max(Comparator.reverseOrder());
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testMaxParameters(Stream<Integer> expected, Stream<Integer> actual) {
+        assertThrows(NullPointerException.class, () -> expected.max(null));
+        assertThrows(NullPointerException.class, () -> actual.max(null));
+    }
+
+    public void testCount(Stream<Integer> expected, Stream<Integer> actual) {
+        var expectedResult = expected.count();
+        var actualResult = actual.count();
+        assertEquals(expectedResult, actualResult);
+        assertEquals(0L, actualResult);
+    }
+
+    public void testAnyMatch(Stream<?> expected, Stream<?> actual) {
+        var expectedResult = expected.anyMatch(failing(Predicate.class));
+        var actualResult = actual.anyMatch(failing(Predicate.class));
+        assertEquals(expectedResult, actualResult);
+    }
+
+    public void testAnyMatchParameters(Stream<?> expected, Stream<?> actual) {
+        assertThrows(NullPointerException.class, () -> expected.anyMatch(null));
+        assertThrows(NullPointerException.class, () -> actual.anyMatch(null));
+    }
+
+    public void testAllMatch(Stream<?> expected, Stream<?> actual) {
+        var expectedResult = expected.allMatch(failing(Predicate.class));
+        var actualResult = actual.allMatch(failing(Predicate.class));
+        assertEquals(expectedResult, actualResult);
+    }
+
+    public void testAllMatchParameters(Stream<?> expected, Stream<?> actual) {
+        assertThrows(NullPointerException.class, () -> expected.allMatch(null));
+        assertThrows(NullPointerException.class, () -> actual.allMatch(null));
+    }
+
+    public void testNoneMatch(Stream<?> expected, Stream<?> actual) {
+        var expectedResult = expected.noneMatch(failing(Predicate.class));
+        var actualResult = actual.noneMatch(failing(Predicate.class));
+        assertEquals(expectedResult, actualResult);
+    }
+
+    public void testNoneMatchParameters(Stream<?> expected, Stream<?> actual) {
+        assertThrows(NullPointerException.class, () -> expected.noneMatch(null));
+        assertThrows(NullPointerException.class, () -> actual.noneMatch(null));
+    }
+
+    public void testFindFirst(Stream<Integer> expected, Stream<Integer> actual) {
+        var expectedResult = expected.findFirst();
+        var actualResult = actual.findFirst();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testFindAny(Stream<Integer> expected, Stream<Integer> actual) {
+        var expectedResult = expected.findAny();
+        var actualResult = actual.findAny();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testLimit(Stream<Integer> expected, Stream<Integer> actual) {
+        var expectedResult = expected.limit(10).toList();
+        var actualResult = actual.limit(10).toList();
+        compareResults(expectedResult, actualResult);
+    }
+
+    public void testLimitParameters(Stream<Integer> expected, Stream<Integer> actual) {
+        assertThrows(IllegalArgumentException.class, () -> expected.limit(-1));
+        assertThrows(IllegalArgumentException.class, () -> actual.limit(-1));
+    }
+}

--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyStreamTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/EmptyStreamTest.java
@@ -29,15 +29,18 @@ import java.util.Comparator;
 import java.util.Set;
 import java.util.Spliterators;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.IntFunction;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.ToDoubleFunction;
 import java.util.function.ToIntFunction;
 import java.util.function.ToLongFunction;
 import java.util.stream.Collector;
+import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -57,380 +60,398 @@ public final class EmptyStreamTest extends EmptyBaseStreamTest {
     @Test
     public void testAll() {
         this.compare(Stream.class,
-                () -> StreamSupport.stream(Spliterators.emptySpliterator(), false),
-                Stream::empty);
+                Stream::empty,
+                () -> StreamSupport.stream(Spliterators.emptySpliterator(), false)
+        );
         this.compare(Stream.class,
-                () -> StreamSupport.stream(Spliterators.emptySpliterator(), true),
-                () -> Stream.empty().parallel());
+                () -> Stream.empty().parallel(),
+                () -> StreamSupport.stream(Spliterators.emptySpliterator(), true)
+        );
     }
 
-    public void testFilter(Stream<Integer> expected, Stream<Integer> actual) {
-        expected = expected.filter(failing(Predicate.class));
+    public void testFilter(Stream<Integer> actual, Stream<Integer> expected) {
         actual = actual.filter(failing(Predicate.class));
-        var expectedResult = expected.toList();
+        expected = expected.filter(failing(Predicate.class));
         var actualResult = actual.toList();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.toList();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testFilterParameters(Stream<Integer> expected, Stream<Integer> actual) {
-        assertThrows(NullPointerException.class, () -> expected.filter(null));
-        assertThrows(NullPointerException.class, () -> actual.filter(null));
+    public void testFilterExceptions(Stream<?> actual, Stream<?> expected) {
+        checkExpectedExceptions(actual, expected, "filter", Predicate.class);
     }
 
-    public void testMap(Stream<Integer> expected, Stream<Integer> actual) {
-        Stream<String> expectedAsStrings = expected.map(failing(Function.class));
+    public void testMap(Stream<Integer> actual, Stream<Integer> expected) {
         Stream<String> actualAsStrings = actual.map(failing(Function.class));
-        var expectedResult = expectedAsStrings.toList();
+        Stream<String> expectedAsStrings = expected.map(failing(Function.class));
         var actualResult = actualAsStrings.toList();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expectedAsStrings.toList();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMapParameters(Stream<Integer> expected, Stream<Integer> actual) {
-        assertThrows(NullPointerException.class, () -> expected.map(null));
-        assertThrows(NullPointerException.class, () -> actual.map(null));
+    public void testMapExceptions(Stream<?> actual, Stream<?> expected) {
+        checkExpectedExceptions(actual, expected, "map", Function.class);
     }
 
-    public void testMapToInt(Stream<Integer> expected, Stream<Integer> actual) {
-        IntStream expectedAsIntStream = expected.mapToInt(failing(ToIntFunction.class));
+    public void testMapToInt(Stream<Integer> actual, Stream<Integer> expected) {
         IntStream actualAsIntStream = actual.mapToInt(failing(ToIntFunction.class));
-        var expectedResult = expectedAsIntStream.toArray();
+        IntStream expectedAsIntStream = expected.mapToInt(failing(ToIntFunction.class));
         var actualResult = actualAsIntStream.toArray();
-        compareResults(expectedResult, actualResult);
-        assertEquals(expected.isParallel(), expectedAsIntStream.isParallel());
+        var expectedResult = expectedAsIntStream.toArray();
+        compareResults(actualResult, expectedResult);
         assertEquals(actual.isParallel(), actualAsIntStream.isParallel());
+        assertEquals(expected.isParallel(), expectedAsIntStream.isParallel());
     }
 
-    public void testMapToIntParameters(Stream<Integer> expected, Stream<Integer> actual) {
-        assertThrows(NullPointerException.class, () -> expected.mapToInt(null));
-        assertThrows(NullPointerException.class, () -> actual.mapToInt(null));
+    public void testMapToIntExceptions(Stream<?> actual, Stream<?> expected) {
+        checkExpectedExceptions(actual, expected, "mapToInt", ToIntFunction.class);
     }
 
-    public void testMapToLong(Stream<Integer> expected, Stream<Integer> actual) {
-        LongStream expectedAsLongStream = expected.mapToLong(failing(ToLongFunction.class));
+    public void testMapToLong(Stream<Integer> actual, Stream<Integer> expected) {
         LongStream actualAsLongStream = actual.mapToLong(failing(ToLongFunction.class));
-        var expectedResult = expectedAsLongStream.toArray();
+        LongStream expectedAsLongStream = expected.mapToLong(failing(ToLongFunction.class));
         var actualResult = actualAsLongStream.toArray();
-        compareResults(expectedResult, actualResult);
-        assertEquals(expected.isParallel(), expectedAsLongStream.isParallel());
+        var expectedResult = expectedAsLongStream.toArray();
+        compareResults(actualResult, expectedResult);
         assertEquals(actual.isParallel(), actualAsLongStream.isParallel());
+        assertEquals(expected.isParallel(), expectedAsLongStream.isParallel());
     }
 
-    public void testMapToLongParameters(Stream<Integer> expected, Stream<Integer> actual) {
-        assertThrows(NullPointerException.class, () -> expected.mapToLong(null));
-        assertThrows(NullPointerException.class, () -> actual.mapToLong(null));
+    public void testMapToLongExceptions(Stream<Integer> actual, Stream<Integer> expected) {
+        checkExpectedExceptions(actual, expected, "mapToLong", ToLongFunction.class);
     }
 
-    public void testMapToDouble(Stream<Integer> expected, Stream<Integer> actual) {
-        DoubleStream expectedAsDoubleStream = expected.mapToDouble(failing(ToDoubleFunction.class));
+    public void testMapToDouble(Stream<Integer> actual, Stream<Integer> expected) {
         DoubleStream actualAsDoubleStream = actual.mapToDouble(failing(ToDoubleFunction.class));
-        var expectedResult = expectedAsDoubleStream.toArray();
+        DoubleStream expectedAsDoubleStream = expected.mapToDouble(failing(ToDoubleFunction.class));
         var actualResult = actualAsDoubleStream.toArray();
-        compareResults(expectedResult, actualResult);
-        assertEquals(expected.isParallel(), expectedAsDoubleStream.isParallel());
+        var expectedResult = expectedAsDoubleStream.toArray();
+        compareResults(actualResult, expectedResult);
         assertEquals(actual.isParallel(), actualAsDoubleStream.isParallel());
+        assertEquals(expected.isParallel(), expectedAsDoubleStream.isParallel());
     }
 
-    public void testMapToDoubleParameters(Stream<Integer> expected, Stream<Integer> actual) {
-        assertThrows(NullPointerException.class, () -> expected.mapToDouble(null));
-        assertThrows(NullPointerException.class, () -> actual.mapToDouble(null));
+    public void testMapToDoubleExceptions(Stream<Integer> actual, Stream<Integer> expected) {
+        checkExpectedExceptions(actual, expected, "mapToDouble", ToDoubleFunction.class);
     }
 
-    public void testFlatMap(Stream<Stream<Integer>> expected, Stream<Stream<Integer>> actual) {
-        var expectedResult = expected.flatMap(Function.identity())
-                .toList();
-        var actualResult = actual.flatMap(Function.identity())
-                .toList();
-        compareResults(expectedResult, actualResult);
+    public void testFlatMap(Stream<Stream<Integer>> actual, Stream<Stream<Integer>> expected) {
+        var actualResult = actual.flatMap(Function.identity()).toList();
+        var expectedResult = expected.flatMap(Function.identity()).toList();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testFlatMapParameters(Stream<Stream<Integer>> expected, Stream<Stream<Integer>> actual) {
-        assertThrows(NullPointerException.class, () -> expected.flatMap(null));
-        assertThrows(NullPointerException.class, () -> actual.flatMap(null));
+    public void testFlatMapExceptions(Stream<Stream<Integer>> actual, Stream<Stream<Integer>> expected) {
+        checkExpectedExceptions(actual, expected, "flatMap", Function.class);
     }
 
-    public void testFlatMapToInt(Stream<IntStream> expected, Stream<IntStream> actual) {
-        var expectedResult = expected.flatMapToInt(Function.identity())
-                .toArray();
-        var actualResult = actual.flatMapToInt(Function.identity())
-                .toArray();
-        compareResults(expectedResult, actualResult);
+    public void testFlatMapToInt(Stream<IntStream> actual, Stream<IntStream> expected) {
+        var actualResult = actual.flatMapToInt(Function.identity()).toArray();
+        var expectedResult = expected.flatMapToInt(Function.identity()).toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testFlatMapToIntParameters(Stream<IntStream> expected, Stream<IntStream> actual) {
-        assertThrows(NullPointerException.class, () -> expected.flatMapToInt(null));
-        assertThrows(NullPointerException.class, () -> actual.flatMapToInt(null));
+    public void testFlatMapToIntExceptions(Stream<IntStream> actual, Stream<IntStream> expected) {
+        checkExpectedExceptions(actual, expected, "flatMapToInt", Function.class);
     }
 
-    public void testFlatMapToLong(Stream<LongStream> expected, Stream<LongStream> actual) {
-        var expectedResult = expected.flatMapToLong(Function.identity())
-                .toArray();
-        var actualResult = actual.flatMapToLong(Function.identity())
-                .toArray();
-        compareResults(expectedResult, actualResult);
+    public void testFlatMapToLong(Stream<LongStream> actual, Stream<LongStream> expected) {
+        var actualResult = actual.flatMapToLong(Function.identity()).toArray();
+        var expectedResult = expected.flatMapToLong(Function.identity()).toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testFlatMapToLongParameters(Stream<LongStream> expected, Stream<LongStream> actual) {
-        assertThrows(NullPointerException.class, () -> expected.flatMapToLong(null));
-        assertThrows(NullPointerException.class, () -> actual.flatMapToLong(null));
+    public void testFlatMapToLongExceptions(Stream<LongStream> actual, Stream<LongStream> expected) {
+        checkExpectedExceptions(actual, expected, "flatMapToLong", Function.class);
     }
 
-    public void testFlatMapToDouble(Stream<DoubleStream> expected, Stream<DoubleStream> actual) {
-        var expectedResult = expected.flatMapToDouble(Function.identity())
-                .toArray();
-        var actualResult = actual.flatMapToDouble(Function.identity())
-                .toArray();
-        compareResults(expectedResult, actualResult);
+    public void testFlatMapToDouble(Stream<DoubleStream> actual, Stream<DoubleStream> expected) {
+        var actualResult = actual.flatMapToDouble(Function.identity()).toArray();
+        var expectedResult = expected.flatMapToDouble(Function.identity()).toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testFlatMapToDoubleParameters(Stream<DoubleStream> expected, Stream<DoubleStream> actual) {
-        assertThrows(NullPointerException.class, () -> expected.flatMapToDouble(null));
-        assertThrows(NullPointerException.class, () -> actual.flatMapToDouble(null));
+    public void testFlatMapToDoubleExceptions(Stream<DoubleStream> actual, Stream<DoubleStream> expected) {
+        checkExpectedExceptions(actual, expected, "flatMapToDouble", Function.class);
     }
 
-    public void testMapMulti(Stream<Number> expected, Stream<Number> actual) {
-        var expectedResult = expected.mapMulti(failing(BiConsumer.class))
-                .toList();
-        var actualResult = actual.mapMulti(failing(BiConsumer.class))
-                .toList();
-        compareResults(expectedResult, actualResult);
+    public void testMapMulti(Stream<Number> actual, Stream<Number> expected) {
+        var actualResult = actual.mapMulti(failing(BiConsumer.class)).toList();
+        var expectedResult = expected.mapMulti(failing(BiConsumer.class)).toList();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMapMultiParameters(Stream<Number> expected, Stream<Number> actual) {
-        assertThrows(NullPointerException.class, () -> expected.mapMulti(null));
-        assertThrows(NullPointerException.class, () -> actual.mapMulti(null));
+    public void testMapMultiExceptions(Stream<Number> actual, Stream<Number> expected) {
+        checkExpectedExceptions(actual, expected, "mapMulti", BiConsumer.class);
     }
 
-    public void testMapMultiToInt(Stream<Number> expected, Stream<Number> actual) {
-        var expectedResult = expected.mapMultiToInt(failing(BiConsumer.class))
-                .toArray();
-        var actualResult = actual.mapMultiToInt(failing(BiConsumer.class))
-                .toArray();
-        compareResults(expectedResult, actualResult);
+    public void testMapMultiToInt(Stream<Number> actual, Stream<Number> expected) {
+        var actualResult = actual.mapMultiToInt(failing(BiConsumer.class)).toArray();
+        var expectedResult = expected.mapMultiToInt(failing(BiConsumer.class)).toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMapMultiToIntParameters(Stream<Number> expected, Stream<Number> actual) {
-        assertThrows(NullPointerException.class, () -> expected.mapMultiToInt(null));
-        assertThrows(NullPointerException.class, () -> actual.mapMultiToInt(null));
+    public void testMapMultiToIntExceptions(Stream<Number> actual, Stream<Number> expected) {
+        checkExpectedExceptions(actual, expected, "mapMultiToInt", BiConsumer.class);
     }
 
-    public void testMapMultiToLong(Stream<Number> expected, Stream<Number> actual) {
-        var expectedResult = expected.mapMultiToLong(failing(BiConsumer.class))
-                .toArray();
-        var actualResult = actual.mapMultiToLong(failing(BiConsumer.class))
-                .toArray();
-
-        compareResults(expectedResult, actualResult);
+    public void testMapMultiToLong(Stream<Number> actual, Stream<Number> expected) {
+        var actualResult = actual.mapMultiToLong(failing(BiConsumer.class)).toArray();
+        var expectedResult = expected.mapMultiToLong(failing(BiConsumer.class)).toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMapMultiToLongParameters(Stream<Number> expected, Stream<Number> actual) {
-        assertThrows(NullPointerException.class, () -> expected.mapMultiToLong(null));
-        assertThrows(NullPointerException.class, () -> actual.mapMultiToLong(null));
+    public void testMapMultiToLongExceptions(Stream<Number> actual, Stream<Number> expected) {
+        checkExpectedExceptions(actual, expected, "mapMultiToLong", BiConsumer.class);
     }
 
-    public void testMapMultiToDouble(Stream<Number> expected, Stream<Number> actual) {
-        var expectedResult = expected.mapMultiToDouble(failing(BiConsumer.class))
-                .toArray();
-        var actualResult = actual.mapMultiToDouble(failing(BiConsumer.class))
-                .toArray();
-
-        compareResults(expectedResult, actualResult);
+    public void testMapMultiToDouble(Stream<Number> actual, Stream<Number> expected) {
+        var actualResult = actual.mapMultiToDouble(failing(BiConsumer.class)).toArray();
+        var expectedResult = expected.mapMultiToDouble(failing(BiConsumer.class)).toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMapMultiToDoubleParameters(Stream<Number> expected, Stream<Number> actual) {
-        assertThrows(NullPointerException.class, () -> expected.mapMultiToDouble(null));
-        assertThrows(NullPointerException.class, () -> actual.mapMultiToDouble(null));
+    public void testMapMultiToDoubleExceptions(Stream<Number> actual, Stream<Number> expected) {
+        checkExpectedExceptions(actual, expected, "mapMultiToDouble", BiConsumer.class);
     }
 
-    public void testDistinct(Stream<?> expected, Stream<?> actual) {
-        expected = expected.distinct();
+    public void testDistinct(Stream<?> actual, Stream<?> expected) {
         actual = actual.distinct();
-        var expectedResult = expected.toList();
+        expected = expected.distinct();
         var actualResult = actual.toList();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.toList();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testSorted(Stream<Integer> expected, Stream<Integer> actual) {
-        expected = expected.sorted();
+    public void testDistinctExceptions(Stream<Number> actual, Stream<Number> expected) {
+        checkExpectedExceptions(actual, expected, "distinct");
+    }
+
+    public void testSorted(Stream<Integer> actual, Stream<Integer> expected) {
         actual = actual.sorted();
-        var expectedResult = expected.toList();
+        expected = expected.sorted();
         var actualResult = actual.toList();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.toList();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testSortedComparator(Stream<Integer> expected, Stream<Integer> actual) {
-        expected = expected.sorted(Comparator.reverseOrder());
+    public void testSortedExceptions(Stream<Number> actual, Stream<Number> expected) {
+        checkExpectedExceptions(actual, expected, "sorted");
+    }
+
+    public void testSortedComparator(Stream<Integer> actual, Stream<Integer> expected) {
         actual = actual.sorted(Comparator.reverseOrder());
-        var expectedResult = expected.toList();
+        expected = expected.sorted(Comparator.reverseOrder());
         var actualResult = actual.toList();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.toList();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testSortedComparatorParameters(Stream<Integer> expected, Stream<Integer> actual) {
-        assertThrows(NullPointerException.class, () -> expected.sorted(null));
-        assertThrows(NullPointerException.class, () -> actual.sorted(null));
+    public void testSortedComparatorNullPointerExceptions(Stream<Integer> actual, Stream<Integer> expected) {
+        checkExpectedExceptions(actual, expected, "sorted", Comparator.class);
     }
 
-    public void testPeek(Stream<Integer> expected, Stream<Integer> actual) {
-        expected.peek(failing(Consumer.class)).toList();
+    public void testPeek(Stream<Integer> actual, Stream<Integer> expected) {
         actual.peek(failing(Consumer.class)).toList();
+        expected.peek(failing(Consumer.class)).toList();
     }
 
-    public void testPeekParameters(Stream<Integer> expected, Stream<Integer> actual) {
-        assertThrows(NullPointerException.class, () -> expected.peek(null));
-        assertThrows(NullPointerException.class, () -> actual.peek(null));
+    public void testPeekExceptions(Stream<Integer> actual, Stream<Integer> expected) {
+        checkExpectedExceptions(actual, expected, "peek", Consumer.class);
     }
 
-    public void testSkip(Stream<Integer> expected, Stream<Integer> actual) {
-        var expectedResult = expected.skip(10).toList();
+    public void testSkip(Stream<Integer> actual, Stream<Integer> expected) {
         var actualResult = actual.skip(10).toList();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.skip(10).toList();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testSkipParameters(Stream<Integer> expected, Stream<Integer> actual) {
-        assertThrows(IllegalArgumentException.class, () -> expected.skip(-1));
+    public void testSkipExceptions(Stream<Integer> actual, Stream<Integer> expected) {
         assertThrows(IllegalArgumentException.class, () -> actual.skip(-1));
+        assertThrows(IllegalArgumentException.class, () -> expected.skip(-1));
+
+        actual.skip(0); // should be ok
+        expected.skip(0); // should be ok
+        actual.skip(0); // should be ok
+        expected.skip(0); // should be ok
+
+        actual.skip(10);
+        expected.skip(10);
+        assertThrows(IllegalStateException.class, () -> actual.skip(10));
+        assertThrows(IllegalStateException.class, () -> expected.skip(10));
     }
 
-    public void testTakeWhile(Stream<Integer> expected, Stream<Integer> actual) {
-        var expectedResult = expected.takeWhile(failing(Predicate.class))
-                .toList();
-        var actualResult = actual.takeWhile(failing(Predicate.class))
-                .toList();
-        compareResults(expectedResult, actualResult);
+    public void testTakeWhile(Stream<Integer> actual, Stream<Integer> expected) {
+        var actualResult = actual.takeWhile(failing(Predicate.class)).toList();
+        var expectedResult = expected.takeWhile(failing(Predicate.class)).toList();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testTakeWhileParameters(Stream<Integer> expected, Stream<Integer> actual) {
-        assertThrows(NullPointerException.class, () -> expected.takeWhile(null));
-        assertThrows(NullPointerException.class, () -> actual.takeWhile(null));
+    public void testTakeWhileExceptions(Stream<Integer> actual, Stream<Integer> expected) {
+        checkExpectedExceptions(actual, expected, "takeWhile", Predicate.class);
     }
 
-    public void testDropWhile(Stream<Integer> expected, Stream<Integer> actual) {
-        var expectedResult = expected.dropWhile(failing(Predicate.class))
-                .toList();
-        var actualResult = actual.dropWhile(failing(Predicate.class))
-                .toList();
-        compareResults(expectedResult, actualResult);
+    public void testDropWhile(Stream<Integer> actual, Stream<Integer> expected) {
+        var actualResult = actual.dropWhile(failing(Predicate.class)).toList();
+        var expectedResult = expected.dropWhile(failing(Predicate.class)).toList();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testDropWhileParameters(Stream<Integer> expected, Stream<Integer> actual) {
-        assertThrows(NullPointerException.class, () -> expected.dropWhile(null));
-        assertThrows(NullPointerException.class, () -> actual.dropWhile(null));
+    public void testDropWhileExceptions(Stream<Integer> actual, Stream<Integer> expected) {
+        checkExpectedExceptions(actual, expected, "dropWhile", Predicate.class);
     }
 
-    public void testForEach(Stream<Integer> expected, Stream<Integer> actual) {
-        expected.forEach(failing(Consumer.class));
+    public void testForEach(Stream<Integer> actual, Stream<Integer> expected) {
         actual.forEach(failing(Consumer.class));
+        expected.forEach(failing(Consumer.class));
     }
 
-    public void testForEachParameters(Stream<Integer> expected, Stream<Integer> actual) {
-        assertThrows(NullPointerException.class, () -> expected.forEach(null));
+    public void testForEachExceptions(Stream<Integer> actual, Stream<Integer> expected) {
         assertThrows(NullPointerException.class, () -> actual.forEach(null));
+        assertThrows(NullPointerException.class, () -> expected.forEach(null));
+
+        var actualException = getThrowableType(() -> actual.forEach(null));
+        var expectedException = getThrowableType(() -> expected.forEach(null));
+        assertSame(actualException, expectedException);
+
+        actualException = getThrowableType(() -> actual.forEach(null));
+        expectedException = getThrowableType(() -> expected.forEach(null));
+        assertSame(actualException, expectedException);
+
+        actualException = getThrowableType(() -> actual.forEach(failing(Consumer.class)));
+        expectedException = getThrowableType(() -> expected.forEach(failing(Consumer.class)));
+        assertSame(actualException, expectedException);
+
+        actualException = getThrowableType(() -> actual.forEach(failing(Consumer.class)));
+        expectedException = getThrowableType(() -> expected.forEach(failing(Consumer.class)));
+        assertSame(actualException, expectedException);
     }
 
-    public void testForEachOrdered(Stream<Integer> expected, Stream<Integer> actual) {
-        expected.forEachOrdered(failing(Consumer.class));
+    public void testForEachOrdered(Stream<Integer> actual, Stream<Integer> expected) {
         actual.forEachOrdered(failing(Consumer.class));
+        expected.forEachOrdered(failing(Consumer.class));
     }
 
-    public void testForEachOrderedParameters(Stream<Integer> expected, Stream<Integer> actual) {
-        assertThrows(NullPointerException.class, () -> expected.forEachOrdered(null));
+    public void testForEachOrderedExceptions(Stream<Integer> actual, Stream<Integer> expected) {
         assertThrows(NullPointerException.class, () -> actual.forEachOrdered(null));
+        assertThrows(NullPointerException.class, () -> expected.forEachOrdered(null));
+
+        var actualException = getThrowableType(() -> actual.forEachOrdered(null));
+        var expectedException = getThrowableType(() -> expected.forEachOrdered(null));
+        assertSame(actualException, expectedException);
+
+        actualException = getThrowableType(() -> actual.forEachOrdered(null));
+        expectedException = getThrowableType(() -> expected.forEachOrdered(null));
+        assertSame(actualException, expectedException);
+
+        actualException = getThrowableType(() -> actual.forEachOrdered(failing(Consumer.class)));
+        expectedException = getThrowableType(() -> expected.forEachOrdered(failing(Consumer.class)));
+        assertSame(actualException, expectedException);
+
+        actualException = getThrowableType(() -> actual.forEachOrdered(failing(Consumer.class)));
+        expectedException = getThrowableType(() -> expected.forEachOrdered(failing(Consumer.class)));
+        assertSame(actualException, expectedException);
     }
 
-    public void testToArray(Stream<Integer> expected, Stream<Integer> actual) {
-        var expectedResult = expected.toArray();
+    public void testToArray(Stream<Integer> actual, Stream<Integer> expected) {
         var actualResult = actual.toArray();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.toArray();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testToArrayFunction(Stream<Integer> expected, Stream<Integer> actual) {
-        var expectedResult = expected.toArray(Integer[]::new);
+    public void testToArrayExceptions(Stream<Integer> actual, Stream<Integer> expected) {
+        checkExpectedExceptions(actual, expected, "toArray");
+    }
+
+    public void testToArrayFunction(Stream<Integer> actual, Stream<Integer> expected) {
         var actualResult = actual.toArray(Integer[]::new);
-        compareResults(expectedResult, actualResult);
-        assertEquals(Integer.class, expectedResult.getClass()
-                .getComponentType());
+        var expectedResult = expected.toArray(Integer[]::new);
+        compareResults(actualResult, expectedResult);
+        assertEquals(Integer.class, expectedResult.getClass().getComponentType());
     }
 
-    public void testToArrayFunctionParameters(Stream<Integer> expected, Stream<Integer> actual) {
-        assertThrows(NullPointerException.class, () -> expected.toArray(null));
-        assertThrows(NullPointerException.class, () -> actual.toArray(null));
+    public void testToArrayFunctionExceptions(Stream<Integer> actual, Stream<Integer> expected) {
+        checkExpectedExceptions(actual, expected, "toArray", IntFunction.class);
     }
 
-    public void testReduceIdentityAccumulator(Stream<Object> expected, Stream<Object> actual) {
+    public void testToArrayFunctionReturnNullException(Stream<Integer> actual, Stream<Integer> expected) {
+        assertThrows(NullPointerException.class, () -> actual.toArray(i -> null));
+        assertThrows(NullPointerException.class, () -> expected.toArray(i -> null));
+    }
+
+    public void testReduceIdentityAccumulator(Stream<Object> actual, Stream<Object> expected) {
         var magicIdentity = new Object();
-        var expectedResult = expected.reduce(magicIdentity, failing(BinaryOperator.class));
         var actualResult = actual.reduce(magicIdentity, failing(BinaryOperator.class));
+        var expectedResult = expected.reduce(magicIdentity, failing(BinaryOperator.class));
 
-        assertSame(magicIdentity, expectedResult);
         assertSame(magicIdentity, actualResult);
+        assertSame(magicIdentity, expectedResult);
     }
 
-    public void testReduceIdentityAccumulatorParameters(Stream<Object> expected, Stream<Object> actual) {
-        // null identity should be fine
-        expected.reduce(null, failing(BinaryOperator.class));
-        actual.reduce(null, failing(BinaryOperator.class));
-        var magicIdentity = new Object();
-        assertThrows(NullPointerException.class, () -> expected.reduce(magicIdentity, null));
-        assertThrows(NullPointerException.class, () -> actual.reduce(magicIdentity, null));
+    public void testReduceIdentityAccumulatorExceptions(Stream<Object> actual, Stream<Object> expected) {
+        checkExpectedExceptions(actual, expected, "reduce", Object.class, BinaryOperator.class);
     }
 
-    public void testReduceAccumulator(Stream<Object> expected, Stream<Object> actual) {
-        var expectedResult = expected.reduce(failing(BinaryOperator.class));
+    public void testReduceAccumulator(Stream<Object> actual, Stream<Object> expected) {
         var actualResult = actual.reduce(failing(BinaryOperator.class));
+        var expectedResult = expected.reduce(failing(BinaryOperator.class));
 
-        compareResults(expectedResult, actualResult);
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testReduceAccumulatorParameters(Stream<Object> expected, Stream<Object> actual) {
-        assertThrows(NullPointerException.class, () -> expected.reduce(null));
-        assertThrows(NullPointerException.class, () -> actual.reduce(null));
+    public void testReduceAccumulatorExceptions(Stream<Object> actual, Stream<Object> expected) {
+        checkExpectedExceptions(actual, expected, "reduce", BinaryOperator.class);
     }
 
-    public void testReduceIdentityAccumulatorCombiner(Stream<Object> expected, Stream<Object> actual) {
+    public void testReduceIdentityAccumulatorCombiner(Stream<Object> actual, Stream<Object> expected) {
         var magicIdentity = new Object();
-        var expectedResult = expected.reduce(magicIdentity, failing(BinaryOperator.class), failing(BinaryOperator.class));
         var actualResult = actual.reduce(magicIdentity, failing(BinaryOperator.class), failing(BinaryOperator.class));
+        var expectedResult = expected.reduce(magicIdentity, failing(BinaryOperator.class), failing(BinaryOperator.class));
 
-        assertSame(magicIdentity, expectedResult);
         assertSame(magicIdentity, actualResult);
+        assertSame(magicIdentity, expectedResult);
     }
 
-    public void testReduceIdentityAccumulatorCombinerParameters(Stream<Object> expected, Stream<Object> actual) {
-        var accumulator = failing(BinaryOperator.class);
-        var combiner = failing(BinaryOperator.class);
-        // null identity should be fine
-        expected.reduce(null, accumulator, combiner);
-        actual.reduce(null, accumulator, combiner);
-        var magicIdentity = new Object();
-        assertThrows(NullPointerException.class, () -> expected.reduce(magicIdentity, null, combiner));
-        assertThrows(NullPointerException.class, () -> actual.reduce(magicIdentity, null, combiner));
-        assertThrows(NullPointerException.class, () -> expected.reduce(magicIdentity, accumulator, null));
-        assertThrows(NullPointerException.class, () -> actual.reduce(magicIdentity, accumulator, null));
+    public void testReduceIdentityAccumulatorCombinerExceptions(Stream<Object> actual, Stream<Object> expected) {
+        checkExpectedExceptions(actual, expected, "reduce", Object.class, BiFunction.class, BinaryOperator.class);
     }
 
-    public void testCollectSupplierAccumulatorCombiner(Stream<Integer> expected, Stream<Integer> actual) {
+    public void testCollectSupplierAccumulatorCombiner(Stream<Integer> actual, Stream<Integer> expected) {
         var magicIdentity = new Object();
-        var expectedResult = expected.collect(() -> magicIdentity, failing(BiConsumer.class), failing(BiConsumer.class));
         var actualResult = actual.collect(() -> magicIdentity, failing(BiConsumer.class), failing(BiConsumer.class));
+        var expectedResult = expected.collect(() -> magicIdentity, failing(BiConsumer.class), failing(BiConsumer.class));
 
-        assertSame(magicIdentity, expectedResult);
         assertSame(magicIdentity, actualResult);
+        assertSame(magicIdentity, expectedResult);
     }
 
-    public void testCollectSupplierAccumulatorCombinerParameters(Stream<Integer> expected, Stream<Integer> actual) {
+    public void testCollectSupplierAccumulatorCombinerExceptions(Stream<Integer> actual, Stream<Integer> expected) {
         var magicIdentity = new Object();
         Supplier<Object> supplier = () -> magicIdentity;
         var accumulator = failing(BiConsumer.class);
         var combiner = failing(BiConsumer.class);
-        assertThrows(NullPointerException.class, () -> expected.collect(null, accumulator, combiner));
         assertThrows(NullPointerException.class, () -> actual.collect(null, accumulator, combiner));
-        assertThrows(NullPointerException.class, () -> expected.collect(supplier, null, combiner));
+        assertThrows(NullPointerException.class, () -> expected.collect(null, accumulator, combiner));
         assertThrows(NullPointerException.class, () -> actual.collect(supplier, null, combiner));
-        assertThrows(NullPointerException.class, () -> expected.collect(supplier, accumulator, null));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, null, combiner));
         assertThrows(NullPointerException.class, () -> actual.collect(supplier, accumulator, null));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, accumulator, null));
+
+        actual.collect(supplier, accumulator, combiner);
+        expected.collect(supplier, accumulator, combiner);
+
+        assertThrows(NullPointerException.class, () -> actual.collect(null, accumulator, combiner));
+        assertThrows(NullPointerException.class, () -> expected.collect(null, accumulator, combiner));
+        assertThrows(NullPointerException.class, () -> actual.collect(supplier, null, combiner));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, null, combiner));
+        assertThrows(NullPointerException.class, () -> actual.collect(supplier, accumulator, null));
+        assertThrows(NullPointerException.class, () -> expected.collect(supplier, accumulator, null));
+
+        assertThrows(IllegalStateException.class, () -> actual.collect(supplier, accumulator, combiner));
+        assertThrows(IllegalStateException.class, () -> expected.collect(supplier, accumulator, combiner));
     }
 
-    public void testCollectCollector(Stream<Object> expected, Stream<Object> actual) {
+    public void testCollectCollector(Stream<Object> actual, Stream<Object> expected) {
         var magicIdentity = new Object();
         var superMagicIdentity = new Object();
         Collector<Object, Object, Object> collector = new Collector<>() {
@@ -462,106 +483,131 @@ public final class EmptyStreamTest extends EmptyBaseStreamTest {
                 return Set.of();
             }
         };
-        var expectedResult = expected.collect(collector);
         var actualResult = actual.collect(collector);
+        var expectedResult = expected.collect(collector);
 
-        assertSame(superMagicIdentity, expectedResult);
         assertSame(superMagicIdentity, actualResult);
+        assertSame(superMagicIdentity, expectedResult);
     }
 
-    public void testCollectCollectorParameters(Stream<Object> expected, Stream<Object> actual) {
-        assertThrows(NullPointerException.class, () -> expected.collect(null));
+    public void testCollectCollectorExceptions(Stream<Object> actual, Stream<Object> expected) {
         assertThrows(NullPointerException.class, () -> actual.collect(null));
+        assertThrows(NullPointerException.class, () -> expected.collect(null));
+
+        actual.collect(Collectors.toList());
+        expected.collect(Collectors.toList());
+
+        assertThrows(NullPointerException.class, () -> actual.collect(null));
+        assertThrows(NullPointerException.class, () -> expected.collect(null));
+
+        assertThrows(IllegalStateException.class, () -> actual.collect(Collectors.toList()));
+        assertThrows(IllegalStateException.class, () -> expected.collect(Collectors.toList()));
     }
 
-    public void testToList(Stream<Integer> expected, Stream<Integer> actual) {
-        var expectedResult = expected.toList();
+    public void testToList(Stream<Integer> actual, Stream<Integer> expected) {
         var actualResult = actual.toList();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.toList();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMin(Stream<Integer> expected, Stream<Integer> actual) {
-        var expectedResult = expected.min(Comparator.reverseOrder());
+    public void testToListExceptions(Stream<Object> actual, Stream<Object> expected) {
+        checkExpectedExceptions(actual, expected, "toList");
+    }
+
+    public void testMin(Stream<Integer> actual, Stream<Integer> expected) {
         var actualResult = actual.min(Comparator.reverseOrder());
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.min(Comparator.reverseOrder());
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMinParameters(Stream<Integer> expected, Stream<Integer> actual) {
-        assertThrows(NullPointerException.class, () -> expected.min(null));
-        assertThrows(NullPointerException.class, () -> actual.min(null));
+    public void testMinExceptions(Stream<Object> actual, Stream<Object> expected) {
+        checkExpectedExceptions(actual, expected, "min", Comparator.class);
     }
 
-    public void testMax(Stream<Integer> expected, Stream<Integer> actual) {
-        var expectedResult = expected.max(Comparator.reverseOrder());
+    public void testMax(Stream<Integer> actual, Stream<Integer> expected) {
         var actualResult = actual.max(Comparator.reverseOrder());
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.max(Comparator.reverseOrder());
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testMaxParameters(Stream<Integer> expected, Stream<Integer> actual) {
-        assertThrows(NullPointerException.class, () -> expected.max(null));
-        assertThrows(NullPointerException.class, () -> actual.max(null));
+    public void testMaxExceptions(Stream<Object> actual, Stream<Object> expected) {
+        checkExpectedExceptions(actual, expected, "max", Comparator.class);
     }
 
-    public void testCount(Stream<Integer> expected, Stream<Integer> actual) {
-        var expectedResult = expected.count();
+    public void testCount(Stream<Integer> actual, Stream<Integer> expected) {
         var actualResult = actual.count();
-        assertEquals(expectedResult, actualResult);
-        assertEquals(0L, actualResult);
+        var expectedResult = expected.count();
+        assertEquals(actualResult, expectedResult);
+        assertEquals(actualResult, 0L);
     }
 
-    public void testAnyMatch(Stream<?> expected, Stream<?> actual) {
-        var expectedResult = expected.anyMatch(failing(Predicate.class));
+    public void testCountExceptions(Stream<Object> actual, Stream<Object> expected) {
+        checkExpectedExceptions(actual, expected, "count");
+    }
+
+    public void testAnyMatch(Stream<?> actual, Stream<?> expected) {
         var actualResult = actual.anyMatch(failing(Predicate.class));
-        assertEquals(expectedResult, actualResult);
+        var expectedResult = expected.anyMatch(failing(Predicate.class));
+        assertEquals(actualResult, expectedResult);
     }
 
-    public void testAnyMatchParameters(Stream<?> expected, Stream<?> actual) {
-        assertThrows(NullPointerException.class, () -> expected.anyMatch(null));
-        assertThrows(NullPointerException.class, () -> actual.anyMatch(null));
+    public void testAnyMatchExceptions(Stream<?> actual, Stream<?> expected) {
+        checkExpectedExceptions(actual, expected, "anyMatch", Predicate.class);
     }
 
-    public void testAllMatch(Stream<?> expected, Stream<?> actual) {
-        var expectedResult = expected.allMatch(failing(Predicate.class));
+    public void testAllMatch(Stream<?> actual, Stream<?> expected) {
         var actualResult = actual.allMatch(failing(Predicate.class));
-        assertEquals(expectedResult, actualResult);
+        var expectedResult = expected.allMatch(failing(Predicate.class));
+        assertEquals(actualResult, expectedResult);
     }
 
-    public void testAllMatchParameters(Stream<?> expected, Stream<?> actual) {
-        assertThrows(NullPointerException.class, () -> expected.allMatch(null));
-        assertThrows(NullPointerException.class, () -> actual.allMatch(null));
+    public void testAllMatchExceptions(Stream<?> actual, Stream<?> expected) {
+        checkExpectedExceptions(actual, expected, "allMatch", Predicate.class);
     }
 
-    public void testNoneMatch(Stream<?> expected, Stream<?> actual) {
-        var expectedResult = expected.noneMatch(failing(Predicate.class));
+    public void testNoneMatch(Stream<?> actual, Stream<?> expected) {
         var actualResult = actual.noneMatch(failing(Predicate.class));
-        assertEquals(expectedResult, actualResult);
+        var expectedResult = expected.noneMatch(failing(Predicate.class));
+        assertEquals(actualResult, expectedResult);
     }
 
-    public void testNoneMatchParameters(Stream<?> expected, Stream<?> actual) {
-        assertThrows(NullPointerException.class, () -> expected.noneMatch(null));
-        assertThrows(NullPointerException.class, () -> actual.noneMatch(null));
+    public void testNoneMatchExceptions(Stream<?> actual, Stream<?> expected) {
+        checkExpectedExceptions(actual, expected, "noneMatch", Predicate.class);
     }
 
-    public void testFindFirst(Stream<Integer> expected, Stream<Integer> actual) {
-        var expectedResult = expected.findFirst();
+    public void testFindFirst(Stream<Integer> actual, Stream<Integer> expected) {
         var actualResult = actual.findFirst();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.findFirst();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testFindAny(Stream<Integer> expected, Stream<Integer> actual) {
-        var expectedResult = expected.findAny();
+    public void testFindFirstExceptions(Stream<?> actual, Stream<?> expected) {
+        checkExpectedExceptions(actual, expected, "findFirst");
+    }
+
+    public void testFindAny(Stream<Integer> actual, Stream<Integer> expected) {
         var actualResult = actual.findAny();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.findAny();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testLimit(Stream<Integer> expected, Stream<Integer> actual) {
-        var expectedResult = expected.limit(10).toList();
+    public void testFindAnyExceptions(Stream<?> actual, Stream<?> expected) {
+        checkExpectedExceptions(actual, expected, "findAny");
+    }
+
+    public void testLimit(Stream<Integer> actual, Stream<Integer> expected) {
         var actualResult = actual.limit(10).toList();
-        compareResults(expectedResult, actualResult);
+        var expectedResult = expected.limit(10).toList();
+        compareResults(actualResult, expectedResult);
     }
 
-    public void testLimitParameters(Stream<Integer> expected, Stream<Integer> actual) {
-        assertThrows(IllegalArgumentException.class, () -> expected.limit(-1));
+    public void testLimitExceptions(Stream<Integer> actual, Stream<Integer> expected) {
         assertThrows(IllegalArgumentException.class, () -> actual.limit(-1));
+        assertThrows(IllegalArgumentException.class, () -> expected.limit(-1));
+
+        actual.limit(10);
+        expected.limit(10);
+        assertThrows(IllegalStateException.class, () -> actual.limit(10));
+        assertThrows(IllegalStateException.class, () -> expected.limit(10));
     }
 }

--- a/test/micro/org/openjdk/bench/java/util/stream/EmptyStreams.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/EmptyStreams.java
@@ -162,26 +162,4 @@ public class EmptyStreams {
     public void mixOfCollectionsAndSizesAndStreams() {
         decorateStream(createStream(length, typeOfCollection), typeOfStreamDecoration);
     }
-
-    @Benchmark
-    public OptionalInt emptyStreamCreatedWithStreamSupport() {
-        return addStreamFilters(
-                StreamSupport.stream(
-                        Spliterators.emptySpliterator(), false));
-    }
-
-    @Benchmark
-    public OptionalInt emptyStreamCreatedWithStreamEmpty() {
-        return addStreamFilters(Stream.empty());
-    }
-
-    @Benchmark
-    public OptionalInt emptyStreamCreatedWithStreamOf() {
-        return addStreamFilters(Stream.of());
-    }
-
-    @Benchmark
-    public OptionalInt emptyStreamCreatedWithArrayListStream() {
-        return addStreamFilters(new ArrayList<String>().stream());
-    }
 }

--- a/test/micro/org/openjdk/bench/java/util/stream/EmptyStreams.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/EmptyStreams.java
@@ -60,10 +60,10 @@ import java.util.stream.StreamSupport;
  * @author Heinz Kabutz, heinz@javaspecialists.eu
  */
 @BenchmarkMode(Mode.Throughput)
-@OutputTimeUnit(TimeUnit.SECONDS)
-@Fork(3)
-@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(value = 2)
+@Warmup(iterations = 20, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class EmptyStreams {
     @Param({"0", "1", "10", "100"})

--- a/test/micro/org/openjdk/bench/java/util/stream/EmptyStreams.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/EmptyStreams.java
@@ -152,20 +152,6 @@ public class EmptyStreams {
                             .max(Integer::compare)
             );
 
-    private static OptionalInt addStreamFilters(Stream<String> stream) {
-        return stream
-                .filter(Objects::nonNull)
-                .filter(s -> s.length() > 0)
-                .mapToInt(Integer::parseInt)
-                .map(i -> i * 2)
-                .mapToLong(i -> i + 1000)
-                .mapToDouble(i -> i * 3.5)
-                .boxed()
-                .mapToLong(Double::intValue)
-                .mapToInt(d -> (int) d)
-                .max();
-    }
-
     @Benchmark
     public void mixOfCollectionsAndSizesAndStreams() {
         decorateStream(createStream());

--- a/test/micro/org/openjdk/bench/java/util/stream/EmptyStreams.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/EmptyStreams.java
@@ -22,11 +22,35 @@
  */
 package org.openjdk.bench.java.util.stream;
 
-import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.stream.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Spliterators;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * Benchmark for checking that the new empty stream
@@ -37,27 +61,113 @@ import java.util.stream.*;
  */
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(3)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class EmptyStreams {
+    @Param({"0", "1", "10", "100"})
+    private int length;
+
+    @Param({"minimal", "basic", "complex", "crossover"})
+    private String typeOfStreamDecoration;
+
+    @Param({"ArrayList", "ConcurrentLinkedQueue", "ConcurrentSkipListSet", "CopyOnWriteArrayList", "ConcurrentHashMap"})
+    private String typeOfCollection;
+
+    private static final Map<Integer/*length*/, Map<String/*typeOfCollection*/, Collection<Integer>>> collectionData =
+            Map.ofEntries(
+                    makeMapEntries(0),
+                    makeMapEntries(1),
+                    makeMapEntries(3),
+                    makeMapEntries(5),
+                    makeMapEntries(10),
+                    makeMapEntries(20),
+                    makeMapEntries(100)
+            );
+
+    private static Map.Entry<Integer, Map<String, Collection<Integer>>> makeMapEntries(int length) {
+        return Map.entry(length, Map.of(
+                "ArrayList", makeCollection(length, ArrayList::new),
+                "ConcurrentLinkedQueue", makeCollection(length, ConcurrentLinkedQueue::new),
+                "ConcurrentSkipListSet", makeCollection(length, ConcurrentSkipListSet::new),
+                "CopyOnWriteArrayList", makeCollection(length, CopyOnWriteArrayList::new),
+                "ConcurrentHashMap", makeCollection(length, ConcurrentHashMap::newKeySet)
+        ));
+    }
+
+    private static Collection<Integer> makeCollection(int length, Supplier<Collection<Integer>> supplier) {
+        return IntStream.range(0, length).boxed().collect(Collectors.toCollection(supplier));
+    }
+
+    private static Stream<Integer> createStream(int length, String typeOfCollection) {
+        return collectionData.get(length).get(typeOfCollection).stream();
+    }
+
+    private static Optional<Integer> decorateStream(Stream<Integer> stream, String typeOfStreamDecoration) {
+        return streamDecorators.get(typeOfStreamDecoration).apply(stream);
+    }
+
+    private static final Map<String, Function<Stream<Integer>, Optional<Integer>>> streamDecorators =
+            Map.of(
+                    // with no additional intermediate operations
+                    "minimal", stream ->
+                            stream.max(Integer::compare),
+                    // basic filter/map
+                    "basic", stream -> stream
+                            .filter(Objects::nonNull)
+                            .map(Function.identity())
+                            .max(Integer::compare),
+                    // more complex, including sorted and distinct, both of which
+                    // would cause a fallback to the old empty stream approach
+                    "complex", stream -> stream
+                            .filter(Objects::nonNull)
+                            .map(Function.identity())
+                            .filter(Objects::nonNull)
+                            .sorted() // causes it to change to old empty stream
+                            .distinct()
+                            .max(Integer::compare),
+                    // we crossover from an Object Stream to an IntStream, LongStream,
+                    // etc. but always with operations that keep using the empty streams
+                    "crossover", stream -> stream
+                            .filter(Objects::nonNull)
+                            .map(String::valueOf)
+                            .filter(s -> s.length() > 0)
+                            .mapToInt(Integer::parseInt)
+                            .map(i -> i * 2)
+                            .mapToLong(i -> i + 1000)
+                            .mapToDouble(i -> i * 3.5)
+                            .boxed()
+                            .mapToLong(Double::intValue)
+                            .mapToInt(d -> (int) d)
+                            .boxed()
+                            .max(Integer::compare)
+            );
+
     private static OptionalInt addStreamFilters(Stream<String> stream) {
         return stream
-            .filter(Objects::nonNull)
-            .filter(s -> s.length() > 0)
-            .mapToInt(Integer::parseInt)
-            .map(i -> i * 2)
-            .mapToLong(i -> i + 1000)
-            .mapToDouble(i -> i * 3.5)
-            .boxed()
-            .mapToLong(Double::intValue)
-            .mapToInt(d -> (int)d)
-            .max();
+                .filter(Objects::nonNull)
+                .filter(s -> s.length() > 0)
+                .mapToInt(Integer::parseInt)
+                .map(i -> i * 2)
+                .mapToLong(i -> i + 1000)
+                .mapToDouble(i -> i * 3.5)
+                .boxed()
+                .mapToLong(Double::intValue)
+                .mapToInt(d -> (int) d)
+                .max();
+    }
+
+    @Benchmark
+    public void mixOfCollectionsAndSizesAndStreams() {
+        decorateStream(createStream(length, typeOfCollection), typeOfStreamDecoration);
     }
 
     @Benchmark
     public OptionalInt emptyStreamCreatedWithStreamSupport() {
         return addStreamFilters(
-            StreamSupport.stream(
-                Spliterators.emptySpliterator(), false));
+                StreamSupport.stream(
+                        Spliterators.emptySpliterator(), false));
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/util/stream/EmptyStreams.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/EmptyStreams.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.util.stream;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.stream.*;
+
+/**
+ * Benchmark for checking that the new empty stream
+ * implementations are faster than the old way of creating
+ * empty streams from empty spliterators.
+ *
+ * @author Heinz Kabutz, heinz@javaspecialists.eu
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+public class EmptyStreams {
+    private static OptionalInt addStreamFilters(Stream<String> stream) {
+        return stream
+            .filter(Objects::nonNull)
+            .filter(s -> s.length() > 0)
+            .mapToInt(Integer::parseInt)
+            .map(i -> i * 2)
+            .mapToLong(i -> i + 1000)
+            .mapToDouble(i -> i * 3.5)
+            .boxed()
+            .mapToLong(Double::intValue)
+            .mapToInt(d -> (int)d)
+            .max();
+    }
+
+    @Benchmark
+    public OptionalInt emptyStreamCreatedWithStreamSupport() {
+        return addStreamFilters(
+            StreamSupport.stream(
+                Spliterators.emptySpliterator(), false));
+    }
+
+    @Benchmark
+    public OptionalInt emptyStreamCreatedWithStreamEmpty() {
+        return addStreamFilters(Stream.empty());
+    }
+
+    @Benchmark
+    public OptionalInt emptyStreamCreatedWithStreamOf() {
+        return addStreamFilters(Stream.of());
+    }
+
+    @Benchmark
+    public OptionalInt emptyStreamCreatedWithArrayListStream() {
+        return addStreamFilters(new ArrayList<String>().stream());
+    }
+}

--- a/test/micro/org/openjdk/bench/java/util/stream/EmptyStreamsMixedLength.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/EmptyStreamsMixedLength.java
@@ -110,7 +110,7 @@ public class EmptyStreamsMixedLength {
             case "ArrayList" -> ArrayList::new;
             case "ConcurrentLinkedQueue" -> ConcurrentLinkedQueue::new;
             case "ConcurrentSkipListSet" -> ConcurrentSkipListSet::new;
-            case "CopyOnWriteArrayist" -> CopyOnWriteArrayList::new;
+            case "CopyOnWriteArrayList" -> CopyOnWriteArrayList::new;
             case "ConcurrentHashMap" -> ConcurrentHashMap::newKeySet;
             default -> throw new AssertionError("Incorrect collection type : " + b_typeOfCollection);
         };

--- a/test/micro/org/openjdk/bench/java/util/stream/EmptyStreamsMixedLength.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/EmptyStreamsMixedLength.java
@@ -8,126 +8,148 @@ import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Map;
+import java.util.Collections;
+import java.util.IntSummaryStatistics;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.Random;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 /**
- * Benchmark for checking that having mixed types for the 
+ * Benchmark for checking that having mixed types for the
  * streams does not make performance worse. We test this by
- * having collections of length 0 .. 3.
+ * having collections of differing lengths within each run,
+ * with different percentage of empty collections, ranging
+ * from 0% to 100%. We also pre-create all the Function
+ * instances necessary for creating the streams and to
+ * decorate them.
  *
  * @author Heinz Kabutz, heinz@javaspecialists.eu
  */
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 2)//, jvmArgsAppend = {"-XX:+UseParallelGC", "-Xmx16g", "-Xms16g", "-XX:+AlwaysPreTouch", "-XX:NewRatio=1", "-XX:SurvivorRatio=1"})
-@Warmup(iterations = 20, time = 3, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+@Warmup(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class EmptyStreamsMixedLength {
-    private static final int MAXIMUM_STREAM_LENGTH = 3;
-    private static byte[] lengths = new byte[64 * 1024];
-    static {
-        int[] ints = new Random(0).ints(lengths.length, 0, MAXIMUM_STREAM_LENGTH + 1)
-                .toArray();
-        for (int i = 0; i < lengths.length; i++) {
-            lengths[i] = (byte) ints[i];
-        }
-    }
-
-    private int length_pos = 0;
-
-    private int nextLength() {
-        int nextIndex = length_pos++;
-        if (length_pos == lengths.length) length_pos = 0;
-        return lengths[nextIndex];
-    }
+    @Param({"20", "50", "80", "90", "99", "1", "10"})
+    private int a_percentageOfEmptyStreams;
 
     @Param({"ArrayList", "ConcurrentLinkedQueue", "ConcurrentSkipListSet", "CopyOnWriteArrayList", "ConcurrentHashMap"})
-    private String a_typeOfCollection;
+    private String b_typeOfCollection;
 
     @Param({"minimal", "basic", "complex", "crossover"})
-    private String b_typeOfStreamDecoration;
+    private String c_typeOfStreamDecoration;
 
-    @Param({"old", "new"})
-    private String c_streamCreation;
+    @Param({"old", "new", "guarded"})
+    private String d_streamCreation;
 
-    private static final Map<Integer/*length*/, Map<String/*typeOfCollection*/, Collection<Integer>>> collectionData =
-            Map.ofEntries(
-                    makeMapEntries(0),
-                    makeMapEntries(1),
-                    makeMapEntries(2),
-                    makeMapEntries(3)
-            );
+    protected static final int NUMBER_OF_COLLECTIONS = 16 * 1024;
+    private List<Collection<Integer>> collections;
+    private int length_pos;
+    private Function<Collection<Integer>, Stream<Integer>> streamCreator;
+    private Function<Stream<Integer>, Optional<Integer>> streamDecorator;
 
-    private static Map.Entry<Integer, Map<String, Collection<Integer>>> makeMapEntries(int length) {
-        return Map.entry(length, Map.of(
-                "ArrayList", makeCollection(length, ArrayList::new),
-                "ConcurrentLinkedQueue", makeCollection(length, ConcurrentLinkedQueue::new),
-                "ConcurrentSkipListSet", makeCollection(length, ConcurrentSkipListSet::new),
-                "CopyOnWriteArrayList", makeCollection(length, CopyOnWriteArrayList::new),
-                "ConcurrentHashMap", makeCollection(length, ConcurrentHashMap::newKeySet)
-        ));
+    @Setup
+    public void setupExperiment() {
+        System.out.println("EmptyStreamsMixedLength.setupExperiment");
+        collections = new ArrayList<>();
+        length_pos = 0;
+        var collectionSupplier = makeCollectionSupplier();
+        List<Integer> lengths = new ArrayList<>();
+        for (int i = 0; i < NUMBER_OF_COLLECTIONS; i++) {
+            var collection = collectionSupplier.get();
+            if (i >= NUMBER_OF_COLLECTIONS * a_percentageOfEmptyStreams / 100) {
+                int numberOfElements = ThreadLocalRandom.current().nextInt(1, 11);
+                ThreadLocalRandom.current().ints(numberOfElements).forEach(collection::add);
+            }
+            collections.add(collection);
+        }
+        Collections.shuffle(collections, new Random(42));
+        var lengthDistribution = collections.stream()
+                .collect(Collectors.groupingBy(Collection::size, TreeMap::new, Collectors.counting()));
+        var empties = lengthDistribution.getOrDefault(0, 0L);
+        System.out.printf("%d/%d (%.0f%%) are empty, lengthDistribution = %s%n",
+                empties,
+                NUMBER_OF_COLLECTIONS,
+                100.0 * empties / NUMBER_OF_COLLECTIONS,
+                lengthDistribution);
+        this.streamCreator = makeStreamCreator();
+        this.streamDecorator = makeStreamDecorator();
     }
 
-    private static Collection<Integer> makeCollection(int length, Supplier<Collection<Integer>> supplier) {
-        return IntStream.range(0, length).boxed().collect(Collectors.toCollection(supplier));
+    @TearDown
+    public void cleanupExperiment() {
+        collections = null;
+        streamCreator = null;
+        streamDecorator = null;
     }
 
-    private Stream<Integer> createStream() {
-        Collection<Integer> collection = collectionData.get(nextLength()).get(a_typeOfCollection);
-        return switch (c_streamCreation) {
-            case "old" -> StreamSupport.stream(collection.spliterator(), false);
-            case "new" -> collection.stream();
-            default -> throw new AssertionError();
+    private Supplier<Collection<Integer>> makeCollectionSupplier() {
+        return switch (b_typeOfCollection) {
+            case "ArrayList" -> ArrayList::new;
+            case "ConcurrentLinkedQueue" -> ConcurrentLinkedQueue::new;
+            case "ConcurrentSkipListSet" -> ConcurrentSkipListSet::new;
+            case "CopyOnWriteArrayist" -> CopyOnWriteArrayList::new;
+            case "ConcurrentHashMap" -> ConcurrentHashMap::newKeySet;
+            default -> throw new AssertionError("Incorrect collection type : " + b_typeOfCollection);
         };
     }
 
-    private Optional<Integer> decorateStream(Stream<Integer> stream) {
-        return streamDecorators.get(b_typeOfStreamDecoration).apply(stream);
+    private Function<Collection<Integer>, Stream<Integer>> makeStreamCreator() {
+        return collection ->
+                switch (d_streamCreation) {
+                    case "old" -> createOld(collection);
+                    case "new" -> createNew(collection);
+                    case "guarded" -> collection.isEmpty() ? null : createOld(collection);
+                    default -> throw new AssertionError("Unknown stream creation : " + d_streamCreation);
+                };
     }
 
-    private static final Map<String, Function<Stream<Integer>, Optional<Integer>>> streamDecorators =
-            Map.of(
-                    // with no additional intermediate operations
-                    "minimal", stream ->
-                            stream.max(Integer::compare),
-                    // basic filter/map
-                    "basic", stream -> stream
+    private Function<Stream<Integer>, Optional<Integer>> makeStreamDecorator() {
+        return switch (c_typeOfStreamDecoration) {
+            // with no additional intermediate operations
+            case "minimal" -> stream ->
+                    stream.max(Integer::compare);
+            // basic filter/map
+            case "basic" -> stream ->
+                    stream
                             .filter(Objects::nonNull)
                             .map(Function.identity())
-                            .max(Integer::compare),
-                    // more complex, including sorted and distinct, both of which
-                    // would cause a fallback to the old empty stream approach
-                    "complex", stream -> stream
+                            .max(Integer::compare);
+            // more complex, including sorted and distinct
+            case "complex" -> stream ->
+                    stream
                             .filter(Objects::nonNull)
                             .map(Function.identity())
                             .filter(Objects::nonNull)
                             .sorted() // causes it to change to old empty stream
                             .distinct()
-                            .max(Integer::compare),
-                    // we crossover from an Object Stream to an IntStream, LongStream,
-                    // etc. but always with operations that keep using the empty streams
-                    "crossover", stream -> stream
+                            .max(Integer::compare);
+            // we crossover from an Object Stream to an IntStream, LongStream,
+            // etc. but always with operations that keep using the empty streams
+            case "crossover" -> stream ->
+                    stream
                             .filter(Objects::nonNull)
                             .map(String::valueOf)
                             .filter(s -> s.length() > 0)
@@ -139,25 +161,30 @@ public class EmptyStreamsMixedLength {
                             .mapToLong(Double::intValue)
                             .mapToInt(d -> (int) d)
                             .boxed()
-                            .max(Integer::compare)
-            );
+                            .max(Integer::compare);
+            default -> throw new AssertionError("Unknown stream decoration: " + c_typeOfStreamDecoration);
+        };
+    }
 
-    private static OptionalInt addStreamFilters(Stream<String> stream) {
-        return stream
-                .filter(Objects::nonNull)
-                .filter(s -> s.length() > 0)
-                .mapToInt(Integer::parseInt)
-                .map(i -> i * 2)
-                .mapToLong(i -> i + 1000)
-                .mapToDouble(i -> i * 3.5)
-                .boxed()
-                .mapToLong(Double::intValue)
-                .mapToInt(d -> (int) d)
-                .max();
+    private Stream<Integer> createOld(Collection<Integer> collection) {
+        return StreamSupport.stream(collection.spliterator(), false);
+    }
+
+    private Stream<Integer> createNew(Collection<Integer> collection) {
+        if (collection.isEmpty()) return StreamSupport.emptyStream(collection.spliterator());
+        else return createOld(collection);
+    }
+
+    private Collection<Integer> nextCollection() {
+        int index = length_pos++;
+        if (length_pos == NUMBER_OF_COLLECTIONS) length_pos = 0;
+        return collections.get(index);
     }
 
     @Benchmark
-    public void mixOfCollectionsAndSizesAndStreams() {
-        decorateStream(createStream());
+    public void mixOfCollectionsAndSizeMixesAndStreams() {
+        var collection = nextCollection();
+        var stream = streamCreator.apply(collection);
+        Optional<Integer> max = stream != null ? streamDecorator.apply(stream) : Optional.empty();
     }
 }


### PR DESCRIPTION
This is a draft proposal for how we could improve stream performance for the case where the streams are empty. Empty collections are common-place. If we iterate over them with an Iterator, we would have to create one small Iterator object (which could often be eliminated) and if it is empty we are done. However, with Streams we first have to build up the entire pipeline, until we realize that there is no work to do. With this example, we change Collection#stream() to first check if the collection is empty, and if it is, we simply return an EmptyStream. We also have EmptyIntStream, EmptyLongStream and EmptyDoubleStream. We have taken great care for these to have the same characteristics and behaviour as the streams returned by Stream.empty(), IntStream.empty(), etc. 

Some of the JDK tests fail with this, due to ClassCastExceptions (our EmptyStream is not an AbstractPipeline) and AssertionError, since we can call some methods repeatedly on the stream without it failing. On the plus side, creating a complex stream on an empty stream gives us upwards of 50x increase in performance due to a much smaller object allocation rate. This PR includes the code for the change, unit tests and also a JMH benchmark to demonstrate the improvement.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8277095](https://bugs.openjdk.java.net/browse/JDK-8277095): Empty streams create too many objects


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6275/head:pull/6275` \
`$ git checkout pull/6275`

Update a local copy of the PR: \
`$ git checkout pull/6275` \
`$ git pull https://git.openjdk.java.net/jdk pull/6275/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6275`

View PR using the GUI difftool: \
`$ git pr show -t 6275`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6275.diff">https://git.openjdk.java.net/jdk/pull/6275.diff</a>

</details>
