### PR TITLE
JDK-8276150: Quarantined jpackage apps are labeled as "damaged"

### DIFF
--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacAppImageBuilder.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacAppImageBuilder.java
@@ -329,7 +329,8 @@ public class MacAppImageBuilder extends AbstractAppImageBuilder {
         }
 
         copyRuntimeFiles(params);
-        sign(params);
+
+        doSigning(params);
     }
 
     private void copyRuntimeFiles(Map<String, ? super Object> params)
@@ -355,7 +356,12 @@ public class MacAppImageBuilder extends AbstractAppImageBuilder {
         }
     }
 
-    private void sign(Map<String, ? super Object> params) throws IOException {
+    private void doSigning(Map<String, ? super Object> params)
+            throws IOException {
+
+        // signing or not, unsign first ...
+        unsignAppBundle(params, root);
+
         if (Optional.ofNullable(
                 SIGN_BUNDLE.fetchFrom(params)).orElse(Boolean.TRUE)) {
             try {
@@ -647,7 +653,52 @@ public class MacAppImageBuilder extends AbstractAppImageBuilder {
         IOUtils.exec(pb);
     }
 
-    static void signAppBundle(
+    private static void unsignAppBundle(Map<String, ? super Object> params,
+            Path appLocation) throws IOException {
+
+        // unsign all dylibs and executables
+        try (Stream<Path> stream = Files.walk(appLocation)) {
+            stream.peek(path -> { // fix permissions
+                try {
+                    Set<PosixFilePermission> pfp =
+                            Files.getPosixFilePermissions(path);
+                    if (!pfp.contains(PosixFilePermission.OWNER_WRITE)) {
+                        pfp = EnumSet.copyOf(pfp);
+                        pfp.add(PosixFilePermission.OWNER_WRITE);
+                        Files.setPosixFilePermissions(path, pfp);
+                    }
+                } catch (IOException e) {
+                    Log.verbose(e);
+                }
+            }).filter(p -> Files.isRegularFile(p) &&
+                      (Files.isExecutable(p) || p.toString().endsWith(".dylib"))
+                      && !(p.toString().contains("dylib.dSYM/Contents"))
+                     ).forEach(p -> {
+                // If p is a symlink then skip.
+                if (Files.isSymbolicLink(p)) {
+                    Log.verbose(MessageFormat.format(I18N.getString(
+                            "message.ignoring.symlink"), p.toString()));
+                } else {
+                    List<String> args = new ArrayList<>();
+                    args.addAll(Arrays.asList("/usr/bin/codesign",
+                            "--remove-signature", p.toString()));
+                    try {
+                        Set<PosixFilePermission> oldPermissions =
+                                Files.getPosixFilePermissions(p);
+                        p.toFile().setWritable(true, true);
+                        ProcessBuilder pb = new ProcessBuilder(args);
+                        IOUtils.exec(pb);
+                        Files.setPosixFilePermissions(p,oldPermissions);
+                    } catch (IOException ioe) {
+                        Log.verbose(ioe);
+                        return;
+                    }
+                }
+            });
+        }
+    }
+
+    private static void signAppBundle(
             Map<String, ? super Object> params, Path appLocation,
             String signingIdentity, String identifierPrefix, Path entitlements)
             throws IOException {
@@ -682,29 +733,7 @@ public class MacAppImageBuilder extends AbstractAppImageBuilder {
                     Log.verbose(MessageFormat.format(I18N.getString(
                             "message.ignoring.symlink"), p.toString()));
                 } else {
-                    List<String> args;
-                    // runtime and Framework files will be signed below
-                    // but they need to be unsigned first here
-                    if ((p.toString().contains("/Contents/runtime")) ||
-                        (p.toString().contains("/Contents/Frameworks"))) {
-
-                        args = new ArrayList<>();
-                        args.addAll(Arrays.asList("/usr/bin/codesign",
-                                "--remove-signature", p.toString()));
-                        try {
-                            Set<PosixFilePermission> oldPermissions =
-                                    Files.getPosixFilePermissions(p);
-                            p.toFile().setWritable(true, true);
-                            ProcessBuilder pb = new ProcessBuilder(args);
-                            IOUtils.exec(pb);
-                            Files.setPosixFilePermissions(p,oldPermissions);
-                        } catch (IOException ioe) {
-                            Log.verbose(ioe);
-                            toThrow.set(ioe);
-                            return;
-                        }
-                    }
-                    args = new ArrayList<>();
+                    List<String> args = new ArrayList<>();
                     args.addAll(Arrays.asList("/usr/bin/codesign",
                             "--timestamp",
                             "--options", "runtime",


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276150](https://bugs.openjdk.java.net/browse/JDK-8276150): Quarantined jpackage apps are labeled as "damaged"


### Reviewers
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6396/head:pull/6396` \
`$ git checkout pull/6396`

Update a local copy of the PR: \
`$ git checkout pull/6396` \
`$ git pull https://git.openjdk.java.net/jdk pull/6396/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6396`

View PR using the GUI difftool: \
`$ git pr show -t 6396`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6396.diff">https://git.openjdk.java.net/jdk/pull/6396.diff</a>

</details>
