### PR TITLE
8277494: [BACKOUT] JDK-8276150 Quarantined jpackage apps are labeled as "damaged"

### DIFF
--- a/test/jdk/tools/jpackage/macosx/SigningAppImageTest.java
+++ b/test/jdk/tools/jpackage/macosx/SigningAppImageTest.java
@@ -22,11 +22,8 @@
  */
 
 import java.nio.file.Path;
-import java.util.List;
-
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.Annotations.Test;
-import jdk.jpackage.test.Annotations.Parameters;
 
 /**
  * Tests generation of app image with --mac-sign and related arguments. Test will
@@ -60,36 +57,21 @@ import jdk.jpackage.test.Annotations.Parameters;
  */
 public class SigningAppImageTest {
 
-    final boolean doSign;
-
-    public SigningAppImageTest(String flag) {
-        this.doSign = "true".equals(flag);
-    }
-
-    @Parameters
-    public static List<Object[]> data() {
-        return List.of(new Object[][] {{"true"}, {"false"}});
-    }
-
     @Test
-    public void test() throws Exception {
+    public static void test() throws Exception {
         SigningCheck.checkCertificates();
 
         JPackageCommand cmd = JPackageCommand.helloAppImage();
-        if (doSign) {
-            cmd.addArguments("--mac-sign", "--mac-signing-key-user-name",
-                    SigningBase.DEV_NAME, "--mac-signing-keychain",
-                    SigningBase.KEYCHAIN);
-        }
+        cmd.addArguments("--mac-sign", "--mac-signing-key-user-name",
+                SigningBase.DEV_NAME, "--mac-signing-keychain",
+                SigningBase.KEYCHAIN);
         cmd.executeAndAssertHelloAppImageCreated();
 
         Path launcherPath = cmd.appLauncherPath();
-        SigningBase.verifyCodesign(launcherPath, doSign);
+        SigningBase.verifyCodesign(launcherPath, true);
 
         Path appImage = cmd.outputBundle();
-        SigningBase.verifyCodesign(appImage, doSign);
-        if (doSign) {
-            SigningBase.verifySpctl(appImage, "exec");
-        }
+        SigningBase.verifyCodesign(appImage, true);
+        SigningBase.verifySpctl(appImage, "exec");
     }
 }


### PR DESCRIPTION
This reverts commit 936f7ff49ed86adb74bb1ff10d93cb3d7f7d70a0.

So far we've had 3 failed Tier2 job sets in a row. My Mach5 Tier2 of this [BACKOUT] has 
passed the macosx-aarch64 test task that was failing before.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277494](https://bugs.openjdk.java.net/browse/JDK-8277494): [BACKOUT] JDK-8276150 Quarantined jpackage apps are labeled as "damaged"


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6483/head:pull/6483` \
`$ git checkout pull/6483`

Update a local copy of the PR: \
`$ git checkout pull/6483` \
`$ git pull https://git.openjdk.java.net/jdk pull/6483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6483`

View PR using the GUI difftool: \
`$ git pr show -t 6483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6483.diff">https://git.openjdk.java.net/jdk/pull/6483.diff</a>

</details>
