### PR TITLE
8153133: Thread.dumpStack() can use StackWalker

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -31,6 +31,8 @@ import java.lang.ref.WeakReference;
 import java.security.AccessController;
 import java.security.AccessControlContext;
 import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
@@ -1380,13 +1382,19 @@ public class Thread implements Runnable {
     public static void dumpStack() {
         var walker = StackWalker.getInstance();
         if (walker != null) {
-            System.err.println(Thread.currentThread().name + " Stack trace");
+            List<StackTraceElement> stes = new ArrayList<>();
             walker.forEach(new Consumer<StackWalker.StackFrame>() {
                 @Override
                 public void accept(final StackWalker.StackFrame stackFrame) {
-                    System.err.println("\tat " + stackFrame.toStackTraceElement());
+                    stes.add(stackFrame.toStackTraceElement());
                 }
             });
+            synchronized (System.err) {
+                System.err.println(Thread.currentThread().name + " Stack trace");
+                for (StackTraceElement ste : stes) {
+                    System.err.println("\tat " + ste);
+                }
+            }
             return;
         }
         // Thread.dumpStack() could be called during the static initialization of

--- a/test/jdk/java/lang/Thread/DumpStackTest.java
+++ b/test/jdk/java/lang/Thread/DumpStackTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.Charset;
+
+/**
+ * @test
+ * @bug 8153133
+ * @summary Test Thread.dumpStack()
+ * @run testng/othervm DumpStackTest
+ * @run testng/othervm -Djava.security.manager -Djava.security.policy=${test.src}/dump-stack-test.policy DumpStackTest
+ * @run testng/othervm -Djava.security.debug=access,stack -Djava.security.manager -Djava.security.policy=${test.src}/dump-stack-test.policy DumpStackTest
+ */
+public class DumpStackTest {
+
+    private PrintStream originalSysErr;
+    private ByteArrayOutputStream switchedSysErrOS;
+
+    @BeforeTest
+    public void beforeTest() {
+        originalSysErr = System.err;
+        switchedSysErrOS = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(switchedSysErrOS));
+    }
+
+    @AfterTest
+    public void afterTest() {
+        if (originalSysErr != null) {
+            System.setErr(originalSysErr);
+        }
+    }
+
+    /**
+     * Initiates a call tree which finally ends up calling Thread.dumpStack(). The stacktrace is then
+     * verified to match the expected call stack.
+     */
+    @Test
+    public void testDumpStack() {
+        triggerDumpStackCall();
+        // capture the generated stacktrace in System.err
+        String dumpStackOutput = switchedSysErrOS.toString(Charset.defaultCharset());
+        System.out.println("Thread.dumpStack() generated following output:\n" + dumpStackOutput);
+        Assert.assertFalse(dumpStackOutput.isEmpty(), "System.err content is empty");
+        if (System.getProperty("java.security.debug") != null
+                && System.getProperty("java.security.debug").contains("stack")) {
+            // in the case where java.security.debug system property contains "stack" as a value,
+            // we don't do additional line by line checks of the stacktrace, because the System.err
+            // will be polluted with a lot of other stacktraces from within the security layer.
+            // As long as the Thread.dumpStack() call from within this test method succeeds without
+            // any exceptions, we consider this test as passed.
+            return;
+        }
+        // split by lines
+        String[] lines = dumpStackOutput.split(System.lineSeparator());
+        // We only verify the stacktrace starting with this current test method's stackframe. We
+        // aren't interested in anything before this stackframe since those frames belong to the
+        // test infrastructure framework and can potentially change.
+        // In these verifications we ignore the line numbers in the stacktrace.
+        Assert.assertTrue(lines[1].startsWith("\tat java.base/java.lang.Thread.dumpStack(Thread.java:"));
+        Assert.assertTrue(lines[2].startsWith("\tat DumpStackTest$Parent.doSomething(DumpStackTest.java:"));
+        Assert.assertTrue(lines[3].startsWith("\tat DumpStackTest.c(DumpStackTest.java:"));
+        Assert.assertTrue(lines[4].startsWith("\tat DumpStackTest.b(DumpStackTest.java:"));
+        Assert.assertTrue(lines[5].startsWith("\tat DumpStackTest.a(DumpStackTest.java:"));
+        Assert.assertTrue(lines[6].startsWith("\tat DumpStackTest.triggerDumpStackCall(DumpStackTest.java:"));
+        Assert.assertTrue(lines[7].startsWith("\tat DumpStackTest.testDumpStack(DumpStackTest.java:"));
+    }
+
+    private void triggerDumpStackCall() {
+        a();
+    }
+
+    private void a() {
+        b();
+    }
+
+    private void b() {
+        c();
+    }
+
+    private void c() {
+        new Child().doSomething();
+    }
+
+    private static class Parent {
+
+        protected void doSomething() {
+            Thread.dumpStack();
+        }
+    }
+
+    private static class Child extends Parent {
+    }
+}

--- a/test/jdk/java/lang/Thread/DumpStackTest.java
+++ b/test/jdk/java/lang/Thread/DumpStackTest.java
@@ -22,13 +22,22 @@
  */
 
 import org.testng.Assert;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @test
@@ -43,15 +52,15 @@ public class DumpStackTest {
     private PrintStream originalSysErr;
     private ByteArrayOutputStream switchedSysErrOS;
 
-    @BeforeTest
-    public void beforeTest() {
+    @BeforeMethod
+    public void beforeEachTest() {
         originalSysErr = System.err;
         switchedSysErrOS = new ByteArrayOutputStream();
         System.setErr(new PrintStream(switchedSysErrOS));
     }
 
-    @AfterTest
-    public void afterTest() {
+    @AfterMethod
+    public void afterEachTest() {
         if (originalSysErr != null) {
             System.setErr(originalSysErr);
         }
@@ -71,7 +80,7 @@ public class DumpStackTest {
         if (System.getProperty("java.security.debug") != null
                 && System.getProperty("java.security.debug").contains("stack")) {
             // in the case where java.security.debug system property contains "stack" as a value,
-            // we don't do additional line by line checks of the stacktrace, because the System.err
+            // we don't do additional line by line checks of the stacktrace because the System.err
             // will be polluted with a lot of other stacktraces from within the security layer.
             // As long as the Thread.dumpStack() call from within this test method succeeds without
             // any exceptions, we consider this test as passed.
@@ -79,17 +88,114 @@ public class DumpStackTest {
         }
         // split by lines
         String[] lines = dumpStackOutput.split(System.lineSeparator());
-        // We only verify the stacktrace starting with this current test method's stackframe. We
+        assertStackTrace(lines, 1);
+    }
+
+    /**
+     * Launches multiple threads, each of which initiate a call tree which finally
+     * ends up calling Thread.dumpStack(). The stacktrace generated in each thread is then verified
+     * to match the expected call stack.
+     */
+    @Test
+    public void testMultiThreadDumpStack() throws Exception {
+        int numThreads = 5;
+        String threadNamePrefix = "test-dump-stack-";
+        ExecutorService execService = Executors.newFixedThreadPool(numThreads, new ThreadFactory() {
+            private final AtomicInteger id = new AtomicInteger();
+
+            @Override
+            public Thread newThread(final Runnable r) {
+                Thread t = new Thread(r);
+                t.setName(threadNamePrefix + id.incrementAndGet());
+                return t;
+            }
+        });
+        try {
+            CountDownLatch taskTriggerLatch = new CountDownLatch(numThreads);
+            List<Future<Void>> results = new ArrayList<>();
+            for (int i = 0; i < numThreads; i++) {
+                results.add(execService.submit(new Callable<Void>() {
+                    @Override
+                    public Void call() throws Exception {
+                        // let the other tasks know we are ready to trigger our work
+                        taskTriggerLatch.countDown();
+                        // wait for the other task to let us know they are ready to trigger their work too
+                        taskTriggerLatch.await();
+                        triggerDumpStackCall();
+                        return null;
+                    }
+                }));
+            }
+            // wait for completion of each task
+            for (int i = 0; i < numThreads; i++) {
+                results.get(i).get();
+            }
+        } finally {
+            execService.shutdown();
+        }
+        // capture the generated stacktrace in System.err
+        String dumpStackOutput = switchedSysErrOS.toString(Charset.defaultCharset());
+        System.out.println("Thread.dumpStack() across multiple threads generated following output:\n" + dumpStackOutput);
+        Assert.assertFalse(dumpStackOutput.isEmpty(), "System.err content is empty");
+        if (System.getProperty("java.security.debug") != null
+                && System.getProperty("java.security.debug").contains("stack")) {
+            // in the case where java.security.debug system property contains "stack" as a value,
+            // we don't do additional line by line checks of the stacktrace because the System.err
+            // will be polluted with a lot of other stacktraces from within the security layer.
+            // As long as the Thread.dumpStack() call from within this test method succeeds without
+            // any exceptions, we consider this test as passed.
+            return;
+        }
+        // split by lines
+        String[] lines = dumpStackOutput.split(System.lineSeparator());
+        for (int i = 0; i < numThreads; i++) {
+            String threadDumpFirstLine = threadNamePrefix + (i + 1) + " Stack trace";
+            // find the first line of each thread's stack
+            int lineIndex = findMatchingLine(lines, threadDumpFirstLine);
+            Assert.assertNotEquals(lineIndex, -1, "\"" + threadDumpFirstLine
+                    + "\" missing in System.err content");
+            // starting the next line we expect the stacktrace
+            assertStackTrace(lines, lineIndex + 1);
+        }
+    }
+
+    /**
+     * Returns the index from the "lines" array if that line equals the expectedContent.
+     * Else returns -1.
+     */
+    private static int findMatchingLine(String[] lines, String expectedContent) {
+        for (int i = 0; i < lines.length; i++) {
+            if (lines[i].equals(expectedContent)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Verifies that the {@code lines} contains the expected stacktrace element lines.
+     * The {@code firstLineIndex} represents the index in the lines array from where the
+     * verification should be started
+     */
+    private void assertStackTrace(String[] lines, int firstLineIndex) {
+        // We only verify the stacktrace starting with this current test's stackframe. We
         // aren't interested in anything before this stackframe since those frames belong to the
         // test infrastructure framework and can potentially change.
         // In these verifications we ignore the line numbers in the stacktrace.
-        Assert.assertTrue(lines[1].startsWith("\tat java.base/java.lang.Thread.dumpStack(Thread.java:"));
-        Assert.assertTrue(lines[2].startsWith("\tat DumpStackTest$Parent.doSomething(DumpStackTest.java:"));
-        Assert.assertTrue(lines[3].startsWith("\tat DumpStackTest.c(DumpStackTest.java:"));
-        Assert.assertTrue(lines[4].startsWith("\tat DumpStackTest.b(DumpStackTest.java:"));
-        Assert.assertTrue(lines[5].startsWith("\tat DumpStackTest.a(DumpStackTest.java:"));
-        Assert.assertTrue(lines[6].startsWith("\tat DumpStackTest.triggerDumpStackCall(DumpStackTest.java:"));
-        Assert.assertTrue(lines[7].startsWith("\tat DumpStackTest.testDumpStack(DumpStackTest.java:"));
+        // Each thread stack trace will be of the form:
+        // <thread-name> Stack trace
+        //	at java.base/java.lang.Thread.dumpStack(Thread.java:xxx)
+        //	at DumpStackTest$Parent.doSomething(DumpStackTest.java:xxx)
+        //	at DumpStackTest.c(DumpStackTest.java:xxx)
+        //	at DumpStackTest.b(DumpStackTest.java:xxx)
+        //	at DumpStackTest.a(DumpStackTest.java:xxx)
+        //	at DumpStackTest.triggerDumpStackCall(DumpStackTest.java:xxx)
+        Assert.assertTrue(lines[firstLineIndex].startsWith("\tat java.base/java.lang.Thread.dumpStack(Thread.java:"));
+        Assert.assertTrue(lines[firstLineIndex + 1].startsWith("\tat DumpStackTest$Parent.doSomething(DumpStackTest.java:"));
+        Assert.assertTrue(lines[firstLineIndex + 2].startsWith("\tat DumpStackTest.c(DumpStackTest.java:"));
+        Assert.assertTrue(lines[firstLineIndex + 3].startsWith("\tat DumpStackTest.b(DumpStackTest.java:"));
+        Assert.assertTrue(lines[firstLineIndex + 4].startsWith("\tat DumpStackTest.a(DumpStackTest.java:"));
+        Assert.assertTrue(lines[firstLineIndex + 5].startsWith("\tat DumpStackTest.triggerDumpStackCall(DumpStackTest.java:"));
     }
 
     private void triggerDumpStackCall() {

--- a/test/jdk/java/lang/Thread/DumpStackTest.java
+++ b/test/jdk/java/lang/Thread/DumpStackTest.java
@@ -184,12 +184,12 @@ public class DumpStackTest {
         // In these verifications we ignore the line numbers in the stacktrace.
         // Each thread stack trace will be of the form:
         // <thread-name> Stack trace
-        //	at java.base/java.lang.Thread.dumpStack(Thread.java:xxx)
-        //	at DumpStackTest$Parent.doSomething(DumpStackTest.java:xxx)
-        //	at DumpStackTest.c(DumpStackTest.java:xxx)
-        //	at DumpStackTest.b(DumpStackTest.java:xxx)
-        //	at DumpStackTest.a(DumpStackTest.java:xxx)
-        //	at DumpStackTest.triggerDumpStackCall(DumpStackTest.java:xxx)
+        //  at java.base/java.lang.Thread.dumpStack(Thread.java:xxx)
+        //  at DumpStackTest$Parent.doSomething(DumpStackTest.java:xxx)
+        //  at DumpStackTest.c(DumpStackTest.java:xxx)
+        //  at DumpStackTest.b(DumpStackTest.java:xxx)
+        //  at DumpStackTest.a(DumpStackTest.java:xxx)
+        //  at DumpStackTest.triggerDumpStackCall(DumpStackTest.java:xxx)
         Assert.assertTrue(lines[firstLineIndex].startsWith("\tat java.base/java.lang.Thread.dumpStack(Thread.java:"));
         Assert.assertTrue(lines[firstLineIndex + 1].startsWith("\tat DumpStackTest$Parent.doSomething(DumpStackTest.java:"));
         Assert.assertTrue(lines[firstLineIndex + 2].startsWith("\tat DumpStackTest.c(DumpStackTest.java:"));

--- a/test/jdk/java/lang/Thread/dump-stack-test.policy
+++ b/test/jdk/java/lang/Thread/dump-stack-test.policy
@@ -29,6 +29,8 @@ grant {
     permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
     // the test switches the System.err stream
     permission java.lang.RuntimePermission "setIO";
+    // test calls ExecutorService.shutdown()
+    permission java.lang.RuntimePermission "modifyThread";
 };
 
 

--- a/test/jdk/java/lang/Thread/dump-stack-test.policy
+++ b/test/jdk/java/lang/Thread/dump-stack-test.policy
@@ -1,0 +1,34 @@
+//
+// Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+// DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+//
+// This code is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License version 2 only, as
+// published by the Free Software Foundation.
+//
+// This code is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// version 2 for more details (a copy is included in the LICENSE file that
+// accompanied this code).
+//
+// You should have received a copy of the GNU General Public License version
+// 2 along with this work; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+// or visit www.oracle.com if you need additional information or have any
+// questions.
+//
+
+grant {
+    // common permission necessary for test infrastructure
+    permission java.io.FilePermission "<<ALL FILES>>", "read,write";
+    permission java.util.PropertyPermission "*", "read";
+    permission java.lang.RuntimePermission "accessDeclaredMembers";
+    permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+    // the test switches the System.err stream
+    permission java.lang.RuntimePermission "setIO";
+};
+
+


### PR DESCRIPTION
Can I please get a review of this change which seeks to implement the enhancement noted in https://bugs.openjdk.java.net/browse/JDK-8153133?

The commit in this PR uses the `StackWalker` API to dump the stacktrace of the thread. A few things to note about this change:

- Previously, the dumped stacktrace would be preceded by a line (from the `Exception` instance) which would state `java.lang.Exception: Stack trace` and the rest of the lines would be the stacktrace. The change in this PR does a small (unrelated) enhacement  which now includes the thread name in the message. So something like `MainThread Stack trace` where `MainThread` is the name of the thread whose stacktrace is being dumped. The linked JBS doesn't mention this change as a necessity but I decided to include it in this PR since I've always missed the thread name in that dumped stacktrace and since we are now using the StackWalker API, the mention of `java.lang.Exception: ...` line in the thread dump will no longer make sense (unless we wanted backward compatibility)
- The change doesn't use lambda to allow `Thread.dumpStack()` to be called (for debugging purposes) from places where lambda usage might be too early. 
- The change also includes a fallback to use the `Exception.printStackTrace()` to allow for calls to `Thread.dumpStack()` when `StackWalker` class itself is being initialized.

The PR also includes a new jtreg test which verifies this change. The test has 3 test actions - one without security manager, one with security manager and one with `java.security.debug=access,stack` to exercise the case where Thread.dumpStack() gets called during StackWalker class initialization.

The linked JBS issue notes that it would be good to use the StackWalker API even in the `Thread.getStackTrace` implementation. This PR however doesn't include that change because I wanted to tackle that separately since I think that would need to run some performance benchmarks to evaluate any performance changes. The current `Thread.dumpStack` method clearly states that it is meant for debugging purposes so I haven't run any kind of performance benchmarks on this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8153133](https://bugs.openjdk.java.net/browse/JDK-8153133): Thread.dumpStack() can use StackWalker


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6292/head:pull/6292` \
`$ git checkout pull/6292`

Update a local copy of the PR: \
`$ git checkout pull/6292` \
`$ git pull https://git.openjdk.java.net/jdk pull/6292/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6292`

View PR using the GUI difftool: \
`$ git pr show -t 6292`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6292.diff">https://git.openjdk.java.net/jdk/pull/6292.diff</a>

</details>
