### PR TITLE
8276093: Improve naming in closures to iterate over card sets 

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.hpp
@@ -291,7 +291,7 @@ private:
   //
   // on the given class.
   template <class CardVisitor>
-  void iterate_cards_during_transfer(CardSetPtr const card_set, CardVisitor& found);
+  void iterate_cards_during_transfer(CardSetPtr const card_set, CardVisitor& vl);
 
   uint card_set_type_to_mem_object_type(uintptr_t type) const;
   uint8_t* allocate_mem_object(uintptr_t type);
@@ -353,21 +353,21 @@ public:
   // start_iterate().
   //
   template <class CardOrRangeVisitor>
-  void iterate_cards_or_ranges_in_container(CardSetPtr const card_set, CardOrRangeVisitor& found);
+  void iterate_cards_or_ranges_in_container(CardSetPtr const card_set, CardOrRangeVisitor& cl);
 
   class CardSetPtrClosure {
   public:
     virtual void do_cardsetptr(uint region_idx, size_t num_occupied, CardSetPtr card_set) = 0;
   };
 
-  void iterate_containers(CardSetPtrClosure* iter, bool safepoint = false);
+  void iterate_containers(CardSetPtrClosure* cl, bool safepoint = false);
 
   class CardClosure {
   public:
     virtual void do_card(uint region_idx, uint card_idx) = 0;
   };
 
