### PR TITLE
8277371: Remove unnecessary DefNewGeneration::ref_processor_init()

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -878,11 +878,6 @@ void DefNewGeneration::record_spaces_top() {
   from()->set_top_for_allocations();
 }
 
-void DefNewGeneration::ref_processor_init() {
-  Generation::ref_processor_init();
-}
-
-
 void DefNewGeneration::update_counters() {
   if (UsePerfData) {
     _eden_counters->update_all();

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -202,8 +202,6 @@ protected:
                    size_t max_byte_size,
                    const char* policy="Serial young collection pauses");
 
-  virtual void ref_processor_init();
-
   virtual Generation::Name kind() { return Generation::DefNew; }
 
   // Accessing spaces

--- a/src/hotspot/share/gc/shared/generation.hpp
+++ b/src/hotspot/share/gc/shared/generation.hpp
@@ -118,7 +118,7 @@ class Generation: public CHeapObj<mtGC> {
   };
 
   // allocate and initialize ("weak") refs processing support
-  virtual void ref_processor_init();
+  void ref_processor_init();
   void set_ref_processor(ReferenceProcessor* rp) {
     assert(_ref_processor == NULL, "clobbering existing _ref_processor");
     _ref_processor = rp;


### PR DESCRIPTION
Simple change of removing a method that just calls the overridden method in base class.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277371](https://bugs.openjdk.java.net/browse/JDK-8277371): Remove unnecessary DefNewGeneration::ref_processor_init()


### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6448/head:pull/6448` \
`$ git checkout pull/6448`

Update a local copy of the PR: \
`$ git checkout pull/6448` \
`$ git pull https://git.openjdk.java.net/jdk pull/6448/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6448`

View PR using the GUI difftool: \
`$ git pr show -t 6448`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6448.diff">https://git.openjdk.java.net/jdk/pull/6448.diff</a>

</details>
