### PR TITLE
8274856: Failing jpackage tests with fastdebug/release build

### DIFF
--- a/src/jdk.jpackage/linux/native/applauncher/LinuxLauncher.c
+++ b/src/jdk.jpackage/linux/native/applauncher/LinuxLauncher.c
@@ -29,7 +29,9 @@
 #include <dlfcn.h>
 #include <errno.h>
 #include <linux/limits.h>
+#include <sys/wait.h>
 #include <unistd.h>
+#include <stddef.h>
 #include <libgen.h>
 #include "JvmLauncher.h"
 #include "LinuxPackage.h"
@@ -43,7 +45,7 @@ static int appArgc;
 static char **appArgv;
 
 
-static JvmlLauncherData* initJvmlLauncherData(void) {
+static JvmlLauncherData* initJvmlLauncherData(int* size) {
     char* launcherLibPath = 0;
     void* jvmLauncherLibHandle = 0;
     JvmlLauncherAPI_GetAPIFunc getApi = 0;
@@ -86,7 +88,7 @@ static JvmlLauncherData* initJvmlLauncherData(void) {
         goto cleanup;
     }
 
-    result = jvmLauncherCreateJvmlLauncherData(api, jvmLauncherHandle);
+    result = jvmLauncherCreateJvmlLauncherData(api, jvmLauncherHandle, size);
     /* Handle released in jvmLauncherCreateJvmlLauncherData() */
     jvmLauncherHandle = 0;
 
@@ -131,18 +133,129 @@ cleanup:
 }
 
 
+static void closePipeEnd(int* pipefd, int idx) {
+    if (pipefd[idx] >= 0) {
+        close(pipefd[idx]);
+        pipefd[idx] = -1;
+    }
+}
+
+
+static void initJvmlLauncherDataPointers(void* baseAddress,
+                                        JvmlLauncherData* jvmLauncherData) {
+    ptrdiff_t offset = (char*)jvmLauncherData - (char*)baseAddress;
+    int i;
+
+    jvmLauncherData->jliLibPath += offset;
+    jvmLauncherData->jliLaunchArgv =
+            (char**)((char*)jvmLauncherData->jliLaunchArgv + offset);
+    jvmLauncherData->envVarNames =
+            (char**)((char*)jvmLauncherData->envVarNames + offset);
+    jvmLauncherData->envVarValues =
+            (char**)((char*)jvmLauncherData->envVarValues + offset);
+
+    for (i = 0; i != jvmLauncherData->jliLaunchArgc; i++) {
+        jvmLauncherData->jliLaunchArgv[i] += offset;
+    }
+
+    for (i = 0; i != jvmLauncherData->envVarCount; i++) {
+        jvmLauncherData->envVarNames[i] += offset;
+        jvmLauncherData->envVarValues[i] += offset;
+    }
+}
+
+
 int main(int argc, char *argv[]) {
+    int pipefd[2];
+    pid_t cpid;
     int exitCode = STATUS_FAILURE;
-    JvmlLauncherData* jvmLauncherData;
+    JvmlLauncherData* jvmLauncherData = 0;
+    int jvmLauncherDataBufferSize = 0;
 
     appArgc = argc;
     appArgv = argv;
 
-    jvmLauncherData = initJvmlLauncherData();
-    if (jvmLauncherData) {
-        exitCode = launchJvm(jvmLauncherData);
-        free(jvmLauncherData);
+    if (pipe(pipefd) == -1) {
+        JP_LOG_ERRNO;
+        return exitCode;
     }
 
+    cpid = fork();
+    if (cpid == -1) {
+        JP_LOG_ERRNO;
+    } else if (cpid == 0) /* Child process */ {
+        /* Close unused read end */
+        closePipeEnd(pipefd, 0);
+
+        jvmLauncherData = initJvmlLauncherData(&jvmLauncherDataBufferSize);
+        if (jvmLauncherData) {
+            /* Buffer size */
+            if (write(pipefd[1], &jvmLauncherDataBufferSize,
+                                    sizeof(jvmLauncherDataBufferSize)) == -1) {
+                JP_LOG_ERRNO;
+                goto cleanup;
+            }
+            if (jvmLauncherDataBufferSize) {
+                /* Buffer address */
+                if (write(pipefd[1], &jvmLauncherData,
+                                            sizeof(jvmLauncherData)) == -1) {
+                    JP_LOG_ERRNO;
+                    goto cleanup;
+                }
+                /* Buffer data */
+                if (write(pipefd[1], jvmLauncherData,
+                                            jvmLauncherDataBufferSize) == -1) {
+                    JP_LOG_ERRNO;
+                    goto cleanup;
+                }
+            }
+        }
+
+        exitCode = 0;
+    } else if (cpid > 0) {
+        void* baseAddress = 0;
+
+        /* Close unused write end */
+        closePipeEnd(pipefd, 1);
+
+        if (read(pipefd[0], &jvmLauncherDataBufferSize,
+                                sizeof(jvmLauncherDataBufferSize)) == -1) {
+            JP_LOG_ERRNO;
+            goto cleanup;
+        }
+
+        if (jvmLauncherDataBufferSize == 0) {
+            JP_LOG_ERRNO;
+            goto cleanup;
+        }
+
+        if (read(pipefd[0], &baseAddress, sizeof(baseAddress)) == -1) {
+            JP_LOG_ERRNO;
+            goto cleanup;
+        }
+
+        jvmLauncherData = malloc(jvmLauncherDataBufferSize);
+        if (!jvmLauncherData) {
+            JP_LOG_ERRNO;
+            goto cleanup;
+        }
+
+        if (read(pipefd[0], jvmLauncherData,
+                                        jvmLauncherDataBufferSize) == -1) {
+            JP_LOG_ERRNO;
+            goto cleanup;
+        }
+
+        closePipeEnd(pipefd, 0);
+        wait(NULL); /* Wait child process to terminate */
+
+        initJvmlLauncherDataPointers(baseAddress, jvmLauncherData);
+        exitCode = launchJvm(jvmLauncherData);
+    }
+
+cleanup:
+    closePipeEnd(pipefd, 0);
+    closePipeEnd(pipefd, 1);
+    free(jvmLauncherData);
     return exitCode;
 }

--- a/src/jdk.jpackage/linux/native/libapplauncher/LinuxLauncherLib.cpp
+++ b/src/jdk.jpackage/linux/native/libapplauncher/LinuxLauncherLib.cpp
@@ -113,17 +113,9 @@ void launchApp() {
         launchInfo = (tstrings::any() << thisHash).str();
     }
 
-    JP_TRY;
-    if (0 != setenv(_JPACKAGE_LAUNCHER.c_str(), launchInfo.c_str(), 1)) {
-        JP_THROW(tstrings::any() << "setenv(" << _JPACKAGE_LAUNCHER
-                << ", " << launchInfo << ") failed. Error: " << lastCRTError());
-    } else {
-        LOG_TRACE(tstrings::any() << "Set "
-                << _JPACKAGE_LAUNCHER << "=[" << launchInfo << "]");
-    }
-    JP_CATCH_ALL;
-
     jvmLauncher = appLauncher.createJvmLauncher();
+
+    jvmLauncher->addEnvVariable(_JPACKAGE_LAUNCHER, launchInfo);
 }
 
 } // namespace

