### PR TITLE
8277336: Improve CollectedHeap::safepoint_workers comments

### DIFF
--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -461,14 +461,15 @@ class CollectedHeap : public CHeapObj<mtInternal> {
   // this collector.  The default implementation returns false.
   virtual bool supports_concurrent_gc_breakpoints() const;
 
-  // Provides a thread pool to SafepointSynchronize to use
-  // for parallel safepoint cleanup.
-  // GCs that use a GC worker thread pool may want to share
-  // it for use during safepoint cleanup. This is only possible
-  // if the GC can pause and resume concurrent work (e.g. G1
-  // concurrent marking) for an intermittent non-GC safepoint.
-  // If this method returns NULL, SafepointSynchronize will
-  // perform cleanup tasks serially in the VMThread.
+  // Workers used in non-GC safepoints for parallel safepoint cleanup. If this
+  // method returns NULL, cleanup tasks are done serially in the VMThread. See
+  // `SafepointSynchronize::do_cleanup_tasks` for details.
+  // GCs using a GC worker thread pool inside GC safepoints may opt to share
+  // that pool with non-GC safepoints, avoiding creating extraneous threads.
+  // Such sharing is safe, because GC safepoints and non-GC safepoints never
+  // overlap. For example, `G1CollectedHeap::workers()` (for GC safepoints) and
+  // `G1CollectedHeap::safepoint_workers()` (for non-GC safepoints) return the
+  // same thread-pool.
   virtual WorkerThreads* safepoint_workers() { return NULL; }
 
   // Support for object pinning. This is used by JNI Get*Critical()


### PR DESCRIPTION
Simple change of updating comments.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277336](https://bugs.openjdk.java.net/browse/JDK-8277336): Improve CollectedHeap::safepoint_workers comments


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6432/head:pull/6432` \
`$ git checkout pull/6432`

Update a local copy of the PR: \
`$ git checkout pull/6432` \
`$ git pull https://git.openjdk.java.net/jdk pull/6432/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6432`

View PR using the GUI difftool: \
`$ git pr show -t 6432`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6432.diff">https://git.openjdk.java.net/jdk/pull/6432.diff</a>

</details>
