### PR TITLE
JDK-8276731: Metaspace chunks are uncommitted twice

### DIFF
--- a/src/hotspot/share/memory/metaspace/chunkManager.cpp
+++ b/src/hotspot/share/memory/metaspace/chunkManager.cpp
@@ -264,12 +264,6 @@ void ChunkManager::return_chunk_locked(Metachunk* c) {
     c = merged;
   }
 
-  if (Settings::uncommit_free_chunks() &&
-      c->word_size() >= Settings::commit_granule_words()) {
-    UL2(debug, "uncommitting free chunk " METACHUNK_FORMAT ".", METACHUNK_FORMAT_ARGS(c));
-    c->uncommit_locked();
-  }
-
   return_chunk_simple_locked(c);
   DEBUG_ONLY(verify_locked();)
   SOMETIMES(c->vsnode()->verify_locked();)


### PR DESCRIPTION
Small patch for a minor, benign error, which just eats up a bit of unnecessary processing time.

Metaspace returns memory to the OS by uncommitting free chunks when we unload classes. Today, we uncommit free metaspace chunks twice, and the second uncommit has no effect. Therefore, one of the uncommits is unnecessary.

In detail, when class unloading happens, we enter CLDG::purge():

- CLDG::purge()
  - delete each CLD in the `_unloading` list
    - which deletes the associated metaspace arena(s)
      - which causes the arenas to return all of their now unused chunks to the chunk manager (`ChunkManager::return_chunk()`)
        - where the buddy allocator combines them with their neighbors if they are free
          - (A) and the resulting larger chunk gets uncommitted if it is larger than a commit granule

- then we pop back to CLDG::purge() and call `Metaspace::purge()`
  - (B) `Metaspace::purge()` iterates through all free chunks in the chunk manager, now maximally folded, and uncommits those which are larger than a commit granule.
  
(A) and (B) are redundant. (B) uncommits memory which had already been uncommitted in step (A). Either A or B could be dropped.

I opt for keeping (B) and dropping (A) since:
- it is the expected behavior. We expect `Metaspace::purge()` to do some purging.
- (B) is less work than (A) since space is maximally defragmented at this point. All free chunks have been processed already and are therefore maximally folded by the buddy allocator.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276731](https://bugs.openjdk.java.net/browse/JDK-8276731): Metaspace chunks are uncommitted twice


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6277/head:pull/6277` \
`$ git checkout pull/6277`

Update a local copy of the PR: \
`$ git checkout pull/6277` \
`$ git pull https://git.openjdk.java.net/jdk pull/6277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6277`

View PR using the GUI difftool: \
`$ git pr show -t 6277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6277.diff">https://git.openjdk.java.net/jdk/pull/6277.diff</a>

</details>
