### PR TITLE
8277441: CompileQueue::add fails with assert(_last->next() == __null) failed: not last

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -411,6 +411,7 @@ void CompileQueue::free_all() {
     CompileTask::free(current);
   }
   _first = NULL;
+  _last = NULL;
 
   // Wake up all threads that block on the queue.
   MethodCompileQueue_lock->notify_all();


### PR DESCRIPTION
In the rare case that the compiler threads fail during initialization or the code cache is full and flushing is disabled, we completely disable JIT compilation and shut down the compiler runtime:
https://github.com/openjdk/jdk/blob/2f4b5405f0b53782f3ed5274f68b31eb968efb6d/src/hotspot/share/compiler/compileBroker.cpp#L1813-L1817

In the process, we free all compiler queues and set `CompileQueue::_first` to `NULL` and put the `CompileTasks` on the free list: https://github.com/openjdk/jdk/blob/2f4b5405f0b53782f3ed5274f68b31eb968efb6d/src/hotspot/share/compiler/compileTask.cpp#L84

In rare cases, although compilation is disabled, another waiting thread might still call `CompileQueue::add`. That code then fails because `_last != NULL` and `_last->next()` is set to `_task_free_list`. 
https://github.com/openjdk/jdk/blob/2f4b5405f0b53782f3ed5274f68b31eb968efb6d/src/hotspot/share/compiler/compileBroker.cpp#L362-L369

The fix is to set `_last` to `NULL` in `CompileQueue::free_all`. Adding to the compile queue then succeeds which is harmless because queues have only been freed to make the compiler threads exit faster:
https://github.com/openjdk/jdk/blob/2f4b5405f0b53782f3ed5274f68b31eb968efb6d/src/hotspot/share/compiler/compileBroker.cpp#L1823

The test that triggered this will be added with [PR 6364](https://github.com/openjdk/jdk/pull/6364). I verified that it now passes.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277441](https://bugs.openjdk.java.net/browse/JDK-8277441): CompileQueue::add fails with assert(_last->next() == __null) failed: not last


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6503/head:pull/6503` \
`$ git checkout pull/6503`

Update a local copy of the PR: \
`$ git checkout pull/6503` \
`$ git pull https://git.openjdk.java.net/jdk pull/6503/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6503`

View PR using the GUI difftool: \
`$ git pr show -t 6503`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6503.diff">https://git.openjdk.java.net/jdk/pull/6503.diff</a>

</details>
