### PR TITLE
8277411: C2 fast_unlock intrinsic on AArch64 has unnecessary ownership check

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -4007,19 +4007,15 @@ encode %{
     __ bind(object_has_monitor);
     STATIC_ASSERT(markWord::monitor_value <= INT_MAX);
     __ add(tmp, tmp, -(int)markWord::monitor_value); // monitor
-    __ ldr(rscratch1, Address(tmp, ObjectMonitor::owner_offset_in_bytes()));
     __ ldr(disp_hdr, Address(tmp, ObjectMonitor::recursions_offset_in_bytes()));
 
     Label notRecursive;
-    __ cmp(rscratch1, rthread);
-    __ br(Assembler::NE, cont);
-
     __ cbz(disp_hdr, notRecursive);
 
     // Recursive lock
     __ sub(disp_hdr, disp_hdr, 1u);
     __ str(disp_hdr, Address(tmp, ObjectMonitor::recursions_offset_in_bytes()));
-    // flag == EQ was set in the ownership check above
+    __ cmp(disp_hdr, disp_hdr); // Sets flags for result
     __ b(cont);
 
     __ bind(notRecursive);


### PR DESCRIPTION
The AArch64 fast_unlock C2 code checks if the current thread owns the lock. This can be surprisingly expensive in workload where locking is contended. The check is however optional (helpful only for finding JNI code bugs), and indeed not emitted for x86_64. This patch removes the check on AArch64 as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277411](https://bugs.openjdk.java.net/browse/JDK-8277411): C2 fast_unlock intrinsic on AArch64 has unnecessary ownership check


### Reviewers
 * [Nick Gasson](https://openjdk.java.net/census#ngasson) (@nick-arm - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6498/head:pull/6498` \
`$ git checkout pull/6498`

Update a local copy of the PR: \
`$ git checkout pull/6498` \
`$ git pull https://git.openjdk.java.net/jdk pull/6498/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6498`

View PR using the GUI difftool: \
`$ git pr show -t 6498`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6498.diff">https://git.openjdk.java.net/jdk/pull/6498.diff</a>

</details>
