### PR TITLE
8277089: Use system binutils to build hsdis

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -817,8 +817,19 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_HSDIS],
       BINUTILS_DIR="$with_binutils"
     fi
 
-    AC_MSG_CHECKING([for binutils to use with hsdis])
-    if test "x$BINUTILS_DIR" != x; then
+    if test "x$BINUTILS_DIR" = xsystem; then
+      if test "x$OPENJDK_TARGET_OS" != xlinux; then
+        AC_MSG_CHECKING([for binutils to use with hsdis])
+        AC_MSG_RESULT([invalid])
+        AC_MSG_ERROR([binutils on system is supported for Linux only])
+      fi
+      AC_CHECK_LIB(bfd, bfd_openr, [ HSDIS_LIBS="$HSDIS_LIBS -lbfd" ], [ AC_MSG_ERROR([libbfd not found]) ])
+      AC_CHECK_LIB(opcodes, disassembler, [ HSDIS_LIBS="$HSDIS_LIBS -lopcodes" ], [ AC_MSG_ERROR([libopcodes not found]) ])
+      AC_CHECK_LIB(iberty, xmalloc, [ HSDIS_LIBS="$HSDIS_LIBS -liberty" ], [ AC_MSG_ERROR([libiberty not found]) ])
+      AC_CHECK_LIB(z, deflate, [ HSDIS_LIBS="$HSDIS_LIBS -lz" ], [ AC_MSG_ERROR([libz not found]) ])
+      HSDIS_CFLAGS="-DSYSTEM_BINUTILS"
+    elif test "x$BINUTILS_DIR" != x; then
+      AC_MSG_CHECKING([for binutils to use with hsdis])
       if test -e $BINUTILS_DIR/bfd/libbfd.a && \
           test -e $BINUTILS_DIR/opcodes/libopcodes.a && \
           test -e $BINUTILS_DIR/libiberty/libiberty.a; then
@@ -830,6 +841,7 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_HSDIS],
         AC_MSG_ERROR([$BINUTILS_DIR does not contain a proper binutils installation])
       fi
     else
