### PR TITLE
8276229: Stop allowing implicit updates in G1BlockOffsetTable

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -141,26 +141,11 @@ private:
   // Returns the address of a block whose start is at most "addr".
   inline HeapWord* block_at_or_preceding(const void* addr) const;
 
+  // Return the address of the beginning of the block that contains "addr".
   // "q" is a block boundary that is <= "addr"; "n" is the address of the
-  // next block (or the end of the space.)  Return the address of the
-  // beginning of the block that contains "addr".  Does so without side
-  // effects (see, e.g., spec of  block_start.)
-  inline HeapWord* forward_to_block_containing_addr_const(HeapWord* q, HeapWord* n,
-                                                          const void* addr) const;
-
-  // "q" is a block boundary that is <= "addr"; return the address of the
-  // beginning of the block that contains "addr".  May have side effects
-  // on "this", by updating imprecise entries.
-  inline HeapWord* forward_to_block_containing_addr(HeapWord* q,
-                                                    const void* addr);
-
-  // "q" is a block boundary that is <= "addr"; "n" is the address of the
-  // next block (or the end of the space.)  Return the address of the
-  // beginning of the block that contains "addr".  May have side effects
-  // on "this", by updating imprecise entries.
-  HeapWord* forward_to_block_containing_addr_slow(HeapWord* q,
-                                                  HeapWord* n,
-                                                  const void* addr);
+  // next block (or the end of the space.)
+  inline HeapWord* forward_to_block_containing_addr(HeapWord* q, HeapWord* n,
+                                                    const void* addr) const;
 
   // Requires that "*threshold_" be the first array entry boundary at or
   // above "blk_start".  If the block starts at or crosses "*threshold_", records

--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -83,10 +83,6 @@ inline HeapWord* HeapRegion::block_start(const void* p) {
   return _bot_part.block_start(p);
 }
 
-inline HeapWord* HeapRegion::block_start_const(const void* p) const {
-  return _bot_part.block_start_const(p);
-}
-
 inline bool HeapRegion::is_obj_dead_with_size(const oop obj, const G1CMBitMap* const prev_bitmap, size_t* size) const {
   HeapWord* addr = cast_from_oop<HeapWord*>(obj);
 
@@ -355,8 +351,6 @@ HeapWord* HeapRegion::oops_on_memregion_seq_iterate_careful(MemRegion mr,
   HeapWord* const end = mr.end();
 
   // Find the obj that extends onto mr.start().
-  // Update BOT as needed while finding start of (possibly dead)
-  // object containing the start of the region.
   HeapWord* cur = block_start(start);
 
 #ifdef ASSERT


### PR DESCRIPTION
Please review this change that removes some code that is no longer needed.

**Summary**
In [JDK-8272083](https://bugs.openjdk.java.net/browse/JDK-8276229) G1 was changed to create a precise and complete BOT during evacuation (in the GC pause). This removes the need to update the BOT when looking up block starts. This previously happened in concurrent refinement and while scanning the heap in the pause, but with the precise BOT we should no longer require any such updates.

This change removes the slow path function that did the updates `forward_to_block_containing_addr_slow(...)`. It also renames some functions to no longer include a `_const` post-fix because there are only "const" versions of the functions remaining.

**Testing**

- [x] Mach5 1-3
- [x] Local stress-testing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276229](https://bugs.openjdk.java.net/browse/JDK-8276229): Stop allowing implicit updates in G1BlockOffsetTable


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6332/head:pull/6332` \
`$ git checkout pull/6332`

Update a local copy of the PR: \
`$ git checkout pull/6332` \
`$ git pull https://git.openjdk.java.net/jdk pull/6332/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6332`

View PR using the GUI difftool: \
`$ git pr show -t 6332`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6332.diff">https://git.openjdk.java.net/jdk/pull/6332.diff</a>

</details>
