### PR TITLE
8276721: G1: Refine G1EvacFailureObjectsSet::iterate

### DIFF
--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -165,7 +165,7 @@ public:
                                         during_concurrent_start,
                                         _worker_id);
     // Iterates evac failure objs which are recorded during evacuation.
-    hr->iterate_evac_failure_objs(&rspc);
+    hr->process_and_drop_evac_failure_objs(&rspc);
     // Need to zap the remainder area of the processed region.
     rspc.zap_remainder();
 

--- a/src/hotspot/share/gc/g1/g1EvacFailureObjectsSet.hpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailureObjectsSet.hpp
@@ -72,8 +72,9 @@ public:
   // Record an object that failed evacuation.
   void record(oop obj);
 
-  // Apply the given ObjectClosure to all objects that failed evacuation. Objects
-  // are passed in increasing address order.
+  // Apply the given ObjectClosure to all objects that failed evacuation and
+  // empties the list after processing.
+  // Objects are passed in increasing address order.
   void process_and_drop(ObjectClosure* closure);
 };
 

--- a/src/hotspot/share/gc/g1/g1EvacFailureObjectsSet.hpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailureObjectsSet.hpp
@@ -74,7 +74,7 @@ public:
 
   // Apply the given ObjectClosure to all objects that failed evacuation. Objects
   // are passed in increasing address order.
-  void iterate(ObjectClosure* closure);
+  void process_and_drop(ObjectClosure* closure);
 };
 
 

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -106,8 +106,8 @@ void HeapRegion::handle_evacuation_failure() {
   _next_marked_bytes = 0;
 }
 
-void HeapRegion::iterate_evac_failure_objs(ObjectClosure* closure) {
-  _evac_failure_objs.iterate(closure);
+void HeapRegion::process_and_drop_evac_failure_objs(ObjectClosure* closure) {
+  _evac_failure_objs.process_and_drop(closure);
 }
 
 void HeapRegion::unlink_from_list() {

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -561,7 +561,7 @@ public:
   void record_evac_failure_obj(oop obj);
   // Applies the given closure to all previously recorded objects
   // that failed evacuation in ascending address order.
-  void iterate_evac_failure_objs(ObjectClosure* closure);
+  void process_and_drop_evac_failure_objs(ObjectClosure* closure);
 
   // Iterate over the objects overlapping the given memory region, applying cl
   // to all references in the region.  This is a helper for


### PR DESCRIPTION
Currently, G1EvacFailureObjectsSet::iterate(ObjectClosure* closure) is not a const method, but it looks like a const method. It will be a surprise for reader, i.e. you would not expect that an iteration method is destructive, clearing out the set it just iterated over.
We should refine it in some way.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276721](https://bugs.openjdk.java.net/browse/JDK-8276721): G1: Refine G1EvacFailureObjectsSet::iterate


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 21188299c5e57f101e67a77349f7d69899305d2d
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to 21188299c5e57f101e67a77349f7d69899305d2d


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6303/head:pull/6303` \
`$ git checkout pull/6303`

Update a local copy of the PR: \
`$ git checkout pull/6303` \
`$ git pull https://git.openjdk.java.net/jdk pull/6303/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6303`

View PR using the GUI difftool: \
`$ git pr show -t 6303`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6303.diff">https://git.openjdk.java.net/jdk/pull/6303.diff</a>

</details>
