### PR TITLE
8277013: Allow creation of module graphs without defining modules to the VM

### DIFF
--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2335,7 +2335,7 @@ public final class System {
             public Module defineModule(ClassLoader loader,
                                        ModuleDescriptor descriptor,
                                        URI uri) {
-                return new Module(null, loader, descriptor, uri);
+                return new Module(null, loader, descriptor, uri, true);
             }
             public Module defineUnnamedModule(ClassLoader loader) {
                 return new Module(loader);

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2335,7 +2335,7 @@ public final class System {
             public Module defineModule(ClassLoader loader,
                                        ModuleDescriptor descriptor,
                                        URI uri) {
-                return new Module(null, loader, descriptor, uri, true);
+                return new Module(null, loader, descriptor, uri);
             }
             public Module defineUnnamedModule(ClassLoader loader) {
                 return new Module(loader);


### PR DESCRIPTION
Related JBS issue: https://bugs.openjdk.java.net/browse/JDK-8277013

The GraalVM Native Image module support must create the runtime boot-module layer at image build time; module instances created at build time need to reflect module relations at runtime, i.e., their opens, reads, and exports. To achieve this, we had to duplicate and modify a significant portion of the module synthesis methods from the JDK. The GraalVM PR that demonstrates this duplication can be found at:
  ​https://github.com/oracle/graal/blob/9bfa3a312d7d0309eb014d52e49afd7136d9e77e/substratevm/src/com.oracle.svm.hosted.jdk11/src/com/oracle/svm/hosted/ModuleLayerFeature.java#L269

The hard-to-maintain code duplication is necessary as synthesizing module graphs in the JDK unconditionally defines modules to the VM which causes an error due to module redefinition. For example, methods `System.defineModule`, `ModuleLayer` factories and constructor, and `Module` constructor unconditionally update the VM state. All these methods eventually reach the `Module` constructor or the `Modules.defineModules` method.

We propose that the `Module` constructor and the `Modules.defineModules` conditionally update the VM state (similarly to 'Module.implAddReads`). The JDK would call these methods so they update the VM state and GraalVM Native Image would call them without updating the state.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8277013](https://bugs.openjdk.java.net/browse/JDK-8277013): Allow creation of module graphs without defining modules to the VM


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6356/head:pull/6356` \
`$ git checkout pull/6356`

Update a local copy of the PR: \
`$ git checkout pull/6356` \
`$ git pull https://git.openjdk.java.net/jdk pull/6356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6356`

View PR using the GUI difftool: \
`$ git pr show -t 6356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6356.diff">https://git.openjdk.java.net/jdk/pull/6356.diff</a>

</details>
