### PR TITLE
8277397: ZGC: Add JFR event for temporary latency measurements

### DIFF
--- a/src/hotspot/share/gc/z/zTracer.cpp
+++ b/src/hotspot/share/gc/z/zTracer.cpp
@@ -131,3 +131,16 @@ void ZTracer::send_thread_phase(const char* name, const Ticks& start, const Tick
     e.commit();
   }
 }
+
+void ZTracer::send_thread_event(const char* name, const Ticks& start, const Ticks& end) {
+  NoSafepointVerifier nsv;
+
+  EventZThreadEvent e(UNTIMED);
+  if (e.should_commit()) {
+    e.set_gcId(GCId::current_or_undefined());
+    e.set_name(name);
+    e.set_starttime(start);
+    e.set_endtime(end);
+    e.commit();
+  }
+}

--- a/src/hotspot/share/gc/z/zTracer.cpp
+++ b/src/hotspot/share/gc/z/zTracer.cpp
@@ -132,10 +132,10 @@ void ZTracer::send_thread_phase(const char* name, const Ticks& start, const Tick
   }
 }
 
-void ZTracer::send_thread_event(const char* name, const Ticks& start, const Ticks& end) {
+void ZTracer::send_thread_debug(const char* name, const Ticks& start, const Ticks& end) {
   NoSafepointVerifier nsv;
 
-  EventZThreadEvent e(UNTIMED);
+  EventZThreadDebug e(UNTIMED);
   if (e.should_commit()) {
     e.set_gcId(GCId::current_or_undefined());
     e.set_name(name);

--- a/src/hotspot/share/gc/z/zTracer.hpp
+++ b/src/hotspot/share/gc/z/zTracer.hpp
@@ -39,6 +39,7 @@ private:
   void send_stat_counter(const ZStatCounter& counter, uint64_t increment, uint64_t value);
   void send_stat_sampler(const ZStatSampler& sampler, uint64_t value);
   void send_thread_phase(const char* name, const Ticks& start, const Ticks& end);
+  void send_thread_event(const char* name, const Ticks& start, const Ticks& end);
 
 public:
   static ZTracer* tracer();
@@ -47,6 +48,7 @@ public:
   void report_stat_counter(const ZStatCounter& counter, uint64_t increment, uint64_t value);
   void report_stat_sampler(const ZStatSampler& sampler, uint64_t value);
   void report_thread_phase(const char* name, const Ticks& start, const Ticks& end);
+  void report_thread_event(const char* name, const Ticks& start, const Ticks& end);
 };
 
 class ZTraceThreadPhase : public StackObj {
@@ -57,6 +59,17 @@ private:
 public:
   ZTraceThreadPhase(const char* name);
   ~ZTraceThreadPhase();
+};
+
+// For temporary latency measurements during development and debugging
+class ZTraceThreadEvent : public StackObj {
+private:
+  const Ticks       _start;
+  const char* const _name;
+
+public:
+  ZTraceThreadEvent(const char* name);
+  ~ZTraceThreadEvent();
 };
 
 #endif // SHARE_GC_Z_ZTRACER_HPP

--- a/src/hotspot/share/gc/z/zTracer.hpp
+++ b/src/hotspot/share/gc/z/zTracer.hpp
@@ -39,7 +39,7 @@ private:
   void send_stat_counter(const ZStatCounter& counter, uint64_t increment, uint64_t value);
   void send_stat_sampler(const ZStatSampler& sampler, uint64_t value);
   void send_thread_phase(const char* name, const Ticks& start, const Ticks& end);
-  void send_thread_event(const char* name, const Ticks& start, const Ticks& end);
+  void send_thread_debug(const char* name, const Ticks& start, const Ticks& end);
 
 public:
   static ZTracer* tracer();
@@ -48,28 +48,18 @@ public:
   void report_stat_counter(const ZStatCounter& counter, uint64_t increment, uint64_t value);
   void report_stat_sampler(const ZStatSampler& sampler, uint64_t value);
   void report_thread_phase(const char* name, const Ticks& start, const Ticks& end);
-  void report_thread_event(const char* name, const Ticks& start, const Ticks& end);
-};
-
-class ZTraceThreadPhase : public StackObj {
-private:
-  const Ticks       _start;
-  const char* const _name;
-
-public:
-  ZTraceThreadPhase(const char* name);
-  ~ZTraceThreadPhase();
+  void report_thread_debug(const char* name, const Ticks& start, const Ticks& end);
 };
 
 // For temporary latency measurements during development and debugging
-class ZTraceThreadEvent : public StackObj {
+class ZTraceThreadDebug : public StackObj {
 private:
   const Ticks       _start;
   const char* const _name;
 
 public:
-  ZTraceThreadEvent(const char* name);
-  ~ZTraceThreadEvent();
+  ZTraceThreadDebug(const char* name);
+  ~ZTraceThreadDebug();
 };
 
 #endif // SHARE_GC_Z_ZTRACER_HPP

--- a/src/hotspot/share/gc/z/zTracer.inline.hpp
+++ b/src/hotspot/share/gc/z/zTracer.inline.hpp
@@ -50,12 +50,26 @@ inline void ZTracer::report_thread_phase(const char* name, const Ticks& start, c
   }
 }
 
+inline void ZTracer::report_thread_event(const char* name, const Ticks& start, const Ticks& end) {
+  if (EventZThreadEvent::is_enabled()) {
+    send_thread_event(name, start, end);
+  }
+}
+
 inline ZTraceThreadPhase::ZTraceThreadPhase(const char* name) :
     _start(Ticks::now()),
     _name(name) {}
 
 inline ZTraceThreadPhase::~ZTraceThreadPhase() {
   ZTracer::tracer()->report_thread_phase(_name, _start, Ticks::now());
+}
+
+inline ZTraceThreadEvent::ZTraceThreadEvent(const char* name) :
+    _start(Ticks::now()),
+    _name(name) {}
+
+inline ZTraceThreadEvent::~ZTraceThreadEvent() {
+  ZTracer::tracer()->report_thread_event(_name, _start, Ticks::now());
 }
 
 #endif // SHARE_GC_Z_ZTRACER_INLINE_HPP

--- a/src/hotspot/share/gc/z/zTracer.inline.hpp
+++ b/src/hotspot/share/gc/z/zTracer.inline.hpp
@@ -50,26 +50,18 @@ inline void ZTracer::report_thread_phase(const char* name, const Ticks& start, c
   }
 }
 
