### PR TITLE
8276994: java/nio/channels/Channels/TransferTo.java leaves multi-GB files in /tmp

### DIFF
--- a/test/jdk/java/nio/channels/Channels/TransferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo.java
@@ -70,6 +70,8 @@ public class TransferTo {
 
     private static final Random RND = RandomFactory.getRandom();
 
+    private static final Path CWD = Path.of(".");
+
     /*
      * Provides test scenarios, i. e. combinations of input and output streams to be tested.
      */
@@ -138,10 +140,10 @@ public class TransferTo {
      */
     @Test
     public void testMoreThanTwoGB() throws IOException {
-        Path sourceFile = Files.createTempFile("test2GBSource", null);
+        Path sourceFile = Files.createTempFile(CWD, "test2GBSource", null);
         try {
             // preparing two temporary files which will be compared at the end of the test
-            Path targetFile = Files.createTempFile("test2GBtarget", null);
+            Path targetFile = Files.createTempFile(CWD, "test2GBtarget", null);
             try {
                 // writing 3 GB of random bytes into source file
                 for (int i = 0; i < NUM_WRITES; i++)
@@ -242,7 +244,7 @@ public class TransferTo {
         return new InputStreamProvider() {
             @Override
             public InputStream input(byte... bytes) throws Exception {
-                Path path = Files.createTempFile(null, null);
+                Path path = Files.createTempFile(CWD, "fileChannelInput", null);
                 Files.write(path, bytes);
                 FileChannel fileChannel = FileChannel.open(path);
                 return Channels.newInputStream(fileChannel);
@@ -268,7 +270,7 @@ public class TransferTo {
     private static OutputStreamProvider fileChannelOutput() {
         return new OutputStreamProvider() {
             public OutputStream output(Consumer<Supplier<byte[]>> spy) throws Exception {
-                Path path = Files.createTempFile(null, null);
+                Path path = Files.createTempFile(CWD, "fileChannelOutput", null);
                 FileChannel fileChannel = FileChannel.open(path, StandardOpenOption.WRITE);
                 spy.accept(() -> {
                     try {

--- a/test/jdk/java/nio/channels/Channels/TransferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo.java
@@ -32,11 +32,15 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -69,6 +73,8 @@ public class TransferTo {
     private static final long BYTES_WRITTEN = (long) NUM_WRITES * BYTES_PER_WRITE;
 
     private static final Random RND = RandomFactory.getRandom();
+
+    private static Collection<Path> tempFiles;
 
     /*
      * Provides test scenarios, i. e. combinations of input and output streams to be tested.
@@ -138,35 +144,27 @@ public class TransferTo {
      */
     @Test
     public void testMoreThanTwoGB() throws IOException {
-        Path sourceFile = Files.createTempFile("test2GBSource", null);
-        try {
-            // preparing two temporary files which will be compared at the end of the test
-            Path targetFile = Files.createTempFile("test2GBtarget", null);
-            try {
-                // writing 3 GB of random bytes into source file
-                for (int i = 0; i < NUM_WRITES; i++)
-                    Files.write(sourceFile, createRandomBytes(BYTES_PER_WRITE, 0), StandardOpenOption.APPEND);
+        // preparing two temporary files which will be compared at the end of the test
+        Path sourceFile = newTempFile();
+        Path targetFile = newTempFile();
 
-                // performing actual transfer, effectively by multiple invocations of Filechannel.transferTo(FileChannel)
-                long count;
-                try (InputStream inputStream = Channels.newInputStream(FileChannel.open(sourceFile));
-                     OutputStream outputStream = Channels
-                             .newOutputStream(FileChannel.open(targetFile, StandardOpenOption.WRITE))) {
-                    count = inputStream.transferTo(outputStream);
-                }
+        // writing 3 GB of random bytes into source file
+        for (int i = 0; i < NUM_WRITES; i++)
+            Files.write(sourceFile, createRandomBytes(BYTES_PER_WRITE, 0), StandardOpenOption.APPEND);
 
-                // comparing reported transferred bytes, must be 3 GB
-                assertEquals(count, BYTES_WRITTEN);
-
-                // comparing content of both files, failing in case of any difference
-                assertEquals(Files.mismatch(sourceFile, targetFile), -1);
-
-            } finally {
-                 Files.delete(targetFile);
-            }
-        } finally {
-            Files.delete(sourceFile);
+        // performing actual transfer, effectively by multiple invocations of Filechannel.transferTo(FileChannel)
+        long count;
+        try (InputStream inputStream = Channels.newInputStream(FileChannel.open(sourceFile));
+             OutputStream outputStream = Channels
+                     .newOutputStream(FileChannel.open(targetFile, StandardOpenOption.WRITE))) {
+            count = inputStream.transferTo(outputStream);
         }
+
+        // comparing reported transferred bytes, must be 3 GB
+        assertEquals(count, BYTES_WRITTEN);
+
+        // comparing content of both files, failing in case of any difference
+        assertEquals(Files.mismatch(sourceFile, targetFile), -1);
     }
 
     /*
@@ -242,7 +240,7 @@ public class TransferTo {
         return new InputStreamProvider() {
             @Override
             public InputStream input(byte... bytes) throws Exception {
-                Path path = Files.createTempFile(null, null);
+                Path path = newTempFile();
                 Files.write(path, bytes);
                 FileChannel fileChannel = FileChannel.open(path);
                 return Channels.newInputStream(fileChannel);
@@ -268,7 +266,7 @@ public class TransferTo {
     private static OutputStreamProvider fileChannelOutput() {
         return new OutputStreamProvider() {
             public OutputStream output(Consumer<Supplier<byte[]>> spy) throws Exception {
-                Path path = Files.createTempFile(null, null);
+                Path path = newTempFile();
                 FileChannel fileChannel = FileChannel.open(path, StandardOpenOption.WRITE);
                 spy.accept(() -> {
                     try {
@@ -282,4 +280,29 @@ public class TransferTo {
         };
     }
 
+    @BeforeClass
+    public static void createTempFileRegistry() {
+        tempFiles = new LinkedList();
+    }
+
+    @AfterClass
+    public static void deleteTempFiles() {
+        tempFiles.forEach(path -> {
+            try {
+                Files.delete(path);
+            } catch (IOException e) {
+                // ignored
+            }
+        });
+        tempFiles = null;
+    }
+
+    /*
+     * Creates a temporary file and registers it for later cleanup after tests.
+     */
+    private static Path newTempFile() throws IOException {
+        Path path = Files.createTempFile("transferTo", null);
+        tempFiles.add(path);
+        return path;
+    }
 }


### PR DESCRIPTION
This PR proposes to cleanup *all* temp files of the `TransferTo` test, not just the 2GB files. Also it separates the actual test logic from the cleanup logic, so the test cases are simple to understand again as they are not interwoven with cleanup code anymore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8276994](https://bugs.openjdk.java.net/browse/JDK-8276994): java/nio/channels/Channels/TransferTo.java leaves multi-GB files in /tmp ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6379/head:pull/6379` \
`$ git checkout pull/6379`

Update a local copy of the PR: \
`$ git checkout pull/6379` \
`$ git pull https://git.openjdk.java.net/jdk pull/6379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6379`

View PR using the GUI difftool: \
`$ git pr show -t 6379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6379.diff">https://git.openjdk.java.net/jdk/pull/6379.diff</a>

</details>
