### PR TITLE
8275643: C2's unaryOp vector intrinsic does not properly handle LongVector.neg

### DIFF
--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -292,6 +292,7 @@ int VectorSupport::vop2ideal(jint id, BasicType bt) {
         case T_BYTE:   // fall-through
         case T_SHORT:  // fall-through
         case T_INT:    return Op_NegI;
+        case T_LONG:   return Op_NegL;
         case T_FLOAT:  return Op_NegF;
         case T_DOUBLE: return Op_NegD;
         default: fatal("NEG: %s", type2name(bt));

--- a/test/hotspot/jtreg/compiler/vectorapi/TestLongVectorNeg.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestLongVectorNeg.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import jdk.incubator.vector.LongVector;
+
+/*
+ * @test
+ * @bug 8275643
+ * @summary Test that LongVector.neg is properly handled by the _VectorUnaryOp C2 intrinsic
+ * @modules jdk.incubator.vector
+ * @run main/othervm -XX:-TieredCompilation -XX:+AlwaysIncrementalInline -Xbatch
+ *                   -XX:CompileCommand=dontinline,compiler.vectorapi.TestLongVectorNeg::test
+ *                   compiler.vectorapi.TestLongVectorNeg
+ */
+public class TestLongVectorNeg {
+
+    static LongVector test(LongVector v) {
+        return v.neg();
+    }
+
+    public static void main(String[] args) {
+        LongVector v = LongVector.zero(LongVector.SPECIES_128);
+        for (int i = 0; i < 50_000; ++i) {
+            v.abs(); // Warmup to make sure the !VO_SPECIAL code path is taken as well
+            test(v);
+        }
+    }
+}


### PR DESCRIPTION
Code in `LongVector::lanewiseTemplate` currently implements the `NEG` operation as a `SUB` and has a corresponding `FIXME` comment:
https://github.com/openjdk/jdk/blob/e9934e1243929514e147ecdd3cefa74168ed0500/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java#L534-L541

The implicit assumption is that since we will never pass `NEG` to `VectorSupport.unaryOp` in line 540, the corresponding C2 intrinsic does not need to handle that case. That's not guaranteed though because C2 might still compile that path when not being able to prove that it's unreachable at parse time. As a result, we then assert in the intrinsic because the negation operation on a long vector is currently not supported (i.e. there is no `Op_NegVL`). I propose to simply handle this case in ` VectorSupport::vop2ideal`. We will then bail out from intrinsification with `operation not supported: opc=NegL bt=long` because `VectorNode::opcode` returns 0:
https://github.com/openjdk/jdk/blob/e9934e1243929514e147ecdd3cefa74168ed0500/src/hotspot/share/opto/vectorIntrinsics.cpp#L390-L394

Question to the Vector API experts: There are other `FIXME: Support this in the JIT` comments in the code. Do these code paths suffer from similar issues? Is there a tracking RFE/bug?

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275643](https://bugs.openjdk.java.net/browse/JDK-8275643): C2's unaryOp vector intrinsic does not properly handle LongVector.neg


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Sandhya Viswanathan](https://openjdk.java.net/census#sviswanathan) (@sviswa7 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6428/head:pull/6428` \
`$ git checkout pull/6428`

Update a local copy of the PR: \
`$ git checkout pull/6428` \
`$ git pull https://git.openjdk.java.net/jdk pull/6428/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6428`

View PR using the GUI difftool: \
`$ git pr show -t 6428`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6428.diff">https://git.openjdk.java.net/jdk/pull/6428.diff</a>

</details>
