### PR TITLE
8277012: Use blessed modifier order in src/utils

### DIFF
--- a/src/utils/IdealGraphVisualizer/Bytecodes/src/main/java/com/sun/hotspot/igv/bytecodes/BytecodeViewTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/Bytecodes/src/main/java/com/sun/hotspot/igv/bytecodes/BytecodeViewTopComponent.java
@@ -188,7 +188,7 @@ final class BytecodeViewTopComponent extends TopComponent implements ExplorerMan
 
     }
 
-    final static class ResolvableHelper implements Serializable {
+    static final class ResolvableHelper implements Serializable {
 
         private static final long serialVersionUID = 1L;
 

--- a/src/utils/IdealGraphVisualizer/ControlFlow/src/main/java/com/sun/hotspot/igv/controlflow/ControlFlowTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/ControlFlow/src/main/java/com/sun/hotspot/igv/controlflow/ControlFlowTopComponent.java
@@ -165,7 +165,7 @@ final class ControlFlowTopComponent extends TopComponent implements LookupListen
         scene.getView().requestFocus();
     }
 
-    final static class ResolvableHelper implements Serializable {
+    static final class ResolvableHelper implements Serializable {
 
         private static final long serialVersionUID = 1L;
 

--- a/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/serialization/BinaryParser.java
+++ b/src/utils/IdealGraphVisualizer/Data/src/main/java/com/sun/hotspot/igv/data/serialization/BinaryParser.java
@@ -91,7 +91,7 @@ public class BinaryParser implements GraphParser {
         String toString(Length l);
     }
 
-    private static abstract class Member implements LengthToString {
+    private abstract static class Member implements LengthToString {
         public final Klass holder;
         public final int accessFlags;
         public final String name;

--- a/src/utils/IdealGraphVisualizer/FilterWindow/src/main/java/com/sun/hotspot/igv/filterwindow/FilterTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/FilterWindow/src/main/java/com/sun/hotspot/igv/filterwindow/FilterTopComponent.java
@@ -659,7 +659,7 @@ public final class FilterTopComponent extends TopComponent implements LookupList
         updateComboBox();
     }
 
-    final static class ResolvableHelper implements Serializable {
+    static final class ResolvableHelper implements Serializable {
 
         private static final long serialVersionUID = 1L;
 

--- a/src/utils/IdealGraphVisualizer/Settings/src/main/java/com/sun/hotspot/igv/settings/Settings.java
+++ b/src/utils/IdealGraphVisualizer/Settings/src/main/java/com/sun/hotspot/igv/settings/Settings.java
@@ -32,18 +32,18 @@ import java.util.prefs.Preferences;
  */
 public class Settings {
 
-    public final static String NODE_TEXT = "nodeText";
-    public final static String NODE_TEXT_DEFAULT = "[idx] [name]";
-    public final static String NODE_SHORT_TEXT = "nodeShortText";
-    public final static String NODE_SHORT_TEXT_DEFAULT = "[idx] [name]";
-    public final static String NODE_WIDTH = "nodeWidth";
-    public final static String NODE_WIDTH_DEFAULT = "100";
-    public final static String PORT = "port";
-    public final static String PORT_BINARY = "portBinary";
-    public final static String PORT_DEFAULT = "4444";
-    public final static String PORT_BINARY_DEFAULT = "4445";
-    public final static String DIRECTORY = "directory";
-    public final static String DIRECTORY_DEFAULT = System.getProperty("user.dir");
+    public static final String NODE_TEXT = "nodeText";
+    public static final String NODE_TEXT_DEFAULT = "[idx] [name]";
+    public static final String NODE_SHORT_TEXT = "nodeShortText";
+    public static final String NODE_SHORT_TEXT_DEFAULT = "[idx] [name]";
+    public static final String NODE_WIDTH = "nodeWidth";
+    public static final String NODE_WIDTH_DEFAULT = "100";
+    public static final String PORT = "port";
+    public static final String PORT_BINARY = "portBinary";
+    public static final String PORT_DEFAULT = "4444";
+    public static final String PORT_BINARY_DEFAULT = "4445";
+    public static final String DIRECTORY = "directory";
+    public static final String DIRECTORY_DEFAULT = System.getProperty("user.dir");
 
     public static Preferences get() {
         return Preferences.userNodeForPackage(Settings.class);

--- a/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/BasicLogEvent.java
+++ b/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/BasicLogEvent.java
@@ -90,5 +90,5 @@ public abstract class BasicLogEvent implements LogEvent {
         this.compilation = compilation;
     }
 
-    abstract public void print(PrintStream stream, boolean printID);
+    public abstract void print(PrintStream stream, boolean printID);
 }

--- a/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/LogCleanupReader.java
+++ b/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/LogCleanupReader.java
@@ -54,9 +54,9 @@ class LogCleanupReader extends Reader {
         reader = r;
     }
 
-    static final private Matcher duplicateCompileID = Pattern.compile(".+ compile_id='[0-9]+'.*( compile_id='[0-9]+)").matcher("");
-    static final private Matcher compilerName = Pattern.compile("' (C[12]) compile_id=").matcher("");
-    static final private Matcher destroyVM = Pattern.compile("'(destroy_vm)/").matcher("");
+    private static final Matcher duplicateCompileID = Pattern.compile(".+ compile_id='[0-9]+'.*( compile_id='[0-9]+)").matcher("");
+    private static final Matcher compilerName = Pattern.compile("' (C[12]) compile_id=").matcher("");
+    private static final Matcher destroyVM = Pattern.compile("'(destroy_vm)/").matcher("");
 
     /**
      * The log cleanup takes place in this method. If any of the three patterns

--- a/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/LogParser.java
+++ b/src/utils/LogCompilation/src/main/java/com/sun/hotspot/tools/compiler/LogParser.java
@@ -439,9 +439,9 @@ public class LogParser extends DefaultHandler implements ErrorHandler {
             this.method = method;
             this.bci = bci;
         }
-        final public Method method;
-        final public int bci;
-        final public String toString() {
+        public final Method method;
+        public final int bci;
+        public final String toString() {
             return "@" + bci + " " + method;
         }
     }

--- a/src/utils/src/build/tools/commentchecker/CommentChecker.java
+++ b/src/utils/src/build/tools/commentchecker/CommentChecker.java
@@ -57,7 +57,7 @@ public class CommentChecker {
     static int errors = 0;
 
     // Turn on this flag and recompile to dump this tool's state changes.
-    final static boolean verbose = false;
+    static final boolean verbose = false;
 
     static void check(String fileName) {
         BufferedReader in = null;

--- a/src/utils/src/build/tools/dirdiff/DirDiff.java
+++ b/src/utils/src/build/tools/dirdiff/DirDiff.java
@@ -29,7 +29,7 @@ import java.io.File;
 import java.util.TreeSet;
 
 public class DirDiff implements Runnable {
-    private final static String FILE_SEPARATOR = System.getProperty("file.separator");
+    private static final String FILE_SEPARATOR = System.getProperty("file.separator");
     private static final boolean traversSccsDirs;
     private static final boolean recurseExtraDirs;
     private static final boolean verboseMode;


### PR DESCRIPTION
I ran bin/blessed-modifier-order.sh on source code in src/utils. This scripts verifies that modifiers are in the "blessed" order, and fixes it otherwise. I have manually checked the changes made by the script to make sure they are sound.

There are no clear ownership of this code, but I believe it's kind of hotspot-related.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277012](https://bugs.openjdk.java.net/browse/JDK-8277012): Use blessed modifier order in src/utils


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6354/head:pull/6354` \
`$ git checkout pull/6354`

Update a local copy of the PR: \
`$ git checkout pull/6354` \
`$ git pull https://git.openjdk.java.net/jdk pull/6354/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6354`

View PR using the GUI difftool: \
`$ git pr show -t 6354`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6354.diff">https://git.openjdk.java.net/jdk/pull/6354.diff</a>

</details>
