### PR TITLE
8276889: Improve compatibility discussion in instanceKlass.cpp

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -728,7 +728,6 @@ oop InstanceKlass::protection_domain() const {
   return java_lang_Class::protection_domain(java_mirror());
 }
 
-// To remove these from requires an incompatible change and CSR review.
 objArrayOop InstanceKlass::signers() const {
   // return the signers from the mirror
   return java_lang_Class::signers(java_mirror());


### PR DESCRIPTION
I removed the confusing comment that was missing some words, and linked the RFE to this one that the comment was referring to.  At one point in time, I really wanted to remove this code (still do but not as much now).  With JVMTI Heap functions deprecated JDK-8268242, maybe soon.
Please review this trivial change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276889](https://bugs.openjdk.java.net/browse/JDK-8276889): Improve compatibility discussion in instanceKlass.cpp


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6340/head:pull/6340` \
`$ git checkout pull/6340`

Update a local copy of the PR: \
`$ git checkout pull/6340` \
`$ git pull https://git.openjdk.java.net/jdk pull/6340/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6340`

View PR using the GUI difftool: \
`$ git pr show -t 6340`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6340.diff">https://git.openjdk.java.net/jdk/pull/6340.diff</a>

</details>
