### PR TITLE
8276678: Malformed Javadoc inline tags in JDK source in com/sun/beans/decoder/DocumentHandler.java

### DIFF
--- a/src/java.desktop/share/classes/com/sun/beans/decoder/DocumentHandler.java
+++ b/src/java.desktop/share/classes/com/sun/beans/decoder/DocumentHandler.java
@@ -199,8 +199,8 @@ public final class DocumentHandler extends DefaultHandler {
      * Indicates whether the variable with specified identifier is defined.
      *
      * @param id  the identifier
-     * @return @{code true} if the variable is defined;
-     *         @{code false} otherwise
+     * @return {@code true} if the variable is defined;
+     *         {@code false} otherwise
      */
     public boolean hasVariable(String id) {
         return this.environment.containsKey(id);


### PR DESCRIPTION
fixed malformed inline tags

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276678](https://bugs.openjdk.java.net/browse/JDK-8276678): Malformed Javadoc inline tags in JDK source in com/sun/beans/decoder/DocumentHandler.java


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6298/head:pull/6298` \
`$ git checkout pull/6298`

Update a local copy of the PR: \
`$ git checkout pull/6298` \
`$ git pull https://git.openjdk.java.net/jdk pull/6298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6298`

View PR using the GUI difftool: \
`$ git pr show -t 6298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6298.diff">https://git.openjdk.java.net/jdk/pull/6298.diff</a>

</details>
