### PR TITLE
8277404: Test VMDeprecatedOptions.java failing with Unable to create shared archive file

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -106,7 +106,6 @@ runtime/os/TestTracePageSizes.java#G1 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 runtime/jni/checked/TestPrimitiveArrayCriticalWithBadParam.java 8277350 macosx-x64
-runtime/CommandLine/VMDeprecatedOptions.java 8277404 windows-x64
 
 applications/jcstress/copy.java 8229852 linux-all
 

--- a/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
@@ -48,9 +48,9 @@ public class VMDeprecatedOptions {
         {"TLABStats",                 "false"},
         {"AllowRedefinitionToAddDeleteMethods", "true"},
         {"UseSharedSpaces",           "false"},
-        {"RequireSharedSpaces",       "true"},
-        {"DumpSharedSpaces",          "true"},
-        {"DynamicDumpSharedSpaces",   "true"},
+        {"RequireSharedSpaces",       "false"},
+        {"DumpSharedSpaces",          "false"},
+        {"DynamicDumpSharedSpaces",   "false"},
 
         // deprecated alias flags (see also aliased_jvm_flags):
         {"DefaultMaxRAMFraction", "4"},


### PR DESCRIPTION
Please review this trivial fix so that test VMDeprecatedVMOptions.java runs with the CDS options set to false.  This prevents the test from trying to dump an archive and prevents it from trying to force usage of the CDS archive.

The fix was tested by running Mach5 tiers 1-2 on Linux, Mac OS, and Windows.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277404](https://bugs.openjdk.java.net/browse/JDK-8277404): Test VMDeprecatedOptions.java failing with Unable to create shared archive file


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6463/head:pull/6463` \
`$ git checkout pull/6463`

Update a local copy of the PR: \
`$ git checkout pull/6463` \
`$ git pull https://git.openjdk.java.net/jdk pull/6463/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6463`

View PR using the GUI difftool: \
`$ git pr show -t 6463`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6463.diff">https://git.openjdk.java.net/jdk/pull/6463.diff</a>

</details>
