### PR TITLE
8277606: String(String) constructor could copy hashIsZero

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -261,6 +261,7 @@ public final class String
         this.value = original.value;
         this.coder = original.coder;
         this.hash = original.hash;
+        this.hashIsZero = original.hashIsZero;
     }
 
     /**


### PR DESCRIPTION
This is a trivial fix to make `String(String)` constructor copy the value of `hashIsZero` field.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277606](https://bugs.openjdk.java.net/browse/JDK-8277606): String(String) constructor could copy hashIsZero


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6511/head:pull/6511` \
`$ git checkout pull/6511`

Update a local copy of the PR: \
`$ git checkout pull/6511` \
`$ git pull https://git.openjdk.java.net/jdk pull/6511/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6511`

View PR using the GUI difftool: \
`$ git pr show -t 6511`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6511.diff">https://git.openjdk.java.net/jdk/pull/6511.diff</a>

</details>
