### PR TITLE
8272042: java.util.ImmutableCollections$Map1 and MapN should not be @ValueBased

### DIFF
--- a/src/java.base/share/classes/java/util/ImmutableCollections.java
+++ b/src/java.base/share/classes/java/util/ImmutableCollections.java
@@ -1062,6 +1062,7 @@ class ImmutableCollections {
 
     // ---------- Map Implementations ----------
 
+    // Not a jdk.internal.ValueBased class; disqualified by fields in superclass AbstractMap
     abstract static class AbstractImmutableMap<K,V> extends AbstractMap<K,V> implements Serializable {
         @Override public void clear() { throw uoe(); }
         @Override public V compute(K key, BiFunction<? super K,? super V,? extends V> rf) { throw uoe(); }
@@ -1092,6 +1093,7 @@ class ImmutableCollections {
         }
     }
 
+    // Not a jdk.internal.ValueBased class; disqualified by fields in superclass AbstractMap
     static final class Map1<K,V> extends AbstractImmutableMap<K,V> {
         @Stable
         private final K k0;
@@ -1158,6 +1160,7 @@ class ImmutableCollections {
      * @param <K> the key type
      * @param <V> the value type
      */
+    // Not a jdk.internal.ValueBased class; disqualified by fields in superclass AbstractMap
     static final class MapN<K,V> extends AbstractImmutableMap<K,V> {
 
         @Stable

--- a/src/java.base/share/classes/java/util/ImmutableCollections.java
+++ b/src/java.base/share/classes/java/util/ImmutableCollections.java
@@ -1062,7 +1062,6 @@ class ImmutableCollections {
 
     // ---------- Map Implementations ----------
 
-    @jdk.internal.ValueBased
     abstract static class AbstractImmutableMap<K,V> extends AbstractMap<K,V> implements Serializable {
         @Override public void clear() { throw uoe(); }
         @Override public V compute(K key, BiFunction<? super K,? super V,? extends V> rf) { throw uoe(); }
@@ -1093,7 +1092,6 @@ class ImmutableCollections {
         }
     }
 
-    @jdk.internal.ValueBased
     static final class Map1<K,V> extends AbstractImmutableMap<K,V> {
         @Stable
         private final K k0;
@@ -1160,7 +1158,6 @@ class ImmutableCollections {
      * @param <K> the key type
      * @param <V> the value type
      */
-    @jdk.internal.ValueBased
     static final class MapN<K,V> extends AbstractImmutableMap<K,V> {
 
         @Stable


### PR DESCRIPTION
The `jdk.internal.ValueBased` annotation was incorrectly applied to subclasses of java.util.AbstractMap.
[ValueBased](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/doc-files/ValueBased.html) requires that supertypes have no instance fields; AbstractMap has instance fields keySet and values.

Remove the internal @ValueBased annotation for subclasses of AbstractMap including:
AbstractImmutableMap, Map1, and MapN.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272042](https://bugs.openjdk.java.net/browse/JDK-8272042): java.util.ImmutableCollections$Map1 and MapN should not be @ValueBased


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to c1f579ea5ce4e4462d196c59be3fc5339baba3d0
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to c1f579ea5ce4e4462d196c59be3fc5339baba3d0
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6480/head:pull/6480` \
`$ git checkout pull/6480`

Update a local copy of the PR: \
`$ git checkout pull/6480` \
`$ git pull https://git.openjdk.java.net/jdk pull/6480/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6480`

View PR using the GUI difftool: \
`$ git pr show -t 6480`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6480.diff">https://git.openjdk.java.net/jdk/pull/6480.diff</a>

</details>
