### PR TITLE
JDK-8277383: VM.metaspace optionally show chunk freelist details

### DIFF
--- a/src/hotspot/share/memory/metaspace/metaspaceDCmd.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceDCmd.cpp
@@ -42,6 +42,7 @@ MetaspaceDCmd::MetaspaceDCmd(outputStream* output, bool heap) :
   _by_spacetype("by-spacetype", "Break down numbers by loader type.", "BOOLEAN", false, "false"),
   _by_chunktype("by-chunktype", "Break down numbers by chunk type.", "BOOLEAN", false, "false"),
   _show_vslist("vslist", "Shows details about the underlying virtual space.", "BOOLEAN", false, "false"),
+  _show_chunkfreelist("chunkfreelist", "Shows details about global chunk free lists (ChunkManager).", "BOOLEAN", false, "false"),
   _scale("scale", "Memory usage in which to scale. Valid values are: 1, KB, MB or GB (fixed scale) "
          "or \"dynamic\" for a dynamically chosen scale.",
          "STRING", false, "dynamic"),
@@ -53,6 +54,7 @@ MetaspaceDCmd::MetaspaceDCmd(outputStream* output, bool heap) :
   _dcmdparser.add_dcmd_option(&_by_chunktype);
   _dcmdparser.add_dcmd_option(&_by_spacetype);
   _dcmdparser.add_dcmd_option(&_show_vslist);
+  _dcmdparser.add_dcmd_option(&_show_chunkfreelist);
   _dcmdparser.add_dcmd_option(&_scale);
 }
 
@@ -96,6 +98,7 @@ void MetaspaceDCmd::execute(DCmdSource source, TRAPS) {
     if (_by_chunktype.value())         flags |= (int)MetaspaceReporter::Option::BreakDownByChunkType;
     if (_by_spacetype.value())         flags |= (int)MetaspaceReporter::Option::BreakDownBySpaceType;
     if (_show_vslist.value())          flags |= (int)MetaspaceReporter::Option::ShowVSList;
+    if (_show_chunkfreelist.value())   flags |= (int)MetaspaceReporter::Option::ShowChunkFreeList;
     VM_PrintMetadata op(output(), scale, flags);
     VMThread::execute(&op);
   }

--- a/src/hotspot/share/memory/metaspace/metaspaceDCmd.hpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceDCmd.hpp
@@ -38,6 +38,7 @@ class MetaspaceDCmd : public DCmdWithParser {
   DCmdArgument<bool> _by_spacetype;
   DCmdArgument<bool> _by_chunktype;
   DCmdArgument<bool> _show_vslist;
+  DCmdArgument<bool> _show_chunkfreelist;
   DCmdArgument<char*> _scale;
   DCmdArgument<bool> _show_classes;
 public:

--- a/src/hotspot/share/memory/metaspace/metaspaceReporter.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceReporter.cpp
@@ -300,6 +300,24 @@ void MetaspaceReporter::print_report(outputStream* out, size_t scale, int flags)
     out->cr();
   }
 
+  // -- Print Chunkmanager details.
+  if ((flags & (int)Option::ShowChunkFreeList) > 0) {
+    out->cr();
+    out->print_cr("Chunk freelist details:");
+    if (Metaspace::using_class_space()) {
+      out->print_cr("   Non-Class:");
+    }
+    ChunkManager::chunkmanager_nonclass()->print_on(out);
+    out->cr();
+    if (Metaspace::using_class_space()) {
+      out->print_cr("       Class:");
+      ChunkManager::chunkmanager_class()->print_on(out);
+      out->cr();
+    }
+  }
+  out->cr();
+
+
   //////////// Waste section ///////////////////////////
   // As a convenience, print a summary of common waste.
   out->cr();

--- a/src/hotspot/share/memory/metaspace/metaspaceReporter.hpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceReporter.hpp
@@ -44,7 +44,9 @@ public:
     // Print details about the underlying virtual spaces.
     ShowVSList                  = (1 << 3),
     // If show_loaders: show loaded classes for each loader.
-    ShowClasses                 = (1 << 4)
+    ShowClasses                 = (1 << 4),
+    // Print details about the underlying virtual spaces.
+    ShowChunkFreeList           = (1 << 5)
   };
 
   // This will print out a basic metaspace usage report but


