### PR TITLE
8276921: G1: Remove redundant failed evacuation regions calculation in RemoveSelfForwardPtrHRClosure

### DIFF
--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -146,8 +146,8 @@ class RemoveSelfForwardPtrHRClosure: public HeapRegionClosure {
   G1CollectedHeap* _g1h;
   uint _worker_id;
 
-  G1EvacFailureRegions* _evac_failure_regions;
   DEBUG_ONLY(uint volatile* _num_failed_regions;)
+  G1EvacFailureRegions* _evac_failure_regions;
 
 public:
   RemoveSelfForwardPtrHRClosure(uint worker_id,
@@ -155,8 +155,9 @@ public:
                                 G1EvacFailureRegions* evac_failure_regions) :
     _g1h(G1CollectedHeap::heap()),
     _worker_id(worker_id),
+    DEBUG_ONLY(_num_failed_regions(num_failed_regions) COMMA)
     _evac_failure_regions(evac_failure_regions) {
-    DEBUG_ONLY(_num_failed_regions = num_failed_regions;)
+    // DEBUG_ONLY(_num_failed_regions = num_failed_regions;)
   }
 
   size_t remove_self_forward_ptr_by_walking_hr(HeapRegion* hr,

--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -146,16 +146,13 @@ class RemoveSelfForwardPtrHRClosure: public HeapRegionClosure {
   G1CollectedHeap* _g1h;
   uint _worker_id;
 
-  DEBUG_ONLY(uint volatile* _num_failed_regions;)
   G1EvacFailureRegions* _evac_failure_regions;
 
 public:
   RemoveSelfForwardPtrHRClosure(uint worker_id,
-                                uint volatile* num_failed_regions,
                                 G1EvacFailureRegions* evac_failure_regions) :
     _g1h(G1CollectedHeap::heap()),
     _worker_id(worker_id),
-    DEBUG_ONLY(_num_failed_regions(num_failed_regions) COMMA)
     _evac_failure_regions(evac_failure_regions) {
   }
 
@@ -194,8 +191,6 @@ public:
       hr->rem_set()->clear_locked(true);
 
       hr->note_self_forwarding_removal_end(live_bytes);
-
-      DEBUG_ONLY(Atomic::inc(_num_failed_regions, memory_order_relaxed);)
     }
     return false;
   }
@@ -205,17 +200,15 @@ G1ParRemoveSelfForwardPtrsTask::G1ParRemoveSelfForwardPtrsTask(G1EvacFailureRegi
   WorkerTask("G1 Remove Self-forwarding Pointers"),
   _g1h(G1CollectedHeap::heap()),
   _hrclaimer(_g1h->workers()->active_workers()),
-  _evac_failure_regions(evac_failure_regions),
-  _num_failed_regions(0) { }
+  _evac_failure_regions(evac_failure_regions) { }
 
 void G1ParRemoveSelfForwardPtrsTask::work(uint worker_id) {
-  RemoveSelfForwardPtrHRClosure rsfp_cl(worker_id, &_num_failed_regions, _evac_failure_regions);
+  RemoveSelfForwardPtrHRClosure rsfp_cl(worker_id, _evac_failure_regions);
 
   // Iterate through all regions that failed evacuation during the entire collection.
   _evac_failure_regions->par_iterate(&rsfp_cl, &_hrclaimer, worker_id);
 }
 
 uint G1ParRemoveSelfForwardPtrsTask::num_failed_regions() const {
-  assert(_num_failed_regions == _evac_failure_regions->num_regions_failed_evacuation(), "must be");
   return _evac_failure_regions->num_regions_failed_evacuation();
 }

--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -157,7 +157,6 @@ public:
     _worker_id(worker_id),
     DEBUG_ONLY(_num_failed_regions(num_failed_regions) COMMA)
     _evac_failure_regions(evac_failure_regions) {
-    // DEBUG_ONLY(_num_failed_regions = num_failed_regions;)
   }
 
   size_t remove_self_forward_ptr_by_walking_hr(HeapRegion* hr,

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -107,12 +107,6 @@ public:
     _task(evac_failure_regions),
     _evac_failure_regions(evac_failure_regions) { }
 
-  ~RemoveSelfForwardPtrsTask() {
-    assert(_task.num_failed_regions() == _evac_failure_regions->num_regions_failed_evacuation(),
-           "Removed regions %u inconsistent with expected %u",
-           _task.num_failed_regions(), _evac_failure_regions->num_regions_failed_evacuation());
-  }
-
   double worker_cost() const override {
     assert(_evac_failure_regions->evacuation_failed(), "Should not call this if not executed");
     return _evac_failure_regions->num_regions_failed_evacuation();


### PR DESCRIPTION
This is a minor optimization.
We already have the number of failed evacuation region numbers, there is no need to calculate it on fly, at least in product code, so make it debug only, and add assert to verify the result.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276921](https://bugs.openjdk.java.net/browse/JDK-8276921): G1: Remove redundant failed evacuation regions calculation in RemoveSelfForwardPtrHRClosure


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6362/head:pull/6362` \
`$ git checkout pull/6362`

Update a local copy of the PR: \
`$ git checkout pull/6362` \
`$ git pull https://git.openjdk.java.net/jdk pull/6362/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6362`

View PR using the GUI difftool: \
`$ git pr show -t 6362`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6362.diff">https://git.openjdk.java.net/jdk/pull/6362.diff</a>

</details>