--- a/src/jdk.jpackage/share/native/applauncher/AppLauncher.cpp
+++ b/src/jdk.jpackage/share/native/applauncher/AppLauncher.cpp
@@ -130,14 +130,14 @@ Jvm* AppLauncher::createJvmLauncher() const {
             PropertyName::arguments, args);
     }
 
+    std::unique_ptr<Jvm> jvm(new Jvm());
+
     if (!libEnvVariableContainsAppDir()) {
-        SysInfo::setEnvVariable(libEnvVarName, SysInfo::getEnvVariable(
+        (*jvm).addEnvVariable(libEnvVarName, SysInfo::getEnvVariable(
                 std::nothrow, libEnvVarName)
                 + FileUtils::pathSeparator
                 + appDirPath);
     }
-
-    std::unique_ptr<Jvm> jvm(new Jvm());
 
     (*jvm)
         .setPath(findJvmLib(cfgFile, defaultRuntimePath, jvmLibNames))

--- a/src/jdk.jpackage/share/native/applauncher/JvmLauncher.h
+++ b/src/jdk.jpackage/share/native/applauncher/JvmLauncher.h
@@ -29,16 +29,27 @@
 
 
 #include "jni.h" /* JNIEXPORT */
+#ifdef _WIN32
+#include <windows.h>
+#include <tchar.h>
+#endif
 
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+#ifndef _WIN32
+typedef char TCHAR;
+#endif
+
 typedef struct {
     const char* jliLibPath;
     int jliLaunchArgc;
+    int envVarCount;
     char** jliLaunchArgv;
+    TCHAR** envVarNames;
+    TCHAR** envVarValues;
 } JvmlLauncherData;
 
 typedef void* JvmlLauncherHandle;
@@ -71,7 +82,8 @@ static inline JvmlLauncherData* jvmLauncherInitJvmlLauncherData(JvmlLauncherAPI*
     return (*api->initJvmlLauncherData)(h, ptr, bufferSize);
 }
 
-JvmlLauncherData* jvmLauncherCreateJvmlLauncherData(JvmlLauncherAPI* api, JvmlLauncherHandle h);
+JvmlLauncherData* jvmLauncherCreateJvmlLauncherData(JvmlLauncherAPI* api,
+                                            JvmlLauncherHandle h, int* size);
 int jvmLauncherStartJvm(JvmlLauncherData* jvmArgs, void* JLI_Launch);
 
 void jvmLauncherLog(const char* format, ...);
@@ -105,6 +117,12 @@ public:
         return *this;
     }
 
+    Jvm& addEnvVariable(const tstring& name, const tstring& value) {
+        envVarNames.push_back(name);
+        envVarValues.push_back(value);
+        return *this;
+    }
+
     Jvm& setPath(const tstring& v) {
         jvmPath = v;
         return *this;
@@ -118,11 +136,15 @@ public:
 
     void launch();
 
+    void setEnvVariables();
+
     JvmlLauncherHandle exportLauncher() const;
 
 private:
     tstring jvmPath;
     tstring_array args;
+    tstring_array envVarNames;
+    tstring_array envVarValues;
 };
 
 #endif // #ifdef __cplusplus

--- a/src/jdk.jpackage/share/native/applauncher/JvmLauncherLib.c
+++ b/src/jdk.jpackage/share/native/applauncher/JvmLauncherLib.c
@@ -26,6 +26,9 @@
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
+#ifdef LINUX
+#include <unistd.h>
+#endif
 
 #include "JvmLauncher.h"
 
@@ -44,7 +47,7 @@ typedef int (JNICALL *JLI_LaunchFuncType)(int argc, char ** argv,
 
 
 JvmlLauncherData* jvmLauncherCreateJvmlLauncherData(
-                                JvmlLauncherAPI* api, JvmlLauncherHandle h) {
+                    JvmlLauncherAPI* api, JvmlLauncherHandle h, int* size) {
     JvmlLauncherData* result = 0;
     void* buf = 0;
     int jvmLauncherDataBufferSize;
@@ -69,6 +72,9 @@ JvmlLauncherData* jvmLauncherCreateJvmlLauncherData(
     if (result) {
         /* Don't free the buffer in clean up. */
         buf = 0;
+        if (size) {
+            *size = jvmLauncherDataBufferSize;
+        }
     }
 
 cleanup:
@@ -85,13 +91,33 @@ static void dumpJvmlLauncherData(const JvmlLauncherData* jvmArgs) {
     for (i = 0; i < jvmArgs->jliLaunchArgc; ++i) {
         JP_LOG_TRACE("jli arg[%d]: [%s]", i, jvmArgs->jliLaunchArgv[i]);
     }
+    for (i = 0; i < jvmArgs->envVarCount; ++i) {
+        JP_LOG_TRACE("env var[%d]: %s=[%s]", i, jvmArgs->envVarNames[i],
+                                                jvmArgs->envVarValues[i]);
+    }
 }
 
 
 int jvmLauncherStartJvm(JvmlLauncherData* jvmArgs, void* JLI_Launch) {
+    int i;
     int exitCode;
 
     dumpJvmlLauncherData(jvmArgs);
+
+    for (i = 0; i < jvmArgs->envVarCount; ++i) {
+#ifdef _WIN32
+        if (!SetEnvironmentVariable(jvmArgs->envVarNames[i],
+                                                jvmArgs->envVarValues[i])) {
+            JP_LOG_TRACE("SetEnvironmentVariable(%d) failed", i);
+        }
+#else
+        if (setenv(jvmArgs->envVarNames[i],
+                                        jvmArgs->envVarValues[i], 1) != 0) {
+            JP_LOG_TRACE("setenv(%d) failed", i);
+        }
+#endif
+    }
+
     exitCode = (*((JLI_LaunchFuncType)JLI_Launch))(
         jvmArgs->jliLaunchArgc, jvmArgs->jliLaunchArgv,
         0, 0,
@@ -121,6 +147,9 @@ void jvmLauncherLog(const char* format, ...) {
 #if defined(__GNUC__) && __GNUC__ >= 5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif
+#ifdef LINUX
+    fprintf(stderr, "[%d]: ", getpid());
 #endif
     vfprintf(stderr, format, args);
     fprintf(stderr, "\n");

--- a/src/jdk.jpackage/unix/native/common/UnixSysInfo.cpp
+++ b/src/jdk.jpackage/unix/native/common/UnixSysInfo.cpp
@@ -56,7 +56,10 @@ bool isEnvVariableSet(const tstring& name) {
 }
 
 void setEnvVariable(const tstring& name, const tstring& value) {
-    ::setenv(name.c_str(), value.c_str(), 1);
+    if (::setenv(name.c_str(), value.c_str(), 1) != 0) {
+        JP_THROW(tstrings::any() << "setenv(" << name << ", " << value 
+                                    << ") failed. Error: " << lastCRTError());
+    }
 }
 
 

--- a/src/jdk.jpackage/unix/native/common/UnixSysInfo.cpp
+++ b/src/jdk.jpackage/unix/native/common/UnixSysInfo.cpp
@@ -57,7 +57,7 @@ bool isEnvVariableSet(const tstring& name) {
 
 void setEnvVariable(const tstring& name, const tstring& value) {
     if (::setenv(name.c_str(), value.c_str(), 1) != 0) {
-        JP_THROW(tstrings::any() << "setenv(" << name << ", " << value 
+        JP_THROW(tstrings::any() << "setenv(" << name << ", " << value
                                     << ") failed. Error: " << lastCRTError());
     }
 }

--- a/src/jdk.jpackage/windows/native/applauncher/WinLauncher.cpp
+++ b/src/jdk.jpackage/windows/native/applauncher/WinLauncher.cpp
@@ -154,6 +154,8 @@ void launchApp() {
     std::unique_ptr<Jvm> jvm(appLauncher.createJvmLauncher());
 
     if (restart) {
+        jvm->setEnvVariables();
+
         jvm = std::unique_ptr<Jvm>();
 
         STARTUPINFOW si;


### PR DESCRIPTION
The fix is to isolate C++ calls in the separate forked child process on Linux. 
This change requires the passing of JLI command line arguments and values of environment variables between two processes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274856](https://bugs.openjdk.java.net/browse/JDK-8274856): Failing jpackage tests with fastdebug/release build


### Reviewers
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - **Reviewer**)
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6283/head:pull/6283` \
`$ git checkout pull/6283`

Update a local copy of the PR: \
`$ git checkout pull/6283` \
`$ git pull https://git.openjdk.java.net/jdk pull/6283/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6283`

View PR using the GUI difftool: \
`$ git pr show -t 6283`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6283.diff">https://git.openjdk.java.net/jdk/pull/6283.diff</a>

</details>
