### PR TITLE
JDK-8276800 Fix table headers in NumericShaper.html

### DIFF
--- a/src/java.desktop/share/classes/java/awt/font/NumericShaper.java
+++ b/src/java.desktop/share/classes/java/awt/font/NumericShaper.java
@@ -119,18 +119,18 @@ import jdk.internal.access.SharedSecrets;
  * <tbody>
  *   <tr>
  *     <th scope="rowgroup" rowspan="2" id="rowheader1">Arabic
- *     <td headers="rowheader1 colheader2">{@link NumericShaper#ARABIC NumericShaper.ARABIC}
+ *     <th scope="row">{@link NumericShaper#ARABIC NumericShaper.ARABIC}
  *     <br>
  *     {@link NumericShaper#EASTERN_ARABIC NumericShaper.EASTERN_ARABIC}
  *     <td headers="rowheader1 colheader3">{@link NumericShaper#EASTERN_ARABIC NumericShaper.EASTERN_ARABIC}
  *   <tr>
- *     <td headers="rowheader1 colheader2">{@link NumericShaper.Range#ARABIC}
+ *     <th scope="row">{@link NumericShaper.Range#ARABIC}
  *     <br>
  *     {@link NumericShaper.Range#EASTERN_ARABIC}
  *     <td headers="rowheader1 colheader3">{@link NumericShaper.Range#EASTERN_ARABIC}
  *   <tr>
- *     <th scope="row">Tai Tham
- *     <td>{@link NumericShaper.Range#TAI_THAM_HORA}
+ *     <th scope="rowgroup">Tai Tham
+ *     <th scope="row">{@link NumericShaper.Range#TAI_THAM_HORA}
  *     <br>
  *     {@link NumericShaper.Range#TAI_THAM_THAM}
  *     <td>{@link NumericShaper.Range#TAI_THAM_THAM}

--- a/src/java.desktop/share/classes/java/awt/font/NumericShaper.java
+++ b/src/java.desktop/share/classes/java/awt/font/NumericShaper.java
@@ -118,22 +118,19 @@ import jdk.internal.access.SharedSecrets;
  * </thead>
  * <tbody>
  *   <tr>
- *     <th scope="rowgroup" rowspan="2">Arabic
- *     <td>{@link NumericShaper#ARABIC NumericShaper.ARABIC}
+ *     <td rowspan="2" style="font-weight:bold; text-align:center">Arabic
+ *     <th scope="row" style="font-weight:normal; text-align:left">{@link NumericShaper#ARABIC NumericShaper.ARABIC}
  *     <br>
  *     {@link NumericShaper#EASTERN_ARABIC NumericShaper.EASTERN_ARABIC}
  *     <td>{@link NumericShaper#EASTERN_ARABIC NumericShaper.EASTERN_ARABIC}
- *   </tr>
  *   <tr>
- *     <td>{@link NumericShaper.Range#ARABIC}
+ *     <th scope="row" style="font-weight:normal; text-align:left">{@link NumericShaper.Range#ARABIC}
  *     <br>
  *     {@link NumericShaper.Range#EASTERN_ARABIC}
  *     <td>{@link NumericShaper.Range#EASTERN_ARABIC}
- * </tbody>
- * <tbody>
  *   <tr>
- *     <th scope="row">Tai Tham
- *     <td>{@link NumericShaper.Range#TAI_THAM_HORA}
+ *     <td style="font-weight:bold; text-align:center">Tai Tham
+ *     <th scope="row" style="font-weight:normal; text-align:left">{@link NumericShaper.Range#TAI_THAM_HORA}
  *     <br>
  *     {@link NumericShaper.Range#TAI_THAM_THAM}
  *     <td>{@link NumericShaper.Range#TAI_THAM_THAM}

--- a/src/java.desktop/share/classes/java/awt/font/NumericShaper.java
+++ b/src/java.desktop/share/classes/java/awt/font/NumericShaper.java
@@ -112,22 +112,24 @@ import jdk.internal.access.SharedSecrets;
  * <caption>NumericShaper constants precedence</caption>
  * <thead>
  *   <tr>
- *     <th scope="col" id="colheader1">Unicode Range
- *     <th scope="col" id="colheader2">{@code NumericShaper} Constants
- *     <th scope="col" id="colheader3">Precedence
+ *     <th scope="col">Unicode Range
+ *     <th scope="col">{@code NumericShaper} Constants
+ *     <th scope="col">Precedence
  * </thead>
  * <tbody>
  *   <tr>
- *     <th scope="rowgroup" rowspan="2" id="rowheader1">Arabic
+ *     <th scope="rowgroup" rowspan="2">Arabic
  *     <th scope="row">{@link NumericShaper#ARABIC NumericShaper.ARABIC}
  *     <br>
  *     {@link NumericShaper#EASTERN_ARABIC NumericShaper.EASTERN_ARABIC}
- *     <td headers="rowheader1 colheader3">{@link NumericShaper#EASTERN_ARABIC NumericShaper.EASTERN_ARABIC}
+ *     <td>{@link NumericShaper#EASTERN_ARABIC NumericShaper.EASTERN_ARABIC}
  *   <tr>
  *     <th scope="row">{@link NumericShaper.Range#ARABIC}
  *     <br>
  *     {@link NumericShaper.Range#EASTERN_ARABIC}
- *     <td headers="rowheader1 colheader3">{@link NumericShaper.Range#EASTERN_ARABIC}
+ *     <td>{@link NumericShaper.Range#EASTERN_ARABIC}
+ * </tbody>
+ * <tbody>
  *   <tr>
  *     <th scope="rowgroup">Tai Tham
  *     <th scope="row">{@link NumericShaper.Range#TAI_THAM_HORA}

--- a/src/java.desktop/share/classes/java/awt/font/NumericShaper.java
+++ b/src/java.desktop/share/classes/java/awt/font/NumericShaper.java
@@ -112,25 +112,25 @@ import jdk.internal.access.SharedSecrets;
  * <caption>NumericShaper constants precedence</caption>
  * <thead>
  *   <tr>
- *     <th scope="col">Unicode Range
- *     <th scope="col">{@code NumericShaper} Constants
- *     <th scope="col">Precedence
+ *     <th scope="col" id="colheader1">Unicode Range
+ *     <th scope="col" id="colheader2">{@code NumericShaper} Constants
+ *     <th scope="col" id="colheader3">Precedence
  * </thead>
  * <tbody>
  *   <tr>
- *     <td rowspan="2" style="font-weight:bold; text-align:center">Arabic
- *     <th scope="row" style="font-weight:normal; text-align:left">{@link NumericShaper#ARABIC NumericShaper.ARABIC}
+ *     <th scope="rowgroup" rowspan="2" id="rowheader1">Arabic
+ *     <td headers="rowheader1 colheader2">{@link NumericShaper#ARABIC NumericShaper.ARABIC}
  *     <br>
  *     {@link NumericShaper#EASTERN_ARABIC NumericShaper.EASTERN_ARABIC}
- *     <td>{@link NumericShaper#EASTERN_ARABIC NumericShaper.EASTERN_ARABIC}
+ *     <td headers="rowheader1 colheader3">{@link NumericShaper#EASTERN_ARABIC NumericShaper.EASTERN_ARABIC}
  *   <tr>
- *     <th scope="row" style="font-weight:normal; text-align:left">{@link NumericShaper.Range#ARABIC}
+ *     <td headers="rowheader1 colheader2">{@link NumericShaper.Range#ARABIC}
  *     <br>
  *     {@link NumericShaper.Range#EASTERN_ARABIC}
- *     <td>{@link NumericShaper.Range#EASTERN_ARABIC}
+ *     <td headers="rowheader1 colheader3">{@link NumericShaper.Range#EASTERN_ARABIC}
  *   <tr>
- *     <td style="font-weight:bold; text-align:center">Tai Tham
- *     <th scope="row" style="font-weight:normal; text-align:left">{@link NumericShaper.Range#TAI_THAM_HORA}
+ *     <th scope="row">Tai Tham
+ *     <td>{@link NumericShaper.Range#TAI_THAM_HORA}
  *     <br>
  *     {@link NumericShaper.Range#TAI_THAM_THAM}
  *     <td>{@link NumericShaper.Range#TAI_THAM_THAM}


### PR DESCRIPTION
This change introduces no visual difference, but improves a11y.
EDIT: There is a slight visual change regarding centering in a few cells.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276800](https://bugs.openjdk.java.net/browse/JDK-8276800): Fix table headers in NumericShaper.html


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to 71f26cd7908a21448d30befc333110c3cbaaae1c
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6291/head:pull/6291` \
`$ git checkout pull/6291`

Update a local copy of the PR: \
`$ git checkout pull/6291` \
`$ git pull https://git.openjdk.java.net/jdk pull/6291/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6291`

View PR using the GUI difftool: \
`$ git pr show -t 6291`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6291.diff">https://git.openjdk.java.net/jdk/pull/6291.diff</a>

</details>
