### PR TITLE
8276658: Clean up JNI local handles code

### DIFF
--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -87,7 +87,7 @@ ciInstanceKlass::ciInstanceKlass(Klass* k) :
     (void)CURRENT_ENV->get_object(holder);
   }
 
-  Thread *thread = Thread::current();
+  JavaThread *thread = JavaThread::current();
   if (ciObjectFactory::is_initialized()) {
     _loader = JNIHandles::make_local(thread, ik->class_loader());
     _protection_domain = JNIHandles::make_local(thread,

--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -259,8 +259,6 @@ class CompileBroker: AllStatic {
                            int compilable, const char* failure_reason);
   static void update_compile_perf_data(CompilerThread *thread, const methodHandle& method, bool is_osr);
 
-  static void push_jni_handle_block();
-  static void pop_jni_handle_block();
   static void collect_statistics(CompilerThread* thread, elapsedTimer time, CompileTask* task);
 
   static void compile_method_base(const methodHandle& method,

--- a/src/hotspot/share/gc/shared/concurrentGCThread.cpp
+++ b/src/hotspot/share/gc/shared/concurrentGCThread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,9 +42,6 @@ void ConcurrentGCThread::create_and_start(ThreadPriority prio) {
 }
 
 void ConcurrentGCThread::run() {
-  // Setup handle area
-  set_active_handles(JNIHandleBlock::allocate_block());
-
   // Wait for initialization to complete
   wait_init_completed();
 

--- a/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
+++ b/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
@@ -55,53 +55,6 @@ bool register_jfr_dcmds() {
   return true;
 }
 
-// JNIHandle management
-
-// ------------------------------------------------------------------
-// push_jni_handle_block
-//
-// Push on a new block of JNI handles.
-static void push_jni_handle_block(JavaThread* const thread) {
-  DEBUG_ONLY(JfrJavaSupport::check_java_thread_in_vm(thread));
-
-  // Allocate a new block for JNI handles.
-  // Inlined code from jni_PushLocalFrame()
-  JNIHandleBlock* prev_handles = thread->active_handles();
-  JNIHandleBlock* entry_handles = JNIHandleBlock::allocate_block(thread);
-  assert(entry_handles != NULL && prev_handles != NULL, "should not be NULL");
-  entry_handles->set_pop_frame_link(prev_handles);  // make sure prev handles get gc'd.
-  thread->set_active_handles(entry_handles);
-}
-
-// ------------------------------------------------------------------
-// pop_jni_handle_block
-//
-// Pop off the current block of JNI handles.
-static void pop_jni_handle_block(JavaThread* const thread) {
-  DEBUG_ONLY(JfrJavaSupport::check_java_thread_in_vm(thread));
-
-  // Release our JNI handle block
-  JNIHandleBlock* entry_handles = thread->active_handles();
-  JNIHandleBlock* prev_handles = entry_handles->pop_frame_link();
-  // restore
-  thread->set_active_handles(prev_handles);
-  entry_handles->set_pop_frame_link(NULL);
-  JNIHandleBlock::release_block(entry_handles, thread); // may block
-}
-
-class JNIHandleBlockManager : public StackObj {
- private:
-  JavaThread* const _thread;
- public:
-  JNIHandleBlockManager(JavaThread* thread) : _thread(thread) {
-    push_jni_handle_block(_thread);
-  }
-
-  ~JNIHandleBlockManager() {
-    pop_jni_handle_block(_thread);
-  }
-};
-
 static bool is_module_available(outputStream* output, TRAPS) {
   return JfrJavaSupport::is_jdk_jfr_module_available(output, THREAD);
 }
@@ -223,7 +176,9 @@ void JfrDCmd::invoke(JfrJavaArguments& method, TRAPS) const {
   constructor_args.set_klass(javaClass(), CHECK);
 
   HandleMark hm(THREAD);
-  JNIHandleBlockManager jni_handle_management(THREAD);
+  JNIHandleMark jni_handle_management(THREAD);
+
+  DEBUG_ONLY(JfrJavaSupport::check_java_thread_in_vm(THREAD));
 
   const oop dcmd = construct_dcmd_instance(&constructor_args, CHECK);
 
@@ -494,7 +449,7 @@ void JfrConfigureFlightRecorderDCmd::execute(DCmdSource source, TRAPS) {
   }
 
   HandleMark hm(THREAD);
-  JNIHandleBlockManager jni_handle_management(THREAD);
+  JNIHandleMark jni_handle_management(THREAD);
 
   JavaValue result(T_OBJECT);
   JfrJavaArguments constructor_args(&result);

--- a/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
+++ b/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
@@ -178,8 +178,6 @@ void JfrDCmd::invoke(JfrJavaArguments& method, TRAPS) const {
   HandleMark hm(THREAD);
   JNIHandleMark jni_handle_management(THREAD);
 
-  DEBUG_ONLY(JfrJavaSupport::check_java_thread_in_vm(THREAD));
-
   const oop dcmd = construct_dcmd_instance(&constructor_args, CHECK);
 
   Handle h_dcmd_instance(THREAD, dcmd);

--- a/src/hotspot/share/jfr/jni/jfrJavaSupport.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJavaSupport.cpp
@@ -71,7 +71,7 @@ static void check_new_unstarted_java_thread(JavaThread* t) {
  */
 jobject JfrJavaSupport::local_jni_handle(const oop obj, JavaThread* t) {
   DEBUG_ONLY(check_java_thread_in_vm(t));
-  return t->active_handles()->allocate_handle(obj);
+  return t->active_handles()->allocate_handle(t, obj);
 }
 
 jobject JfrJavaSupport::local_jni_handle(const jobject handle, JavaThread* t) {

--- a/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
+++ b/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
@@ -899,7 +899,7 @@ GrowableArray<ScopeValue*>* CodeInstaller::record_virtual_objects(JVMCIObject de
     }
     Klass* klass = jvmci_env()->asKlass(type);
     oop javaMirror = klass->java_mirror();
-    ScopeValue *klass_sv = new ConstantOopWriteValue(JNIHandles::make_local(Thread::current(), javaMirror));
+    ScopeValue *klass_sv = new ConstantOopWriteValue(JNIHandles::make_local(javaMirror));
     ObjectValue* sv = is_auto_box ? new AutoBoxObjectValue(id, klass_sv) : new ObjectValue(id, klass_sv);
     if (id < 0 || id >= objects->length()) {
       JVMCI_ERROR_NULL("virtual object id %d out of bounds", id);

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -86,29 +86,6 @@ static void requireInHotSpot(const char* caller, JVMCI_TRAPS) {
   }
 }
 
-void JNIHandleMark::push_jni_handle_block(JavaThread* thread) {
-  if (thread != NULL) {
-    // Allocate a new block for JNI handles.
-    // Inlined code from jni_PushLocalFrame()
-    JNIHandleBlock* java_handles = thread->active_handles();
-    JNIHandleBlock* compile_handles = JNIHandleBlock::allocate_block(thread);
-    assert(compile_handles != NULL && java_handles != NULL, "should not be NULL");
-    compile_handles->set_pop_frame_link(java_handles);
-    thread->set_active_handles(compile_handles);
-  }
-}
-
-void JNIHandleMark::pop_jni_handle_block(JavaThread* thread) {
-  if (thread != NULL) {
-    // Release our JNI handle block
-    JNIHandleBlock* compile_handles = thread->active_handles();
-    JNIHandleBlock* java_handles = compile_handles->pop_frame_link();
-    thread->set_active_handles(java_handles);
-    compile_handles->set_pop_frame_link(NULL);
-    JNIHandleBlock::release_block(compile_handles, thread); // may block
-  }
-}
-
 class JVMCITraceMark : public StackObj {
   const char* _msg;
  public:

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.hpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -171,17 +171,6 @@ class JavaArgumentUnboxer : public SignatureIterator {
     default:            ShouldNotReachHere();
     }
   }
-};
-
-class JNIHandleMark : public StackObj {
-  JavaThread* _thread;
-  public:
-    JNIHandleMark(JavaThread* thread) : _thread(thread) { push_jni_handle_block(thread); }
-    ~JNIHandleMark() { pop_jni_handle_block(_thread); }
-
-  private:
-    static void push_jni_handle_block(JavaThread* thread);
-    static void pop_jni_handle_block(JavaThread* thread);
 };
 
 #endif // SHARE_JVMCI_JVMCICOMPILERTOVM_HPP

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -639,11 +639,8 @@ JNI_ENTRY(jint, jni_PushLocalFrame(JNIEnv *env, jint capacity))
     HOTSPOT_JNI_PUSHLOCALFRAME_RETURN((uint32_t)JNI_ERR);
     return JNI_ERR;
   }
-  JNIHandleBlock* old_handles = thread->active_handles();
-  JNIHandleBlock* new_handles = JNIHandleBlock::allocate_block(thread);
-  assert(new_handles != NULL, "should not be NULL");
-  new_handles->set_pop_frame_link(old_handles);
-  thread->set_active_handles(new_handles);
+
+  thread->push_jni_handle_block();
   jint ret = JNI_OK;
   HOTSPOT_JNI_PUSHLOCALFRAME_RETURN(ret);
   return ret;

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -1510,7 +1510,7 @@ JvmtiModuleClosure::get_all_modules(JvmtiEnv* env, jint* module_count_ptr, jobje
     return JVMTI_ERROR_OUT_OF_MEMORY;
   }
   for (jint idx = 0; idx < len; idx++) {
-    array[idx] = JNIHandles::make_local(Thread::current(), _tbl->at(idx).resolve());
+    array[idx] = JNIHandles::make_local(_tbl->at(idx).resolve());
   }
   _tbl = NULL;
   *modules_ptr = array;

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -141,20 +141,11 @@ private:
   JavaThread *_thread;
   JNIEnv* _jni_env;
   JvmtiThreadState::ExceptionState _saved_exception_state;
-#if 0
-  JNIHandleBlock* _hblock;
-#endif
 
 public:
   JvmtiEventMark(JavaThread *thread) :  _thread(thread),
                                         _jni_env(thread->jni_environment()),
                                         _saved_exception_state(JvmtiThreadState::ES_CLEARED) {
-#if 0
-    _hblock = thread->active_handles();
-    _hblock->clear_thoroughly(); // so we can be safe
-#else
-    // we want to use the code above - but that needs the JNIHandle changes - later...
-    // for now, steal JNI push local frame code
     JvmtiThreadState *state = thread->jvmti_thread_state();
     // we are before an event.
     // Save current jvmti thread exception state.
@@ -162,31 +153,13 @@ public:
       _saved_exception_state = state->get_exception_state();
     }
 
-    JNIHandleBlock* old_handles = thread->active_handles();
-    JNIHandleBlock* new_handles = JNIHandleBlock::allocate_block(thread);
-    assert(new_handles != NULL, "should not be NULL");
-    new_handles->set_pop_frame_link(old_handles);
-    thread->set_active_handles(new_handles);
-#endif
+    thread->push_jni_handle_block();
     assert(thread == JavaThread::current(), "thread must be current!");
     thread->frame_anchor()->make_walkable(thread);
   };
 
   ~JvmtiEventMark() {
-#if 0
-    _hblock->clear(); // for consistency with future correct behavior
-#else
-    // we want to use the code above - but that needs the JNIHandle changes - later...
-    // for now, steal JNI pop local frame code
-    JNIHandleBlock* old_handles = _thread->active_handles();
-    JNIHandleBlock* new_handles = old_handles->pop_frame_link();
-    assert(new_handles != NULL, "should not be NULL");
-    _thread->set_active_handles(new_handles);
-    // Note that we set the pop_frame_link to NULL explicitly, otherwise
-    // the release_block call will release the blocks.
-    old_handles->set_pop_frame_link(NULL);
-    JNIHandleBlock::release_block(old_handles, _thread); // may block
-#endif
+    _thread->pop_jni_handle_block();
 
     JvmtiThreadState* state = _thread->jvmti_thread_state();
     // we are continuing after an event.
@@ -196,13 +169,7 @@ public:
     }
   }
 
-#if 0
-  jobject to_jobject(oop obj) { return obj == NULL? NULL : _hblock->allocate_handle_fast(obj); }
-#else
-  // we want to use the code above - but that needs the JNIHandle changes - later...
-  // for now, use regular make_local
   jobject to_jobject(oop obj) { return JNIHandles::make_local(_thread,obj); }
-#endif
 
   jclass to_jclass(Klass* klass) { return (klass == NULL ? NULL : (jclass)to_jobject(klass->java_mirror())); }
 

--- a/src/hotspot/share/runtime/jniHandles.cpp
+++ b/src/hotspot/share/runtime/jniHandles.cpp
@@ -302,12 +302,7 @@ bool JNIHandles::current_thread_in_native() {
           JavaThread::cast(thread)->thread_state() == _thread_in_native);
 }
 
-
-int             JNIHandleBlock::_blocks_allocated     = 0;
-JNIHandleBlock* JNIHandleBlock::_block_free_list      = NULL;
-#ifndef PRODUCT
-JNIHandleBlock* JNIHandleBlock::_block_list           = NULL;
-#endif
+int JNIHandleBlock::_blocks_allocated = 0;
 
 static inline bool is_tagged_free_list(uintptr_t value) {
   return (value & 1u) != 0;
@@ -348,36 +343,18 @@ JNIHandleBlock* JNIHandleBlock::allocate_block(JavaThread* thread, AllocFailType
   if (thread != NULL && thread->free_handle_block() != NULL) {
     block = thread->free_handle_block();
     thread->set_free_handle_block(block->_next);
-  }
-  else {
-    // locking with safepoint checking introduces a potential deadlock:
-    // - we would hold JNIHandleBlockFreeList_lock and then Threads_lock
-    // - another would hold Threads_lock (jni_AttachCurrentThread) and then
-    //   JNIHandleBlockFreeList_lock (JNIHandleBlock::allocate_block)
-    MutexLocker ml(JNIHandleBlockFreeList_lock,
-                   Mutex::_no_safepoint_check_flag);
-    if (_block_free_list == NULL) {
-      // Allocate new block
-      if (alloc_failmode == AllocFailStrategy::RETURN_NULL) {
-        block = new (std::nothrow) JNIHandleBlock();
-        if (block == NULL) {
-          return NULL;
-        }
-      } else {
-        block = new JNIHandleBlock();
+  } else {
+    // Allocate new block
+    if (alloc_failmode == AllocFailStrategy::RETURN_NULL) {
+      block = new (std::nothrow) JNIHandleBlock();
+      if (block == NULL) {
+        return NULL;
       }
-      _blocks_allocated++;
-      block->zap();
-      #ifndef PRODUCT
-      // Link new block to list of all allocated blocks
-      block->_block_list_link = _block_list;
-      _block_list = block;
-      #endif
     } else {
-      // Get block from free list
-      block = _block_free_list;
-      _block_free_list = _block_free_list->_next;
+      block = new JNIHandleBlock();
     }
+    Atomic::inc(&_blocks_allocated);
+    block->zap();
   }
   block->_top = 0;
   block->_next = NULL;
@@ -412,20 +389,8 @@ void JNIHandleBlock::release_block(JNIHandleBlock* block, JavaThread* thread) {
     block = NULL;
   }
   if (block != NULL) {
-    // Return blocks to free list
-    // locking with safepoint checking introduces a potential deadlock:
-    // - we would hold JNIHandleBlockFreeList_lock and then Threads_lock
-    // - another would hold Threads_lock (jni_AttachCurrentThread) and then
-    //   JNIHandleBlockFreeList_lock (JNIHandleBlock::allocate_block)
-    MutexLocker ml(JNIHandleBlockFreeList_lock,
-                   Mutex::_no_safepoint_check_flag);
-    while (block != NULL) {
-      block->zap();
-      JNIHandleBlock* next = block->_next;
-      block->_next = _block_free_list;
-      _block_free_list = block;
-      block = next;
-    }
+    Atomic::dec(&_blocks_allocated);
+    delete block;
   }
   if (pop_frame_link != NULL) {
     // As a sanity check we release blocks pointed to by the pop_frame_link.
@@ -609,46 +574,3 @@ const size_t JNIHandleBlock::get_number_of_live_handles() {
 size_t JNIHandleBlock::memory_usage() const {
   return length() * sizeof(JNIHandleBlock);
 }
-
-
-#ifndef PRODUCT
-
-bool JNIHandles::is_local_handle(jobject handle) {
-  return JNIHandleBlock::any_contains(handle);
-}
-
-bool JNIHandleBlock::any_contains(jobject handle) {
-  assert(handle != NULL, "precondition");
-  for (JNIHandleBlock* current = _block_list; current != NULL; current = current->_block_list_link) {
-    if (current->contains(handle)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-void JNIHandleBlock::print_statistics() {
-  int used_blocks = 0;
-  int free_blocks = 0;
-  int used_handles = 0;
-  int free_handles = 0;
-  JNIHandleBlock* block = _block_list;
-  while (block != NULL) {
-    if (block->_top > 0) {
-      used_blocks++;
-    } else {
-      free_blocks++;
-    }
-    used_handles += block->_top;
-    free_handles += (block_size_in_oops - block->_top);
-    block = block->_block_list_link;
-  }
-  tty->print_cr("JNIHandleBlocks statistics");
-  tty->print_cr("- blocks allocated: %d", used_blocks + free_blocks);
-  tty->print_cr("- blocks in use:    %d", used_blocks);
-  tty->print_cr("- blocks free:      %d", free_blocks);
-  tty->print_cr("- handles in use:   %d", used_handles);
-  tty->print_cr("- handles free:     %d", free_handles);
-}
-
-#endif

--- a/src/hotspot/share/runtime/jniHandles.hpp
+++ b/src/hotspot/share/runtime/jniHandles.hpp
@@ -111,11 +111,6 @@ class JNIHandles : AllStatic {
   static size_t global_handle_memory_usage();
   static size_t weak_global_handle_memory_usage();
 
-#ifndef PRODUCT
-  // Is handle from any local block of any thread?
-  static bool is_local_handle(jobject handle);
-#endif
-
   // precondition: handle != NULL.
   static jobjectRefType handle_type(JavaThread* thread, jobject handle);
 
@@ -145,6 +140,7 @@ class JNIHandleBlock : public CHeapObj<mtInternal> {
 
   uintptr_t       _handles[block_size_in_oops]; // The handles
   int             _top;                         // Index of next unused handle
+  int             _allocate_before_rebuild;     // Number of blocks to allocate before rebuilding free list
   JNIHandleBlock* _next;                        // Link to next block
 
   // The following instance variables are only used by the first block in a chain.
@@ -152,17 +148,9 @@ class JNIHandleBlock : public CHeapObj<mtInternal> {
   JNIHandleBlock* _last;                        // Last block in use
   JNIHandleBlock* _pop_frame_link;              // Block to restore on PopLocalFrame call
   uintptr_t*      _free_list;                   // Handle free list
-  int             _allocate_before_rebuild;     // Number of blocks to allocate before rebuilding free list
 
   // Check JNI, "planned capacity" for current frame (or push/ensure)
   size_t          _planned_capacity;
-
-  #ifndef PRODUCT
-  JNIHandleBlock* _block_list_link;             // Link for list below
-  static JNIHandleBlock* _block_list;           // List of all allocated blocks (for debugging only)
-  #endif
-
-  static JNIHandleBlock* _block_free_list;      // Free list of currently unused blocks
   static int      _blocks_allocated;            // For debugging/printing
 
   // Fill block with bad_handle values
@@ -203,10 +191,6 @@ class JNIHandleBlock : public CHeapObj<mtInternal> {
   bool contains(jobject handle) const;          // Does this block contain handle
   size_t length() const;                        // Length of chain starting with this block
   size_t memory_usage() const;
-  #ifndef PRODUCT
-  static bool any_contains(jobject handle);     // Does any block currently in use contain handle
-  static void print_statistics();
-  #endif
 };
 
 #endif // SHARE_RUNTIME_JNIHANDLES_HPP

--- a/src/hotspot/share/runtime/jniHandles.hpp
+++ b/src/hotspot/share/runtime/jniHandles.hpp
@@ -164,7 +164,7 @@ class JNIHandleBlock : public CHeapObj<mtInternal> {
 
  public:
   // Handle allocation
-  jobject allocate_handle(oop obj, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
+  jobject allocate_handle(JavaThread* caller, oop obj, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
 
   // Block allocation and block free list management
   static JNIHandleBlock* allocate_block(JavaThread* thread = NULL, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);

--- a/src/hotspot/share/runtime/jniHandles.hpp
+++ b/src/hotspot/share/runtime/jniHandles.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,7 +84,7 @@ class JNIHandles : AllStatic {
 
   // Local handles
   static jobject make_local(oop obj);
-  static jobject make_local(Thread* thread, oop obj,  // Faster version when current thread is known
+  static jobject make_local(JavaThread* thread, oop obj,  // Faster version when current thread is known
                             AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
   inline static void destroy_local(jobject handle);
 
@@ -104,7 +104,7 @@ class JNIHandles : AllStatic {
   static void print();
   static void verify();
   // The category predicates all require handle != NULL.
-  static bool is_local_handle(Thread* thread, jobject handle);
+  static bool is_local_handle(JavaThread* thread, jobject handle);
   static bool is_frame_handle(JavaThread* thread, jobject handle);
   static bool is_global_handle(jobject handle);
   static bool is_weak_global_handle(jobject handle);
@@ -117,7 +117,7 @@ class JNIHandles : AllStatic {
 #endif
 
   // precondition: handle != NULL.
-  static jobjectRefType handle_type(Thread* thread, jobject handle);
+  static jobjectRefType handle_type(JavaThread* thread, jobject handle);
 
   // Garbage collection support(global handles only, local handles are traversed from thread)
   // Traversal of regular global handles
@@ -179,8 +179,8 @@ class JNIHandleBlock : public CHeapObj<mtInternal> {
   jobject allocate_handle(oop obj, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
 
   // Block allocation and block free list management
-  static JNIHandleBlock* allocate_block(Thread* thread = NULL, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
-  static void release_block(JNIHandleBlock* block, Thread* thread = NULL);
+  static JNIHandleBlock* allocate_block(JavaThread* thread = NULL, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
+  static void release_block(JNIHandleBlock* block, JavaThread* thread = NULL);
 
   // JNI PushLocalFrame/PopLocalFrame support
   JNIHandleBlock* pop_frame_link() const          { return _pop_frame_link; }

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -48,7 +48,6 @@ Mutex*   Module_lock                  = NULL;
 Mutex*   CompiledIC_lock              = NULL;
 Mutex*   InlineCacheBuffer_lock       = NULL;
 Mutex*   VMStatistic_lock             = NULL;
-Mutex*   JNIHandleBlockFreeList_lock  = NULL;
 Mutex*   JmethodIdCreation_lock       = NULL;
 Mutex*   JfieldIdCreation_lock        = NULL;
 Monitor* JNICritical_lock             = NULL;
@@ -259,7 +258,6 @@ void mutex_init() {
 
   def(SharedDictionary_lock        , PaddedMutex  , safepoint);
   def(VMStatistic_lock             , PaddedMutex  , safepoint);
-  def(JNIHandleBlockFreeList_lock  , PaddedMutex  , nosafepoint-1);      // handles are used by VM thread
   def(SignatureHandlerLibrary_lock , PaddedMutex  , safepoint);
   def(SymbolArena_lock             , PaddedMutex  , nosafepoint);
   def(ExceptionCache_lock          , PaddedMutex  , safepoint);

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -40,7 +40,6 @@ extern Mutex*   Module_lock;                     // a lock on module and package
 extern Mutex*   CompiledIC_lock;                 // a lock used to guard compiled IC patching and access
 extern Mutex*   InlineCacheBuffer_lock;          // a lock used to guard the InlineCacheBuffer
 extern Mutex*   VMStatistic_lock;                // a lock used to guard statistics count increment
-extern Mutex*   JNIHandleBlockFreeList_lock;     // a lock on the JNI handle block free list
 extern Mutex*   JmethodIdCreation_lock;          // a lock on creating JNI method identifiers
 extern Mutex*   JfieldIdCreation_lock;           // a lock on creating JNI static field identifiers
 extern Monitor* JNICritical_lock;                // a lock used while entering and exiting JNI critical regions, allows GC to sometimes get in

--- a/src/hotspot/share/runtime/nonJavaThread.cpp
+++ b/src/hotspot/share/runtime/nonJavaThread.cpp
@@ -234,7 +234,6 @@ int WatcherThread::sleep() const {
 void WatcherThread::run() {
   assert(this == watcher_thread(), "just checking");
 
-  this->set_active_handles(JNIHandleBlock::allocate_block());
   while (true) {
     assert(watcher_thread() == Thread::current(), "thread consistency check");
     assert(watcher_thread() == this, "thread consistency check");

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1169,13 +1169,6 @@ void os::print_location(outputStream* st, intptr_t x, bool verbose) {
       st->print_cr(INTPTR_FORMAT " is a weak global jni handle", p2i(addr));
       return;
     }
-#ifndef PRODUCT
-    // we don't keep the block list in product mode
-    if (JNIHandles::is_local_handle((jobject) addr)) {
-      st->print_cr(INTPTR_FORMAT " is a local jni handle", p2i(addr));
-      return;
-    }
-#endif
   }
 
   // Check if addr belongs to a Java thread.

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -773,6 +773,9 @@ class JavaThread: public Thread {
   JNIHandleBlock* free_handle_block() const      { return _free_handle_block; }
   void set_free_handle_block(JNIHandleBlock* block) { _free_handle_block = block; }
 
+  void push_jni_handle_block();
+  void pop_jni_handle_block();
+
  private:
   MonitorChunk* _monitor_chunks;              // Contains the off stack monitors
                                               // allocated during deoptimization
@@ -1745,6 +1748,15 @@ class UnlockFlagSaver {
     ~UnlockFlagSaver() {
       _thread->set_do_not_unlock_if_synchronized(_do_not_unlock);
     }
+};
+
+class JNIHandleMark : public StackObj {
+  JavaThread* _thread;
+ public:
+  JNIHandleMark(JavaThread* thread) : _thread(thread) {
+    thread->push_jni_handle_block();
+  }
+  ~JNIHandleMark() { _thread->pop_jni_handle_block(); }
 };
 
 #endif // SHARE_RUNTIME_THREAD_HPP

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -238,12 +238,6 @@ class Thread: public ThreadShadow {
 #endif
 
  private:
-  // Active_handles points to a block of handles
-  JNIHandleBlock* _active_handles;
-
-  // One-element thread local free list
-  JNIHandleBlock* _free_handle_block;
-
   // Point to the last handle mark
   HandleMark* _last_handle_mark;
 
@@ -415,12 +409,6 @@ class Thread: public ThreadShadow {
 
   OSThread* osthread() const                     { return _osthread;   }
   void set_osthread(OSThread* thread)            { _osthread = thread; }
-
-  // JNI handle support
-  JNIHandleBlock* active_handles() const         { return _active_handles; }
-  void set_active_handles(JNIHandleBlock* block) { _active_handles = block; }
-  JNIHandleBlock* free_handle_block() const      { return _free_handle_block; }
-  void set_free_handle_block(JNIHandleBlock* block) { _free_handle_block = block; }
 
   // Internal handle support
   HandleArea* handle_area() const                { return _handle_area; }
@@ -607,7 +595,6 @@ protected:
   // Code generation
   static ByteSize exception_file_offset()        { return byte_offset_of(Thread, _exception_file); }
   static ByteSize exception_line_offset()        { return byte_offset_of(Thread, _exception_line); }
-  static ByteSize active_handles_offset()        { return byte_offset_of(Thread, _active_handles); }
 
   static ByteSize stack_base_offset()            { return byte_offset_of(Thread, _stack_base); }
   static ByteSize stack_size_offset()            { return byte_offset_of(Thread, _stack_size); }
@@ -746,6 +733,13 @@ class JavaThread: public Thread {
   ObjectMonitor* volatile _current_pending_monitor;     // ObjectMonitor this thread is waiting to lock
   bool           _current_pending_monitor_is_from_java; // locking is from Java code
   ObjectMonitor* volatile _current_waiting_monitor;     // ObjectMonitor on which this thread called Object.wait()
+
+  // Active_handles points to a block of handles
+  JNIHandleBlock* _active_handles;
+
+  // One-element thread local free list
+  JNIHandleBlock* _free_handle_block;
+
  public:
   volatile intptr_t _Stalled;
 
@@ -772,6 +766,12 @@ class JavaThread: public Thread {
   void set_current_waiting_monitor(ObjectMonitor* monitor) {
     Atomic::store(&_current_waiting_monitor, monitor);
   }
+
+  // JNI handle support
+  JNIHandleBlock* active_handles() const         { return _active_handles; }
+  void set_active_handles(JNIHandleBlock* block) { _active_handles = block; }
+  JNIHandleBlock* free_handle_block() const      { return _free_handle_block; }
+  void set_free_handle_block(JNIHandleBlock* block) { _free_handle_block = block; }
 
  private:
   MonitorChunk* _monitor_chunks;              // Contains the off stack monitors
@@ -1282,6 +1282,8 @@ class JavaThread: public Thread {
   static ByteSize exception_pc_offset()          { return byte_offset_of(JavaThread, _exception_pc); }
   static ByteSize exception_handler_pc_offset()  { return byte_offset_of(JavaThread, _exception_handler_pc); }
   static ByteSize is_method_handle_return_offset() { return byte_offset_of(JavaThread, _is_method_handle_return); }
+
+  static ByteSize active_handles_offset()        { return byte_offset_of(JavaThread, _active_handles); }
 
   // StackOverflow offsets
   static ByteSize stack_overflow_limit_offset()  {

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -704,7 +704,6 @@
   nonstatic_field(ThreadShadow,                _pending_exception,                            oop)                                   \
   nonstatic_field(ThreadShadow,                _exception_file,                               const char*)                           \
   nonstatic_field(ThreadShadow,                _exception_line,                               int)                                   \
-  nonstatic_field(Thread,                      _active_handles,                               JNIHandleBlock*)                       \
   nonstatic_field(Thread,                      _tlab,                                         ThreadLocalAllocBuffer)                \
   nonstatic_field(Thread,                      _allocated_bytes,                              jlong)                                 \
   nonstatic_field(NamedThread,                 _name,                                         char*)                                 \
@@ -728,6 +727,7 @@
   nonstatic_field(JavaThread,                  _stack_size,                                   size_t)                                \
   nonstatic_field(JavaThread,                  _vframe_array_head,                            vframeArray*)                          \
   nonstatic_field(JavaThread,                  _vframe_array_last,                            vframeArray*)                          \
+  nonstatic_field(JavaThread,                  _active_handles,                               JNIHandleBlock*)                       \
   volatile_nonstatic_field(JavaThread,         _terminated,                                   JavaThread::TerminatedTypes)           \
   nonstatic_field(Thread,                      _resource_area,                                ResourceArea*)                         \
   nonstatic_field(CompilerThread,              _env,                                          ciEnv*)                                \

--- a/src/hotspot/share/runtime/vmThread.cpp
+++ b/src/hotspot/share/runtime/vmThread.cpp
@@ -152,10 +152,10 @@ static VM_None halt_op("Halt");
 void VMThread::run() {
   assert(this == vm_thread(), "check");
 
-  // Notify_lock wait checks on active_handles() to rewait in
+  // Notify_lock wait checks on is_running() to rewait in
   // case of spurious wakeup, it should wait on the last
   // value set prior to the notify
-  this->set_active_handles(JNIHandleBlock::allocate_block());
+  Atomic::store(&_is_running, true);
 
   {
     MutexLocker ml(Notify_lock);

--- a/src/hotspot/share/runtime/vmThread.cpp
+++ b/src/hotspot/share/runtime/vmThread.cpp
@@ -139,7 +139,7 @@ void VMThread::create() {
   }
 }
 
-VMThread::VMThread() : NamedThread() {
+VMThread::VMThread() : NamedThread(), _is_running(false) {
   set_name("VM Thread");
 }
 

--- a/src/hotspot/share/runtime/vmThread.hpp
+++ b/src/hotspot/share/runtime/vmThread.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_RUNTIME_VMTHREAD_HPP
 #define SHARE_RUNTIME_VMTHREAD_HPP
 
+#include "runtime/atomic.hpp"
 #include "runtime/perfDataTypes.hpp"
 #include "runtime/nonJavaThread.hpp"
 #include "runtime/thread.hpp"
@@ -59,6 +60,8 @@ public:
 
 class VMThread: public NamedThread {
  private:
+  volatile bool _is_running;
+
   static ThreadPriority _current_priority;
 
   static bool _should_terminate;
@@ -84,6 +87,7 @@ class VMThread: public NamedThread {
     guarantee(false, "VMThread deletion must fix the race with VM termination");
   }
 
+  bool is_running() const { return Atomic::load(&_is_running); }
 
   // Tester
   bool is_VM_thread() const                      { return true; }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaThread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaThread.java
@@ -52,6 +52,7 @@ public class JavaThread extends Thread {
   private static AddressField  stackBaseField;
   private static CIntegerField stackSizeField;
   private static CIntegerField terminatedField;
+  private static AddressField activeHandlesField;
 
   private static JavaThreadPDAccess access;
 
@@ -95,6 +96,7 @@ public class JavaThread extends Thread {
     stackBaseField    = type.getAddressField("_stack_base");
     stackSizeField    = type.getCIntegerField("_stack_size");
     terminatedField   = type.getCIntegerField("_terminated");
+    activeHandlesField = type.getAddressField("_active_handles");
 
     UNINITIALIZED     = db.lookupIntConstant("_thread_uninitialized").intValue();
     NEW               = db.lookupIntConstant("_thread_new").intValue();
@@ -407,6 +409,14 @@ public class JavaThread extends Thread {
       return OopUtilities.threadOopGetParkBlocker(threadObj);
     }
     return null;
+  }
+
+  public JNIHandleBlock activeHandles() {
+    Address a = activeHandlesField.getAddress(addr);
+    if (a == null) {
+      return null;
+    }
+    return new JNIHandleBlock(a);
   }
 
   public void printInfoOn(PrintStream tty) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Thread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Thread.java
@@ -37,7 +37,6 @@ public class Thread extends VMObject {
   // Thread::SuspendFlags enum constants
   private static int HAS_ASYNC_EXCEPTION;
 
-  private static AddressField activeHandlesField;
   private static AddressField currentPendingMonitorField;
   private static AddressField currentWaitingMonitorField;
 
@@ -59,7 +58,6 @@ public class Thread extends VMObject {
     HAS_ASYNC_EXCEPTION = db.lookupIntConstant("JavaThread::_has_async_exception").intValue();
 
     tlabFieldOffset    = typeThread.getField("_tlab").getOffset();
-    activeHandlesField = typeThread.getAddressField("_active_handles");
     currentPendingMonitorField = typeJavaThread.getAddressField("_current_pending_monitor");
     currentWaitingMonitorField = typeJavaThread.getAddressField("_current_waiting_monitor");
     allocatedBytesField = typeThread.getJLongField("_allocated_bytes");
@@ -79,14 +77,6 @@ public class Thread extends VMObject {
 
   public ThreadLocalAllocBuffer tlab() {
     return new ThreadLocalAllocBuffer(addr.addOffsetTo(tlabFieldOffset));
-  }
-
-  public JNIHandleBlock activeHandles() {
-    Address a = activeHandlesField.getAddress(addr);
-    if (a == null) {
-      return null;
-    }
-    return new JNIHandleBlock(a);
   }
 
   public long allocatedBytes() {


### PR DESCRIPTION
JNI Local handles can only be created by JavaThread (there's an assert in make_local) but the fields are added to Thread.
Move the fields to JavaThread and adding JavaThread* argument.
Also, the global freelist isn't very useful now that global JNI handles don't use JNIHandleBlock, so the locking that claims incorrectly to block for safepoint is removed.
Lastly, there's at least 3 places that duplicate pushing a new JNIHandleBlock to the thread for temporarily adding JNI local handles. These have been moved to common code with a JNIHandleMark object, moved from jvmci code.
The commits are separate to help reviewing, but the entire change has been tested together with tier1-6.
The commits in this change have been performance tested individually and together with no meaningful differences from mainline.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276658](https://bugs.openjdk.java.net/browse/JDK-8276658): Clean up JNI local handles code


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to f31dfeee1de9e824fb7a39166ba815be51142eb3
 * [Patricio Chilano Mateo](https://openjdk.java.net/census#pchilanomate) (@pchilano - Committer) ⚠️ Review applies to f31dfeee1de9e824fb7a39166ba815be51142eb3


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6336/head:pull/6336` \
`$ git checkout pull/6336`

Update a local copy of the PR: \
`$ git checkout pull/6336` \
`$ git pull https://git.openjdk.java.net/jdk pull/6336/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6336`

View PR using the GUI difftool: \
`$ git pr show -t 6336`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6336.diff">https://git.openjdk.java.net/jdk/pull/6336.diff</a>

</details>
