### PR TITLE
JDK-8277029: JMM GetDiagnosticXXXInfo APIs should verify output array sizes

### DIFF
--- a/src/hotspot/share/include/jmm.h
+++ b/src/hotspot/share/include/jmm.h
@@ -329,8 +329,7 @@ typedef struct jmmInterface_1_ {
   void         (JNICALL *GetDiagnosticCommandInfo)
                                                  (JNIEnv *env,
                                                   jobjectArray cmds,
-                                                  dcmdInfo *infoArray,
-                                                  jint count);
+                                                  dcmdInfo *infoArray);
   void         (JNICALL *GetDiagnosticCommandArgumentsInfo)
                                                  (JNIEnv *env,
                                                   jstring commandName,

--- a/src/hotspot/share/include/jmm.h
+++ b/src/hotspot/share/include/jmm.h
@@ -329,11 +329,13 @@ typedef struct jmmInterface_1_ {
   void         (JNICALL *GetDiagnosticCommandInfo)
                                                  (JNIEnv *env,
                                                   jobjectArray cmds,
-                                                  dcmdInfo *infoArray);
+                                                  dcmdInfo *infoArray,
+                                                  jint count);
   void         (JNICALL *GetDiagnosticCommandArgumentsInfo)
                                                  (JNIEnv *env,
                                                   jstring commandName,
-                                                  dcmdArgInfo *infoArray);
+                                                  dcmdArgInfo *infoArray,
+                                                  jint count);
   jstring      (JNICALL *ExecuteDiagnosticCommand)
                                                  (JNIEnv *env,
                                                   jstring command);

--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -1965,7 +1965,7 @@ JVM_ENTRY(jobjectArray, jmm_GetDiagnosticCommands(JNIEnv *env))
 JVM_END
 
 JVM_ENTRY(void, jmm_GetDiagnosticCommandInfo(JNIEnv *env, jobjectArray cmds,
-          dcmdInfo* infoArray, jint count))
+          dcmdInfo* infoArray))
   if (cmds == NULL || infoArray == NULL) {
     THROW(vmSymbols::java_lang_NullPointerException());
   }