-inline void ZTracer::report_thread_event(const char* name, const Ticks& start, const Ticks& end) {
-  if (EventZThreadEvent::is_enabled()) {
-    send_thread_event(name, start, end);
+inline void ZTracer::report_thread_debug(const char* name, const Ticks& start, const Ticks& end) {
+  if (EventZThreadDebug::is_enabled()) {
+    send_thread_debug(name, start, end);
   }
 }
 
-inline ZTraceThreadPhase::ZTraceThreadPhase(const char* name) :
+inline ZTraceThreadDebug::ZTraceThreadDebug(const char* name) :
     _start(Ticks::now()),
     _name(name) {}
 
-inline ZTraceThreadPhase::~ZTraceThreadPhase() {
-  ZTracer::tracer()->report_thread_phase(_name, _start, Ticks::now());
-}
-
-inline ZTraceThreadEvent::ZTraceThreadEvent(const char* name) :
-    _start(Ticks::now()),
-    _name(name) {}
-
-inline ZTraceThreadEvent::~ZTraceThreadEvent() {
-  ZTracer::tracer()->report_thread_event(_name, _start, Ticks::now());
+inline ZTraceThreadDebug::~ZTraceThreadDebug() {
+  ZTracer::tracer()->report_thread_debug(_name, _start, Ticks::now());
 }
 
 #endif // SHARE_GC_Z_ZTRACER_INLINE_HPP

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -1034,6 +1034,11 @@
     <Field type="string" name="name" label="Name" />
   </Event>
 
+  <Event name="ZThreadEvent" category="Java Virtual Machine, GC, Detailed" label="ZGC Thread Event" thread="true" experimental="true">
+    <Field type="uint" name="gcId" label="GC Identifier" relation="GcId"/>
+    <Field type="string" name="name" label="Name" />
+  </Event>
+
   <Event name="ZUncommit" category="Java Virtual Machine, GC, Detailed" label="ZGC Uncommit" description="Uncommitting of memory" thread="true">
     <Field type="ulong" contentType="bytes" name="uncommitted" label="Uncommitted" />
   </Event>

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -1034,7 +1034,7 @@
     <Field type="string" name="name" label="Name" />
   </Event>
 
-  <Event name="ZThreadEvent" category="Java Virtual Machine, GC, Detailed" label="ZGC Thread Event" thread="true" experimental="true">
+  <Event name="ZThreadEvent" category="Java Virtual Machine, GC, Detailed" label="ZGC Thread Event" description="Temporary latency measurements used during development and debugging of ZGC" thread="true" experimental="true">
     <Field type="uint" name="gcId" label="GC Identifier" relation="GcId"/>
     <Field type="string" name="name" label="Name" />
   </Event>

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -1034,7 +1034,7 @@
     <Field type="string" name="name" label="Name" />
   </Event>
 
-  <Event name="ZThreadEvent" category="Java Virtual Machine, GC, Detailed" label="ZGC Thread Event" description="Temporary latency measurements used during development and debugging of ZGC" thread="true" experimental="true">
+  <Event name="ZThreadDebug" category="Java Virtual Machine, GC, Detailed" label="ZGC Thread Event" description="Temporary latency measurements used during development and debugging of ZGC" thread="true" experimental="true">
     <Field type="uint" name="gcId" label="GC Identifier" relation="GcId"/>
     <Field type="string" name="name" label="Name" />
   </Event>

--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -775,6 +775,11 @@
       <setting name="threshold">0 ms</setting>
     </event>
 
+    <event name="jdk.ZThreadEvent">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
     <event name="jdk.ZUncommit">
       <setting name="enabled">true</setting>
       <setting name="threshold">0 ms</setting>

--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -775,7 +775,7 @@
       <setting name="threshold">0 ms</setting>
     </event>
 
-    <event name="jdk.ZThreadEvent">
+    <event name="jdk.ZThreadDebug">
       <setting name="enabled">true</setting>
       <setting name="threshold">0 ms</setting>
     </event>

--- a/src/jdk.jfr/share/conf/jfr/profile.jfc
+++ b/src/jdk.jfr/share/conf/jfr/profile.jfc
@@ -775,6 +775,11 @@
       <setting name="threshold">0 ms</setting>
     </event>
 
+    <event name="jdk.ZThreadEvent">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
     <event name="jdk.ZUncommit">
       <setting name="enabled">true</setting>
       <setting name="threshold">0 ms</setting>

--- a/src/jdk.jfr/share/conf/jfr/profile.jfc
+++ b/src/jdk.jfr/share/conf/jfr/profile.jfc
@@ -775,7 +775,7 @@
       <setting name="threshold">0 ms</setting>
     </event>
 
-    <event name="jdk.ZThreadEvent">
+    <event name="jdk.ZThreadDebug">
       <setting name="enabled">true</setting>
       <setting name="threshold">0 ms</setting>
     </event>


### PR DESCRIPTION
I often measure latencies and stalls using JFR events. I'd like to add an event that can be used for these ad-hoc measurements during development and debugging.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277397](https://bugs.openjdk.java.net/browse/JDK-8277397): ZGC: Add JFR event for temporary latency measurements


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)
 * [Jaroslav Bachorik](https://openjdk.java.net/census#jbachorik) (@jbachorik - **Reviewer**)
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6454/head:pull/6454` \
`$ git checkout pull/6454`

Update a local copy of the PR: \
`$ git checkout pull/6454` \
`$ git pull https://git.openjdk.java.net/jdk pull/6454/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6454`

View PR using the GUI difftool: \
`$ git pr show -t 6454`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6454.diff">https://git.openjdk.java.net/jdk/pull/6454.diff</a>

</details>
