### PR TITLE
8277556: Call ReferenceProcessorPhaseTimes::set_processing_is_mt once

### DIFF
--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -198,6 +198,8 @@ ReferenceProcessorStats ReferenceProcessor::process_discovered_references(RefPro
 
   update_soft_ref_master_clock();
 
+  phase_times.set_processing_is_mt(processing_is_mt());
+
   {
     RefProcTotalPhaseTimesTracker tt(SoftWeakFinalRefsPhase, &phase_times);
     process_soft_weak_final_refs(proxy_task, phase_times);
@@ -730,8 +732,6 @@ void ReferenceProcessor::process_soft_weak_final_refs(RefProcProxyTask& proxy_ta
   phase_times.set_ref_discovered(REF_WEAK, num_weak_refs);
   phase_times.set_ref_discovered(REF_FINAL, num_final_refs);
 
-  phase_times.set_processing_is_mt(processing_is_mt());
-
   if (num_total_refs == 0) {
     log_debug(gc, ref)("Skipped SoftWeakFinalRefsPhase of Reference Processing: no references");
     return;
@@ -764,7 +764,6 @@ void ReferenceProcessor::process_final_keep_alive(RefProcProxyTask& proxy_task,
                                                   ReferenceProcessorPhaseTimes& phase_times) {
 
   size_t const num_final_refs = total_count(_discoveredFinalRefs);
-  phase_times.set_processing_is_mt(processing_is_mt());
 
   if (num_final_refs == 0) {
     log_debug(gc, ref)("Skipped KeepAliveFinalRefsPhase of Reference Processing: no references");
@@ -791,7 +790,6 @@ void ReferenceProcessor::process_phantom_refs(RefProcProxyTask& proxy_task,
 
   size_t const num_phantom_refs = total_count(_discoveredPhantomRefs);
   phase_times.set_ref_discovered(REF_PHANTOM, num_phantom_refs);
-  phase_times.set_processing_is_mt(processing_is_mt());
 
   if (num_phantom_refs == 0) {
     log_debug(gc, ref)("Skipped PhantomRefsPhase of Reference Processing: no references");


### PR DESCRIPTION
Simple change of moving the call site of `set_processing_is_mt`.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277556](https://bugs.openjdk.java.net/browse/JDK-8277556): Call ReferenceProcessorPhaseTimes::set_processing_is_mt once


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6500/head:pull/6500` \
`$ git checkout pull/6500`

Update a local copy of the PR: \
`$ git checkout pull/6500` \
`$ git pull https://git.openjdk.java.net/jdk pull/6500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6500`

View PR using the GUI difftool: \
`$ git pr show -t 6500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6500.diff">https://git.openjdk.java.net/jdk/pull/6500.diff</a>

</details>
