### PR TITLE
8276679: Malformed Javadoc inline tags in JDK source in javax/swing

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JTree.java
+++ b/src/java.desktop/share/classes/javax/swing/JTree.java
@@ -3675,7 +3675,7 @@ public class JTree extends JComponent implements Scrollable, Accessible
      * This will fail if a <code>TreeWillExpandListener</code> vetos it.
      *
      * @param path a {@code TreePath} identifying a node
-     * @param state if {@code true}, all parents of @{code path} and path are marked as expanded.
+     * @param state if {@code true}, all parents of {@code path} and path are marked as expanded.
      *              Otherwise, all parents of {@code path} are marked EXPANDED,
      *              but {@code path} itself is marked collapsed.
      */

--- a/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
@@ -106,12 +106,12 @@ public class SwingUtilities implements SwingConstants
     }
 
     /**
-     * Return {@code true} if @{code a} contains {@code b}
+     * Return {@code true} if {@code a} contains {@code b}
      *
      * @param a the first rectangle
      * @param b the second rectangle
      *
-     * @return {@code true} if @{code a} contains {@code b}
+     * @return {@code true} if {@code a} contains {@code b}
      */
     public static final boolean isRectangleContainingRectangle(Rectangle a,Rectangle b) {
         return b.x >= a.x && (b.x + b.width) <= (a.x + a.width) &&

--- a/src/java.desktop/share/classes/javax/swing/event/HyperlinkEvent.java
+++ b/src/java.desktop/share/classes/javax/swing/event/HyperlinkEvent.java
@@ -175,7 +175,7 @@ public class HyperlinkEvent extends EventObject {
     /**
      * Returns the {@code InputEvent} that triggered the hyperlink event.
      * This will typically be a {@code MouseEvent}.  If a constructor is used
-     * that does not specify an {@code InputEvent}, or @{code null}
+     * that does not specify an {@code InputEvent}, or {@code null}
      * was specified as the {@code InputEvent}, this returns {@code null}.
      *
      * @return  InputEvent that triggered the hyperlink event, or null

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboBoxUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboBoxUI.java
@@ -95,7 +95,7 @@ public class BasicComboBoxUI extends ComboBoxUI {
     protected ComboPopup popup;
 
     /**
-     * The Component that the @{code ComboBoxEditor} uses for editing.
+     * The Component that the {@code ComboBoxEditor} uses for editing.
      */
     protected Component editor;
 


### PR DESCRIPTION
Fixed multiple malformed Javadoc inline tags where the `@` is placed in front of the opening curly bracket (instead of behind).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276679](https://bugs.openjdk.java.net/browse/JDK-8276679): Malformed Javadoc inline tags in JDK source in javax/swing


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6290/head:pull/6290` \
`$ git checkout pull/6290`

Update a local copy of the PR: \
`$ git checkout pull/6290` \
`$ git pull https://git.openjdk.java.net/jdk pull/6290/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6290`

View PR using the GUI difftool: \
`$ git pr show -t 6290`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6290.diff">https://git.openjdk.java.net/jdk/pull/6290.diff</a>

</details>
