### PR TITLE
8277508: need to check has_predicated_vectors before calling scalable_predicate_reg_slots

### DIFF
--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -634,18 +634,20 @@ void Matcher::init_first_stack_mask() {
   if (Matcher::supports_scalable_vector()) {
     int k = 1;
     OptoReg::Name in = OptoReg::add(_in_arg_limit, -1);
-    // Exclude last input arg stack slots to avoid spilling vector register there,
-    // otherwise RegVectMask spills could stomp over stack slots in caller frame.
-    for (; (in >= init_in) && (k < scalable_predicate_reg_slots()); k++) {
-      scalable_stack_mask.Remove(in);
-      in = OptoReg::add(in, -1);
-    }
+    if (Matcher::has_predicated_vectors()) {
+      // Exclude last input arg stack slots to avoid spilling vector register there,
+      // otherwise RegVectMask spills could stomp over stack slots in caller frame.
+      for (; (in >= init_in) && (k < scalable_predicate_reg_slots()); k++) {
+        scalable_stack_mask.Remove(in);
+        in = OptoReg::add(in, -1);
+      }
 
-    // For RegVectMask
-    scalable_stack_mask.clear_to_sets(scalable_predicate_reg_slots());
-    assert(scalable_stack_mask.is_AllStack(), "should be infinite stack");
-    *idealreg2spillmask[Op_RegVectMask] = *idealreg2regmask[Op_RegVectMask];
-    idealreg2spillmask[Op_RegVectMask]->OR(scalable_stack_mask);
+      // For RegVectMask
+      scalable_stack_mask.clear_to_sets(scalable_predicate_reg_slots());
+      assert(scalable_stack_mask.is_AllStack(), "should be infinite stack");
+      *idealreg2spillmask[Op_RegVectMask] = *idealreg2regmask[Op_RegVectMask];
+      idealreg2spillmask[Op_RegVectMask]->OR(scalable_stack_mask);
+    }
 
     // Exclude last input arg stack slots to avoid spilling vector register there,
     // otherwise vector spills could stomp over stack slots in caller frame.


### PR DESCRIPTION
Hi, Team,
A separate set of predicate registers is not mandatory for an implementation of scalable vectors. It will cause a failure in some platform which supports scalable vectors without explicit predicated registers, like riscv. All code about RegVectMask should be covered by has_predicated_vectors here in Matcher::init_first_stack_mask().

Yadong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277508](https://bugs.openjdk.java.net/browse/JDK-8277508): need to check has_predicated_vectors before calling scalable_predicate_reg_slots


### Reviewers
 * [Ningsheng Jian](https://openjdk.java.net/census#njian) (@nsjian - Committer)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Nick Gasson](https://openjdk.java.net/census#ngasson) (@nick-arm - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6492/head:pull/6492` \
`$ git checkout pull/6492`

Update a local copy of the PR: \
`$ git checkout pull/6492` \
`$ git pull https://git.openjdk.java.net/jdk pull/6492/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6492`

View PR using the GUI difftool: \
`$ git pr show -t 6492`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6492.diff">https://git.openjdk.java.net/jdk/pull/6492.diff</a>

</details>
