### PR TITLE
8276775: ZonedDateTime/OffsetDateTime.toString return invalid ISO-8601 for years <= 1893

### DIFF
--- a/src/java.base/share/classes/java/time/OffsetDateTime.java
+++ b/src/java.base/share/classes/java/time/OffsetDateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1897,7 +1897,7 @@ public final class OffsetDateTime
     /**
      * Outputs this date-time as a {@code String}, such as {@code 2007-12-03T10:15:30+01:00}.
      * <p>
-     * The output will be one of the following ISO-8601 formats:
+     * The output will be one of the following formats:
      * <ul>
      * <li>{@code uuuu-MM-dd'T'HH:mmXXXXX}</li>
      * <li>{@code uuuu-MM-dd'T'HH:mm:ssXXXXX}</li>
@@ -1906,7 +1906,8 @@ public final class OffsetDateTime
      * <li>{@code uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSSXXXXX}</li>
      * </ul>
      * The format used will be the shortest that outputs the full value of
-     * the time where the omitted parts are implied to be zero.
+     * the time where the omitted parts are implied to be zero. The output
+     * is compatible with ISO 8601 if the seconds in the offset are zero.
      *
      * @return a string representation of this date-time, not null
      */

--- a/src/java.base/share/classes/java/time/ZonedDateTime.java
+++ b/src/java.base/share/classes/java/time/ZonedDateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2207,7 +2207,8 @@ public final class ZonedDateTime
      * <p>
      * The format consists of the {@code LocalDateTime} followed by the {@code ZoneOffset}.
      * If the {@code ZoneId} is not the same as the offset, then the ID is output.
-     * The output is compatible with ISO-8601 if the offset and ID are the same.
+     * The output is compatible with ISO-8601 if the offset and ID are the same,
+     * and the seconds in the offset are zero.
      *
      * @return a string representation of this date-time, not null
      */


### PR DESCRIPTION
Simple doc clarification where the `toString()` output only conforms to ISO 8601 if the seconds in the offset are zero.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276775](https://bugs.openjdk.java.net/browse/JDK-8276775): ZonedDateTime/OffsetDateTime.toString return invalid ISO-8601 for years <= 1893


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Stephen Colebourne](https://openjdk.java.net/census#scolebourne) (@jodastephen - Author)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6321/head:pull/6321` \
`$ git checkout pull/6321`

Update a local copy of the PR: \
`$ git checkout pull/6321` \
`$ git pull https://git.openjdk.java.net/jdk pull/6321/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6321`

View PR using the GUI difftool: \
`$ git pr show -t 6321`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6321.diff">https://git.openjdk.java.net/jdk/pull/6321.diff</a>

</details>
