### PR TITLE
8277015: Use blessed modifier order in Panama code

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/PlatformLayouts.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/PlatformLayouts.java
@@ -278,7 +278,7 @@ public class PlatformLayouts {
          * used to mark variadic parameters on systems such as macOS which pass these
          * entirely on the stack. The attribute value must be a boolean.
          */
-        public final static String STACK_VARARGS_ATTRIBUTE_NAME = "abi/aarch64/stack_varargs";
+        public static final String STACK_VARARGS_ATTRIBUTE_NAME = "abi/aarch64/stack_varargs";
 
         /**
          * Return a new memory layout which describes a variadic parameter to be

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
@@ -296,7 +296,7 @@ public abstract non-sealed class ResourceScopeImpl implements ResourceScope, Sco
             }
         }
 
-        public static abstract class ResourceCleanup {
+        public abstract static class ResourceCleanup {
             ResourceCleanup next;
 
             public abstract void cleanup();

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/SystemLookup.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/SystemLookup.java
@@ -45,7 +45,7 @@ public class SystemLookup implements SymbolLookup {
 
     private SystemLookup() { }
 
-    final static SystemLookup INSTANCE = new SystemLookup();
+    static final SystemLookup INSTANCE = new SystemLookup();
 
     /*
      * On POSIX systems, dlsym will allow us to lookup symbol in library dependencies; the same trick doesn't work

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -487,7 +487,7 @@ public abstract class Binding {
         }
     }
 
-    static abstract class Move extends Binding {
+    abstract static class Move extends Binding {
         private final VMStorage storage;
         private final Class<?> type;
 
@@ -593,7 +593,7 @@ public abstract class Binding {
         }
     }
 
-    private static abstract class Dereference extends Binding {
+    private abstract static class Dereference extends Binding {
         private final long offset;
         private final Class<?> type;
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -219,7 +219,7 @@ public class CallArranger {
         }
     }
 
-    static abstract class BindingCalculator {
+    abstract static class BindingCalculator {
         protected final StorageCalculator storageCalculator;
 
         protected BindingCalculator(boolean forArguments) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -239,7 +239,7 @@ public class CallArranger {
         }
     }
 
-    static abstract class BindingCalculator {
+    abstract static class BindingCalculator {
         protected final StorageCalculator storageCalculator;
 
         protected BindingCalculator(boolean forArguments) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -3905,8 +3905,8 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         // Virtual constructors
 
         @ForceInline
-        @Override final
-        public ByteVector fromArray(Object a, int offset) {
+        @Override public
+        final ByteVector fromArray(Object a, int offset) {
             // User entry point:  Be careful with inputs.
             return ByteVector
                 .fromArray(this, (byte[]) a, offset);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -3498,8 +3498,8 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         // Virtual constructors
 
         @ForceInline
-        @Override final
-        public DoubleVector fromArray(Object a, int offset) {
+        @Override public
+        final DoubleVector fromArray(Object a, int offset) {
             // User entry point:  Be careful with inputs.
             return DoubleVector
                 .fromArray(this, (double[]) a, offset);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -3485,8 +3485,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
         // Virtual constructors
 
         @ForceInline
-        @Override final
-        public FloatVector fromArray(Object a, int offset) {
+        @Override public
+        final FloatVector fromArray(Object a, int offset) {
             // User entry point:  Be careful with inputs.
             return FloatVector
                 .fromArray(this, (float[]) a, offset);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -3603,8 +3603,8 @@ public abstract class IntVector extends AbstractVector<Integer> {
         // Virtual constructors
 
         @ForceInline
-        @Override final
-        public IntVector fromArray(Object a, int offset) {
+        @Override public
+        final IntVector fromArray(Object a, int offset) {
             // User entry point:  Be careful with inputs.
             return IntVector
                 .fromArray(this, (int[]) a, offset);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -3497,8 +3497,8 @@ public abstract class LongVector extends AbstractVector<Long> {
         // Virtual constructors
 
         @ForceInline
-        @Override final
-        public LongVector fromArray(Object a, int offset) {
+        @Override public
+        final LongVector fromArray(Object a, int offset) {
             // User entry point:  Be careful with inputs.
             return LongVector
                 .fromArray(this, (long[]) a, offset);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -3900,8 +3900,8 @@ public abstract class ShortVector extends AbstractVector<Short> {
         // Virtual constructors
 
         @ForceInline
-        @Override final
-        public ShortVector fromArray(Object a, int offset) {
+        @Override public
+        final ShortVector fromArray(Object a, int offset) {
             // User entry point:  Be careful with inputs.
             return ShortVector
                 .fromArray(this, (short[]) a, offset);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorOperators.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorOperators.java
@@ -771,7 +771,7 @@ public abstract class VectorOperators {
                                     kind, dom, ran);
     }
 
-    private static abstract class OperatorImpl implements Operator {
+    private abstract static class OperatorImpl implements Operator {
         private final String symName;
         private final String opName;
         private final int opInfo;
@@ -1081,7 +1081,7 @@ public abstract class VectorOperators {
         private static final @Stable ConversionImpl<?,?>[][][]
             CACHES = new ConversionImpl<?,?>[KIND_LIMIT][LINE_LIMIT][LINE_LIMIT];
 
-        private synchronized static void initCaches() {
+        private static synchronized void initCaches() {
             for (var f : VectorOperators.class.getFields()) {
                 if (f.getType() != Conversion.class)  continue;
                 ConversionImpl<?,?> conv;


### PR DESCRIPTION
I ran bin/blessed-modifier-order.sh on source owned by Project Panama. This scripts verifies that modifiers are in the "blessed" order, and fixes it otherwise. I have manually checked the changes made by the script to make sure they are sound.

In this case, while the script did into the "correct" thing, it turns out that the method signatures in `src/jdk.incubator.vector/share/classes/jdk/incubator/vector` has some room for improvement... The files contains method headers which look like this:

```
        final @Override
        @ForceInline
        long longToElementBits(...

        @ForceInline
        static long toIntegralChecked(...

        @ForceInline
        @Override final
        ByteVector dummyVector(...
```

My personal opinion is that these should have been written like this:

```
        @Override
        @ForceInline
        final long longToElementBits(...

        @ForceInline
        static long toIntegralChecked(...

        @ForceInline
        @Override
        final ByteVector dummyVector(...
```

or possibly


```
        @Override @ForceInline
        final long longToElementBits(...

        @ForceInline
        static long toIntegralChecked(...

        @ForceInline @Override
        final ByteVector dummyVector(...
```

If you want me to make that change as well as part of the fix, let me know.

Furthermore, I don't know how much the code in mainline differs from the code in the Panama branches. If the discrepancy is large, you might want to run `bash bin/blessed-modifier-order.sh src/jdk.incubator.vector` and  `bash bin/blessed-modifier-order.sh src/jdk.incubator.foreign` in those branches.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8277015](https://bugs.openjdk.java.net/browse/JDK-8277015): Use blessed modifier order in Panama code


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6355/head:pull/6355` \
`$ git checkout pull/6355`

Update a local copy of the PR: \
`$ git checkout pull/6355` \
`$ git pull https://git.openjdk.java.net/jdk pull/6355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6355`

View PR using the GUI difftool: \
`$ git pr show -t 6355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6355.diff">https://git.openjdk.java.net/jdk/pull/6355.diff</a>

</details>
