### PR TITLE
8277534: Remove unused ReferenceProcessor::has_discovered_references

### DIFF
--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -1054,15 +1054,6 @@ bool ReferenceProcessor::discover_reference(oop obj, ReferenceType rt) {
   return true;
 }
 
-bool ReferenceProcessor::has_discovered_references() {
-  for (uint i = 0; i < _max_num_queues * number_of_subclasses_of_ref(); i++) {
-    if (!_discovered_refs[i].is_empty()) {
-      return true;
-    }
-  }
-  return false;
-}
-
 void ReferenceProcessor::preclean_discovered_references(BoolObjectClosure* is_alive,
                                                         EnqueueDiscoveredFieldClosure* enqueue,
                                                         YieldClosure* yield,

--- a/src/hotspot/share/gc/shared/referenceProcessor.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.hpp
@@ -421,9 +421,6 @@ public:
   // Discover a Reference object, using appropriate discovery criteria
   virtual bool discover_reference(oop obj, ReferenceType rt);
 
-  // Has discovered references that need handling
-  bool has_discovered_references();
-
   // Process references found during GC (called by the garbage collector)
   ReferenceProcessorStats
   process_discovered_references(RefProcProxyTask& proxy_task,


### PR DESCRIPTION
Trivial change of removing dead code.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277534](https://bugs.openjdk.java.net/browse/JDK-8277534): Remove unused ReferenceProcessor::has_discovered_references


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6496/head:pull/6496` \
`$ git checkout pull/6496`

Update a local copy of the PR: \
`$ git checkout pull/6496` \
`$ git pull https://git.openjdk.java.net/jdk pull/6496/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6496`

View PR using the GUI difftool: \
`$ git pr show -t 6496`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6496.diff">https://git.openjdk.java.net/jdk/pull/6496.diff</a>

</details>
