### PR TITLE
8277313: Validate header failed for test/jdk/java/net/httpclient/HeadTest.java

### DIFF
--- a/test/jdk/java/net/httpclient/HeadTest.java
+++ b/test/jdk/java/net/httpclient/HeadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
With the integration of JDK-8276559, validate header failed as there is one missing comma after 2021 in `test/jdk/java/net/httpclient/HeadTest.java`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277313](https://bugs.openjdk.java.net/browse/JDK-8277313): Validate header failed for test/jdk/java/net/httpclient/HeadTest.java


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6424/head:pull/6424` \
`$ git checkout pull/6424`

Update a local copy of the PR: \
`$ git checkout pull/6424` \
`$ git pull https://git.openjdk.java.net/jdk pull/6424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6424`

View PR using the GUI difftool: \
`$ git pr show -t 6424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6424.diff">https://git.openjdk.java.net/jdk/pull/6424.diff</a>

</details>
