### PR TITLE
8277087: ZipException: zip END header not found at ZipFile#Source.findEND

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
@@ -144,11 +144,14 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
      *            ZIP file comment is greater than 0xFFFF bytes
      */
     public void setComment(String comment) {
+        byte[] bytes = null;
         if (comment != null) {
-            this.comment = zc.getBytes(comment);
-            if (this.comment.length > 0xffff)
-                throw new IllegalArgumentException("ZIP file comment too long.");
+            bytes = zc.getBytes(comment);
+            if (bytes.length > 0xffff) {
+                throw new IllegalArgumentException("ZIP file comment too long");
+            }
         }
+        this.comment = bytes;
     }
 
     /**

--- a/test/jdk/java/util/zip/ZipOutputStream/EmptyComment.java
+++ b/test/jdk/java/util/zip/ZipOutputStream/EmptyComment.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.ByteArrayOutputStream;
+import java.util.function.Consumer;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+/**
+ * @test
+ * @bug 8277087
+ * @summary Verifies various use cases when the zip comment should be empty
+ */
+public final class EmptyComment {
+
+    public static void main(String[] args) throws Exception {
+        // Simple cases where the comment is set to empty text
+        test(zos -> {
+            // do nothing
+        });
+        test(zos -> {
+            zos.setComment(null);
+        });
+        test(zos -> {
+            zos.setComment("");
+        });
+        test(zos -> {
+            zos.setComment("");
+            zos.setComment(null);
+        });
+        test(zos -> {
+            zos.setComment(null);
+            zos.setComment("");
+        });
+        test(zos -> {
+            zos.setComment("Comment");
+            zos.setComment(null);
+        });
+        test(zos -> {
+            zos.setComment("Comment");
+            zos.setComment("");
+        });
+
+        // Overflow, the text is too long to be stored as a comment
+        for (int count : new int[]{0xFFFF + 1, 0xFFFF + 2, 0xFFFF * 2}) {
+            test(zos -> {
+                try {
+                    zos.setComment("X".repeat(count));
+                } catch (IllegalArgumentException ignored) {
+                    // skip
+                }
+            });
+        }
+    }
+
+    private static void test(Consumer<ZipOutputStream> test) throws Exception {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             ZipOutputStream zos = new ZipOutputStream(baos)) {
+
+            test.accept(zos);
+
+            zos.putNextEntry(new ZipEntry("x"));
+            zos.finish();
+
+            byte[] data = baos.toByteArray();
+            // Since the comment is empty this will be two last bytes
+            int pos = data.length - ZipFile.ENDHDR + ZipFile.ENDCOM;
+            int len = (data[pos] & 0xFF) + ((data[pos + 1] & 0xFF) << 8);
+            if (len != 0) {
+                throw new RuntimeException("zip comment is not empty: " + len);
+            }
+        }
+    }
+}

