### PR TITLE
Single-char-String fast path for String::indexOf.

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -2495,6 +2495,9 @@ public final class String
      *          or {@code -1} if there is no such occurrence.
      */
     public int indexOf(String str) {
+        if (str.length() == 1) {
+            return indexOf(str.charAt(0));
+        }
         byte coder = coder();
         if (coder == str.coder()) {
             return isLatin1() ? StringLatin1.indexOf(value, str.value)


### PR DESCRIPTION
Hello,

This PR adds a fast path to String.indexOf(String) which calls String.indexOf(char) if the length is 1.

This is to my knowledge last method in `java.lang.String` with a char variant outperforming the single-char-String counterpart.
`String.contains(single-char-string)` also benefits from this optimization as a side effect. Which can be fairly common, since IDEs usually suggest to refactor `indexOf('c') != -1` or `indexOf("c") != -1` to `contains("c")` for readability reasons.


```
    17.0.1 reference
    Benchmark                       Mode  Cnt  Score   Error  Units
    CharVsStringJMH.containsString  avgt    5  7.215 ± 0.067  ns/op
    CharVsStringJMH.indexOfChar     avgt    5  4.174 ± 0.079  ns/op
    CharVsStringJMH.indexOfString   avgt    5  7.212 ± 0.053  ns/op

    18 patched
    Benchmark                       Mode  Cnt  Score   Error  Units
    CharVsStringJMH.containsString  avgt    5  4.388 ± 0.055  ns/op
    CharVsStringJMH.indexOfChar     avgt    5  4.149 ± 0.076  ns/op
    CharVsStringJMH.indexOfString   avgt    5  4.464 ± 0.038  ns/op
```



```java
    private final String str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
    @Benchmark
    public void indexOfChar(Blackhole bh) throws InterruptedException {
        bh.consume(str.indexOf('d') != -1);
    }

    @Benchmark
    public void indexOfString(Blackhole bh) throws InterruptedException {
        bh.consume(str.indexOf("d") != -1);
    }

    @Benchmark
    public void containsString(Blackhole bh) throws InterruptedException {
        bh.consume(str.contains("d"));
    }
```
I keep this as draft until it was discussed on the mailinglist.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6509/head:pull/6509` \
`$ git checkout pull/6509`

Update a local copy of the PR: \
`$ git checkout pull/6509` \
`$ git pull https://git.openjdk.java.net/jdk pull/6509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6509`

View PR using the GUI difftool: \
`$ git pr show -t 6509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6509.diff">https://git.openjdk.java.net/jdk/pull/6509.diff</a>

</details>
