### PR TITLE
[PATCH] Remove redundant null check in JrtPath.getAttributes

### DIFF
--- a/src/java.base/share/classes/jdk/internal/jrtfs/JrtPath.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/JrtPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -651,11 +651,7 @@ final class JrtPath implements Path {
     }
 
     final JrtFileAttributes getAttributes(LinkOption... options) throws IOException {
-        JrtFileAttributes zfas = jrtfs.getFileAttributes(this, options);
-        if (zfas == null) {
-            throw new NoSuchFileException(toString());
-        }
-        return zfas;
+        return jrtfs.getFileAttributes(this, options);
     }
 
     final void setAttribute(String attribute, Object value, LinkOption... options)


### PR DESCRIPTION
We use AspectJ in our project, and I noticed that considerable amount of time is taken by scanning JRT filesystem.
https://github.com/eclipse/org.aspectj/blob/67b1c353a02c335074a736ebf76a49bf24eefb19/bcel-builder/src/main/java/org/aspectj/apache/bcel/util/ClassPath.java#L454
It uses `Files.walkFileTree` to walk through all classes. Visitor consumes `Path` instances together with `BasicFileAttributes`. And it seems that reading attributes is most expensive there.
I noticed that at least this `null` check is redundant:
jdk.internal.jrtfs.JrtFileSystem.getFileAttributes never return null - it throws NoSuchFileException by itself

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6376/head:pull/6376` \
`$ git checkout pull/6376`

Update a local copy of the PR: \
`$ git checkout pull/6376` \
`$ git pull https://git.openjdk.java.net/jdk pull/6376/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6376`

View PR using the GUI difftool: \
`$ git pr show -t 6376`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6376.diff">https://git.openjdk.java.net/jdk/pull/6376.diff</a>

</details>