@@ -1984,11 +1984,7 @@ JVM_ENTRY(void, jmm_GetDiagnosticCommandInfo(JNIEnv *env, jobjectArray cmds,
 
   GrowableArray<DCmdInfo *>* info_list = DCmdFactory::DCmdInfo_list(DCmd_Source_MBean);
 
-  const int num_cmds = cmds_ah->length();
-  if (num_cmds != count) {
-    assert(false, "GetDiagnosticCommandInfo count mismatch (%d vs %d)", count, num_cmds);
-    THROW_MSG(vmSymbols::java_lang_InternalError(), "GetDiagnosticCommandInfo count mismatch");
-  }
+  int num_cmds = cmds_ah->length();
   for (int i = 0; i < num_cmds; i++) {
     oop cmd = cmds_ah->obj_at(i);
     if (cmd == NULL) {

--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -1965,7 +1965,7 @@ JVM_ENTRY(jobjectArray, jmm_GetDiagnosticCommands(JNIEnv *env))
 JVM_END
 
 JVM_ENTRY(void, jmm_GetDiagnosticCommandInfo(JNIEnv *env, jobjectArray cmds,
-          dcmdInfo* infoArray))
+          dcmdInfo* infoArray, jint count))
   if (cmds == NULL || infoArray == NULL) {
     THROW(vmSymbols::java_lang_NullPointerException());
   }
@@ -1984,7 +1984,11 @@ JVM_ENTRY(void, jmm_GetDiagnosticCommandInfo(JNIEnv *env, jobjectArray cmds,
 
   GrowableArray<DCmdInfo *>* info_list = DCmdFactory::DCmdInfo_list(DCmd_Source_MBean);
 
-  int num_cmds = cmds_ah->length();
+  const int num_cmds = cmds_ah->length();
+  if (num_cmds != count) {
+    assert(false, "GetDiagnosticCommandInfo count mismatch (%d vs %d)", count, num_cmds);
+    THROW_MSG(vmSymbols::java_lang_InternalError(), "GetDiagnosticCommandInfo count mismatch");
+  }
   for (int i = 0; i < num_cmds; i++) {
     oop cmd = cmds_ah->obj_at(i);
     if (cmd == NULL) {
@@ -2015,7 +2019,7 @@ JVM_ENTRY(void, jmm_GetDiagnosticCommandInfo(JNIEnv *env, jobjectArray cmds,
 JVM_END
 
 JVM_ENTRY(void, jmm_GetDiagnosticCommandArgumentsInfo(JNIEnv *env,
-          jstring command, dcmdArgInfo* infoArray))
+          jstring command, dcmdArgInfo* infoArray, jint count))
   ResourceMark rm(THREAD);
   oop cmd = JNIHandles::resolve_external_guard(command);
   if (cmd == NULL) {
@@ -2039,10 +2043,12 @@ JVM_ENTRY(void, jmm_GetDiagnosticCommandArgumentsInfo(JNIEnv *env,
   }
   DCmdMark mark(dcmd);
   GrowableArray<DCmdArgumentInfo*>* array = dcmd->argument_info_array();
-  if (array->length() == 0) {
-    return;
+  const int num_args = array->length();
+  if (num_args != count) {
+    assert(false, "jmm_GetDiagnosticCommandArgumentsInfo count mismatch (%d vs %d)", count, num_args);
+    THROW_MSG(vmSymbols::java_lang_InternalError(), "jmm_GetDiagnosticCommandArgumentsInfo count mismatch");
   }
-  for (int i = 0; i < array->length(); i++) {
+  for (int i = 0; i < num_args; i++) {
     infoArray[i].name = array->at(i)->name();
     infoArray[i].description = array->at(i)->description();
     infoArray[i].type = array->at(i)->type();

--- a/src/jdk.management/share/native/libmanagement_ext/DiagnosticCommandImpl.c
+++ b/src/jdk.management/share/native/libmanagement_ext/DiagnosticCommandImpl.c
@@ -79,7 +79,7 @@ jobject getDiagnosticCommandArgumentInfoArray(JNIEnv *env, jstring command,
     return NULL;
   }
   jmm_interface->GetDiagnosticCommandArgumentsInfo(env, command,
-                                                   dcmd_arg_info_array);
+                                                   dcmd_arg_info_array, num_arg);
   dcmdArgInfoCls = (*env)->FindClass(env,
                                      "com/sun/management/internal/DiagnosticCommandArgumentInfo");
   POP_EXCEPTION_CHECK_AND_FREE(0, dcmd_arg_info_array);
@@ -189,7 +189,7 @@ Java_com_sun_management_internal_DiagnosticCommandImpl_getDiagnosticCommandInfo
       JNU_ThrowOutOfMemoryError(env, NULL);
       return NULL;
   }
-  jmm_interface->GetDiagnosticCommandInfo(env, commands, dcmd_info_array);
+  jmm_interface->GetDiagnosticCommandInfo(env, commands, dcmd_info_array, num_commands);
   for (i=0; i<num_commands; i++) {
       // Ensure capacity for 6 + 3 local refs:
       //  6 => jname, jdesc, jimpact, cmd, args, obj

--- a/src/jdk.management/share/native/libmanagement_ext/DiagnosticCommandImpl.c
+++ b/src/jdk.management/share/native/libmanagement_ext/DiagnosticCommandImpl.c
@@ -189,7 +189,7 @@ Java_com_sun_management_internal_DiagnosticCommandImpl_getDiagnosticCommandInfo
       JNU_ThrowOutOfMemoryError(env, NULL);
       return NULL;
   }
-  jmm_interface->GetDiagnosticCommandInfo(env, commands, dcmd_info_array, num_commands);
+  jmm_interface->GetDiagnosticCommandInfo(env, commands, dcmd_info_array);
   for (i=0; i<num_commands; i++) {
       // Ensure capacity for 6 + 3 local refs:
       //  6 => jname, jdesc, jimpact, cmd, args, obj


### PR DESCRIPTION
jmm_GetDiagnosticCommandArgumentsInfo and jmm_GetDiagnosticCommandInfo are used to query the hotspot about diagnostic commands. They provide output arrays for the information:

```
void jmm_GetDiagnosticCommandArgumentsInfo(JNIEnv *env,
          jstring command, dcmdArgInfo* infoArray)
```

but array size is implicitly assumed to be known to both caller and callee. Caller and callee negotiate those sizes in prior steps, but things can go wrong. E.g. I recently hunted a bug where `DCmd::number_arguments()` was off - did not reflect the real number of its jcmd parameters - which led to a hidden memory overwriter.

Thankfully, JDK-8264565 rewrote the dcmd framework to deal with this particular issue (The VM I analyzed was older). Still, it would be good if we had additional safety measures here.

-------------

Testing:
- manual tests with artificially induced error in one dcmd for debug, release
- GHAs (which include tier1 serviceability jcmd tests which use JMX and exercise these APIs)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277029](https://bugs.openjdk.java.net/browse/JDK-8277029): JMM GetDiagnosticXXXInfo APIs should verify output array sizes


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6363/head:pull/6363` \
`$ git checkout pull/6363`

Update a local copy of the PR: \
`$ git checkout pull/6363` \
`$ git pull https://git.openjdk.java.net/jdk pull/6363/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6363`

View PR using the GUI difftool: \
`$ git pr show -t 6363`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6363.diff">https://git.openjdk.java.net/jdk/pull/6363.diff</a>

</details>
