### PR TITLE
8276665: ObjectInputStream.GetField.get(name, object) should throw ClassNotFoundException

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -298,6 +298,15 @@ public class ObjectInputStream
                 .privilegedGetProperty("jdk.serialSetFilterAfterRead");
 
         /**
+         * Property to control {@link GetField#get(String, Object)} conversion of
+         * {@link ClassNotFoundException} to {@code null}. If set to {@code true}
+         * {@link GetField#get(String, Object)} returns null otherwise
+         * throwing @link ClassNotFoundException}.
+         */
+        private static final boolean GETFIELD_CNFE_RETURNS_NULL = GetBooleanAction
+                .privilegedGetProperty("jdk.serialGetFieldCnfeReturnsNull");
+
+        /**
          * Property to override the implementation limit on the number
          * of interfaces allowed for Proxies. The property value is clamped to 0..65535.
          * The maximum number of interfaces allowed for a proxy is limited to 65535 by
@@ -1596,12 +1605,13 @@ public class ObjectInputStream
          * @param  val the default value to use if {@code name} does not
          *         have a value
          * @return the value of the named {@code Object} field
+         * @throws ClassNotFoundException Class of a serialized object cannot be found.
          * @throws IOException if there are I/O errors while reading from the
          *         underlying {@code InputStream}
          * @throws IllegalArgumentException if type of {@code name} is
          *         not serializable or if the field type is incorrect
          */
-        public abstract Object get(String name, Object val) throws IOException;
+        public abstract Object get(String name, Object val) throws IOException, ClassNotFoundException;
     }
 
     /**
@@ -2645,13 +2655,19 @@ public class ObjectInputStream
             return (off >= 0) ? Bits.getDouble(primValues, off) : val;
         }
 
-        public Object get(String name, Object val) {
+        public Object get(String name, Object val) throws ClassNotFoundException {
             int off = getFieldOffset(name, Object.class);
             if (off >= 0) {
                 int objHandle = objHandles[off];
                 handles.markDependency(passHandle, objHandle);
-                return (handles.lookupException(objHandle) == null) ?
-                    objValues[off] : null;
+                ClassNotFoundException ex = handles.lookupException(objHandle);
+                if (ex == null)
+                    return objValues[off];
+                if (Caches.GETFIELD_CNFE_RETURNS_NULL) {
+                    // Revert to the prior behavior; return null instead of CNFE
+                    return null;
+                }
+                throw ex;
             } else {
                 return val;
             }

--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -301,7 +301,7 @@ public class ObjectInputStream
          * Property to control {@link GetField#get(String, Object)} conversion of
          * {@link ClassNotFoundException} to {@code null}. If set to {@code true}
          * {@link GetField#get(String, Object)} returns null otherwise
-         * throwing @link ClassNotFoundException}.
+         * throwing {@link ClassNotFoundException}.
          */
         private static final boolean GETFIELD_CNFE_RETURNS_NULL = GetBooleanAction
                 .privilegedGetProperty("jdk.serialGetFieldCnfeReturnsNull");

