### PR TITLE
8277102: Dubious PrintCompilation output

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -924,7 +924,7 @@ void nmethod::print_on(outputStream* st, const char* msg) const {
       CompileTask::print(st, this, msg, /*short_form:*/ true);
       st->print_cr(" (" INTPTR_FORMAT ")", p2i(this));
     } else {
-      CompileTask::print(st, this, msg, /*short_form:*/ false, /* cr */ true, /* timestamp */ false);
+      CompileTask::print(st, this, msg, /*short_form:*/ false);
     }
   }
 }

--- a/src/hotspot/share/compiler/compileTask.cpp
+++ b/src/hotspot/share/compiler/compileTask.cpp
@@ -236,13 +236,11 @@ void CompileTask::print_tty() {
 // CompileTask::print_impl
 void CompileTask::print_impl(outputStream* st, Method* method, int compile_id, int comp_level,
                              bool is_osr_method, int osr_bci, bool is_blocking,
-                             const char* msg, bool short_form, bool cr, bool timestamp,
+                             const char* msg, bool short_form, bool cr,
                              jlong time_queued, jlong time_started) {
   if (!short_form) {
-    if (timestamp) {
-      // Print current time
-      st->print("%7d ", (int)tty->time_stamp().milliseconds());
-    }
+    // Print current time
+    st->print("%7d ", (int)tty->time_stamp().milliseconds());
     if (Verbose && time_queued != 0) {
       // Print time in queue and time being processed by compiler thread
       jlong now = os::elapsed_counter();

--- a/src/hotspot/share/compiler/compileTask.hpp
+++ b/src/hotspot/share/compiler/compileTask.hpp
@@ -187,16 +187,16 @@ class CompileTask : public CHeapObj<mtCompiler> {
 private:
   static void  print_impl(outputStream* st, Method* method, int compile_id, int comp_level,
                                       bool is_osr_method = false, int osr_bci = -1, bool is_blocking = false,
-                                      const char* msg = NULL, bool short_form = false, bool cr = true, bool timestamp = true,
+                                      const char* msg = NULL, bool short_form = false, bool cr = true,
                                       jlong time_queued = 0, jlong time_started = 0);
 
 public:
   void         print(outputStream* st = tty, const char* msg = NULL, bool short_form = false, bool cr = true);
   void         print_ul(const char* msg = NULL);
-  static void  print(outputStream* st, const nmethod* nm, const char* msg = NULL, bool short_form = false, bool cr = true, bool timestamp = true) {
+  static void  print(outputStream* st, const nmethod* nm, const char* msg = NULL, bool short_form = false, bool cr = true) {
     print_impl(st, nm->method(), nm->compile_id(), nm->comp_level(),
                            nm->is_osr_method(), nm->is_osr_method() ? nm->osr_entry_bci() : -1, /*is_blocking*/ false,
-                           msg, short_form, cr, timestamp);
+                           msg, short_form, cr);
   }
   static void  print_ul(const nmethod* nm, const char* msg = NULL);
 

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/DisassembleCodeBlobTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/DisassembleCodeBlobTest.java
@@ -101,7 +101,16 @@ public class DisassembleCodeBlobTest {
         // Therefore compare strings 2 and 3.
         String str2 = CompilerToVMHelper.disassembleCodeBlob(installedCode);
         String str3 = CompilerToVMHelper.disassembleCodeBlob(installedCode);
-        Asserts.assertEQ(str2, str3,
+        String[] str2Lines = str2.split(System.lineSeparator());
+        String[] str3Lines = str3.split(System.lineSeparator());
+        // skip the first two lines since it contains a timestamp that may vary from different invocations
+        // <empty-line>
+        // Compiled method (c2)     309  463       4       compiler.jvmci.compilerToVM.CompileCodeTestCase$Dummy::staticMethod (1 bytes)
+        // <empty-line>
+        // Compiled method (c2)     310  463       4       compiler.jvmci.compilerToVM.CompileCodeTestCase$Dummy::staticMethod (1 bytes)
+        for (int i = 2; i < str2Lines.length; i++) {
+            Asserts.assertEQ(str2Lines[i], str3Lines[i],
                 testCase + " : 3nd invocation returned different value from 2nd");
+        }
     }
 }


### PR DESCRIPTION
The output of PrintCompilation is ill-formed:

```
     22 1 3 java.lang.Object::<init> (1 bytes)
     25 2 3 java.lang.String::hashCode (60 bytes)
     25 3 3 java.lang.String::coder (15 bytes)
     27 4 3 Reduced::foo (12 bytes)
     27 5 3 java.lang.Boolean::valueOf (14 bytes)
     27 6 3 java.lang.Boolean::hashCode (8 bytes)
     27 8 4 Reduced::foo (12 bytes)
     27 7 2 java.lang.Boolean::hashCode (14 bytes)
   4 3 Reduced::foo (12 bytes) made not entrant
     29 9 % 3 Reduced::main @ 4 (33 bytes)
     29 10 3 Reduced::main (33 bytes)
     29 11 % 4 Reduced::main @ 4 (33 bytes)
   9 % 3 Reduced::main @ 4 (33 bytes) made not entrant
  11 % 4 Reduced::main @ 4 (33 bytes) made not entrant
```

This seems related to [JDK-8272586](https://bugs.openjdk.java.net/browse/JDK-8272586), which print timestamp optionally. As #5446 mentioned, printing timestamp would break DisassembleCodeBlobTest.java since it expects disassembling a given nmethod twice to produce the same result. Maybe we should fix DisassembleCodeBlobTest.java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277102](https://bugs.openjdk.java.net/browse/JDK-8277102): Dubious PrintCompilation output


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Doug Simon](https://openjdk.java.net/census#dnsimon) (@dougxc - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6386/head:pull/6386` \
`$ git checkout pull/6386`

Update a local copy of the PR: \
`$ git checkout pull/6386` \
`$ git pull https://git.openjdk.java.net/jdk pull/6386/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6386`

View PR using the GUI difftool: \
`$ git pr show -t 6386`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6386.diff">https://git.openjdk.java.net/jdk/pull/6386.diff</a>

</details>
