### PR TITLE
8277324: C2 compilation fails with "bad AD file" on x86-32 after JDK-8276162 due to missing match rule

### DIFF
--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -13154,20 +13154,18 @@ instruct cmovII_reg_LTGE_U(cmpOpU cmp, flagsReg_ulong_LTGE flags, rRegI dst, rRe
   predicate(VM_Version::supports_cmov() && ( _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::lt || _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::ge ));
   match(Set dst (CMoveI (Binary cmp flags) (Binary dst src)));
   ins_cost(200);
-  format %{ "CMOV$cmp $dst,$src" %}
-  opcode(0x0F,0x40);
-  ins_encode( enc_cmov(cmp), RegReg( dst, src ) );
-  ins_pipe( pipe_cmov_reg );
+  expand %{
+    cmovII_reg_LTGE(cmp, flags, dst, src);
+  %}
 %}
 
 instruct cmovII_mem_LTGE_U(cmpOpU cmp, flagsReg_ulong_LTGE flags, rRegI dst, memory src) %{
   predicate(VM_Version::supports_cmov() && ( _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::lt || _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::ge ));
   match(Set dst (CMoveI (Binary cmp flags) (Binary dst (LoadI src))));
   ins_cost(250);
-  format %{ "CMOV$cmp $dst,$src" %}
-  opcode(0x0F,0x40);
-  ins_encode( enc_cmov(cmp), RegMem( dst, src ) );
-  ins_pipe( pipe_cmov_mem );
+  expand %{
+    cmovII_mem_LTGE(cmp, flags, dst, src);
+  %}
 %}
 
 // Compare 2 longs and CMOVE ptrs.
@@ -13337,20 +13335,18 @@ instruct cmovII_reg_EQNE_U(cmpOpU cmp, flagsReg_ulong_EQNE flags, rRegI dst, rRe
   predicate(VM_Version::supports_cmov() && ( _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::eq || _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::ne ));
   match(Set dst (CMoveI (Binary cmp flags) (Binary dst src)));
   ins_cost(200);
-  format %{ "CMOV$cmp $dst,$src" %}
-  opcode(0x0F,0x40);
-  ins_encode( enc_cmov(cmp), RegReg( dst, src ) );
-  ins_pipe( pipe_cmov_reg );
+  expand %{
+    cmovII_reg_EQNE(cmp, flags, dst, src);
+  %}
 %}
 
 instruct cmovII_mem_EQNE_U(cmpOpU cmp, flagsReg_ulong_EQNE flags, rRegI dst, memory src) %{
   predicate(VM_Version::supports_cmov() && ( _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::eq || _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::ne ));
   match(Set dst (CMoveI (Binary cmp flags) (Binary dst (LoadI src))));
   ins_cost(250);
-  format %{ "CMOV$cmp $dst,$src" %}
-  opcode(0x0F,0x40);
-  ins_encode( enc_cmov(cmp), RegMem( dst, src ) );
-  ins_pipe( pipe_cmov_mem );
+  expand %{
+    cmovII_mem_EQNE(cmp, flags, dst, src);
+  %}
 %}
 
 // Compare 2 longs and CMOVE ptrs.
@@ -13509,22 +13505,18 @@ instruct cmovLL_reg_LEGT_U(cmpOpU_commute cmp, flagsReg_ulong_LEGT flags, eRegL 
   match(Set dst (CMoveL (Binary cmp flags) (Binary dst src)));
   predicate(VM_Version::supports_cmov() && ( _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::le || _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::gt ));
   ins_cost(400);
-  format %{ "CMOV$cmp $dst.lo,$src.lo\n\t"
-            "CMOV$cmp $dst.hi,$src.hi" %}
-  opcode(0x0F,0x40);
-  ins_encode( enc_cmov(cmp), RegReg_Lo2( dst, src ), enc_cmov(cmp), RegReg_Hi2( dst, src ) );
-  ins_pipe( pipe_cmov_reg_long );
+  expand %{
+    cmovLL_reg_LEGT(cmp, flags, dst, src);
+  %}
 %}
 
 instruct cmovLL_mem_LEGT_U(cmpOpU_commute cmp, flagsReg_ulong_LEGT flags, eRegL dst, load_long_memory src) %{
   match(Set dst (CMoveL (Binary cmp flags) (Binary dst (LoadL src))));
   predicate(VM_Version::supports_cmov() && ( _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::le || _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::gt ));
   ins_cost(500);
-  format %{ "CMOV$cmp $dst.lo,$src.lo\n\t"
-            "CMOV$cmp $dst.hi,$src.hi+4" %}
-  opcode(0x0F,0x40);
-  ins_encode( enc_cmov(cmp), RegMem(dst, src), enc_cmov(cmp), RegMem_Hi(dst, src) );
-  ins_pipe( pipe_cmov_reg_long );
+  expand %{
+    cmovLL_mem_LEGT(cmp, flags, dst, src);
+  %}
 %}
 
 // Compare 2 longs and CMOVE ints.
