### PR TITLE
8227020: Unclosed input streams in URL Class Loader for JARs with META-INF/INDEX.LIST

### DIFF
--- a/test/jdk/java/net/URLClassLoader/IndexedJarResourceLeakTest.java
+++ b/test/jdk/java/net/URLClassLoader/IndexedJarResourceLeakTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.util.JarBuilder;
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * @test
+ * @bug 8227020
+ * @summary Tests that URLClassLoader properly closes resources corresponding to jar files loaded
+ * from those listed in META-INF/INDEX.LIST
+ * @library /test/lib
+ * @run testng/othervm -Djdk.net.URLClassPath.enableJarIndex=true IndexedJarResourceLeakTest
+ */
+public class IndexedJarResourceLeakTest {
+
+    private static Path jarFile;
+    private static Path siblingJarFile;
+    private static final String RESOURCE_CONTENT = "hello";
+    private static final Path CWD = Path.of(".").toAbsolutePath().normalize();
+
+    @BeforeTest
+    public void beforeTest() throws Exception {
+        jarFile = Files.createTempFile(CWD, "JDK-8227020-", ".jar");
+        siblingJarFile = Files.createTempFile(CWD, "JDK-8227020-sibling", ".jar");
+        // create jar index which will be as follows:
+        // JarIndex-Version: 1.0
+        //
+        // sibling.jar
+        // hello
+        String jarIndexContent = "JarIndex-Version: 1.0 \n\n"
+                + siblingJarFile.getFileName().toString() + "\n"
+                + "hello\n\n";
+        // create a jar with a jar index which contains an index entry for a sibling jar resources
+        new JarBuilder(jarFile.toString())
+                .addEntry("META-INF/INDEX.LIST", jarIndexContent.getBytes(StandardCharsets.UTF_8))
+                .build();
+        // create the sibling jar with the hello/ dir and hello/hello.txt entries
+        new JarBuilder(siblingJarFile.toString())
+                .addEntry("hello/", new byte[0])
+                .addEntry("hello/hello.txt", RESOURCE_CONTENT.getBytes(StandardCharsets.UTF_8))
+                .build();
+    }
+
+    @AfterTest
+    public void afterTest() throws IOException {
+        Files.deleteIfExists(jarFile);
+        Files.deleteIfExists(siblingJarFile);
+    }
+
+    /**
+     * Creates a URLClassLoader with a path to one single jar file containing the
+     * META-INF/INDEX.LIST. The index points to a sibling jar file for a particular
+     * resource. The test then loads that resource through the URLClassLoader and
+     * expects the resource to be found. Finally, the URLClassLoader is closed
+     * and both the jar files (one that was passed to the URL classpath and
+     * the other sibling jar which was listed in the index) are deleted.
+     * The test expects that the deletion of these jar files works fine after the
+     * URLClassLoader is closed.
+     */
+    @Test
+    public void testIndexedResource() throws Exception {
+        // Create a URLClassLoader with just the jar file in the classpath.
+        // The sibling jar isn't added in the classpath list and instead is
+        // expected to be picked up through the META-INF/INDEX.LIST entry
+        try (URLClassLoader urlClassLoader = new URLClassLoader(
+                new URL[]{jarFile.toUri().toURL()}, null)) {
+            // load a resource that is part of the sibling jar
+            try (InputStream is = urlClassLoader.getResourceAsStream("hello/hello.txt")) {
+                Assert.assertNotNull(is, "Missing resource hello/hello.txt from URLClassLoader");
+                String content = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+                Assert.assertEquals(content, RESOURCE_CONTENT,
+                        "Unexpected content in resource returned by classloader");
+            }
+        }
+        // now attempt deleting each of these jars and expect the deletion to succeed
+        Files.delete(jarFile);
+        System.out.println("Successfully deleted " + jarFile);
+        Files.delete(siblingJarFile);
+        System.out.println("Successfully deleted " + siblingJarFile);
+    }
+}


### PR DESCRIPTION
Can I please get a review for this change which proposes to fix the issue noted in https://bugs.openjdk.java.net/browse/JDK-8227020?

The linked issue talks about non-normalized paths contributing to the leak. However, the root cause is applicable for regular normalized paths too. The `URLClassLoader` is backed by an instance of `jdk.internal.loader.URLClassPath`. This `URLClassPath` keeps track of a `loader` for each of the paths that are either provided directly as the `URL[]` or are inferred through the `Class-Path` attribute of each loaded jar.  This it does in 2 different fields. One is a mapping between the String representation of the URL for which the loader was created. This field is the `lmap` and the other is a list of `loaders`. The list of `loaders` is the search path for loading any resources from this `URLClassPath`. When the `closeLoaders()` is called by the `URLClassLoader`, this `loaders` list is iterated to close each of the `loader` for the opened resources (which in the context of this issue translates to closing a `java.util.jar.JarFile`).

A jar can have a `META-INF/INDEX.LIST`, which is a index of resources listed against each jar file. The `URLClassPath` when looking for resources in a `Loader` parses this index to search for resources. While doing so, if it finds a jar listed in the index, for which a `Loader` hasn't yet been created then it creates a new loader for such a jar and adds it to the `lmap`. However, it doesn't add this to the `loaders` list, the one which is used to close the opened jar files. As a result, it ends up opening a `JarFile` which is never closed, even if the `URLClassPath`'s `closeLoaders()` is called, thus triggering a leak.

The commit in this PR adds the newly created loader to the list of `loaders` so that it is properly closed, when the `closeLoaders` gets called.

I have reviewed the code to see if this has any other side effects and from what I can see, the addition of this new loader to the list shouldn't cause any other issues for reasons that follow:

- the order in the `loaders` list doesn't seem to have any one-to-one mapping with the URL[] of classpath elements. In fact, loaders for newly discovered URLs from the `Class-Path` attribute get added dynamically to this list. So adding this new loader found in the index shouldn't cause any issues when it comes to the order of loaders in the list.
- The `URLClassPath` is already returning resources from a loader corresponding to a jar `X` listed in the index even if that jar `X` isn't part of the original URL[] forming the classpath of the `URLClassPath`. So adding this `loader` to the "search path" won't introduce any new behaviour.

A new jtreg test has been introduced to reproduce this issue and verify the fix. The test has been run on a Windows setup where the test reproduces this issue without this fix and verifies the fix.

Recently, the jar index feature has been disabled as part of https://bugs.openjdk.java.net/browse/JDK-8273401. However, since users can enable this feature by using a specific system property and since this issue relates to a leak, I decided to see if there is interest in this fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8227020](https://bugs.openjdk.java.net/browse/JDK-8227020): Unclosed input streams in URL Class Loader for JARs with META-INF/INDEX.LIST


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6389/head:pull/6389` \
`$ git checkout pull/6389`

Update a local copy of the PR: \
`$ git checkout pull/6389` \
`$ git pull https://git.openjdk.java.net/jdk pull/6389/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6389`

View PR using the GUI difftool: \
`$ git pr show -t 6389`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6389.diff">https://git.openjdk.java.net/jdk/pull/6389.diff</a>

</details>
