### PR TITLE
8277385: Zero: Enable CompactStrings support

### DIFF
--- a/src/hotspot/cpu/zero/globals_zero.hpp
+++ b/src/hotspot/cpu/zero/globals_zero.hpp
@@ -69,8 +69,7 @@ define_pd_global(uintx, TypeProfileLevel, 0);
 
 define_pd_global(bool, PreserveFramePointer, false);
 
-// No performance work done here yet.
-define_pd_global(bool, CompactStrings, false);
+define_pd_global(bool, CompactStrings, true);
 
 #define ARCH_FLAGS(develop,                                                 \
                    product,                                                 \


### PR DESCRIPTION
This enables `CompactStrings` for Zero. When we were doing original Compact Strings in JDK 9, we disabled the support on non-primary platforms, hoping relevant maintainers would follow up with platform-specific work. Here is me following up, as Zero maintainer :) 

There is little to do on Zero side, as it is pure interpreter without String intrinsics. Other platforms had old-shaped String intrinsics, so for them enabling the feature would mean implementing Compact-String-shaped intrinsics too. But this is irrelevant for Zero. There is still benefit of doing less work with smaller Strings.

There are no regressions on the benchmarks I tried, and some benchmarks improve significantly. Notably, specjvm:{compiler,sunflow,derby,xmlvalidation} improve about 5%, specjvm:{serial,xmltransform} improve about 20% on x86_64.

Additional testing:
 - [x] Linux x86_64 Zero benchmarks
 - [x] Linux x86_64 Zero `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277385](https://bugs.openjdk.java.net/browse/JDK-8277385): Zero: Enable CompactStrings support


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6459/head:pull/6459` \
`$ git checkout pull/6459`

Update a local copy of the PR: \
`$ git checkout pull/6459` \
`$ git pull https://git.openjdk.java.net/jdk pull/6459/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6459`

View PR using the GUI difftool: \
`$ git pr show -t 6459`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6459.diff">https://git.openjdk.java.net/jdk/pull/6459.diff</a>

</details>
