### PR TITLE
8276743: Make openjdk build Zip Archive generation "reproducible"

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -324,7 +324,7 @@ $(eval $(call SetupTarget, vscode-project-ccls, \
 # aren't built until after libjava and libjvm are available to link to.
 $(eval $(call SetupTarget, demos-jdk, \
     MAKEFILE := CompileDemos, \
-    DEPS := java.base-libs exploded-image, \
+    DEPS := java.base-libs exploded-image buildtools-jdk, \
 ))
 
 $(eval $(call SetupTarget, test-image-demos-jdk, \
@@ -383,12 +383,12 @@ bootcycle-images:
 
 $(eval $(call SetupTarget, zip-security, \
     MAKEFILE := ZipSecurity, \
-    DEPS := java.base-java java.security.jgss-java java.security.jgss-libs, \
+    DEPS := buildtools-jdk java.base-java java.security.jgss-java java.security.jgss-libs, \
 ))
 
 $(eval $(call SetupTarget, zip-source, \
     MAKEFILE := ZipSource, \
-    DEPS := gensrc, \
+    DEPS := buildtools-jdk gensrc, \
 ))
 
 $(eval $(call SetupTarget, jrtfs-jar, \
@@ -508,13 +508,13 @@ $(eval $(call SetupTarget, docs-jdk-index, \
 $(eval $(call SetupTarget, docs-zip, \
     MAKEFILE := Docs, \
     TARGET := docs-zip, \
-    DEPS :=  docs-jdk, \
+    DEPS :=  docs-jdk buildtools-jdk, \
 ))
 
 $(eval $(call SetupTarget, docs-specs-zip, \
     MAKEFILE := Docs, \
     TARGET := docs-specs-zip, \
-    DEPS := docs-jdk-specs, \
+    DEPS := docs-jdk-specs buildtools-jdk, \
 ))
 
 $(eval $(call SetupTarget, update-build-docs, \

--- a/make/ToolsJdk.gmk
+++ b/make/ToolsJdk.gmk
@@ -82,8 +82,8 @@ TOOL_GENERATECACERTS = $(JAVA_SMALL) -cp $(BUILDTOOLS_OUTPUTDIR)/jdk_tools_class
 TOOL_GENERATEEMOJIDATA = $(JAVA_SMALL) -cp $(BUILDTOOLS_OUTPUTDIR)/jdk_tools_classes \
     build.tools.generateemojidata.GenerateEmojiData
 
-TOOL_GENERATEZIP = $(JAVA_SMALL) -cp $(BUILDTOOLS_OUTPUTDIR)/jdk_tools_classes \
-    build.tools.generatezip.GenerateZip
+TOOL_MAKEZIPREPRODUCIBLE = $(JAVA_SMALL) -cp $(BUILDTOOLS_OUTPUTDIR)/jdk_tools_classes \
+    build.tools.makezipreproducible.MakeZipReproducible
 
 # TODO: There are references to the jdwpgen.jar in jdk/make/netbeans/jdwpgen/build.xml
 # and nbproject/project.properties in the same dir. Needs to be looked at.

--- a/make/ToolsJdk.gmk
+++ b/make/ToolsJdk.gmk
@@ -82,6 +82,8 @@ TOOL_GENERATECACERTS = $(JAVA_SMALL) -cp $(BUILDTOOLS_OUTPUTDIR)/jdk_tools_class
 TOOL_GENERATEEMOJIDATA = $(JAVA_SMALL) -cp $(BUILDTOOLS_OUTPUTDIR)/jdk_tools_classes \
     build.tools.generateemojidata.GenerateEmojiData
 
+TOOL_GENERATEZIP = $(JAVA_SMALL) -cp $(BUILDTOOLS_OUTPUTDIR)/jdk_tools_classes \
+    build.tools.generatezip.GenerateZip
 
 # TODO: There are references to the jdwpgen.jar in jdk/make/netbeans/jdwpgen/build.xml
 # and nbproject/project.properties in the same dir. Needs to be looked at.

--- a/make/common/ZipArchive.gmk
+++ b/make/common/ZipArchive.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 ifndef _ZIP_ARCHIVE_GMK
 _ZIP_ARCHIVE_GMK := 1
+
+include ../ToolsJdk.gmk
 
 ifeq (,$(_MAKEBASE_GMK))
   $(error You must include MakeBase.gmk prior to including ZipArchive.gmk)
@@ -134,6 +136,8 @@ define SetupZipArchiveBody
   # dir is very small.
   # If zip has nothing to do, it returns 12 and would fail the build. Check for 12
   # and only fail if it's not.
+  # For reproducible builds set the zip access & modify times to SOURCE_DATE_EPOCH
+  # by using a ziptmp folder to generate final zip from using GenerateZip.
   $$($1_ZIP) : $$($1_ALL_SRCS) $$($1_EXTRA_DEPS)
 	$$(call LogWarn, Updating $$($1_NAME))
 	$$(call MakeTargetDir)
@@ -156,14 +160,24 @@ define SetupZipArchiveBody
 	    ) \
 	  ) \
 	)
+	$(RM) -r $$(SUPPORT_OUTPUTDIR)/ziptmp/$1
+	$(MKDIR) -p $$(SUPPORT_OUTPUTDIR)/ziptmp/$1/files
 	$$(foreach s,$$($1_SRC_SLASH), $$(call ExecuteWithLog, \
 	    $$(SUPPORT_OUTPUTDIR)/zip/$$(patsubst $$(OUTPUTDIR)/%,%, $$@), \
-	    (cd $$s && $(ZIPEXE) -qru $$($1_ZIP_OPTIONS) $$@ . \
+	    (cd $$s && $(ZIPEXE) -qru $$($1_ZIP_OPTIONS) \
+	        $$(SUPPORT_OUTPUTDIR)/ziptmp/$1/tmp.zip . \
 	        $$($1_ZIP_INCLUDES) $$($1_ZIP_EXCLUDES) -x \*_the.\* \
 	        $$($1_ZIP_EXCLUDES_$$s) \
 	        || test "$$$$?" = "12" \
 	    ))$$(NEWLINE) \
-	) true \
+	) true
+	$$(call ExecuteWithLog, \
+	    $$(SUPPORT_OUTPUTDIR)/generatezip/$$(patsubst $$(OUTPUTDIR)/%,%, $$@), \
+	    (cd $$(SUPPORT_OUTPUTDIR)/ziptmp/$1/files && \
+	     $(RM) $$@ && \
+	     $(UNZIP) -q $$(SUPPORT_OUTPUTDIR)/ziptmp/$1/tmp.zip && \
+	     $(TOOL_GENERATEZIP) -f $$@ -t $(SOURCE_DATE_EPOCH) . \
+	    ))$$(NEWLINE) \
 	$(TOUCH) $$@
 
   # Add zip to target list

--- a/make/common/ZipArchive.gmk
+++ b/make/common/ZipArchive.gmk
@@ -26,6 +26,7 @@
 ifndef _ZIP_ARCHIVE_GMK
 _ZIP_ARCHIVE_GMK := 1
 
+# Depends on build tools for MakeZipReproducible
 include ../ToolsJdk.gmk
 
 ifeq (,$(_MAKEBASE_GMK))
@@ -137,7 +138,7 @@ define SetupZipArchiveBody
   # If zip has nothing to do, it returns 12 and would fail the build. Check for 12
   # and only fail if it's not.
   # For reproducible builds set the zip access & modify times to SOURCE_DATE_EPOCH
-  # by using a ziptmp folder to generate final zip from using GenerateZip.
+  # by using a ziptmp folder to generate final zip from using MakeZipReproducible.
   $$($1_ZIP) : $$($1_ALL_SRCS) $$($1_EXTRA_DEPS)
 	$$(call LogWarn, Updating $$($1_NAME))
 	$$(call MakeTargetDir)
@@ -160,24 +161,25 @@ define SetupZipArchiveBody
 	    ) \
 	  ) \
 	)
-	$(RM) -r $$(SUPPORT_OUTPUTDIR)/ziptmp/$1
-	$(MKDIR) -p $$(SUPPORT_OUTPUTDIR)/ziptmp/$1/files
 	$$(foreach s,$$($1_SRC_SLASH), $$(call ExecuteWithLog, \
 	    $$(SUPPORT_OUTPUTDIR)/zip/$$(patsubst $$(OUTPUTDIR)/%,%, $$@), \
-	    (cd $$s && $(ZIPEXE) -qru $$($1_ZIP_OPTIONS) \
-	        $$(SUPPORT_OUTPUTDIR)/ziptmp/$1/tmp.zip . \
+	    (cd $$s && $(ZIPEXE) -qru $$($1_ZIP_OPTIONS) $$@ . \
 	        $$($1_ZIP_INCLUDES) $$($1_ZIP_EXCLUDES) -x \*_the.\* \
 	        $$($1_ZIP_EXCLUDES_$$s) \
 	        || test "$$$$?" = "12" \
 	    ))$$(NEWLINE) \
 	) true
-	$$(call ExecuteWithLog, \
-	    $$(SUPPORT_OUTPUTDIR)/generatezip/$$(patsubst $$(OUTPUTDIR)/%,%, $$@), \
-	    (cd $$(SUPPORT_OUTPUTDIR)/ziptmp/$1/files && \
-	     $(RM) $$@ && \
-	     $(UNZIP) -q $$(SUPPORT_OUTPUTDIR)/ziptmp/$1/tmp.zip && \
-	     $(TOOL_GENERATEZIP) -f $$@ -t $(SOURCE_DATE_EPOCH) . \
-	    ))$$(NEWLINE) \
+        ifeq ($(ENABLE_REPRODUCIBLE_BUILD), true)
+	    $$(call ExecuteWithLog, \
+		$$(SUPPORT_OUTPUTDIR)/makezipreproducible/$$(patsubst $$(OUTPUTDIR)/%,%, $$@), \
+		($(RM) $$(SUPPORT_OUTPUTDIR)/ziptmp/$1/tmp.zip && \
+		 $(MKDIR) -p $$(SUPPORT_OUTPUTDIR)/ziptmp/$1 && \
+		 $(TOOL_MAKEZIPREPRODUCIBLE) -f $$(SUPPORT_OUTPUTDIR)/ziptmp/$1/tmp.zip \
+			 		     -t $(SOURCE_DATE_EPOCH) $$@ && \
+		 $(RM) $$@ && \
+		 $(MV) $$(SUPPORT_OUTPUTDIR)/ziptmp/$1/tmp.zip $$@ \
+		))
+        endif
 	$(TOUCH) $$@
 
   # Add zip to target list

--- a/make/jdk/src/classes/build/tools/generatezip/GenerateZip.java
+++ b/make/jdk/src/classes/build/tools/generatezip/GenerateZip.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package build.tools.generatezip;
+
+import java.io.*;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.util.*;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+/**
+ * Generate a zip file in a "reproducible" manner from the input files or
+ * directory.
+ * Standard zip tools rely on OS file list querying whose ordering varies
+ * by platform architecture, this class ensures the zip entries are ordered
+ * and also supports SOURCE_DATE_EPOCH timestamps.
+ */
+public class GenerateZip {
+    String fname = null;
+    String zname = "";
+    long   timestamp = -1L;
+    List<String> files = new ArrayList<>();;
+    boolean verbose = false;
+
+    Set<File> entries = new LinkedHashSet<>();
+
+    private boolean ok;
+
+    public GenerateZip() {
+    }
+
+    public synchronized boolean run(String args[]) {
+        ok = true;
+        if (!parseArgs(args)) {
+            return false;
+        }
+        try {
+            zname = fname.replace(File.separatorChar, '/');
+            if (zname.startsWith("./")) {
+                zname = zname.substring(2);
+            }
+
+            if (verbose) System.out.println("Files or directories to zip: "+files);
+
+            File zipFile = new File(fname);
+            // Check archive to create does not exist
+            if (!zipFile.exists()) {
+                // Process Files
+                for(String file : files) {
+                    Path filepath = Paths.get(file);
+                    processFiles(filepath);
+                }
+
+                try (FileOutputStream out = new FileOutputStream(fname)) {
+                    boolean createOk = create(new BufferedOutputStream(out, 4096));
+                    if (ok) {
+                        ok = createOk;
+                    }
+                }
+            } else {
+                error("Target zip file "+fname+" already exists.");
+                ok = false;
+            }
+        } catch (IOException e) {
+            fatalError(e);
+            ok = false;
+        } catch (Error ee) {
+            ee.printStackTrace();
+            ok = false;
+        } catch (Throwable t) {
+            t.printStackTrace();
+            ok = false;
+        }
+        return ok;
+    }
+
+    boolean parseArgs(String args[]) {
+        try {
+            boolean parsingIncludes = false;
+            boolean parsingExcludes = false;
+            int count = 0;
+            while(count < args.length) {
+                if (args[count].startsWith("-")) {
+                    String flag = args[count].substring(1);
+                    switch (flag.charAt(0)) {
+                    case 'f':
+                        fname = args[++count];
+                        break;
+                    case 't':
+                        // SOURCE_DATE_EPOCH timestamp specified
+                        timestamp = Long.parseLong(args[++count]) * 1000;
+                        break;
+                    case 'v':
+                        verbose = true;
+                        break;
+                    default:
+                        error(String.format("Illegal option -%s", String.valueOf(flag.charAt(0))));
+                        usageError();
+                        return false;
+                    }
+                } else {
+                    // file or dir to zip
+                    files.add(args[count]);
+                }
+                count++;
+            }
+        } catch (ArrayIndexOutOfBoundsException e) {
+            usageError();
+            return false;
+        } catch (NumberFormatException e) {
+            usageError();
+            return false;
+        }
+        if (fname == null) {
+            error(String.format("-f <archiveName> must be specified"));
+            usageError();
+            return false;
+        }
+        // If no files specified then default to current directory
+        if (files.size() == 0) {
+            error("No input directory or files were specified");
+            usageError();
+            return false;
+        }
+
+        return true;
+    }
+
+    // Walk tree matching files and adding to entries list
+    void processFiles(Path path) throws IOException {
+        File fpath = path.toFile();
+        boolean pathIsDir = fpath.isDirectory();
+
+        // Keep a sorted Set of files to be processed, so that the Jmod is reproducible
+        // as Files.walkFileTree order is not defined
+        SortedMap<String, Path> filesToProcess  = new TreeMap<String, Path>();
+
+        Files.walkFileTree(path, Set.of(FileVisitOption.FOLLOW_LINKS),
+            Integer.MAX_VALUE, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                    throws IOException
+                {
+                    Path relPath;
+                    String name;
+                    if (pathIsDir) {
+                        relPath = path.relativize(file);
+                        name = relPath.toString();
+                    } else {
+                        relPath = file;
+                        name = file.toString();
+                    }
+                    filesToProcess.put(name, file);
+                    return FileVisitResult.CONTINUE;
+                }
+        });
+
+        // Process files in sorted order
+        for (Map.Entry<String, Path> entry : filesToProcess.entrySet()) {
+            String name = entry.getKey();
+            Path   filepath = entry.getValue();
+
+            File f = filepath.toFile();
+            entries.add(f);
+        }
+    }
+
+    // Create new zip from entries
+    boolean create(OutputStream out) throws IOException
+    {
+        try (ZipOutputStream zos = new ZipOutputStream(out)) {
+            for (File file: entries) {
+                addFile(zos, file);
+            }
+        }
+        return true;
+    }
+
+    // Ensure a consistent entry name format
+    String entryName(String name) {
+        name = name.replace(File.separatorChar, '/');
+
+        if (name.startsWith("/")) {
+            name = name.substring(1);
+        } else if (name.startsWith("./")) {
+            name = name.substring(2);
+        }
+        return name;
+    }
+
+    // Add File to Zip
+    void addFile(ZipOutputStream zos, File file) throws IOException {
+        String name = file.getPath();
+        boolean isDir = file.isDirectory();
+        if (isDir) {
+            name = name.endsWith(File.separator) ? name : (name + File.separator);
+        }
+        name = entryName(name);
+
+        if (name.equals("") || name.equals(".") || name.equals(zname)) {
+            return;
+        }
+
+        long size = isDir ? 0 : file.length();
+
+        if (verbose) {
+            System.out.println("Adding: "+name);
+        }
+
+        ZipEntry e = new ZipEntry(name);
+        // Set to specified timestamp if set otherwise use file lastModified time
+        if (timestamp != -1L) {
+            e.setTime(timestamp);
+        } else {
+            e.setTime(file.lastModified());
+        }
+        if (size == 0) {
+            e.setMethod(ZipEntry.STORED);
+            e.setSize(0);
+            e.setCrc(0);
+        }
+        zos.putNextEntry(e);
+        if (!isDir) {
+            byte[] buf = new byte[8192];
+            int len;
+            try (FileInputStream fis = new FileInputStream(file);
+                 FileChannel fic = fis.getChannel()) {
+                fic.transferTo(0, fic.size(), Channels.newChannel(zos));
+            }
+        }
+        zos.closeEntry();
+    }
+
+    void usageError() {
+        error(
+        "Usage: GenerateZip [-v] -f <zip_file> <files_or_directories>\n" +
+        "Options:\n" +
+        "   -v  verbose output\n" +
+        "   -f  specify archive file name to create\n" +
+        "   -t  specific SOURCE_DATE_EPOCH value to use for timestamps\n" +
+        "If any file is a directory then it is processed recursively.\n");
+    }
+
+    void fatalError(Exception e) {
+        e.printStackTrace();
+    }
+
+    protected void error(String s) {
+        System.err.println(s);
+    }
+
+    public static void main(String args[]) {
+        GenerateZip z = new GenerateZip();
+        System.exit(z.run(args) ? 0 : 1);
+    }
+}
+

--- a/make/jdk/src/classes/build/tools/makezipreproducible/MakeZipReproducible.java
+++ b/make/jdk/src/classes/build/tools/makezipreproducible/MakeZipReproducible.java
@@ -37,7 +37,7 @@ import java.util.zip.ZipOutputStream;
 
 /**
  * Generate a zip file in a "reproducible" manner from the input zip file.
- * Standard zip tools rely on OS file list querying whose ordering varies
+ * Standard zip tools rely on OS file list querying whose ordering can vary
  * by platform architecture, this class ensures the zip entries are ordered
  * and also supports SOURCE_DATE_EPOCH timestamps.
  */


### PR DESCRIPTION
This PR adds a new openjdk build tool MakeZipReproducible, which if ENABLE_REPRODUCIBLE_BUILD is enabled, generates a final "zip" file in a deterministic way, ensuring ordering and timestamps are set as specified.

Using this tool in ZipArchive.gmk will ensure src.zip is then created deterministically.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276743](https://bugs.openjdk.java.net/browse/JDK-8276743): Make openjdk build Zip Archive generation "reproducible"


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6311/head:pull/6311` \
`$ git checkout pull/6311`

Update a local copy of the PR: \
`$ git checkout pull/6311` \
`$ git pull https://git.openjdk.java.net/jdk pull/6311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6311`

View PR using the GUI difftool: \
`$ git pr show -t 6311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6311.diff">https://git.openjdk.java.net/jdk/pull/6311.diff</a>

</details>
