### PR TITLE
8276654: element-list order is non deterministic

### DIFF
--- a/make/modules/jdk.javadoc/Gendata.gmk
+++ b/make/modules/jdk.javadoc/Gendata.gmk
@@ -72,7 +72,8 @@ $(JDK_JAVADOC_DIR)/_element_lists.marker: \
     $(MODULE_INFOS)
 	$(call MakeTargetDir)
 	$(call LogInfo, Creating javadoc element lists)
-	$(RM) -r $(ELEMENT_LISTS_DIR)
+	$(RM) $(ELEMENT_LISTS_DIR)/element-list-{$(call CommaList, \
+	    $(call sequence,$(GENERATE_SYMBOLS_FROM_JDK_VERSION),$(JDK_SOURCE_TARGET_VERSION)))}.txt
         # Generate element-list files for JDK 11 to current-1
 	$(call ExecuteWithLog, $@_historic, \
 	    $(JAVA_SMALL) $(INTERIM_LANGTOOLS_ARGS) \

--- a/make/modules/jdk.javadoc/Gendata.gmk
+++ b/make/modules/jdk.javadoc/Gendata.gmk
@@ -73,8 +73,8 @@ $(JDK_JAVADOC_DIR)/_element_lists.marker: \
 	$(call MakeTargetDir)
 	$(call LogInfo, Creating javadoc element lists)
 	$(RM) $(ELEMENT_LISTS_DIR)/element-list-{$(call CommaList, \
-		$(call sequence,$(GENERATE_SYMBOLS_FROM_JDK_VERSION), \
-				$(JDK_SOURCE_TARGET_VERSION)))}.txt
+		$(call sequence, $(GENERATE_SYMBOLS_FROM_JDK_VERSION), \
+				 $(JDK_SOURCE_TARGET_VERSION)))}.txt
         # Generate element-list files for JDK 11 to current-1
 	$(call ExecuteWithLog, $@_historic, \
 	    $(JAVA_SMALL) $(INTERIM_LANGTOOLS_ARGS) \

--- a/make/modules/jdk.javadoc/Gendata.gmk
+++ b/make/modules/jdk.javadoc/Gendata.gmk
@@ -73,7 +73,8 @@ $(JDK_JAVADOC_DIR)/_element_lists.marker: \
 	$(call MakeTargetDir)
 	$(call LogInfo, Creating javadoc element lists)
 	$(RM) $(ELEMENT_LISTS_DIR)/element-list-{$(call CommaList, \
-	    $(call sequence,$(GENERATE_SYMBOLS_FROM_JDK_VERSION),$(JDK_SOURCE_TARGET_VERSION)))}.txt
+		$(call sequence,$(GENERATE_SYMBOLS_FROM_JDK_VERSION), \
+				$(JDK_SOURCE_TARGET_VERSION)))}.txt
         # Generate element-list files for JDK 11 to current-1
 	$(call ExecuteWithLog, $@_historic, \
 	    $(JAVA_SMALL) $(INTERIM_LANGTOOLS_ARGS) \


### PR DESCRIPTION
Fixes: https://bugs.openjdk.java.net/browse/JDK-8276654

A intermittent problem with the make dependencies means the jdk.javadoc element-list-.txt generation can remove the src defined element|package-list-<7,8,9,10>.txt files.
Recreatable by using --with-jobs=1 causing jdk.javadoc "gendata" to always occur after "java" module build dependency.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276654](https://bugs.openjdk.java.net/browse/JDK-8276654): element-list order is non deterministic


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6278/head:pull/6278` \
`$ git checkout pull/6278`

Update a local copy of the PR: \
`$ git checkout pull/6278` \
`$ git pull https://git.openjdk.java.net/jdk pull/6278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6278`

View PR using the GUI difftool: \
`$ git pr show -t 6278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6278.diff">https://git.openjdk.java.net/jdk/pull/6278.diff</a>

</details>
