### PR TITLE
8276905: Use appropriate macosx_version_minimum value while compiling metal shaders

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -839,9 +839,10 @@ endif
 # pipeline only on Macosx >=10.14. For Macosx versions <10.14 even if
 # we enable Metal pipeline using -Dsun.java2d.metal=true, at
 # runtime we force it to use OpenGL pipeline. And MACOSX_VERSION_MIN
-# for aarch64 is 11.00.00 at the time of introducing MACOSX_METAL_VERSION_MIN.
+# for aarch64 has always been >10.14 so we use continue to use
+# MACOSX_VERSION_MIN for aarch64.
 ifeq ($(OPENJDK_TARGET_CPU_ARCH), xaarch64)
-    MACOSX_METAL_VERSION_MIN=11.00.00
+    MACOSX_METAL_VERSION_MIN=$(MACOSX_VERSION_MIN)
 else
     MACOSX_METAL_VERSION_MIN=10.14.0
 endif

--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -845,7 +845,7 @@ ifeq ($(call isTargetOs, macosx), true)
       DEPS := $(SHADERS_SRC), \
       OUTPUT_FILE := $(SHADERS_AIR), \
       SUPPORT_DIR := $(SHADERS_SUPPORT_DIR), \
-      COMMAND := $(METAL) -c -std=osx-metal2.0 -o $(SHADERS_AIR) $(SHADERS_SRC), \
+      COMMAND := $(METAL) -c -std=osx-metal2.0 -mmacosx-version-min=10.12.00 -o $(SHADERS_AIR) $(SHADERS_SRC), \
   ))
 
   $(eval $(call SetupExecute, metallib_shaders, \

--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -845,7 +845,9 @@ ifeq ($(call isTargetOs, macosx), true)
       DEPS := $(SHADERS_SRC), \
       OUTPUT_FILE := $(SHADERS_AIR), \
       SUPPORT_DIR := $(SHADERS_SUPPORT_DIR), \
-      COMMAND := $(METAL) -c -std=osx-metal2.0 -mmacosx-version-min=10.12.00 -o $(SHADERS_AIR) $(SHADERS_SRC), \
+      COMMAND := $(METAL) -c -std=osx-metal2.0 \
+          -mmacosx-version-min=$(MACOSX_VERSION_MIN) \
+          -o $(SHADERS_AIR) $(SHADERS_SRC), \
   ))
 
   $(eval $(call SetupExecute, metallib_shaders, \

--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -834,6 +834,18 @@ endif
 
 ################################################################################
 
+# MACOSX_METAL_VERSION_MIN specifies the lowest version of Macosx
+# that should be used to compile Metal shaders. We support Metal
+# pipeline only on Macosx >=10.14. For Macosx versions <10.14 even if
+# we enable Metal pipeline using -Dsun.java2d.metal=true, at
+# runtime we force it to use OpenGL pipeline. And MACOSX_VERSION_MIN
+# for aarch64 is 11.00.00 at the time of introducing MACOSX_METAL_VERSION_MIN.
+ifeq ($(OPENJDK_TARGET_CPU_ARCH), xaarch64)
+    MACOSX_METAL_VERSION_MIN=11.00.00
+else
+    MACOSX_METAL_VERSION_MIN=10.14.0
+endif
+
 ifeq ($(call isTargetOs, macosx), true)
   SHADERS_SRC := $(TOPDIR)/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/shaders.metal
   SHADERS_SUPPORT_DIR := $(SUPPORT_OUTPUTDIR)/native/java.desktop/libosxui
@@ -846,7 +858,7 @@ ifeq ($(call isTargetOs, macosx), true)
       OUTPUT_FILE := $(SHADERS_AIR), \
       SUPPORT_DIR := $(SHADERS_SUPPORT_DIR), \
       COMMAND := $(METAL) -c -std=osx-metal2.0 \
-          -mmacosx-version-min=$(MACOSX_VERSION_MIN) \
+          -mmacosx-version-min=$(MACOSX_METAL_VERSION_MIN) \
           -o $(SHADERS_AIR) $(SHADERS_SRC), \
   ))
 


### PR DESCRIPTION
When JDK is built on BigSur with Xcode12.5 and used to run jtreg tests in macOS10.15 with Xcode <=12.4 we are getting compilation error. We dont set any deployment target when when we use xcrun to create .air file and this issue looks similar to https://developer.apple.com/forums/thread/105719. Also https://developer.apple.com/forums/thread/105719 states that even if they set app deployment target they need to explicitly set deployment in "xcrun metal".

Made same change to use -mmacosx-version-min=10.12.00 in our make file. Whether we should keep 10.12.00 or 10.13/14 is open to discussion for metal pipeline.

SwingSet2, J2DDemo & JCK/jtreg runs in CI are green. Also Vitaly(Submitter) has confirmed that patch resolves the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276905](https://bugs.openjdk.java.net/browse/JDK-8276905): Use appropriate macosx_version_minimum value while compiling metal shaders


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Author)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6346/head:pull/6346` \
`$ git checkout pull/6346`

Update a local copy of the PR: \
`$ git checkout pull/6346` \
`$ git pull https://git.openjdk.java.net/jdk pull/6346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6346`

View PR using the GUI difftool: \
`$ git pr show -t 6346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6346.diff">https://git.openjdk.java.net/jdk/pull/6346.diff</a>

</details>
