### PR TITLE
8275037: Test vmTestbase/nsk/sysdict/vm/stress/btree/btree011/btree011.java crashes with memory exhaustion on Windows

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/share/GenClassesBuilder.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/share/GenClassesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,6 +71,7 @@ public class GenClassesBuilder {
         moveJavaFiles(genSrcDir, prefix);
 
         JDKToolLauncher javac = JDKToolLauncher.create("javac")
+                                               .addToolArg("-J-Xmx1G")
                                                .addToolArg("-d")
                                                .addToolArg(classesDir.toString())
                                                .addToolArg("-cp")

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/share/SysDictTest.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/share/SysDictTest.java
@@ -148,8 +148,8 @@ public abstract class SysDictTest extends ThreadedGCTest {
                     // set name into public variable just to be sure
                     // that class is loaded
                     tmp = clz.getName();
-                } catch (OutOfMemoryError | ClassNotFoundException e) {
-                    // just ignore
+                } catch (OutOfMemoryError | ClassNotFoundException | NoClassDefFoundError e) {
+                    // just ignore, note that CNFE and NCDFE can be caused by OOM exceptions.
                 } catch (StackOverflowError soe) {
                     // just ignore, chains could be too large
                     // StackOverflowError could be in some sparcs


### PR DESCRIPTION
Please review this fix for JDK-8275037.  The .../sysdict/vm/stress/btree tests were intermittently failing on Windows because invocations of javac by the tests were running out of memory.  The fix sets the maximum heap to 1G when the tests invoke javac.

Additionally, the fix ignores NoClassDefFoundError exceptions thrown by Class.forName() because those exceptions can be caused by a running out of memory when initializing a class.

The fix was tested by running each .../sysdict/vm/stress test over 2000 times on Windows x64 debug builds.  Additionally, each test was run hundreds of times on Linux x64, Linux aarch64, Macosx x64, and Macosx aarch64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275037](https://bugs.openjdk.java.net/browse/JDK-8275037): Test vmTestbase/nsk/sysdict/vm/stress/btree/btree011/btree011.java crashes with memory exhaustion on Windows


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6419/head:pull/6419` \
`$ git checkout pull/6419`

Update a local copy of the PR: \
`$ git checkout pull/6419` \
`$ git pull https://git.openjdk.java.net/jdk pull/6419/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6419`

View PR using the GUI difftool: \
`$ git pr show -t 6419`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6419.diff">https://git.openjdk.java.net/jdk/pull/6419.diff</a>

</details>
