### PR TITLE
change return value of DumpRegion::expand_to

### DIFF
--- a/src/hotspot/share/cds/archiveUtils.cpp
+++ b/src/hotspot/share/cds/archiveUtils.cpp
@@ -144,7 +144,7 @@ void ArchivePtrMarker::compact(size_t max_non_null_offset) {
   _compacted = true;
 }
 
-char* DumpRegion::expand_top_to(char* newtop) {
+void DumpRegion::expand_top_to(char* newtop) {
   assert(is_allocatable(), "must be initialized and not packed");
   assert(newtop >= _top, "must not grow backwards");
   if (newtop > _end) {
@@ -165,8 +165,6 @@ char* DumpRegion::expand_top_to(char* newtop) {
                                     "Please reduce the number of shared classes.");
     }
   }
-
-  return _top;
 }
 
 void DumpRegion::commit_to(char* newtop) {

--- a/src/hotspot/share/cds/archiveUtils.hpp
+++ b/src/hotspot/share/cds/archiveUtils.hpp
@@ -144,7 +144,7 @@ public:
     : _name(name), _base(NULL), _top(NULL), _end(NULL),
       _max_delta(max_delta), _is_packed(false) {}
 
-  char* expand_top_to(char* newtop);
+  void expand_top_to(char* newtop);
   char* allocate(size_t num_bytes);
 
   void append_intptr_t(intptr_t n, bool need_to_mark = false);


### PR DESCRIPTION
Trivial.

`DumpRegion::expand_top_to` returns the top of the region after expanding, but that value is unused. Can be made a void method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6385/head:pull/6385` \
`$ git checkout pull/6385`

Update a local copy of the PR: \
`$ git checkout pull/6385` \
`$ git pull https://git.openjdk.java.net/jdk pull/6385/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6385`

View PR using the GUI difftool: \
`$ git pr show -t 6385`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6385.diff">https://git.openjdk.java.net/jdk/pull/6385.diff</a>

</details>
