### PR TITLE
8277059: Use blessed modifier order in java.xml

### DIFF
--- a/src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMSignatureMethod.java
+++ b/src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMSignatureMethod.java
@@ -387,7 +387,7 @@ public abstract class DOMSignatureMethod extends AbstractDOMSignatureMethod {
             super(dmElem);
         }
 
-        abstract public PSSParameterSpec getPSSParameterSpec();
+        public abstract PSSParameterSpec getPSSParameterSpec();
 
         @Override
         Signature getSignature(Provider p)

--- a/src/java.xml/share/classes/com/sun/java_cup/internal/runtime/lr_parser.java
+++ b/src/java.xml/share/classes/com/sun/java_cup/internal/runtime/lr_parser.java
@@ -161,7 +161,7 @@ public abstract class lr_parser {
   /** The default number of Symbols after an error we much match to consider
    *  it recovered from.
    */
-  protected final static int _error_sync_size = 3;
+  protected static final int _error_sync_size = 3;
 
   /*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . .*/
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/DOM.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/DOM.java
@@ -31,21 +31,21 @@ import org.w3c.dom.NodeList;
  * @author Santiago Pericas-Geertsen
  */
 public interface DOM {
-    public final static int  FIRST_TYPE             = 0;
+    public static final int  FIRST_TYPE             = 0;
 
-    public final static int  NO_TYPE                = -1;
+    public static final int  NO_TYPE                = -1;
 
     // 0 is reserved for NodeIterator.END
-    public final static int NULL     = 0;
+    public static final int NULL     = 0;
 
     // used by some node iterators to know which node to return
-    public final static int RETURN_CURRENT = 0;
-    public final static int RETURN_PARENT  = 1;
+    public static final int RETURN_CURRENT = 0;
+    public static final int RETURN_PARENT  = 1;
 
     // Constants used by getResultTreeFrag to indicate the types of the RTFs.
-    public final static int SIMPLE_RTF   = 0;
-    public final static int ADAPTIVE_RTF = 1;
-    public final static int TREE_RTF     = 2;
+    public static final int SIMPLE_RTF   = 0;
+    public static final int ADAPTIVE_RTF = 1;
+    public static final int TREE_RTF     = 2;
 
     /** returns singleton iterator containg the document root */
     public DTMAxisIterator getIterator();

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/AttributeValueTemplate.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/AttributeValueTemplate.java
@@ -46,11 +46,11 @@ import java.util.StringTokenizer;
  */
 final class AttributeValueTemplate extends AttributeValue {
 
-    final static int OUT_EXPR = 0;
-    final static int IN_EXPR  = 1;
-    final static int IN_EXPR_SQUOTES = 2;
-    final static int IN_EXPR_DQUOTES = 3;
-    final static String DELIMITER = "\uFFFE";      // A Unicode nonchar
+    static final int OUT_EXPR = 0;
+    static final int IN_EXPR  = 1;
+    static final int IN_EXPR_SQUOTES = 2;
+    static final int IN_EXPR_DQUOTES = 3;
+    static final String DELIMITER = "\uFFFE";      // A Unicode nonchar
 
     public AttributeValueTemplate(String value, Parser parser,
         SyntaxTreeNode parent)

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/FunctionCall.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/FunctionCall.java
@@ -71,47 +71,47 @@ class FunctionCall extends Expression {
     // Arguments to this function call (might not be any)
     private final List<Expression> _arguments;
     // Empty argument list, used for certain functions
-    private final static List<Expression> EMPTY_ARG_LIST = new ArrayList<>(0);
+    private static final List<Expression> EMPTY_ARG_LIST = new ArrayList<>(0);
 
     // Valid namespaces for Java function-call extension
-    protected final static String EXT_XSLTC =
+    protected static final String EXT_XSLTC =
         TRANSLET_URI;
 
-    protected final static String JAVA_EXT_XSLTC =
+    protected static final String JAVA_EXT_XSLTC =
         EXT_XSLTC + "/java";
 
-    protected final static String EXT_XALAN =
+    protected static final String EXT_XALAN =
         "http://xml.apache.org/xalan";
 
-    protected final static String JAVA_EXT_XALAN =
+    protected static final String JAVA_EXT_XALAN =
         "http://xml.apache.org/xalan/java";
 
-    protected final static String JAVA_EXT_XALAN_OLD =
+    protected static final String JAVA_EXT_XALAN_OLD =
         "http://xml.apache.org/xslt/java";
 
-    protected final static String EXSLT_COMMON =
+    protected static final String EXSLT_COMMON =
         "http://exslt.org/common";
 
-    protected final static String EXSLT_MATH =
+    protected static final String EXSLT_MATH =
         "http://exslt.org/math";
 
-    protected final static String EXSLT_SETS =
+    protected static final String EXSLT_SETS =
         "http://exslt.org/sets";
 
-    protected final static String EXSLT_DATETIME =
+    protected static final String EXSLT_DATETIME =
         "http://exslt.org/dates-and-times";
 
-    protected final static String EXSLT_STRINGS =
+    protected static final String EXSLT_STRINGS =
         "http://exslt.org/strings";
 
-    protected final static String XALAN_CLASSPACKAGE_NAMESPACE =
+    protected static final String XALAN_CLASSPACKAGE_NAMESPACE =
         "xalan://";
 
     // Namespace format constants
-    protected final static int NAMESPACE_FORMAT_JAVA = 0;
-    protected final static int NAMESPACE_FORMAT_CLASS = 1;
-    protected final static int NAMESPACE_FORMAT_PACKAGE = 2;
-    protected final static int NAMESPACE_FORMAT_CLASS_OR_PACKAGE = 3;
+    protected static final int NAMESPACE_FORMAT_JAVA = 0;
+    protected static final int NAMESPACE_FORMAT_CLASS = 1;
+    protected static final int NAMESPACE_FORMAT_PACKAGE = 2;
+    protected static final int NAMESPACE_FORMAT_CLASS_OR_PACKAGE = 3;
 
     // Namespace format
     private int _namespace_format = NAMESPACE_FORMAT_JAVA;

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/Number.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/Number.java
@@ -60,13 +60,13 @@ final class Number extends Instruction implements Closure {
     private static final int LEVEL_MULTIPLE = 1;
     private static final int LEVEL_ANY      = 2;
 
-    static final private String[] ClassNames = {
+    private static final String[] ClassNames = {
         "com.sun.org.apache.xalan.internal.xsltc.dom.SingleNodeCounter",          // LEVEL_SINGLE
         "com.sun.org.apache.xalan.internal.xsltc.dom.MultipleNodeCounter", // LEVEL_MULTIPLE
         "com.sun.org.apache.xalan.internal.xsltc.dom.AnyNodeCounter"      // LEVEL_ANY
     };
 
-    static final private String[] FieldNames = {
+    private static final String[] FieldNames = {
         "___single_node_counter",                  // LEVEL_SINGLE
         "___multiple_node_counter",                // LEVEL_MULTIPLE
         "___any_node_counter"                      // LEVEL_ANY

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/Output.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/Output.java
@@ -66,9 +66,9 @@ final class Output extends TopLevelElement {
     private boolean _disabled = false;
 
     // Some global constants
-    private final static String STRING_SIG = "Ljava/lang/String;";
-    private final static String XML_VERSION = "1.0";
-    private final static String HTML_VERSION = "4.0";
+    private static final String STRING_SIG = "Ljava/lang/String;";
+    private static final String XML_VERSION = "1.0";
+    private static final String HTML_VERSION = "4.0";
 
     /**
      * Displays the contents of this element (for debugging)

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/UseAttributeSets.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/UseAttributeSets.java
@@ -41,7 +41,7 @@ import java.util.StringTokenizer;
 final class UseAttributeSets extends Instruction {
 
     // Only error that can occur:
-    private final static String ATTR_SET_NOT_FOUND =
+    private static final String ATTR_SET_NOT_FOUND =
         "";
 
     // Contains the names of all references attribute sets

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/Whitespace.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/Whitespace.java
@@ -63,7 +63,7 @@ final class Whitespace extends TopLevelElement {
     /**
      * Auxillary class for encapsulating a single strip/preserve rule
      */
-    final static class WhitespaceRule {
+    static final class WhitespaceRule {
         private final int _action;
         private String _namespace; // Should be replaced by NS type (int)
         private String _element;   // Should be replaced by node type (int)

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/XPathLexer.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/XPathLexer.java
@@ -267,7 +267,7 @@ class XPathLexer implements com.sun.java_cup.internal.runtime.Scanner {
                         throw new Error("Fatal Error.\n");
                 }
         }
-        static private int[][] unpackFromString(int size1, int size2, String st) {
+        private static int[][] unpackFromString(int size1, int size2, String st) {
                 int colonIndex = -1;
                 String lengthString;
                 int sequenceLength = 0;
@@ -540,7 +540,7 @@ class XPathLexer implements com.sun.java_cup.internal.runtime.Scanner {
                 /* 232 */ YY_NO_ANCHOR,
                 /* 233 */ YY_NO_ANCHOR
         };
-        static private int yy_cmap[] = unpackFromString(1,65538,
+        private static int yy_cmap[] = unpackFromString(1,65538,
 "54:9,27:2,54,27:2,54:18,27,17,53,54,15,54:2,55,25,26,1,3,11,4,13,2,56:10,10" +
 ",54,18,16,19,54,12,44,57:3,46,57:3,51,57:4,48,52,43,57,47,50,45,57:3,49,57:" +
 "2,41,54,42,54,58,54,35,38,29,5,21,39,33,36,6,57,20,37,8,28,9,30,57,31,32,23" +
@@ -574,7 +574,7 @@ class XPathLexer implements com.sun.java_cup.internal.runtime.Scanner {
 ":1008,54:17,58:64,57:84,58:12,57:90,58:10,57:40,58:31443,57:11172,58:92,54:" +
 "8448,58:1232,54:32,58:526,54:2,0:2")[0];
 
-        static private int yy_rmap[] = unpackFromString(1,234,
+        private static int yy_rmap[] = unpackFromString(1,234,
 "0,1:2,2,1:2,3,4,1,5,6,1:3,7,8,1:5,9,1,10:2,1:3,11,1:5,12,10,1,10:5,1:2,10,1" +
 ":2,13,1,10,1,14,10,15,16,1:2,10:4,17,1:2,18,19,20,21,22,23,24,25,26,27,1,25" +
 ",10,28:2,29,5,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,5" +
@@ -586,7 +586,7 @@ class XPathLexer implements com.sun.java_cup.internal.runtime.Scanner {
 ",156,157,158,159,160,161,162,163,164,165,166,167,168,169,170,171,172,173,17" +
 "4,175,176,177,178,179,180,181")[0];
 
-        static private int yy_nxt[][] = unpackFromString(182,61,
+        private static int yy_nxt[][] = unpackFromString(182,61,
 "1,2,3,4,5,6,65,184,204,70,7,8,9,10,11,12,13,66,14,15,211,184:2,215,184,16,1" +
 "7,18,218,220,221,184,222,184:2,223,184:3,224,184,19,20,184:10,71,74,77,21,1" +
 "84:2,67,74,-1:63,22,-1:62,184:2,73,184:3,64,-1:2,76,-1:6,184,79,184:3,-1:3," +

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/XPathParser.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/XPathParser.java
@@ -925,12 +925,12 @@ public class XPathParser extends lr_parser {
     /**
      * Used by function calls with no args.
      */
-    static public final List<Expression> EmptyArgs = new ArrayList<>(0);
+    public static final List<Expression> EmptyArgs = new ArrayList<>(0);
 
     /**
      * Reference to non-existing variable.
      */
-    static public final VariableRef DummyVarRef = null;
+    public static final VariableRef DummyVarRef = null;
 
     /**
      * Reference to the Parser class.

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/ClassGenerator.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/ClassGenerator.java
@@ -46,7 +46,7 @@ import com.sun.org.apache.xalan.internal.xsltc.compiler.Stylesheet;
  * @author Santiago Pericas-Geertsen
  */
 public class ClassGenerator extends ClassGen {
-    protected final static int TRANSLET_INDEX = 0;
+    protected static final int TRANSLET_INDEX = 0;
     protected static int INVALID_INDEX  = -1;
 
     private Stylesheet _stylesheet;

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/ErrorMsg.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/ErrorMsg.java
@@ -175,10 +175,10 @@ public final class ErrorMsg {
     // This array and the following 4 strings are read from that bundle.
     private static ResourceBundle _bundle;
 
-    public final static String ERROR_MESSAGES_KEY   = "ERROR_MESSAGES_KEY";
-    public final static String COMPILER_ERROR_KEY   = "COMPILER_ERROR_KEY";
-    public final static String COMPILER_WARNING_KEY = "COMPILER_WARNING_KEY";
-    public final static String RUNTIME_ERROR_KEY    = "RUNTIME_ERROR_KEY";
+    public static final String ERROR_MESSAGES_KEY   = "ERROR_MESSAGES_KEY";
+    public static final String COMPILER_ERROR_KEY   = "COMPILER_ERROR_KEY";
+    public static final String COMPILER_WARNING_KEY = "COMPILER_WARNING_KEY";
+    public static final String RUNTIME_ERROR_KEY    = "RUNTIME_ERROR_KEY";
 
     static {
         _bundle = SecuritySupport.getResourceBundle(

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/MarkerInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/MarkerInstruction.java
@@ -61,7 +61,7 @@ abstract class MarkerInstruction extends Instruction {
      * current {@link com.sun.org.apache.bcel.internal.generic.ClassGen}
      * @return <code>0</code> always
      */
-    final public int consumeStack(ConstantPoolGen cpg) {
+    public final int consumeStack(ConstantPoolGen cpg) {
         return 0;
     }
     /**
@@ -72,7 +72,7 @@ abstract class MarkerInstruction extends Instruction {
      * current {@link com.sun.org.apache.bcel.internal.generic.ClassGen}
      * @return <code>0</code> always
      */
-    final public int produceStack(ConstantPoolGen cpg) {
+    public final int produceStack(ConstantPoolGen cpg) {
         return 0;
     }
 
@@ -91,6 +91,6 @@ abstract class MarkerInstruction extends Instruction {
      * output stream.
      * @param out Output stream
      */
-    final public void dump(DataOutputStream out) throws IOException {
+    public final void dump(DataOutputStream out) throws IOException {
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/BitArray.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/BitArray.java
@@ -42,7 +42,7 @@ public class BitArray implements Externalizable {
 
     // This table is used to prevent expensive shift operations
     // (These operations are inexpensive on CPUs but very expensive on JVMs.)
-    private final static int[] _masks = {
+    private static final int[] _masks = {
         0x80000000, 0x40000000, 0x20000000, 0x10000000,
         0x08000000, 0x04000000, 0x02000000, 0x01000000,
         0x00800000, 0x00400000, 0x00200000, 0x00100000,
@@ -52,7 +52,7 @@ public class BitArray implements Externalizable {
         0x00000080, 0x00000040, 0x00000020, 0x00000010,
         0x00000008, 0x00000004, 0x00000002, 0x00000001 };
 
-    private final static boolean DEBUG_ASSERTIONS = false;
+    private static final boolean DEBUG_ASSERTIONS = false;
 
     /**
      * Constructor. Defines the initial size of the bit array (in bits).

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/KeyIndex.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/KeyIndex.java
@@ -501,7 +501,7 @@ public class KeyIndex extends DTMAxisIteratorBase {
     /**
      * Used to represent an empty node set.
      */
-    final private static IntegerArray EMPTY_NODES = new IntegerArray(0);
+    private static final IntegerArray EMPTY_NODES = new IntegerArray(0);
 
 
     /**

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/NodeCounter.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/NodeCounter.java
@@ -57,13 +57,13 @@ public abstract class NodeCounter {
     private int _nSepars  = 0;
     private int _nFormats = 0;
 
-    private final static String[] Thousands =
+    private static final String[] Thousands =
         {"", "m", "mm", "mmm" };
-    private final static String[] Hundreds =
+    private static final String[] Hundreds =
     {"", "c", "cc", "ccc", "cd", "d", "dc", "dcc", "dccc", "cm"};
-    private final static String[] Tens =
+    private static final String[] Tens =
     {"", "x", "xx", "xxx", "xl", "l", "lx", "lxx", "lxxx", "xc"};
-    private final static String[] Ones =
+    private static final String[] Ones =
     {"", "i", "ii", "iii", "iv", "v", "vi", "vii", "viii", "ix"};
 
     private StringBuilder _tempBuffer = new StringBuilder();
@@ -92,7 +92,7 @@ public abstract class NodeCounter {
      * Set the start node for this counter. The same <tt>NodeCounter</tt>
      * object can be used multiple times by resetting the starting node.
      */
-    abstract public NodeCounter setStartNode(int node);
+    public abstract NodeCounter setStartNode(int node);
 
     /**
      * If the user specified a value attribute, use this instead of
@@ -248,7 +248,7 @@ public abstract class NodeCounter {
      * Returns the position of <tt>node</tt> according to the level and
      * the from and count patterns.
      */
-    abstract public String getCounter();
+    public abstract String getCounter();
 
     /**
      * Returns the position of <tt>node</tt> according to the level and

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/NodeIteratorBase.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/NodeIteratorBase.java
@@ -74,7 +74,7 @@ public abstract class NodeIteratorBase implements NodeIterator {
      * restartable, then do nothing. If node is equal to END then
      * subsequent calls to next() must return END.
      */
-    abstract public NodeIterator setStartNode(int node);
+    public abstract NodeIterator setStartNode(int node);
 
     /**
      * Reset this iterator using state from last call to

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/SAXImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/SAXImpl.java
@@ -104,10 +104,10 @@ public final class SAXImpl extends SAX2DTM2
     /* ------------------------------------------------------------------- */
 
     // empty String for null attribute values
-    private final static String EMPTYSTRING = "";
+    private static final String EMPTYSTRING = "";
 
     // empty iterator to be returned when there are no children
-    private final static DTMAxisIterator EMPTYITERATOR = EmptyIterator.getInstance();
+    private static final DTMAxisIterator EMPTYITERATOR = EmptyIterator.getInstance();
     // The number of expanded names
     private int _namesSize = -1;
 
@@ -122,7 +122,7 @@ public final class SAXImpl extends SAX2DTM2
 
     // The URI to this document
     // private String _documentURI = null;
-    static private int _documentURIIndex = 0;
+    private static int _documentURIIndex = 0;
 
     // The owner Document when the input source is DOMSource.
     private Document _document;

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/SimpleResultTreeImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/SimpleResultTreeImpl.java
@@ -215,7 +215,7 @@ public class SimpleResultTreeImpl extends EmptySerializer implements DOM, DTM
     }  // END of SingletonIterator
 
     // empty iterator to be returned when there are no children
-    private final static DTMAxisIterator EMPTY_ITERATOR =
+    private static final DTMAxisIterator EMPTY_ITERATOR =
         new DTMAxisIteratorBase() {
             public DTMAxisIterator reset() { return this; }
             public DTMAxisIterator setStartNode(int node) { return this; }

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/SingleNodeCounter.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/SingleNodeCounter.java
@@ -32,7 +32,7 @@ import com.sun.org.apache.xml.internal.dtm.Axis;
  * @author Santiago Pericas-Geertsen
  */
 public abstract class SingleNodeCounter extends NodeCounter {
-    static private final int[] EmptyArray = new int[] { };
+    private static final int[] EmptyArray = new int[] { };
     DTMAxisIterator _countSiblings = null;
 
     public SingleNodeCounter(Translet translet,

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/SortingIterator.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/SortingIterator.java
@@ -31,7 +31,7 @@ import com.sun.org.apache.xml.internal.dtm.ref.DTMAxisIteratorBase;
  * @author Morten Jorgensen
  */
 public final class SortingIterator extends DTMAxisIteratorBase {
-    private final static int INIT_DATA_SIZE = 16;
+    private static final int INIT_DATA_SIZE = 16;
 
     private DTMAxisIterator _source;
     private NodeSortRecordFactory _factory;

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/UnionIterator.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/dom/UnionIterator.java
@@ -38,7 +38,7 @@ public final class UnionIterator extends MultiValuedNodeHeapIterator {
     /** wrapper for NodeIterators to support iterator
         comparison on the value of their next() method
     */
-    final private DOM _dom;
+    private final DOM _dom;
 
     private final class LookAheadIterator
             extends MultiValuedNodeHeapIterator.HeapNode

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/runtime/AbstractTranslet.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/runtime/AbstractTranslet.java
@@ -101,10 +101,10 @@ public abstract class AbstractTranslet implements Translet {
     protected StringValueHandler stringValueHandler = new StringValueHandler();
 
     // Use one empty string instead of constantly instanciating String("");
-    private final static String EMPTYSTRING = "";
+    private static final String EMPTYSTRING = "";
 
     // This is the name of the index used for ID attributes
-    private final static String ID_INDEX_NAME = "##id";
+    private static final String ID_INDEX_NAME = "##id";
 
     private boolean _overrideDefaultParser;
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/runtime/BasisLibrary.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/runtime/BasisLibrary.java
@@ -65,7 +65,7 @@ import org.xml.sax.SAXException;
  */
 public final class BasisLibrary {
 
-    private final static String EMPTYSTRING = "";
+    private static final String EMPTYSTRING = "";
 
     /**
      * Re-use a single instance of StringBuffer (per thread) in the basis library.
@@ -1602,7 +1602,7 @@ public final class BasisLibrary {
     // All error messages are localized and are stored in resource bundles.
     private static ResourceBundle m_bundle;
 
-    public final static String ERROR_MESSAGES_KEY = "error-messages";
+    public static final String ERROR_MESSAGES_KEY = "error-messages";
 
     static {
         String resource = "com.sun.org.apache.xalan.internal.xsltc.runtime.ErrorMessages";

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/runtime/Constants.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/runtime/Constants.java
@@ -31,13 +31,13 @@ import com.sun.org.apache.xml.internal.dtm.DTM;
  */
 public interface Constants {
 
-    final static int ANY       = -1;
-    final static int ATTRIBUTE = -2;
-    final static int ROOT      = DTM.ROOT_NODE;
-    final static int TEXT      = DTM.TEXT_NODE;
-    final static int ELEMENT   = DTM.ELEMENT_NODE;
-    final static int COMMENT   = DTM.COMMENT_NODE;
-    final static int PROCESSING_INSTRUCTION = DTM.PROCESSING_INSTRUCTION_NODE;
+    static final int ANY       = -1;
+    static final int ATTRIBUTE = -2;
+    static final int ROOT      = DTM.ROOT_NODE;
+    static final int TEXT      = DTM.TEXT_NODE;
+    static final int ELEMENT   = DTM.ELEMENT_NODE;
+    static final int COMMENT   = DTM.COMMENT_NODE;
+    static final int PROCESSING_INSTRUCTION = DTM.PROCESSING_INSTRUCTION_NODE;
 
     public static final String XSLT_URI = "http://www.w3.org/1999/XSL/Transform";
     public static final String NAMESPACE_FEATURE =

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/runtime/output/TransletOutputHandlerFactory.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/runtime/output/TransletOutputHandlerFactory.java
@@ -74,7 +74,7 @@ public class TransletOutputHandlerFactory {
     private boolean _overrideDefaultParser;
     private ErrorListener _errListener;
 
-    static public TransletOutputHandlerFactory newInstance(boolean overrideDefaultParser,
+    public static TransletOutputHandlerFactory newInstance(boolean overrideDefaultParser,
             ErrorListener errListener) {
         return new TransletOutputHandlerFactory(overrideDefaultParser, errListener);
     }

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/DOM2SAX.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/DOM2SAX.java
@@ -49,7 +49,7 @@ import org.xml.sax.helpers.AttributesImpl;
  */
 public class DOM2SAX implements XMLReader, Locator {
 
-    private final static String EMPTYSTRING = "";
+    private static final String EMPTYSTRING = "";
     private static final String XMLNS_PREFIX = "xmlns";
 
     private Node _dom = null;

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/DOM2TO.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/DOM2TO.java
@@ -45,7 +45,7 @@ import com.sun.org.apache.xml.internal.serializer.NamespaceMappings;
  */
 public class DOM2TO implements XMLReader, Locator2 {
 
-    private final static String EMPTYSTRING = "";
+    private static final String EMPTYSTRING = "";
     private static final String XMLNS_PREFIX = "xmlns";
 
     /**

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/TemplatesImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/TemplatesImpl.java
@@ -72,7 +72,7 @@ import jdk.xml.internal.SecuritySupport;
  */
 public final class TemplatesImpl implements Templates, Serializable {
     static final long serialVersionUID = 673094361519270707L;
-    public final static String DESERIALIZE_TRANSLET = "jdk.xml.enableTemplatesImplDeserialization";
+    public static final String DESERIALIZE_TRANSLET = "jdk.xml.enableTemplatesImplDeserialization";
 
     /**
      * Name of the superclass of all translets. This is needed to
@@ -197,7 +197,7 @@ public final class TemplatesImpl implements Templates, Serializable {
          }
 
         /**
-         * Access to final protected superclass member from outer class.
+         * Access to protected final superclass member from outer class.
          */
         Class<?> defineClass(final byte[] b) {
             return defineClass(null, b, 0, b.length);

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/TransformerFactoryImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/TransformerFactoryImpl.java
@@ -94,16 +94,16 @@ public class TransformerFactoryImpl
     extends SAXTransformerFactory implements SourceLoader
 {
     // Public constants for attributes supported by the XSLTC TransformerFactory.
-    public final static String TRANSLET_NAME = "translet-name";
-    public final static String DESTINATION_DIRECTORY = "destination-directory";
-    public final static String PACKAGE_NAME = "package-name";
-    public final static String JAR_NAME = "jar-name";
-    public final static String GENERATE_TRANSLET = "generate-translet";
-    public final static String AUTO_TRANSLET = "auto-translet";
-    public final static String USE_CLASSPATH = "use-classpath";
-    public final static String DEBUG = "debug";
-    public final static String ENABLE_INLINING = "enable-inlining";
-    public final static String INDENT_NUMBER = "indent-number";
+    public static final String TRANSLET_NAME = "translet-name";
+    public static final String DESTINATION_DIRECTORY = "destination-directory";
+    public static final String PACKAGE_NAME = "package-name";
+    public static final String JAR_NAME = "jar-name";
+    public static final String GENERATE_TRANSLET = "generate-translet";
+    public static final String AUTO_TRANSLET = "auto-translet";
+    public static final String USE_CLASSPATH = "use-classpath";
+    public static final String DEBUG = "debug";
+    public static final String ENABLE_INLINING = "enable-inlining";
+    public static final String INDENT_NUMBER = "indent-number";
 
     /**
      * Default error listener
@@ -134,7 +134,7 @@ public class TransformerFactoryImpl
      * compared to the rest of his bulk, waved helplessly before his eyes.
      * "What has happened to me?", he thought. It was no dream....
      */
-    protected final static String DEFAULT_TRANSLET_NAME = "GregorSamsa";
+    protected static final String DEFAULT_TRANSLET_NAME = "GregorSamsa";
 
     /**
      * The class name of the translet

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/TransformerImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/TransformerImpl.java
@@ -107,7 +107,7 @@ public final class TransformerImpl extends Transformer
     implements DOMCache
 {
 
-    private final static String LEXICAL_HANDLER_PROPERTY =
+    private static final String LEXICAL_HANDLER_PROPERTY =
         "http://xml.org/sax/properties/lexical-handler";
 
     /**

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/AttributeMap.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/AttributeMap.java
@@ -276,7 +276,7 @@ public class AttributeMap extends NamedNodeMapImpl {
      * Internal removeNamedItem method allowing to specify whether an exception
      * must be thrown if the specified name is not found.
      */
-    final protected Node internalRemoveNamedItem(String name, boolean raiseEx){
+    protected final Node internalRemoveNamedItem(String name, boolean raiseEx){
         if (isReadOnly()) {
                 String msg = DOMMessageFormatter.formatMessage(DOMMessageFormatter.DOM_DOMAIN, "NO_MODIFICATION_ALLOWED_ERR", null);
                 throw new DOMException(DOMException.NO_MODIFICATION_ALLOWED_ERR, msg);
@@ -388,7 +388,7 @@ public class AttributeMap extends NamedNodeMapImpl {
      * exception must be thrown if the specified local name and namespace URI
      * is not found.
      */
-    final protected Node internalRemoveNamedItemNS(String namespaceURI,
+    protected final Node internalRemoveNamedItemNS(String namespaceURI,
             String name,
             boolean raiseEx) {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/CoreDOMImplementationImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/CoreDOMImplementationImpl.java
@@ -517,7 +517,7 @@ public class CoreDOMImplementationImpl
         }
 
     /** NON-DOM: retrieve DTD loader */
-    synchronized final XMLDTDLoader getDTDLoader(String xmlVersion) {
+    final synchronized XMLDTDLoader getDTDLoader(String xmlVersion) {
         // return an instance of XML11DTDProcessor
         if ("1.1".equals(xmlVersion)) {
             while (freeXML11DTDLoaderIndex >= 0) {
@@ -553,7 +553,7 @@ public class CoreDOMImplementationImpl
     }
 
     /** NON-DOM: release DTD loader */
-    synchronized final void releaseDTDLoader(String xmlVersion, XMLDTDLoader loader) {
+    final synchronized void releaseDTDLoader(String xmlVersion, XMLDTDLoader loader) {
         // release an instance of XMLDTDLoader
         if ("1.1".equals(xmlVersion)) {
             ++freeXML11DTDLoaderIndex;

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/CoreDocumentImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/CoreDocumentImpl.java
@@ -146,7 +146,7 @@ public class CoreDocumentImpl
     transient Object fXPathEvaluator = null;
 
     /** Table for quick check of child insertion. */
-    private final static int[] kidOK;
+    private static final int[] kidOK;
 
     /**
      * Number of alterations made to this document since its creation.
@@ -344,7 +344,7 @@ public class CoreDocumentImpl
 
     // even though ownerDocument refers to this in this implementation
     // the DOM Level 2 spec says it must be null, so make it appear so
-    final public Document getOwnerDocument() {
+    public final Document getOwnerDocument() {
         return null;
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/DOMConfigurationImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/DOMConfigurationImpl.java
@@ -187,7 +187,7 @@ public class DOMConfigurationImpl extends ParserConfigurationSettings
         Constants.JAXP_PROPERTY_PREFIX + Constants.SCHEMA_SOURCE;
 
     /** Property identifier: DTD validator. */
-    protected final static String DTD_VALIDATOR_PROPERTY =
+    protected static final String DTD_VALIDATOR_PROPERTY =
         Constants.XERCES_PROPERTY_PREFIX + Constants.DTD_VALIDATOR_PROPERTY;
 
     /** Property identifier: datatype validator factory. */
@@ -224,20 +224,20 @@ public class DOMConfigurationImpl extends ParserConfigurationSettings
     /** Normalization features*/
     protected short features = 0;
 
-    protected final static short NAMESPACES          = 0x1<<0;
-    protected final static short DTNORMALIZATION     = 0x1<<1;
-    protected final static short ENTITIES            = 0x1<<2;
-    protected final static short CDATA               = 0x1<<3;
-    protected final static short SPLITCDATA          = 0x1<<4;
-    protected final static short COMMENTS            = 0x1<<5;
-    protected final static short VALIDATE            = 0x1<<6;
-    protected final static short PSVI                = 0x1<<7;
-    protected final static short WELLFORMED          = 0x1<<8;
-    protected final static short NSDECL              = 0x1<<9;
+    protected static final short NAMESPACES          = 0x1<<0;
+    protected static final short DTNORMALIZATION     = 0x1<<1;
+    protected static final short ENTITIES            = 0x1<<2;
+    protected static final short CDATA               = 0x1<<3;
+    protected static final short SPLITCDATA          = 0x1<<4;
+    protected static final short COMMENTS            = 0x1<<5;
+    protected static final short VALIDATE            = 0x1<<6;
+    protected static final short PSVI                = 0x1<<7;
+    protected static final short WELLFORMED          = 0x1<<8;
+    protected static final short NSDECL              = 0x1<<9;
 
-    protected final static short INFOSET_TRUE_PARAMS = NAMESPACES | COMMENTS | WELLFORMED | NSDECL;
-    protected final static short INFOSET_FALSE_PARAMS = ENTITIES | DTNORMALIZATION | CDATA;
-    protected final static short INFOSET_MASK = INFOSET_TRUE_PARAMS | INFOSET_FALSE_PARAMS;
+    protected static final short INFOSET_TRUE_PARAMS = NAMESPACES | COMMENTS | WELLFORMED | NSDECL;
+    protected static final short INFOSET_FALSE_PARAMS = ENTITIES | DTNORMALIZATION | CDATA;
+    protected static final short INFOSET_MASK = INFOSET_TRUE_PARAMS | INFOSET_FALSE_PARAMS;
 
     // components
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/DOMNormalizer.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/DOMNormalizer.java
@@ -97,14 +97,14 @@ public class DOMNormalizer implements XMLDocumentHandler {
     // constants
     //
     /** Debug normalize document*/
-    protected final static boolean DEBUG_ND = false;
+    protected static final boolean DEBUG_ND = false;
     /** Debug namespace fix up algorithm*/
-    protected final static boolean DEBUG = false;
+    protected static final boolean DEBUG = false;
     /** Debug document handler events */
-    protected final static boolean DEBUG_EVENTS = false;
+    protected static final boolean DEBUG_EVENTS = false;
 
     /** prefix added by namespace fixup algorithm should follow a pattern "NS" + index*/
-    protected final static String PREFIX = "NS";
+    protected static final String PREFIX = "NS";
 
     //
     // Data

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/DeferredDocumentImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/DeferredDocumentImpl.java
@@ -133,8 +133,8 @@ public class DeferredDocumentImpl
     //
     // private data
     //
-    private transient final StringBuilder fBufferStr = new StringBuilder();
-    private transient final List<String> fStrChunks = new ArrayList<>();
+    private final transient StringBuilder fBufferStr = new StringBuilder();
+    private final transient List<String> fStrChunks = new ArrayList<>();
 
     //
     // Constructors

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/NamedNodeMapImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/NamedNodeMapImpl.java
@@ -74,9 +74,9 @@ public class NamedNodeMapImpl
 
     protected short flags;
 
-    protected final static short READONLY     = 0x1<<0;
-    protected final static short CHANGED      = 0x1<<1;
-    protected final static short HASDEFAULTS  = 0x1<<2;
+    protected static final short READONLY     = 0x1<<0;
+    protected static final short CHANGED      = 0x1<<1;
+    protected static final short HASDEFAULTS  = 0x1<<2;
 
     /** Nodes. */
     @SuppressWarnings("serial") // Type of field is not Serializable

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/NodeImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/NodeImpl.java
@@ -144,16 +144,16 @@ public abstract class NodeImpl
 
     protected short flags;
 
-    protected final static short READONLY     = 0x1<<0;
-    protected final static short SYNCDATA     = 0x1<<1;
-    protected final static short SYNCCHILDREN = 0x1<<2;
-    protected final static short OWNED        = 0x1<<3;
-    protected final static short FIRSTCHILD   = 0x1<<4;
-    protected final static short SPECIFIED    = 0x1<<5;
-    protected final static short IGNORABLEWS  = 0x1<<6;
-    protected final static short HASSTRING    = 0x1<<7;
-    protected final static short NORMALIZED = 0x1<<8;
-    protected final static short ID           = 0x1<<9;
+    protected static final short READONLY     = 0x1<<0;
+    protected static final short SYNCDATA     = 0x1<<1;
+    protected static final short SYNCCHILDREN = 0x1<<2;
+    protected static final short OWNED        = 0x1<<3;
+    protected static final short FIRSTCHILD   = 0x1<<4;
+    protected static final short SPECIFIED    = 0x1<<5;
+    protected static final short IGNORABLEWS  = 0x1<<6;
+    protected static final short HASSTRING    = 0x1<<7;
+    protected static final short NORMALIZED = 0x1<<8;
+    protected static final short ID           = 0x1<<9;
 
     //
     // Constructors

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/Constants.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/Constants.java
@@ -493,17 +493,17 @@ public final class Constants {
     // general constants
 
     /** Element PSVI is stored in augmentations using string "ELEMENT_PSVI" */
-    public final static String ELEMENT_PSVI = "ELEMENT_PSVI";
+    public static final String ELEMENT_PSVI = "ELEMENT_PSVI";
 
     /** Attribute PSVI is stored in augmentations using string "ATTRIBUTE_PSVI" */
-    public final static String ATTRIBUTE_PSVI = "ATTRIBUTE_PSVI";
+    public static final String ATTRIBUTE_PSVI = "ATTRIBUTE_PSVI";
 
     /**
      * Boolean indicating whether an attribute is declared in the DTD is stored
      * in augmentations using the string "ATTRIBUTE_DECLARED". The absence of this
      * augmentation indicates that the attribute was not declared in the DTD.
      */
-    public final static String ATTRIBUTE_DECLARED = "ATTRIBUTE_DECLARED";
+    public static final String ATTRIBUTE_DECLARED = "ATTRIBUTE_DECLARED";
 
 
     /**
@@ -515,7 +515,7 @@ public final class Constants {
      * {@link org.w3c.dom.Attr#getSchemaTypeInfo()} and
      * {@link org.w3c.dom.Element#getSchemaTypeInfo()} and
      */
-    public final static String TYPEINFO = "org.w3c.dom.TypeInfo";
+    public static final String TYPEINFO = "org.w3c.dom.TypeInfo";
 
     /**
      * Whether an attribute is an id or not is stored in augmentations
@@ -525,7 +525,7 @@ public final class Constants {
      * This will ultimately controls {@link com.sun.org.apache.xerces.internal.parsers.AbstractDOMParser}
      * about whether it will mark an attribute as ID or not.
      */
-    public final static String ID_ATTRIBUTE = "ID_ATTRIBUTE";
+    public static final String ID_ATTRIBUTE = "ID_ATTRIBUTE";
 
     // XML version constants
 
@@ -535,7 +535,7 @@ public final class Constants {
      * The absence of this augmentation indicates that the entity had a
      * declaration and was expanded.
      */
-    public final static String ENTITY_SKIPPED = "ENTITY_SKIPPED";
+    public static final String ENTITY_SKIPPED = "ENTITY_SKIPPED";
 
     /**
      * Boolean indicating whether a character is a probable white space
@@ -544,7 +544,7 @@ public final class Constants {
      * The absence of this augmentation indicates that the character is not
      * probable white space and/or was not included from a character reference.
      */
-    public final static String CHAR_REF_PROBABLE_WS = "CHAR_REF_PROBABLE_WS";
+    public static final String CHAR_REF_PROBABLE_WS = "CHAR_REF_PROBABLE_WS";
 
     /** Boolean indicating if this entity is the last opened entity.
      *
@@ -552,25 +552,25 @@ public final class Constants {
      *@see com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl#endEntity()
      *@see com.sun.org.apache.xerces.internal.impl.XMLDTDScannerImpl#endEntity()
      */
-    public final static String LAST_ENTITY = "LAST_ENTITY";
+    public static final String LAST_ENTITY = "LAST_ENTITY";
 
     // XML version constants
-    public final static short XML_VERSION_ERROR = -1;
-    public final static short XML_VERSION_1_0 = 1;
-    public final static short XML_VERSION_1_1 = 2;
+    public static final short XML_VERSION_ERROR = -1;
+    public static final short XML_VERSION_1_0 = 1;
+    public static final short XML_VERSION_1_1 = 2;
 
 
 
     // DOM related constants
-    public final static String ANONYMOUS_TYPE_NAMESPACE =
+    public static final String ANONYMOUS_TYPE_NAMESPACE =
         "http://apache.org/xml/xmlschema/1.0/anonymousTypes";
 
 
 
     // Constant to enable Schema 1.1 support
-    public final static boolean SCHEMA_1_1_SUPPORT = false;
-    public final static short SCHEMA_VERSION_1_0          = 1;
-    public final static short SCHEMA_VERSION_1_0_EXTENDED = 2;
+    public static final boolean SCHEMA_1_1_SUPPORT = false;
+    public static final short SCHEMA_VERSION_1_0          = 1;
+    public static final short SCHEMA_VERSION_1_0_EXTENDED = 2;
 
     // private
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLDocumentFragmentScannerImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLDocumentFragmentScannerImpl.java
@@ -175,7 +175,7 @@ public class XMLDocumentFragmentScannerImpl
     /** access external dtd: file protocol
      *  For DOM/SAX, the secure feature is set to true by default
      */
-    final static String EXTERNAL_ACCESS_DEFAULT = JdkConstants.EXTERNAL_ACCESS_DEFAULT;
+    static final String EXTERNAL_ACCESS_DEFAULT = JdkConstants.EXTERNAL_ACCESS_DEFAULT;
 
     // recognized features and properties
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLScanner.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLScanner.java
@@ -215,28 +215,28 @@ public abstract class XMLScanner
     // symbols
 
     /** Symbol: "version". */
-    protected final static String fVersionSymbol = "version".intern();
+    protected static final String fVersionSymbol = "version".intern();
 
     /** Symbol: "encoding". */
-    protected final static String fEncodingSymbol = "encoding".intern();
+    protected static final String fEncodingSymbol = "encoding".intern();
 
     /** Symbol: "standalone". */
-    protected final static String fStandaloneSymbol = "standalone".intern();
+    protected static final String fStandaloneSymbol = "standalone".intern();
 
     /** Symbol: "amp". */
-    protected final static String fAmpSymbol = "amp".intern();
+    protected static final String fAmpSymbol = "amp".intern();
 
     /** Symbol: "lt". */
-    protected final static String fLtSymbol = "lt".intern();
+    protected static final String fLtSymbol = "lt".intern();
 
     /** Symbol: "gt". */
-    protected final static String fGtSymbol = "gt".intern();
+    protected static final String fGtSymbol = "gt".intern();
 
     /** Symbol: "quot". */
-    protected final static String fQuotSymbol = "quot".intern();
+    protected static final String fQuotSymbol = "quot".intern();
 
     /** Symbol: "apos". */
-    protected final static String fAposSymbol = "apos".intern();
+    protected static final String fAposSymbol = "apos".intern();
 
     // temporary variables
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLStreamReaderImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLStreamReaderImpl.java
@@ -674,7 +674,7 @@ public class XMLStreamReaderImpl implements javax.xml.stream.XMLStreamReader {
         fEventType = fScanner.next();
     }
 
-    final static String getEventTypeString(int eventType) {
+    static final String getEventTypeString(int eventType) {
         switch (eventType) {
             case XMLEvent.START_ELEMENT:
                 return "START_ELEMENT";

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLVersionDetector.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLVersionDetector.java
@@ -49,7 +49,7 @@ public class XMLVersionDetector {
     // Constants
     //
 
-    private final static char[] XML11_VERSION = new char[]{'1', '.', '1'};
+    private static final char[] XML11_VERSION = new char[]{'1', '.', '1'};
 
 
     // property identifiers
@@ -71,7 +71,7 @@ public class XMLVersionDetector {
     //
 
     /** Symbol: "version". */
-    protected final static String fVersionSymbol = "version".intern();
+    protected static final String fVersionSymbol = "version".intern();
 
     // symbol:  [xml]:
     protected static final String fXMLSymbol = "[xml]".intern();

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dtd/XML11DTDValidator.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dtd/XML11DTDValidator.java
@@ -38,7 +38,7 @@ public class XML11DTDValidator extends XMLDTDValidator {
     // Constants
     //
 
-    protected final static String DTD_VALIDATOR_PROPERTY =
+    protected static final String DTD_VALIDATOR_PROPERTY =
         Constants.XERCES_PROPERTY_PREFIX+Constants.DTD_VALIDATOR_PROPERTY;
 
     //

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/SchemaDVFactory.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/SchemaDVFactory.java
@@ -53,7 +53,7 @@ public abstract class SchemaDVFactory {
      * @exception DVFactoryException  cannot create an instance of the specified
      *                                class name or the default class name
      */
-    public static synchronized final SchemaDVFactory getInstance() throws DVFactoryException {
+    public static final synchronized SchemaDVFactory getInstance() throws DVFactoryException {
         return getInstance(DEFAULT_FACTORY_CLASS);
     } //getInstance():  SchemaDVFactory
 
@@ -66,7 +66,7 @@ public abstract class SchemaDVFactory {
      * @exception DVFactoryException  cannot create an instance of the specified
      *                                class name or the default class name
      */
-    public static synchronized final SchemaDVFactory getInstance(String factoryClass) throws DVFactoryException {
+    public static final synchronized SchemaDVFactory getInstance(String factoryClass) throws DVFactoryException {
 
         try {
             // if the class name is not specified, use the default one

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/util/Base64.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/util/Base64.java
@@ -40,18 +40,18 @@ package com.sun.org.apache.xerces.internal.impl.dv.util;
  */
 public final class  Base64 {
 
-    static private final int  BASELENGTH         = 128;
-    static private final int  LOOKUPLENGTH       = 64;
-    static private final int  TWENTYFOURBITGROUP = 24;
-    static private final int  EIGHTBIT           = 8;
-    static private final int  SIXTEENBIT         = 16;
-    static private final int  SIXBIT             = 6;
-    static private final int  FOURBYTE           = 4;
-    static private final int  SIGN               = -128;
-    static private final char PAD                = '=';
-    static private final boolean fDebug          = false;
-    static final private byte [] base64Alphabet        = new byte[BASELENGTH];
-    static final private char [] lookUpBase64Alphabet  = new char[LOOKUPLENGTH];
+    private static final int  BASELENGTH         = 128;
+    private static final int  LOOKUPLENGTH       = 64;
+    private static final int  TWENTYFOURBITGROUP = 24;
+    private static final int  EIGHTBIT           = 8;
+    private static final int  SIXTEENBIT         = 16;
+    private static final int  SIXBIT             = 6;
+    private static final int  FOURBYTE           = 4;
+    private static final int  SIGN               = -128;
+    private static final char PAD                = '=';
+    private static final boolean fDebug          = false;
+    private static final byte [] base64Alphabet        = new byte[BASELENGTH];
+    private static final char [] lookUpBase64Alphabet  = new char[LOOKUPLENGTH];
 
     static {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/util/HexBin.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/util/HexBin.java
@@ -31,10 +31,10 @@ package com.sun.org.apache.xerces.internal.impl.dv.util;
  * @author Jeffrey Rodriguez
  */
 public final class  HexBin {
-    static private final int  BASELENGTH   = 128;
-    static private final int  LOOKUPLENGTH = 16;
-    static final private byte [] hexNumberTable    = new byte[BASELENGTH];
-    static final private char [] lookUpHexAlphabet = new char[LOOKUPLENGTH];
+    private static final int  BASELENGTH   = 128;
+    private static final int  LOOKUPLENGTH = 16;
+    private static final byte [] hexNumberTable    = new byte[BASELENGTH];
+    private static final char [] lookUpHexAlphabet = new char[LOOKUPLENGTH];
 
 
     static {
@@ -65,7 +65,7 @@ public final class  HexBin {
      * @param binaryData array of byte to encode
      * @return return encoded string
      */
-    static public String encode(byte[] binaryData) {
+    public static String encode(byte[] binaryData) {
         if (binaryData == null)
             return null;
         int lengthData   = binaryData.length;
@@ -88,7 +88,7 @@ public final class  HexBin {
      * @param encoded encoded string
      * @return return array of byte to encode
      */
-    static public byte[] decode(String encoded) {
+    public static byte[] decode(String encoded) {
         if (encoded == null)
             return null;
         int lengthData = encoded.length();

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/AbstractDateTimeDV.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/AbstractDateTimeDV.java
@@ -56,9 +56,9 @@ public abstract class AbstractDateTimeDV extends TypeValidator {
     //define shared variables for date/time
     //define constants to be used in assigning default values for
     //all date/time excluding duration
-    protected final static int YEAR = 2000;
-    protected final static int MONTH = 01;
-    protected final static int DAY = 01;
+    protected static final int YEAR = 2000;
+    protected static final int MONTH = 01;
+    protected static final int DAY = 01;
     protected static final DatatypeFactory datatypeFactory = new DatatypeFactoryImpl();
 
     @Override

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/DayDV.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/DayDV.java
@@ -38,7 +38,7 @@ import com.sun.org.apache.xerces.internal.impl.dv.ValidationContext;
 public class DayDV extends AbstractDateTimeDV {
 
     //size without time zone: ---09
-    private final static int DAY_SIZE=5;
+    private static final int DAY_SIZE=5;
 
     public Object getActualValue(String content, ValidationContext context) throws InvalidDatatypeValueException {
         try{

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/DurationDV.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/DurationDV.java
@@ -49,7 +49,7 @@ public class DurationDV extends AbstractDateTimeDV {
     // see 3.2.6 duration W3C schema datatype specs
     //
     // the dates are in format: {CCYY,MM,DD, H, S, M, MS, timezone}
-    private final static DateTimeData[] DATETIMES= {
+    private static final DateTimeData[] DATETIMES= {
         new DateTimeData(1696, 9, 1, 0, 0, 0, 'Z', null, true, null),
         new DateTimeData(1697, 2, 1, 0, 0, 0, 'Z', null, true, null),
         new DateTimeData(1903, 3, 1, 0, 0, 0, 'Z', null, true, null),

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/ListDV.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/ListDV.java
@@ -55,7 +55,7 @@ public class ListDV extends TypeValidator{
         return ((ListData)value).getLength();
     }
 
-    final static class ListData extends AbstractList<Object> implements ObjectList {
+    static final class ListData extends AbstractList<Object> implements ObjectList {
         final Object[] data;
         private String canonical;
         public ListData(Object[] data) {

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/MonthDayDV.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/MonthDayDV.java
@@ -40,7 +40,7 @@ import com.sun.org.apache.xerces.internal.impl.dv.ValidationContext;
 public class MonthDayDV extends AbstractDateTimeDV {
 
     //size without time zone: --MM-DD
-    private final static int MONTHDAY_SIZE = 7;
+    private static final int MONTHDAY_SIZE = 7;
 
     /**
      * Convert a string to a compiled form

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/XSSimpleTypeDecl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/xs/XSSimpleTypeDecl.java
@@ -3440,7 +3440,7 @@ public class XSSimpleTypeDecl implements XSSimpleType, TypeInfo {
         }
     }
 
-    private static abstract class AbstractObjectList extends AbstractList<Object> implements ObjectList {
+    private abstract static class AbstractObjectList extends AbstractList<Object> implements ObjectList {
         public Object get(int index) {
             if (index >= 0 && index < getLength()) {
                 return item(index);

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xpath/regex/CaseInsensitiveMap.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xpath/regex/CaseInsensitiveMap.java
@@ -44,7 +44,7 @@ final class CaseInsensitiveMap {
      *  Return a list of code point characters (not including the input value)
      *  that can be substituted in a case insensitive match
      */
-    static public int[] get(int codePoint) {
+    public static int[] get(int codePoint) {
         return (codePoint < 0x10000) ? getMapping(codePoint) : null;
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xpath/regex/ParserForXMLSchema.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xpath/regex/ParserForXMLSchema.java
@@ -369,9 +369,9 @@ class ParserForXMLSchema extends RegexParser {
         return c;
     }
 
-    static private Map<String, Token> ranges = null;
-    static private Map<String, Token> ranges2 = null;
-    static synchronized protected RangeToken getRange(String name, boolean positive) {
+    private static Map<String, Token> ranges = null;
+    private static Map<String, Token> ranges2 = null;
+    protected static synchronized RangeToken getRange(String name, boolean positive) {
         if (ranges == null) {
             ranges = new HashMap<>();
             ranges2 = new HashMap<>();

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xpath/regex/RegexParser.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xpath/regex/RegexParser.java
@@ -76,9 +76,9 @@ class RegexParser {
     ResourceBundle resources;
     int chardata;
     int nexttoken;
-    static protected final int S_NORMAL = 0;
-    static protected final int S_INBRACKETS = 1;
-    static protected final int S_INXBRACKETS = 2;
+    protected static final int S_NORMAL = 0;
+    protected static final int S_INBRACKETS = 1;
+    protected static final int S_INXBRACKETS = 2;
     int context = S_NORMAL;
     int parenOpened = 1;
     int parennumber = 1;
@@ -1191,7 +1191,7 @@ class RegexParser {
         return c;
     }
 
-    static private final int hexChar(int ch) {
+    private static final int hexChar(int ch) {
         if (ch < '0')  return -1;
         if (ch > 'f')  return -1;
         if (ch <= '9')  return ch-'0';
@@ -1201,7 +1201,7 @@ class RegexParser {
         return ch-'a'+10;
     }
 
-    static protected final void addCaseInsensitiveChar(RangeToken tok, int c) {
+    protected static final void addCaseInsensitiveChar(RangeToken tok, int c) {
         final int[] caseMap = CaseInsensitiveMap.get(c);
         tok.addRange(c, c);
 
@@ -1213,7 +1213,7 @@ class RegexParser {
 
     }
 
-    static protected final void addCaseInsensitiveCharRange(RangeToken tok, int start, int end) {
+    protected static final void addCaseInsensitiveCharRange(RangeToken tok, int start, int end) {
         int[] caseMap;
         int r1, r2;
         if (start <= end) {

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xpath/regex/RegularExpression.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xpath/regex/RegularExpression.java
@@ -1748,7 +1748,7 @@ public class RegularExpression implements java.io.Serializable {
     transient BMPattern fixedStringTable = null;
     transient boolean fixedStringOnly = false;
 
-    static abstract class ExpressionTarget {
+    abstract static class ExpressionTarget {
         abstract char charAt(int index);
         abstract boolean regionMatches(boolean ignoreCase, int offset, int limit, String part, int partlen);
         abstract boolean regionMatches(boolean ignoreCase, int offset, int limit, int offset2, int partlen);

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xpath/regex/Token.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xpath/regex/Token.java
@@ -167,7 +167,7 @@ class Token implements java.io.Serializable {
         if (COUNTTOKENS)  Token.tokens ++;
         return new Token.CharToken(Token.CHAR, ch);
     }
-    static private Token.CharToken createAnchor(int ch) {
+    private static Token.CharToken createAnchor(int ch) {
         if (COUNTTOKENS)  Token.tokens ++;
         return new Token.CharToken(Token.ANCHOR, ch);
     }
@@ -742,7 +742,7 @@ class Token implements java.io.Serializable {
     };
     private static final int NONBMP_BLOCK_START = 84;
 
-    static protected RangeToken getRange(String name, boolean positive) {
+    protected static RangeToken getRange(String name, boolean positive) {
         // use local variable for better performance
         Map<String, Token> localCat = Token.categories;
         if (localCat == null) {
@@ -983,7 +983,7 @@ class Token implements java.io.Serializable {
         return positive ? (RangeToken)localCat.get(name)
             : (RangeToken)Token.categories2.get(name);
     }
-    static protected RangeToken getRange(String name, boolean positive, boolean xs) {
+    protected static RangeToken getRange(String name, boolean positive, boolean xs) {
         RangeToken range = Token.getRange(name, positive);
         if (xs && range != null && Token.isRegisterNonXS(name))
             range = null;
@@ -995,11 +995,11 @@ class Token implements java.io.Serializable {
      * This method is called by only getRange().
      * So this method need not MT-safe.
      */
-    static protected void registerNonXS(String name) {
+    protected static void registerNonXS(String name) {
         Token.nonxs.add(name);
     }
 
-    static protected boolean isRegisterNonXS(String name) {
+    protected static boolean isRegisterNonXS(String name) {
         return Token.nonxs.contains(name);
     }
 
@@ -1031,7 +1031,7 @@ class Token implements java.io.Serializable {
     +"\u0E3A"//;THAI CHARACTER PHINTHU;Mn;9;ON;;;;;N;THAI VOWEL SIGN PHINTHU;;;;
     +"\u0F84";//;TIBETAN MARK HALANTA;Mn;9;ON;;;;;N;TIBETAN VIRAMA;;;;
 
-    static private Token token_grapheme = null;
+    private static Token token_grapheme = null;
     static synchronized Token getGraphemePattern() {
         if (Token.token_grapheme != null)
             return Token.token_grapheme;
@@ -1070,7 +1070,7 @@ class Token implements java.io.Serializable {
     /**
      * Combing Character Sequence in Perl 5.6.
      */
-    static private Token token_ccs = null;
+    private static Token token_ccs = null;
     static synchronized Token getCombiningCharacterSequence() {
         if (Token.token_ccs != null)
             return Token.token_ccs;

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/SchemaGrammar.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/SchemaGrammar.java
@@ -1176,7 +1176,7 @@ public class SchemaGrammar implements XSGrammar, XSNamespaceItem {
 
     // anyType and anySimpleType: because there are so many places where
     // we need direct access to these two types
-    public final static XSComplexTypeDecl fAnyType = new XSAnyType();
+    public static final XSComplexTypeDecl fAnyType = new XSAnyType();
     private static class XSAnyType extends XSComplexTypeDecl {
         public XSAnyType () {
             fName = SchemaSymbols.ATTVAL_ANYTYPE;
@@ -1289,13 +1289,13 @@ public class SchemaGrammar implements XSGrammar, XSNamespaceItem {
     } // class BuiltinAttrDecl
 
     // the grammars to hold components of the schema namespace
-    public final static BuiltinSchemaGrammar SG_SchemaNS = new BuiltinSchemaGrammar(GRAMMAR_XS, Constants.SCHEMA_VERSION_1_0);
-    private final static BuiltinSchemaGrammar SG_SchemaNSExtended = new BuiltinSchemaGrammar(GRAMMAR_XS, Constants.SCHEMA_VERSION_1_0_EXTENDED);
+    public static final BuiltinSchemaGrammar SG_SchemaNS = new BuiltinSchemaGrammar(GRAMMAR_XS, Constants.SCHEMA_VERSION_1_0);
+    private static final BuiltinSchemaGrammar SG_SchemaNSExtended = new BuiltinSchemaGrammar(GRAMMAR_XS, Constants.SCHEMA_VERSION_1_0_EXTENDED);
 
-    public final static XSSimpleType fAnySimpleType = (XSSimpleType)SG_SchemaNS.getGlobalTypeDecl(SchemaSymbols.ATTVAL_ANYSIMPLETYPE);
+    public static final XSSimpleType fAnySimpleType = (XSSimpleType)SG_SchemaNS.getGlobalTypeDecl(SchemaSymbols.ATTVAL_ANYSIMPLETYPE);
 
     // the grammars to hold components of the schema-instance namespace
-    public final static BuiltinSchemaGrammar SG_XSI = new BuiltinSchemaGrammar(GRAMMAR_XSI, Constants.SCHEMA_VERSION_1_0);
+    public static final BuiltinSchemaGrammar SG_XSI = new BuiltinSchemaGrammar(GRAMMAR_XSI, Constants.SCHEMA_VERSION_1_0);
 
     public static SchemaGrammar getS4SGrammar(short schemaVersion) {
         if (schemaVersion == Constants.SCHEMA_VERSION_1_0) {

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/XSAttributeDecl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/XSAttributeDecl.java
@@ -46,9 +46,9 @@ import com.sun.org.apache.xerces.internal.xs.XSValue;
 public class XSAttributeDecl implements XSAttributeDeclaration {
 
     // scopes
-    public final static short     SCOPE_ABSENT        = 0;
-    public final static short     SCOPE_GLOBAL        = 1;
-    public final static short     SCOPE_LOCAL         = 2;
+    public static final short     SCOPE_ABSENT        = 0;
+    public static final short     SCOPE_GLOBAL        = 1;
+    public static final short     SCOPE_LOCAL         = 2;
 
     // the name of the attribute
     String fName = null;

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/XSDDescription.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/XSDDescription.java
@@ -42,33 +42,33 @@ public class XSDDescription extends XMLResourceIdentifierImpl
     /**
      * Indicate that this description was just initialized.
      */
-    public final static short CONTEXT_INITIALIZE = -1;
+    public static final short CONTEXT_INITIALIZE = -1;
     /**
      * Indicate that the current schema document is <include>d by another
      * schema document.
      */
-    public final static short CONTEXT_INCLUDE   = 0;
+    public static final short CONTEXT_INCLUDE   = 0;
     /**
      * Indicate that the current schema document is <redefine>d by another
      * schema document.
      */
-    public final static short CONTEXT_REDEFINE  = 1;
+    public static final short CONTEXT_REDEFINE  = 1;
     /**
      * Indicate that the current schema document is <import>ed by another
      * schema document.
      */
-    public final static short CONTEXT_IMPORT    = 2;
+    public static final short CONTEXT_IMPORT    = 2;
     /**
      * Indicate that the current schema document is being preparsed.
      */
-    public final static short CONTEXT_PREPARSE  = 3;
+    public static final short CONTEXT_PREPARSE  = 3;
     /**
      * Indicate that the parse of the current schema document is triggered
      * by xsi:schemaLocation/noNamespaceSchemaLocation attribute(s) in the
      * instance document. This value is only used if we don't defer the loading
      * of schema documents.
      */
-    public final static short CONTEXT_INSTANCE  = 4;
+    public static final short CONTEXT_INSTANCE  = 4;
     /**
      * Indicate that the parse of the current schema document is triggered by
      * the occurrence of an element whose namespace is the target namespace
@@ -76,7 +76,7 @@ public class XSDDescription extends XMLResourceIdentifierImpl
      * loading of schema documents until a component from that namespace is
      * referenced from the instance.
      */
-    public final static short CONTEXT_ELEMENT   = 5;
+    public static final short CONTEXT_ELEMENT   = 5;
     /**
      * Indicate that the parse of the current schema document is triggered by
      * the occurrence of an attribute whose namespace is the target namespace
@@ -84,7 +84,7 @@ public class XSDDescription extends XMLResourceIdentifierImpl
      * loading of schema documents until a component from that namespace is
      * referenced from the instance.
      */
-    public final static short CONTEXT_ATTRIBUTE = 6;
+    public static final short CONTEXT_ATTRIBUTE = 6;
     /**
      * Indicate that the parse of the current schema document is triggered by
      * the occurrence of an "xsi:type" attribute, whose value (a QName) has
@@ -92,7 +92,7 @@ public class XSDDescription extends XMLResourceIdentifierImpl
      * This value is only used if we do defer the loading of schema documents
      * until a component from that namespace is referenced from the instance.
      */
-    public final static short CONTEXT_XSITYPE   = 7;
+    public static final short CONTEXT_XSITYPE   = 7;
 
     // REVISIT: write description of these fields
     protected short fContextType;

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/XSElementDecl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/XSElementDecl.java
@@ -48,9 +48,9 @@ import com.sun.org.apache.xerces.internal.xs.XSValue;
 public class XSElementDecl implements XSElementDeclaration {
 
     // scopes
-    public final static short     SCOPE_ABSENT        = 0;
-    public final static short     SCOPE_GLOBAL        = 1;
-    public final static short     SCOPE_LOCAL         = 2;
+    public static final short     SCOPE_ABSENT        = 0;
+    public static final short     SCOPE_GLOBAL        = 1;
+    public static final short     SCOPE_LOCAL         = 2;
 
     // name of the element
     public String fName = null;

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java
@@ -67,7 +67,7 @@ public class SchemaParsingConfig extends BasicParserConfiguration
     // Constants
     //
 
-    protected final static String XML11_DATATYPE_VALIDATOR_FACTORY =
+    protected static final String XML11_DATATYPE_VALIDATOR_FACTORY =
         "com.sun.org.apache.xerces.internal.impl.dv.dtd.XML11DTDDVFactoryImpl";
 
     // feature identifiers

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/traversers/XSDComplexTypeTraverser.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/traversers/XSDComplexTypeTraverser.java
@@ -68,7 +68,7 @@ import org.w3c.dom.Element;
 class  XSDComplexTypeTraverser extends XSDAbstractParticleTraverser {
 
     // size of stack to hold globals:
-    private final static int GLOBAL_NUM = 11;
+    private static final int GLOBAL_NUM = 11;
 
     private static XSParticleDecl fErrorContent = null;
     private static XSWildcardDecl fErrorWildcard = null;

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/traversers/XSDHandler.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/traversers/XSDHandler.java
@@ -234,17 +234,17 @@ public class XSDHandler {
 
     // different sorts of declarations; should make lookup and
     // traverser calling more efficient/less bulky.
-    final static int ATTRIBUTE_TYPE          = 1;
-    final static int ATTRIBUTEGROUP_TYPE     = 2;
-    final static int ELEMENT_TYPE            = 3;
-    final static int GROUP_TYPE              = 4;
-    final static int IDENTITYCONSTRAINT_TYPE = 5;
-    final static int NOTATION_TYPE           = 6;
-    final static int TYPEDECL_TYPE           = 7;
+    static final int ATTRIBUTE_TYPE          = 1;
+    static final int ATTRIBUTEGROUP_TYPE     = 2;
+    static final int ELEMENT_TYPE            = 3;
+    static final int GROUP_TYPE              = 4;
+    static final int IDENTITYCONSTRAINT_TYPE = 5;
+    static final int NOTATION_TYPE           = 6;
+    static final int TYPEDECL_TYPE           = 7;
 
     // this string gets appended to redefined names; it's purpose is to be
     // as unlikely as possible to cause collisions.
-    public final static String REDEF_IDENTIFIER = "_fn3dktizrknc9pi";
+    public static final String REDEF_IDENTIFIER = "_fn3dktizrknc9pi";
 
     //protected data that can be accessible by any traverser
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/jaxp/DefaultValidationErrorHandler.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/jaxp/DefaultValidationErrorHandler.java
@@ -31,7 +31,7 @@ import org.xml.sax.helpers.DefaultHandler;
  */
 
 class DefaultValidationErrorHandler extends DefaultHandler {
-    static private int ERROR_COUNT_LIMIT = 10;
+    private static int ERROR_COUNT_LIMIT = 10;
     private int errorCount = 0;
     private Locale locale = Locale.getDefault();
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/jaxp/datatype/XMLGregorianCalendarImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/jaxp/datatype/XMLGregorianCalendarImpl.java
@@ -198,15 +198,15 @@ public class XMLGregorianCalendarImpl
         implements Serializable, Cloneable {
 
     /** Backup values **/
-    transient private BigInteger orig_eon;
-    transient private int orig_year = DatatypeConstants.FIELD_UNDEFINED;
-    transient private int orig_month = DatatypeConstants.FIELD_UNDEFINED;
-    transient private int orig_day = DatatypeConstants.FIELD_UNDEFINED;
-    transient private int orig_hour = DatatypeConstants.FIELD_UNDEFINED;
-    transient private int orig_minute = DatatypeConstants.FIELD_UNDEFINED;
-    transient private int orig_second = DatatypeConstants.FIELD_UNDEFINED;
-    transient private BigDecimal orig_fracSeconds;
-    transient private int orig_timezone = DatatypeConstants.FIELD_UNDEFINED;
+    private transient BigInteger orig_eon;
+    private transient int orig_year = DatatypeConstants.FIELD_UNDEFINED;
+    private transient int orig_month = DatatypeConstants.FIELD_UNDEFINED;
+    private transient int orig_day = DatatypeConstants.FIELD_UNDEFINED;
+    private transient int orig_hour = DatatypeConstants.FIELD_UNDEFINED;
+    private transient int orig_minute = DatatypeConstants.FIELD_UNDEFINED;
+    private transient int orig_second = DatatypeConstants.FIELD_UNDEFINED;
+    private transient BigDecimal orig_fracSeconds;
+    private transient int orig_timezone = DatatypeConstants.FIELD_UNDEFINED;
 
     /**
      * <p>Eon of this <code>XMLGregorianCalendar</code>.</p>

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/jaxp/validation/DOMResultBuilder.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/jaxp/validation/DOMResultBuilder.java
@@ -70,7 +70,7 @@ import org.w3c.dom.Text;
 final class DOMResultBuilder implements DOMDocumentHandler {
 
     /** Table for quick check of child insertion. */
-    private final static int[] kidOK;
+    private static final int[] kidOK;
 
     static {
         kidOK = new int[13];

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParserImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParserImpl.java
@@ -150,7 +150,7 @@ extends AbstractDOMParser implements LSParser, DOMConfiguration {
 
     private Thread currentThread;
 
-    protected final static boolean DEBUG = false;
+    protected static final boolean DEBUG = false;
 
     private String fSchemaLocation = null;
         private DOMStringList fRecognizedParameters;

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11Configuration.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11Configuration.java
@@ -86,7 +86,7 @@ public class XML11Configuration extends ParserConfigurationSettings
     //
     // Constants
     //
-    protected final static String XML11_DATATYPE_VALIDATOR_FACTORY =
+    protected static final String XML11_DATATYPE_VALIDATOR_FACTORY =
         "com.sun.org.apache.xerces.internal.impl.dv.dtd.XML11DTDDVFactoryImpl";
 
     // feature identifiers

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11DTDConfiguration.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11DTDConfiguration.java
@@ -111,7 +111,7 @@ public class XML11DTDConfiguration extends ParserConfigurationSettings
     //
     // Constants
     //
-    protected final static String XML11_DATATYPE_VALIDATOR_FACTORY =
+    protected static final String XML11_DATATYPE_VALIDATOR_FACTORY =
         "com.sun.org.apache.xerces.internal.impl.dv.dtd.XML11DTDDVFactoryImpl";
 
     // feature identifiers

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11NonValidatingConfiguration.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11NonValidatingConfiguration.java
@@ -84,7 +84,7 @@ public class XML11NonValidatingConfiguration extends ParserConfigurationSettings
     //
     // Constants
     //
-    protected final static String XML11_DATATYPE_VALIDATOR_FACTORY =
+    protected static final String XML11_DATATYPE_VALIDATOR_FACTORY =
         "com.sun.org.apache.xerces.internal.impl.dv.dtd.XML11DTDDVFactoryImpl";
 
     // feature identifiers

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XMLGrammarPreparser.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XMLGrammarPreparser.java
@@ -58,7 +58,7 @@ public class XMLGrammarPreparser {
     //
 
     // feature:  continue-after-fatal-error
-    private final static String CONTINUE_AFTER_FATAL_ERROR =
+    private static final String CONTINUE_AFTER_FATAL_ERROR =
         Constants.XERCES_FEATURE_PREFIX + Constants.CONTINUE_AFTER_FATAL_ERROR_FEATURE;
 
     /** Property identifier: symbol table. */

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/util/AugmentationsImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/util/AugmentationsImpl.java
@@ -104,17 +104,17 @@ public class AugmentationsImpl implements Augmentations{
     }
 
     abstract class AugmentationsItemsContainer {
-        abstract public Object putItem(Object key, Object item);
-        abstract public Object getItem(Object key);
-        abstract public Object removeItem(Object key);
-        abstract public Enumeration<Object> keys();
-        abstract public void clear();
-        abstract public boolean isFull();
-        abstract public AugmentationsItemsContainer expand();
+        public abstract Object putItem(Object key, Object item);
+        public abstract Object getItem(Object key);
+        public abstract Object removeItem(Object key);
+        public abstract Enumeration<Object> keys();
+        public abstract void clear();
+        public abstract boolean isFull();
+        public abstract AugmentationsItemsContainer expand();
     }
 
     class SmallContainer extends AugmentationsItemsContainer {
-        final static int SIZE_LIMIT = 10;
+        static final int SIZE_LIMIT = 10;
         final Object[] fAugmentations = new Object[SIZE_LIMIT*2];
         int fNumEntries = 0;
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/util/EncodingMap.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/util/EncodingMap.java
@@ -479,10 +479,10 @@ public class EncodingMap {
     //
 
     /** fIANA2JavaMap */
-    protected final static Map<String, String> fIANA2JavaMap;
+    protected static final Map<String, String> fIANA2JavaMap;
 
     /** fJava2IANAMap */
-    protected final static Map<String, String> fJava2IANAMap;
+    protected static final Map<String, String> fJava2IANAMap;
 
     //
     // Static initialization

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/util/SecurityManager.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/util/SecurityManager.java
@@ -45,17 +45,17 @@ public final class SecurityManager {
     // Constants
     //
     // default value for entity expansion limit
-    private final static int DEFAULT_ENTITY_EXPANSION_LIMIT = 64000;
+    private static final int DEFAULT_ENTITY_EXPANSION_LIMIT = 64000;
 
     /**
      * Default value of number of nodes created. *
      */
-    private final static int DEFAULT_MAX_OCCUR_NODE_LIMIT = 5000;
+    private static final int DEFAULT_MAX_OCCUR_NODE_LIMIT = 5000;
 
     //
     // Data
     //
-    private final static int DEFAULT_ELEMENT_ATTRIBUTE_LIMIT = 10000;
+    private static final int DEFAULT_ELEMENT_ATTRIBUTE_LIMIT = 10000;
 
     /**
      * Entity expansion limit. *

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/util/XMLSymbols.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/util/XMLSymbols.java
@@ -38,7 +38,7 @@ public class XMLSymbols {
     /**
      * The empty string.
      */
-    public final static String EMPTY_STRING = "".intern();
+    public static final String EMPTY_STRING = "".intern();
 
     //==========================
     // Namespace prefixes/uris
@@ -47,12 +47,12 @@ public class XMLSymbols {
     /**
      * The internalized "xml" prefix.
      */
-    public final static String PREFIX_XML = "xml".intern();
+    public static final String PREFIX_XML = "xml".intern();
 
     /**
      * The internalized "xmlns" prefix.
      */
-    public final static String PREFIX_XMLNS = "xmlns".intern();
+    public static final String PREFIX_XMLNS = "xmlns".intern();
 
     //==========================
     // DTD symbols

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xinclude/XIncludeHandler.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xinclude/XIncludeHandler.java
@@ -133,33 +133,33 @@ import org.xml.sax.InputSource;
 public class XIncludeHandler
     implements XMLComponent, XMLDocumentFilter, XMLDTDFilter {
 
-    public final static String HTTP_ACCEPT = "Accept";
-    public final static String HTTP_ACCEPT_LANGUAGE = "Accept-Language";
-    public final static String XPOINTER = "xpointer";
+    public static final String HTTP_ACCEPT = "Accept";
+    public static final String HTTP_ACCEPT_LANGUAGE = "Accept-Language";
+    public static final String XPOINTER = "xpointer";
 
-    public final static String XINCLUDE_NS_URI =
+    public static final String XINCLUDE_NS_URI =
         "http://www.w3.org/2001/XInclude".intern();
-    public final static String XINCLUDE_INCLUDE = "include".intern();
-    public final static String XINCLUDE_FALLBACK = "fallback".intern();
+    public static final String XINCLUDE_INCLUDE = "include".intern();
+    public static final String XINCLUDE_FALLBACK = "fallback".intern();
 
-    public final static String XINCLUDE_PARSE_XML = "xml".intern();
-    public final static String XINCLUDE_PARSE_TEXT = "text".intern();
+    public static final String XINCLUDE_PARSE_XML = "xml".intern();
+    public static final String XINCLUDE_PARSE_TEXT = "text".intern();
 
-    public final static String XINCLUDE_ATTR_HREF = "href".intern();
-    public final static String XINCLUDE_ATTR_PARSE = "parse".intern();
-    public final static String XINCLUDE_ATTR_ENCODING = "encoding".intern();
-    public final static String XINCLUDE_ATTR_ACCEPT = "accept".intern();
-    public final static String XINCLUDE_ATTR_ACCEPT_LANGUAGE = "accept-language".intern();
+    public static final String XINCLUDE_ATTR_HREF = "href".intern();
+    public static final String XINCLUDE_ATTR_PARSE = "parse".intern();
+    public static final String XINCLUDE_ATTR_ENCODING = "encoding".intern();
+    public static final String XINCLUDE_ATTR_ACCEPT = "accept".intern();
+    public static final String XINCLUDE_ATTR_ACCEPT_LANGUAGE = "accept-language".intern();
 
     // Top Level Information Items have [included] property in infoset
-    public final static String XINCLUDE_INCLUDED = "[included]".intern();
+    public static final String XINCLUDE_INCLUDED = "[included]".intern();
 
     /** The identifier for the Augmentation that contains the current base URI */
-    public final static String CURRENT_BASE_URI = "currentBaseURI";
+    public static final String CURRENT_BASE_URI = "currentBaseURI";
 
     // used for adding [base URI] attributes
-    private final static String XINCLUDE_BASE = "base".intern();
-    private final static QName XML_BASE_QNAME =
+    private static final String XINCLUDE_BASE = "base".intern();
+    private static final QName XML_BASE_QNAME =
         new QName(
             XMLSymbols.PREFIX_XML,
             XINCLUDE_BASE,
@@ -167,15 +167,15 @@ public class XIncludeHandler
             NamespaceContext.XML_URI);
 
     // used for adding [language] attributes
-    private final static String XINCLUDE_LANG = "lang".intern();
-    private final static QName XML_LANG_QNAME =
+    private static final String XINCLUDE_LANG = "lang".intern();
+    private static final QName XML_LANG_QNAME =
         new QName(
             XMLSymbols.PREFIX_XML,
             XINCLUDE_LANG,
             (XMLSymbols.PREFIX_XML + ":" + XINCLUDE_LANG).intern(),
             NamespaceContext.XML_URI);
 
-    private final static QName NEW_NS_ATTR_QNAME =
+    private static final QName NEW_NS_ATTR_QNAME =
         new QName(
             XMLSymbols.PREFIX_XMLNS,
             "",
@@ -183,13 +183,13 @@ public class XIncludeHandler
             NamespaceContext.XMLNS_URI);
 
     // Processing States
-    private final static int STATE_NORMAL_PROCESSING = 1;
+    private static final int STATE_NORMAL_PROCESSING = 1;
     // we go into this state after a successful include (thus we ignore the children
     // of the include) or after a fallback
-    private final static int STATE_IGNORE = 2;
+    private static final int STATE_IGNORE = 2;
     // we go into this state after a failed include.  If we don't encounter a fallback
     // before we reach the end include tag, it's a fatal error
-    private final static int STATE_EXPECT_FALLBACK = 3;
+    private static final int STATE_EXPECT_FALLBACK = 3;
 
     // recognized features and properties
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/NamespaceContext.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/NamespaceContext.java
@@ -46,14 +46,14 @@ public interface NamespaceContext {
      * The XML Namespace ("http://www.w3.org/XML/1998/namespace"). This is
      * the Namespace URI that is automatically mapped to the "xml" prefix.
      */
-    public final static String XML_URI = "http://www.w3.org/XML/1998/namespace".intern();
+    public static final String XML_URI = "http://www.w3.org/XML/1998/namespace".intern();
 
     /**
      * XML Information Set REC
      * all namespace attributes (including those named xmlns,
      * whose [prefix] property has no value) have a namespace URI of http://www.w3.org/2000/xmlns/
      */
-    public final static String XMLNS_URI = "http://www.w3.org/2000/xmlns/".intern();
+    public static final String XMLNS_URI = "http://www.w3.org/2000/xmlns/".intern();
 
     //
     // NamespaceContext methods

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/grammars/XMLSchemaDescription.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/grammars/XMLSchemaDescription.java
@@ -37,28 +37,28 @@ public interface XMLSchemaDescription extends XMLGrammarDescription {
      * Indicate that the current schema document is &lt;include&gt;d by another
      * schema document.
      */
-    public final static short CONTEXT_INCLUDE   = 0;
+    public static final short CONTEXT_INCLUDE   = 0;
     /**
      * Indicate that the current schema document is &lt;redefine&gt;d by another
      * schema document.
      */
-    public final static short CONTEXT_REDEFINE  = 1;
+    public static final short CONTEXT_REDEFINE  = 1;
     /**
      * Indicate that the current schema document is &lt;import&gt;ed by another
      * schema document.
      */
-    public final static short CONTEXT_IMPORT    = 2;
+    public static final short CONTEXT_IMPORT    = 2;
     /**
      * Indicate that the current schema document is being preparsed.
      */
-    public final static short CONTEXT_PREPARSE  = 3;
+    public static final short CONTEXT_PREPARSE  = 3;
     /**
      * Indicate that the parse of the current schema document is triggered
      * by xsi:schemaLocation/noNamespaceSchemaLocation attribute(s) in the
      * instance document. This value is only used if we don't defer the loading
      * of schema documents.
      */
-    public final static short CONTEXT_INSTANCE  = 4;
+    public static final short CONTEXT_INSTANCE  = 4;
     /**
      * Indicate that the parse of the current schema document is triggered by
      * the occurrence of an element whose namespace is the target namespace
@@ -66,7 +66,7 @@ public interface XMLSchemaDescription extends XMLGrammarDescription {
      * loading of schema documents until a component from that namespace is
      * referenced from the instance.
      */
-    public final static short CONTEXT_ELEMENT   = 5;
+    public static final short CONTEXT_ELEMENT   = 5;
     /**
      * Indicate that the parse of the current schema document is triggered by
      * the occurrence of an attribute whose namespace is the target namespace
@@ -74,7 +74,7 @@ public interface XMLSchemaDescription extends XMLGrammarDescription {
      * loading of schema documents until a component from that namespace is
      * referenced from the instance.
      */
-    public final static short CONTEXT_ATTRIBUTE = 6;
+    public static final short CONTEXT_ATTRIBUTE = 6;
     /**
      * Indicate that the parse of the current schema document is triggered by
      * the occurrence of an "xsi:type" attribute, whose value (a QName) has
@@ -82,7 +82,7 @@ public interface XMLSchemaDescription extends XMLGrammarDescription {
      * This value is only used if we do defer the loading of schema documents
      * until a component from that namespace is referenced from the instance.
      */
-    public final static short CONTEXT_XSITYPE   = 7;
+    public static final short CONTEXT_XSITYPE   = 7;
 
     /**
      * Get the context. The returned value is one of the pre-defined

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/CoroutineManager.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/CoroutineManager.java
@@ -150,8 +150,8 @@ public class CoroutineManager
   Object m_yield=null;
 
   // Expose???
-  final static int NOBODY=-1;
-  final static int ANYBODY=-1;
+  static final int NOBODY=-1;
+  static final int ANYBODY=-1;
 
   /** Internal field used to confirm that the coroutine now waking up is
    * in fact the one we intended to resume. Some such selection mechanism

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/DTMDefaultBase.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/DTMDefaultBase.java
@@ -894,7 +894,7 @@ public abstract class DTMDefaultBase implements DTM
    * @param nodeIdentity Internal offset to this node's records.
    * @return NodeHandle (external representation of node)
    * */
-  final public int makeNodeHandle(int nodeIdentity)
+  public final int makeNodeHandle(int nodeIdentity)
   {
     if(NULL==nodeIdentity) return NULL;
 
@@ -921,7 +921,7 @@ public abstract class DTMDefaultBase implements DTM
    * @param nodeHandle (external representation of node)
    * @return nodeIdentity Internal offset to this node's records.
    * */
-  final public int makeNodeIdentity(int nodeHandle)
+  public final int makeNodeIdentity(int nodeHandle)
   {
     if(NULL==nodeHandle) return NULL;
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/DTMManagerDefault.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/DTMManagerDefault.java
@@ -130,7 +130,7 @@ public class DTMManagerDefault extends DTMManager
    * @param dtm Should be a valid reference to a DTM.
    * @param id Integer DTM ID to be bound to this DTM
    */
-  synchronized public void addDTM(DTM dtm, int id) {    addDTM(dtm,id,0); }
+  public synchronized void addDTM(DTM dtm, int id) {    addDTM(dtm,id,0); }
 
 
   /**
@@ -143,7 +143,7 @@ public class DTMManagerDefault extends DTMManager
    * public DTM Handle. For the first DTM ID accessing each DTM, this is 0;
    * for overflow addressing it will be a multiple of 1<<IDENT_DTM_NODE_BITS.
    */
-  synchronized public void addDTM(DTM dtm, int id, int offset)
+  public synchronized void addDTM(DTM dtm, int id, int offset)
   {
                 if(id>=IDENT_MAX_DTMS)
                 {
@@ -184,7 +184,7 @@ public class DTMManagerDefault extends DTMManager
   /**
    * Get the first free DTM ID available. %OPT% Linear search is inefficient!
    */
-  synchronized public int getFirstFreeDTMID()
+  public synchronized int getFirstFreeDTMID()
   {
     int n = m_dtms.length;
     for (int i = 1; i < n; i++)
@@ -236,7 +236,7 @@ public class DTMManagerDefault extends DTMManager
    *
    * @return a non-null DTM reference.
    */
-  synchronized public DTM getDTM(Source source, boolean unique,
+  public synchronized DTM getDTM(Source source, boolean unique,
                                  DTMWSFilter whiteSpaceFilter,
                                  boolean incremental, boolean doIndexing)
   {
@@ -490,7 +490,7 @@ public class DTMManagerDefault extends DTMManager
    *
    * @return a valid DTM handle.
    */
-  synchronized public int getDTMHandleFromNode(org.w3c.dom.Node node)
+  public synchronized int getDTMHandleFromNode(org.w3c.dom.Node node)
   {
     if(null == node)
       throw new IllegalArgumentException(XMLMessages.createXMLMessage(XMLErrorResources.ER_NODE_NON_NULL, null)); //"node must be non-null for getDTMHandleFromNode!");
@@ -595,7 +595,7 @@ public class DTMManagerDefault extends DTMManager
    *
    * @return non-null XMLReader reference ready to parse.
    */
-  synchronized public XMLReader getXMLReader(Source inputSource)
+  public synchronized XMLReader getXMLReader(Source inputSource)
   {
 
     try
@@ -629,7 +629,7 @@ public class DTMManagerDefault extends DTMManager
    *
    * @param reader The XMLReader to be released.
    */
-  synchronized public void releaseXMLReader(XMLReader reader) {
+  public synchronized void releaseXMLReader(XMLReader reader) {
     if (m_readerManager != null) {
       m_readerManager.releaseXMLReader(reader);
     }
@@ -642,7 +642,7 @@ public class DTMManagerDefault extends DTMManager
    *
    * @return a reference to the DTM object containing this node.
    */
-  synchronized public DTM getDTM(int nodeHandle)
+  public synchronized DTM getDTM(int nodeHandle)
   {
     try
     {
@@ -668,7 +668,7 @@ public class DTMManagerDefault extends DTMManager
    * @return The DTM ID (as the high bits of a NodeHandle, not as our
    * internal index), or -1 if the DTM doesn't belong to this manager.
    */
-  synchronized public int getDTMIdentity(DTM dtm)
+  public synchronized int getDTMIdentity(DTM dtm)
   {
         // Shortcut using DTMDefaultBase's extension hooks
         // %REVIEW% Should the lookup be part of the basic DTM API?
@@ -709,7 +709,7 @@ public class DTMManagerDefault extends DTMManager
    * @return true if the DTM was released, false if shouldHardDelete was set
    * and we decided not to.
    */
-  synchronized public boolean release(DTM dtm, boolean shouldHardDelete)
+  public synchronized boolean release(DTM dtm, boolean shouldHardDelete)
   {
     if(DEBUG)
     {
@@ -760,7 +760,7 @@ public class DTMManagerDefault extends DTMManager
    *
    * NEEDSDOC (createDocumentFragment) @return
    */
-  synchronized public DTM createDocumentFragment()
+  public synchronized DTM createDocumentFragment()
   {
 
     try
@@ -789,7 +789,7 @@ public class DTMManagerDefault extends DTMManager
    *
    * NEEDSDOC (createDTMIterator) @return
    */
-  synchronized public DTMIterator createDTMIterator(int whatToShow, DTMFilter filter,
+  public synchronized DTMIterator createDTMIterator(int whatToShow, DTMFilter filter,
                                        boolean entityReferenceExpansion)
   {
 
@@ -806,7 +806,7 @@ public class DTMManagerDefault extends DTMManager
    *
    * NEEDSDOC (createDTMIterator) @return
    */
-  synchronized public DTMIterator createDTMIterator(String xpathString,
+  public synchronized DTMIterator createDTMIterator(String xpathString,
                                        PrefixResolver presolver)
   {
 
@@ -822,7 +822,7 @@ public class DTMManagerDefault extends DTMManager
    *
    * NEEDSDOC (createDTMIterator) @return
    */
-  synchronized public DTMIterator createDTMIterator(int node)
+  public synchronized DTMIterator createDTMIterator(int node)
   {
 
     /** @todo: implement this com.sun.org.apache.xml.internal.dtm.DTMManager abstract method */
@@ -838,7 +838,7 @@ public class DTMManagerDefault extends DTMManager
    *
    * NEEDSDOC (createDTMIterator) @return
    */
-  synchronized public DTMIterator createDTMIterator(Object xpathCompiler, int pos)
+  public synchronized DTMIterator createDTMIterator(Object xpathCompiler, int pos)
   {
 
     /** @todo: implement this com.sun.org.apache.xml.internal.dtm.DTMManager abstract method */

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/IncrementalSAXSource_Filter.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/IncrementalSAXSource_Filter.java
@@ -115,7 +115,7 @@ implements IncrementalSAXSource, ContentHandler, DTDHandler, LexicalHandler, Err
   //
   // Factories
   //
-  static public IncrementalSAXSource createIncrementalSAXSource(CoroutineManager co, int controllerCoroutineID) {
+  public static IncrementalSAXSource createIncrementalSAXSource(CoroutineManager co, int controllerCoroutineID) {
     return new IncrementalSAXSource_Filter(co, controllerCoroutineID);
   }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/IncrementalSAXSource_Xerces.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/IncrementalSAXSource_Xerces.java
@@ -184,7 +184,7 @@ public class IncrementalSAXSource_Xerces
   //
   // Factories
   //
-  static public IncrementalSAXSource createIncrementalSAXSource()
+  public static IncrementalSAXSource createIncrementalSAXSource()
         {
                 try
                 {
@@ -200,7 +200,7 @@ public class IncrementalSAXSource_Xerces
                 }
   }
 
-  static public IncrementalSAXSource
+  public static IncrementalSAXSource
   createIncrementalSAXSource(SAXParser parser) {
                 try
                 {

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/dom2dtm/DOM2DTM.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/dom2dtm/DOM2DTM.java
@@ -75,7 +75,7 @@ public class DOM2DTM extends DTMDefaultBaseIterators
 
   /** The current position in the DOM tree. Last node examined for
    * possible copying to DTM. */
-  transient private Node m_pos;
+  private transient Node m_pos;
   /** The current position in the DTM tree. Who children get appended to. */
   private int m_last_parent=0;
   /** The current position in the DTM tree. Who children reference as their
@@ -85,7 +85,7 @@ public class DOM2DTM extends DTMDefaultBaseIterators
   /** The top of the subtree.
    * %REVIEW%: 'may not be the same as m_context if "//foo" pattern.'
    * */
-  transient private Node m_root;
+  private transient Node m_root;
 
   /** True iff the first element has been processed. This is used to control
       synthesis of the implied xml: namespace declaration node. */
@@ -94,7 +94,7 @@ public class DOM2DTM extends DTMDefaultBaseIterators
   /** true if ALL the nodes in the m_root subtree have been processed;
    * false if our incremental build has not yet finished scanning the
    * DOM tree.  */
-  transient private boolean m_nodesAreProcessed;
+  private transient boolean m_nodesAreProcessed;
 
   /** The node objects.  The instance part of the handle indexes
    * directly into this vector.  Each DTM node may actually be

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/sax2dtm/SAX2DTM.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/sax2dtm/SAX2DTM.java
@@ -108,40 +108,40 @@ public class SAX2DTM extends DTMDefaultBaseIterators
   /** The parent stack, needed only for construction.
    * Made protected rather than private so SAX2RTFDTM can access it.
    */
-  transient protected IntStack m_parents;
+  protected transient IntStack m_parents;
 
   /** The current previous node, needed only for construction time.
    * Made protected rather than private so SAX2RTFDTM can access it.
    */
-  transient protected int m_previous = 0;
+  protected transient int m_previous = 0;
 
   /** Namespace support, only relevent at construction time.
    * Made protected rather than private so SAX2RTFDTM can access it.
    */
-  transient protected Vector<String> m_prefixMappings = new Vector<>();
+  protected transient Vector<String> m_prefixMappings = new Vector<>();
 
   /** Namespace support, only relevent at construction time.
    * Made protected rather than private so SAX2RTFDTM can access it.
    */
-  transient protected IntStack m_contextIndexes;
+  protected transient IntStack m_contextIndexes;
 
   /** Type of next characters() event within text block in prgress. */
-  transient protected int m_textType = DTM.TEXT_NODE;
+  protected transient int m_textType = DTM.TEXT_NODE;
 
   /**
    * Type of coalesced text block. See logic in the characters()
    * method.
    */
-  transient protected int m_coalescedTextType = DTM.TEXT_NODE;
+  protected transient int m_coalescedTextType = DTM.TEXT_NODE;
 
   /** The SAX Document locator */
-  transient protected Locator m_locator = null;
+  protected transient Locator m_locator = null;
 
   /** The SAX Document system-id */
-  transient private String m_systemId = null;
+  private transient String m_systemId = null;
 
   /** We are inside the DTD.  This is used for ignoring comments.  */
-  transient protected boolean m_insideDTD = false;
+  protected transient boolean m_insideDTD = false;
 
   /** Tree Walker for dispatchToEvents. */
   protected DTMTreeWalker m_walker = new DTMTreeWalker();

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/sax2dtm/SAX2DTM2.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/sax2dtm/SAX2DTM2.java
@@ -1774,16 +1774,16 @@ public class SAX2DTM2 extends SAX2DTM
    * doing this.
    */
   // The number of bits for the length of a Text node.
-  protected final static int TEXT_LENGTH_BITS = 10;
+  protected static final int TEXT_LENGTH_BITS = 10;
 
   // The number of bits for the offset of a Text node.
-  protected final static int TEXT_OFFSET_BITS = 21;
+  protected static final int TEXT_OFFSET_BITS = 21;
 
   // The maximum length value
-  protected final static int TEXT_LENGTH_MAX = (1<<TEXT_LENGTH_BITS) - 1;
+  protected static final int TEXT_LENGTH_MAX = (1<<TEXT_LENGTH_BITS) - 1;
 
   // The maximum offset value
-  protected final static int TEXT_OFFSET_MAX = (1<<TEXT_OFFSET_BITS) - 1;
+  protected static final int TEXT_OFFSET_MAX = (1<<TEXT_OFFSET_BITS) - 1;
 
   // True if we want to build the ID index table.
   protected boolean m_buildIdIndex = true;

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serialize/DOMSerializerImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serialize/DOMSerializerImpl.java
@@ -100,18 +100,18 @@ public class DOMSerializerImpl implements LSSerializer, DOMConfiguration {
      */
     protected short features = 0;
 
-    protected final static short NAMESPACES = 0x1 << 0;
-    protected final static short WELLFORMED = 0x1 << 1;
-    protected final static short ENTITIES = 0x1 << 2;
-    protected final static short CDATA = 0x1 << 3;
-    protected final static short SPLITCDATA = 0x1 << 4;
-    protected final static short COMMENTS = 0x1 << 5;
-    protected final static short DISCARDDEFAULT = 0x1 << 6;
-    protected final static short INFOSET = 0x1 << 7;
-    protected final static short XMLDECL = 0x1 << 8;
-    protected final static short NSDECL = 0x1 << 9;
-    protected final static short DOM_ELEMENT_CONTENT_WHITESPACE = 0x1 << 10;
-    protected final static short PRETTY_PRINT = 0x1 << 11;
+    protected static final short NAMESPACES = 0x1 << 0;
+    protected static final short WELLFORMED = 0x1 << 1;
+    protected static final short ENTITIES = 0x1 << 2;
+    protected static final short CDATA = 0x1 << 3;
+    protected static final short SPLITCDATA = 0x1 << 4;
+    protected static final short COMMENTS = 0x1 << 5;
+    protected static final short DISCARDDEFAULT = 0x1 << 6;
+    protected static final short INFOSET = 0x1 << 7;
+    protected static final short XMLDECL = 0x1 << 8;
+    protected static final short NSDECL = 0x1 << 9;
+    protected static final short DOM_ELEMENT_CONTENT_WHITESPACE = 0x1 << 10;
+    protected static final short PRETTY_PRINT = 0x1 << 11;
 
     // well-formness checking
     private DOMErrorHandler fErrorHandler = null;

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serialize/XML11Serializer.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serialize/XML11Serializer.java
@@ -114,7 +114,7 @@ extends XMLSerializer {
     protected boolean fDOML1 = false;
     // counter for new prefix names
     protected int fNamespaceCounter = 1;
-    protected final static String PREFIX = "NS";
+    protected static final String PREFIX = "NS";
 
     /**
      * Controls whether namespace fixup should be performed during

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serialize/XMLSerializer.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serialize/XMLSerializer.java
@@ -121,7 +121,7 @@ extends BaseMarkupSerializer {
     /** symbol table for serialization */
     protected SymbolTable fSymbolTable;
 
-    protected final static String PREFIX = "NS";
+    protected static final String PREFIX = "NS";
 
     /**
      * Controls whether namespace fixup should be performed during

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/EncodingInfo.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/EncodingInfo.java
@@ -259,23 +259,23 @@ public final class EncodingInfo extends Object
         /**
          * The encoding.
          */
-        final private String m_encoding;
+        private final String m_encoding;
         /**
          * m_first through m_last is the range of unicode
          * values that this object will return an answer on.
          * It may delegate to a similar object with a different
          * range
          */
-        final private int m_first;
+        private final int m_first;
 
         /**
          * m_explFirst through m_explLast is the range of unicode
          * value that this object handles explicitly and does not
          * delegate to a similar object.
          */
-        final private int m_explFirst;
-        final private int m_explLast;
-        final private int m_last;
+        private final int m_explFirst;
+        private final int m_explLast;
+        private final int m_last;
 
         /**
          * The object, of the same type as this one,
@@ -305,12 +305,12 @@ public final class EncodingInfo extends Object
          * A flag to record if we already know the answer
          * for the given unicode value.
          */
-        final private boolean m_alreadyKnown[] = new boolean[RANGE];
+        private final boolean m_alreadyKnown[] = new boolean[RANGE];
         /**
          * A table holding the answer on whether the given unicode
          * value is in the encoding.
          */
-        final private boolean m_isInEncoding[] = new boolean[RANGE];
+        private final boolean m_isInEncoding[] = new boolean[RANGE];
 
         private EncodingImpl() {
             // This object will answer whether any unicode value

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/Encodings.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/Encodings.java
@@ -178,7 +178,7 @@ public final class Encodings extends Object
      * possibly the same String.
      * @xsl.usage internal
      */
-    static private String toUpperCaseFast(final String s) {
+    private static String toUpperCaseFast(final String s) {
 
         boolean different = false;
         final int mx = s.length();
@@ -308,7 +308,7 @@ public final class Encodings extends Object
     // Using an inner static class here prevent initialization races
     // where the hash maps could be used before they were populated.
     //
-    private final static class EncodingInfos {
+    private static final class EncodingInfos {
         // These maps are final and not modified after initialization.
         private final Map<String, EncodingInfo> _encodingTableKeyJava = new HashMap<>();
         private final Map<String, EncodingInfo> _encodingTableKeyMime = new HashMap<>();
@@ -576,6 +576,6 @@ public final class Encodings extends Object
         return codePoint;
     }
 
-    private final static EncodingInfos _encodingInfos = new EncodingInfos();
+    private static final EncodingInfos _encodingInfos = new EncodingInfos();
 
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/OutputPropertiesFactory.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/OutputPropertiesFactory.java
@@ -291,7 +291,7 @@ public final class OutputPropertiesFactory
      *
      * @return Properties object that holds the defaults for the given method.
      */
-    static public final Properties getDefaultMethodProperties(String method)
+    public static final Properties getDefaultMethodProperties(String method)
     {
         Properties defaultProperties = null;
 
@@ -348,7 +348,7 @@ public final class OutputPropertiesFactory
      * @param values values corresponding to the keys
      * @param defaults Default properties, which may be null.
      */
-    static private Properties initProperties(String[] keys, String[] values, Properties defaults)
+    private static Properties initProperties(String[] keys, String[] values, Properties defaults)
     {
         Properties props = new Properties(defaults);
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/ToHTMLStream.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/ToHTMLStream.java
@@ -517,7 +517,7 @@ public final class ToHTMLStream extends ToStream
     /**
      * Dummy element for elements not found.
      */
-    static private final ElemDesc m_dummy = new ElemDesc(0 | ElemDesc.BLOCK);
+    private static final ElemDesc m_dummy = new ElemDesc(0 | ElemDesc.BLOCK);
 
     /** True if URLs should be specially escaped with the %xx form. */
     private boolean m_specialEscapeURLs = true;

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/ToStream.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/ToStream.java
@@ -56,7 +56,7 @@ import org.xml.sax.SAXException;
  * @xsl.usage internal
  * @LastModified: June 2021
  */
-abstract public class ToStream extends SerializerBase {
+public abstract class ToStream extends SerializerBase {
 
     private static final String COMMENT_BEGIN = "<!--";
     private static final String COMMENT_END = "-->";
@@ -1538,7 +1538,7 @@ abstract public class ToStream extends SerializerBase {
      * @param isText indicates whether the node to be traversed is text
      * @throws org.xml.sax.SAXException
      */
-    final protected void flushCharactersBuffer(boolean isText) throws SAXException {
+    protected final void flushCharactersBuffer(boolean isText) throws SAXException {
         try {
             if (shouldFormatOutput() && m_charactersBuffer.isAnyCharactersBuffered()) {
                 if (m_elemContext.m_isCdataSection) {
@@ -3133,7 +3133,7 @@ abstract public class ToStream extends SerializerBase {
      * the same code.
      */
     private class WritertoStringBuffer extends Writer {
-        final private StringBuffer m_stringbuf;
+        private final StringBuffer m_stringbuf;
 
         /**
          * @see java.io.Writer#write(char[], int, int)

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/TreeWalker.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/TreeWalker.java
@@ -49,15 +49,15 @@ public final class TreeWalker
 {
 
   /** Local reference to a ContentHandler          */
-  final private ContentHandler m_contentHandler;
+  private final ContentHandler m_contentHandler;
   /**
    * If m_contentHandler is a SerializationHandler, then this is
    * a reference to the same object.
    */
-  final private SerializationHandler m_Serializer;
+  private final SerializationHandler m_Serializer;
 
   /** Locator object for this TreeWalker          */
-  final private LocatorImpl m_locator = new LocatorImpl();
+  private final LocatorImpl m_locator = new LocatorImpl();
 
   /**
    * Get the ContentHandler used for the tree walk.

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/dom3/DOM3TreeWalker.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/dom3/DOM3TreeWalker.java
@@ -139,63 +139,63 @@ final class DOM3TreeWalker {
     // DOMConfiguration paramter settings
     // ***********************************************************************
     // Parameter canonical-form, true [optional] - NOT SUPPORTED
-    private final static int CANONICAL = 0x1 << 0;
+    private static final int CANONICAL = 0x1 << 0;
 
     // Parameter cdata-sections, true [required] (default)
-    private final static int CDATA = 0x1 << 1;
+    private static final int CDATA = 0x1 << 1;
 
     // Parameter check-character-normalization, true [optional] - NOT SUPPORTED
-    private final static int CHARNORMALIZE = 0x1 << 2;
+    private static final int CHARNORMALIZE = 0x1 << 2;
 
     // Parameter comments, true [required] (default)
-    private final static int COMMENTS = 0x1 << 3;
+    private static final int COMMENTS = 0x1 << 3;
 
     // Parameter datatype-normalization, true [optional] - NOT SUPPORTED
-    private final static int DTNORMALIZE = 0x1 << 4;
+    private static final int DTNORMALIZE = 0x1 << 4;
 
     // Parameter element-content-whitespace, true [required] (default) - value - false [optional] NOT SUPPORTED
-    private final static int ELEM_CONTENT_WHITESPACE = 0x1 << 5;
+    private static final int ELEM_CONTENT_WHITESPACE = 0x1 << 5;
 
     // Parameter entities, true [required] (default)
-    private final static int ENTITIES = 0x1 << 6;
+    private static final int ENTITIES = 0x1 << 6;
 
     // Parameter infoset, true [required] (default), false has no effect --> True has no effect for the serializer
-    private final static int INFOSET = 0x1 << 7;
+    private static final int INFOSET = 0x1 << 7;
 
     // Parameter namespaces, true [required] (default)
-    private final static int NAMESPACES = 0x1 << 8;
+    private static final int NAMESPACES = 0x1 << 8;
 
     // Parameter namespace-declarations, true [required] (default)
-    private final static int NAMESPACEDECLS = 0x1 << 9;
+    private static final int NAMESPACEDECLS = 0x1 << 9;
 
     // Parameter normalize-characters, true [optional] - NOT SUPPORTED
-    private final static int NORMALIZECHARS = 0x1 << 10;
+    private static final int NORMALIZECHARS = 0x1 << 10;
 
     // Parameter split-cdata-sections, true [required] (default)
-    private final static int SPLITCDATA = 0x1 << 11;
+    private static final int SPLITCDATA = 0x1 << 11;
 
     // Parameter validate, true [optional] - NOT SUPPORTED
-    private final static int VALIDATE = 0x1 << 12;
+    private static final int VALIDATE = 0x1 << 12;
 
     // Parameter validate-if-schema, true [optional] - NOT SUPPORTED
-    private final static int SCHEMAVALIDATE = 0x1 << 13;
+    private static final int SCHEMAVALIDATE = 0x1 << 13;
 
     // Parameter split-cdata-sections, true [required] (default)
-    private final static int WELLFORMED = 0x1 << 14;
+    private static final int WELLFORMED = 0x1 << 14;
 
     // Parameter discard-default-content, true [required] (default)
     // Not sure how this will be used in level 2 Documents
-    private final static int DISCARDDEFAULT = 0x1 << 15;
+    private static final int DISCARDDEFAULT = 0x1 << 15;
 
     // Parameter format-pretty-print, true [optional]
-    private final static int PRETTY_PRINT = 0x1 << 16;
+    private static final int PRETTY_PRINT = 0x1 << 16;
 
     // Parameter ignore-unknown-character-denormalizations, true [required] (default)
     // We currently do not support XML 1.1 character normalization
-    private final static int IGNORE_CHAR_DENORMALIZE = 0x1 << 17;
+    private static final int IGNORE_CHAR_DENORMALIZE = 0x1 << 17;
 
     // Parameter discard-default-content, true [required] (default)
-    private final static int XMLDECL = 0x1 << 18;
+    private static final int XMLDECL = 0x1 << 18;
 
     /**
      * Constructor.

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/dom3/LSSerializerImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/dom3/LSSerializerImpl.java
@@ -72,7 +72,7 @@ import org.w3c.dom.ls.LSSerializerFilter;
  * @xsl.usage internal
  * @LastModified: May 2021
  */
-final public class LSSerializerImpl implements DOMConfiguration, LSSerializer {
+public final class LSSerializerImpl implements DOMConfiguration, LSSerializer {
 
     /** private data members */
     private Serializer fXMLSerializer = null;
@@ -108,66 +108,66 @@ final public class LSSerializerImpl implements DOMConfiguration, LSSerializer {
     // DOM Level 3 DOM Configuration parameter names
     // ************************************************************************
     // Parameter canonical-form, true [optional] - NOT SUPPORTED
-    private final static int CANONICAL = 0x1 << 0;
+    private static final int CANONICAL = 0x1 << 0;
 
     // Parameter cdata-sections, true [required] (default)
-    private final static int CDATA = 0x1 << 1;
+    private static final int CDATA = 0x1 << 1;
 
     // Parameter check-character-normalization, true [optional] - NOT SUPPORTED
-    private final static int CHARNORMALIZE = 0x1 << 2;
+    private static final int CHARNORMALIZE = 0x1 << 2;
 
     // Parameter comments, true [required] (default)
-    private final static int COMMENTS = 0x1 << 3;
+    private static final int COMMENTS = 0x1 << 3;
 
     // Parameter datatype-normalization, true [optional] - NOT SUPPORTED
-    private final static int DTNORMALIZE = 0x1 << 4;
+    private static final int DTNORMALIZE = 0x1 << 4;
 
     // Parameter element-content-whitespace, true [required] (default) - value - false [optional] NOT SUPPORTED
-    private final static int ELEM_CONTENT_WHITESPACE = 0x1 << 5;
+    private static final int ELEM_CONTENT_WHITESPACE = 0x1 << 5;
 
     // Parameter entities, true [required] (default)
-    private final static int ENTITIES = 0x1 << 6;
+    private static final int ENTITIES = 0x1 << 6;
 
     // Parameter infoset, true [required] (default), false has no effect --> True has no effect for the serializer
-    private final static int INFOSET = 0x1 << 7;
+    private static final int INFOSET = 0x1 << 7;
 
     // Parameter namespaces, true [required] (default)
-    private final static int NAMESPACES = 0x1 << 8;
+    private static final int NAMESPACES = 0x1 << 8;
 
     // Parameter namespace-declarations, true [required] (default)
-    private final static int NAMESPACEDECLS = 0x1 << 9;
+    private static final int NAMESPACEDECLS = 0x1 << 9;
 
     // Parameter normalize-characters, true [optional] - NOT SUPPORTED
-    private final static int NORMALIZECHARS = 0x1 << 10;
+    private static final int NORMALIZECHARS = 0x1 << 10;
 
     // Parameter split-cdata-sections, true [required] (default)
-    private final static int SPLITCDATA = 0x1 << 11;
+    private static final int SPLITCDATA = 0x1 << 11;
 
     // Parameter validate, true [optional] - NOT SUPPORTED
-    private final static int VALIDATE = 0x1 << 12;
+    private static final int VALIDATE = 0x1 << 12;
 
     // Parameter validate-if-schema, true [optional] - NOT SUPPORTED
-    private final static int SCHEMAVALIDATE = 0x1 << 13;
+    private static final int SCHEMAVALIDATE = 0x1 << 13;
 
     // Parameter split-cdata-sections, true [required] (default)
-    private final static int WELLFORMED = 0x1 << 14;
+    private static final int WELLFORMED = 0x1 << 14;
 
     // Parameter discard-default-content, true [required] (default)
     // Not sure how this will be used in level 2 Documents
-    private final static int DISCARDDEFAULT = 0x1 << 15;
+    private static final int DISCARDDEFAULT = 0x1 << 15;
 
     // Parameter format-pretty-print, true [optional]
-    private final static int PRETTY_PRINT = 0x1 << 16;
+    private static final int PRETTY_PRINT = 0x1 << 16;
 
     // Parameter ignore-unknown-character-denormalizations, true [required] (default)
     // We currently do not support XML 1.1 character normalization
-    private final static int IGNORE_CHAR_DENORMALIZE = 0x1 << 17;
+    private static final int IGNORE_CHAR_DENORMALIZE = 0x1 << 17;
 
     // Parameter discard-default-content, true [required] (default)
-    private final static int XMLDECL = 0x1 << 18;
+    private static final int XMLDECL = 0x1 << 18;
 
     // Parameter is-standalone, jdk specific, not required
-    private final static int IS_STANDALONE = 0x1 << 19;
+    private static final int IS_STANDALONE = 0x1 << 19;
 
     // ************************************************************************
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/dom3/NamespaceSupport.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/dom3/NamespaceSupport.java
@@ -47,14 +47,14 @@ public class NamespaceSupport {
      * The XML Namespace ("http://www.w3.org/XML/1998/namespace"). This is
      * the Namespace URI that is automatically mapped to the "xml" prefix.
      */
-    public final static String XML_URI = "http://www.w3.org/XML/1998/namespace".intern();
+    public static final String XML_URI = "http://www.w3.org/XML/1998/namespace".intern();
 
     /**
      * XML Information Set REC
      * all namespace attributes (including those named xmlns,
      * whose [prefix] property has no value) have a namespace URI of http://www.w3.org/2000/xmlns/
      */
-    public final static String XMLNS_URI = "http://www.w3.org/2000/xmlns/".intern();
+    public static final String XMLNS_URI = "http://www.w3.org/2000/xmlns/".intern();
 
         //
     // Data

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/LocaleUtility.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/LocaleUtility.java
@@ -32,8 +32,8 @@ public class LocaleUtility {
     /**
      * IETF RFC 1766 tag separator
      */
-    public final static char IETF_SEPARATOR = '-';
-    public final static String EMPTY_STRING = "";
+    public static final char IETF_SEPARATOR = '-';
+    public static final String EMPTY_STRING = "";
 
 
  public static Locale langToLocale(String lang) {

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/StringBufferPool.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/StringBufferPool.java
@@ -40,7 +40,7 @@ public class StringBufferPool
    *
    * @return A string buffer ready for use.
    */
-  public synchronized static FastStringBuffer get()
+  public static synchronized FastStringBuffer get()
   {
     return (FastStringBuffer) m_stringBufPool.getInstance();
   }
@@ -50,7 +50,7 @@ public class StringBufferPool
    *
    * @param sb Must be a non-null reference to a string buffer.
    */
-  public synchronized static void free(FastStringBuffer sb)
+  public static synchronized void free(FastStringBuffer sb)
   {
     // Since this isn't synchronized, setLength must be
     // done before the instance is freed.

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/StringComparable.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/StringComparable.java
@@ -33,9 +33,9 @@ import java.util.Locale;
 */
 public class StringComparable implements Comparable<StringComparable>  {
 
-     public final static int UNKNOWN_CASE = -1;
-     public final static int UPPER_CASE = 1;
-     public final static int LOWER_CASE = 2;
+     public static final int UNKNOWN_CASE = -1;
+     public static final int UPPER_CASE = 1;
+     public static final int LOWER_CASE = 2;
 
      private  String m_text;
      private  Locale m_locale;
@@ -53,7 +53,7 @@ public class StringComparable implements Comparable<StringComparable>  {
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
-    public final static Comparable getComparator( final String text, final Locale locale,
+    public static final Comparable getComparator( final String text, final Locale locale,
             final Collator collator, final String caseOrder){
         if((caseOrder == null) ||(caseOrder.length() == 0)){// no case-order specified
             return  ((RuleBasedCollator)collator).getCollationKey(text);

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/res/XResourceBundleBase.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/res/XResourceBundleBase.java
@@ -28,7 +28,7 @@ import java.util.ListResourceBundle;
  * and should be called XalanResourceBundle, or some such.
  * @xsl.usage internal
  */
-abstract public class XResourceBundleBase extends ListResourceBundle
+public abstract class XResourceBundleBase extends ListResourceBundle
 {
 
   /**
@@ -38,7 +38,7 @@ abstract public class XResourceBundleBase extends ListResourceBundle
    *
    * @return error string associated with the given error code
    */
-  abstract public String getMessageKey(int errorCode);
+  public abstract String getMessageKey(int errorCode);
 
   /**
    * Get the warning string associated with the error code
@@ -47,5 +47,5 @@ abstract public class XResourceBundleBase extends ListResourceBundle
    *
    * @return warning string associated with the given error code
    */
-  abstract public String getWarningKey(int errorCode);
+  public abstract String getWarningKey(int errorCode);
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/NodeSet.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/NodeSet.java
@@ -716,7 +716,7 @@ public class NodeSet
 
   /** If this node is being used as an iterator, the next index that nextNode()
    *  will return.  */
-  transient protected int m_next = 0;
+  protected transient int m_next = 0;
 
   /**
    * Get the current position, which is one less than
@@ -768,11 +768,11 @@ public class NodeSet
   }
 
   /** True if this list can be mutated.  */
-  transient protected boolean m_mutable = true;
+  protected transient boolean m_mutable = true;
 
   /** True if this list is cached.
    *  @serial  */
-  transient protected boolean m_cacheNodes = true;
+  protected transient boolean m_cacheNodes = true;
 
   /**
    * Get whether or not this is a cached node set.
@@ -808,7 +808,7 @@ public class NodeSet
   }
 
 
-  transient private int m_last = 0;
+  private transient int m_last = 0;
 
   public int getLast()
   {

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/NodeSetDTM.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/NodeSetDTM.java
@@ -1102,7 +1102,7 @@ public class NodeSetDTM extends NodeVector
 
   /** If this node is being used as an iterator, the next index that nextNode()
    *  will return.  */
-  transient protected int m_next = 0;
+  protected transient int m_next = 0;
 
   /**
    * Get the current position, which is one less than
@@ -1158,11 +1158,11 @@ public class NodeSetDTM extends NodeVector
   }
 
   /** True if this list can be mutated.  */
-  transient protected boolean m_mutable = true;
+  protected transient boolean m_mutable = true;
 
   /** True if this list is cached.
    *  @serial  */
-  transient protected boolean m_cacheNodes = true;
+  protected transient boolean m_cacheNodes = true;
 
   /** The root of the iteration, if available. */
   protected int m_root = DTM.NULL;
@@ -1211,7 +1211,7 @@ public class NodeSetDTM extends NodeVector
     return m_mutable;
   }
 
-  transient private int m_last = 0;
+  private transient int m_last = 0;
 
   public int getLast()
   {

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/ChildTestIterator.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/ChildTestIterator.java
@@ -37,7 +37,7 @@ public class ChildTestIterator extends BasicTestIterator
 {
     static final long serialVersionUID = -7936835957960705722L;
   /** The traverser to use to navigate over the descendants. */
-  transient protected DTMAxisTraverser m_traverser;
+  protected transient DTMAxisTraverser m_traverser;
 
   /** The extended type ID, not set until setRoot. */
 //  protected int m_extendedTypeID;

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/DescendantIterator.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/DescendantIterator.java
@@ -356,7 +356,7 @@ public class DescendantIterator extends LocPathIterator
 
 
   /** The traverser to use to navigate over the descendants. */
-  transient protected DTMAxisTraverser m_traverser;
+  protected transient DTMAxisTraverser m_traverser;
 
   /** The axis that we are traversing. */
   protected int m_axis;

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/FilterExprIterator.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/FilterExprIterator.java
@@ -39,7 +39,7 @@ public class FilterExprIterator extends BasicTestIterator
   private Expression m_expr;
 
   /** The result of executing m_expr.  Needs to be deep cloned on clone op.  */
-  transient private XNodeSet m_exprObj;
+  private transient XNodeSet m_exprObj;
 
   private boolean m_mustHardReset = false;
   private boolean m_canDetachNodeset = true;

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/FilterExprIteratorSimple.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/FilterExprIteratorSimple.java
@@ -46,7 +46,7 @@ public class FilterExprIteratorSimple extends LocPathIterator
   private Expression m_expr;
 
   /** The result of executing m_expr.  Needs to be deep cloned on clone op.  */
-  transient private XNodeSet m_exprObj;
+  private transient XNodeSet m_exprObj;
 
   private boolean m_mustHardReset = false;
   private boolean m_canDetachNodeset = true;

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/FilterExprWalker.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/FilterExprWalker.java
@@ -224,7 +224,7 @@ public class FilterExprWalker extends AxesWalker
   private Expression m_expr;
 
   /** The result of executing m_expr.  Needs to be deep cloned on clone op.  */
-  transient private XNodeSet m_exprObj;
+  private transient XNodeSet m_exprObj;
 
   private boolean m_mustHardReset = false;
   private boolean m_canDetachNodeset = true;

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/LocPathIterator.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/LocPathIterator.java
@@ -928,13 +928,13 @@ public abstract class LocPathIterator extends PredicatedNodeTest
    * because the hold running state, and thus the original iterator
    * expression from the stylesheet pool can not be used.
    */
-  transient protected IteratorPool m_clones = new IteratorPool(this);
+  protected transient IteratorPool m_clones = new IteratorPool(this);
 
   /**
    * The dtm of the context node.  Careful about using this... it may not
    * be the dtm of the current node.
    */
-  transient protected DTM m_cdtm;
+  protected transient DTM m_cdtm;
 
   /**
    * The stack frame index for this iterator.
@@ -950,13 +950,13 @@ public abstract class LocPathIterator extends PredicatedNodeTest
   private boolean m_isTopLevel = false;
 
   /** The last node that was fetched, usually by nextNode. */
-  transient public int m_lastFetched = DTM.NULL;
+  public transient int m_lastFetched = DTM.NULL;
 
   /**
    * The context node for this iterator, which doesn't change through
    * the course of the iteration.
    */
-  transient protected int m_context = DTM.NULL;
+  protected transient int m_context = DTM.NULL;
 
   /**
    * The node context from where the expression is being
@@ -964,14 +964,14 @@ public abstract class LocPathIterator extends PredicatedNodeTest
    * from m_context in that this is the context for the entire
    * expression, rather than the context for the subexpression.
    */
-  transient protected int m_currentContextNode = DTM.NULL;
+  protected transient int m_currentContextNode = DTM.NULL;
 
   /**
    * The current position of the context node.
    */
-  transient protected int m_pos = 0;
+  protected transient int m_pos = 0;
 
-  transient protected int m_length = -1;
+  protected transient int m_length = -1;
 
   /**
    * Fast access to the current prefix resolver.  It isn't really
@@ -985,7 +985,7 @@ public abstract class LocPathIterator extends PredicatedNodeTest
    * The XPathContext reference, needed for execution of many
    * operations.
    */
-  transient protected XPathContext m_execContext;
+  protected transient XPathContext m_execContext;
 
   /**
    * Returns true if all the nodes in the iteration well be returned in document

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/NodeSequence.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/NodeSequence.java
@@ -843,7 +843,7 @@ public class NodeSequence extends XObject
     * <p>
     * Its use-count is the number of NodeSequence objects that use it.
     */
-   private final static class IteratorCache {
+   private static final class IteratorCache {
        /**
         * A list of nodes already obtained from the iterator.
         * As the iterator is walked the nodes obtained from

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/PredicatedNodeTest.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/PredicatedNodeTest.java
@@ -596,7 +596,7 @@ public abstract class PredicatedNodeTest extends NodeTest implements SubContextL
     }
 
   /** This is true if nextNode returns null. */
-  transient protected boolean m_foundLast = false;
+  protected transient boolean m_foundLast = false;
 
   /** The owning location path iterator.
    *  @serial */
@@ -617,7 +617,7 @@ public abstract class PredicatedNodeTest extends NodeTest implements SubContextL
    * An array of counts that correspond to the number
    * of predicates the step contains.
    */
-  transient protected int[] m_proximityPositions;
+  protected transient int[] m_proximityPositions;
 
   /** If true, diagnostic messages about predicate execution will be posted.  */
   static final boolean DEBUG_PREDICATECOUNTING = false;

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/WalkerFactory.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/WalkerFactory.java
@@ -352,7 +352,7 @@ public class WalkerFactory
      * @param axis One of Axis.ANCESTOR, etc.
      * @return One of BIT_ANCESTOR, etc.
      */
-    static public int getAnalysisBitFromAxes(int axis)
+    public static int getAnalysisBitFromAxes(int axis)
     {
       switch (axis) // Generate new traverser
         {
@@ -1597,7 +1597,7 @@ public class WalkerFactory
    *
    * @throws javax.xml.transform.TransformerException
    */
-  static public boolean isNaturalDocOrder(int analysis)
+  public static boolean isNaturalDocOrder(int analysis)
   {
     if(canCrissCross(analysis) || isSet(analysis, BIT_NAMESPACE) ||
        walksFilteredList(analysis))

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/compiler/Compiler.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/compiler/Compiler.java
@@ -1109,7 +1109,7 @@ private static final boolean DEBUG = false;
   /**
    * Get the next available method id
    */
-  synchronized private long getNextMethodId()
+  private synchronized long getNextMethodId()
   {
     if (s_nextMethodId == Long.MAX_VALUE)
       s_nextMethodId = 0;

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/compiler/XPathParser.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/compiler/XPathParser.java
@@ -41,7 +41,7 @@ public class XPathParser
         // %REVIEW% Is there a better way of doing this?
         // Upside is minimum object churn. Downside is that we don't have a useful
         // backtrace in the exception itself -- but we don't expect to need one.
-        static public final String CONTINUE_AFTER_FATAL_ERROR="CONTINUE_AFTER_FATAL_ERROR";
+        public static final String CONTINUE_AFTER_FATAL_ERROR="CONTINUE_AFTER_FATAL_ERROR";
 
   /**
    * The XPath to be processed.
@@ -68,9 +68,9 @@ public class XPathParser
   /**
    * Results from checking FilterExpr syntax
    */
-  protected final static int FILTER_MATCH_FAILED     = 0;
-  protected final static int FILTER_MATCH_PRIMARY    = 1;
-  protected final static int FILTER_MATCH_PREDICATES = 2;
+  protected static final int FILTER_MATCH_FAILED     = 0;
+  protected static final int FILTER_MATCH_PRIMARY    = 1;
+  protected static final int FILTER_MATCH_PREDICATES = 2;
 
   // counts open predicates
   private int countPredicate;

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/functions/FuncExtFunctionAvailable.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/functions/FuncExtFunctionAvailable.java
@@ -36,7 +36,7 @@ public class FuncExtFunctionAvailable extends FunctionOneArg
 {
     static final long serialVersionUID = 5118814314918592241L;
 
-    transient private FunctionTable m_functionTable = null;
+    private transient FunctionTable m_functionTable = null;
 
   /**
    * Execute the function.  The function must return

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/objects/XNumber.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/objects/XNumber.java
@@ -353,7 +353,7 @@ public class XNumber extends XObject
    *
    * @return a string of '0' with the given length
    */
-  static private String zeros(int n)
+  private static String zeros(int n)
   {
     if (n < 1)
       return "";

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/objects/XObject.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/objects/XObject.java
@@ -162,7 +162,7 @@ public class XObject extends Expression implements Serializable, Cloneable
    *
    * @return the right XObject based on the type of the object passed.
    */
-  static public XObject create(Object val)
+  public static XObject create(Object val)
   {
     return XObjectFactory.create(val);
   }
@@ -177,7 +177,7 @@ public class XObject extends Expression implements Serializable, Cloneable
    *
    * @return the right XObject based on the type of the object passed.
    */
-  static public XObject create(Object val, XPathContext xctxt)
+  public static XObject create(Object val, XPathContext xctxt)
   {
     return XObjectFactory.create(val, xctxt);
   }

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/objects/XObjectFactory.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/objects/XObjectFactory.java
@@ -41,7 +41,7 @@ public class XObjectFactory
    *
    * @return the right XObject based on the type of the object passed.
    */
-  static public XObject create(Object val)
+  public static XObject create(Object val)
   {
 
     XObject result;
@@ -80,7 +80,7 @@ public class XObjectFactory
    *
    * @return the right XObject based on the type of the object passed.
    */
-  static public XObject create(Object val, XPathContext xctxt)
+  public static XObject create(Object val, XPathContext xctxt)
   {
 
     XObject result;

--- a/src/java.xml/share/classes/com/sun/xml/internal/stream/writers/XMLStreamWriterImpl.java
+++ b/src/java.xml/share/classes/com/sun/xml/internal/stream/writers/XMLStreamWriterImpl.java
@@ -149,7 +149,7 @@ public final class XMLStreamWriterImpl extends AbstractMap<Object, Object>
 
     private ElementStack fElementStack = new ElementStack(); //Change this .-Venu
 
-    final private String DEFAULT_PREFIX = fSymbolTable.addSymbol("");
+    private final String DEFAULT_PREFIX = fSymbolTable.addSymbol("");
 
     private final ReadOnlyIterator<String> fReadOnlyIterator = new ReadOnlyIterator<>();
 

--- a/src/java.xml/share/classes/javax/xml/catalog/BaseEntry.java
+++ b/src/java.xml/share/classes/javax/xml/catalog/BaseEntry.java
@@ -81,7 +81,7 @@ abstract class BaseEntry {
             return literal.equals(type);
         }
 
-        static public CatalogEntryType getType(String entryType) {
+        public static CatalogEntryType getType(String entryType) {
             for (CatalogEntryType type : CatalogEntryType.values()) {
                 if (type.isType(entryType)) {
                     return type;

--- a/src/java.xml/share/classes/javax/xml/catalog/GroupEntry.java
+++ b/src/java.xml/share/classes/javax/xml/catalog/GroupEntry.java
@@ -118,7 +118,7 @@ class GroupEntry extends BaseEntry {
             this.literal = literal;
         }
 
-        static public ResolveType getType(String resolveType) {
+        public static ResolveType getType(String resolveType) {
             for (ResolveType type : ResolveType.values()) {
                 if (type.isType(resolveType)) {
                     return type;

--- a/src/java.xml/share/classes/javax/xml/catalog/Util.java
+++ b/src/java.xml/share/classes/javax/xml/catalog/Util.java
@@ -47,12 +47,12 @@ import jdk.xml.internal.SecuritySupport;
  */
 class Util {
 
-    final static String URN = "urn:publicid:";
-    final static String PUBLICID_PREFIX = "-//";
-    final static String PUBLICID_PREFIX_ALT = "+//";
-    final static String SCHEME_FILE = "file";
-    final static String SCHEME_JAR = "jar";
-    final static String SCHEME_JARFILE = "jar:file:";
+    static final String URN = "urn:publicid:";
+    static final String PUBLICID_PREFIX = "-//";
+    static final String PUBLICID_PREFIX_ALT = "+//";
+    static final String SCHEME_FILE = "file";
+    static final String SCHEME_JAR = "jar";
+    static final String SCHEME_JARFILE = "jar:file:";
 
     /**
      * Finds an entry in the catalog that matches with the publicId or systemId.

--- a/src/java.xml/share/classes/javax/xml/datatype/FactoryFinder.java
+++ b/src/java.xml/share/classes/javax/xml/datatype/FactoryFinder.java
@@ -54,7 +54,7 @@ class FactoryFinder {
     /**
      * Cache for properties in java.home/conf/jaxp.properties
      */
-    private final static Properties cacheProps = new Properties();
+    private static final Properties cacheProps = new Properties();
 
     /**
      * Flag indicating if properties from java.home/conf/jaxp.properties
@@ -93,7 +93,7 @@ class FactoryFinder {
      *
      * Use bootstrap classLoader if cl = null and useBSClsLoader is true
      */
-    static private Class<?> getProviderClass(String className, ClassLoader cl,
+    private static Class<?> getProviderClass(String className, ClassLoader cl,
             boolean doFallback, boolean useBSClsLoader) throws ClassNotFoundException
     {
         try {

--- a/src/java.xml/share/classes/javax/xml/parsers/FactoryFinder.java
+++ b/src/java.xml/share/classes/javax/xml/parsers/FactoryFinder.java
@@ -92,7 +92,7 @@ class FactoryFinder {
      *
      * Use bootstrap classLoader if cl = null and useBSClsLoader is true
      */
-    static private Class<?> getProviderClass(String className, ClassLoader cl,
+    private static Class<?> getProviderClass(String className, ClassLoader cl,
             boolean doFallback, boolean useBSClsLoader) throws ClassNotFoundException
     {
         try {

--- a/src/java.xml/share/classes/javax/xml/stream/FactoryFinder.java
+++ b/src/java.xml/share/classes/javax/xml/stream/FactoryFinder.java
@@ -55,7 +55,7 @@ class FactoryFinder {
     /**
      * Cache for properties in java.home/conf/jaxp.properties
      */
-    final private static Properties cacheProps = new Properties();
+    private static final Properties cacheProps = new Properties();
 
     /**
      * Flag indicating if properties from java.home/conf/jaxp.properties
@@ -94,7 +94,7 @@ class FactoryFinder {
      *
      * Use bootstrap classLoader if cl = null and useBSClsLoader is true
      */
-    static private Class<?> getProviderClass(String className, ClassLoader cl,
+    private static Class<?> getProviderClass(String className, ClassLoader cl,
             boolean doFallback, boolean useBSClsLoader) throws ClassNotFoundException
     {
         try {

--- a/src/java.xml/share/classes/javax/xml/transform/FactoryFinder.java
+++ b/src/java.xml/share/classes/javax/xml/transform/FactoryFinder.java
@@ -56,7 +56,7 @@ class FactoryFinder {
     /**
      * Cache for properties in java.home/conf/jaxp.properties
      */
-    private final static Properties cacheProps = new Properties();
+    private static final Properties cacheProps = new Properties();
 
     /**
      * Flag indicating if properties from java.home/conf/jaxp.properties
@@ -95,7 +95,7 @@ class FactoryFinder {
      *
      * Use bootstrap classLoader if cl = null and useBSClsLoader is true
      */
-    static private Class<?> getProviderClass(String className, ClassLoader cl,
+    private static Class<?> getProviderClass(String className, ClassLoader cl,
             boolean doFallback, boolean useBSClsLoader) throws ClassNotFoundException
     {
         try {

--- a/src/java.xml/share/classes/javax/xml/xpath/XPathEvaluationResult.java
+++ b/src/java.xml/share/classes/javax/xml/xpath/XPathEvaluationResult.java
@@ -116,7 +116,7 @@ public interface XPathEvaluationResult<T> {
          * @return the QName type that matches with the specified class type,
          * null if there is no match
          */
-            static public QName getQNameType(Class<?> clsType) {
+            public static QName getQNameType(Class<?> clsType) {
             for (XPathResultType type : XPathResultType.values()) {
                 if (type.equalsClassType(clsType)) {
                     return type.qnameType;

--- a/src/java.xml/share/classes/javax/xml/xpath/XPathFactoryFinder.java
+++ b/src/java.xml/share/classes/javax/xml/xpath/XPathFactoryFinder.java
@@ -65,7 +65,7 @@ class XPathFactoryFinder  {
     /**
      * <p>First time requires initialization overhead.</p>
      */
-    private volatile static boolean firstTime = true;
+    private static volatile boolean firstTime = true;
 
     /**
      * <p>Conditional debug printing.</p>

--- a/src/java.xml/share/classes/jdk/xml/internal/JdkConstants.java
+++ b/src/java.xml/share/classes/jdk/xml/internal/JdkConstants.java
@@ -218,9 +218,9 @@ public final class JdkConstants {
     public static final String JDK_EXT_CLASSLOADER = "jdk.xml.extensionClassLoader";
 
     //legacy System Properties
-    public final static String ENTITY_EXPANSION_LIMIT = "entityExpansionLimit";
+    public static final String ENTITY_EXPANSION_LIMIT = "entityExpansionLimit";
     public static final String ELEMENT_ATTRIBUTE_LIMIT = "elementAttributeLimit" ;
-    public final static String MAX_OCCUR_LIMIT = "maxOccurLimit";
+    public static final String MAX_OCCUR_LIMIT = "maxOccurLimit";
 
     /**
      * A string "yes" that can be used for properties such as getEntityCountInfo
@@ -348,7 +348,7 @@ public final class JdkConstants {
      * Reset SymbolTable feature System property name is identical to feature
      * name
      */
-    public final static String RESET_SYMBOL_TABLE = "jdk.xml.resetSymbolTable";
+    public static final String RESET_SYMBOL_TABLE = "jdk.xml.resetSymbolTable";
     /**
      * Default value of RESET_SYMBOL_TABLE. This will read the System property
      */
@@ -370,7 +370,7 @@ public final class JdkConstants {
      * chunks that are larger than the specified size to ones that are equal to
      * or smaller than the size.
      */
-    public final static String CDATA_CHUNK_SIZE = "jdk.xml.cdataChunkSize";
+    public static final String CDATA_CHUNK_SIZE = "jdk.xml.cdataChunkSize";
     public static final int CDATA_CHUNK_SIZE_DEFAULT
             = SecuritySupport.getJAXPSystemProperty(Integer.class, CDATA_CHUNK_SIZE, "0");
 

--- a/src/java.xml/share/classes/jdk/xml/internal/JdkXmlFeatures.java
+++ b/src/java.xml/share/classes/jdk/xml/internal/JdkXmlFeatures.java
@@ -43,7 +43,7 @@ public class JdkXmlFeatures {
 
     public static final String CATALOG_FEATURES = "javax.xml.catalog.catalogFeatures";
 
-    public final static String PROPERTY_USE_CATALOG = XMLConstants.USE_CATALOG;
+    public static final String PROPERTY_USE_CATALOG = XMLConstants.USE_CATALOG;
 
     public static enum XmlFeature {
         /**

--- a/src/java.xml/share/classes/jdk/xml/internal/JdkXmlUtils.java
+++ b/src/java.xml/share/classes/jdk/xml/internal/JdkXmlUtils.java
@@ -67,12 +67,12 @@ public class JdkXmlUtils {
     /**
      * Catalog features
      */
-    public final static String USE_CATALOG = XMLConstants.USE_CATALOG;
-    public final static String SP_USE_CATALOG = "javax.xml.useCatalog";
-    public final static String CATALOG_FILES = CatalogFeatures.Feature.FILES.getPropertyName();
-    public final static String CATALOG_DEFER = CatalogFeatures.Feature.DEFER.getPropertyName();
-    public final static String CATALOG_PREFER = CatalogFeatures.Feature.PREFER.getPropertyName();
-    public final static String CATALOG_RESOLVE = CatalogFeatures.Feature.RESOLVE.getPropertyName();
+    public static final String USE_CATALOG = XMLConstants.USE_CATALOG;
+    public static final String SP_USE_CATALOG = "javax.xml.useCatalog";
+    public static final String CATALOG_FILES = CatalogFeatures.Feature.FILES.getPropertyName();
+    public static final String CATALOG_DEFER = CatalogFeatures.Feature.DEFER.getPropertyName();
+    public static final String CATALOG_PREFER = CatalogFeatures.Feature.PREFER.getPropertyName();
+    public static final String CATALOG_RESOLVE = CatalogFeatures.Feature.RESOLVE.getPropertyName();
 
 
 

--- a/src/java.xml/share/classes/jdk/xml/internal/SecuritySupport.java
+++ b/src/java.xml/share/classes/jdk/xml/internal/SecuritySupport.java
@@ -45,7 +45,7 @@ import java.util.ResourceBundle;
  * This class contains utility methods for reading resources in the JAXP packages
  */
 public class SecuritySupport {
-    public final static String NEWLINE = System.lineSeparator();
+    public static final String NEWLINE = System.lineSeparator();
 
     /**
      * Cache for properties in java.home/conf/jaxp.properties

--- a/src/java.xml/share/classes/org/xml/sax/helpers/NamespaceSupport.java
+++ b/src/java.xml/share/classes/org/xml/sax/helpers/NamespaceSupport.java
@@ -100,7 +100,7 @@ public class NamespaceSupport
      * <p>This is the Namespace URI that is automatically mapped
      * to the "xml" prefix.</p>
      */
-    public final static String XMLNS =
+    public static final String XMLNS =
         "http://www.w3.org/XML/1998/namespace";
 
 
@@ -120,14 +120,14 @@ public class NamespaceSupport
      * @see #setNamespaceDeclUris
      * @see #isNamespaceDeclUris
      */
-    public final static String NSDECL =
+    public static final String NSDECL =
         "http://www.w3.org/xmlns/2000/";
 
 
     /**
      * An empty enumeration.
      */
-    private final static Enumeration<String> EMPTY_ENUMERATION =
+    private static final Enumeration<String> EMPTY_ENUMERATION =
             Collections.enumeration(new ArrayList<String>());
 
 

--- a/src/java.xml/share/classes/org/xml/sax/helpers/ParserAdapter.java
+++ b/src/java.xml/share/classes/org/xml/sax/helpers/ParserAdapter.java
@@ -167,10 +167,10 @@ public class ParserAdapter implements XMLReader, DocumentHandler
     //
     // Internal constants for the sake of convenience.
     //
-    private final static String FEATURES = "http://xml.org/sax/features/";
-    private final static String NAMESPACES = FEATURES + "namespaces";
-    private final static String NAMESPACE_PREFIXES = FEATURES + "namespace-prefixes";
-    private final static String XMLNS_URIs = FEATURES + "xmlns-uris";
+    private static final String FEATURES = "http://xml.org/sax/features/";
+    private static final String NAMESPACES = FEATURES + "namespaces";
+    private static final String NAMESPACE_PREFIXES = FEATURES + "namespace-prefixes";
+    private static final String XMLNS_URIs = FEATURES + "xmlns-uris";
 
 
     /**

--- a/src/java.xml/share/classes/org/xml/sax/helpers/XMLReaderFactory.java
+++ b/src/java.xml/share/classes/org/xml/sax/helpers/XMLReaderFactory.java
@@ -70,7 +70,7 @@ import org.xml.sax.XMLReader;
  * instead.
  */
 @Deprecated(since="9")
-final public class XMLReaderFactory
+public final class XMLReaderFactory
 {
     /**
      * Private constructor.


### PR DESCRIPTION
I ran bin/blessed-modifier-order.sh on source code in java.xml and java.xml.crypto. This scripts verifies that modifiers are in the "blessed" order, and fixes it otherwise. I have manually checked the changes made by the script to make sure they are sound.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8277059](https://bugs.openjdk.java.net/browse/JDK-8277059): Use blessed modifier order in java.xml


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6369/head:pull/6369` \
`$ git checkout pull/6369`

Update a local copy of the PR: \
`$ git checkout pull/6369` \
`$ git pull https://git.openjdk.java.net/jdk pull/6369/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6369`

View PR using the GUI difftool: \
`$ git pr show -t 6369`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6369.diff">https://git.openjdk.java.net/jdk/pull/6369.diff</a>

</details>