@@ -13552,20 +13544,18 @@ instruct cmovII_reg_LEGT_U(cmpOpU_commute cmp, flagsReg_ulong_LEGT flags, rRegI 
   predicate(VM_Version::supports_cmov() && ( _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::le || _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::gt ));
   match(Set dst (CMoveI (Binary cmp flags) (Binary dst src)));
   ins_cost(200);
-  format %{ "CMOV$cmp $dst,$src" %}
-  opcode(0x0F,0x40);
-  ins_encode( enc_cmov(cmp), RegReg( dst, src ) );
-  ins_pipe( pipe_cmov_reg );
+  expand %{
+    cmovII_reg_LEGT(cmp, flags, dst, src);
+  %}
 %}
 
 instruct cmovII_mem_LEGT_U(cmpOpU_commute cmp, flagsReg_ulong_LEGT flags, rRegI dst, memory src) %{
   predicate(VM_Version::supports_cmov() && ( _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::le || _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::gt ));
   match(Set dst (CMoveI (Binary cmp flags) (Binary dst (LoadI src))));
   ins_cost(250);
-  format %{ "CMOV$cmp $dst,$src" %}
-  opcode(0x0F,0x40);
-  ins_encode( enc_cmov(cmp), RegMem( dst, src ) );
-  ins_pipe( pipe_cmov_mem );
+  expand %{
+    cmovII_mem_LEGT(cmp, flags, dst, src);
+  %}
 %}
 
 // Compare 2 longs and CMOVE ptrs.

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -13150,7 +13150,27 @@ instruct cmovII_mem_LTGE(cmpOp cmp, flagsReg_long_LTGE flags, rRegI dst, memory 
   ins_pipe( pipe_cmov_mem );
 %}
 
