### PR TITLE
8275329: ZGC: vmTestbase/gc/gctests/SoftReference/soft004/soft004.java fails with assert(_phases->length() <= 1000) failed: Too many recored phases?

### DIFF
--- a/src/hotspot/share/gc/shared/gcTimer.cpp
+++ b/src/hotspot/share/gc/shared/gcTimer.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "gc/shared/gcTimer.hpp"
+#include "gc/shared/gc_globals.hpp"
 #include "utilities/growableArray.hpp"
 
 // the "time" parameter for most functions
@@ -130,7 +131,7 @@ void TimePartitions::clear() {
 }
 
 void TimePartitions::report_gc_phase_start(const char* name, const Ticks& time, GCPhase::PhaseType type) {
-  assert(_phases->length() <= 1000, "Too many recorded phases? (count: %d)", _phases->length());
+  assert(UseZGC || _phases->length() <= 1000, "Too many recorded phases? (count: %d)", _phases->length());
 
   int level = _active_phases.count();
 


### PR DESCRIPTION
In ZGC, the phases the "Pause Mark End" and "Concurrent Mark Continue" can be executed multiple times in the same GC cycle. This can happen for two reasons:

1) After "Concurrent Mark Continue" has terminated, but before "Pause Mark End" has started, a `SoftReference` or a `WeakReference` is resurrected by a call to `Reference.get()` from a Java thread.

2) A Java thread "hides" work from the GC worker threads doing marking, by detaching unmarked objects from the graph and push it to a thread local mark stack, that the GC needs to flush out. An example of this is when a Java thread continuously removes the first element in a single linked list that hasn't been marked yet.

The above events are typically rare, but it is possible to write a program that causes the above GC phases to be executed a large number of times. The test that failed (`soft004.java`) runs into case 2 above, where it has ~50,000,000 SoftReferences in the reference processing pending list (a single linked list) and continuously removes the first element until the list if empty. This causes more than 1000 "Pause Mark End" attempt to happen. For that reason, we don't want `TimePartitions` to assert if there are more than 1000 phases. This patch disables the assert in question if ZGC is used. An alternative would be to remove the assert completely, but @stefank preferred to just disable it for ZGC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275329](https://bugs.openjdk.java.net/browse/JDK-8275329): ZGC: vmTestbase/gc/gctests/SoftReference/soft004/soft004.java fails with assert(_phases->length() <= 1000) failed: Too many recored phases?


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6358/head:pull/6358` \
`$ git checkout pull/6358`

Update a local copy of the PR: \
`$ git checkout pull/6358` \
`$ git pull https://git.openjdk.java.net/jdk pull/6358/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6358`

View PR using the GUI difftool: \
`$ git pr show -t 6358`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6358.diff">https://git.openjdk.java.net/jdk/pull/6358.diff</a>

</details>
