### PR TITLE
8277322: Document that setting an invalid property jdk.serialFilter disables deserialization

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputFilter.java
+++ b/src/java.base/share/classes/java/io/ObjectInputFilter.java
@@ -524,9 +524,11 @@ public interface ObjectInputFilter {
      * If the system property is not defined, and the {@link java.security.Security} property
      * {@code jdk.serialFilter} is defined then it is used to configure the filter.
      * The filter is created as if {@link #createFilter(String) createFilter} is called;
-     * if the filter string is invalid, an {@link ExceptionInInitializerError} is thrown.
-     * Otherwise, the filter is not configured during initialization and
-     * can be set with {@link #setSerialFilter(ObjectInputFilter) Config.setSerialFilter}.
+     * if the filter string is invalid, an {@link ExceptionInInitializerError} is thrown
+     * and the initialization fails; subsequent attempts to use the configuration or
+     * serialization will fail with an implementation specific exception.
+     * If the system property {@code jdk.serialFilter} is not set on the command line
+     * it can be set with {@link #setSerialFilter(ObjectInputFilter) Config.setSerialFilter}.
      * Setting the {@code jdk.serialFilter} with {@link System#setProperty(String, String)
      * System.setProperty} <em>does not set the filter</em>.
      * The syntax for the property value is the same as for the


### PR DESCRIPTION
The effects of an invalid `jdk.serialFilter` property are not completely documented. If the value of the system property jdk.serialFilter is invalid, deserialization should not be possible and it should be clear in the specification. 

Specify an implementation specific exception is thrown in the case where deserialization is invoked after reporting the invalid jdk.serialFilter.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ The change requires a CSR request to be approved.

### Issue
 * [JDK-8277322](https://bugs.openjdk.java.net/browse/JDK-8277322): Document that setting an invalid property jdk.serialFilter disables deserialization


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6508/head:pull/6508` \
`$ git checkout pull/6508`

Update a local copy of the PR: \
`$ git checkout pull/6508` \
`$ git pull https://git.openjdk.java.net/jdk pull/6508/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6508`

View PR using the GUI difftool: \
`$ git pr show -t 6508`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6508.diff">https://git.openjdk.java.net/jdk/pull/6508.diff</a>

</details>
