### PR TITLE
8277394: Remove the use of safepoint_workers in reference processor

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1830,7 +1830,8 @@ void G1CollectedHeap::ref_processing_init() {
                            // thread counts must be considered for discovery.
                            MAX2(ParallelGCThreads, ConcGCThreads),         // degree of mt discovery
                            true,                                           // Reference discovery is concurrent
-                           &_is_alive_closure_cm);                         // is alive closure
+                           &_is_alive_closure_cm,                          // is alive closure
+                           workers());                                     // workers for processing refs
 
   // STW ref processor
   _ref_processor_stw =
@@ -1838,7 +1839,8 @@ void G1CollectedHeap::ref_processing_init() {
                            ParallelGCThreads,                    // degree of mt processing
                            ParallelGCThreads,                    // degree of mt discovery
                            false,                                // Reference discovery is not concurrent
-                           &_is_alive_closure_stw);              // is alive closure
+                           &_is_alive_closure_stw,               // is alive closure
+                           workers());                           // workers for processing refs
 }
 
 SoftRefPolicy* G1CollectedHeap::soft_ref_policy() {

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -854,7 +854,8 @@ public:
       ParallelGCThreads,   // mt processing degree
       ParallelGCThreads,   // mt discovery degree
       true,                // atomic_discovery
-      is_alive_non_header) {
+      is_alive_non_header,
+      &ParallelScavengeHeap::heap()->workers()) {
   }
 
   template<typename T> bool discover(oop obj, ReferenceType type) {

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -801,7 +801,8 @@ void PSScavenge::initialize() {
                            ParallelGCThreads,          // mt processing degree
                            ParallelGCThreads,          // mt discovery degree
                            false,                      // concurrent_discovery
-                           NULL);                      // header provides liveness info
+                           nullptr,                    // header provides liveness info
+                           &ParallelScavengeHeap::heap()->workers());
 
   // Cache the cardtable
   _card_table = heap->card_table();

--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -253,6 +253,9 @@ private:
   DiscoveredList* _discoveredFinalRefs;
   DiscoveredList* _discoveredPhantomRefs;
 
+  // Workers to process the discovered non-strong references.
+  WorkerThreads* _workers;
+
   void run_task(RefProcTask& task, RefProcProxyTask& proxy_task, bool marks_oops_alive);
 
   // Drop Soft/Weak/Final references with a NULL or live referent, and clear
@@ -376,7 +379,8 @@ public:
                      uint mt_processing_degree = 1,
                      uint mt_discovery_degree  = 1,
                      bool concurrent_discovery = false,
-                     BoolObjectClosure* is_alive_non_header = NULL);
+                     BoolObjectClosure* is_alive_non_header = nullptr,
+                     WorkerThreads* workers = nullptr);
 
   // RefDiscoveryPolicy values
   enum DiscoveryPolicy {


### PR DESCRIPTION
Simple change of passing workers to the reference processor constructor.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8277394](https://bugs.openjdk.java.net/browse/JDK-8277394): Remove the use of safepoint_workers in reference processor


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6453/head:pull/6453` \
`$ git checkout pull/6453`

Update a local copy of the PR: \
`$ git checkout pull/6453` \
`$ git pull https://git.openjdk.java.net/jdk pull/6453/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6453`

View PR using the GUI difftool: \
`$ git pr show -t 6453`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6453.diff">https://git.openjdk.java.net/jdk/pull/6453.diff</a>

</details>
