### PR TITLE
8277246: Check for NonRepudiation as well when validating a TSA certificate

### DIFF
--- a/src/java.base/share/classes/sun/security/validator/EndEntityChecker.java
+++ b/src/java.base/share/classes/sun/security/validator/EndEntityChecker.java
@@ -105,6 +105,7 @@ class EndEntityChecker {
 
     // bit numbers in the key usage extension
     private static final int KU_SIGNATURE = 0;
+    private static final int KU_NON_REPUDIATION = 1;
     private static final int KU_KEY_ENCIPHERMENT = 2;
     private static final int KU_KEY_AGREEMENT = 4;
 
@@ -351,11 +352,19 @@ class EndEntityChecker {
 
     /**
      * Check whether this certificate can be used by a time stamping authority
-     * server. RFC 3161 section 2.3 only requires EKU with id-kp-timeStamping.
+     * server (see RFC 3161, section 2.3).
      * @throws CertificateException if not.
      */
     private void checkTSAServer(X509Certificate cert, Set<String> exts)
             throws CertificateException {
+        // KU and EKU should be consistent
+        if (!checkKeyUsage(cert, KU_SIGNATURE)
+                && !checkKeyUsage(cert, KU_NON_REPUDIATION)) {
+            throw new ValidatorException
+                ("KeyUsage does not allow digital signatures or non repudiation",
+                ValidatorException.T_EE_EXTENSIONS, cert);
+        }
+
         if (cert.getExtendedKeyUsage() == null) {
             throw new ValidatorException
                 ("Certificate does not contain an extended key usage " +

--- a/src/java.base/share/classes/sun/security/validator/EndEntityChecker.java
+++ b/src/java.base/share/classes/sun/security/validator/EndEntityChecker.java
@@ -356,12 +356,6 @@ class EndEntityChecker {
      */
     private void checkTSAServer(X509Certificate cert, Set<String> exts)
             throws CertificateException {
-        if (checkKeyUsage(cert, KU_SIGNATURE) == false) {
-            throw new ValidatorException
-                ("KeyUsage does not allow digital signatures",
-                ValidatorException.T_EE_EXTENSIONS, cert);
-        }
-
         if (cert.getExtendedKeyUsage() == null) {
             throw new ValidatorException
                 ("Certificate does not contain an extended key usage " +

--- a/src/java.base/share/classes/sun/security/validator/EndEntityChecker.java
+++ b/src/java.base/share/classes/sun/security/validator/EndEntityChecker.java
@@ -351,7 +351,7 @@ class EndEntityChecker {
 
     /**
      * Check whether this certificate can be used by a time stamping authority
-     * server (see RFC 3161, section 2.3).
+     * server. RFC 3161 section 2.3 only requires EKU with id-kp-timeStamping.
      * @throws CertificateException if not.
      */
     private void checkTSAServer(X509Certificate cert, Set<String> exts)

--- a/test/jdk/sun/security/tools/jarsigner/TimestampCheck.java
+++ b/test/jdk/sun/security/tools/jarsigner/TimestampCheck.java
@@ -845,7 +845,7 @@ public class TimestampCheck {
         gencert("weakkeysize");
         gencert("disabledkeysize");
         gencert("badku", "-ext ku:critical=keyAgreement");
-        gencert("ts", "-ext eku:critical=ts -validity 500");
+        gencert("ts", "-ext eku:critical=ts -ext ku=nonrep -validity 500");
 
         gencert("expired", "-validity 10 -startdate -12d");
         gencert("expiring", "-validity 178");


### PR DESCRIPTION
There is no need to check for the KeyUsage extension when validating a TSA certificate.

A test is modified where a TSA cert has a KeyUsage but without the DigitalSignature bit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277246](https://bugs.openjdk.java.net/browse/JDK-8277246): Check for NonRepudiation as well when validating a TSA certificate


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**) ⚠️ Review applies to a5b3bc86fe37de72e54c40866ed3754ff0cfe797
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6416/head:pull/6416` \
`$ git checkout pull/6416`

Update a local copy of the PR: \
`$ git checkout pull/6416` \
`$ git pull https://git.openjdk.java.net/jdk pull/6416/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6416`

View PR using the GUI difftool: \
`$ git pr show -t 6416`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6416.diff">https://git.openjdk.java.net/jdk/pull/6416.diff</a>

</details>
