### PR TITLE
8277137: Set OnSpinWaitInst/OnSpinWaitInstCount defaults to "isb"/1 for Arm Neoverse N1

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -203,8 +203,11 @@ void VM_Version::initialize() {
       FLAG_SET_DEFAULT(UseSIMDForMemoryOps, true);
     }
 
-    if (FLAG_IS_DEFAULT(OnSpinWaitInst) && FLAG_IS_DEFAULT(OnSpinWaitInstCount)) {
+    if (FLAG_IS_DEFAULT(OnSpinWaitInst)) {
       FLAG_SET_DEFAULT(OnSpinWaitInst, "isb");
+    }
+
+    if (FLAG_IS_DEFAULT(OnSpinWaitInstCount)) {
       FLAG_SET_DEFAULT(OnSpinWaitInstCount, 1);
     }
   }

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -202,6 +202,10 @@ void VM_Version::initialize() {
     if (FLAG_IS_DEFAULT(UseSIMDForMemoryOps)) {
       FLAG_SET_DEFAULT(UseSIMDForMemoryOps, true);
     }
+
+    if (FLAG_IS_DEFAULT(OnSpinWaitInst) && FLAG_IS_DEFAULT(OnSpinWaitInstCount)) {
+      FLAG_SET_DEFAULT(OnSpinWaitInst, "isb");
+    }
   }
 
   if (_cpu == CPU_ARM) {

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -205,6 +205,7 @@ void VM_Version::initialize() {
 
     if (FLAG_IS_DEFAULT(OnSpinWaitInst) && FLAG_IS_DEFAULT(OnSpinWaitInstCount)) {
       FLAG_SET_DEFAULT(OnSpinWaitInst, "isb");
+      FLAG_SET_DEFAULT(OnSpinWaitInstCount, 1);
     }
   }
 

--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitAArch64DefaultFlags.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitAArch64DefaultFlags.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test TestOnSpinWaitAArch64DefaultFlags
+ * @summary Check default values of '-XX:OnSpinWaitInst' and '-XX:OnSpinWaitInstCount' for AArch64 implementations.
+ * @bug 8277137
+ * @library /test/lib /
+ *
+ * @requires os.arch=="aarch64"
+ *
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI
+ *                   compiler.onSpinWait.TestOnSpinWaitAArch64DefaultFlags
+ */
+
+package compiler.onSpinWait;
+
+import java.util.Iterator;
+import java.util.List;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import sun.hotspot.cpuinfo.CPUInfo;
+
+public class TestOnSpinWaitAArch64DefaultFlags {
+    private static boolean isCPUModelNeoverseN1(String cpuModel) {
+        return cpuModel.contains("0xd0c");
+    }
+
+    private static void checkFlagsDefaultsEqualTo(String expectedOnSpinWaitInstValue, String expectedOnSpinWaitInstCountValue) throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+PrintFlagsFinal", "-version");
+        OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
+        analyzer.shouldHaveExitValue(0);
+
+        Iterator<String> iter = analyzer.asLines().listIterator();
+        String line = null;
+        boolean hasExpectedOnSpinWaitInstValue = false;
+        boolean hasExpectedOnSpinWaitInstCountValue = false;
+        while (iter.hasNext()) {
+            line = iter.next();
+            if (!hasExpectedOnSpinWaitInstValue && line.contains("ccstr OnSpinWaitInst")) {
+                hasExpectedOnSpinWaitInstValue = line.contains("= " + expectedOnSpinWaitInstValue);
+            }
+
+            if (!hasExpectedOnSpinWaitInstCountValue && line.contains("uint OnSpinWaitInstCount")) {
+                hasExpectedOnSpinWaitInstCountValue = line.contains("= " + expectedOnSpinWaitInstCountValue);
+            }
+        }
+        if (!hasExpectedOnSpinWaitInstValue) {
+            System.out.println(analyzer.getOutput());
+            throw new RuntimeException("OnSpinWaitInst with the expected value '" + expectedOnSpinWaitInstValue + "' not found.");
+        }
+        if (!hasExpectedOnSpinWaitInstCountValue) {
+            System.out.println(analyzer.getOutput());
+            throw new RuntimeException("OnSpinWaitInstCount with the expected value '" + expectedOnSpinWaitInstCountValue + "' not found.");
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        List<String> cpuFeatures = CPUInfo.getFeatures();
+        if (cpuFeatures.isEmpty()) {
+            System.out.println("Skip because no CPU features are available.");
+            return;
+        }
+
+        final String cpuModel = cpuFeatures.get(0);
+
+        if (isCPUModelNeoverseN1(cpuModel)) {
+            checkFlagsDefaultsEqualTo("isb", "1");
+        } else {
+            System.out.println("Skip because no defaults for CPU model: " + cpuModel);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitAArch64DefaultFlags.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitAArch64DefaultFlags.java
@@ -49,8 +49,7 @@ public class TestOnSpinWaitAArch64DefaultFlags {
         return cpuModel.contains("0xd0c");
     }
 
-    private static void checkFlagsDefaultsEqualTo(String expectedOnSpinWaitInstValue, String expectedOnSpinWaitInstCountValue) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+PrintFlagsFinal", "-version");
+    private static void checkFinalFlagsEqualTo(ProcessBuilder pb, String expectedOnSpinWaitInstValue, String expectedOnSpinWaitInstCountValue) throws Exception {
         OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
         analyzer.shouldHaveExitValue(0);
 
@@ -88,7 +87,9 @@ public class TestOnSpinWaitAArch64DefaultFlags {
         final String cpuModel = cpuFeatures.get(0);
 
         if (isCPUModelNeoverseN1(cpuModel)) {
-            checkFlagsDefaultsEqualTo("isb", "1");
+            checkFinalFlagsEqualTo(ProcessTools.createJavaProcessBuilder("-XX:+PrintFlagsFinal", "-version"), "isb", "1");
+            checkFinalFlagsEqualTo(ProcessTools.createJavaProcessBuilder("-XX:+UnlockDiagnosticVMOptions", "-XX:OnSpinWaitInstCount=2", "-XX:+PrintFlagsFinal", "-version"),
+                "isb", "2");
         } else {
             System.out.println("Skip because no defaults for CPU model: " + cpuModel);
         }


### PR DESCRIPTION
One `ISB` implementation of `Thread.OnSpinWait` shows performance improvements on Graviton2 (Arm Neoverse N1 implementation), e.g. https://github.com/openjdk/jdk/pull/5562#issuecomment-966153163. 

Testing:
- `make test TEST=gtest`: Passed
- `make run-test TEST=tier1`: Passed
- `make run-test TEST=tier2`: Passed
- `make run-test TEST=hotspot/jtreg/compiler/onSpinWait`: Passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277137](https://bugs.openjdk.java.net/browse/JDK-8277137): Set OnSpinWaitInst/OnSpinWaitInstCount defaults to "isb"/1 for Arm Neoverse N1


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [Nick Gasson](https://openjdk.java.net/census#ngasson) (@nick-arm - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6415/head:pull/6415` \
`$ git checkout pull/6415`

Update a local copy of the PR: \
`$ git checkout pull/6415` \
`$ git pull https://git.openjdk.java.net/jdk pull/6415/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6415`

View PR using the GUI difftool: \
`$ git pr show -t 6415`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6415.diff">https://git.openjdk.java.net/jdk/pull/6415.diff</a>

</details>
