### PR TITLE
8276846: JDK-8273416 is incomplete for UseSSE=1

### DIFF
--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -7204,7 +7204,7 @@ instruct castLL( eRegL dst ) %{
 %}
 
 instruct castFF( regF dst ) %{
-  predicate(UseSSE >= 2);
+  predicate(UseSSE >= 1);
   match(Set dst (CastFF dst));
   format %{ "#castFF of $dst" %}
   ins_encode( /*empty encoding*/ );
@@ -7222,7 +7222,7 @@ instruct castDD( regD dst ) %{
 %}
 
 instruct castFF_PR( regFPR dst ) %{
-  predicate(UseSSE < 2);
+  predicate(UseSSE < 1);
   match(Set dst (CastFF dst));
   format %{ "#castFF of $dst" %}
   ins_encode( /*empty encoding*/ );


### PR DESCRIPTION
When doing the fix for [JDK-8273416](https://bugs.openjdk.java.net/browse/JDK-8273416), I made a mistake of not running with `UseSSE=1`. That one highlights a bug (see JIRA for reproducer): I have misjudged that `float` and `double` args are handled at the same SSE levels, which they are not. `doubles` uses FPU with SSE={0,1}, and `float` uses FPU with SSE={0}. See for example the blurbs in `MacroAssembler::{load|store}_{float|double}`. So the new predicate for `regFPR` argument mishandles UseSSE=1 case: we should not allow `castFF_PR` to match then.

Additional testing:
 - [x] Linux x86_32 `tier1` with `-XX:UseAVX=0 -XX:UseSSE=0`
 - [x] Linux x86_32 `tier1` with `-XX:UseAVX=0 -XX:UseSSE=1`
 - [x] Linux x86_32 `tier1` with `-XX:UseAVX=0 -XX:UseSSE=2`
 - [x] Linux x86_32 `tier1` with `-XX:UseAVX=0 -XX:UseSSE=3`
 - [x] Linux x86_32 `tier1` with `-XX:UseAVX=0 -XX:UseSSE=4`
 - [x] Linux x86_32 `tier1` with `-XX:UseAVX=1 -XX:UseSSE=4`
 - [x] Linux x86_32 `tier1` with `-XX:UseAVX=2 -XX:UseSSE=4`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276846](https://bugs.openjdk.java.net/browse/JDK-8276846): JDK-8273416 is incomplete for UseSSE=1


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6308/head:pull/6308` \
`$ git checkout pull/6308`

Update a local copy of the PR: \
`$ git checkout pull/6308` \
`$ git pull https://git.openjdk.java.net/jdk pull/6308/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6308`

View PR using the GUI difftool: \
`$ git pr show -t 6308`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6308.diff">https://git.openjdk.java.net/jdk/pull/6308.diff</a>

</details>
