### PR TITLE
8276836: Error in javac caused by switch expression without result expressions: Internal error: stack sim error

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -2215,6 +2215,10 @@ public class Gen extends JCTree.Visitor {
                     opcode = opcode & 0xFF;
                 }
             }
+            // Pop the left operand if rhs is switch expression and the code generation is not enabled.
+            if (rhs.hasTag(SWITCH_EXPRESSION) && !code.isAlive()) {
+                code.state.pop(lhs.type);
+            }
             if (opcode >= ifeq && opcode <= if_acmpne ||
                 opcode == if_acmp_null || opcode == if_acmp_nonnull) {
                 return items.makeCondItem(opcode);

--- a/test/langtools/tools/javac/switchexpr/SwitchExpressionWithoutResult.java
+++ b/test/langtools/tools/javac/switchexpr/SwitchExpressionWithoutResult.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8276836
+ * @summary the switch expression without result causes Internal error: stack sim error.
+ * @compile SwitchExpressionWithoutResult.java
+ */
+
+public class SwitchExpressionWithoutResult {
+    private int testSwitchExpressionInPlusOp(int p) {
+        return 4 + switch (p) {
+            case 1 -> throw new RuntimeException("1");
+            case 2 -> throw new RuntimeException("2");
+            case 3 -> throw new RuntimeException("3");
+            default -> {
+                if (true) throw new RuntimeException();
+                else yield 0;
+            }
+        };
+    }
+
+    private int testSwitchExpressionInMultiOp(int p) {
+        return 4 * switch (p) {
+            case 1 -> throw new RuntimeException("1");
+            case 2 -> throw new RuntimeException("2");
+            case 3 -> throw new RuntimeException("3");
+            default -> {
+                if (true) throw new RuntimeException();
+                else yield 0;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Hi all,

The method `Gen#visitSwitchExpression` will switch code generation off by using the method `Code#markDead` when it meets the code like `throw new RuntimeException()`. Then the method `Gen#completeBinop` won't generate the expected code and wiil let the left operand stay in the stack without handling it.

This patch pops the left operand from the stack to solve this issue. And the corresponding test is added.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8276836](https://bugs.openjdk.java.net/browse/JDK-8276836): Error in javac caused by switch expression without result expressions: Internal error: stack sim error


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6350/head:pull/6350` \
`$ git checkout pull/6350`

Update a local copy of the PR: \
`$ git checkout pull/6350` \
`$ git pull https://git.openjdk.java.net/jdk pull/6350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6350`

View PR using the GUI difftool: \
`$ git pr show -t 6350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6350.diff">https://git.openjdk.java.net/jdk/pull/6350.diff</a>

</details>
