### PR TITLE
8265795: vmTestbase/nsk/jvmti/AttachOnDemand/attach022/TestDescription.java fails when running with JEP 416

### DIFF
--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -331,10 +331,11 @@ UNSAFE_LEAF(void, Unsafe_FullFence(JNIEnv *env, jobject unsafe)) {
 
 UNSAFE_ENTRY(jobject, Unsafe_AllocateInstance(JNIEnv *env, jobject unsafe, jclass cls)) {
   instanceOop i = InstanceKlass::allocate_instance(JNIHandles::resolve_non_null(cls), CHECK_NULL);
+  jobject res = JNIHandles::make_local(THREAD, i);
   if (JvmtiExport::should_post_vm_object_alloc()) {
     JvmtiExport::post_vm_object_alloc(thread, i);
   }
-  return JNIHandles::make_local(THREAD, i);
+  return res;
 } UNSAFE_END
 
 UNSAFE_ENTRY(jlong, Unsafe_AllocateMemory0(JNIEnv *env, jobject unsafe, jlong size)) {

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -41,6 +41,7 @@
 #include "oops/objArrayOop.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/typeArrayOop.inline.hpp"
+#include "prims/jvmtiExport.hpp"
 #include "prims/unsafe.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/handles.inline.hpp"
@@ -330,6 +331,9 @@ UNSAFE_LEAF(void, Unsafe_FullFence(JNIEnv *env, jobject unsafe)) {
 
 UNSAFE_ENTRY(jobject, Unsafe_AllocateInstance(JNIEnv *env, jobject unsafe, jclass cls)) {
   instanceOop i = InstanceKlass::allocate_instance(JNIHandles::resolve_non_null(cls), CHECK_NULL);
+  if (JvmtiExport::should_post_vm_object_alloc()) {
+    JvmtiExport::post_vm_object_alloc(thread, i);
+  }
   return JNIHandles::make_local(THREAD, i);
 } UNSAFE_END
 

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -330,12 +330,9 @@ UNSAFE_LEAF(void, Unsafe_FullFence(JNIEnv *env, jobject unsafe)) {
 ////// Allocation requests
 
 UNSAFE_ENTRY(jobject, Unsafe_AllocateInstance(JNIEnv *env, jobject unsafe, jclass cls)) {
+  JvmtiVMObjectAllocEventCollector oam;
   instanceOop i = InstanceKlass::allocate_instance(JNIHandles::resolve_non_null(cls), CHECK_NULL);
-  jobject res = JNIHandles::make_local(THREAD, i);
-  if (JvmtiExport::should_post_vm_object_alloc()) {
-    JvmtiExport::post_vm_object_alloc(thread, i);
-  }
-  return res;
+  return JNIHandles::make_local(THREAD, i);
 } UNSAFE_END
 
 UNSAFE_ENTRY(jlong, Unsafe_AllocateMemory0(JNIEnv *env, jobject unsafe, jlong size)) {

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -38,8 +38,6 @@
 #
 #############################################################################
 
-vmTestbase/nsk/jvmti/AttachOnDemand/attach002a/TestDescription.java 8265795 generic-all
-vmTestbase/nsk/jvmti/AttachOnDemand/attach022/TestDescription.java 8265795 generic-all
 vmTestbase/nsk/jdi/ObjectReference/referringObjects/referringObjects002/referringObjects002.java 8265796  generic-all
 
 #############################################################################

--- a/test/hotspot/jtreg/serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Verifies that a VMObjectAlloc event is generated for object created using MethodHandle
+ * @requires vm.jvmti
+ * @run main/othervm/native -agentlib:VMObjectAlloc VMObjectAllocTest
+ */
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+public class VMObjectAllocTest {
+
+    private static native int getNumberOfAllocation();
+
+    public VMObjectAllocTest(String str) {
+    }
+
+    public static void main(String[] args) throws Throwable {
+
+        MethodHandles.Lookup publicLookup = MethodHandles.publicLookup();
+        MethodType mt = MethodType.methodType(void.class, String.class);
+        MethodHandle mh = publicLookup.findConstructor(VMObjectAllocTest.class, mt);
+        mh.invoke("str");
+
+        if(getNumberOfAllocation() != 1) {
+            throw new Exception("Number of allocation != 1");
+        }
+    }
+}

--- a/test/hotspot/jtreg/serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java
@@ -46,7 +46,7 @@ public class VMObjectAllocTest {
         MethodHandle mh = publicLookup.findConstructor(VMObjectAllocTest.class, mt);
         mh.invoke("str");
 
-        if(getNumberOfAllocation() != 1) {
+        if (getNumberOfAllocation() != 1) {
             throw new Exception("Number of allocation != 1");
         }
     }

--- a/test/hotspot/jtreg/serviceability/jvmti/VMObjectAlloc/libVMObjectAlloc.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/VMObjectAlloc/libVMObjectAlloc.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <string.h>
+#include "jvmti.h"
+
+extern "C" {
+
+static int number_of_allocation = 0;
+
+extern JNIEXPORT void JNICALL
+VMObjectAlloc(jvmtiEnv *jvmti,
+              JNIEnv* jni,
+              jthread thread,
+              jobject object,
+              jclass cls,
+              jlong size) {
+  char *signature = NULL;
+  jvmtiError err = jvmti->GetClassSignature(cls, &signature, NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    jni->FatalError("Failed during the GetClassSignature call");
+  }
+
+  printf("VMObjectAlloc called for %s\n", signature);
+
+  if (!strcmp(signature, "LVMObjectAllocTest;")) {
+    number_of_allocation++;
+  }
+}
+
+
+JNIEXPORT jint JNICALL
+Java_VMObjectAllocTest_getNumberOfAllocation(JNIEnv *env, jclass cls) {
+  return number_of_allocation;
+}
+
+extern JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+  jvmtiEnv *jvmti;
+  jvmtiEventCallbacks callbacks;
+  jvmtiError err;
+  jvmtiCapabilities caps;
+
+  if (jvm->GetEnv((void **) &jvmti, JVMTI_VERSION) != JNI_OK) {
+    return JNI_ERR;
+  }
+
+  memset(&callbacks, 0, sizeof(callbacks));
+  callbacks.VMObjectAlloc = &VMObjectAlloc;
+  memset(&caps, 0, sizeof(caps));
+  caps.can_generate_vm_object_alloc_events = 1;
+
+  err = jvmti->AddCapabilities( &caps);
+  if (err != JVMTI_ERROR_NONE) {
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventCallbacks(&callbacks, sizeof(jvmtiEventCallbacks));
+  if (err != JVMTI_ERROR_NONE) {
+    return JNI_ERR;
+  }
+
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_OBJECT_ALLOC , NULL);
+  if (err != JVMTI_ERROR_NONE) {
+    return JNI_ERR;
+  }
+
+  return JNI_OK;
+}
+
+}

--- a/test/hotspot/jtreg/serviceability/jvmti/VMObjectAlloc/libVMObjectAlloc.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/VMObjectAlloc/libVMObjectAlloc.cpp
@@ -88,4 +88,4 @@ Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   return JNI_OK;
 }
 
-}
+} //extern "C"


### PR DESCRIPTION
The VMObjectAlloc jvmti event was not generated for objects created using MethodHanldle. The fix adds posting of the event into Unsafe_AllocateInstance.

While fixing this bug I noticed that event is not posted in the intrinsics version for many functions where it is used. Including  but not limited to clone(), invoke()m allocateInstance() and allocateUninitializedArray(). There are might be other intensified functions (not analogs JVM_ENTRY versions) that allocate objects without post events. 

I think it is needed to implement some common way to handle this and cover it in another issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265795](https://bugs.openjdk.java.net/browse/JDK-8265795): vmTestbase/nsk/jvmti/AttachOnDemand/attach022/TestDescription.java fails when running with JEP 416


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to e160dbe3eafe82c83319d0bb1baab5702686aef9
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to e160dbe3eafe82c83319d0bb1baab5702686aef9


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6478/head:pull/6478` \
`$ git checkout pull/6478`

Update a local copy of the PR: \
`$ git checkout pull/6478` \
`$ git pull https://git.openjdk.java.net/jdk pull/6478/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6478`

View PR using the GUI difftool: \
`$ git pr show -t 6478`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6478.diff">https://git.openjdk.java.net/jdk/pull/6478.diff</a>

</details>
