### PR TITLE
8277159: Fix java/nio/file/FileStore/Basic.java test by ignoring /run/user/* mount points

### DIFF
--- a/test/jdk/java/nio/file/FileStore/Basic.java
+++ b/test/jdk/java/nio/file/FileStore/Basic.java
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4313887 6873621 6979526 7006126 7020517 8264400 8277159
+ * @bug 4313887 6873621 6979526 7006126 7020517 8264400
  * @summary Unit test for java.nio.file.FileStore
  * @key intermittent
  * @library .. /test/lib

--- a/test/jdk/java/nio/file/FileStore/Basic.java
+++ b/test/jdk/java/nio/file/FileStore/Basic.java
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4313887 6873621 6979526 7006126 7020517 8264400
+ * @bug 4313887 6873621 6979526 7006126 7020517 8264400 8277159
  * @summary Unit test for java.nio.file.FileStore
  * @key intermittent
  * @library .. /test/lib
@@ -145,6 +145,16 @@ public class Basic {
                     // reflect whether the space attributes would be accessible
                     // were access to be permitted
                     System.err.format("%s is inaccessible\n", store);
+                } catch (FileSystemException fse) {
+                    // On Linux, ignore the FSE if the path is one of the
+                    // /run/user/$UID mounts created by pam_systemd(8) as it
+                    // might be mounted as a fuse.portal filesystem and
+                    // its access attempt might fail with EPERM
+                    if (!Platform.isLinux() || store.toString().indexOf("/run/user") == -1) {
+                        throw new RuntimeException(fse);
+                    } else {
+                        System.err.format("%s error: %s\n", store, fse);
+                    }
                 }
 
                 // two distinct FileStores should not be equal


### PR DESCRIPTION
…/user/* mount points

The fix to the test is the same as in #5136 . The possible problem with this test was identified in [this comment](https://github.com/openjdk/jdk/pull/5136#issuecomment-900402107), however FileSystemException is thrown instead of NoSuchFileException in this case, thus the special check for "/run/user" is added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277159](https://bugs.openjdk.java.net/browse/JDK-8277159): Fix java/nio/file/FileStore/Basic.java test by ignoring /run/user/* mount points


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6399/head:pull/6399` \
`$ git checkout pull/6399`

Update a local copy of the PR: \
`$ git checkout pull/6399` \
`$ git pull https://git.openjdk.java.net/jdk pull/6399/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6399`

View PR using the GUI difftool: \
`$ git pr show -t 6399`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6399.diff">https://git.openjdk.java.net/jdk/pull/6399.diff</a>

</details>
