### PR TITLE
8277560: Remove WorkerDataArray::_is_serial

### DIFF
--- a/src/hotspot/share/gc/shared/workerDataArray.cpp
+++ b/src/hotspot/share/gc/shared/workerDataArray.cpp
@@ -37,16 +37,6 @@ double WorkerDataArray<double>::uninitialized() {
 }
 
 template <>
-void WorkerDataArray<double>::WDAPrinter::summary(outputStream* out, double time) {
-  out->print_cr(" %.1lfms", time * MILLIUNITS);
-}
-
-template <>
-void WorkerDataArray<size_t>::WDAPrinter::summary(outputStream* out, size_t value) {
-  out->print_cr(" " SIZE_FORMAT, value);
-}
-
-template <>
 void WorkerDataArray<double>::WDAPrinter::summary(outputStream* out, double min, double avg, double max, double diff, double sum, bool print_sum) {
   out->print(" Min: %4.1lf, Avg: %4.1lf, Max: %4.1lf, Diff: %4.1lf", min * MILLIUNITS, avg * MILLIUNITS, max * MILLIUNITS, diff* MILLIUNITS);
   if (print_sum) {

--- a/src/hotspot/share/gc/shared/workerDataArray.hpp
+++ b/src/hotspot/share/gc/shared/workerDataArray.hpp
@@ -46,7 +46,7 @@ private:
   WorkerDataArray<size_t>* _thread_work_items[MaxThreadWorkItems];
 
  public:
-  WorkerDataArray(const char* short_name, const char* title, uint length, bool is_serial = false);
+  WorkerDataArray(const char* short_name, const char* title, uint length);
   ~WorkerDataArray();
 
   // Create an integer sub-item at the given index to this WorkerDataArray. If length_override

--- a/src/hotspot/share/gc/shared/workerDataArray.hpp
+++ b/src/hotspot/share/gc/shared/workerDataArray.hpp
@@ -91,9 +91,7 @@ private:
  private:
   class WDAPrinter {
   public:
-    static void summary(outputStream* out, double time);
     static void summary(outputStream* out, double min, double avg, double max, double diff, double sum, bool print_sum);
-    static void summary(outputStream* out, size_t value);
     static void summary(outputStream* out, size_t min, double avg, size_t max, size_t diff, size_t sum, bool print_sum);
 
     static void details(const WorkerDataArray<double>* phase, outputStream* out);

--- a/src/hotspot/share/gc/shared/workerDataArray.inline.hpp
+++ b/src/hotspot/share/gc/shared/workerDataArray.inline.hpp
@@ -31,14 +31,12 @@
 #include "utilities/ostream.hpp"
 
 template <typename T>
-WorkerDataArray<T>::WorkerDataArray(const char* short_name, const char* title, uint length, bool is_serial) :
+WorkerDataArray<T>::WorkerDataArray(const char* short_name, const char* title, uint length) :
  _data(NULL),
  _length(length),
  _short_name(short_name),
- _title(title),
- _is_serial(is_serial) {
+ _title(title) {
   assert(length > 0, "Must have some workers to store data for");
-  assert(!is_serial || length == 1, "Serial phase must only have a single entry.");
   _data = NEW_C_HEAP_ARRAY(T, _length, mtGC);
   for (uint i = 0; i < MaxThreadWorkItems; i++) {
     _thread_work_items[i] = NULL;
@@ -158,39 +156,31 @@ void WorkerDataArray<T>::set_all(T value) {
 
 template <class T>
 void WorkerDataArray<T>::print_summary_on(outputStream* out, bool print_sum) const {
-  if (_is_serial) {
-    out->print("%s:", title());
-  } else {
-    out->print("%-30s", title());
-  }
+  out->print("%-30s", title());
 
   uint start = 0;
   while (start < _length && get(start) == uninitialized()) {
     start++;
   }
   if (start < _length) {
-    if (_is_serial) {
-      WDAPrinter::summary(out, get(0));
-    } else {
-      T min = get(start);
-      T max = min;
-      T sum = 0;
-      uint contributing_threads = 0;
-      for (uint i = start; i < _length; ++i) {
-        T value = get(i);
-        if (value != uninitialized()) {
-          max = MAX2(max, value);
-          min = MIN2(min, value);
-          sum += value;
-          contributing_threads++;
-        }
+    T min = get(start);
+    T max = min;
+    T sum = 0;
+    uint contributing_threads = 0;
+    for (uint i = start; i < _length; ++i) {
+      T value = get(i);
+      if (value != uninitialized()) {
+        max = MAX2(max, value);
+        min = MIN2(min, value);
+        sum += value;
+        contributing_threads++;
       }
-      T diff = max - min;
-      assert(contributing_threads != 0, "Must be since we found a used value for the start index");
-      double avg = sum / (double) contributing_threads;
-      WDAPrinter::summary(out, min, avg, max, diff, sum, print_sum);
-      out->print_cr(", Workers: %d", contributing_threads);
     }
+    T diff = max - min;
+    assert(contributing_threads != 0, "Must be since we found a used value for the start index");
+    double avg = sum / (double) contributing_threads;
+    WDAPrinter::summary(out, min, avg, max, diff, sum, print_sum);
+    out->print_cr(", Workers: %d", contributing_threads);
   } else {
     // No data for this phase.
     out->print_cr(" skipped");


### PR DESCRIPTION
Simple change of removing effectively dead code.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277560](https://bugs.openjdk.java.net/browse/JDK-8277560): Remove WorkerDataArray::_is_serial


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to 7138fb8d5b617d15967d2945f95d758ce1a7a710
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6502/head:pull/6502` \
`$ git checkout pull/6502`

Update a local copy of the PR: \
`$ git checkout pull/6502` \
`$ git pull https://git.openjdk.java.net/jdk pull/6502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6502`

View PR using the GUI difftool: \
`$ git pr show -t 6502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6502.diff">https://git.openjdk.java.net/jdk/pull/6502.diff</a>

</details>
