### PR TITLE
8273095: vmTestbase/vm/mlvm/anonloader/stress/oome/heap/Test.java fails with "wrong OOME"

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -35,8 +35,6 @@ vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java 8265295 lin
 
 vmTestbase/nsk/jvmti/scenarios/sampling/SP07/sp07t002/TestDescription.java 8245680 windows-x64
 
-vmTestbase/vm/mlvm/hiddenloader/stress/oome/heap/Test.java 8273095 generic-all
-
 serviceability/sa/TestJhsdbJstackMixed.java 8248675 linux-aarch64
 
 compiler/codegen/aes/TestAESMain.java 8274323 linux-x64,windows-x64

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/hiddenloader/stress/oome/heap/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/hiddenloader/stress/oome/heap/Test.java
@@ -63,7 +63,7 @@ public class Test extends MlvmOOMTest {
     @Override
     protected void checkOOME(OutOfMemoryError oome) {
         String message = oome.getMessage();
-        if (!"Java heap space".equals(message)) {
+        if (!message.startsWith("Java heap space")) {
             throw new RuntimeException("TEST FAIL : wrong OOME", oome);
         }
     }


### PR DESCRIPTION
Relaxes exception message check so that both "Java heap space: failed reallocation of scalar replaced objects" and "Java heap space" are excepted.  This is consistent with how other tests that check for "Java heap space" behave.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273095](https://bugs.openjdk.java.net/browse/JDK-8273095): vmTestbase/vm/mlvm/anonloader/stress/oome/heap/Test.java fails with "wrong OOME"


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6489/head:pull/6489` \
`$ git checkout pull/6489`

Update a local copy of the PR: \
`$ git checkout pull/6489` \
`$ git pull https://git.openjdk.java.net/jdk pull/6489/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6489`

View PR using the GUI difftool: \
`$ git pr show -t 6489`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6489.diff">https://git.openjdk.java.net/jdk/pull/6489.diff</a>

</details>
