### PR TITLE
8276808: java/nio/channels/Channels/TransferTo.java timed out

### DIFF
--- a/test/jdk/java/nio/channels/Channels/TransferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo.java
@@ -52,7 +52,7 @@ import static org.testng.Assert.assertTrue;
  * @test
  * @library /test/lib
  * @build jdk.test.lib.RandomFactory
- * @run testng/othervm TransferTo
+ * @run testng/othervm/timeout=180 TransferTo
  * @bug 8265891
  * @summary tests whether sun.nio.ChannelInputStream.transferTo conforms to the
  *          InputStream.transferTo contract defined in the javadoc


### PR DESCRIPTION
The test looks to have been about 95% complete when it timed out, so try increasing the timeout value by 50% to 1.5 the default value.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276808](https://bugs.openjdk.java.net/browse/JDK-8276808): java/nio/channels/Channels/TransferTo.java timed out


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6299/head:pull/6299` \
`$ git checkout pull/6299`

Update a local copy of the PR: \
`$ git checkout pull/6299` \
`$ git pull https://git.openjdk.java.net/jdk pull/6299/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6299`

View PR using the GUI difftool: \
`$ git pr show -t 6299`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6299.diff">https://git.openjdk.java.net/jdk/pull/6299.diff</a>

</details>
