### PR TITLE
JDK-8268582: javadoc throws NPE with --ignore-source-errors option

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -2893,8 +2893,11 @@ public class Utils {
     }
 
     public PreviewSummary declaredUsingPreviewAPIs(Element el) {
-        List<TypeElement> usedInDeclaration = new ArrayList<>();
-        usedInDeclaration.addAll(annotations2Classes(el));
+        if (el.asType().getKind() == ERROR) {
+            // Can happen with undocumented --ignore-source-errors option
+            return new PreviewSummary(Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
+        }
+        List<TypeElement> usedInDeclaration = new ArrayList<>(annotations2Classes(el));
         switch (el.getKind()) {
             case ANNOTATION_TYPE, CLASS, ENUM, INTERFACE, RECORD -> {
                 TypeElement te = (TypeElement) el;

--- a/test/langtools/jdk/javadoc/tool/IgnoreSourceErrors.java
+++ b/test/langtools/jdk/javadoc/tool/IgnoreSourceErrors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8175219
+ * @bug 8175219 8268582
  * @summary test --ignore-errors works correctly
  * @modules
  *      jdk.javadoc/jdk.javadoc.internal.api
@@ -73,6 +73,12 @@ public class IgnoreSourceErrors  extends TestRunner {
         if (!out.contains("modifier static not allowed here")) {
             throw new Exception("expected string not found \'modifier static not allowed here\'");
         }
+        if (!out.contains("package invalid.example does not exist")) {
+            throw new Exception("expected string not found \'package invalid.example does not exist\'");
+        }
+        if (!out.contains("cannot find symbol")) {
+            throw new Exception("expected string not found \'cannot find symbol\'");
+        }
     }
 
     @Test
@@ -84,12 +90,19 @@ public class IgnoreSourceErrors  extends TestRunner {
         if (!out.contains("modifier static not allowed here")) {
             throw new Exception("expected string not found \'modifier static not allowed here\'");
         }
+        if (!out.contains("package invalid.example does not exist")) {
+            throw new Exception("expected string not found \'package invalid.example does not exist\'");
+        }
+        if (!out.contains("cannot find symbol")) {
+            throw new Exception("expected string not found \'cannot find symbol\'");
+        }
     }
 
     void emitSample(Path file) throws IOException {
         String[] contents = {
             "/** A java file with errors */",
-            "public static class Foo {}"
+            "import invalid.example.OtherClass;",
+            "public static class Foo<T> extends OtherClass<T> {}"
         };
         Files.write(file, Arrays.asList(contents), StandardOpenOption.CREATE);
     }


### PR DESCRIPTION
Please review a simple fix for a javadoc NPE when using the undocumented `--ignore-source-errors` option with an non-existing type.

Note that this just fixes the particular error that occurs when looking for preview API use in invalid types. It is possible that other source errors trigger other errors in javadoc, but I don't think it is worth the time to go and actively look for them.

In particular, the NPE that is documented by the stack trace in the JBS issue was different from the one fixed here and does not occur anymore, and the one fixed here did not yet exist in JDK 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268582](https://bugs.openjdk.java.net/browse/JDK-8268582): javadoc throws NPE with --ignore-source-errors option


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6506/head:pull/6506` \
`$ git checkout pull/6506`

Update a local copy of the PR: \
`$ git checkout pull/6506` \
`$ git pull https://git.openjdk.java.net/jdk pull/6506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6506`

View PR using the GUI difftool: \
`$ git pr show -t 6506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6506.diff">https://git.openjdk.java.net/jdk/pull/6506.diff</a>

</details>
