### PR TITLE
JDK-8277522: Make formatting of null consistent in Elements

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
@@ -69,7 +69,7 @@ public interface Elements {
      * </ul>
      *
      * If this process leads to a list with a single element,
-     * the single element is returned, otherwise null is returned.
+     * the single element is returned, otherwise {@code null} is returned.
      *
      * @param name fully qualified package name,
      *             or an empty string for an unnamed package
@@ -156,7 +156,7 @@ public interface Elements {
      * </ul>
      *
      * If this process leads to a list with a single element,
-     * the single element is returned, otherwise null is returned.
+     * the single element is returned, otherwise {@code null} is returned.
      *
      * @param name the canonical name
      * @return the named type element,
@@ -735,7 +735,7 @@ public interface Elements {
     }
 
     /**
-     * Returns the record component for the given accessor. Returns null if the
+     * Returns the record component for the given accessor. Returns {@code null} if the
      * given method is not a record component accessor.
      *
      * @implSpec The default implementation of this method checks if the element
@@ -747,7 +747,7 @@ public interface Elements {
      * record component is returned, in any other case {@code null} is returned.
      *
      * @param accessor the method for which the record component should be found.
-     * @return the record component, or null if the given method is not a record
+     * @return the record component, or {@code null} if the given method is not a record
      * component accessor
      * @since 16
      */

--- a/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
@@ -68,8 +68,8 @@ public interface Elements {
      *     </li>
      * </ul>
      *
-     * If this process leads to a list with a single element,
-     * the single element is returned, otherwise {@code null} is returned.
+     * If this process leads to a list with a single element, the
+     * single element is returned, otherwise {@code null} is returned.
      *
      * @param name fully qualified package name,
      *             or an empty string for an unnamed package
@@ -155,8 +155,8 @@ public interface Elements {
      *     </li>
      * </ul>
      *
-     * If this process leads to a list with a single element,
-     * the single element is returned, otherwise {@code null} is returned.
+     * If this process leads to a list with a single element, the
+     * single element is returned, otherwise {@code null} is returned.
      *
      * @param name the canonical name
      * @return the named type element,
@@ -735,8 +735,9 @@ public interface Elements {
     }
 
     /**
-     * Returns the record component for the given accessor. Returns {@code null} if the
-     * given method is not a record component accessor.
+     * Returns the record component for the given accessor. Returns
+     * {@code null} if the given method is not a record component
+     * accessor.
      *
      * @implSpec The default implementation of this method checks if the element
      * enclosing the accessor has kind {@link ElementKind#RECORD RECORD} if that is
@@ -747,8 +748,8 @@ public interface Elements {
      * record component is returned, in any other case {@code null} is returned.
      *
      * @param accessor the method for which the record component should be found.
-     * @return the record component, or {@code null} if the given method is not a record
-     * component accessor
+     * @return the record component, or {@code null} if the given
+     * method is not a record component accessor
      * @since 16
      */
     default RecordComponentElement recordComponentFor(ExecutableElement accessor) {


### PR DESCRIPTION
Simple formatting cleanup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277522](https://bugs.openjdk.java.net/browse/JDK-8277522): Make formatting of null consistent in Elements


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**) ⚠️ Review applies to b94c5095a443df487f2e65c62a5e21daa3265e47


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6494/head:pull/6494` \
`$ git checkout pull/6494`

Update a local copy of the PR: \
`$ git checkout pull/6494` \
`$ git pull https://git.openjdk.java.net/jdk pull/6494/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6494`

View PR using the GUI difftool: \
`$ git pr show -t 6494`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6494.diff">https://git.openjdk.java.net/jdk/pull/6494.diff</a>

</details>
