### PR TITLE
JDK-8276809: java/awt/font/JNICheck/FreeTypeScalerJNICheck.java shows JNI warning on Windows

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2011, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,15 +123,11 @@ BOOL DWMIsCompositionEnabled() {
     }
 
     dwmIsCompositionEnabled = bRes;
-    jboolean hasException;
 
     JNIEnv *env = (JNIEnv *)JNU_GetEnv(jvm, JNI_VERSION_1_2);
-    JNU_CallStaticMethodByName(env, &hasException,
+    JNU_CallStaticMethodByName(env, NULL,
                               "sun/awt/Win32GraphicsEnvironment",
                               "dwmCompositionChanged", "(Z)V", (jboolean)bRes);
-    if (hasException) {
-        J2dTraceLn(J2D_TRACE_ERROR, "Exception occured while executing dwmCompositionChanged");
-    }
     return bRes;
 }
 

--- a/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
@@ -123,12 +123,15 @@ BOOL DWMIsCompositionEnabled() {
     }
 
     dwmIsCompositionEnabled = bRes;
-    jboolean ignoreException;
+    jboolean hasException;
 
     JNIEnv *env = (JNIEnv *)JNU_GetEnv(jvm, JNI_VERSION_1_2);
-    JNU_CallStaticMethodByName(env, &ignoreException,
+    JNU_CallStaticMethodByName(env, &hasException,
                               "sun/awt/Win32GraphicsEnvironment",
                               "dwmCompositionChanged", "(Z)V", (jboolean)bRes);
+    if (hasException) {
+        J2dTraceLn(J2D_TRACE_ERROR, "Exception occured while executing dwmCompositionChanged");
+    }
     return bRes;
 }
 

--- a/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,9 +123,10 @@ BOOL DWMIsCompositionEnabled() {
     }
 
     dwmIsCompositionEnabled = bRes;
+    jboolean ignoreException;
 
     JNIEnv *env = (JNIEnv *)JNU_GetEnv(jvm, JNI_VERSION_1_2);
-    JNU_CallStaticMethodByName(env, NULL,
+    JNU_CallStaticMethodByName(env, &ignoreException,
                               "sun/awt/Win32GraphicsEnvironment",
                               "dwmCompositionChanged", "(Z)V", (jboolean)bRes);
     return bRes;

--- a/test/jdk/java/awt/font/JNICheck/FreeTypeScalerJNICheck.java
+++ b/test/jdk/java/awt/font/JNICheck/FreeTypeScalerJNICheck.java
@@ -24,6 +24,7 @@
 
 /* @test
  * @bug 8269223
+ * @requires os.family != "windows"
  * @summary Verifies that -Xcheck:jni issues no warnings from freetypeScaler.c
  * @library /test/lib
  * @run main FreeTypeScalerJNICheck


### PR DESCRIPTION
The new test java/awt/font/JNICheck/FreeTypeScalerJNICheck.java introduced with https://bugs.openjdk.java.net/browse/JDK-8269223 adds -Xcheck:jni to an awt related test, and shows on Windows server 2019 the following JNI warning , so the test  JNICheck/FreeTypeScalerJNICheck.java fails on this Windows version.

:stdErr:
Thu Oct 28 01:27:10 CEST 2021
stdout: [WARNING in native method: JNI call made without checking exceptions when required to from CallStaticVoidMethodV
               at sun.awt.Win32GraphicsEnvironment.initDisplay(java.desktop@18.0.0.1-internal/Native Method)
               at sun.awt.Win32GraphicsEnvironment.initDisplayWrapper(java.desktop@18.0.0.1-internal/Win32GraphicsEnvironment.java:95)
               at sun.awt.Win32GraphicsEnvironment.<clinit>(java.desktop@18.0.0.1-internal/Win32GraphicsEnvironment.java:63)
               at sun.awt.PlatformGraphicsInfo.createGE(java.desktop@18.0.0.1-internal/PlatformGraphicsInfo.java:34)
               at java.awt.GraphicsEnvironment$LocalGE.createGE(java.desktop@18.0.0.1-internal/GraphicsEnvironment.java:93)
               at java.awt.GraphicsEnvironment$LocalGE.<clinit>(java.desktop@18.0.0.1-internal/GraphicsEnvironment.java:84)
               at java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment(java.desktop@18.0.0.1-internal/GraphicsEnvironment.java:106)
               at FreeTypeScalerJNICheck.runTest(FreeTypeScalerJNICheck.java:53)
               at FreeTypeScalerJNICheck.main(FreeTypeScalerJNICheck.java:44)

We can get rid of the warning by adjusting a JNU_CallStaticMethodByName call in awt_Win32GraphicsEnv.cpp .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276809](https://bugs.openjdk.java.net/browse/JDK-8276809): java/awt/font/JNICheck/FreeTypeScalerJNICheck.java shows JNI warning on Windows


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**) ⚠️ Review applies to 5d18a76cb967e9ede6394cbd6c28bb61facf785c


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6306/head:pull/6306` \
`$ git checkout pull/6306`

Update a local copy of the PR: \
`$ git checkout pull/6306` \
`$ git pull https://git.openjdk.java.net/jdk pull/6306/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6306`

View PR using the GUI difftool: \
`$ git pr show -t 6306`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6306.diff">https://git.openjdk.java.net/jdk/pull/6306.diff</a>

</details>
