### PR TITLE
8277414: ProblemList runtime/CommandLine/VMDeprecatedOptions.java on windows-x64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -106,6 +106,7 @@ runtime/os/TestTracePageSizes.java#G1 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 runtime/jni/checked/TestPrimitiveArrayCriticalWithBadParam.java 8277350 macosx-x64
+runtime/CommandLine/VMDeprecatedOptions.java 8277404 windows-x64
 
 applications/jcstress/copy.java 8229852 linux-all
 


### PR DESCRIPTION
A trivial fix to ProblemList runtime/CommandLine/VMDeprecatedOptions.java on windows-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277414](https://bugs.openjdk.java.net/browse/JDK-8277414): ProblemList runtime/CommandLine/VMDeprecatedOptions.java on windows-x64


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6460/head:pull/6460` \
`$ git checkout pull/6460`

Update a local copy of the PR: \
`$ git checkout pull/6460` \
`$ git pull https://git.openjdk.java.net/jdk pull/6460/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6460`

View PR using the GUI difftool: \
`$ git pr show -t 6460`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6460.diff">https://git.openjdk.java.net/jdk/pull/6460.diff</a>

</details>
