### PR TITLE
8274784: jshell: Garbled character was displayed by System.out.println(...) on Japanese Windows

### DIFF
--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/AbstractTerminal.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/AbstractTerminal.java
@@ -10,6 +10,7 @@ package jdk.internal.org.jline.terminal.impl;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
+import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -55,7 +56,8 @@ public abstract class AbstractTerminal implements Terminal {
     public AbstractTerminal(String name, String type, Charset encoding, SignalHandler signalHandler) throws IOException {
         this.name = name;
         this.type = type != null ? type : "ansi";
-        this.encoding = encoding != null ? encoding : Charset.defaultCharset();
+        this.encoding = encoding != null ? encoding :
+            Charset.forName(new OutputStreamWriter(System.out).getEncoding(), Charset.defaultCharset());
         for (Signal signal : Signal.values()) {
             handlers.put(signal, signalHandler);
         }

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/AbstractTerminal.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/AbstractTerminal.java
@@ -10,7 +10,6 @@ package jdk.internal.org.jline.terminal.impl;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
-import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -56,8 +55,7 @@ public abstract class AbstractTerminal implements Terminal {
     public AbstractTerminal(String name, String type, Charset encoding, SignalHandler signalHandler) throws IOException {
         this.name = name;
         this.type = type != null ? type : "ansi";
-        this.encoding = encoding != null ? encoding :
-            Charset.forName(new OutputStreamWriter(System.out).getEncoding(), Charset.defaultCharset());
+        this.encoding = encoding != null ? encoding : System.out.charset();
         for (Signal signal : Signal.values()) {
             handlers.put(signal, signalHandler);
         }

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/RemoteExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/RemoteExecutionControl.java
@@ -26,11 +26,9 @@ package jdk.jshell.execution;
 
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.lang.reflect.Method;
 import java.net.Socket;
-import java.nio.charset.Charset;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -65,17 +63,11 @@ public class RemoteExecutionControl extends DirectExecutionControl implements Ex
         InputStream inStream = socket.getInputStream();
         OutputStream outStream = socket.getOutputStream();
         Map<String, Consumer<OutputStream>> outputs = new HashMap<>();
-        outputs.put("out", st -> System.setOut(new PrintStream(st, true, getPrintStreamCharset(System.out))));
-        outputs.put("err", st -> System.setErr(new PrintStream(st, true, getPrintStreamCharset(System.err))));
+        outputs.put("out", st -> System.setOut(new PrintStream(st, true, System.out.charset())));
+        outputs.put("err", st -> System.setErr(new PrintStream(st, true, System.err.charset())));
         Map<String, Consumer<InputStream>> input = new HashMap<>();
         input.put("in", System::setIn);
         forwardExecutionControlAndIO(new RemoteExecutionControl(), inStream, outStream, outputs, input);
-    }
-
-    // Get PrintStream charset
-    private static Charset getPrintStreamCharset(PrintStream ps) {
-        return Charset.forName(new OutputStreamWriter(ps).getEncoding(),
-            Charset.defaultCharset());
     }
 
     // These three variables are used by the main JShell process in interrupting

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/RemoteExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/RemoteExecutionControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,11 @@ package jdk.jshell.execution;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.lang.reflect.Method;
 import java.net.Socket;
+import java.nio.charset.Charset;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -63,11 +65,17 @@ public class RemoteExecutionControl extends DirectExecutionControl implements Ex
         InputStream inStream = socket.getInputStream();
         OutputStream outStream = socket.getOutputStream();
         Map<String, Consumer<OutputStream>> outputs = new HashMap<>();
-        outputs.put("out", st -> System.setOut(new PrintStream(st, true)));
-        outputs.put("err", st -> System.setErr(new PrintStream(st, true)));
+        outputs.put("out", st -> System.setOut(new PrintStream(st, true, getPrintStreamCharset(System.out))));
+        outputs.put("err", st -> System.setErr(new PrintStream(st, true, getPrintStreamCharset(System.err))));
         Map<String, Consumer<InputStream>> input = new HashMap<>();
         input.put("in", System::setIn);
         forwardExecutionControlAndIO(new RemoteExecutionControl(), inStream, outStream, outputs, input);
+    }
+
+    // Get PrintStream charset
+    private static Charset getPrintStreamCharset(PrintStream ps) {
+        return Charset.forName(new OutputStreamWriter(ps).getEncoding(),
+            Charset.defaultCharset());
     }
 
     // These three variables are used by the main JShell process in interrupting


### PR DESCRIPTION
JEP-400 was implemented by JDK18-b13.
After JDK18-b13, garbled character was displayed by following code on Japanese Windows' command prompt.

System.out.println("\u3042")

Japanese "A" should be display ed, but garbled character was displayed.
Also saved jshell command list did not work as expected if Japanese character was there.

Following issue has some information
8274544: Langtools command's usage were garbled on Japanese Windows #5771
https://github.com/openjdk/jdk/pull/5771
This issue also happens on Linux ja_JP.eucjp locale.
RemoteExecutionControl.java change is required for this issue.

Also we cannot input Japanese character on Linux ja_JP.eucjp locale terminal.
AbstractTerminal.java change is required for this issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274784](https://bugs.openjdk.java.net/browse/JDK-8274784): jshell: Garbled character was displayed by System.out.println(...) on Japanese Windows


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6505/head:pull/6505` \
`$ git checkout pull/6505`

Update a local copy of the PR: \
`$ git checkout pull/6505` \
`$ git pull https://git.openjdk.java.net/jdk pull/6505/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6505`

View PR using the GUI difftool: \
`$ git pr show -t 6505`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6505.diff">https://git.openjdk.java.net/jdk/pull/6505.diff</a>

</details>
