### PR TITLE
JDK-8277028: Use service type documentation as fallback for @provides

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriterImpl.java
@@ -763,12 +763,14 @@ public class ModuleWriterImpl extends HtmlDocletWriter implements ModuleSummaryW
             Content desc = new ContentBuilder();
             if (display(providesTrees)) {
                 description = providesTrees.get(srv);
-                desc.add((description != null && !description.isEmpty())
-                        ? HtmlTree.DIV(HtmlStyle.block, description)
-                        : Entity.NO_BREAK_SPACE);
+                if (description != null && !description.isEmpty()) {
+                    desc.add(HtmlTree.DIV(HtmlStyle.block, description));
+                } else {
+                    addSummaryComment(srv, desc);
+                }
             } else {
                 desc.add(Entity.NO_BREAK_SPACE);
-                }
+            }
             // Only display the implementation details in the "all" mode.
             if (moduleMode == ModuleMode.ALL && !implSet.isEmpty()) {
                 desc.add(new HtmlTree(TagName.BR));


### PR DESCRIPTION
This is a simple change to display the first sentence of the service type description in the "Provides" section of a module page if the `@provides` javadoc tag does not contain a description. This is the same we handle entries in the "Uses" section when no description is available from the `@uses` tag. The rationale is that it is still more useful to provide generic information about the service type than nothing if no provider-specific information is available.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277028](https://bugs.openjdk.java.net/browse/JDK-8277028): Use service type documentation as fallback for @provides


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6387/head:pull/6387` \
`$ git checkout pull/6387`

Update a local copy of the PR: \
`$ git checkout pull/6387` \
`$ git pull https://git.openjdk.java.net/jdk pull/6387/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6387`

View PR using the GUI difftool: \
`$ git pr show -t 6387`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6387.diff">https://git.openjdk.java.net/jdk/pull/6387.diff</a>

</details>
