### PR TITLE
8276790: Rename GenericCDSFileMapHeader::_base_archive_path_offset

### DIFF
--- a/src/hotspot/share/cds/cdsConstants.cpp
+++ b/src/hotspot/share/cds/cdsConstants.cpp
@@ -35,7 +35,7 @@ CDSConst CDSConstants::offsets[] = {
   { "GenericCDSFileMapHeader::_crc",                       offset_of(GenericCDSFileMapHeader, _crc)            },
   { "GenericCDSFileMapHeader::_version",                   offset_of(GenericCDSFileMapHeader, _version)        },
   { "GenericCDSFileMapHeader::_header_size",               offset_of(GenericCDSFileMapHeader, _header_size)    },
-  { "GenericCDSFileMapHeader::_base_archive_path_offset",  offset_of(GenericCDSFileMapHeader, _base_archive_path_offset) },
+  { "GenericCDSFileMapHeader::_base_archive_name_offset",  offset_of(GenericCDSFileMapHeader, _base_archive_name_offset) },
   { "GenericCDSFileMapHeader::_base_archive_name_size",    offset_of(GenericCDSFileMapHeader, _base_archive_name_size)   },
   { "CDSFileMapHeaderBase::_space[0]",                     offset_of(CDSFileMapHeaderBase, _space)             },
   { "FileMapHeader::_jvm_ident",                           offset_of(FileMapHeader, _jvm_ident)                },

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -243,14 +243,14 @@ public:
   int crc()                               const { return _generic_header._crc;      }
   int version()                           const { return _generic_header._version;  }
   unsigned int header_size()              const { return _generic_header._header_size;              }
-  unsigned int base_archive_path_offset() const { return _generic_header._base_archive_path_offset; }
+  unsigned int base_archive_name_offset() const { return _generic_header._base_archive_name_offset; }
   unsigned int base_archive_name_size()   const { return _generic_header._base_archive_name_size;   }
 
   void set_magic(unsigned int m)                    { _generic_header._magic = m;       }
   void set_crc(int crc_value)                       { _generic_header._crc = crc_value; }
   void set_version(int v)                           { _generic_header._version = v;     }
   void set_header_size(unsigned int s)              { _generic_header._header_size = s;              }
-  void set_base_archive_path_offset(unsigned int s) { _generic_header._base_archive_path_offset = s; }
+  void set_base_archive_name_offset(unsigned int s) { _generic_header._base_archive_name_offset = s; }
   void set_base_archive_name_size(unsigned int s)   { _generic_header._base_archive_name_size = s;   }
 
   size_t core_region_alignment()           const { return _core_region_alignment; }
@@ -313,7 +313,7 @@ public:
   }
 
   void populate(FileMapInfo *info, size_t core_region_alignment, size_t header_size,
-                size_t base_archive_name_size, size_t base_archive_path_offset);
+                size_t base_archive_name_size, size_t base_archive_name_offset);
   static bool is_valid_region(int region) {
     return (0 <= region && region < NUM_CDS_REGIONS);
   }

