### PR TITLE
8266593: vmTestbase/nsk/jvmti/PopFrame/popframe011 fails with "assert(java_thread == _state->get_thread()) failed: Must be"

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -1393,7 +1393,7 @@ SetForceEarlyReturn::doit(Thread *target, bool self) {
   Thread* current_thread = Thread::current();
   HandleMark   hm(current_thread);
 
-  if (java_thread->is_exiting() || java_thread->threadObj() == NULL) {
+  if (java_thread->is_exiting()) {
     return; /* JVMTI_ERROR_THREAD_NOT_ALIVE (default) */
   }
   if (!self) {
@@ -1527,7 +1527,7 @@ UpdateForPopTopFrameClosure::doit(Thread *target, bool self) {
   HandleMark hm(current_thread);
   JavaThread* java_thread = JavaThread::cast(target);
 
-  if (java_thread->is_exiting() || java_thread->threadObj() == NULL) {
+  if (java_thread->is_exiting()) {
     return; /* JVMTI_ERROR_THREAD_NOT_ALIVE (default) */
   }
   assert(java_thread == _state->get_thread(), "Must be");
@@ -1619,7 +1619,7 @@ SetFramePopClosure::doit(Thread *target, bool self) {
   ResourceMark rm;
   JavaThread* java_thread = JavaThread::cast(target);
 
-  if (java_thread->is_exiting() || java_thread->threadObj() == NULL) {
+  if (java_thread->is_exiting()) {
     return; /* JVMTI_ERROR_THREAD_NOT_ALIVE (default) */
   }
   assert(_state->get_thread() == java_thread, "Must be");

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -1393,6 +1393,9 @@ SetForceEarlyReturn::doit(Thread *target, bool self) {
   Thread* current_thread = Thread::current();
   HandleMark   hm(current_thread);
 
+  if (java_thread->is_exiting() || java_thread->threadObj() == NULL) {
+    return; /* JVMTI_ERROR_THREAD_NOT_ALIVE (default) */
+  }
   if (!self) {
     if (!java_thread->is_suspended()) {
       _result = JVMTI_ERROR_THREAD_NOT_SUSPENDED;
@@ -1523,6 +1526,10 @@ UpdateForPopTopFrameClosure::doit(Thread *target, bool self) {
   Thread* current_thread  = Thread::current();
   HandleMark hm(current_thread);
   JavaThread* java_thread = JavaThread::cast(target);
+
+  if (java_thread->is_exiting() || java_thread->threadObj() == NULL) {
+    return; /* JVMTI_ERROR_THREAD_NOT_ALIVE (default) */
+  }
   assert(java_thread == _state->get_thread(), "Must be");
 
   if (!self && !java_thread->is_suspended()) {
@@ -1599,14 +1606,12 @@ UpdateForPopTopFrameClosure::doit(Thread *target, bool self) {
   // It's fine to update the thread state here because no JVMTI events
   // shall be posted for this PopFrame.
 
-  if (!java_thread->is_exiting() && java_thread->threadObj() != NULL) {
-    _state->update_for_pop_top_frame();
-    java_thread->set_popframe_condition(JavaThread::popframe_pending_bit);
-    // Set pending step flag for this popframe and it is cleared when next
-    // step event is posted.
-    _state->set_pending_step_for_popframe();
-    _result = JVMTI_ERROR_NONE;
-  }
+  _state->update_for_pop_top_frame();
+  java_thread->set_popframe_condition(JavaThread::popframe_pending_bit);
+  // Set pending step flag for this popframe and it is cleared when next
+  // step event is posted.
+  _state->set_pending_step_for_popframe();
+  _result = JVMTI_ERROR_NONE;
 }
 
 void
@@ -1614,6 +1619,9 @@ SetFramePopClosure::doit(Thread *target, bool self) {
   ResourceMark rm;
   JavaThread* java_thread = JavaThread::cast(target);
 
+  if (java_thread->is_exiting() || java_thread->threadObj() == NULL) {
+    return; /* JVMTI_ERROR_THREAD_NOT_ALIVE (default) */
+  }
   assert(_state->get_thread() == java_thread, "Must be");
 
   if (!self && !java_thread->is_suspended()) {
@@ -1633,9 +1641,6 @@ SetFramePopClosure::doit(Thread *target, bool self) {
   }
 
   assert(vf->frame_pointer() != NULL, "frame pointer mustn't be NULL");
-  if (java_thread->is_exiting() || java_thread->threadObj() == NULL) {
-    return; /* JVMTI_ERROR_THREAD_NOT_ALIVE (default) */
-  }
   int frame_number = _state->count_frames() - _depth;
   _state->env_thread_state((JvmtiEnvBase*)_env)->set_frame_pop(frame_number);
   _result = JVMTI_ERROR_NONE;

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -161,7 +161,6 @@ vmTestbase/nsk/jvmti/scenarios/jni_interception/JI05/ji05t001/TestDescription.ja
 vmTestbase/nsk/jvmti/scenarios/jni_interception/JI06/ji06t001/TestDescription.java 8219652 aix-ppc64
 vmTestbase/nsk/jvmti/SetJNIFunctionTable/setjniftab001/TestDescription.java 8219652 aix-ppc64
 vmTestbase/nsk/jvmti/SuspendThread/suspendthrd003/TestDescription.java 8264605 generic-all
-vmTestbase/nsk/jvmti/PopFrame/popframe011/TestDescription.java 8266593 generic-all
 
 vmTestbase/gc/lock/jni/jnilock002/TestDescription.java 8192647 generic-all
 


### PR DESCRIPTION
The test fails when the target JavaThread has is_exiting() status. In such a case the JvmtiExport::cleanup_thread(this) has already made a clean up of its jvmtiThreadState, so the JavaThread address returned by _state->get_thread() is 0xbabababababababa.
The fix is to add a check for is_exiting() status into handshake closure do_thread() early.
There following handshake closures are fixed by this update:
  - UpdateForPopTopFrameClosure
 - SetForceEarlyReturn
 - SetFramePopClosure

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266593](https://bugs.openjdk.java.net/browse/JDK-8266593): vmTestbase/nsk/jvmti/PopFrame/popframe011 fails with "assert(java_thread == _state->get_thread()) failed: Must be"


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6440/head:pull/6440` \
`$ git checkout pull/6440`

Update a local copy of the PR: \
`$ git checkout pull/6440` \
`$ git pull https://git.openjdk.java.net/jdk pull/6440/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6440`

View PR using the GUI difftool: \
`$ git pr show -t 6440`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6440.diff">https://git.openjdk.java.net/jdk/pull/6440.diff</a>

</details>
