### PR TITLE
8276677: Malformed Javadoc inline tags in JDK source in javax/net/ssl

### DIFF
--- a/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
@@ -339,7 +339,7 @@ import java.util.function.BiFunction;
  * The ApplicationProtocol {@code String} values returned by the methods
  * in this class are in the network byte representation sent by the peer.
  * The bytes could be directly compared, or converted to its Unicode
- * {code String} format for comparison.
+ * {@code String} format for comparison.
  *
  * <blockquote><pre>
  *     String networkString = sslEngine.getHandshakeApplicationProtocol();

--- a/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
@@ -133,7 +133,7 @@ import java.util.function.BiFunction;
  * <P> The ApplicationProtocol {@code String} values returned by the methods
  * in this class are in the network byte representation sent by the peer.
  * The bytes could be directly compared, or converted to its Unicode
- * {code String} format for comparison.
+ * {@code String} format for comparison.
  *
  * <blockquote><pre>
  *     String networkString = sslSocket.getHandshakeApplicationProtocol();


### PR DESCRIPTION
Minor typos.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276677](https://bugs.openjdk.java.net/browse/JDK-8276677): Malformed Javadoc inline tags in JDK source in javax/net/ssl


### Reviewers
 * [Jamil Nimeh](https://openjdk.java.net/census#jnimeh) (@jnimeh - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6301/head:pull/6301` \
`$ git checkout pull/6301`

Update a local copy of the PR: \
`$ git checkout pull/6301` \
`$ git pull https://git.openjdk.java.net/jdk pull/6301/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6301`

View PR using the GUI difftool: \
`$ git pr show -t 6301`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6301.diff">https://git.openjdk.java.net/jdk/pull/6301.diff</a>

</details>
