### PR TITLE
8276835: G1: make G1EvacFailureObjectsSet::record inline

### DIFF
--- a/src/hotspot/share/gc/g1/g1EvacFailureObjectsSet.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailureObjectsSet.cpp
@@ -26,7 +26,6 @@
 #include "gc/g1/g1EvacFailureObjectsSet.hpp"
 #include "gc/g1/g1CollectedHeap.hpp"
 #include "gc/g1/g1SegmentedArray.inline.hpp"
-#include "gc/g1/heapRegion.hpp"
 #include "gc/g1/heapRegion.inline.hpp"
 #include "utilities/quickSort.hpp"
 
@@ -60,13 +59,6 @@ G1EvacFailureObjectsSet::G1EvacFailureObjectsSet(uint region_idx, HeapWord* bott
   _bottom(bottom),
   _offsets(&_alloc_options, &_free_buffer_list)  {
   assert(HeapRegion::LogOfHRGrainBytes < 32, "must be");
-}
-
-void G1EvacFailureObjectsSet::record(oop obj) {
-  assert(obj != NULL, "must be");
-  assert(_region_idx == G1CollectedHeap::heap()->heap_region_containing(obj)->hrm_index(), "must be");
-  OffsetInRegion* e = _offsets.allocate();
-  *e = to_offset(obj);
 }
 
 // Helper class to join, sort and iterate over the previously collected segmented

--- a/src/hotspot/share/gc/g1/g1EvacFailureObjectsSet.hpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailureObjectsSet.hpp
@@ -70,7 +70,7 @@ public:
   G1EvacFailureObjectsSet(uint region_idx, HeapWord* bottom);
 
   // Record an object that failed evacuation.
-  void record(oop obj);
+  inline void record(oop obj);
 
   // Apply the given ObjectClosure to all objects that failed evacuation and
   // empties the list after processing.

--- a/src/hotspot/share/gc/g1/g1EvacFailureObjectsSet.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailureObjectsSet.inline.hpp
@@ -22,6 +22,9 @@
  *
  */
 
+#ifndef SHARE_GC_G1_G1EVACFAILUREOBJECTSSET_INLINE_HPP
+#define SHARE_GC_G1_G1EVACFAILUREOBJECTSSET_INLINE_HPP
+
 #include "gc/g1/g1EvacFailureObjectsSet.hpp"
 #include "gc/g1/g1CollectedHeap.hpp"
 #include "gc/g1/g1SegmentedArray.inline.hpp"
@@ -33,3 +36,5 @@ void G1EvacFailureObjectsSet::record(oop obj) {
   OffsetInRegion* e = _offsets.allocate();
   *e = to_offset(obj);
 }
+
+#endif //SHARE_GC_G1_G1EVACFAILUREOBJECTSSET_INLINE_HPP

--- a/src/hotspot/share/gc/g1/g1EvacFailureObjectsSet.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailureObjectsSet.inline.hpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, Huawei and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "gc/g1/g1EvacFailureObjectsSet.hpp"
+#include "gc/g1/g1CollectedHeap.hpp"
+#include "gc/g1/g1SegmentedArray.inline.hpp"
+#include "gc/g1/heapRegion.inline.hpp"
+
+void G1EvacFailureObjectsSet::record(oop obj) {
+  assert(obj != NULL, "must be");
+  assert(_region_idx == G1CollectedHeap::heap()->heap_region_containing(obj)->hrm_index(), "must be");
+  OffsetInRegion* e = _offsets.allocate();
+  *e = to_offset(obj);
+}

--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -30,6 +30,7 @@
 #include "gc/g1/g1BlockOffsetTable.inline.hpp"
 #include "gc/g1/g1CollectedHeap.inline.hpp"
 #include "gc/g1/g1ConcurrentMarkBitMap.inline.hpp"
+#include "gc/g1/g1EvacFailureObjectsSet.inline.hpp"
 #include "gc/g1/g1Predictions.hpp"
 #include "gc/g1/g1SegmentedArray.inline.hpp"
 #include "oops/oop.inline.hpp"


### PR DESCRIPTION
This is a minor improvement to make G1EvacFailureObjectsSet::record inline, which was not.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276835](https://bugs.openjdk.java.net/browse/JDK-8276835): G1: Make G1EvacFailureObjectsSet::record inline


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6322/head:pull/6322` \
`$ git checkout pull/6322`

Update a local copy of the PR: \
`$ git checkout pull/6322` \
`$ git pull https://git.openjdk.java.net/jdk pull/6322/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6322`

View PR using the GUI difftool: \
`$ git pr show -t 6322`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6322.diff">https://git.openjdk.java.net/jdk/pull/6322.diff</a>

</details>
