### PR TITLE
8277343: dynamicArchive/SharedArchiveFileOption.java failed: '-XX:+RecordDynamicDumpInfo is unsupported when a dynamic CDS archive is specified in -XX:SharedArchiveFile:' missing

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicArchiveTestBase.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicArchiveTestBase.java
@@ -291,7 +291,7 @@ class DynamicArchiveTestBase {
      *   UseCompressedClassPointers options. Those "compressed" options were
      *   enabled when the default CDS archive was built.
      */
-    private static boolean isUseSharedSpacesDisabled() {
+    public static boolean isUseSharedSpacesDisabled() {
         return (WB.getBooleanVMFlag("UseSharedSpaces") == false);
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/SharedArchiveFileOption.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/SharedArchiveFileOption.java
@@ -180,10 +180,14 @@ public class SharedArchiveFileOption extends DynamicArchiveTestBase {
             .assertAbnormalExit("-XX:ArchiveClassesAtExit is unsupported when a dynamic CDS archive is specified in -XX:SharedArchiveFile:");
 
         testcase("A dynamic archive is already loaded when -XX:+RecordDynamicDumpInfo is specified");
-        run2(null, topArchiveName,
-             "-XX:+RecordDynamicDumpInfo",
-             "-cp", appJar, mainClass)
-            .assertAbnormalExit("-XX:+RecordDynamicDumpInfo is unsupported when a dynamic CDS archive is specified in -XX:SharedArchiveFile:");
+        if (isUseSharedSpacesDisabled()) {
+            System.out.println("This test is not applicable when JTREG tests are executed with -Xshare:off, or if the JDK doesn't have a default archive.");
+        } else {
+          run2(null, topArchiveName,
+               "-XX:+RecordDynamicDumpInfo",
+               "-cp", appJar, mainClass)
+              .assertAbnormalExit("-XX:+RecordDynamicDumpInfo is unsupported when a dynamic CDS archive is specified in -XX:SharedArchiveFile:");
+        }
 
         testcase("-XX:+RecordDynamicDumpInfo cannot be used with -XX:ArchiveClassesAtExit");
         dump2(baseArchiveName,


### PR DESCRIPTION
Please fix this trivial fix. The affected test case expected the following message

```
-XX:+RecordDynamicDumpInfo is unsupported when a dynamic CDS archive is specified in -XX:SharedArchiveFile: 
```

but if we run with `jtreg -vmoption:-Xshare:off` the test case takes a different path, resulting in a different message:

```
Cannot have more than 1 archive file specified in -XX:SharedArchiveFile during CDS dumping
```

Since the latter message is already being tested in another case in SharedArchiveFileOption.java, we can simple disable this test case under this condition.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277343](https://bugs.openjdk.java.net/browse/JDK-8277343): dynamicArchive/SharedArchiveFileOption.java failed: '-XX:+RecordDynamicDumpInfo is unsupported when a dynamic CDS archive is specified in -XX:SharedArchiveFile:' missing


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6437/head:pull/6437` \
`$ git checkout pull/6437`

Update a local copy of the PR: \
`$ git checkout pull/6437` \
`$ git pull https://git.openjdk.java.net/jdk pull/6437/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6437`

View PR using the GUI difftool: \
`$ git pr show -t 6437`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6437.diff">https://git.openjdk.java.net/jdk/pull/6437.diff</a>

</details>
