### PR TITLE
8277042: add test for 8276036 to compiler/codecache

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -40,7 +40,7 @@ public class CodeCacheFullCountTest {
         if (args.length == 1) {
             wasteCodeCache();
         } else {
-            runtest();
+            runTest();
         }
     }
 
@@ -53,7 +53,7 @@ public class CodeCacheFullCountTest {
         }
     }
 
-    public static void runtest() throws Throwable {
+    public static void runTest() throws Throwable {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
           "-XX:ReservedCodeCacheSize=2496k", "-XX:-UseCodeCacheFlushing", "CodeCacheFullCountTest", "WasteCodeCache");
         OutputAnalyzer oa = ProcessTools.executeProcess(pb);
@@ -68,7 +68,7 @@ public class CodeCacheFullCountTest {
                 throw new RuntimeException("the value of full_count is wrong.");
             }
         } else {
-            throw new RuntimeException("codecache shortage was not occured.");
+            throw new RuntimeException("codecache shortage did not occur.");
         }
     }
 
@@ -95,18 +95,22 @@ public class CodeCacheFullCountTest {
 abstract class Foo {
     public abstract int foo();
 }
+
 class Foo1 extends Foo {
     private int a;
     public int foo() { return a; }
 }
+
 class Foo2 extends Foo {
     private int a;
     public int foo() { return a; }
 }
+
 class Foo3 extends Foo {
     private int a;
     public int foo() { return a; }
 }
+
 class Foo4 extends Foo {
     private int a;
     public int foo() { return a; }

--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -31,7 +31,7 @@ import jdk.test.lib.process.ProcessTools;
 
 /*
  * @test
- * @bug 8276036 8277213
+ * @bug 8276036 8277213 8277441
  * @summary test for the value of full_count in the message of insufficient codecache
  * @library /test/lib
  */

--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -31,7 +31,7 @@ import jdk.test.lib.process.ProcessTools;
 
 /*
  * @test
- * @bug 8276036
+ * @bug 8276036 8277213
  * @summary test for the value of full_count in the message of insufficient codecache
  * @library /test/lib
  */

--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.lang.reflect.Field;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+/*
+ * @test
+ * @bug 8276036
+ * @summary test for the value of full_count in the message of insufficient codecache
+ * @library /test/lib
+ */
+public class CodeCacheFullCountTest {
+    public static void main(String args[]) throws Throwable {
+        if (args.length == 1) {
+            wasteCodeCache();
+        } else {
+            runtest();
+        }
+    }
+
+    public static void wasteCodeCache()  throws Exception {
+        URL url = CodeCacheFullCountTest.class.getProtectionDomain().getCodeSource().getLocation();
+
+        for (int i = 0; i < 500; i++) {
+            ClassLoader cl = new MyClassLoader(url);
+            refClass(cl.loadClass("SomeClass"));
+        }
+    }
+
+    public static void runtest() throws Throwable {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+          "-XX:ReservedCodeCacheSize=2496k", "-XX:-UseCodeCacheFlushing", "CodeCacheFullCountTest", "WasteCodeCache");
+        OutputAnalyzer oa = ProcessTools.executeProcess(pb);
+        oa.shouldHaveExitValue(0);
+        String stdout = oa.getStdout();
+
+        Pattern pattern = Pattern.compile("full_count=(\\d)");
+        Matcher stdoutMatcher = pattern.matcher(stdout);
+        if (stdoutMatcher.find()) {
+            int fullCount = Integer.parseInt(stdoutMatcher.group(1));
+            if (fullCount != 1) {
+                throw new RuntimeException("the value of full_count is wrong.");
+            }
+        } else {
+            throw new RuntimeException("codecache shortage was not occured.");
+        }
+    }
+
+    private static void refClass(Class clazz) throws Exception {
+        Field name = clazz.getDeclaredField("NAME");
+        name.setAccessible(true);
+        name.get(null);
+    }
+
+    private static class MyClassLoader extends URLClassLoader {
+        public MyClassLoader(URL url) {
+            super(new URL[]{url}, null);
+        }
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            try {
+                return super.loadClass(name, resolve);
+            } catch (ClassNotFoundException e) {
+                return Class.forName(name, resolve, CodeCacheFullCountTest.class.getClassLoader());
+            }
+        }
+    }
+}
+
+abstract class Foo {
+    public abstract int foo();
+}
+class Foo1 extends Foo {
+    private int a;
+    public int foo() { return a; }
+}
+class Foo2 extends Foo {
+    private int a;
+    public int foo() { return a; }
+}
+class Foo3 extends Foo {
+    private int a;
+    public int foo() { return a; }
+}
+class Foo4 extends Foo {
+    private int a;
+    public int foo() { return a; }
+}
+
+class SomeClass {
+    static final String NAME = "name";
+
+    static {
+        int res =0;
+        Foo[] foos = new Foo[] { new Foo1(), new Foo2(), new Foo3(), new Foo4() };
+        for (int i = 0; i < 100000; i++) {
+            res = foos[i % foos.length].foo();
+        }
+    }
+}


### PR DESCRIPTION
Could you please review the 8277042 code?  
This is the enhancement for 8276036.  
I add a new test to verify the value of full_count in the message of insufficient codecache.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277042](https://bugs.openjdk.java.net/browse/JDK-8277042): add test for 8276036 to compiler/codecache


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to 4d29d81a11d1b70ba546f13f149a81eb907a39f1
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6364/head:pull/6364` \
`$ git checkout pull/6364`

Update a local copy of the PR: \
`$ git checkout pull/6364` \
`$ git pull https://git.openjdk.java.net/jdk pull/6364/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6364`

View PR using the GUI difftool: \
`$ git pr show -t 6364`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6364.diff">https://git.openjdk.java.net/jdk/pull/6364.diff</a>

</details>
