### PR TITLE
JDK-8277303: Terminology mismatch between JLS17-3.9 and SE17's javax.lang.model.SourceVersion method specs

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
+++ b/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
@@ -312,8 +312,8 @@ public enum SourceVersion {
      * Character#isJavaIdentifierStart(int)} returns {@code true},
      * followed only by characters for which {@link
      * Character#isJavaIdentifierPart(int)} returns {@code true}.
-     * This pattern matches regular identifiers, keywords, restricted
-     * keywords, restricted identifiers and the literals {@code "true"},
+     * This pattern matches regular identifiers, keywords, contextual
+     * keywords, and the literals {@code "true"},
      * {@code "false"}, {@code "null"}.
      *
      * The method returns {@code false} for all other strings.
@@ -359,8 +359,8 @@ public enum SourceVersion {
      * {@code false} for keywords, boolean literals, and the null
      * literal in any segment.
      *
-     * This method returns {@code true} for <i>restricted
-     * keywords</i> and <i>restricted identifiers</i>.
+     * This method returns {@code true} for <i>contextual
+     * keywords</i>.
      *
      * @param name the string to check
      * @return {@code true} if this string is a
@@ -385,8 +385,8 @@ public enum SourceVersion {
      * {@code false} for keywords, boolean literals, and the null
      * literal in any segment.
      *
-     * This method returns {@code true} for <i>restricted
-     * keywords</i> and <i>restricted identifiers</i>.
+     * This method returns {@code true} for <i>contextual
+     * keywords</i>.
      *
      * @param name the string to check
      * @param version the version to use
@@ -409,8 +409,8 @@ public enum SourceVersion {
     /**
      * Returns whether or not {@code s} is a keyword, boolean literal,
      * or null literal in the latest source version.
-     * This method returns {@code false} for <i>restricted
-     * keywords</i> and <i>restricted identifiers</i>.
+     * This method returns {@code false} for <i>contextual
+     * keywords</i>.
      *
      * @param s the string to check
      * @return {@code true} if {@code s} is a keyword, or boolean
@@ -426,8 +426,8 @@ public enum SourceVersion {
     /**
      * Returns whether or not {@code s} is a keyword, boolean literal,
      * or null literal in the given source version.
-     * This method returns {@code false} for <i>restricted
-     * keywords</i> and <i>restricted identifiers</i>.
+     * This method returns {@code false} for <i>contextual
+     * keywords</i>.
      *
      * @param s the string to check
      * @param version the version to use


### PR DESCRIPTION
Please review this simple terminology update along with the corresponding CSR:

https://bugs.openjdk.java.net/browse/JDK-8277325

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277303](https://bugs.openjdk.java.net/browse/JDK-8277303): Terminology mismatch between JLS17-3.9 and SE17's javax.lang.model.SourceVersion method specs


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6425/head:pull/6425` \
`$ git checkout pull/6425`

Update a local copy of the PR: \
`$ git checkout pull/6425` \
`$ git pull https://git.openjdk.java.net/jdk pull/6425/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6425`

View PR using the GUI difftool: \
`$ git pr show -t 6425`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6425.diff">https://git.openjdk.java.net/jdk/pull/6425.diff</a>

</details>
