### PR TITLE
8276662: Scalability bottleneck in SymbolTable::lookup_common()

### DIFF
--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -134,7 +134,7 @@ public:
   // We use default allocation/deallocation but counted
   static void* allocate_node(void* context, size_t size, Value const& value) {
     SymbolTable::item_added();
-    if (_lookup_shared_first && (_items_count > 1024)) {
+    if (_lookup_shared_first && (_items_count > 1024)) { // enough local symbols to change search order
         _lookup_shared_first = false;
     }
     return AllocateHeap(size, mtSymbol);

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -176,7 +176,7 @@ void SymbolTable::create_table ()  {
   } else {
     _arena = new (mtSymbol) Arena(mtSymbol, symbol_alloc_arena_size);
   }
-  
+
 #if INCLUDE_CDS
   _lookup_shared_first = !_shared_table.empty();
 #else

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -134,6 +134,9 @@ public:
   // We use default allocation/deallocation but counted
   static void* allocate_node(void* context, size_t size, Value const& value) {
     SymbolTable::item_added();
+    if (_lookup_shared_first && (_items_count > 1024)) {
+        _lookup_shared_first = false;
+    }
     return AllocateHeap(size, mtSymbol);
   }
   static void free_node(void* context, void* memory, Value const& value) {
@@ -173,6 +176,12 @@ void SymbolTable::create_table ()  {
   } else {
     _arena = new (mtSymbol) Arena(mtSymbol, symbol_alloc_arena_size);
   }
+  
+#if INCLUDE_CDS
+  _lookup_shared_first = !_shared_table.empty();
+#else
+  _lookup_shared_first = false;
+#endif
 }
 
 void SymbolTable::delete_symbol(Symbol* sym) {
@@ -314,16 +323,12 @@ Symbol* SymbolTable::lookup_common(const char* name,
   if (_lookup_shared_first) {
     sym = lookup_shared(name, len, hash);
     if (sym == NULL) {
-      _lookup_shared_first = false;
       sym = lookup_dynamic(name, len, hash);
     }
   } else {
     sym = lookup_dynamic(name, len, hash);
     if (sym == NULL) {
       sym = lookup_shared(name, len, hash);
-      if (sym != NULL) {
-        _lookup_shared_first = true;
-      }
     }
   }
   return sym;

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -95,6 +95,8 @@ static volatile bool _alt_hash = false;
 #ifdef USE_LIBRARY_BASED_TLS_ONLY
 static volatile bool _lookup_shared_first = false;
 #else
+// "_lookup_shared_first" can get highly contended with many cores if multiple threads
+// are updating "lookup success history" in a global shared variable. If built-in TLS is available, use it.
 static THREAD_LOCAL bool _lookup_shared_first = false;
 #endif
 


### PR DESCRIPTION
Symbol table lookup had an optimization added when the symbol table was split into a shared table (for CDS?) and a local table. The optimization tries to track which table successfully found a symbol, so it can try that table first the next time.

Symbol table lookup is used in many JVM operations, including classloading, serialization, and reflection.

At startup time, more symbols will be from the shared table, but over time lookup can will be from a mix of local and shared symbols (eg user classes still have java.lang.String fields or subclass from java.lang.Object), resulting in multiple threads fighting over the value of this global variable.

With enough threads and cores, this can result in "true sharing" cache line contention.

This fix solves the scalability issue by using a thread-local variable to track which table to search first instead of a static global. The "symbol table success history" also makes more sense logically as a thread local state than as a global state.

Other options would also solve the the scaling problem, but may change the behavior that we're trying to optimize, or add more overhead or complexity than warranted, such as:
- Statically preferring the shared or local table
- Checking the shared table first "early on". When enough local symbols have been added, then check the local table first.  
- Using a NUMA-aware set of N variables distributed over M threads.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276662](https://bugs.openjdk.java.net/browse/JDK-8276662): Scalability bottleneck in SymbolTable::lookup_common()


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to 7baf3fd4425820afefe5fa79e40dab134ec305c1
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 7baf3fd4425820afefe5fa79e40dab134ec305c1
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to 7baf3fd4425820afefe5fa79e40dab134ec305c1
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to 7baf3fd4425820afefe5fa79e40dab134ec305c1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6400/head:pull/6400` \
`$ git checkout pull/6400`

Update a local copy of the PR: \
`$ git checkout pull/6400` \
`$ git pull https://git.openjdk.java.net/jdk pull/6400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6400`

View PR using the GUI difftool: \
`$ git pr show -t 6400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6400.diff">https://git.openjdk.java.net/jdk/pull/6400.diff</a>

</details>
