### PR TITLE
8276887: G1: Move precleaning to Concurrent Mark From Roots subphase

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -909,7 +909,7 @@ class G1CMConcurrentMarkingTask : public WorkerTask {
   G1ConcurrentMark*     _cm;
   ReferenceProcessor*   _cm_rp;
 
-  void do_mark_step(G1CMTask* task) {
+  void do_marking(G1CMTask* task) {
     do {
       task->do_marking_step(G1ConcMarkStepDurationMillis,
                             true  /* do_termination */,
@@ -941,7 +941,7 @@ public:
       G1CMTask* task = _cm->task(worker_id);
       task->record_start_time();
       if (!_cm->has_aborted()) {
-        do_mark_step(task);
+        do_marking(task);
 
         // Marking is complete; preclean non-strong references
         if (G1UseReferencePrecleaning) {

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -919,14 +919,13 @@ class G1CMConcurrentMarkingTask : public WorkerTask {
     } while (!_cm->has_aborted() && task->has_aborted());
   }
 
-  void preclean(uint worker_id) {
+  void preclean() {
     BarrierEnqueueDiscoveredFieldClosure enqueue;
     G1PrecleanYieldClosure yield_cl(_cm);
     _cm_rp->preclean_discovered_references(_cm_rp->is_alive_non_header(),
                                            &enqueue,
                                            &yield_cl,
-                                           _cm->_gc_timer_cm,
-                                           worker_id);
+                                           _cm->_gc_timer_cm);
   }
 public:
   void work(uint worker_id) {
@@ -946,7 +945,7 @@ public:
 
         // Marking is complete; preclean non-strong references
         if (G1UseReferencePrecleaning) {
-          preclean(worker_id);
+          preclean();
         }
       }
       guarantee(!task->has_aborted() || _cm->has_aborted(), "invariant");

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -919,13 +919,14 @@ class G1CMConcurrentMarkingTask : public WorkerTask {
     } while (!_cm->has_aborted() && task->has_aborted());
   }
 
-  void preclean() {
+  void preclean(uint worker_id) {
     BarrierEnqueueDiscoveredFieldClosure enqueue;
     G1PrecleanYieldClosure yield_cl(_cm);
     _cm_rp->preclean_discovered_references(_cm_rp->is_alive_non_header(),
                                            &enqueue,
                                            &yield_cl,
-                                           _cm->_gc_timer_cm);
+                                           _cm->_gc_timer_cm,
+                                           worker_id);
   }
 public:
   void work(uint worker_id) {
@@ -945,7 +946,7 @@ public:
 
         // Marking is complete; preclean non-strong references
         if (G1UseReferencePrecleaning) {
-          preclean();
+          preclean(worker_id);
         }
       }
       guarantee(!task->has_aborted() || _cm->has_aborted(), "invariant");

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -553,9 +553,6 @@ public:
   // Do concurrent phase of marking, to a tentative transitive closure.
   void mark_from_roots();
 
-  // Do concurrent preclean work.
-  void preclean();
-
   void remark();
 
   void swap_mark_bitmaps();

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
@@ -191,15 +191,10 @@ bool G1ConcurrentMarkThread::phase_mark_loop() {
     // Subphase 1: Mark From Roots.
     if (subphase_mark_from_roots()) return true;
 
-    // Subphase 2: Preclean (optional)
-    if (G1UseReferencePrecleaning) {
-      if (subphase_preclean()) return true;
-    }
-
-    // Subphase 3: Wait for Remark.
+    // Subphase 2: Wait for Remark.
     if (subphase_delay_to_keep_mmu_before_remark()) return true;
 
-    // Subphase 4: Remark pause
+    // Subphase 3: Remark pause
     if (subphase_remark()) return true;
 
     // Check if we need to restart the marking loop.
@@ -223,12 +218,6 @@ bool G1ConcurrentMarkThread::subphase_mark_from_roots() {
   ConcurrentGCBreakpoints::at("AFTER MARKING STARTED");
   G1ConcPhaseTimer p(_cm, "Concurrent Mark From Roots");
   _cm->mark_from_roots();
-  return _cm->has_aborted();
-}
-
-bool G1ConcurrentMarkThread::subphase_preclean() {
-  G1ConcPhaseTimer p(_cm, "Concurrent Preclean");
-  _cm->preclean();
   return _cm->has_aborted();
 }
 

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.hpp
@@ -63,7 +63,6 @@ class G1ConcurrentMarkThread: public ConcurrentGCThread {
 
   bool phase_mark_loop();
   bool subphase_mark_from_roots();
-  bool subphase_preclean();
   bool subphase_delay_to_keep_mmu_before_remark();
   bool subphase_remark();
 

--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -1070,18 +1070,20 @@ void ReferenceProcessor::preclean_discovered_references(BoolObjectClosure* is_al
                                                         GCTimer* gc_timer) {
   Ticks preclean_start = Ticks::now();
 
-  ReferenceType ref_type_arr[4] = { REF_SOFT, REF_WEAK, REF_FINAL, REF_PHANTOM };
-  size_t ref_count_arr[4] = {};
+  constexpr int ref_kinds = 4;
+  ReferenceType ref_type_arr[] = { REF_SOFT, REF_WEAK, REF_FINAL, REF_PHANTOM };
+  static_assert(ARRAY_SIZE(ref_type_arr) == ref_kinds, "invariant");
+  size_t ref_count_arr[ref_kinds] = {};
 
   if (discovery_is_mt()) {
-    for (int i = 0; i < 4; ++i) {
+    for (int i = 0; i < ref_kinds; ++i) {
       ReferenceType ref_type = ref_type_arr[i];
       DiscoveredList* list = get_discovered_list(ref_type);
       ref_count_arr[i] = list->length();
       preclean_discovered_reflist(*list, is_alive, enqueue, yield);
     }
   } else {
-    for (int i = 0; i < 4; ++i) {
+    for (int i = 0; i < ref_kinds; ++i) {
       ReferenceType ref_type = ref_type_arr[i];
       // When discovery is *not* multi-threaded, discovered refs are stored in
       // list[0.._num_queues-1]. Loop _num_queues times to cover all lists.

--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -1067,10 +1067,9 @@ bool ReferenceProcessor::has_discovered_references() {
 void ReferenceProcessor::preclean_discovered_references(BoolObjectClosure* is_alive,
                                                         EnqueueDiscoveredFieldClosure* enqueue,
                                                         YieldClosure* yield,
-                                                        GCTimer* gc_timer) {
+                                                        GCTimer* gc_timer,
+                                                        uint worker_id) {
   Ticks preclean_start = Ticks::now();
-
-  uint worker_id = WorkerThread::current()->id();
 
   size_t soft_count    = _discoveredSoftRefs[worker_id].length();
   size_t weak_count    = _discoveredWeakRefs[worker_id].length();

--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -1067,9 +1067,10 @@ bool ReferenceProcessor::has_discovered_references() {
 void ReferenceProcessor::preclean_discovered_references(BoolObjectClosure* is_alive,
                                                         EnqueueDiscoveredFieldClosure* enqueue,
                                                         YieldClosure* yield,
-                                                        GCTimer* gc_timer,
-                                                        uint worker_id) {
+                                                        GCTimer* gc_timer) {
   Ticks preclean_start = Ticks::now();
+
+  uint worker_id = WorkerThread::current()->id();
 
   size_t soft_count    = _discoveredSoftRefs[worker_id].length();
   size_t weak_count    = _discoveredWeakRefs[worker_id].length();

--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -501,27 +501,6 @@ public:
   }
 };
 
-// A utility class to temporarily change the MT'ness of
-// reference discovery for the given ReferenceProcessor
-// in the scope that contains it.
-class ReferenceProcessorMTDiscoveryMutator: StackObj {
- private:
-  ReferenceProcessor* _rp;
-  bool                _saved_mt;
-
- public:
-  ReferenceProcessorMTDiscoveryMutator(ReferenceProcessor* rp,
-                                       bool mt):
-    _rp(rp) {
-    _saved_mt = _rp->discovery_is_mt();
-    _rp->set_mt_discovery(mt);
-  }
-
-  ~ReferenceProcessorMTDiscoveryMutator() {
-    _rp->set_mt_discovery(_saved_mt);
-  }
-};
-
 // A utility class to temporarily change the disposition
 // of the "is_alive_non_header" closure field of the
 // given ReferenceProcessor in the scope that contains it.

--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -318,7 +318,8 @@ public:
   void preclean_discovered_references(BoolObjectClosure* is_alive,
                                       EnqueueDiscoveredFieldClosure* enqueue,
                                       YieldClosure*      yield,
-                                      GCTimer*           gc_timer);
+                                      GCTimer*           gc_timer,
+                                      uint               worker_id);
 
 private:
   // Returns the name of the discovered reference list

--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -318,8 +318,7 @@ public:
   void preclean_discovered_references(BoolObjectClosure* is_alive,
                                       EnqueueDiscoveredFieldClosure* enqueue,
                                       YieldClosure*      yield,
-                                      GCTimer*           gc_timer,
-                                      uint               worker_id);
+                                      GCTimer*           gc_timer);
 
 private:
   // Returns the name of the discovered reference list


### PR DESCRIPTION
Simple change of moving the "Preclean" subphase into "Mark from roots" subphase so that precleaning becomes parallel automatically. Evaluation using a contrived java program shows that multiple GC threads do precleaning. More detailed testing results are available in the JBS ticket.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276887](https://bugs.openjdk.java.net/browse/JDK-8276887): G1: Move precleaning to Concurrent Mark From Roots subphase


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to a0cd3dc0147d35e4d337b5daca64f21a3b3b2b2c
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to f73a6db54bccb7c987e7b7a94ec012ffabb85974
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6327/head:pull/6327` \
`$ git checkout pull/6327`

Update a local copy of the PR: \
`$ git checkout pull/6327` \
`$ git pull https://git.openjdk.java.net/jdk pull/6327/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6327`

View PR using the GUI difftool: \
`$ git pr show -t 6327`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6327.diff">https://git.openjdk.java.net/jdk/pull/6327.diff</a>

</details>
