### PR TITLE
8275728: Add simple Producer/Consumer microbenchmark for Thread.onSpinWait

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/ThreadOnSpinWaitProducerConsumer.java
+++ b/test/micro/org/openjdk/bench/java/lang/ThreadOnSpinWaitProducerConsumer.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2021, Amazon.com Inc. or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.math.BigInteger;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+
+/**
+ * This microbenchmark models producer-consumer.
+ *
+ * The microbenchmark uses two thread: 1 for a producer, 1 for a consumer.
+ * The microbenchmark uses BigInteger to have latencies of producing/consuming
+ * data comparable with synchronization operations.
+ *
+ * Thread.onSpinWait is used in a spin loop which is used to avoid heavy locks.
+ * In the spin loop volatile fields are checked. To reduce overhead accessing them
+ * they are only checked after a number of iterations.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Threads(1)
+public class ThreadOnSpinWaitProducerConsumer {
+    @Param({"100"})
+    public int maxNum;
+
+    @Param({"125"})
+    public int spinNum;
+
+    @Param({"10"})
+    public int checkSpinCondAfterIters;
+
+    @Param({"256"})
+    public int dataBitLength;
+
+    private Thread threadProducer;
+    private Thread threadConsumer;
+    private Object monitor;
+
+    private BigInteger a;
+    private BigInteger b;
+    private Blackhole bh;
+
+    private volatile int dataId;
+    private volatile int seenDataId;
+
+    private int producedDataCount;
+    private int consumedDataCount;
+
+    private void produceData() {
+        if (!isDataSeen()) {
+            return;
+        }
+
+        b = a.not();
+        ++dataId;
+        ++producedDataCount;
+    }
+
+    private void consumeData() {
+        if (isDataSeen()) {
+            return;
+        }
+        bh.consume(a.equals(b.not()));
+        seenDataId = dataId;
+        ++consumedDataCount;
+    }
+
+    private boolean isDataSeen() {
+        return seenDataId == dataId;
+    }
+
+    private boolean isNewData() {
+        return seenDataId != dataId;
+    }
+
+    private boolean spinWaitForCondition(int spinNum, BooleanSupplier cond) {
+        for (int i = 0; i < spinNum; ++i) {
+            if ((i % checkSpinCondAfterIters) == 0 && cond.getAsBoolean()) {
+                return true;
+            }
+            Thread.onSpinWait();
+        }
+        return cond.getAsBoolean();
+    }
+
+    void produce() {
+        try {
+            while (dataId < maxNum) {
+                if (spinWaitForCondition(this.spinNum, this::isDataSeen)) {
+                    synchronized (monitor) {
+                        produceData();
+                        monitor.notify();
+                    }
+                } else {
+                    synchronized (monitor) {
+                        while (!isDataSeen()) {
+                            monitor.wait();
+                        }
+
+                        produceData();
+                        monitor.notify();
+                    }
+                }
+            }
+        } catch (InterruptedException e) {}
+    }
+
+    void consume() {
+        try {
+            for (;;) {
+                if (spinWaitForCondition(this.spinNum, this::isNewData)) {
+                    synchronized (monitor) {
+                         consumeData();
+                         monitor.notify();
+                    }
+                } else {
+                    synchronized (monitor) {
+                        while (isDataSeen()) {
+                            monitor.wait();
+                        }
+
+                        consumeData();
+                        monitor.notify();
+                    }
+                }
+            }
+        } catch (InterruptedException e) {}
+    }
+
+    @Setup(Level.Trial)
+    public void setup01() {
+        Random rnd = new Random(111);
+        a = BigInteger.probablePrime(dataBitLength, rnd);
+        monitor = new Object();
+    }
+
+    @Setup(Level.Invocation)
+    public void setup02() {
+        threadProducer = new Thread(this::produce);
+        threadConsumer = new Thread(this::consume);
+    }
+
+    @Benchmark
+    public void trial(Blackhole bh) throws Exception {
+        this.bh = bh;
+        producedDataCount = 0;
+        consumedDataCount = 0;
+        dataId = 0;
+        seenDataId = 0;
+        threadProducer.start();
+        threadConsumer.start();
+        threadProducer.join();
+
+        synchronized (monitor) {
+            while (!isDataSeen()) {
+                monitor.wait();
+            }
+        }
+        threadConsumer.interrupt();
+
+        if (producedDataCount != maxNum) {
+            throw new RuntimeException("Produced: " + producedDataCount + ". Expected: " + maxNum);
+        }
+        if (producedDataCount != consumedDataCount) {
+            throw new RuntimeException("produced != consumed: " + producedDataCount + " != " + consumedDataCount);
+        }
+    }
+}


### PR DESCRIPTION
This is a microbenchmarks to demonstrate `Thread.onSpinWait` can be used to avoid heavy locks.
The microbenchmark differs from [Gil's original benchmark](https://github.com/giltene/GilExamples/tree/master/SpinWaitTest) and [Dmitry's variations](http://cr.openjdk.java.net/~dchuyko/8186670/yield/spinwait.html). Those benchmarks produce/consume data by incrementing a volatile counter. The latency of such operations is almost zero. They also don't use heavy locks. According to [Gil's SpinWaitTest.java](https://github.com/giltene/GilExamples/blob/master/SpinWaitTest/src/main/java/SpinWaitTest.java):
> This test can be used to measure and document the impact of Runtime.onSpinWait() behavior
>  on thread-to-thread communication latencies. E.g. when the two threads are pinned to
> the two hardware threads of a shared x86 core (with a shared L1), this test will
> demonstrate an estimate the best case thread-to-thread latencies possible on the
> platform

Gil's microbenchmark targets SMT cases (x86 hyperthreading). As not all CPUs support SMT, the microbenchmarks cannot demonstrate benefits of `Thread.onSpinWait`. It is actually opposite. They show `Thread.onSpinWait`  has negative impact on performance.

The microbenchmark from PR uses `BigInteger` to have 100 - 200 ns latencies for producing/consuming data. These latencies can cause either a producer or a consumer to wait each another. Waiting is implemented with `Object.wait`/`Object.notify` which are heavy. `Thread.onSpinWait` can be used in a spin loop to avoid them.

**ARM64 results**:
- No spin loop
```
Benchmark                               (maxNum)  (spinNum)  Mode  Cnt     Score    Error  Units
ThreadOnSpinWaitProducerConsumer.trial       100          0  avgt   75  1520.448 ± 40.507  us/op
```
- No `Thread.onSpinWait` intrinsic
```
Benchmark                               (maxNum)  (spinNum)  Mode  Cnt     Score    Error  Units
ThreadOnSpinWaitProducerConsumer.trial       100        125  avgt   75  1580.756 ± 47.501  us/op
```
- `ISB`-based `Thread.onSpinWait` intrinsic
```
Benchmark                               (maxNum)  (spinNum)  Mode  Cnt    Score     Error  Units
ThreadOnSpinWaitProducerConsumer.trial       100        125  avgt   75  617.454 ± 174.431  us/op
```

**X86_64 results**:
- No spin loop
```
Benchmark                               (maxNum)  (spinNum)  Mode  Cnt    Score     Error  Units
ThreadOnSpinWaitProducerConsumer.trial      100        125  avgt   75  1417.944 ± 1.691  us/op
```
- No `Thread.onSpinWait` intrinsic
```
Benchmark                               (maxNum)  (spinNum)  Mode  Cnt    Score     Error  Units
ThreadOnSpinWaitProducerConsumer.trial      100        125  avgt   75  1410.987 ± 2.093  us/op
```
- `PAUSE`-based `Thread.onSpinWait` intrinsic
```
Benchmark                               (maxNum)  (spinNum)  Mode  Cnt    Score     Error  Units
ThreadOnSpinWaitProducerConsumer.trial      100        125  avgt   75  217.054 ± 1.283  us/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8275728](https://bugs.openjdk.java.net/browse/JDK-8275728): Add simple Producer/Consumer microbenchmark for Thread.onSpinWait


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6338/head:pull/6338` \
`$ git checkout pull/6338`

Update a local copy of the PR: \
`$ git checkout pull/6338` \
`$ git pull https://git.openjdk.java.net/jdk pull/6338/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6338`

View PR using the GUI difftool: \
`$ git pr show -t 6338`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6338.diff">https://git.openjdk.java.net/jdk/pull/6338.diff</a>

</details>
