### PR TITLE
8276850: Remove outdated comment in HeapRegionManager::par_iterate

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegionManager.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionManager.cpp
@@ -593,10 +593,6 @@ void HeapRegionManager::par_iterate(HeapRegionClosure* blk, HeapRegionClaimer* h
     }
     HeapRegion* r = _regions.get_by_index(index);
     // We'll ignore regions already claimed.
-    // However, if the iteration is specified as concurrent, the values for
-    // is_starts_humongous and is_continues_humongous can not be trusted,
-    // and we should just blindly iterate over regions regardless of their
-    // humongous status.
     if (hrclaimer->is_region_claimed(index)) {
       continue;
     }


### PR DESCRIPTION
Hi all,

  please review this (trivial?) removal of a hopelessly outdated comment about a method parameter that has not been there for years now...

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276850](https://bugs.openjdk.java.net/browse/JDK-8276850): Remove outdated comment in HeapRegionManager::par_iterate


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6309/head:pull/6309` \
`$ git checkout pull/6309`

Update a local copy of the PR: \
`$ git checkout pull/6309` \
`$ git pull https://git.openjdk.java.net/jdk pull/6309/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6309`

View PR using the GUI difftool: \
`$ git pr show -t 6309`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6309.diff">https://git.openjdk.java.net/jdk/pull/6309.diff</a>

</details>
