### PR TITLE
8277045: G1: Remove unnecessary set_concurrency call in G1ConcurrentMark::weak_refs_work

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1618,10 +1618,6 @@ void G1ConcurrentMark::weak_refs_work() {
     uint active_workers = (ParallelRefProcEnabled ? _g1h->workers()->active_workers() : 1U);
     active_workers = clamp(active_workers, 1u, _max_num_tasks);
 
-    // Set the concurrency level. The phase was already set prior to
-    // executing the remark task.
-    set_concurrency(active_workers);
-
     // Set the degree of MT processing here.  If the discovery was done MT,
     // the number of threads involved during discovery could differ from
     // the number of active workers.  This is OK as long as the discovered


### PR DESCRIPTION
Simple change of removing an unnecessary method call.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277045](https://bugs.openjdk.java.net/browse/JDK-8277045): G1: Remove unnecessary set_concurrency call in G1ConcurrentMark::weak_refs_work


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6366/head:pull/6366` \
`$ git checkout pull/6366`

Update a local copy of the PR: \
`$ git checkout pull/6366` \
`$ git pull https://git.openjdk.java.net/jdk pull/6366/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6366`

View PR using the GUI difftool: \
`$ git pr show -t 6366`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6366.diff">https://git.openjdk.java.net/jdk/pull/6366.diff</a>

</details>