-  void iterate_cards(CardClosure& iter);
+  void iterate_cards(CardClosure& cl);
 };
 
 class G1CardSetHashTableValue {

--- a/src/hotspot/share/gc/g1/g1CardSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.hpp
@@ -355,19 +355,19 @@ public:
   template <class CardOrRangeVisitor>
   void iterate_cards_or_ranges_in_container(CardSetPtr const card_set, CardOrRangeVisitor& found);
 
-  class G1CardSetPtrIterator {
+  class CardSetPtrClosure {
   public:
     virtual void do_cardsetptr(uint region_idx, size_t num_occupied, CardSetPtr card_set) = 0;
   };
 
-  void iterate_containers(G1CardSetPtrIterator* iter, bool safepoint = false);
+  void iterate_containers(CardSetPtrClosure* iter, bool safepoint = false);
 
-  class G1CardSetCardIterator {
+  class CardClosure {
   public:
     virtual void do_card(uint region_idx, uint card_idx) = 0;
   };
 
-  void iterate_cards(G1CardSetCardIterator& iter);
+  void iterate_cards(CardClosure& iter);
 };
 
 class G1CardSetHashTableValue {

--- a/src/hotspot/share/gc/g1/g1CardSet.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.inline.hpp
@@ -42,18 +42,18 @@ inline G1CardSet::CardSetPtr G1CardSet::make_card_set_ptr(void* value, uintptr_t
 }
 
 template <class CardOrRangeVisitor>
-inline void G1CardSet::iterate_cards_or_ranges_in_container(CardSetPtr const card_set, CardOrRangeVisitor& found) {
+inline void G1CardSet::iterate_cards_or_ranges_in_container(CardSetPtr const card_set, CardOrRangeVisitor& cl) {
   switch (card_set_type(card_set)) {
     case CardSetInlinePtr: {
-      if (found.start_iterate(G1GCPhaseTimes::MergeRSMergedInline)) {
+      if (cl.start_iterate(G1GCPhaseTimes::MergeRSMergedInline)) {
         G1CardSetInlinePtr ptr(card_set);
-        ptr.iterate(found, _config->inline_ptr_bits_per_card());
+        ptr.iterate(cl, _config->inline_ptr_bits_per_card());
       }
       return;
     }
     case CardSetArrayOfCards : {
-      if (found.start_iterate(G1GCPhaseTimes::MergeRSMergedArrayOfCards)) {
-        card_set_ptr<G1CardSetArray>(card_set)->iterate(found);
+      if (cl.start_iterate(G1GCPhaseTimes::MergeRSMergedArrayOfCards)) {
+        card_set_ptr<G1CardSetArray>(card_set)->iterate(cl);
       }
       return;
     }
@@ -65,13 +65,13 @@ inline void G1CardSet::iterate_cards_or_ranges_in_container(CardSetPtr const car
     case CardSetHowl: {
       assert(card_set_type(FullCardSet) == CardSetHowl, "Must be");
       if (card_set == FullCardSet) {
-        if (found.start_iterate(G1GCPhaseTimes::MergeRSMergedFull)) {
-          found(0, _config->max_cards_in_region());
+        if (cl.start_iterate(G1GCPhaseTimes::MergeRSMergedFull)) {
+          cl(0, _config->max_cards_in_region());
         }
         return;
       }
-      if (found.start_iterate(G1GCPhaseTimes::MergeRSMergedHowl)) {
-        card_set_ptr<G1CardSetHowl>(card_set)->iterate(found, _config);
+      if (cl.start_iterate(G1GCPhaseTimes::MergeRSMergedHowl)) {
+        card_set_ptr<G1CardSetHowl>(card_set)->iterate(cl, _config);
       }
       return;
     }

--- a/src/hotspot/share/gc/g1/heapRegionRemSet.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.inline.hpp
@@ -78,7 +78,7 @@ public:
 };
 
 template <typename Closure, template <typename> class CardOrRanges>
-class G1HeapRegionRemSetMergeCardIterator : public G1CardSet::G1CardSetPtrIterator {
+class G1HeapRegionRemSetMergeCardClosure : public G1CardSet::CardSetPtrClosure {
   G1CardSet* _card_set;
   Closure& _iter;
   uint _log_card_regions_per_region;
@@ -87,7 +87,7 @@ class G1HeapRegionRemSetMergeCardIterator : public G1CardSet::G1CardSetPtrIterat
 
 public:
 
-  G1HeapRegionRemSetMergeCardIterator(G1CardSet* card_set,
+  G1HeapRegionRemSetMergeCardClosure(G1CardSet* card_set,
                                       Closure& iter,
                                       uint log_card_regions_per_region,
                                       uint log_card_region_size) :
@@ -108,10 +108,10 @@ public:
 
 template <class CardOrRangeVisitor>
 inline void HeapRegionRemSet::iterate_for_merge(CardOrRangeVisitor& cl) {
-  G1HeapRegionRemSetMergeCardIterator<CardOrRangeVisitor, G1ContainerCardsOrRanges> cl2(&_card_set,
-                                                                                        cl,
-                                                                                        _card_set.config()->log2_card_region_per_heap_region(),
-                                                                                        _card_set.config()->log2_cards_per_card_region());
+  G1HeapRegionRemSetMergeCardClosure<CardOrRangeVisitor, G1ContainerCardsOrRanges> cl2(&_card_set,
+                                                                                       cl,
+                                                                                       _card_set.config()->log2_card_region_per_heap_region(),
+                                                                                       _card_set.config()->log2_cards_per_card_region());
   _card_set.iterate_containers(&cl2, true /* at_safepoint */);
 }
 

--- a/src/hotspot/share/gc/g1/heapRegionRemSet.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.inline.hpp
@@ -57,30 +57,30 @@ void HeapRegionRemSet::set_state_complete() {
 
 template <typename Closure>
 class G1ContainerCardsOrRanges {
-  Closure& _iter;
+  Closure& _cl;
   uint _region_idx;
   uint _offset;
 
 public:
-  G1ContainerCardsOrRanges(Closure& iter, uint region_idx, uint offset) : _iter(iter), _region_idx(region_idx), _offset(offset) { }
+  G1ContainerCardsOrRanges(Closure& cl, uint region_idx, uint offset) : _cl(cl), _region_idx(region_idx), _offset(offset) { }
 
   bool start_iterate(uint tag) {
-    return _iter.start_iterate(tag, _region_idx);
+    return _cl.start_iterate(tag, _region_idx);
   }
 
   void operator()(uint card_idx) {
-    _iter.do_card(card_idx + _offset);
+    _cl.do_card(card_idx + _offset);
   }
 
   void operator()(uint card_idx, uint length) {
-    _iter.do_card_range(card_idx + _offset, length);
+    _cl.do_card_range(card_idx + _offset, length);
   }
 };
 
 template <typename Closure, template <typename> class CardOrRanges>
 class G1HeapRegionRemSetMergeCardClosure : public G1CardSet::CardSetPtrClosure {
   G1CardSet* _card_set;
-  Closure& _iter;
+  Closure& _cl;
   uint _log_card_regions_per_region;
   uint _card_regions_per_region_mask;
   uint _log_card_region_size;
@@ -88,18 +88,18 @@ class G1HeapRegionRemSetMergeCardClosure : public G1CardSet::CardSetPtrClosure {
 public:
 
   G1HeapRegionRemSetMergeCardClosure(G1CardSet* card_set,
-                                      Closure& iter,
+                                      Closure& cl,
                                       uint log_card_regions_per_region,
                                       uint log_card_region_size) :
     _card_set(card_set),
-    _iter(iter),
+    _cl(cl),
     _log_card_regions_per_region(log_card_regions_per_region),
     _card_regions_per_region_mask((1 << log_card_regions_per_region) - 1),
     _log_card_region_size(log_card_region_size) {
   }
 
   void do_cardsetptr(uint card_region_idx, size_t num_occupied, G1CardSet::CardSetPtr card_set) override {
-    CardOrRanges<Closure> cl(_iter,
+    CardOrRanges<Closure> cl(_cl,
                              card_region_idx >> _log_card_regions_per_region,
                              (card_region_idx & _card_regions_per_region_mask) << _log_card_region_size);
     _card_set->iterate_cards_or_ranges_in_container(card_set, cl);

--- a/test/hotspot/gtest/gc/g1/test_g1CardSet.cpp
+++ b/test/hotspot/gtest/gc/g1/test_g1CardSet.cpp
@@ -34,7 +34,7 @@
 
 class G1CardSetTest : public ::testing::Test {
 
-  class G1CountCardsClosure : public G1CardSet::G1CardSetCardIterator {
+  class G1CountCardsClosure : public G1CardSet::CardClosure {
   public:
     size_t _num_cards;
 
@@ -82,7 +82,7 @@ public:
 
   static void translate_cards(uint cards_per_region, uint region_idx, uint* cards, uint num_cards);
 
-  static void iterate_cards(G1CardSet* card_set, G1CardSet::G1CardSetCardIterator* cl);
+  static void iterate_cards(G1CardSet* card_set, G1CardSet::CardClosure* cl);
 };
 
 WorkerThreads* G1CardSetTest::_workers = NULL;
@@ -101,7 +101,7 @@ void G1CardSetTest::add_cards(G1CardSet* card_set, uint cards_per_region, uint* 
   }
 }
 
-class G1CheckCardClosure : public G1CardSet::G1CardSetCardIterator {
+class G1CheckCardClosure : public G1CardSet::CardClosure {
   G1CardSet* _card_set;
 
   uint _cards_per_region;
@@ -163,7 +163,7 @@ void G1CardSetTest::translate_cards(uint cards_per_region, uint region_idx, uint
   }
 }
 
-class G1CountCardsOccupied : public G1CardSet::G1CardSetPtrIterator {
+class G1CountCardsOccupied : public G1CardSet::CardSetPtrClosure {
   size_t _num_occupied;
 
 public:
@@ -178,7 +178,7 @@ public:
 
 void G1CardSetTest::check_iteration(G1CardSet* card_set, const size_t expected, const bool single_threaded) {
 
-  class CheckIterator : public G1CardSet::G1CardSetCardIterator {
+  class CheckIterator : public G1CardSet::CardClosure {
   public:
     G1CardSet* _card_set;
     size_t _num_found;


### PR DESCRIPTION
Hi all,

  can I have reviews for this renaming change that tries to change naming for some remembered set closures to include `Closure` instead of `Iterator` in their names. Additionally I removed two or so `G1` prefixes for nested classes. Hopefully this improves the situation a bit, although it's still a mess of nested closures.

Testing: local compilation, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276093](https://bugs.openjdk.java.net/browse/JDK-8276093): Improve naming in closures to iterate over card sets


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to 455488f86a409e1eb70f3f0ddec7add9635926ac
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6430/head:pull/6430` \
`$ git checkout pull/6430`

Update a local copy of the PR: \
`$ git checkout pull/6430` \
`$ git pull https://git.openjdk.java.net/jdk pull/6430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6430`

View PR using the GUI difftool: \
`$ git pr show -t 6430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6430.diff">https://git.openjdk.java.net/jdk/pull/6430.diff</a>

</details>
