### PR TITLE
8276774: Cookie stored in CookieHandler not sent if user headers contain cookie

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
@@ -109,7 +109,8 @@ class Http1Request {
         final HttpHeaders uh = userHeaders;
 
         // Filter any headers from systemHeaders that are set in userHeaders
-        final HttpHeaders sh = HttpHeaders.of(systemHeaders.map(), (k,v) -> uh.firstValue(k).isEmpty());
+        final HttpHeaders sh = HttpHeaders.of(systemHeaders.map(),
+                (k,v) -> uh.firstValue(k).isEmpty());
 
         // If we're sending this request through a tunnel,
         // then don't send any preemptive proxy-* headers that
@@ -122,8 +123,8 @@ class Http1Request {
         // to the target server.
         collectHeaders1(sb, uh, nocookies);
 
-        // Gather all 'Cookie:' headers and concatenate their
-        // values in a single line.
+        // Gather all 'Cookie:' headers from the unfiltered system headers,
+        // and the user headers, and concatenate their values in a single line
         collectCookies(sb, systemHeaders, userHeaders);
 
         // terminate headers

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
@@ -109,18 +109,18 @@ class Http1Request {
         final HttpHeaders uh = userHeaders;
 
         // Filter any headers from systemHeaders that are set in userHeaders
-        systemHeaders = HttpHeaders.of(systemHeaders.map(), (k,v) -> uh.firstValue(k).isEmpty());
+        final HttpHeaders sh = HttpHeaders.of(systemHeaders.map(), (k,v) -> uh.firstValue(k).isEmpty());
 
         // If we're sending this request through a tunnel,
         // then don't send any preemptive proxy-* headers that
         // the authentication filter may have saved in its
         // cache.
-        collectHeaders1(sb, systemHeaders, nocookies);
+        collectHeaders1(sb, sh, nocookies);
 
         // If we're sending this request through a tunnel,
         // don't send any user-supplied proxy-* headers
         // to the target server.
-        collectHeaders1(sb, userHeaders, nocookies);
+        collectHeaders1(sb, uh, nocookies);
 
         // Gather all 'Cookie:' headers and concatenate their
         // values in a single line.

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -35,7 +35,6 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -247,7 +246,7 @@ class Stream<T> extends ExchangeImpl<T> {
                         debug.log("already completed: dropping error %s", (Object) t);
                 }
             } catch (Throwable x) {
-                Log.logError("Subscriber::onError threw exception: {0}", (Object) t);
+                Log.logError("Subscriber::onError threw exception: {0}", t);
             } finally {
                 cancelImpl(t);
                 drainInputQueue();
@@ -330,10 +329,7 @@ class Stream<T> extends ExchangeImpl<T> {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("streamid: ")
-                .append(streamid);
-        return sb.toString();
+        return "streamid: " + streamid;
     }
 
     private void receiveDataFrame(DataFrame df) {
@@ -400,7 +396,6 @@ class Stream<T> extends ExchangeImpl<T> {
         return sendBodyImpl().thenApply( v -> this);
     }
 
-    @SuppressWarnings("unchecked")
     Stream(Http2Connection connection,
            Exchange<T> e,
            WindowController windowController)
@@ -457,7 +452,7 @@ class Stream<T> extends ExchangeImpl<T> {
             case ResetFrame.TYPE        ->  incoming_reset((ResetFrame) frame);
             case PriorityFrame.TYPE     ->  incoming_priority((PriorityFrame) frame);
 
-            default -> throw new IOException("Unexpected frame: " + frame.toString());
+            default -> throw new IOException("Unexpected frame: " + frame);
         }
     }
 
@@ -663,7 +658,7 @@ class Stream<T> extends ExchangeImpl<T> {
         // Filter any headers from systemHeaders that are set in userHeaders
         //   except for "Cookies" - user cookies will be appended to system
         //   cookies
-        final HttpHeaders sh = HttpHeaders.of(sysh.map(), overrides);
+        sysh = HttpHeaders.of(sysh.map(), overrides);
 
         OutgoingHeaders<Stream<T>> f = new OutgoingHeaders<>(sysh, userh, this);
         if (contentLength == 0) {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -98,6 +98,7 @@ import jdk.internal.net.http.hpack.DecodingCallback;
  */
 class Stream<T> extends ExchangeImpl<T> {
 
+    private static final String COOKIE_HEADER = "Cookie";
     final Logger debug = Utils.getDebugLogger(this::dbgString, Utils.DEBUG);
 
     final ConcurrentLinkedQueue<Http2Frame> inputQ = new ConcurrentLinkedQueue<>();
@@ -655,8 +656,9 @@ class Stream<T> extends ExchangeImpl<T> {
 
         // Don't override Cookie values that have been set by the CookieHandler.
         final HttpHeaders uh = userh;
-        BiPredicate<String, String> overrides = (k, v) -> "Cookie".equalsIgnoreCase(k)
-                || uh.firstValue(k).isEmpty();
+        BiPredicate<String, String> overrides =
+                (k, v) -> COOKIE_HEADER.equalsIgnoreCase(k)
+                          || uh.firstValue(k).isEmpty();
 
         // Filter any headers from systemHeaders that are set in userHeaders
         //   except for "Cookies" - user cookies will be appended to system

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -656,7 +656,7 @@ class Stream<T> extends ExchangeImpl<T> {
                           || uh.firstValue(k).isEmpty();
 
         // Filter any headers from systemHeaders that are set in userHeaders
-        //   except for "Cookies" - user cookies will be appended to system
+        //   except for "Cookie:" - user cookies will be appended to system
         //   cookies
         sysh = HttpHeaders.of(sysh.map(), overrides);
 

--- a/test/jdk/java/net/httpclient/CookieHeaderTest.java
+++ b/test/jdk/java/net/httpclient/CookieHeaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/httpclient/UserCookieTest.java
+++ b/test/jdk/java/net/httpclient/UserCookieTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/httpclient/UserCookieTest.java
+++ b/test/jdk/java/net/httpclient/UserCookieTest.java
@@ -23,8 +23,9 @@
 
 /*
  * @test
- * @bug 8199851
- * @summary Test for multiple vs single cookie header for HTTP/2 vs HTTP/1.1
+ * @bug 8276774
+ * @summary Test that user-supplied cookies are appended to
+ *          server-cookies for HTTP/2 vs HTTP/1.1
  * @modules java.base/sun.net.www.http
  *          java.net.http/jdk.internal.net.http.common
  *          java.net.http/jdk.internal.net.http.frame


### PR DESCRIPTION
Hi,

Please find enclosed a patch that solves an unexpected interaction between server-set cookies and user-set cookies in the `java.net.HttpClient`.

In JDK 12 we fixed [JDK-8213189](https://bugs.openjdk.java.net/browse/JDK-8213189) to allow user-supplied header to take precedence over (that is, replace) system-headers. 
At the time the fact that server cookies would be added to the system-supplied headers by the `CookieHandler` (if present), and that a user-supplied cookie would therefore replace them (instead of simply appending to them)  was overlooked.

This fix proposes to restore the behavior of JDK 11 WRT to cookies - and arrange for user-supplied cookies to be appended to server-supplied cookies.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276774](https://bugs.openjdk.java.net/browse/JDK-8276774): Cookie stored in CookieHandler not sent if user headers contain cookie


### Reviewers
 * [Michael McMahon](https://openjdk.java.net/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6408/head:pull/6408` \
`$ git checkout pull/6408`

Update a local copy of the PR: \
`$ git checkout pull/6408` \
`$ git pull https://git.openjdk.java.net/jdk pull/6408/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6408`

View PR using the GUI difftool: \
`$ git pr show -t 6408`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6408.diff">https://git.openjdk.java.net/jdk/pull/6408.diff</a>

</details>
