### PR TITLE
JDK-8277175 : Add a parallel multiply method to BigInteger

### DIFF
--- a/test/jdk/java/math/BigInteger/BigIntegerParallelMultiplyTest.java
+++ b/test/jdk/java/math/BigInteger/BigIntegerParallelMultiplyTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @run main BigIntegerParallelMultiplyTest
+ * @summary tests parallelMultiply() method in BigInteger
+ * @author Heinz Kabutz heinz@javaspecialists.eu
+ */
+
+import java.math.BigInteger;
+import java.util.function.BinaryOperator;
+
+/**
+ * This is a simple test class created to ensure that the results
+ * of multiply() are the same as multiplyParallel(). We calculate
+ * the Fibonacci numbers using Dijkstra's sum of squares to get
+ * very large numbers (hundreds of thousands of bits).
+ *
+ * @author Heinz Kabutz, heinz@javaspecialists.eu
+ */
+public class BigIntegerParallelMultiplyTest {
+    public static BigInteger fibonacci(int n, BinaryOperator<BigInteger> multiplyOperator) {
+        if (n == 0) return BigInteger.ZERO;
+        if (n == 1) return BigInteger.ONE;
+
+        int half = (n + 1) / 2;
+        BigInteger f0 = fibonacci(half - 1, multiplyOperator);
+        BigInteger f1 = fibonacci(half, multiplyOperator);
+        if (n % 2 == 1) {
+            BigInteger b0 = multiplyOperator.apply(f0, f0);
+            BigInteger b1 = multiplyOperator.apply(f1, f1);
+            return b0.add(b1);
+        } else {
+            BigInteger b0 = f0.shiftLeft(1).add(f1);
+            return multiplyOperator.apply(b0, f1);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        for (int n = 0; n <= 10; n++) {
+            BigInteger fib = fibonacci(n, BigInteger::multiply);
+            System.out.printf("fibonacci(%d) = %d%n", n, fib);
+        }
+
+        compare(1000, 324);
+        compare(10_000, 3473);
+        compare(100_000, 34883);
+        compare(1_000_000, 347084);
+    }
+
+    private static void compare(int n, int expectedBitCount) {
+        BigInteger multiplyResult = fibonacci(n, BigInteger::multiply);
+        BigInteger parallelMultiplyResult = fibonacci(n, BigInteger::parallelMultiply);
+        checkBitCount(n, expectedBitCount, multiplyResult);
+        checkBitCount(n, expectedBitCount, parallelMultiplyResult);
+        if (!multiplyResult.equals(parallelMultiplyResult))
+            throw new AssertionError("multiply() and parallelMultiply() give different results");
+    }
+
+    private static void checkBitCount(int n, int expectedBitCount, BigInteger number) {
+        if (number.bitCount() != expectedBitCount)
+            throw new AssertionError(
+                    "bitCount of fibonacci(" + n + ") was expected to be " + expectedBitCount
+                            + " but was " + number.bitCount());
+    }
+}

--- a/test/micro/org/openjdk/bench/java/math/BigIntegerParallelMultiply.java
+++ b/test/micro/org/openjdk/bench/java/math/BigIntegerParallelMultiply.java
@@ -1,0 +1,61 @@
+package org.openjdk.bench.java.math;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.math.BigInteger;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BinaryOperator;
+
+/**
+ * Benchmark for checking performance difference between
+ * sequential and parallel multiply methods in BigInteger,
+ * using a large Fibonacci calculation of up to n = 100 million.
+ *
+ * @author Heinz Kabutz, heinz@javaspecialists.eu
+ */
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(value = 2, jvmArgsAppend = {"-XX:+UseParallelGC", "-Xmx16g", "-Xms16g", "-XX:+AlwaysPreTouch", "-XX:NewRatio=1", "-XX:SurvivorRatio=1"})
+@Warmup(iterations = 2)
+@Measurement(iterations = 2) // only 2 iterations because each one takes very long
+@State(Scope.Thread)
+public class BigIntegerParallelMultiply {
+    private static BigInteger fibonacci(int n, BinaryOperator<BigInteger> multiplyOperator) {
+        if (n == 0) return BigInteger.ZERO;
+        if (n == 1) return BigInteger.ONE;
+
+        int half = (n + 1) / 2;
+        BigInteger f0 = fibonacci(half - 1, multiplyOperator);
+        BigInteger f1 = fibonacci(half, multiplyOperator);
+        if (n % 2 == 1) {
+            BigInteger b0 = multiplyOperator.apply(f0, f0);
+            BigInteger b1 = multiplyOperator.apply(f1, f1);
+            return b0.add(b1);
+        } else {
+            BigInteger b0 = f0.shiftLeft(1).add(f1);
+            return multiplyOperator.apply(b0, f1);
+        }
+    }
+
+    @Param({"1000000", "10000000", "100000000"})
+    private int n;
+
+    @Benchmark
+    public void multiply() {
+        fibonacci(n, BigInteger::multiply);
+    }
+
+    @Benchmark
+    public void parallelMultiply() {
+        fibonacci(n, BigInteger::parallelMultiply);
+    }
+}


### PR DESCRIPTION
BigInteger currently uses three different algorithms for multiply. The simple quadratic algorithm, then the slightly better Karatsuba if we exceed a bit count and then Toom Cook 3 once we go into the several thousands of bits. Since Toom Cook 3 is a recursive algorithm, it is trivial to parallelize it. I have demonstrated this several times in conference talks. In order to be consistent with other classes such as Arrays and Collection, I have added a parallelMultiply() method. Internally we have added a parameter to the private multiply method to indicate whether the calculation should be done in parallel.

The performance improvements are as should be expected. Fibonacci of 100 million (using a single-threaded Dijkstra's sum of squares version) completes in 9.2 seconds with the parallelMultiply() vs 25.3 seconds with the sequential multiply() method. This is on my 1-8-2 laptop. The final multiplications are with very large numbers, which then benefit from the parallelization of Toom-Cook 3. Fibonacci 100 million is a 347084 bit number.

We have also parallelized the private square() method. Internally, the square() method defaults to be sequential.

Some benchmark results, run on my 1-6-2 server:

```
Benchmark                                          (n)  Mode  Cnt      Score      Error  Units
BigIntegerParallelMultiply.multiply            1000000    ss    4     51.707 ±   11.194  ms/op
BigIntegerParallelMultiply.multiply           10000000    ss    4    988.302 ±  235.977  ms/op
BigIntegerParallelMultiply.multiply          100000000    ss    4  24662.063 ± 1123.329  ms/op
BigIntegerParallelMultiply.parallelMultiply    1000000    ss    4     49.337 ±   26.611  ms/op
BigIntegerParallelMultiply.parallelMultiply   10000000    ss    4    527.560 ±  268.903  ms/op
BigIntegerParallelMultiply.parallelMultiply  100000000    ss    4   9076.551 ± 1899.444  ms/op
```

We can see that for larger calculations (fib 100m), the execution is 2.7x faster in parallel. For medium size (fib 10m) it is 1.873x faster. And for small (fib 1m) it is roughly the same. Considering that the fibonacci algorithm that we used was in itself sequential, and that the last 3 calculations would dominate, 2.7x faster should probably be considered quite good on a 1-6-2 machine.