### PR TITLE
8277576: ProblemList runtime/ErrorHandling/CreateCoredumpOnCrash.java on macosx-X64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -92,6 +92,8 @@ gc/stress/gclocker/TestGCLockerWithG1.java 8180622 generic-all
 gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java 8192647 generic-all
 gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java 8241293 macosx-x64
 
+applications/jcstress/acqrel.java 8277434 linux-aarch64
+
 #############################################################################
 
 # :hotspot_runtime

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -75,6 +75,8 @@ compiler/whitebox/MakeMethodNotCompilableTest.java 8265360 macosx-aarch64
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-x64
 compiler/codecache/TestStressCodeBuffers.java 8272094 generic-aarch64
 
+compiler/onSpinWait/TestOnSpinWaitAArch64DefaultFlags.java 8277503 linux-aarch64
+
 
 #############################################################################
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -104,6 +104,7 @@ runtime/os/TestTracePageSizes.java#G1 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 runtime/jni/checked/TestPrimitiveArrayCriticalWithBadParam.java 8277350 macosx-x64
+runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
 
 applications/jcstress/copy.java 8229852 linux-all
 


### PR DESCRIPTION
A few trivial ProblemListings:

8277576 ProblemList runtime/ErrorHandling/CreateCoredumpOnCrash.java on macosx-X64
8277577 ProblemList compiler/onSpinWait/TestOnSpinWaitAArch64DefaultFlags.java on linux-aarch64
8277578 ProblemList applications/jcstress/acqrel.java on linux-aarch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8277576](https://bugs.openjdk.java.net/browse/JDK-8277576): ProblemList runtime/ErrorHandling/CreateCoredumpOnCrash.java on macosx-X64
 * [JDK-8277577](https://bugs.openjdk.java.net/browse/JDK-8277577): ProblemList compiler/onSpinWait/TestOnSpinWaitAArch64DefaultFlags.java on linux-aarch64
 * [JDK-8277578](https://bugs.openjdk.java.net/browse/JDK-8277578): ProblemList applications/jcstress/acqrel.java on linux-aarch64


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6507/head:pull/6507` \
`$ git checkout pull/6507`

Update a local copy of the PR: \
`$ git checkout pull/6507` \
`$ git pull https://git.openjdk.java.net/jdk pull/6507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6507`

View PR using the GUI difftool: \
`$ git pr show -t 6507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6507.diff">https://git.openjdk.java.net/jdk/pull/6507.diff</a>

</details>
