### PR TITLE
8277213: CompileTask_lock is acquired out of order with MethodCompileQueue_lock

### DIFF
--- a/src/hotspot/share/compiler/compileTask.hpp
+++ b/src/hotspot/share/compiler/compileTask.hpp
@@ -104,7 +104,8 @@ class CompileTask : public CHeapObj<mtCompiler> {
 
  public:
   CompileTask() : _failure_reason(NULL), _failure_reason_on_C_heap(false) {
-    _lock = new Monitor(Mutex::safepoint, "CompileTask_lock");
+    // May hold MethodCompileQueue_lock
+    _lock = new Monitor(Mutex::safepoint-1, "CompileTask_lock");
   }
 
   void initialize(int compile_id, const methodHandle& method, int osr_bci, int comp_level,


### PR DESCRIPTION
In the rare case that the compiler threads fail during initialization or the code cache is full and flushing is disabled, we completely disable JIT compilation and shutdown the compiler runtime:
https://github.com/openjdk/jdk/blob/2f4b5405f0b53782f3ed5274f68b31eb968efb6d/src/hotspot/share/compiler/compileBroker.cpp#L1813-L1817

In the process, we free all compiler queues and notify potentially waiting compiler threads via the `CompileTask::lock()`:
https://github.com/openjdk/jdk/blob/2f4b5405f0b53782f3ed5274f68b31eb968efb6d/src/hotspot/share/compiler/compileBroker.cpp#L397-L408

The problem is that since [JDK-8273917](https://bugs.openjdk.java.net/browse/JDK-8273917) (see [commit](https://github.com/openjdk/jdk/commit/b8af6a9bfb28aaf0fea0cfdaba13236dc8cbaa3a)), the rank of `CompileTask_lock` is `Mutex::safepoint` which is equal to the rank of `MethodCompileQueue_lock` which we are already holding because we modify the compile queue.

I propose to fix this by modifying the rank of the `CompileTask_lock` similar to what is done for other locks:
https://github.com/openjdk/jdk/blob/2f4b5405f0b53782f3ed5274f68b31eb968efb6d/src/hotspot/share/oops/methodData.cpp#L1211-L1212

The test that triggered this will be added with [PR 6364](https://git.openjdk.java.net/jdk/pull/6364). I verified that it now passes.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277213](https://bugs.openjdk.java.net/browse/JDK-8277213): CompileTask_lock is acquired out of order with MethodCompileQueue_lock


### Reviewers
 * [Rickard Bäckman](https://openjdk.java.net/census#rbackman) (@rickard - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6449/head:pull/6449` \
`$ git checkout pull/6449`

Update a local copy of the PR: \
`$ git checkout pull/6449` \
`$ git pull https://git.openjdk.java.net/jdk pull/6449/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6449`

View PR using the GUI difftool: \
`$ git pr show -t 6449`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6449.diff">https://git.openjdk.java.net/jdk/pull/6449.diff</a>

</details>
