### PR TITLE
8277370: configure script cannot distinguish WSL version

### DIFF
--- a/make/autoconf/basic_windows.m4
+++ b/make/autoconf/basic_windows.m4
@@ -36,7 +36,7 @@ AC_DEFUN([BASIC_SETUP_PATHS_WINDOWS],
       # This test is not guaranteed, but there is no documented way of
       # distinguishing between WSL1 and WSL2.
       # Check whether "Hyper-V" appears in /proc/interrupts because WSL2 runs on Hyper-V.
-      grep Hyper-V /proc/interrupts > /dev/null 2>&1
+      $GREP -q Hyper-V /proc/interrupts
       if test $? -eq 0; then
         OPENJDK_BUILD_OS_ENV=windows.wsl2
       else

--- a/make/autoconf/basic_windows.m4
+++ b/make/autoconf/basic_windows.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -34,9 +34,10 @@ AC_DEFUN([BASIC_SETUP_PATHS_WINDOWS],
       OPENJDK_BUILD_OS_ENV=windows.wsl1
     else
       # This test is not guaranteed, but there is no documented way of
-      # distinguishing between WSL1 and WSL2. Assume only WSL2 has WSL_INTEROP
-      # in /run/WSL
-      if test -d "/run/WSL" ; then
+      # distinguishing between WSL1 and WSL2.
+      # Check whether "Hyper-V" appears in /proc/interrupts because WSL2 runs on Hyper-V.
+      grep Hyper-V /proc/interrupts > /dev/null 2>&1
+      if test $? -eq 0; then
         OPENJDK_BUILD_OS_ENV=windows.wsl2
       else
         OPENJDK_BUILD_OS_ENV=windows.wsl1


### PR DESCRIPTION
configure script distinguish WSL version if it is run on WSL. It is assumed WSL 2 if `/run/WSL` exists.
However it exists in spite of WSL 1 on Windows 11 at least. We need to check it with other method.

The method to distinguish WSL version has been discussed on https://github.com/microsoft/WSL/issues/4555 , however they do not seem to get consensus about it. `/run/WSL` was introduced in it, but I think `Hyper-V` in `/proc/interrupt` is more robustness because WSL 2 is run on Hyper-V. https://docs.microsoft.com/en-us/windows/wsl/faq#does-wsl-2-use-hyper-v--will-it-be-available-on-windows-10-home-

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277370](https://bugs.openjdk.java.net/browse/JDK-8277370): configure script cannot distinguish WSL version


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6446/head:pull/6446` \
`$ git checkout pull/6446`

Update a local copy of the PR: \
`$ git checkout pull/6446` \
`$ git pull https://git.openjdk.java.net/jdk pull/6446/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6446`

View PR using the GUI difftool: \
`$ git pr show -t 6446`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6446.diff">https://git.openjdk.java.net/jdk/pull/6446.diff</a>

</details>
