### PR TITLE
8278263: Remove redundant synchronized from URLStreamHandler.openConnection methods

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/mailto/Handler.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/mailto/Handler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,10 +32,6 @@ package sun.net.www.protocol.mailto;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
-import java.io.*;
-import sun.net.www.*;
-//import sun.net.www.protocol.news.ArticlePoster;
-import sun.net.smtp.SmtpClient;
 
 /** open an nntp input stream given a URL */
 public class Handler extends URLStreamHandler {
@@ -99,7 +95,7 @@ public class Handler extends URLStreamHandler {
 //     }
     */
 
-    public synchronized URLConnection openConnection(URL u) {
+    public URLConnection openConnection(URL u) {
         return new MailToURLConnection(u);
     }
 

--- a/src/java.base/unix/classes/sun/net/www/protocol/file/Handler.java
+++ b/src/java.base/unix/classes/sun/net/www/protocol/file/Handler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,10 @@
 
 package sun.net.www.protocol.file;
 
-import java.net.InetAddress;
 import java.net.URLConnection;
 import java.net.URL;
 import java.net.Proxy;
-import java.net.MalformedURLException;
 import java.net.URLStreamHandler;
-import java.io.InputStream;
 import java.io.IOException;
 import sun.net.www.ParseUtil;
 import java.io.File;
@@ -41,14 +38,6 @@ import java.io.File;
  * @author      James Gosling
  */
 public class Handler extends URLStreamHandler {
-
-    private String getHost(URL url) {
-        String host = url.getHost();
-        if (host == null)
-            host = "";
-        return host;
-    }
-
 
     protected void parseURL(URL u, String spec, int start, int limit) {
         /*
@@ -61,18 +50,18 @@ public class Handler extends URLStreamHandler {
          * rather than forcing this to be fixed in the caller of the URL
          * class where it belongs. Since backslash is an "unwise"
          * character that would normally be encoded if literally intended
-         * as a non-seperator character the damage of veering away from the
+         * as a non-separator character the damage of veering away from the
          * specification is presumably limited.
          */
         super.parseURL(u, spec.replace(File.separatorChar, '/'), start, limit);
     }
 
-    public synchronized URLConnection openConnection(URL u)
+    public URLConnection openConnection(URL u)
         throws IOException {
         return openConnection(u, null);
     }
 
-    public synchronized URLConnection openConnection(URL u, Proxy p)
+    public URLConnection openConnection(URL u, Proxy p)
            throws IOException {
         String host = u.getHost();
         if (host == null || host.isEmpty() || host.equals("~") ||

--- a/src/java.base/windows/classes/sun/net/www/protocol/file/Handler.java
+++ b/src/java.base/windows/classes/sun/net/www/protocol/file/Handler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,10 @@
 
 package sun.net.www.protocol.file;
 
-import java.net.InetAddress;
 import java.net.URLConnection;
 import java.net.URL;
 import java.net.Proxy;
-import java.net.MalformedURLException;
 import java.net.URLStreamHandler;
-import java.io.InputStream;
 import java.io.IOException;
 import sun.net.www.ParseUtil;
 import java.io.File;
@@ -41,14 +38,6 @@ import java.io.File;
  * @author      James Gosling
  */
 public class Handler extends URLStreamHandler {
-
-    private String getHost(URL url) {
-        String host = url.getHost();
-        if (host == null)
-            host = "";
-        return host;
-    }
-
 
     protected void parseURL(URL u, String spec, int start, int limit) {
         /*
@@ -61,18 +50,18 @@ public class Handler extends URLStreamHandler {
          * rather than forcing this to be fixed in the caller of the URL
          * class where it belongs. Since backslash is an "unwise"
          * character that would normally be encoded if literally intended
-         * as a non-seperator character the damage of veering away from the
+         * as a non-separator character the damage of veering away from the
          * specification is presumably limited.
          */
         super.parseURL(u, spec.replace(File.separatorChar, '/'), start, limit);
     }
 
-    public synchronized URLConnection openConnection(URL url)
+    public URLConnection openConnection(URL url)
         throws IOException {
         return openConnection(url, null);
     }
 
-    public synchronized URLConnection openConnection(URL url, Proxy p)
+    public URLConnection openConnection(URL url, Proxy p)
            throws IOException {
 
         String path;


### PR DESCRIPTION
All this Handler's are stateless and there is nothing to protect via synchronization.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278263](https://bugs.openjdk.java.net/browse/JDK-8278263): Remove redundant synchronized from URLStreamHandler.openConnection methods


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6373/head:pull/6373` \
`$ git checkout pull/6373`

Update a local copy of the PR: \
`$ git checkout pull/6373` \
`$ git pull https://git.openjdk.java.net/jdk pull/6373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6373`

View PR using the GUI difftool: \
`$ git pr show -t 6373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6373.diff">https://git.openjdk.java.net/jdk/pull/6373.diff</a>

</details>
