### PR TITLE
JDK-8277178: Reduce the priority of data dependent nodes when OptoScheduling enabled

### DIFF
--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -519,7 +519,7 @@ Node* PhaseCFG::select(
   int idx = -1;     // Index in worklist
   int cand_cnt = 0; // Candidate count
   bool block_size_threshold_ok = (recalc_pressure_nodes != NULL) && (block->number_of_nodes() > 10);
-  Node *last_n = block->get_node(--sched_slot);
+  Node* last_n = C->do_scheduling() ? block->get_node(--sched_slot) : nullptr;
 
   for( uint i=0; i<cnt; i++ ) { // Inspect entire worklist
     // Order in worklist is used to break ties.
@@ -604,7 +604,7 @@ Node* PhaseCFG::select(
 
     // If n is related to the last_n(last selected node)
     // and the latency of last_n is greater than 1, another node can be inserted between the n and last_n.
-    if (last_n) {
+    if (last_n != nullptr) {
       for (uint j = 0; j < n->req() ; j++) {
         if ((n->in(j) == last_n) && (n->latency(j) > 1)) { //relate && latency is large
           n_choice = 1;

--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -519,6 +519,7 @@ Node* PhaseCFG::select(
   int idx = -1;     // Index in worklist
   int cand_cnt = 0; // Candidate count
   bool block_size_threshold_ok = (recalc_pressure_nodes != NULL) && (block->number_of_nodes() > 10);
+  Node *last_n = block->get_node(--sched_slot);
 
   for( uint i=0; i<cnt; i++ ) { // Inspect entire worklist
     // Order in worklist is used to break ties.
@@ -599,6 +600,17 @@ Node* PhaseCFG::select(
     // MachTemps should be scheduled last so they are near their uses
     if (n->is_MachTemp()) {
       n_choice = 1;
+    }
+
+    // If n is related to the last_n(last selected node)
+    // and the latency of last_n is greater than 1, another node can be inserted between the n and last_n.
+    if (last_n) {
+      for (uint j = 0; j < n->req() ; j++) {
+        if ((n->in(j) == last_n) && (n->latency(j) > 1)) { //relate && latency is large
+          n_choice = 1;
+          break;
+        }
+      }
     }
 
     uint n_latency = get_latency_for_node(n);

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -2315,36 +2315,8 @@ void Scheduling::AddNodeToAvailableList(Node *n) {
   }
 #endif
 
-  int latency = _current_latency[n->_idx];
-
-  // Insert in latency order (insertion sort)
-  uint i;
-  for ( i=0; i < _available.size(); i++ )
-    if (_current_latency[_available[i]->_idx] > latency)
-      break;
-
-  // Special Check for compares following branches
-  if( n->is_Mach() && _scheduled.size() > 0 ) {
-    int op = n->as_Mach()->ideal_Opcode();
-    Node *last = _scheduled[0];
-    if( last->is_MachIf() && last->in(1) == n &&
-        ( op == Op_CmpI ||
-          op == Op_CmpU ||
-          op == Op_CmpUL ||
-          op == Op_CmpP ||
-          op == Op_CmpF ||
-          op == Op_CmpD ||
-          op == Op_CmpL ) ) {
-
-      // Recalculate position, moving to front of same latency
-      for ( i=0 ; i < _available.size(); i++ )
-        if (_current_latency[_available[i]->_idx] >= latency)
-          break;
-    }
-  }
-
   // Insert the node in the available list
-  _available.insert(i, n);
+  _available.insert(_available.size(), n);
 
 #ifndef PRODUCT
   if (_cfg->C->trace_opto_output())

--- a/test/micro/org/openjdk/bench/vm/compiler/InstructionScheduling.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/InstructionScheduling.java
@@ -28,17 +28,18 @@ import org.openjdk.jmh.annotations.Benchmark;
 public class InstructionScheduling {
 
     public static final int N = 20000;
+    public static final int Ival = 2;
     public static final double fval = 2.00;
     public static double[] D = new double[N];
     public static int[] I = new int[N];
 
     @Benchmark
-    public void testMethod(){
+    public void testMethod() {
         for (int i = 0; i < N; i++) {
             D[i] += D[i] * fval;
             D[i] += D[i] / fval;
-            I[i] += I[i] * 2;
-            I[i] += I[i] / 2;
+            I[i] += I[i] * Ival;
+            I[i] += I[i] / Ival;
         }
     }
 }

--- a/test/micro/org/openjdk/bench/vm/compiler/InstructionScheduling.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/InstructionScheduling.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022, Loongson Technology. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.Benchmark;
+
+public class InstructionScheduling {
+
+    public static final int N = 20000;
+    public static final double fval = 2.00;
+    public static double[] D = new double[N];
+    public static int[] I = new int[N];
+
+    @Benchmark
+    public void testMethod(){
+        for (int i=0; i<N; i++) {
+            D[i] += D[i] * fval;
+            D[i] += D[i] / fval;
+            I[i] += I[i]*2;
+            I[i] += I[i]/2;
+        }
+    }
+}

--- a/test/micro/org/openjdk/bench/vm/compiler/InstructionScheduling.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/InstructionScheduling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2022, Loongson Technology Co. Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,11 +34,11 @@ public class InstructionScheduling {
 
     @Benchmark
     public void testMethod(){
-        for (int i=0; i<N; i++) {
+        for (int i = 0; i < N; i++) {
             D[i] += D[i] * fval;
             D[i] += D[i] / fval;
-            I[i] += I[i]*2;
-            I[i] += I[i]/2;
+            I[i] += I[i] * 2;
+            I[i] += I[i] / 2;
         }
     }
 }


### PR DESCRIPTION
when doing gcm/lcm, We should not only consider the height of nodes(latency), but also consider whether there is data dependency between nodes. When there is data dependency between two nodes and the delay of the previous node is large, another node without data dependency can be considered inserting between the two nodes. For example:
for java code
<pre><code class="java">
    public static final double fval = 2.00;
    public static double[] A = new double[N];
    public static int[] B = new int[N];

    public static void testP(){
	for (int i=0; i<N; i++) {
	   A[i] += A[i] * fval;
	   B[i] += B[i]+2;
        }
    }
</code></pre>

when use `-XX:+OptoScheduling` in aarch64, the sequence is
<pre><code class="shell">
190     B15: #	out( B15 B16 ) <- in( B14 B15 ) Loop( B15-B15 inner main of N118 strip mined) Freq: 9.9999e+11
190     sxtw  R13, R15	# i2l
194 +   add R14, R17, R13, LShiftL #3	# ptr
198     ldrd  V16, [R14, #16]	# double
19c +   fmuld   V18, V16, V17
1a0 +   faddd   V16, V18, V16
1a4     strd  V16, [R14, #16]	# double
1a8 +   add R13, R0, R13, LShiftL #2	# ptr
1ac +   ldrw  R1, [R13, #16]	# int
1b0 +   addw  R14, R1, R1
1b4 +   addw R1, R14, #2
1b8 +   addw R15, R15, #1
1bc     strw  R1, [R13, #16]	# int
1c0 +   cmpw  R15, R12
1c4     blt B15 	// counted loop end  P=1.000000 C=40960.000000
</code></pre>

Then a more efficient sequence should be:
<pre><code class="shell">
190     B15: #	out( B15 B16 ) <- in( B14 B15 ) Loop( B15-B15 inner main of N118 strip mined) Freq: 9.9999e+11
190     sxtw  R13, R14	# i2l
194     add R15, R17, R13, LShiftL #3	# ptr
198     add R13, R0, R13, LShiftL #2	# ptr
19c     ldrd  V16, [R15, #16]	# double
1a0     ldrw  R2, [R13, #16]	# int
1a4     fmuld   V18, V16, V17
1a8     addw  R1, R2, R2
1ac     faddd   V16, V18, V16
1b0     strd  V16, [R15, #16]	# double
1b4     addw R1, R1, #2
1b8     strw  R1, [R13, #16]	# int
1bc     addw R14, R14, #1
1c0     cmpw  R14, R12
1c4     blt B15 	// counted loop end  P=1.000000 C=40960.000000
</code></pre>

This problem also exists in MIPS architecture. This is a patch to fix this problem. Please help review it.
Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8277178](https://bugs.openjdk.java.net/browse/JDK-8277178): Reduce the priority of data dependent nodes when OptoScheduling enabled


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6407/head:pull/6407` \
`$ git checkout pull/6407`

Update a local copy of the PR: \
`$ git checkout pull/6407` \
`$ git pull https://git.openjdk.java.net/jdk pull/6407/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6407`

View PR using the GUI difftool: \
`$ git pr show -t 6407`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6407.diff">https://git.openjdk.java.net/jdk/pull/6407.diff</a>

</details>
