### PR TITLE
[PATCH] Fix String.indexOf() comparison with String.length()

### DIFF
--- a/src/java.base/share/classes/java/net/HostPortrange.java
+++ b/src/java.base/share/classes/java/net/HostPortrange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 
 package java.net;
 
-import java.net.*;
 import java.util.Formatter;
 import java.util.Locale;
 import sun.net.util.IPAddressUtil;
@@ -100,11 +99,11 @@ class HostPortrange {
             // not IPv6 therefore ':' is the port separator
 
             int sep = str.indexOf(':');
-            if (sep != -1 && str.length() > sep) {
+            if (sep != -1) {
                 hoststr = str.substring(0, sep);
                 portstr = str.substring(sep + 1);
             } else {
-                hoststr = sep == -1 ? str : str.substring(0, sep);
+                hoststr = str;
             }
             // is this a domain wildcard specification?
             if (hoststr.lastIndexOf('*') > 0) {

--- a/src/java.base/share/classes/java/net/URI.java
+++ b/src/java.base/share/classes/java/net/URI.java
@@ -2029,13 +2029,8 @@ public final class URI
                 String doquote = authority, dontquote = "";
                 if (end != -1 && authority.indexOf(':') != -1) {
                     // the authority contains an IPv6 address
-                    if (end == authority.length()) {
-                        dontquote = authority;
-                        doquote = "";
-                    } else {
-                        dontquote = authority.substring(0 , end + 1);
-                        doquote = authority.substring(end + 1);
-                    }
+                    dontquote = authority.substring(0 , end + 1);
+                    doquote = authority.substring(end + 1);
                 }
                 sb.append(dontquote);
                 sb.append(quote(doquote,
@@ -2065,15 +2060,9 @@ public final class URI
             if (opaquePart.startsWith("//[")) {
                 int end =  opaquePart.indexOf(']');
                 if (end != -1 && opaquePart.indexOf(':')!=-1) {
-                    String doquote, dontquote;
-                    if (end == opaquePart.length()) {
-                        dontquote = opaquePart;
-                        doquote = "";
-                    } else {
-                        dontquote = opaquePart.substring(0,end+1);
-                        doquote = opaquePart.substring(end+1);
-                    }
-                    sb.append (dontquote);
+                    String dontquote = opaquePart.substring(0, end + 1);
+                    String doquote = opaquePart.substring(end + 1);
+                    sb.append(dontquote);
                     sb.append(quote(doquote, L_URIC, H_URIC));
                 }
             } else {

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -1987,7 +1987,7 @@ public final class Files {
         if (pos == -1) {
             name = attribute;
         } else {
-            name = (pos == attribute.length()) ? "" : attribute.substring(pos+1);
+            name = attribute.substring(pos + 1);
         }
         return map.get(name);
     }

--- a/src/java.base/share/classes/jdk/internal/jrtfs/JrtFileSystem.java
+++ b/src/java.base/share/classes/jdk/internal/jrtfs/JrtFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,6 @@ import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.FileTime;
 import java.nio.file.attribute.UserPrincipalLookupService;
 import java.nio.file.spi.FileSystemProvider;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -64,7 +63,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 import jdk.internal.jimage.ImageReader.Node;
-import static java.util.stream.Collectors.toList;
 
 /**
  * jrt file system implementation built on System jimage files.
@@ -175,7 +173,7 @@ class JrtFileSystem extends FileSystem {
     @Override
     public PathMatcher getPathMatcher(String syntaxAndInput) {
         int pos = syntaxAndInput.indexOf(':');
-        if (pos <= 0 || pos == syntaxAndInput.length()) {
+        if (pos <= 0) {
             throw new IllegalArgumentException("pos is " + pos);
         }
         String syntax = syntaxAndInput.substring(0, pos);
@@ -274,7 +272,7 @@ class JrtFileSystem extends FileSystem {
 
     // check that the options passed are supported by (read-only) jrt file system
     static void checkOptions(Set<? extends OpenOption> options) {
-        // check for options of null type and option is an intance of StandardOpenOption
+        // check for options of null type and option is an instance of StandardOpenOption
         for (OpenOption option : options) {
             Objects.requireNonNull(option);
             if (!(option instanceof StandardOpenOption)) {

--- a/src/java.base/share/classes/sun/net/www/ParseUtil.java
+++ b/src/java.base/share/classes/sun/net/www/ParseUtil.java
@@ -377,15 +377,9 @@ public final class ParseUtil {
             if (authority.startsWith("[")) {
                 int end = authority.indexOf(']');
                 if (end != -1 && authority.indexOf(':')!=-1) {
-                    String doquote, dontquote;
-                    if (end == authority.length()) {
-                        dontquote = authority;
-                        doquote = "";
-                    } else {
-                        dontquote = authority.substring(0,end+1);
-                        doquote = authority.substring(end+1);
-                    }
-                    sb.append (dontquote);
+                    String dontquote = authority.substring(0, end + 1);
+                    String doquote = authority.substring(end + 1);
+                    sb.append(dontquote);
                     sb.append(quote(doquote,
                             L_REG_NAME | L_SERVER,
                             H_REG_NAME | H_SERVER));

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -282,7 +282,7 @@ abstract class UnixFileSystem
     @Override
     public PathMatcher getPathMatcher(String syntaxAndInput) {
         int pos = syntaxAndInput.indexOf(':');
-        if (pos <= 0 || pos == syntaxAndInput.length())
+        if (pos <= 0)
             throw new IllegalArgumentException();
         String syntax = syntaxAndInput.substring(0, pos);
         String input = syntaxAndInput.substring(pos+1);

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystem.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystem.java
@@ -261,7 +261,7 @@ class WindowsFileSystem
     @Override
     public PathMatcher getPathMatcher(String syntaxAndInput) {
         int pos = syntaxAndInput.indexOf(':');
-        if (pos <= 0 || pos == syntaxAndInput.length())
+        if (pos <= 0)
             throw new IllegalArgumentException();
         String syntax = syntaxAndInput.substring(0, pos);
         String input = syntaxAndInput.substring(pos+1);

--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -441,7 +441,7 @@ class ZipFileSystem extends FileSystem {
     @Override
     public PathMatcher getPathMatcher(String syntaxAndInput) {
         int pos = syntaxAndInput.indexOf(':');
-        if (pos <= 0 || pos == syntaxAndInput.length()) {
+        if (pos <= 0) {
             throw new IllegalArgumentException();
         }
         String syntax = syntaxAndInput.substring(0, pos);


### PR DESCRIPTION
Network/FS code in java.base compares result of String.index() with length of corresponding String.
indexOf() always return values less than length of String, and such comparison is always false.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6381/head:pull/6381` \
`$ git checkout pull/6381`

Update a local copy of the PR: \
`$ git checkout pull/6381` \
`$ git pull https://git.openjdk.java.net/jdk pull/6381/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6381`

View PR using the GUI difftool: \
`$ git pr show -t 6381`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6381.diff">https://git.openjdk.java.net/jdk/pull/6381.diff</a>

</details>
