### PR TITLE
JDK-8277003 - JumpableGenerator.rngs() documentation refers to wrong method

### DIFF
--- a/src/java.base/share/classes/java/util/random/RandomGenerator.java
+++ b/src/java.base/share/classes/java/util/random/RandomGenerator.java
@@ -1196,7 +1196,7 @@ public interface RandomGenerator {
          *
          * @return a stream of objects that implement the {@link RandomGenerator} interface
          *
-         * @implSpec The default implementation calls {@link JumpableGenerator#jump jump}().
+         * @implSpec The default implementation calls {@link JumpableGenerator#jumps jumps}().
          */
         default Stream<RandomGenerator> rngs() {
             return this.jumps();


### PR DESCRIPTION
Documentation in `RandomGenerator.rngs()` refers to `JumpableGenerator.jump()` when it should be `JumpableGenerator.jumps()`