### PR TITLE
8276112: Inconsistent scalar replacement debug info at safepoints

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -675,12 +675,13 @@ void CallGenerator::do_late_inline_helper() {
   bool result_not_used = false;
 
   if (is_pure_call()) {
-    if (is_boxing_late_inline() && callprojs.resproj != nullptr) {
-        // replace box node to scalar node only in case it is directly referenced by debug info
-        assert(call->as_CallStaticJava()->is_boxing_method(), "sanity");
-        if (!has_non_debug_usages(callprojs.resproj) && is_box_cache_valid(call)) {
-          scalarize_debug_usages(call, callprojs.resproj);
-        }
+    // Disabled due to JDK-8276112
+    if (false && is_boxing_late_inline() && callprojs.resproj != nullptr) {
+      // replace box node to scalar node only in case it is directly referenced by debug info
+      assert(call->as_CallStaticJava()->is_boxing_method(), "sanity");
+      if (!has_non_debug_usages(callprojs.resproj) && is_box_cache_valid(call)) {
+        scalarize_debug_usages(call, callprojs.resproj);
+      }
     }
 
     // The call is marked as pure (no important side effects), but result isn't used.

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -983,8 +983,10 @@ void GraphKit::add_safepoint_edges(SafePointNode* call, bool must_throw) {
     k = in_jvms->scloff();
     l = in_jvms->scl_size();
     out_jvms->set_scloff(p);
-    for (j = 0; j < l; j++)
+    for (j = 0; j < l; j++) {
+      assert(in_jvms == youngest_jvms, "Unexpected scalar replacement in caller debug info");
       call->set_req(p++, in_map->in(k+j));
+    }
 
     // Finish the new jvms.
     out_jvms->set_endoff(p);

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -983,10 +983,8 @@ void GraphKit::add_safepoint_edges(SafePointNode* call, bool must_throw) {
     k = in_jvms->scloff();
     l = in_jvms->scl_size();
     out_jvms->set_scloff(p);
-    for (j = 0; j < l; j++) {
-      assert(in_jvms == youngest_jvms, "Unexpected scalar replacement in caller debug info");
+    for (j = 0; j < l; j++)
       call->set_req(p++, in_map->in(k+j));
-    }
 
     // Finish the new jvms.
     out_jvms->set_endoff(p);

--- a/src/hotspot/share/opto/macro.hpp
+++ b/src/hotspot/share/opto/macro.hpp
@@ -186,7 +186,6 @@ private:
 
   int replace_input(Node *use, Node *oldref, Node *newref);
   void migrate_outs(Node *old, Node *target);
-  void copy_call_debug_info(CallNode *oldcall, CallNode * newcall);
   Node* opt_bits_test(Node* ctrl, Node* region, int edge, Node* word, int mask, int bits, bool return_fast_path = false);
   void copy_predefined_input_for_runtime_call(Node * ctrl, CallNode* oldcall, CallNode* call);
   CallNode* make_slow_call(CallNode *oldcall, const TypeFunc* slow_call_type, address slow_call,

--- a/test/hotspot/jtreg/compiler/eliminateAutobox/TestIdentityWithEliminateBoxInDebugInfo.java
+++ b/test/hotspot/jtreg/compiler/eliminateAutobox/TestIdentityWithEliminateBoxInDebugInfo.java
@@ -25,12 +25,13 @@
  * @test
  * @bug 8261137
  * @requires vm.flavor == "server"
- * @summary Verify that box object identity matches after deoptimization When it is eliminated.
+ * @summary Verify that box object identity matches after deoptimization when it is eliminated.
  * @library /test/lib
  *
- * @run main/othervm -Xbatch compiler.c2.TestIdentityWithEliminateBoxInDebugInfo
+ * @run main/othervm -Xbatch compiler.eliminateAutobox.TestIdentityWithEliminateBoxInDebugInfo
  */
-package compiler.c2;
+
+package compiler.eliminateAutobox;
 
 import jdk.test.lib.Asserts;
 
@@ -40,12 +41,12 @@ public class TestIdentityWithEliminateBoxInDebugInfo {
     }
 
     public static void helper(TestF f) {
-      // warmup
-      for(int i = 0; i < 100000; i++) {
-        f.apply(true);
-      }
-      // deoptimize
-      f.apply(false);
+        // warmup
+        for (int i = 0; i < 100000; i++) {
+            f.apply(true);
+        }
+        // deoptimize
+        f.apply(false);
     }
 
     public static void runTest() throws Exception {

--- a/test/hotspot/jtreg/compiler/eliminateAutobox/TestSafepointDebugInfo.java
+++ b/test/hotspot/jtreg/compiler/eliminateAutobox/TestSafepointDebugInfo.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key randomness
+ * @bug 8276112
+ * @summary Verify consistency of safepoint debug info when boxes are scalar
+ *          replaced during incremental inlining.
+ * @library /test/lib
+ * @run main/othervm -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:+AlwaysIncrementalInline
+ *                   -XX:CompileCommand=inline,java.lang.Integer.valueOf::valueOf
+ *                   -XX:CompileCommand=compileonly,compiler.eliminateAutobox.TestSafepointDebugInfo::test*
+ *                   compiler.eliminateAutobox.TestSafepointDebugInfo
+ */
+
+package compiler.eliminateAutobox;
+
+import java.util.Random;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
+
+public class TestSafepointDebugInfo {
+
+    private static final Random random = Utils.getRandomInstance();
+
+    static Integer fBox;
+
+    public static Integer helper(int i) {
+        return Integer.valueOf(i);
+    }
+
+    // assert(local) failed: use _top instead of null
+    public static int test1(int i) {
+        Integer box = helper(i);
+        fBox = Integer.valueOf(i);
+        return box.intValue();
+    }
+
+    // Wrong execution, same types
+    public static int test2(int i1, int i2) {
+        Integer box1 = helper(i1);
+        Integer box2 = Integer.valueOf(i2);
+        fBox = Integer.valueOf(i1);
+        return box1.intValue() + box2.intValue();
+    }
+
+    // Wrong execution, different types
+    public static long test3(int i1, long i2) {
+        Integer box1 = helper(i1);
+        Long box2 = Long.valueOf(i2);
+        fBox = Integer.valueOf(i1);
+        return box1.intValue() + box2.longValue();
+    }
+
+    // assert(i < _max) failed: oob: i=16, _max=16
+    public static int test4(int i1, int i2) {
+        Integer box1 = helper(i1);
+        Integer box2 = helper(i2);
+        fBox = Integer.valueOf(i1);
+        return box1.intValue() + box2.intValue();
+    }
+
+    public static Integer test5_helper(int i1, int i2) {
+        Integer box1 = helper(i1);
+        Integer box2 = helper(i2);
+        fBox = Integer.valueOf(i1);
+        return box1.intValue() + box2.intValue();
+    }
+
+    // assert(local) failed: use _top instead of null
+    // Variant with deeper inlining
+    public static int test5(int i1, int i2) {
+        return test5_helper(i1, i2);
+    }
+
+    public static int test6_helper(int i1, int i2) {
+        Integer box = helper(i1);
+        fBox = Integer.valueOf(i2);
+        return box.intValue();
+    }
+
+    // Wrong execution, variant with more arguments
+    public static int test6(int i1, int i2, int i3, int i4) {
+        Integer box1 = helper(i1);
+        Integer box2 = helper(i2);
+        int res = test6_helper(i3, i4);
+        res += box1.intValue() + box2.intValue();
+        return res;
+    }
+
+    public static void main(String[] args) {
+        // Warmup
+	    for (int i = 0; i < 100_000; ++i) {
+	        int val = (i % 10);
+            Asserts.assertEquals(test1(val), val);
+            Asserts.assertEquals(fBox, val);
+            Asserts.assertEquals(test2(val, val), 2*val);
+            Asserts.assertEquals(fBox, val);
+            Asserts.assertEquals(test3(val, val), 2L*val);
+            Asserts.assertEquals(fBox, val);
+            Asserts.assertEquals(test4(val, val), 2*val);
+            Asserts.assertEquals(fBox, val);
+            Asserts.assertEquals(test5(val, val), 2*val);
+            Asserts.assertEquals(fBox, val);
+            Asserts.assertEquals(test6(val, val, val, val), 3*val);
+            Asserts.assertEquals(fBox, val);
+        }
+
+        // Trigger deoptimization by choosing a value that does not
+        // fit in the Integer cache and check the result.
+        int val = 4000;
+        Asserts.assertEquals(test1(val), val);
+        switch (random.nextInt(3)) {
+            case 0:
+                Asserts.assertEquals(test2(val, 1), val + 1);
+                Asserts.assertEquals(fBox, val);
+                Asserts.assertEquals(test3(val, 1), (long)val + 1);
+                Asserts.assertEquals(fBox, val);
+                Asserts.assertEquals(test4(val, 1), val + 1);
+                Asserts.assertEquals(fBox, val);
+                Asserts.assertEquals(test5(val, 1), val + 1);
+                Asserts.assertEquals(fBox, val);
+                Asserts.assertEquals(test6(val, 1, 2, 3), val + 3);
+                Asserts.assertEquals(fBox, 3);
+                break;
+           case 1:
+                Asserts.assertEquals(test2(1, val), val + 1);
+                Asserts.assertEquals(fBox, 1);
+                Asserts.assertEquals(test3(1, val), (long)val + 1);
+                Asserts.assertEquals(fBox, 1);
+                Asserts.assertEquals(test4(1, val), val + 1);
+                Asserts.assertEquals(fBox, 1);
+                Asserts.assertEquals(test5(1, val), val + 1);
+                Asserts.assertEquals(fBox, 1);
+                Asserts.assertEquals(test6(1, val, 2, 3), val + 3);
+                Asserts.assertEquals(fBox, 3);
+                break;
+           case 2:
+                Asserts.assertEquals(test2(1, 2), 3);
+                Asserts.assertEquals(fBox, 1);
+                Asserts.assertEquals(test3(1, 2), 3L);
+                Asserts.assertEquals(fBox, 1);
+                Asserts.assertEquals(test4(1, 2), 3);
+                Asserts.assertEquals(fBox, 1);
+                Asserts.assertEquals(test5(1, 2), 3);
+                Asserts.assertEquals(fBox, 1);
+                Asserts.assertEquals(test6(1, 2, 3, val), 6);
+                Asserts.assertEquals(fBox, val);
+                break;
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/eliminateAutobox/TestSafepointDebugInfo.java
+++ b/test/hotspot/jtreg/compiler/eliminateAutobox/TestSafepointDebugInfo.java
@@ -112,8 +112,8 @@ public class TestSafepointDebugInfo {
 
     public static void main(String[] args) {
         // Warmup
-	    for (int i = 0; i < 100_000; ++i) {
-	        int val = (i % 10);
+        for (int i = 0; i < 100_000; ++i) {
+            int val = (i % 10);
             Asserts.assertEquals(test1(val), val);
             Asserts.assertEquals(fBox, val);
             Asserts.assertEquals(test2(val, val), 2*val);

--- a/test/hotspot/jtreg/compiler/eliminateAutobox/TestSafepointDebugInfo.java
+++ b/test/hotspot/jtreg/compiler/eliminateAutobox/TestSafepointDebugInfo.java
@@ -29,7 +29,6 @@
  *          replaced during incremental inlining.
  * @library /test/lib
  * @run main/othervm -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:+AlwaysIncrementalInline
- *                   -XX:CompileCommand=inline,java.lang.Integer.valueOf::valueOf
  *                   -XX:CompileCommand=compileonly,compiler.eliminateAutobox.TestSafepointDebugInfo::test*
  *                   compiler.eliminateAutobox.TestSafepointDebugInfo
  */


### PR DESCRIPTION
[JDK-8261137](https://bugs.openjdk.java.net/browse/JDK-8261137) introduced aggressive scalar replacement of primitive boxes during incremental inlining if the box is only referenced by safepoint debug info:
https://github.com/openjdk/jdk/blob/e01d6d00bc4ab5ca0d38f8894a78e6d911e0fe93/src/hotspot/share/opto/callGenerator.cpp#L678-L683

It works by replacing safepoint usages by `SafePointScalarObject` nodes and adjusting the JVMState accordingly. For example, in `TestSafepointDebugInfo::test1` the `helper` method in line 56 is inlined and the box result of `Integer.valueOf` is scalar replaced in the safepoint debug info:

```
 315  SafePointScalarObject  ===  0  [[ 40  316  319  337 ]]  # fields@[0..0]  Oop:java/lang/Integer:NotNull:exact * !jvms: 
 316  SafePoint  ===  5  6  317  8  1  1  1  315  10  1  10  [[]]  SafePoint  !jvms: TestSafepointDebugInfo::test1 @ bci:-1 (line 56)
JVMS depth=1 loc=6 stk=8 arg=8 mon=10 scalar=10 end=11 mondepth=0 sp=0 bci=6 reexecute=false method=static jint compiler.eliminateAutobox.TestSafepointDebugInfo.test1(jint)
```

The `scalar` offset in the JVMState points to the integer field in the debug info. The problem is now that additional inlining can happen afterwards "on top of" this JVMState. In this case, the call to `Integer.valueOf` in line 57 is inlined, leading to the following JVMState for the inlined callee:

```
 315  SafePointScalarObject  ===  0  [[ 40  316  319  337 ]]  # fields@[0..0]  Oop:java/lang/Integer:NotNull:exact * !jvms: 
 316  SafePoint  ===  5  6  317  8  1  1  1  315  10  1  10  [[]]  SafePoint  !jvms: TestSafepointDebugInfo::test1 @ bci:-1 (line 56)
JVMS depth=1 loc=6 stk=8 arg=8 mon=10 scalar=10 end=11 mondepth=0 sp=0 bci=6 reexecute=false method=static jint compiler.eliminateAutobox.TestSafepointDebugInfo.test1(jint)
JVMS depth=2 loc=5 stk=6 arg=8 mon=10 scalar=10 end=10 mondepth=0 sp=2 bci=3 reexecute=false method=static jobject java.lang.Integer.valueOf(jint)
``` 

In this simple case, both caller and (inlined) callee state share the same `SafePointNode`. However, the `scalar` offset in the JVMState of the callee (depth 2) is not correct anymore and out of bounds.

Parsing then emits an `unstable_if` trap and `GraphKit::add_safepoint_edges` merges above states to:
```
 315  SafePointScalarObject  ===  0  [[ 40  316  319  337 ]]  # fields@[0..0]  Oop:java/lang/Integer:NotNull:exact * !jvms: 
 337  CallStaticJava  ===  332  1  7  8  1 ( 336  1  315  10  10  10  328 ) [[]] # Static uncommon_trap(reason='unstable_if' action='reinterpret' debug_id='0')  void ( int ) Integer::valueOf @ bci:3 (line 1075) reexecute TestSafepointDebugInfo::test1 @ bci:6 (line 57) !jvms: Integer::valueOf @ bci:3 (line 1075) TestSafepointDebugInfo::test1 @ bci:6 (line 57)
JVMS depth=1 loc=6 stk=8 arg=8 mon=8 scalar=8 end=9 mondepth=0 sp=0 bci=6 reexecute=false method=static jint compiler.eliminateAutobox.TestSafepointDebugInfo.test1(jint)
JVMS depth=2 loc=9 stk=10 arg=12 mon=12 scalar=12 end=12 mondepth=0 sp=2 bci=3 reexecute=true method=static jobject java.lang.Integer.valueOf(jint)
```

We then crash in `PhaseOutput::FillLocArray` when processing the `SafePointScalarObject` and trying to access the corresponding field in the debug info at (out of bounds) offset 12:
https://github.com/openjdk/jdk/blob/e01d6d00bc4ab5ca0d38f8894a78e6d911e0fe93/src/hotspot/share/opto/output.cpp#L833-L836

Even worse, in some scenarios we don't crash/assert but emit incorrect debug info leading to wrong results after deoptimization. For example, `TestSafepointDebugInfo::test2` fails because the `SafePointScalarObject` for `box1` and `box2` point to the same field in the debug info. This can happen if scalar replacement happens again "on top of" an already inconsistent JVMState. Afterwards, the out of bounds offset accidentally points to the field of the newly scalarized object.

Originally, this issue only reproduced intermittently with a long running internal stress test but I was able to extract a set of simple regression tests that trigger different failure modes in the compiler or wrong execution.

I think fixing this is complicated and I therefore propose to disable [JDK-8261137](https://bugs.openjdk.java.net/browse/JDK-8261137) for now and file an enhancement to fix and re-enable it later. We should then also add proper verification code and more complete tests. 

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276112](https://bugs.openjdk.java.net/browse/JDK-8276112): Inconsistent scalar replacement debug info at safepoints


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to abec0b433c81eddbf8f99e19cd007d6bf7883f05
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6333/head:pull/6333` \
`$ git checkout pull/6333`

Update a local copy of the PR: \
`$ git checkout pull/6333` \
`$ git pull https://git.openjdk.java.net/jdk pull/6333/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6333`

View PR using the GUI difftool: \
`$ git pr show -t 6333`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6333.diff">https://git.openjdk.java.net/jdk/pull/6333.diff</a>

</details>
