### PR TITLE
8276763: java/nio/channels/SocketChannel/AdaptorStreams.java fails with "SocketTimeoutException: Read timed out"

### DIFF
--- a/test/jdk/java/nio/channels/SocketChannel/AdaptorStreams.java
+++ b/test/jdk/java/nio/channels/SocketChannel/AdaptorStreams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -158,7 +158,7 @@ public class AdaptorStreams {
         withConnection((sc, peer) -> {
             peer.getOutputStream().write(99);
             Socket s = sc.socket();
-            s.setSoTimeout(1000);
+            s.setSoTimeout(60_000);
             int n = s.getInputStream().read();
             assertEquals(n, 99);
         });
@@ -171,7 +171,7 @@ public class AdaptorStreams {
         withConnection((sc, peer) -> {
             scheduleWrite(peer.getOutputStream(), 99, 1000);
             Socket s = sc.socket();
-            s.setSoTimeout(5000);
+            s.setSoTimeout(60_000);
             int n = s.getInputStream().read();
             assertEquals(n, 99);
         });
@@ -183,7 +183,7 @@ public class AdaptorStreams {
     public void testTimedRead3() throws Exception {
         withConnection((sc, peer) -> {
             Socket s = sc.socket();
-            s.setSoTimeout(1000);
+            s.setSoTimeout(500);
             InputStream in = s.getInputStream();
             expectThrows(SocketTimeoutException.class, () -> in.read());
         });
@@ -196,7 +196,7 @@ public class AdaptorStreams {
         withConnection((sc, peer) -> {
             scheduleClose(sc, 2000);
             Socket s = sc.socket();
-            s.setSoTimeout(60*1000);
+            s.setSoTimeout(60_000);
             InputStream in = s.getInputStream();
             expectThrows(IOException.class, () -> in.read());
         });
@@ -210,7 +210,7 @@ public class AdaptorStreams {
             Socket s = sc.socket();
             Thread.currentThread().interrupt();
             try {
-                s.setSoTimeout(60*1000);
+                s.setSoTimeout(60_000);
                 InputStream in = s.getInputStream();
                 expectThrows(IOException.class, () -> in.read());
             } finally {
@@ -228,7 +228,7 @@ public class AdaptorStreams {
             Future<?> interrupter = scheduleInterrupt(Thread.currentThread(), 2000);
             Socket s = sc.socket();
             try {
-                s.setSoTimeout(60*1000);
+                s.setSoTimeout(60_000);
                 InputStream in = s.getInputStream();
                 expectThrows(IOException.class, () -> in.read());
                 assertTrue(s.isClosed());
@@ -396,7 +396,7 @@ public class AdaptorStreams {
 
             // test read when bytes are available
             peer.getOutputStream().write(99);
-            s.setSoTimeout(60*1000);
+            s.setSoTimeout(60_000);
             int n = s.getInputStream().read();
             assertEquals(n, 99);
         });
@@ -421,7 +421,7 @@ public class AdaptorStreams {
 
             // test read blocking until bytes are available
             scheduleWrite(peer.getOutputStream(), 99, 500);
-            s.setSoTimeout(60*1000);
+            s.setSoTimeout(60_000);
             int n = s.getInputStream().read();
             assertEquals(n, 99);
         });
@@ -436,7 +436,7 @@ public class AdaptorStreams {
 
             // block thread in read
             execute(() -> {
-                s.setSoTimeout(60*1000);
+                s.setSoTimeout(60_000);
                 s.getInputStream().read();
             });
             Thread.sleep(100); // give reader time to block


### PR DESCRIPTION
test/jdk/java/nio/channels/SocketChannel/AdaptorStreams.java tests SocketChannel's socket adaptor. Two of tests, testTimedRead1 and testTimedRead2 have relatively short timeouts which can cause the test to fail if the VM is paused or the machine is hung/overloaded for more than a few seconds. I've changed the timeout used by the two tests to 60s. This change does not impact the duration of the test because the reads do not timeout.

In passing, I've changed testTimedRead3 to use a timeout of 500ms, it is expected to throw SocketTimeoutException, and replaced setSoTimeout(60*1000) with setSoTimeout(60_000) in several other tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276763](https://bugs.openjdk.java.net/browse/JDK-8276763): java/nio/channels/SocketChannel/AdaptorStreams.java fails with "SocketTimeoutException: Read timed out"


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6351/head:pull/6351` \
`$ git checkout pull/6351`

Update a local copy of the PR: \
`$ git checkout pull/6351` \
`$ git pull https://git.openjdk.java.net/jdk pull/6351/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6351`

View PR using the GUI difftool: \
`$ git pr show -t 6351`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6351.diff">https://git.openjdk.java.net/jdk/pull/6351.diff</a>

</details>
