### PR TITLE
8190264: JScrollBar ignores its border when using macOS Mac OS X Aqua look and feel

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaScrollBarUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaScrollBarUI.java
@@ -144,7 +144,8 @@ public class AquaScrollBarUI extends ScrollBarUI {
 
     public void paint(final Graphics g, final JComponent c) {
         syncState(c);
-        painter.paint(g, c, 0, 0, fScrollBar.getWidth(), fScrollBar.getHeight());
+        Rectangle trackBounds = getTrackBounds();
+        painter.paint(g, c, trackBounds.x, trackBounds.y, trackBounds.width, trackBounds.height);
     }
 
     protected State getState(final JComponent c, final ScrollBarPart pressedPart) {
@@ -188,11 +189,17 @@ public class AquaScrollBarUI extends ScrollBarUI {
     }
 
     protected Rectangle getTrackBounds() {
-        return new Rectangle(0, 0, fScrollBar.getWidth(), fScrollBar.getHeight());
+        Insets insets = fScrollBar.getInsets();
+        return new Rectangle(insets.left, 0,
+                fScrollBar.getWidth() - (insets.left + insets.right),
+                fScrollBar.getHeight());
     }
 
     protected Rectangle getDragBounds() {
-        return new Rectangle(0, 0, fScrollBar.getWidth(), fScrollBar.getHeight());
+        Insets insets = fScrollBar.getInsets();
+        return new Rectangle(insets.left, 0,
+            fScrollBar.getWidth() - (insets.left + insets.right),
+            fScrollBar.getHeight());
     }
 
     protected void startTimer(final boolean initial) {
@@ -228,7 +235,9 @@ public class AquaScrollBarUI extends ScrollBarUI {
 
     protected Hit getPartHit(final int x, final int y) {
         syncState(fScrollBar);
-        return JRSUIUtils.HitDetection.getHitForPoint(painter.getControl(), 0, 0, fScrollBar.getWidth(), fScrollBar.getHeight(), x, y);
+        Insets insets = fScrollBar.getInsets();
+        return JRSUIUtils.HitDetection.getHitForPoint(painter.getControl(), 0, 0,
+                fScrollBar.getWidth() - (insets.left + insets.right), fScrollBar.getHeight(), x, y);
     }
 
     protected class PropertyChangeHandler implements PropertyChangeListener {
@@ -344,7 +353,9 @@ public class AquaScrollBarUI extends ScrollBarUI {
             // scroller goes 0-100 with a visible area of 20 we are getting a ratio of the
             // remaining 80.
             syncState(fScrollBar);
-            final double offsetChange = JRSUIUtils.ScrollBar.getNativeOffsetChange(painter.getControl(), 0, 0, fScrollBar.getWidth(), fScrollBar.getHeight(), offsetWeCareAbout, visibleAmt, extent);
+            final Rectangle limitRect = getDragBounds(); // GetThemeTrackDragRect
+            final double offsetChange = JRSUIUtils.ScrollBar.getNativeOffsetChange(painter.getControl(),
+                    limitRect.x, limitRect.y, limitRect.width, limitRect.height, offsetWeCareAbout, visibleAmt, extent);
 
             // the scrollable area is the extent - visible amount;
             final int scrollableArea = extent - visibleAmt;
@@ -597,7 +608,7 @@ public class AquaScrollBarUI extends ScrollBarUI {
         // determine the bounding rectangle for our thumb region
         syncState(fScrollBar);
         double[] rect = new double[4];
-        JRSUIUtils.ScrollBar.getPartBounds(rect, painter.getControl(), 0, 0, fScrollBar.getWidth(), fScrollBar.getHeight(), ScrollBarPart.THUMB);
+        JRSUIUtils.ScrollBar.getPartBounds(rect, painter.getControl(), limitRect.x, limitRect.y, limitRect.width, limitRect.height, ScrollBarPart.THUMB);
         final Rectangle r = new Rectangle((int)rect[0], (int)rect[1], (int)rect[2], (int)rect[3]);
 
         // figure out the scroll-to-here start location based on our orientation, the

--- a/test/jdk/java/awt/Scrollbar/AquaLFScrollbarTest/ScrollBarBorderTest.java
+++ b/test/jdk/java/awt/Scrollbar/AquaLFScrollbarTest/ScrollBarBorderTest.java
@@ -1,8 +1,25 @@
-import java.awt.*;
+import javax.swing.JScrollBar;
+import javax.swing.JPanel;
+import javax.swing.JFrame;
+import javax.swing.BoxLayout;
+import javax.swing.JLabel;
+import javax.swing.Box;
+import javax.swing.UIManager;
+import javax.swing.border.Border;
+import javax.swing.border.EmptyBorder;
+import java.awt.Frame;
+import java.awt.GridBagLayout;
+import java.awt.GridBagConstraints;
+import java.awt.Panel;
+import java.awt.TextArea;
+import java.awt.Button;
+import java.awt.Scrollbar;
+import java.awt.Component;
+import java.awt.Graphics;
+import java.awt.Color;
+import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import javax.swing.*; 
-import javax.swing.border.*;
 
 /*
  * @test
@@ -161,7 +178,7 @@ public class ScrollBarBorderTest implements ActionListener {
 
   // custom border 
   private static class CustomBorder implements Border {
-    public void paintBorder(Component c, Graphics g, int x, int y, int width, int height) { 
+    public void paintBorder(Component c, Graphics g, int x, int y, int width, int height) {
       g.setColor(new Color(255, 0, 0, 100)); 
       g.fillRect(width - 150, y, width, height); 
     } 

--- a/test/jdk/java/awt/Scrollbar/AquaLFScrollbarTest/ScrollBarBorderTest.java
+++ b/test/jdk/java/awt/Scrollbar/AquaLFScrollbarTest/ScrollBarBorderTest.java
@@ -1,0 +1,172 @@
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import javax.swing.*; 
+import javax.swing.border.*;
+
+/*
+ * @test
+ * @run main/manual ScrollBarBorderTest
+ */
+public class ScrollBarBorderTest implements ActionListener {
+
+  // On macOS 10.12.6 using the Mac look and feel (com.apple.laf.AquaLookAndFeel) 
+  // the scroll bar ignores the custom border and allows the scroll thumb to move 
+  // beneath the border. Run with: 
+  // java ScrollBarBorderTest 
+
+  // If run using any other look and feel (e.g. Metal) then the right side of 
+  // the scroll bar stops at the border as expected. Run with: 
+  // java -Dswing.defaultlaf=javax.swing.plaf.metal.MetalLookAndFeel ScrollBarBorderTest 
+
+  // Java version: 1.8.0_151
+
+  private static JScrollBar scrollBar;
+  private static JPanel panel;
+  private static JFrame frame;
+  private static Frame instructionFrame;
+  private static GridBagLayout layout;
+  private static Panel mainControlPanel;
+  private static Panel resultButtonPanel;
+  private static TextArea instructionTextArea;
+  private static Button passButton;
+  private static Button failButton;
+  private static Thread mainThread = null;
+  private static boolean testPassed = false;
+  private static boolean isInterrupted = false;
+  private static final int testTimeOut = 300000;
+  private static String testFailMessage = "testfail";
+
+
+  public void createAndShowGUI() {
+    // create scroll bar
+    scrollBar = new JScrollBar(Scrollbar.HORIZONTAL);
+    scrollBar.setBorder(new CustomBorder());
+    // create panel
+    panel = new JPanel();
+    panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+    panel.setBorder(new EmptyBorder(20, 20, 20, 20));
+    panel.add(new JLabel(UIManager.getLookAndFeel().toString()));
+    panel.add(Box.createVerticalStrut(20));
+    panel.add(scrollBar);
+    // create frame
+    frame = new JFrame("ScrollBarBorderTest");
+    frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+    frame.getContentPane().add(panel);
+    frame.pack();
+    frame.setVisible(true);
+  }
+
+  private void createInstructionUI() {
+    instructionFrame = new Frame("Scrollbar");
+    layout = new GridBagLayout();
+    mainControlPanel = new Panel(layout);
+    resultButtonPanel = new Panel(layout);
+
+    GridBagConstraints gbc = new GridBagConstraints();
+    String instructions
+            = "\nINSTRUCTIONS:\n"
+            + "\n   Try to drag the thumb of the scrollbar into the red zone."
+            + "\n   If the thumb is able to go into the red zone, click fail."
+            + "\n   Otherwise, pass.";
+
+    instructionTextArea = new TextArea(7, 70);
+    instructionTextArea.setText(instructions);
+    instructionTextArea.setEnabled(false);
+    instructionTextArea.setBackground(Color.white);
+
+    gbc.gridx = 0;
+    gbc.gridy = 0;
+    gbc.weightx = 0.5;
+    gbc.fill = GridBagConstraints.HORIZONTAL;
+    mainControlPanel.add(instructionTextArea, gbc);
+
+    passButton = new Button("Pass");
+    passButton.setName("Pass");
+    passButton.addActionListener((ActionListener) this);
+
+    failButton = new Button("Fail");
+    failButton.setName("Fail");
+    failButton.addActionListener((ActionListener) this);
+
+    setButtonEnable(true);
+
+    gbc.gridx = 0;
+    gbc.gridy = 0;
+    resultButtonPanel.add(passButton, gbc);
+    gbc.gridx = 1;
+    gbc.gridy = 0;
+    resultButtonPanel.add(failButton, gbc);
+    gbc.gridx = 0;
+    gbc.gridy = 1;
+    mainControlPanel.add(resultButtonPanel, gbc);
+
+    instructionFrame.add(mainControlPanel);
+    instructionFrame.pack();
+    instructionFrame.setVisible(true);
+  }
+
+  @Override
+  public void actionPerformed(ActionEvent ae) {
+    if (ae.getSource() instanceof Button) {
+      Button btn = (Button) ae.getSource();
+      switch (btn.getName()) {
+        case "Pass":
+          testPassed = true;
+          isInterrupted = true;
+          mainThread.interrupt();
+          break;
+        case "Fail":
+          testPassed = false;
+          isInterrupted = true;
+          mainThread.interrupt();
+          break;
+      }
+    }
+  }
+
+  private static void setButtonEnable(boolean status) {
+    passButton.setEnabled(status);
+    failButton.setEnabled(status);
+  }
+
+  private static void cleanUp() {
+    frame.dispose();
+    instructionFrame.dispose();
+  }
+
+  public static void main(String[] args) {
+    ScrollBarBorderTest borderTest = new ScrollBarBorderTest();
+    borderTest.createInstructionUI();
+    borderTest.createAndShowGUI();
+
+    mainThread = Thread.currentThread();
+    try {
+      mainThread.sleep(testTimeOut);
+    } catch (InterruptedException ex) {
+      if (!testPassed) {
+        throw new RuntimeException(testFailMessage);
+      }
+    } finally {
+      cleanUp();
+    }
+
+    if (!isInterrupted) {
+      throw new RuntimeException("Test Timed out after "
+              + testTimeOut / 1000 + " seconds");
+    }
+  }
+
+
+
+  // custom border 
+  private static class CustomBorder implements Border {
+    public void paintBorder(Component c, Graphics g, int x, int y, int width, int height) { 
+      g.setColor(new Color(255, 0, 0, 100)); 
+      g.fillRect(width - 150, y, width, height); 
+    } 
+    public Insets getBorderInsets(Component c) {return new Insets(0, 0, 0, 150);}
+    public boolean isBorderOpaque() {return true;}
+  } 
+
+} 

--- a/test/jdk/java/awt/Scrollbar/AquaLFScrollbarTest/ScrollBarBorderTest.java
+++ b/test/jdk/java/awt/Scrollbar/AquaLFScrollbarTest/ScrollBarBorderTest.java
@@ -27,14 +27,14 @@ import java.awt.event.ActionListener;
  */
 public class ScrollBarBorderTest implements ActionListener {
 
-  // On macOS 10.12.6 using the Mac look and feel (com.apple.laf.AquaLookAndFeel) 
-  // the scroll bar ignores the custom border and allows the scroll thumb to move 
-  // beneath the border. Run with: 
-  // java ScrollBarBorderTest 
+  // On macOS 10.12.6 using the Mac look and feel (com.apple.laf.AquaLookAndFeel)
+  // the scroll bar ignores the custom border and allows the scroll thumb to move
+  // beneath the border. Run with:
+  // java ScrollBarBorderTest
 
-  // If run using any other look and feel (e.g. Metal) then the right side of 
-  // the scroll bar stops at the border as expected. Run with: 
-  // java -Dswing.defaultlaf=javax.swing.plaf.metal.MetalLookAndFeel ScrollBarBorderTest 
+  // If run using any other look and feel (e.g. Metal) then the right side of
+  // the scroll bar stops at the border as expected. Run with:
+  // java -Dswing.defaultlaf=javax.swing.plaf.metal.MetalLookAndFeel ScrollBarBorderTest
 
   // Java version: 1.8.0_151
 

--- a/test/jdk/java/awt/Scrollbar/AquaLFScrollbarTest/ScrollBarBorderTest.java
+++ b/test/jdk/java/awt/Scrollbar/AquaLFScrollbarTest/ScrollBarBorderTest.java
@@ -27,163 +27,168 @@ import java.awt.event.ActionListener;
  */
 public class ScrollBarBorderTest implements ActionListener {
 
-  // On macOS 10.12.6 using the Mac look and feel (com.apple.laf.AquaLookAndFeel)
-  // the scroll bar ignores the custom border and allows the scroll thumb to move
-  // beneath the border. Run with:
-  // java ScrollBarBorderTest
+    // On macOS 10.12.6 using the Mac look and feel (com.apple.laf.AquaLookAndFeel)
+    // the scroll bar ignores the custom border and allows the scroll thumb to move
+    // beneath the border. Run with:
+    // java ScrollBarBorderTest
 
-  // If run using any other look and feel (e.g. Metal) then the right side of
-  // the scroll bar stops at the border as expected. Run with:
-  // java -Dswing.defaultlaf=javax.swing.plaf.metal.MetalLookAndFeel ScrollBarBorderTest
+    // If run using any other look and feel (e.g. Metal) then the right side of
+    // the scroll bar stops at the border as expected. Run with:
+    // java -Dswing.defaultlaf=javax.swing.plaf.metal.MetalLookAndFeel ScrollBarBorderTest
 
-  // Java version: 1.8.0_151
+    // Java version: 1.8.0_151
 
-  private static JScrollBar scrollBar;
-  private static JPanel panel;
-  private static JFrame frame;
-  private static Frame instructionFrame;
-  private static GridBagLayout layout;
-  private static Panel mainControlPanel;
-  private static Panel resultButtonPanel;
-  private static TextArea instructionTextArea;
-  private static Button passButton;
-  private static Button failButton;
-  private static Thread mainThread = null;
-  private static boolean testPassed = false;
-  private static boolean isInterrupted = false;
-  private static final int testTimeOut = 300000;
-  private static String testFailMessage = "testfail";
+    private static JScrollBar scrollBar;
+    private static JPanel panel;
+    private static JFrame frame;
+    private static Frame instructionFrame;
+    private static GridBagLayout layout;
+    private static Panel mainControlPanel;
+    private static Panel resultButtonPanel;
+    private static TextArea instructionTextArea;
+    private static Button passButton;
+    private static Button failButton;
+    private static Thread mainThread = null;
+    private static boolean testPassed = false;
+    private static boolean isInterrupted = false;
+    private static final int testTimeOut = 300000;
+    private static String testFailMessage = "testfail";
 
 
-  public void createAndShowGUI() {
-    // create scroll bar
-    scrollBar = new JScrollBar(Scrollbar.HORIZONTAL);
-    scrollBar.setBorder(new CustomBorder());
-    // create panel
-    panel = new JPanel();
-    panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
-    panel.setBorder(new EmptyBorder(20, 20, 20, 20));
-    panel.add(new JLabel(UIManager.getLookAndFeel().toString()));
-    panel.add(Box.createVerticalStrut(20));
-    panel.add(scrollBar);
-    // create frame
-    frame = new JFrame("ScrollBarBorderTest");
-    frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-    frame.getContentPane().add(panel);
-    frame.pack();
-    frame.setVisible(true);
-  }
-
-  private void createInstructionUI() {
-    instructionFrame = new Frame("Scrollbar");
-    layout = new GridBagLayout();
-    mainControlPanel = new Panel(layout);
-    resultButtonPanel = new Panel(layout);
-
-    GridBagConstraints gbc = new GridBagConstraints();
-    String instructions
-            = "\nINSTRUCTIONS:\n"
-            + "\n   Try to drag the thumb of the scrollbar into the red zone."
-            + "\n   If the thumb is able to go into the red zone, click fail."
-            + "\n   Otherwise, pass.";
-
-    instructionTextArea = new TextArea(7, 70);
-    instructionTextArea.setText(instructions);
-    instructionTextArea.setEnabled(false);
-    instructionTextArea.setBackground(Color.white);
-
-    gbc.gridx = 0;
-    gbc.gridy = 0;
-    gbc.weightx = 0.5;
-    gbc.fill = GridBagConstraints.HORIZONTAL;
-    mainControlPanel.add(instructionTextArea, gbc);
-
-    passButton = new Button("Pass");
-    passButton.setName("Pass");
-    passButton.addActionListener((ActionListener) this);
-
-    failButton = new Button("Fail");
-    failButton.setName("Fail");
-    failButton.addActionListener((ActionListener) this);
-
-    setButtonEnable(true);
-
-    gbc.gridx = 0;
-    gbc.gridy = 0;
-    resultButtonPanel.add(passButton, gbc);
-    gbc.gridx = 1;
-    gbc.gridy = 0;
-    resultButtonPanel.add(failButton, gbc);
-    gbc.gridx = 0;
-    gbc.gridy = 1;
-    mainControlPanel.add(resultButtonPanel, gbc);
-
-    instructionFrame.add(mainControlPanel);
-    instructionFrame.pack();
-    instructionFrame.setVisible(true);
-  }
-
-  @Override
-  public void actionPerformed(ActionEvent ae) {
-    if (ae.getSource() instanceof Button) {
-      Button btn = (Button) ae.getSource();
-      switch (btn.getName()) {
-        case "Pass":
-          testPassed = true;
-          isInterrupted = true;
-          mainThread.interrupt();
-          break;
-        case "Fail":
-          testPassed = false;
-          isInterrupted = true;
-          mainThread.interrupt();
-          break;
-      }
-    }
-  }
-
-  private static void setButtonEnable(boolean status) {
-    passButton.setEnabled(status);
-    failButton.setEnabled(status);
-  }
-
-  private static void cleanUp() {
-    frame.dispose();
-    instructionFrame.dispose();
-  }
-
-  public static void main(String[] args) {
-    ScrollBarBorderTest borderTest = new ScrollBarBorderTest();
-    borderTest.createInstructionUI();
-    borderTest.createAndShowGUI();
-
-    mainThread = Thread.currentThread();
-    try {
-      mainThread.sleep(testTimeOut);
-    } catch (InterruptedException ex) {
-      if (!testPassed) {
-        throw new RuntimeException(testFailMessage);
-      }
-    } finally {
-      cleanUp();
+    public void createAndShowGUI() {
+        // create scroll bar
+        scrollBar = new JScrollBar(Scrollbar.HORIZONTAL);
+        scrollBar.setBorder(new CustomBorder());
+        // create panel
+        panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        panel.setBorder(new EmptyBorder(20, 20, 20, 20));
+        panel.add(new JLabel(UIManager.getLookAndFeel().toString()));
+        panel.add(Box.createVerticalStrut(20));
+        panel.add(scrollBar);
+        // create frame
+        frame = new JFrame("ScrollBarBorderTest");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.getContentPane().add(panel);
+        frame.pack();
+        frame.setVisible(true);
     }
 
-    if (!isInterrupted) {
-      throw new RuntimeException("Test Timed out after "
-              + testTimeOut / 1000 + " seconds");
+    private void createInstructionUI() {
+        instructionFrame = new Frame("Scrollbar");
+        layout = new GridBagLayout();
+        mainControlPanel = new Panel(layout);
+        resultButtonPanel = new Panel(layout);
+
+        GridBagConstraints gbc = new GridBagConstraints();
+        String instructions
+                = "\nINSTRUCTIONS:\n"
+                + "\n   Try to drag the thumb of the scrollbar into the red zone."
+                + "\n   If the thumb is able to go into the red zone, click fail."
+                + "\n   Otherwise, pass.";
+
+        instructionTextArea = new TextArea(7, 70);
+        instructionTextArea.setText(instructions);
+        instructionTextArea.setEnabled(false);
+        instructionTextArea.setBackground(Color.white);
+
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.weightx = 0.5;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        mainControlPanel.add(instructionTextArea, gbc);
+
+        passButton = new Button("Pass");
+        passButton.setName("Pass");
+        passButton.addActionListener((ActionListener) this);
+
+        failButton = new Button("Fail");
+        failButton.setName("Fail");
+        failButton.addActionListener((ActionListener) this);
+
+        setButtonEnable(true);
+
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        resultButtonPanel.add(passButton, gbc);
+        gbc.gridx = 1;
+        gbc.gridy = 0;
+        resultButtonPanel.add(failButton, gbc);
+        gbc.gridx = 0;
+        gbc.gridy = 1;
+        mainControlPanel.add(resultButtonPanel, gbc);
+
+        instructionFrame.add(mainControlPanel);
+        instructionFrame.pack();
+        instructionFrame.setVisible(true);
     }
-  }
+
+    @Override
+    public void actionPerformed(ActionEvent ae) {
+        if (ae.getSource() instanceof Button) {
+            Button btn = (Button) ae.getSource();
+            switch (btn.getName()) {
+                case "Pass":
+                    testPassed = true;
+                    isInterrupted = true;
+                    mainThread.interrupt();
+                    break;
+                case "Fail":
+                    testPassed = false;
+                    isInterrupted = true;
+                    mainThread.interrupt();
+                    break;
+            }
+        }
+    }
+
+    private static void setButtonEnable(boolean status) {
+        passButton.setEnabled(status);
+        failButton.setEnabled(status);
+    }
+
+    private static void cleanUp() {
+        frame.dispose();
+        instructionFrame.dispose();
+    }
+
+    public static void main(String[] args) {
+        ScrollBarBorderTest borderTest = new ScrollBarBorderTest();
+        borderTest.createInstructionUI();
+        borderTest.createAndShowGUI();
+
+        mainThread = Thread.currentThread();
+        try {
+            mainThread.sleep(testTimeOut);
+        } catch (InterruptedException ex) {
+            if (!testPassed) {
+                throw new RuntimeException(testFailMessage);
+            }
+        } finally {
+            cleanUp();
+        }
+
+        if (!isInterrupted) {
+            throw new RuntimeException("Test Timed out after "
+                    + testTimeOut / 1000 + " seconds");
+        }
+    }
 
 
+    // custom border
+    private static class CustomBorder implements Border {
+        public void paintBorder(Component c, Graphics g, int x, int y, int width, int height) {
+            g.setColor(new Color(255, 0, 0, 100));
+            g.fillRect(width - 150, y, width, height);
+        }
 
-  // custom border 
-  private static class CustomBorder implements Border {
-    public void paintBorder(Component c, Graphics g, int x, int y, int width, int height) {
-      g.setColor(new Color(255, 0, 0, 100)); 
-      g.fillRect(width - 150, y, width, height); 
-    } 
-    public Insets getBorderInsets(Component c) {return new Insets(0, 0, 0, 150);}
-    public boolean isBorderOpaque() {return true;}
-  } 
+        public Insets getBorderInsets(Component c) {
+            return new Insets(0, 0, 0, 150);
+        }
+
+        public boolean isBorderOpaque() {
+            return true;
+        }
+    }
 
 } 


### PR DESCRIPTION
Adjusted the AquaLF scrollbar to account for border inset settings when dragging the thumb and clicking on the track.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8190264](https://bugs.openjdk.java.net/browse/JDK-8190264): JScrollBar ignores its border when using macOS Mac OS X Aqua look and feel


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6341/head:pull/6341` \
`$ git checkout pull/6341`

Update a local copy of the PR: \
`$ git checkout pull/6341` \
`$ git pull https://git.openjdk.java.net/jdk pull/6341/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6341`

View PR using the GUI difftool: \
`$ git pr show -t 6341`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6341.diff">https://git.openjdk.java.net/jdk/pull/6341.diff</a>

</details>