--- a/test/jdk/java/io/Serializable/GetField/ReadFieldsCNF.java
+++ b/test/jdk/java/io/Serializable/GetField/ReadFieldsCNF.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8273660
+ * @summary Verify that ObjectInputStream ReadFields correctly reports ClassNotFoundException
+ *    while getting the field value. The test uses Vector that calls ReadFields from its readObject.
+ * @library /test/lib
+ * @run testng ReadFieldsCNF
+ * @run testng/othervm -Djdk.serialGetFieldCnfeReturnsNull=true ReadFieldsCNF
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.io.StreamCorruptedException;
+import java.nio.charset.StandardCharsets;
+import java.util.Vector;
+
+import org.testng.annotations.Test;
+import org.testng.Assert;
+
+import jdk.test.lib.hexdump.HexPrinter;
+import jdk.test.lib.hexdump.ObjectStreamPrinter;
+
+public class ReadFieldsCNF {
+
+    private static final boolean GETFIELD_CNFE_RETURNS_NULL =
+            Boolean.getBoolean("jdk.serialGetFieldCnfeReturnsNull");
+
+
+    /**
+     * Test a Vector holding a reference to a class instance that will not be found.
+     * @throws IOException If any other exception occurs
+     */
+    @Test
+    private static void testVectorWithRole() throws IOException {
+        System.out.println("Property GETFIELD_CNFE_RETURNS_NULL: " + GETFIELD_CNFE_RETURNS_NULL);
+
+        Role role = new Role();
+        Vector<Role> vector = new Vector<>();
+        vector.add(role);
+
+        // Modify the byte stream to change the classname to be deserialized to
+        // XeadFieldsCNF$Role.
+        byte[] bytes = writeObject(vector);
+
+        // Locate the name of the class to be deserialize
+        String s = new String(bytes, StandardCharsets.ISO_8859_1);  // Map bytes to chars
+        int off = s.indexOf(Role.class.getName());
+        System.out.printf("Role offset: %d (0x%x) : %s%n", off, off, Role.class.getName());
+        if (off < 0) {
+            HexPrinter.simple().formatter(ObjectStreamPrinter.formatter()).format(bytes);
+            Assert.fail("classname not found");
+        }
+
+        bytes[off] = (byte) 'X';  // replace R with X -> Class not found
+
+        // Deserialize the Vector expecting a ClassNotFoundException
+        ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes));
+        try {
+            Object obj = in.readObject();
+            System.out.println("Read: " + obj);
+            Assert.fail("Should not reach here, an exception should always occur");
+        } catch (ClassNotFoundException cnfe) {
+            // Expected ClassNotFoundException
+            String expected = "XeadFieldsCNF$Role";
+            Assert.assertEquals(expected, cnfe.getMessage(), "Wrong classname");
+            if (GETFIELD_CNFE_RETURNS_NULL) {
+                Assert.fail("Expected IOException got ClassNotFoundException", cnfe);
+            }
+            System.out.println("Normal:  OIS.readObject: " + cnfe);
+        } catch (StreamCorruptedException ioe) {
+            if (!GETFIELD_CNFE_RETURNS_NULL) {
+                Assert.fail("Expected ClassNotFoundException got StreamCorruptedException ", ioe);
+            }
+            System.out.println("Normal: " + ioe);
+        }
+        // Other exceptions cause the test to fail
+    }
+
+    /**
+     * For an object holding a reference to a class that will not be found.
+     * @throws IOException If any other exception occurs
+     */
+    @Test
+    private static void testHolderWithRole() throws IOException {
+        System.out.println("Property GETFIELD_CNFE_RETURNS_NULL: " + GETFIELD_CNFE_RETURNS_NULL);
+        Role role = new Role();
+        Holder holder = new Holder(role);
+
+        // Modify the byte stream to change the classname to be deserialized to
+        // XeadFieldsCNF$Role.
+        byte[] bytes = writeObject(holder);
+
+        String s = new String(bytes, StandardCharsets.ISO_8859_1);  // Map bytes to chars
+        int off = s.indexOf(Role.class.getName(), 0);
+        off = s.indexOf(Role.class.getName(), off + 1); // 2nd occurrence of classname
+        System.out.printf("Role offset: %d (0x%x)%n", off, off);
+        if (off < 0) {
+            HexPrinter.simple().formatter(ObjectStreamPrinter.formatter()).format(bytes);
+            Assert.fail("classname found at index: " + off + " (0x" + Integer.toHexString(off) + ")");
+        }
+
+        bytes[off] = (byte) 'X';  // replace R with X -> Class not found
+
+        // Deserialize the Vector expecting a ClassNotFoundException
+        ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes));
+        try {
+            Holder obj = (Holder)in.readObject();
+            System.out.println("Read: " + obj);
+            Assert.fail("Should not reach here, an exception should always occur");
+        } catch (ClassNotFoundException cnfe) {
+            // Expected ClassNotFoundException
+            String expected = "XeadFieldsCNF$Role";
+            Assert.assertEquals(expected, cnfe.getMessage(), "Wrong classname");
+            System.out.println("Normal: OIS.readObject: " + cnfe);
+        } catch (StreamCorruptedException ioe) {
+            if (!GETFIELD_CNFE_RETURNS_NULL) {
+                Assert.fail("Expected ClassNotFoundException got StreamCorruptedException ", ioe);
+            }
+            System.out.println("Normal: " + ioe);
+        }
+        // Other exceptions cause the test to fail
+    }
+
+    private static byte[] writeObject(Object o) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ObjectOutputStream os = new ObjectOutputStream(baos)) {
+            os.writeObject(o);
+        }
+        return baos.toByteArray();
+    }
+
+    static class Role implements Serializable {
+        private static final long serialVersionUID = 0L;
+
+        Role() {}
+    }
+
+    static class Holder implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        Role role;
+
+        Holder(Role role) {
+            this.role = role;
+        }
+
+        private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
+            ObjectInputStream.GetField fields = ois.readFields();
+            try {
+                Object repl = new Object();
+                role = (Role)fields.get("role", repl);
+                System.out.println("Holder.readObject Role: " + role);
+            } catch (Exception ex) {
+                // Catch CNFE and ignore it; check elsewhere that CNFE is thrown from OIS.readObject
+                System.out.println("Normal: exception in Holder.readObject, ignoring: " + ex);
+            }
+        }
+
+        public String toString() {
+            return "role: " + role;
+        }
+    }
+}


### PR DESCRIPTION
The ObjectInputStream.GetField.get(String name, Object val) method is returning null instead of throwing an exception when the class of the object is not found. The caller is not able to correctly handle the case where the class is not found. The signature of GetField.get(name, val) should have a throws ClassNotFoundException and a ClassNotFoundException exception should be thrown.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276665](https://bugs.openjdk.java.net/browse/JDK-8276665): ObjectInputStream.GetField.get(name, object) should throw ClassNotFoundException


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6393/head:pull/6393` \
`$ git checkout pull/6393`

Update a local copy of the PR: \
`$ git checkout pull/6393` \
`$ git pull https://git.openjdk.java.net/jdk pull/6393/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6393`

View PR using the GUI difftool: \
`$ git pr show -t 6393`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6393.diff">https://git.openjdk.java.net/jdk/pull/6393.diff</a>

</details>
