### PR TITLE
8275071: [macos] A11y cursor gets stuck when combobox is closed

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
@@ -164,24 +164,18 @@ class CAccessible extends CFRetainedResource implements Accessible {
                         treeNodeCollapsed(ptr);
                     }
 
-                    // At least for now don't handle combo box menu state changes.
-                    // This may change when later fixing issues which currently
-                    // exist for combo boxes, but for now the following is only
-                    // for JPopupMenus, not for combobox menus.
-                    if (parentRole != AccessibleRole.COMBO_BOX) {
-                        if (thisRole == AccessibleRole.POPUP_MENU) {
-                            if ( newValue != null &&
-                                 ((AccessibleState)newValue) == AccessibleState.VISIBLE ) {
-                                    menuOpened(ptr);
-                            } else if ( oldValue != null &&
-                                        ((AccessibleState)oldValue) == AccessibleState.VISIBLE ) {
-                                menuClosed(ptr);
-                            }
-                        } else if (thisRole == AccessibleRole.MENU_ITEM) {
-                            if ( newValue != null &&
-                                 ((AccessibleState)newValue) == AccessibleState.FOCUSED ) {
-                                menuItemSelected(ptr);
-                            }
+                    if (thisRole == AccessibleRole.POPUP_MENU) {
+                        if ( newValue != null &&
+                                ((AccessibleState)newValue) == AccessibleState.VISIBLE ) {
+                            menuOpened(ptr);
+                        } else if ( oldValue != null &&
+                                ((AccessibleState)oldValue) == AccessibleState.VISIBLE ) {
+                            menuClosed(ptr);
+                        }
+                    } else if (thisRole == AccessibleRole.MENU_ITEM) {
+                        if ( newValue != null &&
+                                ((AccessibleState)newValue) == AccessibleState.FOCUSED ) {
+                            menuItemSelected(ptr);
                         }
                     }
 


### PR DESCRIPTION
Before the new JList accessibility peer implementation sending popup closed
event to the combobox popup could trigger the native memory access error due
to the events arriving in the wrong order. After new implementation is done
it is no longer the case and this workaround needs to be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275071](https://bugs.openjdk.java.net/browse/JDK-8275071): [macos] A11y cursor gets stuck when combobox is closed


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6422/head:pull/6422` \
`$ git checkout pull/6422`

Update a local copy of the PR: \
`$ git checkout pull/6422` \
`$ git pull https://git.openjdk.java.net/jdk pull/6422/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6422`

View PR using the GUI difftool: \
`$ git pr show -t 6422`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6422.diff">https://git.openjdk.java.net/jdk/pull/6422.diff</a>

</details>
