### PR TITLE
8277407: javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java fails to compile after JDK-8276058

### DIFF
--- a/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
+++ b/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
@@ -80,7 +80,7 @@ public class bug6276188 {
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
 
-            Color color = robot.getPixelColor(p.x - OFFSET_X, p.y - OFFSET_y);
+            Color color = robot.getPixelColor(p.x - OFFSET_X, p.y - OFFSET_Y);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
             boolean red = color.getRed() > 0 && color.getGreen() == 0 && color.getBlue() == 0;


### PR DESCRIPTION
Fixed compilation issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277407](https://bugs.openjdk.java.net/browse/JDK-8277407): javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java fails to compile after JDK-8276058


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6458/head:pull/6458` \
`$ git checkout pull/6458`

Update a local copy of the PR: \
`$ git checkout pull/6458` \
`$ git pull https://git.openjdk.java.net/jdk pull/6458/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6458`

View PR using the GUI difftool: \
`$ git pr show -t 6458`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6458.diff">https://git.openjdk.java.net/jdk/pull/6458.diff</a>

</details>