-// Compare 2 longs and CMOVE ints.
+instruct cmovII_reg_LTGE_U(cmpOpU cmp, flagsReg_ulong_LTGE flags, rRegI dst, rRegI src) %{
+  predicate(VM_Version::supports_cmov() && ( _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::lt || _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::ge ));
+  match(Set dst (CMoveI (Binary cmp flags) (Binary dst src)));
+  ins_cost(200);
+  format %{ "CMOV$cmp $dst,$src" %}
+  opcode(0x0F,0x40);
+  ins_encode( enc_cmov(cmp), RegReg( dst, src ) );
+  ins_pipe( pipe_cmov_reg );
+%}
+
+instruct cmovII_mem_LTGE_U(cmpOpU cmp, flagsReg_ulong_LTGE flags, rRegI dst, memory src) %{
+  predicate(VM_Version::supports_cmov() && ( _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::lt || _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::ge ));
+  match(Set dst (CMoveI (Binary cmp flags) (Binary dst (LoadI src))));
+  ins_cost(250);
+  format %{ "CMOV$cmp $dst,$src" %}
+  opcode(0x0F,0x40);
+  ins_encode( enc_cmov(cmp), RegMem( dst, src ) );
+  ins_pipe( pipe_cmov_mem );
+%}
+
+// Compare 2 longs and CMOVE ptrs.
 instruct cmovPP_reg_LTGE(cmpOp cmp, flagsReg_long_LTGE flags, eRegP dst, eRegP src) %{
   predicate(VM_Version::supports_cmov() && ( _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::lt || _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::ge ));
   match(Set dst (CMoveP (Binary cmp flags) (Binary dst src)));
@@ -13313,7 +13333,27 @@ instruct cmovII_mem_EQNE(cmpOp cmp, flagsReg_long_EQNE flags, rRegI dst, memory 
   ins_pipe( pipe_cmov_mem );
 %}
 
-// Compare 2 longs and CMOVE ints.
+instruct cmovII_reg_EQNE_U(cmpOpU cmp, flagsReg_ulong_EQNE flags, rRegI dst, rRegI src) %{
+  predicate(VM_Version::supports_cmov() && ( _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::eq || _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::ne ));
+  match(Set dst (CMoveI (Binary cmp flags) (Binary dst src)));
+  ins_cost(200);
+  format %{ "CMOV$cmp $dst,$src" %}
+  opcode(0x0F,0x40);
+  ins_encode( enc_cmov(cmp), RegReg( dst, src ) );
+  ins_pipe( pipe_cmov_reg );
+%}
+
+instruct cmovII_mem_EQNE_U(cmpOpU cmp, flagsReg_ulong_EQNE flags, rRegI dst, memory src) %{
+  predicate(VM_Version::supports_cmov() && ( _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::eq || _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::ne ));
+  match(Set dst (CMoveI (Binary cmp flags) (Binary dst (LoadI src))));
+  ins_cost(250);
+  format %{ "CMOV$cmp $dst,$src" %}
+  opcode(0x0F,0x40);
+  ins_encode( enc_cmov(cmp), RegMem( dst, src ) );
+  ins_pipe( pipe_cmov_mem );
+%}
+
+// Compare 2 longs and CMOVE ptrs.
 instruct cmovPP_reg_EQNE(cmpOp cmp, flagsReg_long_EQNE flags, eRegP dst, eRegP src) %{
   predicate(VM_Version::supports_cmov() && ( _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::eq || _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::ne ));
   match(Set dst (CMoveP (Binary cmp flags) (Binary dst src)));
@@ -13499,6 +13539,26 @@ instruct cmovII_reg_LEGT(cmpOp_commute cmp, flagsReg_long_LEGT flags, rRegI dst,
 %}
 
 instruct cmovII_mem_LEGT(cmpOp_commute cmp, flagsReg_long_LEGT flags, rRegI dst, memory src) %{
+  predicate(VM_Version::supports_cmov() && ( _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::le || _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::gt ));
+  match(Set dst (CMoveI (Binary cmp flags) (Binary dst (LoadI src))));
+  ins_cost(250);
+  format %{ "CMOV$cmp $dst,$src" %}
+  opcode(0x0F,0x40);
+  ins_encode( enc_cmov(cmp), RegMem( dst, src ) );
+  ins_pipe( pipe_cmov_mem );
+%}
+
+instruct cmovII_reg_LEGT_U(cmpOpU_commute cmp, flagsReg_ulong_LEGT flags, rRegI dst, rRegI src) %{
+  predicate(VM_Version::supports_cmov() && ( _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::le || _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::gt ));
+  match(Set dst (CMoveI (Binary cmp flags) (Binary dst src)));
+  ins_cost(200);
+  format %{ "CMOV$cmp $dst,$src" %}
+  opcode(0x0F,0x40);
+  ins_encode( enc_cmov(cmp), RegReg( dst, src ) );
+  ins_pipe( pipe_cmov_reg );
+%}
+
+instruct cmovII_mem_LEGT_U(cmpOpU_commute cmp, flagsReg_ulong_LEGT flags, rRegI dst, memory src) %{
   predicate(VM_Version::supports_cmov() && ( _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::le || _kids[0]->_kids[0]->_leaf->as_Bool()->_test._test == BoolTest::gt ));
   match(Set dst (CMoveI (Binary cmp flags) (Binary dst (LoadI src))));
   ins_cost(250);


### PR DESCRIPTION
[JDK-8276162](https://bugs.openjdk.java.net/browse/JDK-8276162) introduced an optimization that creates `CMoveI (Bool (CmpUL ...) ...)` shapes but x86-32 misses the corresponding match rules in C2's backend.

I also fixed two comments incorrectly referring to ints instead of ptrs.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277324](https://bugs.openjdk.java.net/browse/JDK-8277324): C2 compilation fails with "bad AD file" on x86-32 after JDK-8276162 due to missing match rule


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6427/head:pull/6427` \
`$ git checkout pull/6427`

Update a local copy of the PR: \
`$ git checkout pull/6427` \
`$ git pull https://git.openjdk.java.net/jdk pull/6427/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6427`

View PR using the GUI difftool: \
`$ git pr show -t 6427`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6427.diff">https://git.openjdk.java.net/jdk/pull/6427.diff</a>

</details>
