### PR TITLE
JDK-8276983: Small fixes to DumpAllocStat::print_stats

### DIFF
--- a/src/hotspot/share/cds/dumpAllocStats.cpp
+++ b/src/hotspot/share/cds/dumpAllocStats.cpp
@@ -42,14 +42,6 @@ void DumpAllocStats::print_stats(int ro_all, int rw_all) {
   _counts[RO][StringBucketType] = _string_stats.bucket_count;
   _bytes [RO][StringBucketType] = _string_stats.bucket_bytes;
 
-  // prevent divide-by-zero
-  if (ro_all < 1) {
-    ro_all = 1;
-  }
-  if (rw_all < 1) {
-    rw_all = 1;
-  }
-
   int all_ro_count = 0;
   int all_ro_bytes = 0;
   int all_rw_count = 0;
@@ -102,8 +94,11 @@ void DumpAllocStats::print_stats(int ro_all, int rw_all) {
                        all_rw_count, all_rw_bytes, all_rw_perc,
                        all_count, all_bytes, all_perc);
 
-  assert(all_ro_bytes == ro_all, "everything should have been counted");
-  assert(all_rw_bytes == rw_all, "everything should have been counted");
+  msg.flush();
+
+  assert(all_ro_bytes == ro_all && all_rw_bytes == rw_all,
+         "everything should have been counted (used/counted: ro %d/%d, rw %d/%d",
+         ro_all, all_ro_bytes, rw_all, all_rw_bytes);
 
 #undef fmt_stats
 }


### PR DESCRIPTION
When looking at CDS code in the context of Lilliput, I had to spend some time in DumpAllocStat::print(). I noticed two small things which can be fixed independently:

- the divide-by-zero check at lines 45ff is not needed, since `percent_of` does this already. It also can cause the asserts at the end of the function to fire wrongly.

- About those asserts: it makes sense to flush the debug message before scope end, otherwise, we won't see the debug message if the asserts fire. If they fire, the debug message would be helpful.

I also improved the assert message somewhat. I noticed that all sizes in this method are `int`, but left it that way because changing it would have too many ripple effects. I guess we won't get CDS archives beyond int_max any time soon.

Thanks, Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276983](https://bugs.openjdk.java.net/browse/JDK-8276983): Small fixes to DumpAllocStat::print_stats


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6347/head:pull/6347` \
`$ git checkout pull/6347`

Update a local copy of the PR: \
`$ git checkout pull/6347` \
`$ git pull https://git.openjdk.java.net/jdk pull/6347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6347`

View PR using the GUI difftool: \
`$ git pr show -t 6347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6347.diff">https://git.openjdk.java.net/jdk/pull/6347.diff</a>

</details>
