### PR TITLE
8277485: Zero: Fix _fast_{i,f}access_0 bytecodes handling

### DIFF
--- a/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
@@ -2805,7 +2805,7 @@ run:
         UPDATE_PC_AND_TOS_AND_CONTINUE(4, 1);
       }
 
-      CASE(_fast_faccess_0): {
+      CASE(_fast_iaccess_0): {
         u2 index = Bytes::get_native_u2(pc+2);
         ConstantPoolCacheEntry* cache = cp->entry_at(index);
         int field_offset = cache->f2_as_index();
@@ -2820,7 +2820,7 @@ run:
         UPDATE_PC_AND_TOS_AND_CONTINUE(4, 1);
       }
 
-      CASE(_fast_iaccess_0): {
+      CASE(_fast_faccess_0): {
         u2 index = Bytes::get_native_u2(pc+2);
         ConstantPoolCacheEntry* cache = cp->entry_at(index);
         int field_offset = cache->f2_as_index();


### PR DESCRIPTION
Hi all,

Please review the fix for zero fast bytecodes implementation.
The bug can be reproduced by building zero on x86_32.

Testing:
  - zero build on x86_{64,32}

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277485](https://bugs.openjdk.java.net/browse/JDK-8277485): Zero: Fix _fast_{i,f}access_0 bytecodes handling


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6479/head:pull/6479` \
`$ git checkout pull/6479`

Update a local copy of the PR: \
`$ git checkout pull/6479` \
`$ git pull https://git.openjdk.java.net/jdk pull/6479/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6479`

View PR using the GUI difftool: \
`$ git pr show -t 6479`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6479.diff">https://git.openjdk.java.net/jdk/pull/6479.diff</a>

</details>
