### PR TITLE
8276609: Document setting property `jdk.serialFilter` to an invalid value throws `ExceptionInInitializerError`

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputFilter.java
+++ b/src/java.base/share/classes/java/io/ObjectInputFilter.java
@@ -523,6 +523,8 @@ public interface ObjectInputFilter {
      * {@systemProperty jdk.serialFilter}, its value is used to configure the filter.
      * If the system property is not defined, and the {@link java.security.Security} property
      * {@code jdk.serialFilter} is defined then it is used to configure the filter.
+     * The filter is created as if {@link #createFilter(String) createFilter} is called;
+     * if the filter string is invalid, an {@link ExceptionInInitializerError} is thrown.
      * Otherwise, the filter is not configured during initialization and
      * can be set with {@link #setSerialFilter(ObjectInputFilter) Config.setSerialFilter}.
      * Setting the {@code jdk.serialFilter} with {@link System#setProperty(String, String)


### PR DESCRIPTION
When set on the command line `jdk.serialFilter` to an invalid value, the invalid value is logged but the application is allowed to start without setting the filter.
This leaves the application without the protections of the serial filter.
The specification should be clarify that an `ExceptionInInitializerError` is thrown when the `jdk.serialFilter` system property is set on the command line to an invalid value.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276609](https://bugs.openjdk.java.net/browse/JDK-8276609): Document setting property `jdk.serialFilter` to an invalid value throws `ExceptionInInitializerError`


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6317/head:pull/6317` \
`$ git checkout pull/6317`

Update a local copy of the PR: \
`$ git checkout pull/6317` \
`$ git pull https://git.openjdk.java.net/jdk pull/6317/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6317`

View PR using the GUI difftool: \
`$ git pr show -t 6317`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6317.diff">https://git.openjdk.java.net/jdk/pull/6317.diff</a>

</details>
