### PR TITLE
8277221: G1: Remove methods without implementations in G1CollectedHeap

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -777,8 +777,6 @@ public:
   // Start a concurrent cycle.
   void start_concurrent_cycle(bool concurrent_operation_is_full_mark);
 
-  void wait_for_root_region_scanning();
-
   void prepare_tlabs_for_mutator();
 
   void retire_tlabs();
@@ -935,9 +933,6 @@ public:
   GrowableArray<MemoryPool*> memory_pools() override;
 
   void fill_with_dummy_object(HeapWord* start, HeapWord* end, bool zap) override;
-
-  // Try to minimize the remembered set.
-  void scrub_rem_set();
 
   // Apply the given closure on all cards in the Hot Card Cache, emptying it.
   void iterate_hcc_closure(G1CardTableEntryClosure* cl, uint worker_id);


### PR DESCRIPTION
Trivial change of removing dead code.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277221](https://bugs.openjdk.java.net/browse/JDK-8277221): G1: Remove methods without implementations in G1CollectedHeap


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6414/head:pull/6414` \
`$ git checkout pull/6414`

Update a local copy of the PR: \
`$ git checkout pull/6414` \
`$ git pull https://git.openjdk.java.net/jdk pull/6414/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6414`

View PR using the GUI difftool: \
`$ git pr show -t 6414`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6414.diff">https://git.openjdk.java.net/jdk/pull/6414.diff</a>

</details>
