### PR TITLE
8276795: Deprecate seldom used CDS flags

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -528,6 +528,10 @@ static SpecialFlag const special_jvm_flags[] = {
   { "FlightRecorder",               JDK_Version::jdk(13), JDK_Version::undefined(), JDK_Version::undefined() },
   { "FilterSpuriousWakeups",        JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::jdk(20) },
   { "MinInliningThreshold",         JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::jdk(20) },
+  { "DumpSharedSpaces",             JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
+  { "DynamicDumpSharedSpaces",      JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
+  { "RequireSharedSpaces",          JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
+  { "UseSharedSpaces",              JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
 
   // --- Deprecated alias flags (see also aliased_jvm_flags) - sorted by obsolete_in then expired_in:
   { "DefaultMaxRAMFraction",        JDK_Version::jdk(8),  JDK_Version::undefined(), JDK_Version::undefined() },

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1801,21 +1801,21 @@ const intx ObjectAlignmentInBytes = 8;
   /* Shared spaces */                                                       \
                                                                             \
   product(bool, UseSharedSpaces, true,                                      \
-          "Use shared spaces for metadata")                                 \
+          "(Deprecated) Use shared spaces for metadata")                    \
                                                                             \
   product(bool, VerifySharedSpaces, false,                                  \
           "Verify integrity of shared spaces")                              \
                                                                             \
   product(bool, RequireSharedSpaces, false,                                 \
-          "Require shared spaces for metadata")                             \
+          "(Deprecated) Require shared spaces for metadata")                \
                                                                             \
   product(bool, DumpSharedSpaces, false,                                    \
-          "Special mode: JVM reads a class list, loads classes, builds "    \
-          "shared spaces, and dumps the shared spaces to a file to be "     \
-          "used in future JVM runs")                                        \
+          "(Deprecated) Special mode: JVM reads a class list, loads "       \
+          "classes, builds shared spaces, and dumps the shared spaces to "  \
+          "a file to be used in future JVM runs")                           \
                                                                             \
   product(bool, DynamicDumpSharedSpaces, false,                             \
-          "Dynamic archive")                                                \
+          "(Deprecated) Dynamic archive")                                   \
                                                                             \
   product(bool, RecordDynamicDumpInfo, false,                               \
           "Record class info for jcmd VM.cds dynamic_dump")                 \

--- a/test/hotspot/jtreg/compiler/intrinsics/klass/TestIsPrimitive.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/klass/TestIsPrimitive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
  *
  * @run main/othervm -ea -Diters=200   -Xint
  *      compiler.intrinsics.klass.TestIsPrimitive
- * @run main/othervm -ea -XX:-UseSharedSpaces -Diters=30000 -XX:TieredStopAtLevel=1
+ * @run main/othervm -ea -Xshare:off -Diters=30000 -XX:TieredStopAtLevel=1
  *      compiler.intrinsics.klass.TestIsPrimitive
  * @run main/othervm -ea -Diters=30000 -XX:TieredStopAtLevel=4
  *      compiler.intrinsics.klass.TestIsPrimitive

--- a/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,10 @@ public class VMDeprecatedOptions {
         {"InitialRAMFraction",        "64"},
         {"TLABStats",                 "false"},
         {"AllowRedefinitionToAddDeleteMethods", "true"},
+        {"UseSharedSpaces",           "false"},
+        {"RequireSharedSpaces",       "true"},
+        {"DumpSharedSpaces",          "true"},
+        {"DynamicDumpSharedSpaces",   "true"},
 
         // deprecated alias flags (see also aliased_jvm_flags):
         {"DefaultMaxRAMFraction", "4"},


### PR DESCRIPTION
Please review this small change to deprecate seldom used CDS flags.  The flags will be deprecated in 18, obsoleted in 19, and removed in a later release.

The changes were tested with Mach5 tiers 1-2 on Linux, Mac OS, and Windows, and Mach5 tiers 3-5 on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276795](https://bugs.openjdk.java.net/browse/JDK-8276795): Deprecate seldom used CDS flags


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6390/head:pull/6390` \
`$ git checkout pull/6390`

Update a local copy of the PR: \
`$ git checkout pull/6390` \
`$ git pull https://git.openjdk.java.net/jdk pull/6390/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6390`

View PR using the GUI difftool: \
`$ git pr show -t 6390`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6390.diff">https://git.openjdk.java.net/jdk/pull/6390.diff</a>

</details>
