### PR TITLE
8277119: Add asserts in GenericTaskQueueSet methods

### DIFF
--- a/src/hotspot/share/gc/shared/taskqueue.hpp
+++ b/src/hotspot/share/gc/shared/taskqueue.hpp
@@ -483,6 +483,7 @@ GenericTaskQueueSet<T, F>::register_queue(uint i, T* q) {
 
 template<class T, MEMFLAGS F> T*
 GenericTaskQueueSet<T, F>::queue(uint i) {
+  assert(i < _n, "index out of range.");
   return _queues[i];
 }
 

--- a/src/hotspot/share/gc/shared/taskqueue.inline.hpp
+++ b/src/hotspot/share/gc/shared/taskqueue.inline.hpp
@@ -320,6 +320,7 @@ GenericTaskQueueSet<T, F>::steal_best_of_2(uint queue_num, E& t) {
 
 template<class T, MEMFLAGS F> bool
 GenericTaskQueueSet<T, F>::steal(uint queue_num, E& t) {
+  assert(queue_num < _n, "index out of range.");
   for (uint i = 0; i < 2 * _n; i++) {
     TASKQUEUE_STATS_ONLY(queue(queue_num)->stats.record_steal_attempt());
     if (steal_best_of_2(queue_num, t)) {


### PR DESCRIPTION
Some methods in GenericTaskQueueSet lack of assert, which is not friendly to debug/troubleshooting.
This is to add necessary asserts.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277119](https://bugs.openjdk.java.net/browse/JDK-8277119): Add asserts in GenericTaskQueueSet methods


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6388/head:pull/6388` \
`$ git checkout pull/6388`

Update a local copy of the PR: \
`$ git checkout pull/6388` \
`$ git pull https://git.openjdk.java.net/jdk pull/6388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6388`

View PR using the GUI difftool: \
`$ git pr show -t 6388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6388.diff">https://git.openjdk.java.net/jdk/pull/6388.diff</a>

</details>
