### PR TITLE
8276833: G1: Make G1EvacFailureRegions::par_iterate const

### DIFF
--- a/src/hotspot/share/gc/g1/g1EvacFailureRegions.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailureRegions.cpp
@@ -56,7 +56,7 @@ void G1EvacFailureRegions::post_collection() {
 
 void G1EvacFailureRegions::par_iterate(HeapRegionClosure* closure,
                                        HeapRegionClaimer* _hrclaimer,
-                                       uint worker_id) {
+                                       uint worker_id) const {
   G1CollectedHeap::heap()->par_iterate_regions_array(closure,
                                                      _hrclaimer,
                                                      _evac_failure_regions,

--- a/src/hotspot/share/gc/g1/g1EvacFailureRegions.hpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailureRegions.hpp
@@ -56,7 +56,7 @@ public:
   bool contains(uint region_idx) const;
   void par_iterate(HeapRegionClosure* closure,
                    HeapRegionClaimer* _hrclaimer,
-                   uint worker_id);
+                   uint worker_id) const;
 
   uint num_regions_failed_evacuation() const {
     return Atomic::load(&_evac_failure_regions_cur_length);


### PR DESCRIPTION
This is a trivial code enhancement to make G1EvacFailureRegions::par_iterate const.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276833](https://bugs.openjdk.java.net/browse/JDK-8276833): G1: Make G1EvacFailureRegions::par_iterate const


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6302/head:pull/6302` \
`$ git checkout pull/6302`

Update a local copy of the PR: \
`$ git checkout pull/6302` \
`$ git pull https://git.openjdk.java.net/jdk pull/6302/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6302`

View PR using the GUI difftool: \
`$ git pr show -t 6302`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6302.diff">https://git.openjdk.java.net/jdk/pull/6302.diff</a>

</details>
