### PR TITLE
JDK-8277172: Remove stray comment mentioning instr_size_for_decode_klass_not_null on x64

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -4786,8 +4786,6 @@ void MacroAssembler::encode_and_move_klass_not_null(Register dst, Register src) 
   }
 }
 
-// !!! If the instructions that get generated here change then function
-// instr_size_for_decode_klass_not_null() needs to get updated.
 void  MacroAssembler::decode_klass_not_null(Register r, Register tmp) {
   assert_different_registers(r, tmp);
   // Note: it will change flags


### PR DESCRIPTION
Trivial cleanup.

https://bugs.openjdk.java.net/browse/JDK-8241825 removed `instr_size_for_decode_klass_not_null()` on x64 but left a comment in place. Remove obsolete comment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277172](https://bugs.openjdk.java.net/browse/JDK-8277172): Remove stray comment mentioning instr_size_for_decode_klass_not_null on x64


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6384/head:pull/6384` \
`$ git checkout pull/6384`

Update a local copy of the PR: \
`$ git checkout pull/6384` \
`$ git pull https://git.openjdk.java.net/jdk pull/6384/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6384`

View PR using the GUI difftool: \
`$ git pr show -t 6384`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6384.diff">https://git.openjdk.java.net/jdk/pull/6384.diff</a>

</details>
