### PR TITLE
8276231: ciReplay: SIGSEGV when replay compiling lambdas

### DIFF
--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -467,6 +467,7 @@ class CompileReplay : public StackObj {
       }
       {
         bool found_it;
+        ik->link_class(CHECK_NULL);
         obj = cp->find_cached_constant_at(cpi, found_it, thread);
       }
     }
@@ -927,6 +928,7 @@ class CompileReplay : public StackObj {
   void process_ciInstanceKlass(TRAPS) {
     InstanceKlass* k = (InstanceKlass*)parse_klass(CHECK);
     if (k == NULL) {
+      skip_remaining();
       return;
     }
     int is_linked = parse_int("is_linked");


### PR DESCRIPTION
To fix the crash, we need to link the class before calling find_cached_constant_at().  I also fixed a confusing "line not properly terminated" error when we fail to load a class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276231](https://bugs.openjdk.java.net/browse/JDK-8276231): ciReplay: SIGSEGV when replay compiling lambdas


### Reviewers
 * [Igor Veresov](https://openjdk.java.net/census#iveresov) (@veresov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6398/head:pull/6398` \
`$ git checkout pull/6398`

Update a local copy of the PR: \
`$ git checkout pull/6398` \
`$ git pull https://git.openjdk.java.net/jdk pull/6398/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6398`

View PR using the GUI difftool: \
`$ git pr show -t 6398`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6398.diff">https://git.openjdk.java.net/jdk/pull/6398.diff</a>

</details>
