### PR TITLE
8276976: Rename LIR_OprDesc to LIR_Opr

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -1564,7 +1564,7 @@ void LIR_Assembler::emit_compare_and_swap(LIR_OpCompareAndSwap* op) {
     assert(op->addr()->is_address(), "what else?");
     LIR_Address* addr_ptr = op->addr()->as_address_ptr();
     assert(addr_ptr->disp() == 0, "need 0 disp");
-    assert(addr_ptr->index() == LIR_OprDesc::illegalOpr(), "need 0 index");
+    assert(addr_ptr->index() == LIR_Opr::illegalOpr(), "need 0 index");
     addr = as_reg(addr_ptr->base());
   }
   Register newval = as_reg(op->new_value());

--- a/src/hotspot/cpu/aarch64/c1_LIR_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIR_aarch64.cpp
@@ -26,22 +26,22 @@
 #include "asm/register.hpp"
 #include "c1/c1_LIR.hpp"
 
-FloatRegister LIR_OprDesc::as_float_reg() const {
+FloatRegister LIR_Opr::as_float_reg() const {
   return as_FloatRegister(fpu_regnr());
 }
 
-FloatRegister LIR_OprDesc::as_double_reg() const {
+FloatRegister LIR_Opr::as_double_reg() const {
   return as_FloatRegister(fpu_regnrLo());
 }
 
 // Reg2 unused.
 LIR_Opr LIR_OprFact::double_fpu(int reg1, int reg2) {
   assert(as_FloatRegister(reg2) == fnoreg, "Not used on this platform");
-  return (LIR_Opr)(intptr_t)((reg1 << LIR_OprDesc::reg1_shift) |
-                             (reg1 << LIR_OprDesc::reg2_shift) |
-                             LIR_OprDesc::double_type          |
-                             LIR_OprDesc::fpu_register         |
-                             LIR_OprDesc::double_size);
+  return (LIR_Opr)(intptr_t)((reg1 << LIR_Opr::reg1_shift) |
+                             (reg1 << LIR_Opr::reg2_shift) |
+                             LIR_Opr::double_type          |
+                             LIR_Opr::fpu_register         |
+                             LIR_Opr::double_size);
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
@@ -1381,7 +1381,7 @@ void LIR_Assembler::emit_compare_and_swap(LIR_OpCompareAndSwap* op) {
     op->addr()->as_pointer_register() :
     op->addr()->as_address_ptr()->base()->as_pointer_register();
   assert(op->addr()->is_register() || op->addr()->as_address_ptr()->disp() == 0, "unexpected disp");
-  assert(op->addr()->is_register() || op->addr()->as_address_ptr()->index() == LIR_OprDesc::illegalOpr(), "unexpected index");
+  assert(op->addr()->is_register() || op->addr()->as_address_ptr()->index() == LIR_Opr::illegalOpr(), "unexpected index");
   if (op->code() == lir_cas_int || op->code() == lir_cas_obj) {
     Register cmpval = op->cmp_value()->as_register();
     Register newval = op->new_value()->as_register();

--- a/src/hotspot/cpu/arm/c1_LIR_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_LIR_arm.cpp
@@ -25,21 +25,21 @@
 #include "precompiled.hpp"
 #include "c1/c1_LIR.hpp"
 
-FloatRegister LIR_OprDesc::as_float_reg() const {
+FloatRegister LIR_Opr::as_float_reg() const {
   return as_FloatRegister(fpu_regnr());
 }
 
-FloatRegister LIR_OprDesc::as_double_reg() const {
+FloatRegister LIR_Opr::as_double_reg() const {
   return as_FloatRegister(fpu_regnrLo());
 }
 
 LIR_Opr LIR_OprFact::double_fpu(int reg1, int reg2) {
   assert(as_FloatRegister(reg2) != fnoreg, "Arm32 holds double in two regs.");
-  return (LIR_Opr)(intptr_t)((reg1 << LIR_OprDesc::reg1_shift) |
-                             (reg2 << LIR_OprDesc::reg2_shift) |
-                             LIR_OprDesc::double_type          |
-                             LIR_OprDesc::fpu_register         |
-                             LIR_OprDesc::double_size);
+  return (LIR_Opr)(intptr_t)((reg1 << LIR_Opr::reg1_shift) |
+                             (reg2 << LIR_Opr::reg2_shift) |
+                             LIR_Opr::double_type          |
+                             LIR_Opr::fpu_register         |
+                             LIR_Opr::double_size);
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/cpu/ppc/c1_LIR_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIR_ppc.cpp
@@ -27,22 +27,22 @@
 #include "asm/register.hpp"
 #include "c1/c1_LIR.hpp"
 
-FloatRegister LIR_OprDesc::as_float_reg() const {
+FloatRegister LIR_Opr::as_float_reg() const {
   return as_FloatRegister(fpu_regnr());
 }
 
-FloatRegister LIR_OprDesc::as_double_reg() const {
+FloatRegister LIR_Opr::as_double_reg() const {
   return as_FloatRegister(fpu_regnrLo());
 }
 
 // Reg2 unused.
 LIR_Opr LIR_OprFact::double_fpu(int reg1, int reg2) {
   assert(!as_FloatRegister(reg2)->is_valid(), "Not used on this platform");
-  return (LIR_Opr)(intptr_t)((reg1 << LIR_OprDesc::reg1_shift) |
-                             (reg1 << LIR_OprDesc::reg2_shift) |
-                             LIR_OprDesc::double_type          |
-                             LIR_OprDesc::fpu_register         |
-                             LIR_OprDesc::double_size);
+  return (LIR_Opr)(intptr_t)((reg1 << LIR_Opr::reg1_shift) |
+                             (reg1 << LIR_Opr::reg2_shift) |
+                             LIR_Opr::double_type          |
+                             LIR_Opr::fpu_register         |
+                             LIR_Opr::double_size);
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/cpu/s390/c1_LIR_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_LIR_s390.cpp
@@ -29,22 +29,22 @@
 #include "c1/c1_LIR.hpp"
 
 
-FloatRegister LIR_OprDesc::as_float_reg() const {
+FloatRegister LIR_Opr::as_float_reg() const {
   return FrameMap::nr2floatreg(fpu_regnr());
 }
 
-FloatRegister LIR_OprDesc::as_double_reg() const {
+FloatRegister LIR_Opr::as_double_reg() const {
   return FrameMap::nr2floatreg(fpu_regnrHi());
 }
 
 // Reg2 unused.
 LIR_Opr LIR_OprFact::double_fpu(int reg1, int reg2) {
   assert(!as_FloatRegister(reg2)->is_valid(), "Not used on this platform");
-  return (LIR_Opr)(intptr_t)((reg1 << LIR_OprDesc::reg1_shift) |
-                             (reg1 << LIR_OprDesc::reg2_shift) |
-                             LIR_OprDesc::double_type          |
-                             LIR_OprDesc::fpu_register         |
-                             LIR_OprDesc::double_size);
+  return (LIR_Opr)(intptr_t)((reg1 << LIR_Opr::reg1_shift) |
+                             (reg1 << LIR_Opr::reg2_shift) |
+                             LIR_Opr::double_type          |
+                             LIR_Opr::fpu_register         |
+                             LIR_Opr::double_size);
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/cpu/x86/c1_LIR_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIR_x86.cpp
@@ -28,21 +28,21 @@
 #include "c1/c1_LIR.hpp"
 
 
-FloatRegister LIR_OprDesc::as_float_reg() const {
+FloatRegister LIR_Opr::as_float_reg() const {
   ShouldNotReachHere();
   return fnoreg;
 }
 
-FloatRegister LIR_OprDesc::as_double_reg() const {
+FloatRegister LIR_Opr::as_double_reg() const {
   ShouldNotReachHere();
   return fnoreg;
 }
 
-XMMRegister LIR_OprDesc::as_xmm_float_reg() const {
+XMMRegister LIR_Opr::as_xmm_float_reg() const {
   return FrameMap::nr2xmmreg(xmm_regnr());
 }
 
-XMMRegister LIR_OprDesc::as_xmm_double_reg() const {
+XMMRegister LIR_Opr::as_xmm_double_reg() const {
   assert(xmm_regnrLo() == xmm_regnrHi(), "assumed in calculation");
   return FrameMap::nr2xmmreg(xmm_regnrLo());
 }
@@ -50,11 +50,11 @@ XMMRegister LIR_OprDesc::as_xmm_double_reg() const {
 // Reg2 unused.
 LIR_Opr LIR_OprFact::double_fpu(int reg1, int reg2) {
   assert(as_FloatRegister(reg2) == fnoreg, "Not used on this platform");
-  return (LIR_Opr)(intptr_t)((reg1 << LIR_OprDesc::reg1_shift) |
-                             (reg1 << LIR_OprDesc::reg2_shift) |
-                             LIR_OprDesc::double_type          |
-                             LIR_OprDesc::fpu_register         |
-                             LIR_OprDesc::double_size);
+  return (LIR_Opr)(intptr_t)((reg1 << LIR_Opr::reg1_shift) |
+                             (reg1 << LIR_Opr::reg2_shift) |
+                             LIR_Opr::double_type          |
+                             LIR_Opr::fpu_register         |
+                             LIR_Opr::double_size);
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -33,15 +33,15 @@
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/vm_version.hpp"
 
-Register LIR_OprDesc::as_register() const {
+Register LIR_Opr::as_register() const {
   return FrameMap::cpu_rnr2reg(cpu_regnr());
 }
 
-Register LIR_OprDesc::as_register_lo() const {
+Register LIR_Opr::as_register_lo() const {
   return FrameMap::cpu_rnr2reg(cpu_regnrLo());
 }
 
-Register LIR_OprDesc::as_register_hi() const {
+Register LIR_Opr::as_register_hi() const {
   return FrameMap::cpu_rnr2reg(cpu_regnrHi());
 }
 
@@ -93,7 +93,7 @@ LIR_Address::Scale LIR_Address::scale(BasicType type) {
 
 //---------------------------------------------------
 
-char LIR_OprDesc::type_char(BasicType t) {
+char LIR_Opr::type_char(BasicType t) {
   switch (t) {
     case T_ARRAY:
       t = T_OBJECT;
@@ -121,7 +121,7 @@ char LIR_OprDesc::type_char(BasicType t) {
 }
 
 #ifndef PRODUCT
-void LIR_OprDesc::validate_type() const {
+void LIR_Opr::validate_type() const {
 
 #ifdef ASSERT
   if (!is_pointer() && !is_illegal()) {
@@ -173,7 +173,7 @@ void LIR_OprDesc::validate_type() const {
 #endif // PRODUCT
 
 
-bool LIR_OprDesc::is_oop() const {
+bool LIR_Opr::is_oop() const {
   if (is_pointer()) {
     return pointer()->is_oop_pointer();
   } else {
@@ -1373,7 +1373,7 @@ void LIR_List::unlock_object(LIR_Opr hdr, LIR_Opr obj, LIR_Opr lock, LIR_Opr scr
 
 void check_LIR() {
   // cannot do the proper checking as PRODUCT and other modes return different results
-  // guarantee(sizeof(LIR_OprDesc) == wordSize, "may not have a v-table");
+  // guarantee(sizeof(LIR_Opr) == wordSize, "may not have a v-table");
 }
 
 
@@ -1448,12 +1448,12 @@ void print_LIR(BlockList* blocks) {
 }
 
 #else
-// LIR_OprDesc
-void LIR_OprDesc::print() const {
+// LIR_Opr
+void LIR_Opr::print() const {
   print(tty);
 }
 
-void LIR_OprDesc::print(outputStream* out) const {
+void LIR_Opr::print(outputStream* out) const {
   if (is_illegal()) {
     return;
   }

--- a/src/hotspot/share/c1/c1_LIR.hpp
+++ b/src/hotspot/share/c1/c1_LIR.hpp
@@ -478,40 +478,31 @@ class LIR_Opr {
   void print(outputStream* out) const PRODUCT_RETURN;
 };
 
-// TODO: Remove this hack.
-// UGLY HACK: add a type alias. `LIR_Opr` is not actually equivalent to the
-// previous `LIR_OprDesc` (`LIR_Opr` is like more similar to previous
-// `LIR_OprDesc*`). The only purpose of this typedef is so that the various
-// `LIR_OprDesc::enum_value` scattered everywhere don't need to be
-// modified. This should be removed, and a textual replacement of
-// `LIR_OprDesc::` to `LIR_Opr::` done throughout the code.
-typedef LIR_Opr LIR_OprDesc;
-
-inline LIR_OprDesc::OprType as_OprType(BasicType type) {
+inline LIR_Opr::OprType as_OprType(BasicType type) {
   switch (type) {
-  case T_INT:      return LIR_OprDesc::int_type;
-  case T_LONG:     return LIR_OprDesc::long_type;
-  case T_FLOAT:    return LIR_OprDesc::float_type;
-  case T_DOUBLE:   return LIR_OprDesc::double_type;
+  case T_INT:      return LIR_Opr::int_type;
+  case T_LONG:     return LIR_Opr::long_type;
+  case T_FLOAT:    return LIR_Opr::float_type;
+  case T_DOUBLE:   return LIR_Opr::double_type;
   case T_OBJECT:
-  case T_ARRAY:    return LIR_OprDesc::object_type;
-  case T_ADDRESS:  return LIR_OprDesc::address_type;
-  case T_METADATA: return LIR_OprDesc::metadata_type;
+  case T_ARRAY:    return LIR_Opr::object_type;
+  case T_ADDRESS:  return LIR_Opr::address_type;
+  case T_METADATA: return LIR_Opr::metadata_type;
   case T_ILLEGAL:  // fall through
-  default: ShouldNotReachHere(); return LIR_OprDesc::unknown_type;
+  default: ShouldNotReachHere(); return LIR_Opr::unknown_type;
   }
 }
 
-inline BasicType as_BasicType(LIR_OprDesc::OprType t) {
+inline BasicType as_BasicType(LIR_Opr::OprType t) {
   switch (t) {
-  case LIR_OprDesc::int_type:     return T_INT;
-  case LIR_OprDesc::long_type:    return T_LONG;
-  case LIR_OprDesc::float_type:   return T_FLOAT;
-  case LIR_OprDesc::double_type:  return T_DOUBLE;
-  case LIR_OprDesc::object_type:  return T_OBJECT;
-  case LIR_OprDesc::address_type: return T_ADDRESS;
-  case LIR_OprDesc::metadata_type:return T_METADATA;
-  case LIR_OprDesc::unknown_type: // fall through
+  case LIR_Opr::int_type:     return T_INT;
+  case LIR_Opr::long_type:    return T_LONG;
+  case LIR_Opr::float_type:   return T_FLOAT;
+  case LIR_Opr::double_type:  return T_DOUBLE;
+  case LIR_Opr::object_type:  return T_OBJECT;
+  case LIR_Opr::address_type: return T_ADDRESS;
+  case LIR_Opr::metadata_type:return T_METADATA;
+  case LIR_Opr::unknown_type: // fall through
   default: ShouldNotReachHere();  return T_ILLEGAL;
   }
 }
@@ -549,14 +540,14 @@ class LIR_Address: public LIR_OprPtr {
 
   LIR_Address(LIR_Opr base, intx disp, BasicType type):
        _base(base)
-     , _index(LIR_OprDesc::illegalOpr())
+     , _index(LIR_Opr::illegalOpr())
      , _scale(times_1)
      , _disp(disp)
      , _type(type) { verify(); }
 
   LIR_Address(LIR_Opr base, BasicType type):
        _base(base)
-     , _index(LIR_OprDesc::illegalOpr())
+     , _index(LIR_Opr::illegalOpr())
      , _scale(times_1)
      , _disp(0)
      , _type(type) { verify(); }
@@ -600,43 +591,43 @@ class LIR_OprFact: public AllStatic {
   static LIR_Opr nullOpr;
 
   static LIR_Opr single_cpu(int reg) {
-    return (LIR_Opr)(intptr_t)((reg  << LIR_OprDesc::reg1_shift) |
-                               LIR_OprDesc::int_type             |
-                               LIR_OprDesc::cpu_register         |
-                               LIR_OprDesc::single_size);
+    return (LIR_Opr)(intptr_t)((reg  << LIR_Opr::reg1_shift) |
+                               LIR_Opr::int_type             |
+                               LIR_Opr::cpu_register         |
+                               LIR_Opr::single_size);
   }
   static LIR_Opr single_cpu_oop(int reg) {
-    return (LIR_Opr)(intptr_t)((reg  << LIR_OprDesc::reg1_shift) |
-                               LIR_OprDesc::object_type          |
-                               LIR_OprDesc::cpu_register         |
-                               LIR_OprDesc::single_size);
+    return (LIR_Opr)(intptr_t)((reg  << LIR_Opr::reg1_shift) |
+                               LIR_Opr::object_type          |
+                               LIR_Opr::cpu_register         |
+                               LIR_Opr::single_size);
   }
   static LIR_Opr single_cpu_address(int reg) {
-    return (LIR_Opr)(intptr_t)((reg  << LIR_OprDesc::reg1_shift) |
-                               LIR_OprDesc::address_type         |
-                               LIR_OprDesc::cpu_register         |
-                               LIR_OprDesc::single_size);
+    return (LIR_Opr)(intptr_t)((reg  << LIR_Opr::reg1_shift) |
+                               LIR_Opr::address_type         |
+                               LIR_Opr::cpu_register         |
+                               LIR_Opr::single_size);
   }
   static LIR_Opr single_cpu_metadata(int reg) {
-    return (LIR_Opr)(intptr_t)((reg  << LIR_OprDesc::reg1_shift) |
-                               LIR_OprDesc::metadata_type        |
-                               LIR_OprDesc::cpu_register         |
-                               LIR_OprDesc::single_size);
+    return (LIR_Opr)(intptr_t)((reg  << LIR_Opr::reg1_shift) |
+                               LIR_Opr::metadata_type        |
+                               LIR_Opr::cpu_register         |
+                               LIR_Opr::single_size);
   }
   static LIR_Opr double_cpu(int reg1, int reg2) {
     LP64_ONLY(assert(reg1 == reg2, "must be identical"));
-    return (LIR_Opr)(intptr_t)((reg1 << LIR_OprDesc::reg1_shift) |
-                               (reg2 << LIR_OprDesc::reg2_shift) |
-                               LIR_OprDesc::long_type            |
-                               LIR_OprDesc::cpu_register         |
-                               LIR_OprDesc::double_size);
+    return (LIR_Opr)(intptr_t)((reg1 << LIR_Opr::reg1_shift) |
+                               (reg2 << LIR_Opr::reg2_shift) |
+                               LIR_Opr::long_type            |
+                               LIR_Opr::cpu_register         |
+                               LIR_Opr::double_size);
   }
 
   static LIR_Opr single_fpu(int reg) {
-    return (LIR_Opr)(intptr_t)((reg  << LIR_OprDesc::reg1_shift) |
-                               LIR_OprDesc::float_type           |
-                               LIR_OprDesc::fpu_register         |
-                               LIR_OprDesc::single_size);
+    return (LIR_Opr)(intptr_t)((reg  << LIR_Opr::reg1_shift) |
+                               LIR_Opr::float_type           |
+                               LIR_Opr::fpu_register         |
+                               LIR_Opr::single_size);
   }
 
   // Platform dependant.
@@ -644,40 +635,40 @@ class LIR_OprFact: public AllStatic {
 
 #ifdef ARM32
   static LIR_Opr single_softfp(int reg) {
-    return (LIR_Opr)(intptr_t)((reg  << LIR_OprDesc::reg1_shift) |
-                               LIR_OprDesc::float_type           |
-                               LIR_OprDesc::cpu_register         |
-                               LIR_OprDesc::single_size);
+    return (LIR_Opr)(intptr_t)((reg  << LIR_Opr::reg1_shift) |
+                               LIR_Opr::float_type           |
+                               LIR_Opr::cpu_register         |
+                               LIR_Opr::single_size);
   }
   static LIR_Opr double_softfp(int reg1, int reg2) {
-    return (LIR_Opr)(intptr_t)((reg1 << LIR_OprDesc::reg1_shift) |
-                               (reg2 << LIR_OprDesc::reg2_shift) |
-                               LIR_OprDesc::double_type          |
-                               LIR_OprDesc::cpu_register         |
-                               LIR_OprDesc::double_size);
+    return (LIR_Opr)(intptr_t)((reg1 << LIR_Opr::reg1_shift) |
+                               (reg2 << LIR_Opr::reg2_shift) |
+                               LIR_Opr::double_type          |
+                               LIR_Opr::cpu_register         |
+                               LIR_Opr::double_size);
   }
 #endif // ARM32
 
 #if defined(X86)
   static LIR_Opr single_xmm(int reg) {
-    return (LIR_Opr)(intptr_t)((reg << LIR_OprDesc::reg1_shift) |
-                               LIR_OprDesc::float_type          |
-                               LIR_OprDesc::fpu_register        |
-                               LIR_OprDesc::single_size         |
-                               LIR_OprDesc::is_xmm_mask);
+    return (LIR_Opr)(intptr_t)((reg << LIR_Opr::reg1_shift) |
+                               LIR_Opr::float_type          |
+                               LIR_Opr::fpu_register        |
+                               LIR_Opr::single_size         |
+                               LIR_Opr::is_xmm_mask);
   }
   static LIR_Opr double_xmm(int reg) {
-    return (LIR_Opr)(intptr_t)((reg << LIR_OprDesc::reg1_shift) |
-                               (reg << LIR_OprDesc::reg2_shift) |
-                               LIR_OprDesc::double_type         |
-                               LIR_OprDesc::fpu_register        |
-                               LIR_OprDesc::double_size         |
-                               LIR_OprDesc::is_xmm_mask);
+    return (LIR_Opr)(intptr_t)((reg << LIR_Opr::reg1_shift) |
+                               (reg << LIR_Opr::reg2_shift) |
+                               LIR_Opr::double_type         |
+                               LIR_Opr::fpu_register        |
+                               LIR_Opr::double_size         |
+                               LIR_Opr::is_xmm_mask);
   }
 #endif // X86
 
   static LIR_Opr virtual_register(int index, BasicType type) {
-    if (index > LIR_OprDesc::vreg_max) {
+    if (index > LIR_Opr::vreg_max) {
       // Running out of virtual registers. Caller should bailout.
       return illegalOpr;
     }
@@ -686,75 +677,75 @@ class LIR_OprFact: public AllStatic {
     switch (type) {
       case T_OBJECT: // fall through
       case T_ARRAY:
-        res = (LIR_Opr)(intptr_t)((index << LIR_OprDesc::data_shift)  |
-                                            LIR_OprDesc::object_type  |
-                                            LIR_OprDesc::cpu_register |
-                                            LIR_OprDesc::single_size  |
-                                            LIR_OprDesc::virtual_mask);
+        res = (LIR_Opr)(intptr_t)((index << LIR_Opr::data_shift)  |
+                                            LIR_Opr::object_type  |
+                                            LIR_Opr::cpu_register |
+                                            LIR_Opr::single_size  |
+                                            LIR_Opr::virtual_mask);
         break;
 
       case T_METADATA:
-        res = (LIR_Opr)(intptr_t)((index << LIR_OprDesc::data_shift)  |
-                                            LIR_OprDesc::metadata_type|
-                                            LIR_OprDesc::cpu_register |
-                                            LIR_OprDesc::single_size  |
-                                            LIR_OprDesc::virtual_mask);
+        res = (LIR_Opr)(intptr_t)((index << LIR_Opr::data_shift)  |
+                                            LIR_Opr::metadata_type|
+                                            LIR_Opr::cpu_register |
+                                            LIR_Opr::single_size  |
+                                            LIR_Opr::virtual_mask);
         break;
 
       case T_INT:
-        res = (LIR_Opr)(intptr_t)((index << LIR_OprDesc::data_shift) |
-                                  LIR_OprDesc::int_type              |
-                                  LIR_OprDesc::cpu_register          |
-                                  LIR_OprDesc::single_size           |
-                                  LIR_OprDesc::virtual_mask);
+        res = (LIR_Opr)(intptr_t)((index << LIR_Opr::data_shift) |
+                                  LIR_Opr::int_type              |
+                                  LIR_Opr::cpu_register          |
+                                  LIR_Opr::single_size           |
+                                  LIR_Opr::virtual_mask);
         break;
 
       case T_ADDRESS:
-        res = (LIR_Opr)(intptr_t)((index << LIR_OprDesc::data_shift) |
-                                  LIR_OprDesc::address_type          |
-                                  LIR_OprDesc::cpu_register          |
-                                  LIR_OprDesc::single_size           |
-                                  LIR_OprDesc::virtual_mask);
+        res = (LIR_Opr)(intptr_t)((index << LIR_Opr::data_shift) |
+                                  LIR_Opr::address_type          |
+                                  LIR_Opr::cpu_register          |
+                                  LIR_Opr::single_size           |
+                                  LIR_Opr::virtual_mask);
         break;
 
       case T_LONG:
-        res = (LIR_Opr)(intptr_t)((index << LIR_OprDesc::data_shift) |
-                                  LIR_OprDesc::long_type             |
-                                  LIR_OprDesc::cpu_register          |
-                                  LIR_OprDesc::double_size           |
-                                  LIR_OprDesc::virtual_mask);
+        res = (LIR_Opr)(intptr_t)((index << LIR_Opr::data_shift) |
+                                  LIR_Opr::long_type             |
+                                  LIR_Opr::cpu_register          |
+                                  LIR_Opr::double_size           |
+                                  LIR_Opr::virtual_mask);
         break;
 
 #ifdef __SOFTFP__
       case T_FLOAT:
-        res = (LIR_Opr)(intptr_t)((index << LIR_OprDesc::data_shift) |
-                                  LIR_OprDesc::float_type  |
-                                  LIR_OprDesc::cpu_register |
-                                  LIR_OprDesc::single_size |
-                                  LIR_OprDesc::virtual_mask);
+        res = (LIR_Opr)(intptr_t)((index << LIR_Opr::data_shift) |
+                                  LIR_Opr::float_type  |
+                                  LIR_Opr::cpu_register |
+                                  LIR_Opr::single_size |
+                                  LIR_Opr::virtual_mask);
         break;
       case T_DOUBLE:
-        res = (LIR_Opr)(intptr_t)((index << LIR_OprDesc::data_shift) |
-                                  LIR_OprDesc::double_type |
-                                  LIR_OprDesc::cpu_register |
-                                  LIR_OprDesc::double_size |
-                                  LIR_OprDesc::virtual_mask);
+        res = (LIR_Opr)(intptr_t)((index << LIR_Opr::data_shift) |
+                                  LIR_Opr::double_type |
+                                  LIR_Opr::cpu_register |
+                                  LIR_Opr::double_size |
+                                  LIR_Opr::virtual_mask);
         break;
 #else // __SOFTFP__
       case T_FLOAT:
-        res = (LIR_Opr)(intptr_t)((index << LIR_OprDesc::data_shift) |
-                                  LIR_OprDesc::float_type           |
-                                  LIR_OprDesc::fpu_register         |
-                                  LIR_OprDesc::single_size          |
-                                  LIR_OprDesc::virtual_mask);
+        res = (LIR_Opr)(intptr_t)((index << LIR_Opr::data_shift) |
+                                  LIR_Opr::float_type           |
+                                  LIR_Opr::fpu_register         |
+                                  LIR_Opr::single_size          |
+                                  LIR_Opr::virtual_mask);
         break;
 
       case
-        T_DOUBLE: res = (LIR_Opr)(intptr_t)((index << LIR_OprDesc::data_shift) |
-                                            LIR_OprDesc::double_type           |
-                                            LIR_OprDesc::fpu_register          |
-                                            LIR_OprDesc::double_size           |
-                                            LIR_OprDesc::virtual_mask);
+        T_DOUBLE: res = (LIR_Opr)(intptr_t)((index << LIR_Opr::data_shift) |
+                                            LIR_Opr::double_type           |
+                                            LIR_Opr::fpu_register          |
+                                            LIR_Opr::double_size           |
+                                            LIR_Opr::virtual_mask);
         break;
 #endif // __SOFTFP__
       default:       ShouldNotReachHere(); res = illegalOpr;
@@ -763,20 +754,20 @@ class LIR_OprFact: public AllStatic {
 #ifdef ASSERT
     res->validate_type();
     assert(res->vreg_number() == index, "conversion check");
-    assert(index >= LIR_OprDesc::vreg_base, "must start at vreg_base");
-    assert(index <= (max_jint >> LIR_OprDesc::data_shift), "index is too big");
+    assert(index >= LIR_Opr::vreg_base, "must start at vreg_base");
+    assert(index <= (max_jint >> LIR_Opr::data_shift), "index is too big");
 
     // old-style calculation; check if old and new method are equal
-    LIR_OprDesc::OprType t = as_OprType(type);
+    LIR_Opr::OprType t = as_OprType(type);
 #ifdef __SOFTFP__
-    LIR_Opr old_res = (LIR_Opr)(intptr_t)((index << LIR_OprDesc::data_shift) |
+    LIR_Opr old_res = (LIR_Opr)(intptr_t)((index << LIR_Opr::data_shift) |
                                t |
-                               LIR_OprDesc::cpu_register |
-                               LIR_OprDesc::size_for(type) | LIR_OprDesc::virtual_mask);
+                               LIR_Opr::cpu_register |
+                               LIR_Opr::size_for(type) | LIR_Opr::virtual_mask);
 #else // __SOFTFP__
-    LIR_Opr old_res = (LIR_Opr)(intptr_t)((index << LIR_OprDesc::data_shift) | t |
-                                          ((type == T_FLOAT || type == T_DOUBLE) ?  LIR_OprDesc::fpu_register : LIR_OprDesc::cpu_register) |
-                               LIR_OprDesc::size_for(type) | LIR_OprDesc::virtual_mask);
+    LIR_Opr old_res = (LIR_Opr)(intptr_t)((index << LIR_Opr::data_shift) | t |
+                                          ((type == T_FLOAT || type == T_DOUBLE) ?  LIR_Opr::fpu_register : LIR_Opr::cpu_register) |
+                               LIR_Opr::size_for(type) | LIR_Opr::virtual_mask);
     assert(res == old_res, "old and new method not equal");
 #endif // __SOFTFP__
 #endif // ASSERT
@@ -792,50 +783,50 @@ class LIR_OprFact: public AllStatic {
     switch (type) {
       case T_OBJECT: // fall through
       case T_ARRAY:
-        res = (LIR_Opr)(intptr_t)((index << LIR_OprDesc::data_shift) |
-                                  LIR_OprDesc::object_type           |
-                                  LIR_OprDesc::stack_value           |
-                                  LIR_OprDesc::single_size);
+        res = (LIR_Opr)(intptr_t)((index << LIR_Opr::data_shift) |
+                                  LIR_Opr::object_type           |
+                                  LIR_Opr::stack_value           |
+                                  LIR_Opr::single_size);
         break;
 
       case T_METADATA:
-        res = (LIR_Opr)(intptr_t)((index << LIR_OprDesc::data_shift) |
-                                  LIR_OprDesc::metadata_type         |
-                                  LIR_OprDesc::stack_value           |
-                                  LIR_OprDesc::single_size);
+        res = (LIR_Opr)(intptr_t)((index << LIR_Opr::data_shift) |
+                                  LIR_Opr::metadata_type         |
+                                  LIR_Opr::stack_value           |
+                                  LIR_Opr::single_size);
         break;
       case T_INT:
-        res = (LIR_Opr)(intptr_t)((index << LIR_OprDesc::data_shift) |
-                                  LIR_OprDesc::int_type              |
-                                  LIR_OprDesc::stack_value           |
-                                  LIR_OprDesc::single_size);
+        res = (LIR_Opr)(intptr_t)((index << LIR_Opr::data_shift) |
+                                  LIR_Opr::int_type              |
+                                  LIR_Opr::stack_value           |
+                                  LIR_Opr::single_size);
         break;
 
       case T_ADDRESS:
-        res = (LIR_Opr)(intptr_t)((index << LIR_OprDesc::data_shift) |
-                                  LIR_OprDesc::address_type          |
-                                  LIR_OprDesc::stack_value           |
-                                  LIR_OprDesc::single_size);
+        res = (LIR_Opr)(intptr_t)((index << LIR_Opr::data_shift) |
+                                  LIR_Opr::address_type          |
+                                  LIR_Opr::stack_value           |
+                                  LIR_Opr::single_size);
         break;
 
       case T_LONG:
-        res = (LIR_Opr)(intptr_t)((index << LIR_OprDesc::data_shift) |
-                                  LIR_OprDesc::long_type             |
-                                  LIR_OprDesc::stack_value           |
-                                  LIR_OprDesc::double_size);
+        res = (LIR_Opr)(intptr_t)((index << LIR_Opr::data_shift) |
+                                  LIR_Opr::long_type             |
+                                  LIR_Opr::stack_value           |
+                                  LIR_Opr::double_size);
         break;
 
       case T_FLOAT:
-        res = (LIR_Opr)(intptr_t)((index << LIR_OprDesc::data_shift) |
-                                  LIR_OprDesc::float_type            |
-                                  LIR_OprDesc::stack_value           |
-                                  LIR_OprDesc::single_size);
+        res = (LIR_Opr)(intptr_t)((index << LIR_Opr::data_shift) |
+                                  LIR_Opr::float_type            |
+                                  LIR_Opr::stack_value           |
+                                  LIR_Opr::single_size);
         break;
       case T_DOUBLE:
-        res = (LIR_Opr)(intptr_t)((index << LIR_OprDesc::data_shift) |
-                                  LIR_OprDesc::double_type           |
-                                  LIR_OprDesc::stack_value           |
-                                  LIR_OprDesc::double_size);
+        res = (LIR_Opr)(intptr_t)((index << LIR_Opr::data_shift) |
+                                  LIR_Opr::double_type           |
+                                  LIR_Opr::stack_value           |
+                                  LIR_Opr::double_size);
         break;
 
       default:       ShouldNotReachHere(); res = illegalOpr;
@@ -843,12 +834,12 @@ class LIR_OprFact: public AllStatic {
 
 #ifdef ASSERT
     assert(index >= 0, "index must be positive");
-    assert(index <= (max_jint >> LIR_OprDesc::data_shift), "index is too big");
+    assert(index <= (max_jint >> LIR_Opr::data_shift), "index is too big");
 
-    LIR_Opr old_res = (LIR_Opr)(intptr_t)((index << LIR_OprDesc::data_shift) |
-                                          LIR_OprDesc::stack_value           |
+    LIR_Opr old_res = (LIR_Opr)(intptr_t)((index << LIR_Opr::data_shift) |
+                                          LIR_Opr::stack_value           |
                                           as_OprType(type)                   |
-                                          LIR_OprDesc::size_for(type));
+                                          LIR_Opr::size_for(type));
     assert(res == old_res, "old and new method not equal");
 #endif
 
@@ -2474,8 +2465,8 @@ class LIR_OpVisitState: public StackObj {
 };
 
 
-inline LIR_Opr LIR_OprDesc::illegalOpr()   { return LIR_OprFact::illegalOpr; };
+inline LIR_Opr LIR_Opr::illegalOpr()   { return LIR_OprFact::illegalOpr; };
 
-inline LIR_Opr LIR_OprDesc::nullOpr()   { return LIR_OprFact::nullOpr; };
+inline LIR_Opr LIR_Opr::nullOpr()   { return LIR_OprFact::nullOpr; };
 
 #endif // SHARE_C1_C1_LIR_HPP

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1019,12 +1019,12 @@ LIR_Opr LIRGenerator::new_register(BasicType type) {
   int vreg_num = _virtual_register_number;
   // Add a little fudge factor for the bailout since the bailout is only checked periodically. This allows us to hand out
   // a few extra registers before we really run out which helps to avoid to trip over assertions.
-  if (vreg_num + 20 >= LIR_OprDesc::vreg_max) {
+  if (vreg_num + 20 >= LIR_Opr::vreg_max) {
     bailout("out of virtual registers in LIR generator");
-    if (vreg_num + 2 >= LIR_OprDesc::vreg_max) {
+    if (vreg_num + 2 >= LIR_Opr::vreg_max) {
       // Wrap it around and continue until bailout really happens to avoid hitting assertions.
-      _virtual_register_number = LIR_OprDesc::vreg_base;
-      vreg_num = LIR_OprDesc::vreg_base;
+      _virtual_register_number = LIR_Opr::vreg_base;
+      vreg_num = LIR_Opr::vreg_base;
     }
   }
   _virtual_register_number += 1;

--- a/src/hotspot/share/c1/c1_LIRGenerator.hpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.hpp
@@ -502,7 +502,7 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
   LIRGenerator(Compilation* compilation, ciMethod* method)
     : _compilation(compilation)
     , _method(method)
-    , _virtual_register_number(LIR_OprDesc::vreg_base)
+    , _virtual_register_number(LIR_Opr::vreg_base)
     , _vreg_flags(num_vreg_flags)
     , _barrier_set(BarrierSet::barrier_set()->barrier_set_c1()) {
   }

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -173,7 +173,7 @@ bool LinearScan::is_precolored_interval(const Interval* i) {
 }
 
 bool LinearScan::is_virtual_interval(const Interval* i) {
-  return i->reg_num() >= LIR_OprDesc::vreg_base;
+  return i->reg_num() >= LIR_Opr::vreg_base;
 }
 
 bool LinearScan::is_precolored_cpu_interval(const Interval* i) {
@@ -182,9 +182,9 @@ bool LinearScan::is_precolored_cpu_interval(const Interval* i) {
 
 bool LinearScan::is_virtual_cpu_interval(const Interval* i) {
 #if defined(__SOFTFP__) || defined(E500V2)
-  return i->reg_num() >= LIR_OprDesc::vreg_base;
+  return i->reg_num() >= LIR_Opr::vreg_base;
 #else
-  return i->reg_num() >= LIR_OprDesc::vreg_base && (i->type() != T_FLOAT && i->type() != T_DOUBLE);
+  return i->reg_num() >= LIR_Opr::vreg_base && (i->type() != T_FLOAT && i->type() != T_DOUBLE);
 #endif // __SOFTFP__ or E500V2
 }
 
@@ -196,7 +196,7 @@ bool LinearScan::is_virtual_fpu_interval(const Interval* i) {
 #if defined(__SOFTFP__) || defined(E500V2)
   return false;
 #else
-  return i->reg_num() >= LIR_OprDesc::vreg_base && (i->type() == T_FLOAT || i->type() == T_DOUBLE);
+  return i->reg_num() >= LIR_Opr::vreg_base && (i->type() == T_FLOAT || i->type() == T_DOUBLE);
 #endif // __SOFTFP__ or E500V2
 }
 
@@ -274,7 +274,7 @@ Interval* LinearScan::create_interval(int reg_num) {
   _intervals.at_put(reg_num, interval);
 
   // assign register number for precolored intervals
-  if (reg_num < LIR_OprDesc::vreg_base) {
+  if (reg_num < LIR_Opr::vreg_base) {
     interval->assign_reg(reg_num);
   }
   return interval;
@@ -819,7 +819,7 @@ void LinearScan::compute_global_live_sets() {
   // (live set must be empty at fixed intervals)
   for (int i = 0; i < num_blocks; i++) {
     BlockBegin* block = block_at(i);
-    for (int j = 0; j < LIR_OprDesc::vreg_base; j++) {
+    for (int j = 0; j < LIR_Opr::vreg_base; j++) {
       assert(block->live_in().at(j)  == false, "live_in  set of fixed register must be empty");
       assert(block->live_out().at(j) == false, "live_out set of fixed register must be empty");
       assert(block->live_gen().at(j) == false, "live_gen set of fixed register must be empty");
@@ -1333,7 +1333,7 @@ void LinearScan::build_intervals() {
     int size = (int)live.size();
     for (int number = (int)live.get_next_one_offset(0, size); number < size; number = (int)live.get_next_one_offset(number + 1, size)) {
       assert(live.at(number), "should not stop here otherwise");
-      assert(number >= LIR_OprDesc::vreg_base, "fixed intervals must not be live on block bounds");
+      assert(number >= LIR_Opr::vreg_base, "fixed intervals must not be live on block bounds");
       TRACE_LINEAR_SCAN(2, tty->print_cr("live in %d to %d", number, block_to + 2));
 
       add_use(number, block_from, block_to + 2, noUse, T_ILLEGAL);
@@ -1706,7 +1706,7 @@ Interval* LinearScan::split_child_at_op_id(Interval* interval, int op_id, LIR_Op
   }
 
   assert(false, "must find an interval, but do a clean bailout in product mode");
-  result = new Interval(LIR_OprDesc::vreg_base);
+  result = new Interval(LIR_Opr::vreg_base);
   result->assign_reg(0);
   result->set_type(T_INT);
   BAILOUT_("LinearScan: interval is NULL", result);
@@ -2435,7 +2435,7 @@ OopMap* LinearScan::compute_oop_map(IntervalWalker* iw, LIR_Op* op, CodeEmitInfo
 
     assert(interval->current_from() <= op->id() && op->id() <= interval->current_to(), "interval should not be active otherwise");
     assert(interval->assigned_regHi() == any_reg, "oop must be single word");
-    assert(interval->reg_num() >= LIR_OprDesc::vreg_base, "fixed interval found");
+    assert(interval->reg_num() >= LIR_Opr::vreg_base, "fixed interval found");
 
     // Check if this range covers the instruction. Intervals that
     // start or end at the current operation are not included in the
@@ -3218,7 +3218,7 @@ void LinearScan::print_reg_num(outputStream* out, int reg_num) {
   if (reg_num == -1) {
     out->print("[ANY]");
     return;
-  } else if (reg_num >= LIR_OprDesc::vreg_base) {
+  } else if (reg_num >= LIR_Opr::vreg_base) {
     out->print("[VREG %d]", reg_num);
     return;
   }
@@ -3298,7 +3298,7 @@ void LinearScan::verify_intervals() {
       has_error = true;
     }
 
-    if (i1->reg_num() >= LIR_OprDesc::vreg_base && i1->type() == T_ILLEGAL) {
+    if (i1->reg_num() >= LIR_Opr::vreg_base && i1->type() == T_ILLEGAL) {
       tty->print_cr("Interval %d has no type assigned", i1->reg_num()); i1->print(); tty->cr();
       has_error = true;
     }
@@ -3969,11 +3969,11 @@ LIR_Opr MoveResolver::get_virtual_register(Interval* interval) {
   // Add a little fudge factor for the bailout since the bailout is only checked periodically. This allows us to hand out
   // a few extra registers before we really run out which helps to avoid to trip over assertions.
   int reg_num = interval->reg_num();
-  if (reg_num + 20 >= LIR_OprDesc::vreg_max) {
+  if (reg_num + 20 >= LIR_Opr::vreg_max) {
     _allocator->bailout("out of virtual registers in linear scan");
-    if (reg_num + 2 >= LIR_OprDesc::vreg_max) {
+    if (reg_num + 2 >= LIR_Opr::vreg_max) {
       // Wrap it around and continue until bailout really happens to avoid hitting assertions.
-      reg_num = LIR_OprDesc::vreg_base;
+      reg_num = LIR_Opr::vreg_base;
     }
   }
   LIR_Opr vreg = LIR_OprFact::virtual_register(reg_num, interval->type());
@@ -4405,7 +4405,7 @@ void Interval::add_use_pos(int pos, IntervalUseKind use_kind) {
 
   // do not add use positions for precolored intervals because
   // they are never used
-  if (use_kind != noUse && reg_num() >= LIR_OprDesc::vreg_base) {
+  if (use_kind != noUse && reg_num() >= LIR_Opr::vreg_base) {
 #ifdef ASSERT
     assert(_use_pos_and_kinds.length() % 2 == 0, "must be");
     for (int i = 0; i < _use_pos_and_kinds.length(); i += 2) {
@@ -4635,7 +4635,7 @@ void Interval::print_on(outputStream* out, bool is_cfg_printer) const {
   const char* UseKind2Name[] = { "N", "L", "S", "M" };
 
   const char* type_name;
-  if (reg_num() < LIR_OprDesc::vreg_base) {
+  if (reg_num() < LIR_Opr::vreg_base) {
     type_name = "fixed";
   } else {
     type_name = type2name(type());
@@ -4652,7 +4652,7 @@ void Interval::print_on(outputStream* out, bool is_cfg_printer) const {
     }
   } else {
     // Improved output for normal debugging.
-    if (reg_num() < LIR_OprDesc::vreg_base) {
+    if (reg_num() < LIR_Opr::vreg_base) {
       LinearScan::print_reg_num(out, assigned_reg());
     } else if (assigned_reg() != -1 && (LinearScan::num_physical_regs(type()) == 1 || assigned_regHi() != -1)) {
       LinearScan::calc_operand_for_interval(this)->print(out);

--- a/src/hotspot/share/c1/c1_LinearScan.hpp
+++ b/src/hotspot/share/c1/c1_LinearScan.hpp
@@ -547,8 +547,8 @@ class Interval : public CompilationResourceObj {
   // accessors
   int              reg_num() const               { return _reg_num; }
   void             set_reg_num(int r)            { assert(_reg_num == -1, "cannot change reg_num"); _reg_num = r; }
-  BasicType        type() const                  { assert(_reg_num == -1 || _reg_num >= LIR_OprDesc::vreg_base, "cannot access type for fixed interval"); return _type; }
-  void             set_type(BasicType type)      { assert(_reg_num < LIR_OprDesc::vreg_base || _type == T_ILLEGAL || _type == type, "overwriting existing type"); _type = type; }
+  BasicType        type() const                  { assert(_reg_num == -1 || _reg_num >= LIR_Opr::vreg_base, "cannot access type for fixed interval"); return _type; }
+  void             set_type(BasicType type)      { assert(_reg_num < LIR_Opr::vreg_base || _type == T_ILLEGAL || _type == type, "overwriting existing type"); _type = type; }
 
   Range*           first() const                 { return _first; }
   int              from() const                  { return _first->from(); }

--- a/src/hotspot/share/gc/g1/c1/g1BarrierSetC1.cpp
+++ b/src/hotspot/share/gc/g1/c1/g1BarrierSetC1.cpp
@@ -152,13 +152,13 @@ void G1BarrierSetC1::post_barrier(LIRAccess& access, LIR_Opr addr, LIR_Opr new_v
     __ unsigned_shift_right(xor_shift_res,
                             LIR_OprFact::intConst(HeapRegion::LogOfHRGrainBytes),
                             xor_shift_res,
-                            LIR_OprDesc::illegalOpr());
+                            LIR_Opr::illegalOpr());
   } else {
     __ logical_xor(addr, new_val, xor_res);
     __ unsigned_shift_right(xor_res,
                             LIR_OprFact::intConst(HeapRegion::LogOfHRGrainBytes),
                             xor_shift_res,
-                            LIR_OprDesc::illegalOpr());
+                            LIR_Opr::illegalOpr());
   }
 
   if (!new_val->is_register()) {


### PR DESCRIPTION
Hi all,

Can I have reviews for this mechanical renaming change as a follow up to https://bugs.openjdk.java.net/browse/JDK-8276453?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276976](https://bugs.openjdk.java.net/browse/JDK-8276976): Rename LIR_OprDesc to LIR_Opr


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Igor Veresov](https://openjdk.java.net/census#iveresov) (@veresov - **Reviewer**)


### Contributors
 * Chuck Rasbold `<rasbold@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6377/head:pull/6377` \
`$ git checkout pull/6377`

Update a local copy of the PR: \
`$ git checkout pull/6377` \
`$ git pull https://git.openjdk.java.net/jdk pull/6377/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6377`

View PR using the GUI difftool: \
`$ git pr show -t 6377`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6377.diff">https://git.openjdk.java.net/jdk/pull/6377.diff</a>

</details>
