### PR TITLE
8276994: java/nio/channels/Channels/TransferTo.java leaves multi-GB files in /tmp

### DIFF
--- a/test/jdk/java/nio/channels/Channels/TransferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo.java
@@ -138,11 +138,11 @@ public class TransferTo {
      */
     @Test
     public void testMoreThanTwoGB() throws IOException {
-        Path sourceFile = Files.createTempFile("test2GBSource", null);;
-        Path targetFile = Files.createTempFile("test2GBtarget", null);;
+        Path sourceFile = Files.createTempFile("test2GBSource", null);
         try {
             // preparing two temporary files which will be compared at the end of the test
-             try {
+            Path targetFile = Files.createTempFile("test2GBtarget", null);
+            try {
                 // writing 3 GB of random bytes into source file
                 for (int i = 0; i < NUM_WRITES; i++)
                     Files.write(sourceFile, createRandomBytes(BYTES_PER_WRITE, 0), StandardOpenOption.APPEND);

--- a/test/jdk/java/nio/channels/Channels/TransferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo.java
@@ -141,24 +141,29 @@ public class TransferTo {
         // preparing two temporary files which will be compared at the end of the test
         Path sourceFile = Files.createTempFile(null, null);
         Path targetFile = Files.createTempFile(null, null);
+        try {
+            // writing 3 GB of random bytes into source file
+            for (int i = 0; i < NUM_WRITES; i++)
+                Files.write(sourceFile, createRandomBytes(BYTES_PER_WRITE, 0), StandardOpenOption.APPEND);
 
-        // writing 3 GB of random bytes into source file
-        for (int i = 0; i < NUM_WRITES; i++)
-            Files.write(sourceFile, createRandomBytes(BYTES_PER_WRITE, 0), StandardOpenOption.APPEND);
+            // performing actual transfer, effectively by multiple invocations of Filechannel.transferTo(FileChannel)
+            long count;
+            try (InputStream inputStream = Channels.newInputStream(FileChannel.open(sourceFile));
+                 OutputStream outputStream = Channels
+                         .newOutputStream(FileChannel.open(targetFile, StandardOpenOption.WRITE))) {
+                count = inputStream.transferTo(outputStream);
+            }
 
-        // performing actual transfer, effectively by multiple invocations of Filechannel.transferTo(FileChannel)
-        long count;
-        try (InputStream inputStream = Channels.newInputStream(FileChannel.open(sourceFile));
-                OutputStream outputStream = Channels
-                        .newOutputStream(FileChannel.open(targetFile, StandardOpenOption.WRITE))) {
-            count = inputStream.transferTo(outputStream);
+            // comparing reported transferred bytes, must be 3 GB
+            assertEquals(count, BYTES_WRITTEN);
+
+            // comparing content of both files, failing in case of any difference
+            assertEquals(Files.mismatch(sourceFile, targetFile), -1);
+        } finally {
+            System.out.printf("Cleaning up: %s, %s%n", sourceFile, targetFile);
+            Files.deleteIfExists(sourceFile);
+            Files.deleteIfExists(targetFile);
         }
-
-        // comparing reported transferred bytes, must be 3 GB
-        assertEquals(count, BYTES_WRITTEN);
-
-        // comparing content of both files, failing in case of any difference
-        assertEquals(Files.mismatch(sourceFile, targetFile), -1);
     }
 
     /*

--- a/test/jdk/java/nio/channels/Channels/TransferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo.java
@@ -138,31 +138,37 @@ public class TransferTo {
      */
     @Test
     public void testMoreThanTwoGB() throws IOException {
-        // preparing two temporary files which will be compared at the end of the test
-        Path sourceFile = Files.createTempFile(null, null);
-        Path targetFile = Files.createTempFile(null, null);
+        Path sourceFile = null;
+        Path targetFile = null;
         try {
-            // writing 3 GB of random bytes into source file
-            for (int i = 0; i < NUM_WRITES; i++)
-                Files.write(sourceFile, createRandomBytes(BYTES_PER_WRITE, 0), StandardOpenOption.APPEND);
+            // preparing two temporary files which will be compared at the end of the test
+             sourceFile = Files.createTempFile("test2GBSource", null);
+             try {
+             targetFile = Files.createTempFile("test2GBtarget", null);
 
-            // performing actual transfer, effectively by multiple invocations of Filechannel.transferTo(FileChannel)
-            long count;
-            try (InputStream inputStream = Channels.newInputStream(FileChannel.open(sourceFile));
-                 OutputStream outputStream = Channels
-                         .newOutputStream(FileChannel.open(targetFile, StandardOpenOption.WRITE))) {
-                count = inputStream.transferTo(outputStream);
+                // writing 3 GB of random bytes into source file
+                for (int i = 0; i < NUM_WRITES; i++)
+                    Files.write(sourceFile, createRandomBytes(BYTES_PER_WRITE, 0), StandardOpenOption.APPEND);
+
+                // performing actual transfer, effectively by multiple invocations of Filechannel.transferTo(FileChannel)
+                long count;
+                try (InputStream inputStream = Channels.newInputStream(FileChannel.open(sourceFile));
+                     OutputStream outputStream = Channels
+                             .newOutputStream(FileChannel.open(targetFile, StandardOpenOption.WRITE))) {
+                    count = inputStream.transferTo(outputStream);
+                }
+
+                // comparing reported transferred bytes, must be 3 GB
+                assertEquals(count, BYTES_WRITTEN);
+
+                // comparing content of both files, failing in case of any difference
+                assertEquals(Files.mismatch(sourceFile, targetFile), -1);
+
+            } finally {
+                 Files.delete(targetFile);
             }
-
-            // comparing reported transferred bytes, must be 3 GB
-            assertEquals(count, BYTES_WRITTEN);
-
-            // comparing content of both files, failing in case of any difference
-            assertEquals(Files.mismatch(sourceFile, targetFile), -1);
         } finally {
-            System.out.printf("Cleaning up: %s, %s%n", sourceFile, targetFile);
-            Files.deleteIfExists(sourceFile);
-            Files.deleteIfExists(targetFile);
+            Files.delete(sourceFile);
         }
     }
 

--- a/test/jdk/java/nio/channels/Channels/TransferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo.java
@@ -138,14 +138,11 @@ public class TransferTo {
      */
     @Test
     public void testMoreThanTwoGB() throws IOException {
-        Path sourceFile = null;
-        Path targetFile = null;
+        Path sourceFile = Files.createTempFile("test2GBSource", null);;
+        Path targetFile = Files.createTempFile("test2GBtarget", null);;
         try {
             // preparing two temporary files which will be compared at the end of the test
-             sourceFile = Files.createTempFile("test2GBSource", null);
              try {
-             targetFile = Files.createTempFile("test2GBtarget", null);
-
                 // writing 3 GB of random bytes into source file
                 for (int i = 0; i < NUM_WRITES; i++)
                     Files.write(sourceFile, createRandomBytes(BYTES_PER_WRITE, 0), StandardOpenOption.APPEND);


### PR DESCRIPTION
Hi,

This patch addresses the issue where the very large temp files are not cleaned up after the testMoreThanTwoGB completes.


Best
Lance

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276994](https://bugs.openjdk.java.net/browse/JDK-8276994): java/nio/channels/Channels/TransferTo.java leaves multi-GB files in /tmp


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6360/head:pull/6360` \
`$ git checkout pull/6360`

Update a local copy of the PR: \
`$ git checkout pull/6360` \
`$ git pull https://git.openjdk.java.net/jdk pull/6360/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6360`

View PR using the GUI difftool: \
`$ git pr show -t 6360`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6360.diff">https://git.openjdk.java.net/jdk/pull/6360.diff</a>

</details>
