### PR TITLE
JDK-8277092: TestMetaspaceAllocationMT2.java#ndebug-default fails with "RuntimeException: Committed seems high: NNNN expected at most MMMM"

### DIFF
--- a/test/hotspot/jtreg/runtime/Metaspace/elastic/MetaspaceTestContext.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/elastic/MetaspaceTestContext.java
@@ -1,9 +1,7 @@
 
 import sun.hotspot.WhiteBox;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 
 public class MetaspaceTestContext {
 
@@ -139,6 +137,9 @@ public class MetaspaceTestContext {
 
         long usageMeasured = usedWords();
         long committedMeasured = committedWords();
+
+        System.out.println("context used words " + usageMeasured + ", committed words " + committedMeasured
+                + ".");
 
         if (usageMeasured > committedMeasured) {
             throw new RuntimeException("Weirdness.");


### PR DESCRIPTION
Test error after [JDK-8276731](https://bugs.openjdk.java.net/browse/JDK-8276731). That patch changed the way metaspace chunks are uncommitted: Before, chunks were uncommitted when being returned to the system; now they are uncommitted only if `Metaspace::purge()` is explicitly called. 

In real VM life, that makes no difference since these two things happen back to back in `CLDG::purge()`. 

But these metaspace tests isolate metaspace arenas and test them as individual units, without involving GC or CLDG, and therefore we need to purge manually. Otherwise, the commit numbers are unpredictable and may be larger than expected.

Tests: manual x64+x86, GHAs (one unrelated error in hs compiler tests on linux x64), SAP nightlies

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277092](https://bugs.openjdk.java.net/browse/JDK-8277092): TestMetaspaceAllocationMT2.java#ndebug-default fails with "RuntimeException: Committed seems high: NNNN expected at most MMMM"


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6451/head:pull/6451` \
`$ git checkout pull/6451`

Update a local copy of the PR: \
`$ git checkout pull/6451` \
`$ git pull https://git.openjdk.java.net/jdk pull/6451/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6451`

View PR using the GUI difftool: \
`$ git pr show -t 6451`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6451.diff">https://git.openjdk.java.net/jdk/pull/6451.diff</a>

</details>
