### PR TITLE
4337793: Mark non-serializable fields of java.security.cert.Certificate and CertPath

### DIFF
--- a/src/java.base/share/classes/java/security/cert/CertPath.java
+++ b/src/java.base/share/classes/java/security/cert/CertPath.java
@@ -270,9 +270,11 @@ public abstract class CertPath implements Serializable {
 
     /**
      * Replaces the {@code CertPath} to be serialized with a
-     * {@code CertPathRep} object.
+     * {@link CertPathRep CertPathRep} object containing the
+     * {@code Certificate} type and encoded bytes of the {@code CertPath}.
      *
-     * @return the {@code CertPathRep} to be serialized
+     * @return a {@code CertPathRep} containing the {@code Certificate} type
+     *         and encoded bytes of the {@code CertPath}
      *
      * @throws ObjectStreamException if a {@code CertPathRep} object
      * representing this certification path could not be created
@@ -299,16 +301,16 @@ public abstract class CertPath implements Serializable {
         @java.io.Serial
         private static final long serialVersionUID = 3015633072427920915L;
 
-        /** The Certificate type */
+        /** The type of {@code Certificate}s in the {@code CertPath}. */
         private String type;
-        /** The encoded form of the cert path */
+        /** The encoded form of the {@code CertPath}. */
         private byte[] data;
 
         /**
          * Creates a {@code CertPathRep} with the specified
          * type and encoded form of a certification path.
          *
-         * @param type the standard name of a {@code CertPath} type
+         * @param type the standard name of a {@code Certificate} type
          * @param data the encoded form of the certification path
          */
         protected CertPathRep(String type, byte[] data) {
@@ -317,11 +319,12 @@ public abstract class CertPath implements Serializable {
         }
 
         /**
-         * Returns a {@code CertPath} constructed from the type and data.
+         * Returns a {@code CertPath} constructed from the type and data of
+         * this {@code CertPathRep}.
          *
          * @return the resolved {@code CertPath} object
          *
-         * @throws ObjectStreamException if a {@code CertPath} could not
+         * @throws ObjectStreamException if a {@code CertPath} object could not
          * be constructed
          */
         @java.io.Serial

--- a/src/java.base/share/classes/java/security/cert/CertPath.java
+++ b/src/java.base/share/classes/java/security/cert/CertPath.java
@@ -123,7 +123,7 @@ public abstract class CertPath implements Serializable {
     private static final long serialVersionUID = 6068470306649138683L;
 
     /** The type of certificates in this chain. */
-    private String type;
+    private final transient String type;
 
     /**
      * Creates a {@code CertPath} of the specified type.

--- a/src/java.base/share/classes/java/security/cert/Certificate.java
+++ b/src/java.base/share/classes/java/security/cert/Certificate.java
@@ -66,10 +66,10 @@ public abstract class Certificate implements java.io.Serializable {
     private static final long serialVersionUID = -3585440601605666277L;
 
     /** The certificate type. */
-    private final String type;
+    private final transient String type;
 
     /** The hash code for the certificate. */
-    private int hash = -1; // Default to -1
+    private transient int hash = -1; // Default to -1
 
     /**
      * Creates a certificate of the specified type.

--- a/src/java.base/share/classes/java/security/cert/Certificate.java
+++ b/src/java.base/share/classes/java/security/cert/Certificate.java
@@ -236,7 +236,7 @@ public abstract class Certificate implements java.io.Serializable {
     public abstract PublicKey getPublicKey();
 
     /**
-     * Alternate Certificate class for serialization.
+     * Alternate {@code Certificate} class for serialization.
      * @since 1.3
      */
     protected static class CertificateRep implements java.io.Serializable {
@@ -251,12 +251,12 @@ public abstract class Certificate implements java.io.Serializable {
         private byte[] data;
 
         /**
-         * Construct the alternate Certificate class with the Certificate
-         * type and Certificate encoding bytes.
+         * Construct the alternate {@code Certificate} class with the
+         * {@code Certificate} type and {@code Certificate} encoding bytes.
          *
-         * @param type the standard name of the Certificate type.
+         * @param type the standard name of the {@code Certificate} type.
          *
-         * @param data the Certificate data.
+         * @param data the {@code Certificate} data.
          */
         protected CertificateRep(String type, byte[] data) {
             this.type = type;
@@ -264,11 +264,12 @@ public abstract class Certificate implements java.io.Serializable {
         }
 
         /**
-         * Resolve the Certificate Object.
+         * Returns a {@code Certificate} with the type and data of this
+         * {@code CertificateRep}.
          *
-         * @return the resolved Certificate Object
+         * @return the resolved {@code Certificate} object
          *
-         * @throws java.io.ObjectStreamException if the Certificate
+         * @throws java.io.ObjectStreamException if the {@code Certificate}
          *      could not be resolved
          */
         @java.io.Serial
@@ -288,12 +289,15 @@ public abstract class Certificate implements java.io.Serializable {
     }
 
     /**
-     * Replace the Certificate to be serialized.
+     * Replace the {@code Certificate} to be serialized with a
+     * {@link CertificateRep CertificateRep} object containing the type and
+     * encoded bytes of the {@code Certificate}.
      *
-     * @return the alternate Certificate object to be serialized
+     * @return a {@code CertificateRep} object containing the type and encoded
+     *         bytes of the {@code Certificate}
      *
-     * @throws java.io.ObjectStreamException if a new object representing
-     * this Certificate could not be created
+     * @throws java.io.ObjectStreamException if a {@code CertificateRep} object
+     *         representing this {@code Certificate} could not be created
      * @since 1.3
      */
     @java.io.Serial


### PR DESCRIPTION
Please review this 20+ year old bug (!), which marks the non-serializable fields of Certificate and CertPath with the transient modifier. These classes use an alternate serialization mechanism by overriding the writeReplace method. However, the fields of each class were never marked as transient and as a result were incorrectly documented in the Serialized Form section of the javadoc.

CSR: https://bugs.openjdk.java.net/browse/JDK-8277128

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-4337793](https://bugs.openjdk.java.net/browse/JDK-4337793): Mark non-serializable fields of java.security.cert.Certificate and CertPath


### Reviewers
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6392/head:pull/6392` \
`$ git checkout pull/6392`

Update a local copy of the PR: \
`$ git checkout pull/6392` \
`$ git pull https://git.openjdk.java.net/jdk pull/6392/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6392`

View PR using the GUI difftool: \
`$ git pr show -t 6392`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6392.diff">https://git.openjdk.java.net/jdk/pull/6392.diff</a>

</details>