--- a/src/hotspot/share/include/cds.h
+++ b/src/hotspot/share/include/cds.h
@@ -67,12 +67,12 @@ typedef struct GenericCDSFileMapHeader {
   int          _crc;                      // header crc checksum
   int          _version;                  // CURRENT_CDS_ARCHIVE_VERSION of the jdk that dumped the this archive
   unsigned int _header_size;              // total size of the header, in bytes
-  unsigned int _base_archive_path_offset; // offset where the base archive name is stored
+  unsigned int _base_archive_name_offset; // offset where the base archive name is stored
                                           //   static archive:  0
                                           //   dynamic archive:
                                           //     0 for default base archive
                                           //     non-zero for non-default base archive
-                                          //       (char*)this + _base_archive_path_offset
+                                          //       (char*)this + _base_archive_name_offset
                                           //       points to a 0-terminated string for the base archive name
   unsigned int _base_archive_name_size;   // size of base archive name including ending '\0'
                                           //   static:  0

--- a/test/hotspot/jtreg/runtime/cds/appcds/SharedArchiveConsistency.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/SharedArchiveConsistency.java
@@ -222,15 +222,15 @@ public class SharedArchiveConsistency {
         CDSArchiveUtils.modifyRegionContentRandomly(copiedJsa);
         testAndCheck(verifyExecArgs);
 
-        // modify _base_archive_path_offet to non-zero
-        System.out.println("\n8. modify _base_archive_path_offset to non-zero\n");
-        String baseArchivePathOffsetName = startNewArchive("base-arhive-path-offset");
-        copiedJsa = CDSArchiveUtils.copyArchiveFile(orgJsaFile, baseArchivePathOffsetName);
-        int baseArchivePathOffset = CDSArchiveUtils.baseArchivePathOffset(copiedJsa);
-        System.out.println("    baseArchivePathOffset = " + baseArchivePathOffset);
-        CDSArchiveUtils.writeData(copiedJsa, CDSArchiveUtils.offsetBaseArchivePathOffset(), 1024);
-        baseArchivePathOffset = CDSArchiveUtils.baseArchivePathOffset(copiedJsa);
-        System.out.println("new baseArchivePathOffset = " + baseArchivePathOffset);
+        // modify _base_archive_name_offet to non-zero
+        System.out.println("\n8. modify _base_archive_name_offset to non-zero\n");
+        String baseArchiveNameOffsetName = startNewArchive("base-arhive-path-offset");
+        copiedJsa = CDSArchiveUtils.copyArchiveFile(orgJsaFile, baseArchiveNameOffsetName);
+        int baseArchiveNameOffset = CDSArchiveUtils.baseArchiveNameOffset(copiedJsa);
+        System.out.println("    baseArchiveNameOffset = " + baseArchiveNameOffset);
+        CDSArchiveUtils.writeData(copiedJsa, CDSArchiveUtils.offsetBaseArchiveNameOffset(), 1024);
+        baseArchiveNameOffset = CDSArchiveUtils.baseArchiveNameOffset(copiedJsa);
+        System.out.println("new baseArchiveNameOffset = " + baseArchiveNameOffset);
         testAndCheck(verifyExecArgs);
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchiveConsistency.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchiveConsistency.java
@@ -112,31 +112,31 @@ public class ArchiveConsistency extends DynamicArchiveTestBase {
         CDSArchiveUtils.modifyHeaderIntField(copiedJsa, CDSArchiveUtils.offsetHeaderSize(),  (int)copiedJsa.length() + 1024);
         runTwo(baseArchiveName, largerHeaderSize,
                appJar, mainClass, 1,
-               new String[] {"_header_size should be equal to _base_archive_path_offset plus _base_archive_name_size",
+               new String[] {"_header_size should be equal to _base_archive_name_offset plus _base_archive_name_size",
                              "Unable to use shared archive"});
 
         // 3. Make base archive path offset beyond of header size
         System.out.println("\n3. Make base archive path offset beyond of header size.");
-        String wrongBaseArchivePathOffset = getNewArchiveName("wrongBaseArchivePathOffset");
-        copiedJsa = CDSArchiveUtils.copyArchiveFile(jsa, wrongBaseArchivePathOffset);
+        String wrongBaseArchiveNameOffset = getNewArchiveName("wrongBaseArchiveNameOffset");
+        copiedJsa = CDSArchiveUtils.copyArchiveFile(jsa, wrongBaseArchiveNameOffset);
         int fileHeaderSize = (int)CDSArchiveUtils.fileHeaderSize(copiedJsa);
-        int baseArchivePathOffset = CDSArchiveUtils.baseArchivePathOffset(copiedJsa);
-        CDSArchiveUtils.modifyHeaderIntField(copiedJsa, CDSArchiveUtils.offsetBaseArchivePathOffset(), baseArchivePathOffset + 1024);
-        runTwo(baseArchiveName, wrongBaseArchivePathOffset,
+        int baseArchiveNameOffset = CDSArchiveUtils.baseArchiveNameOffset(copiedJsa);
+        CDSArchiveUtils.modifyHeaderIntField(copiedJsa, CDSArchiveUtils.offsetBaseArchiveNameOffset(), baseArchiveNameOffset + 1024);
+        runTwo(baseArchiveName, wrongBaseArchiveNameOffset,
                appJar, mainClass, 1,
-               new String[] {"_header_size should be equal to _base_archive_path_offset plus _base_archive_name_size",
+               new String[] {"_header_size should be equal to _base_archive_name_offset plus _base_archive_name_size",
                              "The shared archive file has an incorrect header size",
                              "Unable to use shared archive"});
 
         // 4. Make base archive path offset points to middle of name size
         System.out.println("\n4. Make base archive path offset points to middle of name size");
-        String wrongBasePathOffset = getNewArchiveName("wrongBasePathOffset");
-        copiedJsa = CDSArchiveUtils.copyArchiveFile(jsa, wrongBasePathOffset);
+        String wrongBaseNameOffset = getNewArchiveName("wrongBaseNameOffset");
+        copiedJsa = CDSArchiveUtils.copyArchiveFile(jsa, wrongBaseNameOffset);
         int baseArchiveNameSize = CDSArchiveUtils.baseArchiveNameSize(copiedJsa);
-        baseArchivePathOffset = CDSArchiveUtils.baseArchivePathOffset(copiedJsa);
-        CDSArchiveUtils.modifyHeaderIntField(copiedJsa, baseArchivePathOffset,
-                                             baseArchivePathOffset + baseArchiveNameSize/2);
-        runTwo(baseArchiveName, wrongBasePathOffset,
+        baseArchiveNameOffset = CDSArchiveUtils.baseArchiveNameOffset(copiedJsa);
+        CDSArchiveUtils.modifyHeaderIntField(copiedJsa, baseArchiveNameOffset,
+                                             baseArchiveNameOffset + baseArchiveNameSize/2);
+        runTwo(baseArchiveName, wrongBaseNameOffset,
                appJar, mainClass, 1,
                new String[] {"An error has occurred while processing the shared archive file.",
                              "Header checksum verification failed",
@@ -146,9 +146,9 @@ public class ArchiveConsistency extends DynamicArchiveTestBase {
         System.out.println("\n5. Make base archive name not terminated with '\0'");
         String wrongBaseName = getNewArchiveName("wrongBaseName");
         copiedJsa = CDSArchiveUtils.copyArchiveFile(jsa, wrongBaseName);
-        baseArchivePathOffset = CDSArchiveUtils.baseArchivePathOffset(copiedJsa);
+        baseArchiveNameOffset = CDSArchiveUtils.baseArchiveNameOffset(copiedJsa);
         baseArchiveNameSize = CDSArchiveUtils.baseArchiveNameSize(copiedJsa);
-        long offset = baseArchivePathOffset + baseArchiveNameSize - 1;  // end of line
+        long offset = baseArchiveNameOffset + baseArchiveNameSize - 1;  // end of line
         CDSArchiveUtils.writeData(copiedJsa, offset, new byte[] {(byte)'X'});
 
         runTwo(baseArchiveName, wrongBaseName,
@@ -160,9 +160,9 @@ public class ArchiveConsistency extends DynamicArchiveTestBase {
         System.out.println("\n6. Modify base archive name to a file that doesn't exist");
         String wrongBaseName2 = getNewArchiveName("wrongBaseName2");
         copiedJsa = CDSArchiveUtils.copyArchiveFile(jsa, wrongBaseName2);
-        baseArchivePathOffset = CDSArchiveUtils.baseArchivePathOffset(copiedJsa);
+        baseArchiveNameOffset = CDSArchiveUtils.baseArchiveNameOffset(copiedJsa);
         baseArchiveNameSize = CDSArchiveUtils.baseArchiveNameSize(copiedJsa);
-        offset = baseArchivePathOffset + baseArchiveNameSize - 2;  // the "a" in ".jsa"
+        offset = baseArchiveNameOffset + baseArchiveNameSize - 2;  // the "a" in ".jsa"
         CDSArchiveUtils.writeData(copiedJsa, offset, new byte[] {(byte)'b'}); // .jsa -> .jsb
 
         // Make sure it doesn't exist

--- a/test/lib/jdk/test/lib/cds/CDSArchiveUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSArchiveUtils.java
@@ -50,7 +50,7 @@ public class CDSArchiveUtils {
     private static int offsetCrc;                  // offset of GenericCDSFileMapHeader::_crc
     private static int offsetVersion;              // offset of GenericCDSFileMapHeader::_version
     private static int offsetHeaderSize;           // offset of GenericCDSFileMapHeader::_header_size
-    private static int offsetBaseArchivePathOffset;// offset of GenericCDSFileMapHeader::_base_archive_path_offset
+    private static int offsetBaseArchiveNameOffset;// offset of GenericCDSFileMapHeader::_base_archive_name_offset
     private static int offsetBaseArchiveNameSize;  // offset of GenericCDSFileMapHeader::_base_archive_name_size
     private static int offsetJvmIdent;             // offset of FileMapHeader::_jvm_ident
     private static int spOffsetCrc;                // offset of CDSFileMapRegion::_crc
@@ -87,7 +87,7 @@ public class CDSArchiveUtils {
             offsetCrc = wb.getCDSOffsetForName("GenericCDSFileMapHeader::_crc");
             offsetVersion = wb.getCDSOffsetForName("GenericCDSFileMapHeader::_version");
             offsetHeaderSize = wb.getCDSOffsetForName("GenericCDSFileMapHeader::_header_size");
-            offsetBaseArchivePathOffset = wb.getCDSOffsetForName("GenericCDSFileMapHeader::_base_archive_path_offset");
+            offsetBaseArchiveNameOffset = wb.getCDSOffsetForName("GenericCDSFileMapHeader::_base_archive_name_offset");
             offsetBaseArchiveNameSize = wb.getCDSOffsetForName("GenericCDSFileMapHeader::_base_archive_name_size");
             offsetJvmIdent = wb.getCDSOffsetForName("FileMapHeader::_jvm_ident");
             spOffsetCrc = wb.getCDSOffsetForName("CDSFileMapRegion::_crc");
@@ -121,7 +121,7 @@ public class CDSArchiveUtils {
     public static int offsetCrc()                   { return offsetCrc;                   }
     public static int offsetVersion()               { return offsetVersion;               }
     public static int offsetHeaderSize()            { return offsetHeaderSize;            }
-    public static int offsetBaseArchivePathOffset() { return offsetBaseArchivePathOffset; }
+    public static int offsetBaseArchiveNameOffset() { return offsetBaseArchiveNameOffset; }
     public static int offsetBaseArchiveNameSize()   { return offsetBaseArchiveNameSize;   }
     public static int offsetJvmIdent()              { return offsetJvmIdent;              }
     public static int spOffsetCrc()                 { return spOffsetCrc;                 }
@@ -148,8 +148,8 @@ public class CDSArchiveUtils {
         return alignUpWithAlignment(size);
     }
 
-    public static int baseArchivePathOffset(File jsaFile) throws Exception {
-        return (int)readInt(jsaFile, offsetBaseArchivePathOffset, 4);
+    public static int baseArchiveNameOffset(File jsaFile) throws Exception {
+        return (int)readInt(jsaFile, offsetBaseArchiveNameOffset, 4);
     }
 
     public static int baseArchiveNameSize(File jsaFile) throws Exception {
@@ -158,8 +158,8 @@ public class CDSArchiveUtils {
 
     public static String baseArchiveName(File jsaFile) throws Exception {
         int size = baseArchiveNameSize(jsaFile);
-        int baseArchivePathOffset = (int)readInt(jsaFile, offsetBaseArchivePathOffset, 4);
-        return readString(jsaFile, baseArchivePathOffset, size - 1); // exclude terminating '\0'
+        int baseArchiveNameOffset = (int)readInt(jsaFile, offsetBaseArchiveNameOffset, 4);
+        return readString(jsaFile, baseArchiveNameOffset, size - 1); // exclude terminating '\0'
     }
 
     private static long alignUpWithAlignment(long l) {


### PR DESCRIPTION
Please review this trivial change that improves consistency in the source code:

In the `GenericCDSFileMapHeader` structure, rename

```
_base_archive_path_offset => _base_archive_name_offset
```

I also changed the names used by various tests accordingly.

Running tiers 1-4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276790](https://bugs.openjdk.java.net/browse/JDK-8276790): Rename GenericCDSFileMapHeader::_base_archive_path_offset


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6288/head:pull/6288` \
`$ git checkout pull/6288`

Update a local copy of the PR: \
`$ git checkout pull/6288` \
`$ git pull https://git.openjdk.java.net/jdk pull/6288/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6288`

View PR using the GUI difftool: \
`$ git pr show -t 6288`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6288.diff">https://git.openjdk.java.net/jdk/pull/6288.diff</a>

</details>
