### PR TITLE
JDK-8277175 : Add a parallel multiply method to BigInteger

### DIFF
--- a/src/java.desktop/share/classes/java/awt/geom/CubicCurve2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/CubicCurve2D.java
@@ -312,23 +312,6 @@ public abstract class CubicCurve2D implements Shape, Cloneable {
         }
 
         /**
-         * {@inheritDoc}
-         * @since 1.2
-         */
-        public Rectangle2D getBounds2D() {
-            float left   = Math.min(Math.min(x1, x2),
-                                    Math.min(ctrlx1, ctrlx2));
-            float top    = Math.min(Math.min(y1, y2),
-                                    Math.min(ctrly1, ctrly2));
-            float right  = Math.max(Math.max(x1, x2),
-                                    Math.max(ctrlx1, ctrlx2));
-            float bottom = Math.max(Math.max(y1, y2),
-                                    Math.max(ctrly1, ctrly2));
-            return new Rectangle2D.Float(left, top,
-                                         right - left, bottom - top);
-        }
-
-        /**
          * Use serialVersionUID from JDK 1.6 for interoperability.
          */
         @Serial
@@ -556,23 +539,6 @@ public abstract class CubicCurve2D implements Shape, Cloneable {
             this.ctrly2 = ctrly2;
             this.x2     = x2;
             this.y2     = y2;
-        }
-
-        /**
-         * {@inheritDoc}
-         * @since 1.2
-         */
-        public Rectangle2D getBounds2D() {
-            double left   = Math.min(Math.min(x1, x2),
-                                     Math.min(ctrlx1, ctrlx2));
-            double top    = Math.min(Math.min(y1, y2),
-                                     Math.min(ctrly1, ctrly2));
-            double right  = Math.max(Math.max(x1, x2),
-                                     Math.max(ctrlx1, ctrlx2));
-            double bottom = Math.max(Math.max(y1, y2),
-                                     Math.max(ctrly1, ctrly2));
-            return new Rectangle2D.Double(left, top,
-                                          right - left, bottom - top);
         }
 
         /**
@@ -1507,6 +1473,15 @@ public abstract class CubicCurve2D implements Shape, Cloneable {
      */
     public boolean contains(Rectangle2D r) {
         return contains(r.getX(), r.getY(), r.getWidth(), r.getHeight());
+    }
+
+
+    /**
+     * {@inheritDoc}
+     * @since 1.2
+     */
+    public Rectangle2D getBounds2D() {
+        return Path2D.getBounds2D(getPathIterator(null));
     }
 
     /**

--- a/src/java.desktop/share/classes/java/awt/geom/Path2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Path2D.java
@@ -2096,7 +2096,7 @@ public abstract class Path2D implements Shape, Cloneable {
      * implement support for the {@link Shape#getBounds2D()} method.
      * </p>
      * @return an instance of {@code Rectangle2D} that is a high-precision bounding box of the
-         *         {@code PathIterator}.
+     *         {@code PathIterator}.
      * @see Shape#getBounds2D()
      */
     public static Rectangle2D getBounds2D(PathIterator pi) {
@@ -2108,12 +2108,12 @@ public abstract class Path2D implements Shape, Cloneable {
         double[] coords = new double[6];
         double[] tExtrema = new double[3];
         boolean isEmpty = true;
-        double leftX = 0;
-        double rightX = 0;
-        double topY = 0;
-        double bottomY = 0;
-        double lastX = 0;
-        double lastY = 0;
+        double leftX = 0.0;
+        double rightX = 0.0;
+        double topY = 0.0;
+        double bottomY = 0.0;
+        double lastX = 0.0;
+        double lastY = 0.0;
 
         pathIteratorLoop : while (!pi.isDone()) {
             int type = pi.currentSegment(coords);
@@ -2143,10 +2143,10 @@ public abstract class Path2D implements Shape, Cloneable {
                 topY = bottomY = endY;
             } else {
                 // extend our rectangle to cover the point at t = 1:
-                leftX = endX < leftX ? endX : leftX;
-                rightX = endX > rightX ? endX : rightX;
-                topY = endY < topY ? endY : topY;
-                bottomY = endY > bottomY ? endY : bottomY;
+                leftX = (endX < leftX) ? endX : leftX;
+                rightX = (endX > rightX) ? endX : rightX;
+                topY = (endY < topY) ? endY : topY;
+                bottomY = (endY > bottomY) ? endY : bottomY;
             }
 
             // here's the slightly trickier part: examine quadratic and cubic
@@ -2156,46 +2156,50 @@ public abstract class Path2D implements Shape, Cloneable {
             if (type == PathIterator.SEG_QUADTO) {
                 definedParametricEquations = true;
 
-                x_coeff[3] = 0;
-                x_coeff[2] = lastX - 2 * coords[0] + coords[2];
-                x_coeff[1] = -2 * lastX + 2 * coords[0];
+                x_coeff[3] = 0.0;
+                x_coeff[2] = lastX - 2.0 * coords[0] + coords[2];
+                x_coeff[1] = -2.0 * lastX + 2.0 * coords[0];
                 x_coeff[0] = lastX;
 
                 y_coeff[3] = 0;
-                y_coeff[2] = lastY - 2 * coords[1] + coords[3];
-                y_coeff[1] = -2 * lastY + 2 * coords[1];
+                y_coeff[2] = lastY - 2.0 * coords[1] + coords[3];
+                y_coeff[1] = -2.0 * lastY + 2.0 * coords[1];
                 y_coeff[0] = lastY;
             } else if (type == PathIterator.SEG_CUBICTO) {
                 definedParametricEquations = true;
 
-                x_coeff[3] = -lastX + 3 * coords[0] - 3 * coords[2] + coords[4];
-                x_coeff[2] = 3 * lastX - 6 * coords[0] + 3 * coords[2];
-                x_coeff[1] = -3 * lastX + 3 * coords[0];
+                x_coeff[3] = -lastX + 3.0 * coords[0] - 3.0 * coords[2] + coords[4];
+                x_coeff[2] = 3.0 * lastX - 6.0 * coords[0] + 3.0 * coords[2];
+                x_coeff[1] = -3.0 * lastX + 3.0 * coords[0];
                 x_coeff[0] = lastX;
 
-                y_coeff[3] = -lastY + 3 * coords[1] - 3 * coords[3] + coords[5];
-                y_coeff[2] = 3 * lastY - 6 * coords[1] + 3 * coords[3];
-                y_coeff[1] = -3 * lastY + 3 * coords[1];
+                y_coeff[3] = -lastY + 3.0 * coords[1] - 3.0 * coords[3] + coords[5];
+                y_coeff[2] = 3.0 * lastY - 6.0 * coords[1] + 3.0 * coords[3];
+                y_coeff[1] = -3.0 * lastY + 3.0 * coords[1];
                 y_coeff[0] = lastY;
             } else {
                 definedParametricEquations = false;
             }
 
             if (definedParametricEquations) {
-                int tExtremaCount = Curve.getPossibleExtremaInCubicEquation(x_coeff, tExtrema);
+                int tExtremaCount = Curve.findExtrema(x_coeff, tExtrema);
                 for(int i = 0; i < tExtremaCount; i++) {
                     double t = tExtrema[i];
-                    double x = x_coeff[0] + x_coeff[1] * t + x_coeff[2] * t * t + x_coeff[3] * t * t * t;
-                    leftX = x < leftX ? x : leftX;
-                    rightX = x > rightX ? x : rightX;
+                    if (t > 0 && t < 1) {
+                        double x = x_coeff[0] + t * (x_coeff[1] + t * (x_coeff[2] + t * x_coeff[3]));
+                        leftX = (x < leftX) ? x : leftX;
+                        rightX = (x > rightX) ? x : rightX;
+                    }
                 }
 
-                tExtremaCount = Curve.getPossibleExtremaInCubicEquation(y_coeff, tExtrema);
+                tExtremaCount = Curve.findExtrema(y_coeff, tExtrema);
                 for(int i = 0; i < tExtremaCount; i++) {
                     double t = tExtrema[i];
-                    double y = y_coeff[0] + y_coeff[1] * t + y_coeff[2] * t * t + y_coeff[3] * t * t * t;
-                    topY = y < topY ? y : topY;
-                    bottomY = y > bottomY ? y : bottomY;
+                    if (t > 0 && t < 1) {
+                        double y = y_coeff[0] + t * (y_coeff[1] + t * (y_coeff[2] + t * y_coeff[3]));
+                        topY = (y < topY) ? y : topY;
+                        bottomY = (y > bottomY) ? y : bottomY;
+                    }
                 }
             }
 

--- a/src/java.desktop/share/classes/java/awt/geom/QuadCurve2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/QuadCurve2D.java
@@ -239,19 +239,6 @@ public abstract class QuadCurve2D implements Shape, Cloneable {
         }
 
         /**
-         * {@inheritDoc}
-         * @since 1.2
-         */
-        public Rectangle2D getBounds2D() {
-            float left   = Math.min(Math.min(x1, x2), ctrlx);
-            float top    = Math.min(Math.min(y1, y2), ctrly);
-            float right  = Math.max(Math.max(x1, x2), ctrlx);
-            float bottom = Math.max(Math.max(y1, y2), ctrly);
-            return new Rectangle2D.Float(left, top,
-                                         right - left, bottom - top);
-        }
-
-        /**
          * Use serialVersionUID from JDK 1.6 for interoperability.
          */
         @Serial
@@ -426,19 +413,6 @@ public abstract class QuadCurve2D implements Shape, Cloneable {
             this.ctrly = ctrly;
             this.x2    = x2;
             this.y2    = y2;
-        }
-
-        /**
-         * {@inheritDoc}
-         * @since 1.2
-         */
-        public Rectangle2D getBounds2D() {
-            double left   = Math.min(Math.min(x1, x2), ctrlx);
-            double top    = Math.min(Math.min(y1, y2), ctrly);
-            double right  = Math.max(Math.max(x1, x2), ctrlx);
-            double bottom = Math.max(Math.max(y1, y2), ctrly);
-            return new Rectangle2D.Double(left, top,
-                                          right - left, bottom - top);
         }
 
         /**
@@ -1333,6 +1307,14 @@ public abstract class QuadCurve2D implements Shape, Cloneable {
      */
     public boolean contains(Rectangle2D r) {
         return contains(r.getX(), r.getY(), r.getWidth(), r.getHeight());
+    }
+
+    /**
+     * {@inheritDoc}
+     * @since 1.2
+     */
+    public Rectangle2D getBounds2D() {
+        return Path2D.getBounds2D(getPathIterator(null));
     }
 
     /**

--- a/src/java.desktop/share/classes/sun/awt/geom/Curve.java
+++ b/src/java.desktop/share/classes/sun/awt/geom/Curve.java
@@ -713,9 +713,9 @@ public abstract class Curve {
     }
 
     /**
-     * Return the x values between (0,1) that correspond to possible extrema in a given cubic function.
+     * Return the t values that correspond to possible extrema in a given cubic function.
      * <p>
-     * If the coefficient of the x^3 is large then the polynomial is a cubic and up to
+     * If the coefficient of the t^3 is large then the polynomial is a cubic and up to
      * two values may be returned. If that coefficient is zero then the polynomial
      * is a quadratic and up to one value may be returned. But if that coefficient is
      * small then this method considers the possibility it could be either, so in that
@@ -725,79 +725,55 @@ public abstract class Curve {
      * </p>
      *
      * @param coefficients four coefficients for a cubic polynomial equation. The nth element in this array is
-     *                     the coefficient for (x^n).
-     * @param dest an array to store the x values in. This must be at least 3 elements.
-     * @return the number of x-values that were stored in dest. This will be between 0-3.
+     *                     the coefficient for (t^n).
+     * @param dest an array to store the t values in. This must be at least 3 elements.
+     * @return the number of t-values that were stored in dest. This will be between 0-3.
      */
-    public static int getPossibleExtremaInCubicEquation(double[] coefficients, double[] dest) {
+    public static int findExtrema(double[] coefficients, double[] dest) {
 
         int returnValue = 0;
 
-        if (coefficients[3] != 0) {
+        if (coefficients[3] != 0.0) {
             // evaluate this as a cubic, where:
 
-            // y = c[3] * x^3 + c[2] * x^2 + c[1] * x + c[0]
-            // dy/dx = 3 * c[3] * t^2 + 2 * c[2] * t + c[1]
+            // f(t) = c[3] * t^3 + c[2] * t^2 + c[1] * t + c[0]
+            // df/dt = 3 * c[3] * t^2 + 2 * c[2] * t + c[1]
 
-            // so we'll apply the quadratic formula:
-            // x = [-B +- sqrt(B^2 - 4*A*C)] / (2A)
+            // so we have a quadratic polynomial:
+            // df/dt = A * t^2 + B * t + C
 
             // ... where:
             // A = 3 * c[3]
             // B = 2 * c[2]
             // C = c[1]
 
-            // so we end up with:
-            // x = (-2 * c[2] +- sqrt(2 * 2 * c[2] * c[2] - 4 * 3 * c[3] * c[1])]/(2 * 3 * c[3])
+            double[] eqn = new double[]{ coefficients[1],
+                    2.0 * coefficients[2],
+                    3.0 * coefficients[3] };
+            returnValue = QuadCurve2D.solveQuadratic(eqn, dest);
 
-            double determinant = (4 * coefficients[2] * coefficients[2]
-                    - 12 * coefficients[3] * coefficients[1]);
-            if (determinant < 0) {
-                // there are no solutions
-                return 0;
-            }
-
-            if (determinant == 0) {
-                // there is 1 solution
-                double x = -coefficients[2] / (3 * coefficients[3]);
-                if (x > 0 && x < 1) {
-                    dest[returnValue++] = x;
-                }
-            } else {
-                // there are 2 solutions:
-                determinant = Math.sqrt(determinant);
-                double x = (-2 * coefficients[2] + determinant) / (6 * coefficients[3]);
-                if (x > 0 && x < 1) {
-                    dest[returnValue++] = x;
-                }
-
-                x = (-2 * coefficients[2] - determinant) / (6 * coefficients[3]);
-                if (x > 0 && x < 1) {
-                    dest[returnValue++] = x;
-                }
-            }
+            if (returnValue < 0.0)
+                returnValue = 0;
         }
 
-        if (coefficients[3] > -.01 && coefficients[3] < .01 && coefficients[2] != 0) {
+        if (coefficients[3] > -.01 && coefficients[3] < .01 && coefficients[2] != 0.0) {
             // evaluate this as if it's a quadratic, where:
 
-            // y = c[2] * x^2 + c[1] * x + c[0]
+            // f = c[2] * t^2 + c[1] * t + c[0]
 
             // this only really makes sense if coefficients[3] is close to zero.
             // We chose "less than .01" as the threshold for "close to zero". It's
             // a very generous threshold, but it should be harmless to err on the
             // side of a generously high threshold in this case. The worst-case
-            // scenario is: we return an extra x-value that isn't really an extrema.
+            // scenario is: we return an extra t-value that isn't really an extrema.
 
-            // dy/dx = 2 * c[2] * x + c[1]
+            // df/dt = 2 * c[2] * t + c[1]
 
             // so our only extrema is at:
-            // x = -c[1] / (2*c[2])
+            // t = -c[1] / (2*c[2])
 
-            double x = -coefficients[1] / (2 * coefficients[2]);
-            if (x > 0 && x < 1) {
-                dest[returnValue++] = x;
-            }
+            double t = -coefficients[1] / (2.0 * coefficients[2]);
+            dest[returnValue++] = t;
         }
         return returnValue;
     }

--- a/test/jdk/java/math/BigInteger/BigIntegerParallelMultiplyTest.java
+++ b/test/jdk/java/math/BigInteger/BigIntegerParallelMultiplyTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @run main BigIntegerParallelMultiplyTest
+ * @summary tests parallelMultiply() method in BigInteger
+ * @author Heinz Kabutz heinz@javaspecialists.eu
+ */
+
+import java.math.BigInteger;
+import java.util.function.BinaryOperator;
+
+/**
+ * This is a simple test class created to ensure that the results
+ * of multiply() are the same as multiplyParallel(). We calculate
+ * the Fibonacci numbers using
+ */
+public class BigIntegerParallelMultiplyTest {
+    public static BigInteger fibonacci(int n, BinaryOperator<BigInteger> multiplyOperator) {
+        if (n == 0) return BigInteger.ZERO;
+        if (n == 1) return BigInteger.ONE;
+
+        int half = (n + 1) / 2;
+        BigInteger f0 = fibonacci(half - 1, multiplyOperator);
+        BigInteger f1 = fibonacci(half, multiplyOperator);
+        if (n % 2 == 1) {
+            BigInteger b0 = multiplyOperator.apply(f0, f0);
+            BigInteger b1 = multiplyOperator.apply(f1, f1);
+            return b0.add(b1);
+        } else {
+            BigInteger b0 = f0.shiftLeft(1).add(f1);
+            return multiplyOperator.apply(b0, f1);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        for (int n = 0; n <= 10; n++) {
+            BigInteger fib = fibonacci(n, BigInteger::multiply);
+            System.out.printf("fibonacci(%d) = %d%n", n, fib);
+        }
+
+        compare(1000, 324);
+        compare(10_000, 3473);
+        compare(100_000, 34883);
+        compare(1_000_000, 347084);
+    }
+
+    private static void compare(int n, int expectedBitCount) {
+        BigInteger multiplyResult = fibonacci(n, BigInteger::multiply);
+        BigInteger parallelMultiplyResult = fibonacci(n, BigInteger::parallelMultiply);
+        checkBitCount(n, expectedBitCount, multiplyResult);
+        checkBitCount(n, expectedBitCount, parallelMultiplyResult);
+        if (!multiplyResult.equals(parallelMultiplyResult))
+            throw new AssertionError("multiply() and parallelMultiply() give different results");
+    }
+
+    private static void checkBitCount(int n, int expectedBitCount, BigInteger number) {
+        if (number.bitCount() != expectedBitCount)
+            throw new AssertionError(
+                    "bitCount of fibonacci(" + n + ") was expected to be " + expectedBitCount
+                            + " but was " + number.bitCount());
+    }
+}

--- a/test/jdk/java/math/BigInteger/BigIntegerParallelMultiplyTest.java
+++ b/test/jdk/java/math/BigInteger/BigIntegerParallelMultiplyTest.java
@@ -34,7 +34,10 @@ import java.util.function.BinaryOperator;
 /**
  * This is a simple test class created to ensure that the results
  * of multiply() are the same as multiplyParallel(). We calculate
- * the Fibonacci numbers using
+ * the Fibonacci numbers using Dijkstra's sum of squares to get
+ * very large numbers (hundreds of thousands of bits).
+ *
+ * @author Heinz Kabutz, heinz@javaspecialists.eu
  */
 public class BigIntegerParallelMultiplyTest {
     public static BigInteger fibonacci(int n, BinaryOperator<BigInteger> multiplyOperator) {

--- a/test/micro/org/openjdk/bench/java/math/BigIntegerParallelMultiply.java
+++ b/test/micro/org/openjdk/bench/java/math/BigIntegerParallelMultiply.java
@@ -1,0 +1,61 @@
+package org.openjdk.bench.java.math;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.math.BigInteger;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BinaryOperator;
+
+/**
+ * Benchmark for checking that the new empty stream
+ * implementations are faster than the old way of creating
+ * empty streams from empty spliterators.
+ *
+ * @author Heinz Kabutz, heinz@javaspecialists.eu
+ */
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(value = 2, jvmArgsAppend = {"-XX:+UseParallelGC", "-Xmx16g", "-Xms16g", "-XX:+AlwaysPreTouch", "-XX:NewRatio=1", "-XX:SurvivorRatio=1"})
+@Warmup(iterations = 2)
+@Measurement(iterations = 2) // only 2 iterations because each one takes very long
+@State(Scope.Thread)
+public class BigIntegerParallelMultiply {
+    private static BigInteger fibonacci(int n, BinaryOperator<BigInteger> multiplyOperator) {
+        if (n == 0) return BigInteger.ZERO;
+        if (n == 1) return BigInteger.ONE;
+
+        int half = (n + 1) / 2;
+        BigInteger f0 = fibonacci(half - 1, multiplyOperator);
+        BigInteger f1 = fibonacci(half, multiplyOperator);
+        if (n % 2 == 1) {
+            BigInteger b0 = multiplyOperator.apply(f0, f0);
+            BigInteger b1 = multiplyOperator.apply(f1, f1);
+            return b0.add(b1);
+        } else {
+            BigInteger b0 = f0.shiftLeft(1).add(f1);
+            return multiplyOperator.apply(b0, f1);
+        }
+    }
+
+    @Param({"1000000", "10000000", "100000000"})
+    private int n;
+
+    @Benchmark
+    public void multiply() {
+        fibonacci(n, BigInteger::multiply);
+    }
+
+    @Benchmark
+    public void parallelMultiply() {
+        fibonacci(n, BigInteger::parallelMultiply);
+    }
+}

--- a/test/micro/org/openjdk/bench/java/math/BigIntegerParallelMultiply.java
+++ b/test/micro/org/openjdk/bench/java/math/BigIntegerParallelMultiply.java
@@ -16,9 +16,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BinaryOperator;
 
 /**
- * Benchmark for checking that the new empty stream
- * implementations are faster than the old way of creating
- * empty streams from empty spliterators.
+ * Benchmark for checking performance difference between
+ * sequential and parallel multiply methods in BigInteger,
+ * using a large Fibonacci calculation of up to n = 100 million.
  *
  * @author Heinz Kabutz, heinz@javaspecialists.eu
  */


### PR DESCRIPTION
BigInteger currently uses three different algorithms for multiply. The simple quadratic algorithm, then the slightly better Karatsuba if we exceed a bit count and then Toom Cook 3 once we go into the several thousands of bits. Since Toom Cook 3 is a recursive algorithm, it is trivial to parallelize it. I have demonstrated this several times in conference talks. In order to be consistent with other classes such as Arrays and Collection, I have added a parallelMultiply() method. Internally we have added a parameter to the private multiply method to indicate whether the calculation should be done in parallel.

The performance improvements are as should be expected. Fibonacci of 100 million (using a single-threaded Dijkstra's sum of squares version) completes in 9.2 seconds with the parallelMultiply() vs 25.3 seconds with the sequential multiply() method. This is on my 1-8-2 laptop. The final multiplications are with very large numbers, which then benefit from the parallelization of Toom-Cook 3.  Fibonacci 100 million is a 347084 bit number.

We have also parallelized the private square() method. Internally, the square() method defaults to be sequential.

```
Benchmark                                          (n)  Mode  Cnt      Score      Error  Units
BigIntegerParallelMultiply.multiply            1000000    ss    4     68,043 ±   25,317  ms/op
BigIntegerParallelMultiply.multiply           10000000    ss    4   1073,095 ±  125,296  ms/op
BigIntegerParallelMultiply.multiply          100000000    ss    4  25317,535 ± 5806,205  ms/op
BigIntegerParallelMultiply.parallelMultiply    1000000    ss    4     56,552 ±   22,368  ms/op
BigIntegerParallelMultiply.parallelMultiply   10000000    ss    4    536,193 ±   37,393  ms/op
BigIntegerParallelMultiply.parallelMultiply  100000000    ss    4   9274,657 ±  826,197  ms/op

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8277175](https://bugs.openjdk.java.net/browse/JDK-8277175): Add a parallel multiply method to BigInteger


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6391/head:pull/6391` \
`$ git checkout pull/6391`

Update a local copy of the PR: \
`$ git checkout pull/6391` \
`$ git pull https://git.openjdk.java.net/jdk pull/6391/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6391`

View PR using the GUI difftool: \
`$ git pr show -t 6391`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6391.diff">https://git.openjdk.java.net/jdk/pull/6391.diff</a>

</details>
