### PR TITLE
Simplify async monitor deflation

### DIFF
--- a/src/hotspot/share/gc/shared/oopStorage.inline.hpp
+++ b/src/hotspot/share/gc/shared/oopStorage.inline.hpp
@@ -30,7 +30,8 @@
 #include "memory/allocation.hpp"
 #include "metaprogramming/conditional.hpp"
 #include "metaprogramming/isConst.hpp"
-#include "oops/oop.hpp"
+#include "oops/oop.inline.hpp"
+#include "runtime/objectMonitor.hpp"
 #include "runtime/safepoint.hpp"
 #include "utilities/align.hpp"
 #include "utilities/count_trailing_zeros.hpp"
@@ -263,6 +264,7 @@ public:
         result = _f(ptr);
       } else {
         *ptr = NULL;            // Clear dead value.
+        ObjectMonitor::maybe_deflate_dead(v, ptr);
       }
     }
     return result;

--- a/src/hotspot/share/gc/shared/weakProcessor.inline.hpp
+++ b/src/hotspot/share/gc/shared/weakProcessor.inline.hpp
@@ -33,7 +33,9 @@
 #include "gc/shared/oopStorageSet.hpp"
 #include "gc/shared/weakProcessorTimes.hpp"
 #include "gc/shared/workerThread.hpp"
+#include "oops/oop.inline.hpp"
 #include "prims/resolvedMethodTable.hpp"
+#include "runtime/objectMonitor.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/enumIterator.hpp"
 
@@ -65,7 +67,9 @@ public:
       _keep_alive->do_oop(p);
       ++_live;
     } else {
+      oop v = *p;
       *p = NULL;
+      ObjectMonitor::maybe_deflate_dead(v, p);
       ++_new_dead;
     }
   }

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -698,13 +698,6 @@ const intx ObjectAlignmentInBytes = 8;
           "for use with MonitorUsedDeflationThreshold (0 is off).")         \
           range(0, max_uintx)                                               \
                                                                             \
-  /* notice: the max range value here is max_jint, not max_intx  */         \
-  /* because of overflow issue                                   */         \
-  product(intx, MonitorDeflationMax, 1000000, DIAGNOSTIC,                   \
-          "The maximum number of monitors to deflate, unlink and delete "   \
-          "at one time (minimum is 1024).")                      \
-          range(1024, max_jint)                                             \
-                                                                            \
   product(intx, MonitorUsedDeflationThreshold, 90, DIAGNOSTIC,              \
           "Percentage of used monitors before triggering deflation (0 is "  \
           "off). The check is performed on GuaranteedSafepointInterval "    \

--- a/src/hotspot/share/runtime/synchronizer.hpp
+++ b/src/hotspot/share/runtime/synchronizer.hpp
@@ -146,8 +146,6 @@ class ObjectSynchronizer : AllStatic {
   static void chk_for_block_req(JavaThread* current, const char* op_name,
                                 const char* cnt_name, size_t cnt, LogStream* ls,
                                 elapsedTimer* timer_p);
-  static size_t deflate_monitor_list(Thread* current, LogStream* ls,
-                                     elapsedTimer* timer_p);
   static size_t in_use_list_ceiling();
   static void dec_in_use_list_ceiling();
   static void inc_in_use_list_ceiling();


### PR DESCRIPTION
Experiment that ties objectmonitor lifecycle to lock object lifecycle, instead of trying to pick up and deflate idle monitors.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6420/head:pull/6420` \
`$ git checkout pull/6420`

Update a local copy of the PR: \
`$ git checkout pull/6420` \
`$ git pull https://git.openjdk.java.net/jdk pull/6420/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6420`

View PR using the GUI difftool: \
`$ git pr show -t 6420`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6420.diff">https://git.openjdk.java.net/jdk/pull/6420.diff</a>

</details>
