### PR TITLE
8277429: Conflicting jpackage static library name

### DIFF
--- a/make/modules/jdk.jpackage/Lib.gmk
+++ b/make/modules/jdk.jpackage/Lib.gmk
@@ -92,9 +92,9 @@ ifeq ($(call isTargetOs, linux), true)
   JPACKAGE_LIBAPPLAUNCHER_INCLUDES := $(addprefix -I, $(JPACKAGE_LIBAPPLAUNCHER_SRC))
 
   $(eval $(call SetupJdkLibrary, BUILD_JPACKAGE_LIBAPPLAUNCHER, \
-      NAME := jpackageapplauncher, \
+      NAME := jpackageapplauncheraux, \
       OUTPUT_DIR := $(JPACKAGE_OUTPUT_DIR), \
-      SYMBOLS_DIR := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/libjpackageapplauncher, \
+      SYMBOLS_DIR := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/libjpackageapplauncheraux, \
       SRC := $(JPACKAGE_LIBAPPLAUNCHER_SRC), \
       EXCLUDE_FILES := LinuxLauncher.c LinuxPackage.c, \
       TOOLCHAIN := TOOLCHAIN_LINK_CXX, \

--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxAppImageBuilder.java
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxAppImageBuilder.java
@@ -101,7 +101,7 @@ public class LinuxAppImageBuilder extends AbstractAppImageBuilder {
     private void createLauncherLib() throws IOException {
         Path path = appLayout.pathGroup().getPath(
                 ApplicationLayout.PathRole.LINUX_APPLAUNCHER_LIB);
-        try (InputStream resource = getResourceAsStream("libjpackageapplauncher.so")) {
+        try (InputStream resource = getResourceAsStream("libjpackageapplauncheraux.so")) {
             writeEntry(resource, path);
         }
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277429](https://bugs.openjdk.java.net/browse/JDK-8277429): Conflicting jpackage static library name


### Reviewers
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - **Reviewer**)
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6485/head:pull/6485` \
`$ git checkout pull/6485`

Update a local copy of the PR: \
`$ git checkout pull/6485` \
`$ git pull https://git.openjdk.java.net/jdk pull/6485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6485`

View PR using the GUI difftool: \
`$ git pr show -t 6485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6485.diff">https://git.openjdk.java.net/jdk/pull/6485.diff</a>

</details>
