### PR TITLE
8276805: java/awt/print/PrinterJob/CheckPrivilege.java fails due to disabled SecurityManager

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/CheckPrivilege.java
+++ b/test/jdk/java/awt/print/PrinterJob/CheckPrivilege.java
@@ -27,6 +27,7 @@
  * @bug 4151151
  * @summary Confirm that low-level print code does doPrivilege.
  * @author Graham Hamilton
+ * @run main/othervm -Djava.security.manager=allow CheckPrivilege
  */
 
 import java.awt.print.*;


### PR DESCRIPTION
Current test fails on SecurityManager installation. See the bug for failure details. The fix is to allow SM for this test, until SM is removed wholesale.

Additional testing:
 - [x] Affected test now passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276805](https://bugs.openjdk.java.net/browse/JDK-8276805): java/awt/print/PrinterJob/CheckPrivilege.java fails due to disabled SecurityManager


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6295/head:pull/6295` \
`$ git checkout pull/6295`

Update a local copy of the PR: \
`$ git checkout pull/6295` \
`$ git pull https://git.openjdk.java.net/jdk pull/6295/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6295`

View PR using the GUI difftool: \
`$ git pr show -t 6295`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6295.diff">https://git.openjdk.java.net/jdk/pull/6295.diff</a>

</details>
