### PR TITLE
8276947: Clarify how DateTimeFormatterBuilder.appendFraction handles value ranges

### DIFF
--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -688,8 +688,8 @@ public final class DateTimeFormatterBuilder {
      * If the value is negative an exception will be thrown.
      * If the field does not have a fixed set of valid values then an
      * exception will be thrown.
-     * If the field value in the date-time to be printed is invalid it
-     * cannot be printed and an exception will be thrown.
+     * If the field value in the date-time to be printed is outside the
+     * range of valid values then an exception will be thrown.
      *
      * @param field  the field to append, not null
      * @param minWidth  the minimum width of the field excluding the decimal point, from 0 to 9


### PR DESCRIPTION
This changes the specification of `DateTimeFormatterBuilder.appendFraction` to more clearly specify that the formatter will throw an exception if you attempt to print a value outside of the value range of the given field. Changes suggested by @jodastephen in #6188.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276947](https://bugs.openjdk.java.net/browse/JDK-8276947): Clarify how DateTimeFormatterBuilder.appendFraction handles value ranges


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6335/head:pull/6335` \
`$ git checkout pull/6335`

Update a local copy of the PR: \
`$ git checkout pull/6335` \
`$ git pull https://git.openjdk.java.net/jdk pull/6335/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6335`

View PR using the GUI difftool: \
`$ git pr show -t 6335`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6335.diff">https://git.openjdk.java.net/jdk/pull/6335.diff</a>

</details>
