### PR TITLE
JDK-8277139 Improve code readability in PredecessorValidator (c1_IR.cpp)

### DIFF
--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1300,30 +1300,27 @@ class PredecessorValidator : public BlockClosure {
     for (int i = 0; i < n; i++) {
       BlockBegin* sux = be->sux_at(i);
       assert(!sux->is_set(BlockBegin::exception_entry_flag), "must not be xhandler");
-
-      BlockList* preds = _predecessors->at_grow(sux->block_id(), NULL);
-      if (preds == NULL) {
-        preds = new BlockList();
-        _predecessors->at_put(sux->block_id(), preds);
-      }
-      preds->append(block);
+      collect_predecessor(block, sux);
     }
 
     int m = block->number_of_exception_handlers();
     for (int i = 0; i < m; i++) {
       BlockBegin* sux = block->exception_handler_at(i);
       assert(sux->is_set(BlockBegin::exception_entry_flag), "must be xhandler");
-
-      BlockList* preds = _predecessors->at_grow(sux->block_id(), NULL);
-      if (preds == NULL) {
-        preds = new BlockList();
-        _predecessors->at_put(sux->block_id(), preds);
-      }
-      preds->append(block);
+      collect_predecessor(block, sux);
     }
   }
 
  private:
+  void collect_predecessor(BlockBegin * const pred, const BlockBegin *sux) {
+    BlockList* preds = _predecessors->at_grow(sux->block_id(), NULL);
+    if (preds == NULL) {
+      preds = new BlockList();
+      _predecessors->at_put(sux->block_id(), preds);
+    }
+    preds->append(pred);
+  }
+
   void verify_block_preds_against_collected_preds(const BlockBegin *block) const {
     BlockList* preds = _predecessors->at(block->block_id());
     if (preds == NULL) {

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1318,7 +1318,7 @@ class PredecessorValidator : public BlockClosure {
     }
   }
 
-  void collect_predecessor(BlockBegin* const pred, const BlockBegin *sux) {
+  void collect_predecessor(BlockBegin* const pred, const BlockBegin* sux) {
     BlockList* preds = _predecessors->at_grow(sux->block_id(), NULL);
     if (preds == NULL) {
       preds = new BlockList();

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1295,16 +1295,13 @@ class PredecessorValidator : public BlockClosure {
 
   virtual void block_do(BlockBegin* block) {
     _blocks->append(block);
-    BlockEnd* be = block->end();
-    int n = be->number_of_sux();
-    for (int i = 0; i < n; i++) {
-      BlockBegin* sux = be->sux_at(i);
+    for (int i = 0; i < block->end()->number_of_sux(); i++) {
+      BlockBegin* sux = block->end()->sux_at(i);
       assert(!sux->is_set(BlockBegin::exception_entry_flag), "must not be xhandler");
       collect_predecessor(block, sux);
     }
 
-    int m = block->number_of_exception_handlers();
-    for (int i = 0; i < m; i++) {
+    for (int i = 0; i < block->number_of_exception_handlers(); i++) {
       BlockBegin* sux = block->exception_handler_at(i);
       assert(sux->is_set(BlockBegin::exception_entry_flag), "must be xhandler");
       collect_predecessor(block, sux);

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1279,38 +1279,34 @@ class PredecessorValidator : public BlockClosure {
     _predecessors = new BlockListList(BlockBegin::number_of_blocks(), BlockBegin::number_of_blocks(), NULL);
     _blocks = new BlockList();
 
-    int i;
     hir->start()->iterate_preorder(this);
     if (hir->code() != NULL) {
       assert(hir->code()->length() == _blocks->length(), "must match");
-      for (i = 0; i < _blocks->length(); i++) {
+      for (int i = 0; i < _blocks->length(); i++) {
         assert(hir->code()->contains(_blocks->at(i)), "should be in both lists");
       }
     }
 
-    for (i = 0; i < _blocks->length(); i++) {
+    for (int i = 0; i < _blocks->length(); i++) {
       BlockBegin* block = _blocks->at(i);
       BlockList* preds = _predecessors->at(block->block_id());
       if (preds == NULL) {
         assert(block->number_of_preds() == 0, "should be the same");
         continue;
       }
+      assert(preds->length() == block->number_of_preds(), "should be the same");
 
       // clone the pred list so we can mutate it
       BlockList* pred_copy = new BlockList();
-      int j;
-      for (j = 0; j < block->number_of_preds(); j++) {
+      for (int j = 0; j < block->number_of_preds(); j++) {
         pred_copy->append(block->pred_at(j));
       }
       // sort them in the same order
       preds->sort(cmp);
       pred_copy->sort(cmp);
-      int length = MIN2(preds->length(), block->number_of_preds());
-      for (j = 0; j < block->number_of_preds(); j++) {
+      for (int j = 0; j < block->number_of_preds(); j++) {
         assert(preds->at(j) == pred_copy->at(j), "must match");
       }
-
-      assert(preds->length() == block->number_of_preds(), "should be the same");
     }
   }
 
@@ -1318,8 +1314,7 @@ class PredecessorValidator : public BlockClosure {
     _blocks->append(block);
     BlockEnd* be = block->end();
     int n = be->number_of_sux();
-    int i;
-    for (i = 0; i < n; i++) {
+    for (int i = 0; i < n; i++) {
       BlockBegin* sux = be->sux_at(i);
       assert(!sux->is_set(BlockBegin::exception_entry_flag), "must not be xhandler");
 
@@ -1331,8 +1326,8 @@ class PredecessorValidator : public BlockClosure {
       preds->append(block);
     }
 
-    n = block->number_of_exception_handlers();
-    for (i = 0; i < n; i++) {
+    int m = block->number_of_exception_handlers();
+    for (int i = 0; i < m; i++) {
       BlockBegin* sux = block->exception_handler_at(i);
       assert(sux->is_set(BlockBegin::exception_entry_flag), "must be xhandler");
 

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1318,7 +1318,7 @@ class PredecessorValidator : public BlockClosure {
     }
   }
 
-  void collect_predecessor(BlockBegin * const pred, const BlockBegin *sux) {
+  void collect_predecessor(BlockBegin* const pred, const BlockBegin *sux) {
     BlockList* preds = _predecessors->at_grow(sux->block_id(), NULL);
     if (preds == NULL) {
       preds = new BlockList();
@@ -1327,7 +1327,7 @@ class PredecessorValidator : public BlockClosure {
     preds->append(pred);
   }
 
-  void verify_block_preds_against_collected_preds(const BlockBegin *block) const {
+  void verify_block_preds_against_collected_preds(const BlockBegin* block) const {
     BlockList* preds = _predecessors->at(block->block_id());
     if (preds == NULL) {
       assert(block->number_of_preds() == 0, "should be the same");

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1289,24 +1289,7 @@ class PredecessorValidator : public BlockClosure {
 
     for (int i = 0; i < _blocks->length(); i++) {
       BlockBegin* block = _blocks->at(i);
-      BlockList* preds = _predecessors->at(block->block_id());
-      if (preds == NULL) {
-        assert(block->number_of_preds() == 0, "should be the same");
-        continue;
-      }
-      assert(preds->length() == block->number_of_preds(), "should be the same");
-
-      // clone the pred list so we can mutate it
-      BlockList* pred_copy = new BlockList();
-      for (int j = 0; j < block->number_of_preds(); j++) {
-        pred_copy->append(block->pred_at(j));
-      }
-      // sort them in the same order
-      preds->sort(cmp);
-      pred_copy->sort(cmp);
-      for (int j = 0; j < block->number_of_preds(); j++) {
-        assert(preds->at(j) == pred_copy->at(j), "must match");
-      }
+      verify_block_preds_against_collected_preds(block);
     }
   }
 
@@ -1337,6 +1320,28 @@ class PredecessorValidator : public BlockClosure {
         _predecessors->at_put(sux->block_id(), preds);
       }
       preds->append(block);
+    }
+  }
+
+ private:
+  void verify_block_preds_against_collected_preds(const BlockBegin *block) const {
+    BlockList* preds = _predecessors->at(block->block_id());
+    if (preds == NULL) {
+      assert(block->number_of_preds() == 0, "should be the same");
+      return;
+    }
+    assert(preds->length() == block->number_of_preds(), "should be the same");
+
+    // clone the pred list so we can mutate it
+    BlockList* pred_copy = new BlockList();
+    for (int j = 0; j < block->number_of_preds(); j++) {
+      pred_copy->append(block->pred_at(j));
+    }
+    // sort them in the same order
+    preds->sort(cmp);
+    pred_copy->sort(cmp);
+    for (int j = 0; j < block->number_of_preds(); j++) {
+      assert(preds->at(j) == pred_copy->at(j), "must match");
     }
   }
 };

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1266,7 +1266,7 @@ typedef GrowableArray<BlockList*> BlockListList;
 
 class PredecessorValidator : public BlockClosure {
  private:
-  BlockListList* _predecessors;
+  BlockListList* _predecessors; // Each index i will hold predecessors of block with id i
   BlockList*     _blocks;
 
   static int cmp(BlockBegin** a, BlockBegin** b) {
@@ -1277,7 +1277,7 @@ class PredecessorValidator : public BlockClosure {
   PredecessorValidator(IR* hir) {
     ResourceMark rm;
     _predecessors = new BlockListList(BlockBegin::number_of_blocks(), BlockBegin::number_of_blocks(), NULL);
-    _blocks = new BlockList();
+    _blocks = new BlockList(BlockBegin::number_of_blocks());
 
     hir->start()->iterate_preorder(this);
     if (hir->code() != NULL) {

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1300,7 +1300,7 @@ class PredecessorValidator : public BlockClosure {
   }
 
  private:
-  void verify_successor_xentry_flag(const BlockBegin *block) const {
+  void verify_successor_xentry_flag(const BlockBegin* block) const {
     for (int i = 0; i < block->end()->number_of_sux(); i++) {
       assert(!block->end()->sux_at(i)->is_set(BlockBegin::exception_entry_flag), "must not be xhandler");
     }
@@ -1309,7 +1309,7 @@ class PredecessorValidator : public BlockClosure {
     }
   }
 
-  void collect_predecessors(BlockBegin *block) {
+  void collect_predecessors(BlockBegin* block) {
     for (int i = 0; i < block->end()->number_of_sux(); i++) {
       collect_predecessor(block, block->end()->sux_at(i));
     }


### PR DESCRIPTION
Refactor PredecessorValidator, more or less applying the following:

declare variables where used
redeclare instead of reuse variables
move assert to a more logical place
remove unused length variable
inline variables where senseful
split loops
extract methods

this is done in preparation for work on optimizing IR::verify. IR::verify calls PredecessorValidator. If the work of PredecessorValidator is made clearer, it will be easier to reason about where IR::verify doesn't need to be called (or where a subset of it would suffice).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277139](https://bugs.openjdk.java.net/browse/JDK-8277139): Improve code readability in PredecessorValidator (c1_IR.cpp)


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to 71067986649b56217211b2faebec43727a6cbfb9
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6394/head:pull/6394` \
`$ git checkout pull/6394`

Update a local copy of the PR: \
`$ git checkout pull/6394` \
`$ git pull https://git.openjdk.java.net/jdk pull/6394/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6394`

View PR using the GUI difftool: \
`$ git pr show -t 6394`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6394.diff">https://git.openjdk.java.net/jdk/pull/6394.diff</a>

</details>
