### PR TITLE
8276842 G1: Only calculate size in bytes from words when needed

### DIFF
--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -41,7 +41,7 @@ class RemoveSelfForwardPtrObjClosure: public ObjectClosure {
   G1CollectedHeap* _g1h;
   G1ConcurrentMark* _cm;
   HeapRegion* _hr;
-  size_t _marked_bytes;
+  size_t _marked_words;
   bool _during_concurrent_start;
   uint _worker_id;
   HeapWord* _last_forwarded_object_end;
@@ -53,12 +53,12 @@ public:
     _g1h(G1CollectedHeap::heap()),
     _cm(_g1h->concurrent_mark()),
     _hr(hr),
-    _marked_bytes(0),
+    _marked_words(0),
     _during_concurrent_start(during_concurrent_start),
     _worker_id(worker_id),
     _last_forwarded_object_end(hr->bottom()) { }
 
-  size_t marked_bytes() { return _marked_bytes; }
+  size_t marked_bytes() { return _marked_words * HeapWordSize; }
 
   // Iterate over the live objects in the region to find self-forwarded objects
   // that need to be kept live. We need to update the remembered sets of these
@@ -96,7 +96,7 @@ public:
     }
     size_t obj_size = obj->size();
 
-    _marked_bytes += (obj_size * HeapWordSize);
+    _marked_words += obj_size;
     PreservedMarks::init_forwarded_mark(obj);
 
     HeapWord* obj_end = obj_addr + obj_size;


### PR DESCRIPTION
This is a minor improvement in RemoveSelfForwardPtrObjClosure.
Currently, RemoveSelfForwardPtrObjClosure::do_object calculates from size in words to size in bytes every time, it's not necessary to do so, only needs to calculate the size when needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276842](https://bugs.openjdk.java.net/browse/JDK-8276842): G1: Only calculate size in bytes from words when needed


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6305/head:pull/6305` \
`$ git checkout pull/6305`

Update a local copy of the PR: \
`$ git checkout pull/6305` \
`$ git pull https://git.openjdk.java.net/jdk pull/6305/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6305`

View PR using the GUI difftool: \
`$ git pr show -t 6305`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6305.diff">https://git.openjdk.java.net/jdk/pull/6305.diff</a>

</details>
