### PR TITLE
8277342: vmTestbase/nsk/stress/strace/strace004.java fails with SIGSEGV  in InstanceKlass::jni_id_for

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2061,13 +2061,12 @@ Method* InstanceKlass::lookup_method_in_all_interfaces(Symbol* name,
   return NULL;
 }
 
-/* jni_id_forfor jfieldIds only */
+/* jni_id_for for jfieldIds only */
 JNIid* InstanceKlass::jni_id_for(int offset) {
   MutexLocker ml(JfieldIdCreation_lock);
-  // Retry lookup after we got the lock
   JNIid* probe = jni_ids() == NULL ? NULL : jni_ids()->find(offset);
   if (probe == NULL) {
-    // Slow case, allocate new static field identifier
+    // Allocate new static field identifier
     probe = new JNIid(this, offset, jni_ids());
     set_jni_ids(probe);
   }

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2061,8 +2061,8 @@ Method* InstanceKlass::lookup_method_in_all_interfaces(Symbol* name,
   return NULL;
 }
 
-/* jni_id_for_impl for jfieldIds only */
-JNIid* InstanceKlass::jni_id_for_impl(int offset) {
+/* jni_id_forfor jfieldIds only */
+JNIid* InstanceKlass::jni_id_for(int offset) {
   MutexLocker ml(JfieldIdCreation_lock);
   // Retry lookup after we got the lock
   JNIid* probe = jni_ids() == NULL ? NULL : jni_ids()->find(offset);
@@ -2070,16 +2070,6 @@ JNIid* InstanceKlass::jni_id_for_impl(int offset) {
     // Slow case, allocate new static field identifier
     probe = new JNIid(this, offset, jni_ids());
     set_jni_ids(probe);
-  }
-  return probe;
-}
-
-
-/* jni_id_for for jfieldIds only */
-JNIid* InstanceKlass::jni_id_for(int offset) {
-  JNIid* probe = jni_ids() == NULL ? NULL : jni_ids()->find(offset);
-  if (probe == NULL) {
-    probe = jni_id_for_impl(offset);
   }
   return probe;
 }

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1199,8 +1199,6 @@ private:
   void initialize_impl                           (TRAPS);
   void initialize_super_interfaces               (TRAPS);
   void eager_initialize_impl                     ();
-  /* jni_id_for_impl for jfieldID only */
-  JNIid* jni_id_for_impl                         (int offset);
 
   void add_initialization_error(JavaThread* current, Handle exception);
   oop get_initialization_error(JavaThread* current);


### PR DESCRIPTION
Use the version jni_id_for_impl() as jni_id_for() that takes out the JFieldIdCreation_lock before reading jni_ids in InstanceKlass.
Tested with mach5 tier1-3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277342](https://bugs.openjdk.java.net/browse/JDK-8277342): vmTestbase/nsk/stress/strace/strace004.java fails with SIGSEGV in InstanceKlass::jni_id_for


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 47cb164bdcc5d51a1b23f34d38766f2a9831562b
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6466/head:pull/6466` \
`$ git checkout pull/6466`

Update a local copy of the PR: \
`$ git checkout pull/6466` \
`$ git pull https://git.openjdk.java.net/jdk pull/6466/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6466`

View PR using the GUI difftool: \
`$ git pr show -t 6466`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6466.diff">https://git.openjdk.java.net/jdk/pull/6466.diff</a>

</details>
