### PR TITLE
8277350: runtime/jni/checked/TestPrimitiveArrayCriticalWithBadParam.java times out

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -107,7 +107,6 @@ runtime/os/TestTracePageSizes.java#compiler-options 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#G1 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
-runtime/jni/checked/TestPrimitiveArrayCriticalWithBadParam.java 8277350 macosx-x64
 runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
 
 applications/jcstress/copy.java 8229852 linux-all

--- a/test/hotspot/jtreg/runtime/jni/checked/TestPrimitiveArrayCriticalWithBadParam.java
+++ b/test/hotspot/jtreg/runtime/jni/checked/TestPrimitiveArrayCriticalWithBadParam.java
@@ -55,6 +55,7 @@ public class TestPrimitiveArrayCriticalWithBadParam {
 
     private static void runTest() {
         List<String> pbArgs = new ArrayList<>();
+        pbArgs.add("-XX:-CreateCoredumpOnCrash");
         pbArgs.add("-Xcheck:jni");
         pbArgs.add("-Djava.library.path=" + Utils.TEST_NATIVE_PATH);
         pbArgs.add(TestPrimitiveArrayCriticalWithBadParam.class.getName());


### PR DESCRIPTION
A (trivial?) fix to keep runtime/jni/checked/TestPrimitiveArrayCriticalWithBadParam.java
from timing out on macosx-X64 Mach5 test machines. Also removes the test from the
ProblemList.txt file.

Tested locally on my MBP-13 to verify that the test no longer creates core files.
Will also test with Mach5 Tier[135] to test for "timeouts in execution" task failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277350](https://bugs.openjdk.java.net/browse/JDK-8277350): runtime/jni/checked/TestPrimitiveArrayCriticalWithBadParam.java times out


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6510/head:pull/6510` \
`$ git checkout pull/6510`

Update a local copy of the PR: \
`$ git checkout pull/6510` \
`$ git pull https://git.openjdk.java.net/jdk pull/6510/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6510`

View PR using the GUI difftool: \
`$ git pr show -t 6510`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6510.diff">https://git.openjdk.java.net/jdk/pull/6510.diff</a>

</details>
