### PR TITLE
8270874: JFrame paint artifacts when dragged from standard monitor to HiDPI monitor

### DIFF
--- a/test/jdk/java/awt/Window/WindowResizingOnDPIChanging/WindowResizingOnMovingToAnotherDisplay.java
+++ b/test/jdk/java/awt/Window/WindowResizingOnDPIChanging/WindowResizingOnMovingToAnotherDisplay.java
@@ -53,7 +53,7 @@ import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
 
 /* @test
- * @bug 8147440 8147016
+ * @bug 8147440 8147016 8270874
  * @summary HiDPI (Windows): Swing components have incorrect sizes after
  *          changing display resolution
  * @run main/manual/othervm WindowResizingOnMovingToAnotherDisplay


### PR DESCRIPTION
The bug occurs more often if initially the window is moved partly outside of the first screen(let's name this part as the invisible part), and then slowly moved to the second screen where that invisible part became visible on the second screen.

The problem is how we try to repaint the frame. The Windows send us coordinates to repaint in the device space, if the width/height values are less than a unit in the user's space, we round it to the empty rectangle and skip it.

Solution: request to repaint the smallest non-empty bounding box in the user's space around the region of pixels.

Workaround: repaint the whole window on the component resize/move event or at the end of the drag.

Notes:
 * It is not reproducible(at least much less often) when d3d is enabled because the d3d pipeline sends repaint events more often (example https://github.com/openjdk/jdk/pull/6064). That hides the current issue.
 * It started to be reproducible during the drag from one screen to another after JDK-8211999 because before JDK-8211999 we make a resize at the end of the drag, which caused the full repaint of the window.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270874](https://bugs.openjdk.java.net/browse/JDK-8270874): JFrame paint artifacts when dragged from standard monitor to HiDPI monitor


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6339/head:pull/6339` \
`$ git checkout pull/6339`

Update a local copy of the PR: \
`$ git checkout pull/6339` \
`$ git pull https://git.openjdk.java.net/jdk pull/6339/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6339`

View PR using the GUI difftool: \
`$ git pr show -t 6339`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6339.diff">https://git.openjdk.java.net/jdk/pull/6339.diff</a>

</details>
