### PR TITLE
8277048: Tiny improvements to the specification text for java.util.Properties.load

### DIFF
--- a/src/java.base/share/classes/java/util/Properties.java
+++ b/src/java.base/share/classes/java/util/Properties.java
@@ -236,7 +236,7 @@ public class Properties extends Hashtable<Object,Object> {
      * character stream in a simple line-oriented format.
      * <p>
      * Properties are processed in terms of lines. There are two
-     * kinds of line, <i>natural lines</i> and <i>logical lines</i>.
+     * kinds of lines, <i>natural lines</i> and <i>logical lines</i>.
      * A natural line is defined as a line of
      * characters that is terminated either by a set of line terminator
      * characters ({@code \n} or {@code \r} or {@code \r\n})
@@ -253,8 +253,8 @@ public class Properties extends Hashtable<Object,Object> {
      * <p>
      * A natural line that contains only white space characters is
      * considered blank and is ignored.  A comment line has an ASCII
-     * {@code '#'} or {@code '!'} as its first non-white
-     * space character; comment lines are also ignored and do not
+     * {@code '#'} or {@code '!'} as its first non-whitespace
+     * character; comment lines are also ignored and do not
      * encode key-element information.  In addition to line
      * terminators, this format considers the characters space
      * ({@code ' '}, {@code '\u005Cu0020'}), tab


### PR DESCRIPTION
Please review this simple two-hunk fix to the documentation comment of java.util.Properties#load(java.io.Reader). The first hunk (line/lines) is a suggestion. I believe it reads better since the plurality is more idiomatic; native English speakers should correct me if I'm wrong. The second hunk picks up what was overlooked in JDK-8274075 (https://git.openjdk.java.net/jdk/pull/5610).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277048](https://bugs.openjdk.java.net/browse/JDK-8277048): Tiny improvements to the specification text for java.util.Properties.load


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6367/head:pull/6367` \
`$ git checkout pull/6367`

Update a local copy of the PR: \
`$ git checkout pull/6367` \
`$ git pull https://git.openjdk.java.net/jdk pull/6367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6367`

View PR using the GUI difftool: \
`$ git pr show -t 6367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6367.diff">https://git.openjdk.java.net/jdk/pull/6367.diff</a>

</details>
