### PR TITLE
8277504: Use String.stripTrailing instead of hand-crafted method in SwingUtilities2

### DIFF
--- a/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
+++ b/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
@@ -117,7 +117,7 @@ import static java.awt.geom.AffineTransform.TYPE_TRANSLATION;
  * A collection of utility methods for Swing.
  * <p>
  * <b>WARNING:</b> While this class is public, it should not be treated as
- * public API and its API may change in incompatible ways between dot dot
+ * public API and its API may change in incompatable ways between dot dot
  * releases and even patch releases. You should not rely on this class even
  * existing.
  *
@@ -342,7 +342,7 @@ public class SwingUtilities2 {
      * Graphics.
      *
      * @param c JComponent requesting FontMetrics, may be null
-     * @param g Graphics Graphics
+     * @param c Graphics Graphics
      * @param font Font to get FontMetrics for
      */
     @SuppressWarnings("deprecation")
@@ -1516,7 +1516,7 @@ public class SwingUtilities2 {
     }
 
     /**
-     * Returns true if the given event is correct gesture for
+     * Returns true if the given event is corrent gesture for
      * accessing clipboard
      *
      * @param ie InputEvent to check
@@ -1564,7 +1564,7 @@ public class SwingUtilities2 {
         if (EventQueue.isDispatchThread()) {
             /*
              * Checking event permissions makes sense only for event
-             * dispatching thread
+             * dispathing thread
              */
             if (e instanceof InputEvent
                 && (! checkGesture || isAccessClipboardGesture((InputEvent)e))) {
@@ -1779,7 +1779,7 @@ public class SwingUtilities2 {
 
     /**
      * Returns an integer from the defaults table. If {@code key} does
-     * not map to a valid {@code Integer}, or can not be converted from
+     * not map to a valid {@code Integer}, or can not be convered from
      * a {@code String} to an integer, the value 0 is returned.
      *
      * @param key  an {@code Object} specifying the int.
@@ -1792,7 +1792,7 @@ public class SwingUtilities2 {
     /**
      * Returns an integer from the defaults table that is appropriate
      * for the given locale. If {@code key} does not map to a valid
-     * {@code Integer}, or can not be converted from a {@code String}
+     * {@code Integer}, or can not be convered from a {@code String}
      * to an integer, the value 0 is returned.
      *
      * @param key  an {@code Object} specifying the int. Returned value
@@ -1806,7 +1806,7 @@ public class SwingUtilities2 {
 
     /**
      * Returns an integer from the defaults table. If {@code key} does
-     * not map to a valid {@code Integer}, or can not be converted from
+     * not map to a valid {@code Integer}, or can not be convered from
      * a {@code String} to an integer, {@code default} is
      * returned.
      *
@@ -1823,7 +1823,7 @@ public class SwingUtilities2 {
     /**
      * Returns an integer from the defaults table that is appropriate
      * for the given locale. If {@code key} does not map to a valid
-     * {@code Integer}, or can not be converted from a {@code String}
+     * {@code Integer}, or can not be convered from a {@code String}
      * to an integer, {@code default} is returned.
      *
      * @param key  an {@code Object} specifying the int. Returned value
@@ -2187,7 +2187,7 @@ public class SwingUtilities2 {
     /**
      * Sets the InputEvent.ALT_GRAPH mask on any modifier passed to the function
      * @param modifier the modifier passed
-     * @return the modifier returned with ALT_GRAPH flag set
+     * @return the modifier retiurned with ALT_GRAPH flag set
      */
     public static int setAltGraphMask(int modifier) {
         return (modifier | InputEvent.ALT_GRAPH_DOWN_MASK);
@@ -2206,7 +2206,7 @@ public class SwingUtilities2 {
      * Returns the {@link TreePath} that identifies the changed nodes.
      *
      * @param event  changes in a tree model
-     * @param model  corresponding tree model
+     * @param model  corresponing tree model
      * @return  the path to the changed nodes
      */
     public static TreePath getTreePath(TreeModelEvent event, TreeModel model) {

--- a/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
+++ b/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
@@ -117,7 +117,7 @@ import static java.awt.geom.AffineTransform.TYPE_TRANSLATION;
  * A collection of utility methods for Swing.
  * <p>
  * <b>WARNING:</b> While this class is public, it should not be treated as
- * public API and its API may change in incompatable ways between dot dot
+ * public API and its API may change in incompatible ways between dot dot
  * releases and even patch releases. You should not rely on this class even
  * existing.
  *
@@ -342,7 +342,7 @@ public class SwingUtilities2 {
      * Graphics.
      *
      * @param c JComponent requesting FontMetrics, may be null
-     * @param c Graphics Graphics
+     * @param g Graphics Graphics
      * @param font Font to get FontMetrics for
      */
     @SuppressWarnings("deprecation")
@@ -520,7 +520,7 @@ public class SwingUtilities2 {
                  * it to fit in the screen width. This distributes the spacing
                  * more evenly than directly laying out to the screen advances.
                  */
-                String trimmedText = trimTrailingSpaces(text);
+                String trimmedText = text.stripTrailing();
                 if (!trimmedText.isEmpty()) {
                     float screenWidth = (float) g2d.getFont().getStringBounds
                             (trimmedText, getFontRenderContext(c)).getWidth();
@@ -866,7 +866,7 @@ public class SwingUtilities2 {
                     String text = new String(data, offset, length);
                     TextLayout layout = new TextLayout(text, g2d.getFont(),
                                     deviceFontRenderContext);
-                    String trimmedText = trimTrailingSpaces(text);
+                    String trimmedText = text.stripTrailing();
                     if (!trimmedText.isEmpty()) {
                         float screenWidth = (float)g2d.getFont().
                             getStringBounds(trimmedText, frc).getWidth();
@@ -1321,14 +1321,6 @@ public class SwingUtilities2 {
         return (g instanceof PrinterGraphics || g instanceof PrintGraphics);
     }
 
-    private static String trimTrailingSpaces(String s) {
-        int i = s.length() - 1;
-        while(i >= 0 && Character.isWhitespace(s.charAt(i))) {
-            i--;
-        }
-        return s.substring(0, i + 1);
-    }
-
     private static AttributedCharacterIterator getTrimmedTrailingSpacesIterator
             (AttributedCharacterIterator iterator) {
         int curIdx = iterator.getIndex();
@@ -1524,7 +1516,7 @@ public class SwingUtilities2 {
     }
 
     /**
-     * Returns true if the given event is corrent gesture for
+     * Returns true if the given event is correct gesture for
      * accessing clipboard
      *
      * @param ie InputEvent to check
@@ -1572,7 +1564,7 @@ public class SwingUtilities2 {
         if (EventQueue.isDispatchThread()) {
             /*
              * Checking event permissions makes sense only for event
-             * dispathing thread
+             * dispatching thread
              */
             if (e instanceof InputEvent
                 && (! checkGesture || isAccessClipboardGesture((InputEvent)e))) {
@@ -1787,7 +1779,7 @@ public class SwingUtilities2 {
 
     /**
      * Returns an integer from the defaults table. If {@code key} does
-     * not map to a valid {@code Integer}, or can not be convered from
+     * not map to a valid {@code Integer}, or can not be converted from
      * a {@code String} to an integer, the value 0 is returned.
      *
      * @param key  an {@code Object} specifying the int.
@@ -1800,7 +1792,7 @@ public class SwingUtilities2 {
     /**
      * Returns an integer from the defaults table that is appropriate
      * for the given locale. If {@code key} does not map to a valid
-     * {@code Integer}, or can not be convered from a {@code String}
+     * {@code Integer}, or can not be converted from a {@code String}
      * to an integer, the value 0 is returned.
      *
      * @param key  an {@code Object} specifying the int. Returned value
@@ -1814,7 +1806,7 @@ public class SwingUtilities2 {
 
     /**
      * Returns an integer from the defaults table. If {@code key} does
-     * not map to a valid {@code Integer}, or can not be convered from
+     * not map to a valid {@code Integer}, or can not be converted from
      * a {@code String} to an integer, {@code default} is
      * returned.
      *
@@ -1831,7 +1823,7 @@ public class SwingUtilities2 {
     /**
      * Returns an integer from the defaults table that is appropriate
      * for the given locale. If {@code key} does not map to a valid
-     * {@code Integer}, or can not be convered from a {@code String}
+     * {@code Integer}, or can not be converted from a {@code String}
      * to an integer, {@code default} is returned.
      *
      * @param key  an {@code Object} specifying the int. Returned value
@@ -2195,7 +2187,7 @@ public class SwingUtilities2 {
     /**
      * Sets the InputEvent.ALT_GRAPH mask on any modifier passed to the function
      * @param modifier the modifier passed
-     * @return the modifier retiurned with ALT_GRAPH flag set
+     * @return the modifier returned with ALT_GRAPH flag set
      */
     public static int setAltGraphMask(int modifier) {
         return (modifier | InputEvent.ALT_GRAPH_DOWN_MASK);
@@ -2214,7 +2206,7 @@ public class SwingUtilities2 {
      * Returns the {@link TreePath} that identifies the changed nodes.
      *
      * @param event  changes in a tree model
-     * @param model  corresponing tree model
+     * @param model  corresponding tree model
      * @return  the path to the changed nodes
      */
     public static TreePath getTreePath(TreeModelEvent event, TreeModel model) {


### PR DESCRIPTION
There is opportunity to use String.stripTrailing() method in java.desktop in SwingUtilities2 class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277504](https://bugs.openjdk.java.net/browse/JDK-8277504): Use String.stripTrailing instead of hand-crafted method in SwingUtilities2


### Reviewers
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6436/head:pull/6436` \
`$ git checkout pull/6436`

Update a local copy of the PR: \
`$ git checkout pull/6436` \
`$ git pull https://git.openjdk.java.net/jdk pull/6436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6436`

View PR using the GUI difftool: \
`$ git pr show -t 6436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6436.diff">https://git.openjdk.java.net/jdk/pull/6436.diff</a>

</details>