--- a/test/jdk/java/util/zip/ZipOutputStream/EmptyComment.java
+++ b/test/jdk/java/util/zip/ZipOutputStream/EmptyComment.java
@@ -27,51 +27,58 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertThrows;
+
 /**
  * @test
  * @bug 8277087
  * @summary Verifies various use cases when the zip comment should be empty
+ * @run testng EmptyComment
  */
 public final class EmptyComment {
 
-    public static void main(String[] args) throws Exception {
-        // Simple cases where the comment is set to empty text
-        test(zos -> {
-            // do nothing
-        });
-        test(zos -> {
-            zos.setComment(null);
-        });
-        test(zos -> {
-            zos.setComment("");
-        });
-        test(zos -> {
-            zos.setComment("");
-            zos.setComment(null);
-        });
-        test(zos -> {
-            zos.setComment(null);
-            zos.setComment("");
-        });
-        test(zos -> {
-            zos.setComment("Comment");
-            zos.setComment(null);
-        });
-        test(zos -> {
-            zos.setComment("Comment");
-            zos.setComment("");
-        });
+    @DataProvider()
+    Object[][] longLengths() {
+        return new Object[][]{{0xFFFF + 1}, {0xFFFF + 2}, {0xFFFF * 2}};
+    }
 
-        // Overflow, the text is too long to be stored as a comment
-        for (int count : new int[]{0xFFFF + 1, 0xFFFF + 2, 0xFFFF * 2}) {
-            test(zos -> {
-                try {
-                    zos.setComment("X".repeat(count));
-                } catch (IllegalArgumentException ignored) {
-                    // skip
-                }
-            });
-        }
+    /**
+     * Overflow, the text is too long to be stored as a comment.
+     */
+    @Test(dataProvider = "longLengths")
+    void testOverflow(int length) throws Exception {
+        test(zos -> assertThrows(IllegalArgumentException.class, () -> {
+            zos.setComment("X".repeat(length));
+        }));
+    }
+
+    /**
+     * Simple cases where the comment is set to the empty text.
+     */
+    @Test
+    void testSimpleCases() throws Exception {
+        test(zos -> {/* do nothing */});
+        test(zos -> zos.setComment(null));
+        test(zos -> zos.setComment(""));
+        test(zos -> {
+            zos.setComment("");
+            zos.setComment(null);
+        });
+        test(zos -> {
+            zos.setComment(null);
+            zos.setComment("");
+        });
+        test(zos -> {
+            zos.setComment("Comment");
+            zos.setComment(null);
+        });
+        test(zos -> {
+            zos.setComment("Comment");
+            zos.setComment("");
+        });
     }
 
     private static void test(Consumer<ZipOutputStream> test) throws Exception {
@@ -84,8 +91,17 @@ public final class EmptyComment {
             zos.finish();
 
             byte[] data = baos.toByteArray();
+
+            if (data.length > 0xFFFF) { // just in case
+                throw new RuntimeException("data is too big: " + data.length);
+            }
+            int pk = data.length - ZipFile.ENDHDR;
+            if (data[pk] != 'P' || data[pk + 1] != 'K') {
+                throw new RuntimeException("PK is not found");
+            }
             // Since the comment is empty this will be two last bytes
             int pos = data.length - ZipFile.ENDHDR + ZipFile.ENDCOM;
+
             int len = (data[pos] & 0xFF) + ((data[pos + 1] & 0xFF) << 8);
             if (len != 0) {
                 throw new RuntimeException("zip comment is not empty: " + len);


### PR DESCRIPTION
The ZipOutputStream class may create bogus zip data which cannot be opened by the ZipFile. The root cause is how the comment field is stored by the ZipOutputStream. According to the zip specification, the comment field should not be longer than 0xFFFF bytes, and we try to validate the length of the comment, but unfortunately, we do this after the comment was assigned already. So if the application saves the comment based on the user's input and then gets an exception from the ZipOutputStream.setComment() it may assume that the comment is too long and it will be ignored, but it will be saved as-is to the file.

Please take a look at [this](https://github.com/openjdk/jdk/commit/c435a0905dfae827687ed46015269f9c1b36c239#diff-736e247f0ec294323891a77e16a9f0dba8bc1872131c857edf18c3f349e750eeL117) refactoring, and note:
 * The comment field is assigned before the length check
 * The null comment is ignored

The current fix will move the length validation before being assigned and will use the null comment as an empty text. Note that the behavior of the null parameter is not specified in the method/class/package so we are free here to implement it in any way, any thoughts/suggestions on which is better?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277087](https://bugs.openjdk.java.net/browse/JDK-8277087): ZipException: zip END header not found at ZipFile#Source.findEND


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6380/head:pull/6380` \
`$ git checkout pull/6380`

Update a local copy of the PR: \
`$ git checkout pull/6380` \
`$ git pull https://git.openjdk.java.net/jdk pull/6380/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6380`

View PR using the GUI difftool: \
`$ git pr show -t 6380`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6380.diff">https://git.openjdk.java.net/jdk/pull/6380.diff</a>

</details>