+      AC_MSG_CHECKING([for binutils to use with hsdis])
       AC_MSG_RESULT([missing])
       AC_MSG_NOTICE([--with-hsdis=binutils requires specifying a binutils installation.])
       AC_MSG_NOTICE([Download binutils from https://www.gnu.org/software/binutils and unpack it,])

--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -817,38 +817,53 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_HSDIS],
       BINUTILS_DIR="$with_binutils"
     fi
 
+    binutils_system_error=""
+    HSDIS_LIBS=""
     if test "x$BINUTILS_DIR" = xsystem; then
-      if test "x$OPENJDK_TARGET_OS" != xlinux; then
-        AC_MSG_CHECKING([for binutils to use with hsdis])
-        AC_MSG_RESULT([invalid])
-        AC_MSG_ERROR([binutils on system is supported for Linux only])
-      fi
-      AC_CHECK_LIB(bfd, bfd_openr, [ HSDIS_LIBS="$HSDIS_LIBS -lbfd" ], [ AC_MSG_ERROR([libbfd not found]) ])
-      AC_CHECK_LIB(opcodes, disassembler, [ HSDIS_LIBS="$HSDIS_LIBS -lopcodes" ], [ AC_MSG_ERROR([libopcodes not found]) ])
-      AC_CHECK_LIB(iberty, xmalloc, [ HSDIS_LIBS="$HSDIS_LIBS -liberty" ], [ AC_MSG_ERROR([libiberty not found]) ])
-      AC_CHECK_LIB(z, deflate, [ HSDIS_LIBS="$HSDIS_LIBS -lz" ], [ AC_MSG_ERROR([libz not found]) ])
-      HSDIS_CFLAGS="-DSYSTEM_BINUTILS"
+      AC_CHECK_LIB(bfd, bfd_openr, [ HSDIS_LIBS="-lbfd" ], [ binutils_system_error="libbfd not found" ])
+      AC_CHECK_LIB(opcodes, disassembler, [ HSDIS_LIBS="$HSDIS_LIBS -lopcodes" ], [ binutils_system_error="libopcodes not found" ])
+      AC_CHECK_LIB(iberty, xmalloc, [ HSDIS_LIBS="$HSDIS_LIBS -liberty" ], [ binutils_system_error="libiberty not found" ])
+      AC_CHECK_LIB(z, deflate, [ HSDIS_LIBS="$HSDIS_LIBS -lz" ], [ binutils_system_error="libz not found" ])
     elif test "x$BINUTILS_DIR" != x; then
-      AC_MSG_CHECKING([for binutils to use with hsdis])
       if test -e $BINUTILS_DIR/bfd/libbfd.a && \
           test -e $BINUTILS_DIR/opcodes/libopcodes.a && \
           test -e $BINUTILS_DIR/libiberty/libiberty.a; then
-        AC_MSG_RESULT([$BINUTILS_DIR])
         HSDIS_CFLAGS="-I$BINUTILS_DIR/include -I$BINUTILS_DIR/bfd -DLIBARCH_$OPENJDK_TARGET_CPU_LEGACY_LIB"
         HSDIS_LIBS="$BINUTILS_DIR/bfd/libbfd.a $BINUTILS_DIR/opcodes/libopcodes.a $BINUTILS_DIR/libiberty/libiberty.a $BINUTILS_DIR/zlib/libz.a"
-      else
-        AC_MSG_RESULT([invalid])
-        AC_MSG_ERROR([$BINUTILS_DIR does not contain a proper binutils installation])
       fi
-    else
-      AC_MSG_CHECKING([for binutils to use with hsdis])
-      AC_MSG_RESULT([missing])
-      AC_MSG_NOTICE([--with-hsdis=binutils requires specifying a binutils installation.])
-      AC_MSG_NOTICE([Download binutils from https://www.gnu.org/software/binutils and unpack it,])
-      AC_MSG_NOTICE([and point --with-binutils-src to the resulting directory, or use])
-      AC_MSG_NOTICE([--with-binutils to point to a pre-built binutils installation.])
-      AC_MSG_ERROR([Cannot continue])
     fi
+
+    AC_MSG_CHECKING([for binutils to use with hsdis])
+    case "x$BINUTILS_DIR" in
+      xsystem)
+        if test "x$OPENJDK_TARGET_OS" != xlinux; then
+          AC_MSG_RESULT([invalid])
+          AC_MSG_ERROR([binutils on system is supported for Linux only])
+        elif test "x$binutils_system_error" = x; then
+          AC_MSG_RESULT([system])
+          HSDIS_CFLAGS="-DSYSTEM_BINUTILS"
+        else
+          AC_MSG_RESULT([invalid])
+          AC_MSG_ERROR([$binutils_system_error])
+        fi
+        ;;
+      x)
+        AC_MSG_RESULT([missing])
+        AC_MSG_NOTICE([--with-hsdis=binutils requires specifying a binutils installation.])
+        AC_MSG_NOTICE([Download binutils from https://www.gnu.org/software/binutils and unpack it,])
+        AC_MSG_NOTICE([and point --with-binutils-src to the resulting directory, or use])
+        AC_MSG_NOTICE([--with-binutils to point to a pre-built binutils installation.])
+        AC_MSG_ERROR([Cannot continue])
+        ;;
+      *)
+        if test "x$HSDIS_LIBS" != x; then
+          AC_MSG_RESULT([$BINUTILS_DIR])
+        else
+          AC_MSG_RESULT([invalid])
+          AC_MSG_ERROR([$BINUTILS_DIR does not contain a proper binutils installation])
+        fi
+        ;;
+    esac
   else
     AC_MSG_RESULT([invalid])
     AC_MSG_ERROR([Incorrect hsdis backend "$with_hsdis"])

--- a/src/utils/hsdis/README
+++ b/src/utils/hsdis/README
@@ -67,6 +67,10 @@ you can replace it with "--with-binutils=<location>".
 If you have pre-built binutils binaries, you can point to them directly using
 "--with-binutils=<location>".
 
+If you want to build hsdis with binutils provided by system
+(e.g. binutils-devel from Fedora, binutils-dev from Ubuntu), you can pass
+"--with-binutils=system". "system" is available on Linux only.
+
 When you have created a proper configuration, you can then build the hsdis
 library using "make build-hsdis".
 

--- a/src/utils/hsdis/hsdis.c
+++ b/src/utils/hsdis/hsdis.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -49,14 +49,16 @@
    HotSpot PrintAssembly option.
 */
 
+#ifndef SYSTEM_BINUTILS
 #include <config.h> /* required by bfd.h */
+#endif
+
 #include <errno.h>
 #include <inttypes.h>
 #include <string.h>
 
 #include <libiberty.h>
 #include <bfd.h>
-#include <bfdver.h>
 #include <dis-asm.h>
 
 #include "hsdis.h"
@@ -565,7 +567,7 @@ static void init_disassemble_info_from_bfd(struct disassemble_info* dinfo,
   dinfo->arch = bfd_get_arch(abfd);
   dinfo->mach = bfd_get_mach(abfd);
   dinfo->disassembler_options = disassembler_options;
-#if BFD_VERSION >= 234000000
+#ifdef SEC_ELF_OCTETS
   /* bfd_octets_per_byte() has 2 args since binutils 2.34 */
   dinfo->octets_per_byte = bfd_octets_per_byte (abfd, NULL);
 #else


### PR DESCRIPTION
hsdis requires binutils source tree for building. Most of Linux distros provide binutils package. (e.g. binutils-devel from Fedora, binutils-dev from Ubuntu)
It would be nice to be able to use them like zlib and lcms.

Unfortunately bfdver.h would not be provided because it is not included install files (`make install`) in binutils. So I changed to use `SEC_ELF_OCTETS` macro to detect binutils version because it was introduced at the same time as `bfd_octets_per_byte()`.

https://sourceware.org/git/?p=binutils-gdb.git;a=commit;f=bfd/bfd-in2.h;h=618265039f697eab9e72bb58b95fc2d32925df58

Please see [JDK-8244819](https://bugs.openjdk.java.net/browse/JDK-8244819) why we need version check.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277089](https://bugs.openjdk.java.net/browse/JDK-8277089): Use system binutils to build hsdis


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6378/head:pull/6378` \
`$ git checkout pull/6378`

Update a local copy of the PR: \
`$ git checkout pull/6378` \
`$ git pull https://git.openjdk.java.net/jdk pull/6378/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6378`

View PR using the GUI difftool: \
`$ git pr show -t 6378`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6378.diff">https://git.openjdk.java.net/jdk/pull/6378.diff</a>

</details>
