### PR TITLE
8277449: compiler/vectorapi/TestLongVectorNeg.java fails with release VMs

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/TestLongVectorNeg.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestLongVectorNeg.java
@@ -30,6 +30,7 @@ import jdk.incubator.vector.LongVector;
  * @bug 8275643
  * @summary Test that LongVector.neg is properly handled by the _VectorUnaryOp C2 intrinsic
  * @modules jdk.incubator.vector
+ * @requires vm.debug
  * @run main/othervm -XX:-TieredCompilation -XX:+AlwaysIncrementalInline -Xbatch
  *                   -XX:CompileCommand=dontinline,compiler.vectorapi.TestLongVectorNeg::test
  *                   compiler.vectorapi.TestLongVectorNeg


### PR DESCRIPTION
Hi all,

Please review this trivial fix.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277449](https://bugs.openjdk.java.net/browse/JDK-8277449): compiler/vectorapi/TestLongVectorNeg.java fails with release VMs


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6476/head:pull/6476` \
`$ git checkout pull/6476`

Update a local copy of the PR: \
`$ git checkout pull/6476` \
`$ git pull https://git.openjdk.java.net/jdk pull/6476/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6476`

View PR using the GUI difftool: \
`$ git pr show -t 6476`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6476.diff">https://git.openjdk.java.net/jdk/pull/6476.diff</a>

</details>
