### PR TITLE
8269986: Remove +3 from Symbol::identity_hash()

### DIFF
--- a/src/hotspot/share/oops/symbol.hpp
+++ b/src/hotspot/share/oops/symbol.hpp
@@ -155,7 +155,7 @@ class Symbol : public MetaspaceObj {
   // Returns the largest size symbol we can safely hold.
   static int max_length() { return max_symbol_length; }
   unsigned identity_hash() const {
-    unsigned addr_bits = (unsigned)((uintptr_t)this >> (LogBytesPerWord + 3));
+    unsigned addr_bits = (unsigned)((uintptr_t)this >> LogBytesPerWord);
     return ((unsigned)extract_hash(_hash_and_refcount) & 0xffff) |
            ((addr_bits ^ (length() << 8) ^ (( _body[0] << 8) | _body[1])) << 16);
   }


### PR DESCRIPTION
Please review this trivial change that removes the `+3` from here:

```
  unsigned Symbol::identity_hash() const {
    unsigned addr_bits = (unsigned)((uintptr_t)this >> (LogMinObjAlignmentInBytes + 3));
                                                                                  ^^^
    return ((unsigned)extract_hash(_hash_and_refcount) & 0xffff) |
           ((addr_bits ^ (length() << 8) ^ (( _body[0] << 8) | _body[1])) << 16);
  }
```

The `+3` was intended to avoid getting the same value for these bits:

```
((uintptr_t)this) >> LogMinObjAlignmentInBytes) & 0x07)
```

However, as shown in the [bug report](https://bugs.openjdk.java.net/browse/JDK-8269986), the values for these bits are evenly distributed. So the `+3` is not necessary and may actually be counter-productive.

Testing: Oracle CI tiers 1-4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269986](https://bugs.openjdk.java.net/browse/JDK-8269986): Remove +3 from Symbol::identity_hash()


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6287/head:pull/6287` \
`$ git checkout pull/6287`

Update a local copy of the PR: \
`$ git checkout pull/6287` \
`$ git pull https://git.openjdk.java.net/jdk pull/6287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6287`

View PR using the GUI difftool: \
`$ git pr show -t 6287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6287.diff">https://git.openjdk.java.net/jdk/pull/6287.diff</a>

</details>
