### PR TITLE
8276559: (httpclient) Consider adding an HttpRequest.Builder.HEAD method to build a HEAD request.

### DIFF
--- a/src/java.net.http/share/classes/java/net/http/HttpRequest.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -257,6 +257,19 @@ public abstract class HttpRequest {
         public Builder DELETE();
 
         /**
+         * Sets the request method of this builder to HEAD.
+         *
+         * @implSpec The default implementation is expected to have the same behaviour as:
+         * {@code return method("HEAD", BodyPublishers.noBody());}
+         *
+         * @return this builder
+         * @since 18
+         */
+        default Builder HEAD() {
+            return method("HEAD", BodyPublishers.noBody());
+        }
+
+        /**
          * Sets the request method and request body of this builder to the
          * given values.
          *
@@ -366,6 +379,7 @@ public abstract class HttpRequest {
                     switch (method) {
                         case "GET" -> builder.GET();
                         case "DELETE" -> builder.DELETE();
+                        case "HEAD" -> builder.HEAD();
                         default -> builder.method(method, HttpRequest.BodyPublishers.noBody());
                     }
                 }

--- a/src/java.net.http/share/classes/java/net/http/HttpRequest.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpRequest.java
@@ -373,7 +373,7 @@ public abstract class HttpRequest {
         request.bodyPublisher().ifPresentOrElse(
                 // if body is present, set it
                 bodyPublisher -> builder.method(method, bodyPublisher),
-                // otherwise, the body is absent, special case for GET/DELETE,
+                // otherwise, the body is absent, special case for GET/DELETE/HEAD,
                 // or else use empty body
                 () -> {
                     switch (method) {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpRequestBuilderImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpRequestBuilderImpl.java
@@ -183,6 +183,11 @@ public class HttpRequestBuilderImpl implements HttpRequest.Builder {
     }
 
     @Override
+    public HttpRequest.Builder HEAD() {
+        return method0("HEAD", null);
+    }
+
+    @Override
     public HttpRequest.Builder PUT(BodyPublisher body) {
         return method0("PUT", requireNonNull(body));
     }

--- a/test/jdk/java/net/httpclient/HeadTest.java
+++ b/test/jdk/java/net/httpclient/HeadTest.java
@@ -48,43 +48,20 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import javax.net.ServerSocketFactory;
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.io.Writer;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.ServerSocket;
-import java.net.Socket;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpClient.Redirect;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.StringTokenizer;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.lang.System.out;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.net.HttpURLConnection.HTTP_OK;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 public class HeadTest implements HttpServerAdapters {
 
@@ -98,8 +75,6 @@ public class HeadTest implements HttpServerAdapters {
     String http2URI;
     String https2URI;
 
-    static final String MESSAGE = "Basic HeadTest message body";
-    static final int ITERATIONS = 3;
     static final String CONTENT_LEN = "300";
 
     /*
@@ -132,8 +107,6 @@ public class HeadTest implements HttpServerAdapters {
                 { httpsURI + "transfer/", "HEAD", HTTP_OK, HttpClient.Version.HTTP_2  }
         };
     }
-
-    static final AtomicLong requestCounter = new AtomicLong();
 
     @Test(dataProvider = "positive")
     void test(String uriString, String method,

--- a/test/jdk/java/net/httpclient/HttpRequestBuilderTest.java
+++ b/test/jdk/java/net/httpclient/HttpRequestBuilderTest.java
@@ -36,7 +36,7 @@ import static java.net.http.HttpRequest.BodyPublishers.noBody;
 
 /**
  * @test
- * @bug 8170064
+ * @bug 8170064 8276559
  * @summary  HttpRequest[.Builder] API and behaviour checks
  */
 public class HttpRequestBuilderTest {

--- a/test/jdk/java/net/httpclient/HttpRequestBuilderTest.java
+++ b/test/jdk/java/net/httpclient/HttpRequestBuilderTest.java
@@ -156,6 +156,7 @@ public class HttpRequestBuilderTest {
                         IllegalArgumentException.class);
 
         test0("DELETE", () -> HttpRequest.newBuilder(TEST_URI).DELETE().build(), null);
+        test0("HEAD", () -> HttpRequest.newBuilder(TEST_URI).HEAD().build(), null);
 
         builder = test1("POST", builder, builder::POST,
                         noBody(), null);
@@ -254,7 +255,9 @@ public class HttpRequestBuilderTest {
                () -> HttpRequest.newBuilder(TEST_URI).GET().DELETE(),
                "DELETE");
 
-
+        method("newBuilder(TEST_URI).HEAD().build().method() == HEAD",
+                () -> HttpRequest.newBuilder(TEST_URI).HEAD(),
+                "HEAD");
 
     }
 

--- a/test/jdk/java/net/httpclient/HttpRequestNewBuilderTest.java
+++ b/test/jdk/java/net/httpclient/HttpRequestNewBuilderTest.java
@@ -120,8 +120,8 @@ public class HttpRequestNewBuilderTest {
                         .headers("testName1", "y")
                         .headers("testName1", "z").build() },
                 // dedicated method
+                { HttpRequest.newBuilder(URI.create("https://method-0/")).HEAD().build() },
                 { HttpRequest.newBuilder(URI.create("https://method-1/")).GET().build() },
-                { HttpRequest.newBuilder(URI.create("https://method-1/")).HEAD().build() },
                 { HttpRequest.newBuilder(URI.create("https://method-2/")).DELETE().build() },
                 { HttpRequest.newBuilder(URI.create("https://method-3/")).POST(HttpRequest.BodyPublishers.ofString("testData")).build() },
                 { HttpRequest.newBuilder(URI.create("https://method-4/")).PUT(HttpRequest.BodyPublishers.ofString("testData")).build() },

--- a/test/jdk/java/net/httpclient/HttpRequestNewBuilderTest.java
+++ b/test/jdk/java/net/httpclient/HttpRequestNewBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -121,6 +121,7 @@ public class HttpRequestNewBuilderTest {
                         .headers("testName1", "z").build() },
                 // dedicated method
                 { HttpRequest.newBuilder(URI.create("https://method-1/")).GET().build() },
+                { HttpRequest.newBuilder(URI.create("https://method-1/")).HEAD().build() },
                 { HttpRequest.newBuilder(URI.create("https://method-2/")).DELETE().build() },
                 { HttpRequest.newBuilder(URI.create("https://method-3/")).POST(HttpRequest.BodyPublishers.ofString("testData")).build() },
                 { HttpRequest.newBuilder(URI.create("https://method-4/")).PUT(HttpRequest.BodyPublishers.ofString("testData")).build() },

--- a/test/jdk/java/net/httpclient/HttpRequestNewBuilderTest.java
+++ b/test/jdk/java/net/httpclient/HttpRequestNewBuilderTest.java
@@ -51,7 +51,7 @@ import static org.testng.Assert.fail;
 
 /**
 * @test
-* @bug 8252304
+* @bug 8252304 8276559
 * @summary HttpRequest.newBuilder(HttpRequest) API and behaviour checks
 * @run testng/othervm HttpRequestNewBuilderTest
 */

--- a/test/jdk/java/net/httpclient/RequestBuilderTest.java
+++ b/test/jdk/java/net/httpclient/RequestBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -159,6 +159,10 @@ public class RequestBuilderTest {
         request = newBuilder(uri).DELETE().build();
         assertEquals(request.method(), "DELETE");
         assertTrue(!request.bodyPublisher().isPresent());
+
+        request = newBuilder(uri).HEAD().build();
+        assertEquals(request.method(), "HEAD");
+        assertFalse(request.bodyPublisher().isPresent());
 
         request = newBuilder(uri).GET().POST(BodyPublishers.ofString("")).build();
         assertEquals(request.method(), "POST");

--- a/test/jdk/java/net/httpclient/RequestBuilderTest.java
+++ b/test/jdk/java/net/httpclient/RequestBuilderTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8276559
  * @summary HttpRequest[.Builder] API and behaviour checks
  * @run testng RequestBuilderTest
  */


### PR DESCRIPTION
Can I please get a review for this change which  implements the enhancement noted in https://bugs.openjdk.java.net/browse/JDK-8276559?

The commit in this PR introduces a new `HEAD()` method on the `HttpRequest.Builder` interface. Given that this is a public interface on a public class of a public module, I decided to add this new method as a `default` method to prevent any potential breakages of any non-JDK implementations of this interface. The internal `jdk.internal.net.http.HttpRequestBuilderImpl` which implements this interface, overrides this default implementation to use an implementation of its own.

Existing tests have been updated to include coverage for this new method.

P.S: Slightly unrelated question - is it intentional that the `Builder` interface specifies the visibility modifiers on the interface methods. For example:  `public abstract Builder timeout(Duration duration);`, `public Builder headers(String... headers);` and so on?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276559](https://bugs.openjdk.java.net/browse/JDK-8276559): (httpclient) Consider adding an HttpRequest.Builder.HEAD method to build a HEAD request.


### Reviewers
 * [Christian Stein](https://openjdk.java.net/census#cstein) (@sormuras - Author) ⚠️ Review applies to 4ac690242996027a1a990563cd3efae470edffc0
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6348/head:pull/6348` \
`$ git checkout pull/6348`

Update a local copy of the PR: \
`$ git checkout pull/6348` \
`$ git pull https://git.openjdk.java.net/jdk pull/6348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6348`

View PR using the GUI difftool: \
`$ git pr show -t 6348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6348.diff">https://git.openjdk.java.net/jdk/pull/6348.diff</a>

</details>
