### PR TITLE
8277016: Use blessed modifier order in jdk.httpserver

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ChunkedInputStream.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ChunkedInputStream.java
@@ -41,12 +41,12 @@ class ChunkedInputStream extends LeftOverInputStream {
 
     private boolean needToReadHeader = true;
 
-    final static char CR = '\r';
-    final static char LF = '\n';
+    static final char CR = '\r';
+    static final char LF = '\n';
     /*
      * Maximum chunk header size of 2KB + 2 bytes for CRLF
      */
-    private final static int MAX_CHUNK_HEADER_SIZE = 2050;
+    private static final int MAX_CHUNK_HEADER_SIZE = 2050;
 
     private int numeric (char[] arr, int nchars) throws IOException {
         assert arr.length >= nchars;

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ChunkedOutputStream.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ChunkedOutputStream.java
@@ -51,9 +51,9 @@ class ChunkedOutputStream extends FilterOutputStream
 {
     private boolean closed = false;
     /* max. amount of user data per chunk */
-    final static int CHUNK_SIZE = 4096;
+    static final int CHUNK_SIZE = 4096;
     /* allow 4 bytes for chunk-size plus 4 for CRLFs */
-    final static int OFFSET = 6; /* initial <=4 bytes for len + CRLF */
+    static final int OFFSET = 6; /* initial <=4 bytes for len + CRLF */
     private int pos = OFFSET;
     private int count = 0;
     private byte[] buf = new byte [CHUNK_SIZE+OFFSET+2];

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/Request.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/Request.java
@@ -36,9 +36,9 @@ import com.sun.net.httpserver.*;
  */
 class Request {
 
-    final static int BUF_LEN = 2048;
-    final static byte CR = 13;
-    final static byte LF = 10;
+    static final int BUF_LEN = 2048;
+    static final byte CR = 13;
+    static final byte LF = 10;
 
     private String startLine;
     private SocketChannel chan;
@@ -230,7 +230,7 @@ class Request {
         int readlimit;
         static long readTimeout;
         ServerImpl server;
-        final static int BUFSIZE = 8 * 1024;
+        static final int BUFSIZE = 8 * 1024;
 
         public ReadStream (ServerImpl server, SocketChannel chan) throws IOException {
             this.channel = chan;

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
@@ -75,13 +75,13 @@ class ServerImpl implements TimeSource {
     private volatile long ticks; /* number of clock ticks since server started */
     private HttpServer wrapper;
 
-    final static int CLOCK_TICK = ServerConfig.getClockTick();
-    final static long IDLE_INTERVAL = ServerConfig.getIdleInterval();
-    final static int MAX_IDLE_CONNECTIONS = ServerConfig.getMaxIdleConnections();
-    final static long TIMER_MILLIS = ServerConfig.getTimerMillis ();
-    final static long MAX_REQ_TIME=getTimeMillis(ServerConfig.getMaxReqTime());
-    final static long MAX_RSP_TIME=getTimeMillis(ServerConfig.getMaxRspTime());
-    final static boolean timer1Enabled = MAX_REQ_TIME != -1 || MAX_RSP_TIME != -1;
+    static final int CLOCK_TICK = ServerConfig.getClockTick();
+    static final long IDLE_INTERVAL = ServerConfig.getIdleInterval();
+    static final int MAX_IDLE_CONNECTIONS = ServerConfig.getMaxIdleConnections();
+    static final long TIMER_MILLIS = ServerConfig.getTimerMillis ();
+    static final long MAX_REQ_TIME=getTimeMillis(ServerConfig.getMaxReqTime());
+    static final long MAX_RSP_TIME=getTimeMillis(ServerConfig.getMaxRspTime());
+    static final boolean timer1Enabled = MAX_REQ_TIME != -1 || MAX_RSP_TIME != -1;
 
     private Timer timer, timer1;
     private final Logger logger;

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/SimpleFileServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/SimpleFileServerImpl.java
@@ -144,7 +144,7 @@ final class SimpleFileServerImpl {
         return Startup.OK.statusCode;
     }
 
-    private final static class Out {
+    private static final class Out {
         private final PrintWriter writer;
         private Out() { throw new AssertionError(); }
 


### PR DESCRIPTION
I ran bin/blessed-modifier-order.sh on source in jdk.httpserver. This scripts verifies that modifiers are in the "blessed" order, and fixes it otherwise. I have manually checked the changes made by the script to make sure they are sound.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277016](https://bugs.openjdk.java.net/browse/JDK-8277016): Use blessed modifier order in jdk.httpserver


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6357/head:pull/6357` \
`$ git checkout pull/6357`

Update a local copy of the PR: \
`$ git checkout pull/6357` \
`$ git pull https://git.openjdk.java.net/jdk pull/6357/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6357`

View PR using the GUI difftool: \
`$ git pr show -t 6357`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6357.diff">https://git.openjdk.java.net/jdk/pull/6357.diff</a>

</details>
