### PR TITLE
8276926: Use String.valueOf() when initializing File.separator and File.pathSeparator

### DIFF
--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -220,7 +220,7 @@ public class File
      * string for convenience.  This string contains a single character, namely
      * {@link #separatorChar}.
      */
-    public static final String separator = "" + separatorChar;
+    public static final String separator = String.valueOf(separatorChar);
 
     /**
      * The system-dependent path-separator character.  This field is
@@ -239,7 +239,7 @@ public class File
      * for convenience.  This string contains a single character, namely
      * {@link #pathSeparatorChar}.
      */
-    public static final String pathSeparator = "" + pathSeparatorChar;
+    public static final String pathSeparator = String.valueOf(pathSeparatorChar);
 
 
     /* -- Constructors -- */


### PR DESCRIPTION
Looking into `File.pathSeparator` I've found out that currently we initialize it as
```java
public static final String separator = "" + separatorChar;
```
Which after compilation turns into
```
NEW java/lang/StringBuilder
DUP
INVOKESPECIAL java/lang/StringBuilder.<init> ()V
LDC ""
INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
GETSTATIC java/io/File.pathSeparatorChar : C
INVOKEVIRTUAL java/lang/StringBuilder.append (C)Ljava/lang/StringBuilder;
INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
PUTSTATIC java/io/File.pathSeparator : Ljava/lang/String;
```
This can be simplified to
```java
public static final String separator = String.valueOf(separatorChar);
```
Which is in turn complied into more compact
```
GETSTATIC java/io/File.pathSeparatorChar : C
INVOKESTATIC java/lang/String.valueOf (C)Ljava/lang/String;
PUTSTATIC java/io/File.pathSeparator : Ljava/lang/String;
```
The changed code is likely to slightly improve start-up time as it allocates less and does no bound checks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276926](https://bugs.openjdk.java.net/browse/JDK-8276926): Use String.valueOf() when initializing File.separator and File.pathSeparator


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6326/head:pull/6326` \
`$ git checkout pull/6326`

Update a local copy of the PR: \
`$ git checkout pull/6326` \
`$ git pull https://git.openjdk.java.net/jdk pull/6326/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6326`

View PR using the GUI difftool: \
`$ git pr show -t 6326`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6326.diff">https://git.openjdk.java.net/jdk/pull/6326.diff</a>

</details>