### PR DESCRIPTION
A tiny patch to add an optional suboption to print out chunk freelist details with VM.metaspace; this is a followup from analyzing https://bugs.openjdk.java.net/browse/JDK-8277092.

-----

Tested: GHA, SAP nightlies, manual on x64, x86 Linux
Failing compiler test on x86-32 (compiler/c2/irTests/TestUnsignedComparison.java) unrelated, see JDK-8277324
"C2 compilation fails with "bad AD file" on x86-32 after JDK-8276162 due to missing match rule"

-----

Example use:

```
jcmd  HelloWorld VM.metaspace chunkfreelist

 ...
 
Chunk freelist details:
   Non-Class:
cm non-class-space: 7 chunks, total word size: 326144.
-- List[lv00]: empty
-- List[lv01]:  - <Chunk @0x00007f50d8122db0, state f, base 0x00007f5084600000, level lv01 (262144 words), used 0 words, committed 0 words.> - total : 1 chunks.
-- List[lv02]: empty
-- List[lv03]: empty
-- List[lv04]:  - <Chunk @0x00007f50d8122e88, state f, base 0x00007f5084540000, level lv04 (32768 words), used 0 words, committed 0 words.> - total : 1 chunks.
-- List[lv05]:  - <Chunk @0x00007f50d8122ed0, state f, base 0x00007f5084520000, level lv05 (16384 words), used 0 words, committed 0 words.> - total : 1 chunks.
-- List[lv06]:  - <Chunk @0x00007f50d8122f18, state f, base 0x00007f5084510000, level lv06 (8192 words), used 0 words, committed 0 words.> - total : 1 chunks.
-- List[lv07]:  - <Chunk @0x00007f50d8122f60, state f, base 0x00007f5084508000, level lv07 (4096 words), used 0 words, committed 0 words.> - total : 1 chunks.
-- List[lv08]:  - <Chunk @0x00007f50d8122fa8, state f, base 0x00007f5084504000, level lv08 (2048 words), used 0 words, committed 0 words.> - total : 1 chunks.
-- List[lv09]: empty
-- List[lv10]:  - <Chunk @0x00007f50d8123038, state f, base 0x00007f5084503000, level lv10 (512 words), used 0 words, committed 0 words.> - total : 1 chunks.
-- List[lv11]: empty
-- List[lv12]: empty
total chunks: 7, total word size: 326144.

       Class:
cm class-space: 6 chunks, total word size: 465920.
-- List[lv00]: empty
-- List[lv01]:  - <Chunk @0x00007f50d81229c0, state f, base 0x00000007c0200000, level lv01 (262144 words), used 0 words, committed 0 words.> - total : 1 chunks.
-- List[lv02]:  - <Chunk @0x00007f50d8122a08, state f, base 0x00000007c0100000, level lv02 (131072 words), used 0 words, committed 0 words.> - total : 1 chunks.
-- List[lv03]:  - <Chunk @0x00007f50d8122a50, state f, base 0x00000007c0080000, level lv03 (65536 words), used 0 words, committed 0 words.> - total : 1 chunks.
-- List[lv04]: empty
-- List[lv05]: empty
-- List[lv06]: empty
-- List[lv07]:  - <Chunk @0x00007f50d8122b70, state f, base 0x00000007c0008000, level lv07 (4096 words), used 0 words, committed 0 words.> - total : 1 chunks.
-- List[lv08]:  - <Chunk @0x00007f50d8122bb8, state f, base 0x00000007c0004000, level lv08 (2048 words), used 0 words, committed 0 words.> - total : 1 chunks.
-- List[lv09]:  - <Chunk @0x00007f50d8122c00, state f, base 0x00000007c0002000, level lv09 (1024 words), used 0 words, committed 0 words.> - total : 1 chunks.
-- List[lv10]: empty
-- List[lv11]: empty
-- List[lv12]: empty
total chunks: 6, total word size: 465920.

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277383](https://bugs.openjdk.java.net/browse/JDK-8277383): VM.metaspace optionally show chunk freelist details


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6452/head:pull/6452` \
`$ git checkout pull/6452`

Update a local copy of the PR: \
`$ git checkout pull/6452` \
`$ git pull https://git.openjdk.java.net/jdk pull/6452/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6452`

View PR using the GUI difftool: \
`$ git pr show -t 6452`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6452.diff">https://git.openjdk.java.net/jdk/pull/6452.diff</a>

</details>
