### PR TITLE
8276660: Scalability bottleneck in java.security.Provider.getService()

### DIFF
--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -916,8 +916,8 @@ public abstract class Provider extends Properties {
         if (!checkLegacy(key)) return null;
 
         Object o = super.remove(key);
-        if (o != null && o instanceof String && key instanceof String) {
-            parseLegacy((String)key, (String)o, OPType.REMOVE);
+        if (o instanceof String so && key instanceof String sk) {
+            parseLegacy(sk, so, OPType.REMOVE);
         }
         return o;
     }
@@ -926,8 +926,8 @@ public abstract class Provider extends Properties {
         if (!checkLegacy(key)) return false;
 
         boolean result = super.remove(key, value);
-        if (result && key instanceof String && value instanceof String) {
-            parseLegacy((String)key, (String)value, OPType.REMOVE);
+        if (result && key instanceof String sk && value instanceof String sv) {
+            parseLegacy(sk, sv, OPType.REMOVE);
         }
         return result;
     }
@@ -936,11 +936,11 @@ public abstract class Provider extends Properties {
         if (!checkLegacy(key)) return false;
 
         boolean result = super.replace(key, oldValue, newValue);
-        if (result && key instanceof String) {
-            if (newValue instanceof String) {
-                parseLegacy((String)key, (String)newValue, OPType.REPLACE);
-            } else if (oldValue instanceof String) {
-                parseLegacy((String)key, (String)oldValue, OPType.REMOVE);
+        if (result && key instanceof String sk) {
+            if (newValue instanceof String sv) {
+                parseLegacy(sk, sv, OPType.REPLACE);
+            } else if (oldValue instanceof String sv) {
+                parseLegacy(sk, sv, OPType.REMOVE);
             }
         }
         return result;
@@ -950,12 +950,12 @@ public abstract class Provider extends Properties {
         if (!checkLegacy(key)) return null;
 
         Object o = super.replace(key, value);
-        if (key instanceof String) {
-            if (o != null && o instanceof String) {
-                if (value != null && value instanceof String) {
-                    parseLegacy((String)key, (String)value, OPType.REPLACE);
+        if (key instanceof String sk) {
+            if (o instanceof String so) {
+                if (value instanceof String sv) {
+                    parseLegacy(sk, sv, OPType.REPLACE);
                 } else {
-                    parseLegacy((String)key, (String)o, OPType.REMOVE);
+                    parseLegacy(sk, so, OPType.REMOVE);
                 }
             }
         }
@@ -970,11 +970,11 @@ public abstract class Provider extends Properties {
         for (Map.Entry<Object, Object> entry : super.entrySet()) {
             Object key = entry.getKey();
             Object value = entry.getValue();
-            if ((key instanceof String) && (value instanceof String)) {
-                if (!checkLegacy(key)) {
+            if ((key instanceof String sk) && (value instanceof String sv)) {
+                if (!checkLegacy(sk)) {
                     continue;
                 }
-                parseLegacy((String)key, (String)value, OPType.REPLACE);
+                parseLegacy(sk, sv, OPType.REPLACE);
             }
         }
     }
@@ -986,11 +986,11 @@ public abstract class Provider extends Properties {
         if (!checkLegacy(key)) return null;
 
         Object o = super.merge(key, value, remappingFunction);
-        if (key instanceof String) {
+        if (key instanceof String sk) {
             if (o == null) {
-                parseLegacy((String)key, (String)o, OPType.REMOVE);
-            } else if (o instanceof String) {
-                parseLegacy((String)key, (String)o, OPType.REPLACE);
+                parseLegacy(sk, null, OPType.REMOVE);
+            } else if (o instanceof String so) {
+                parseLegacy(sk, so, OPType.REPLACE);
             }
         }
         return o;
@@ -1003,11 +1003,11 @@ public abstract class Provider extends Properties {
         if (!checkLegacy(key)) return null;
 
         Object o = super.compute(key, remappingFunction);
-        if (key instanceof String) {
+        if (key instanceof String sk) {
             if (o == null) {
-                parseLegacy((String)key, (String)o, OPType.REMOVE);
-            } else if (o instanceof String) {
-                parseLegacy((String)key, (String)o, OPType.REPLACE);
+                parseLegacy(sk, null, OPType.REMOVE);
+            } else if (o instanceof String so) {
+                parseLegacy(sk, so, OPType.REPLACE);
             }
         }
         return o;
@@ -1019,8 +1019,8 @@ public abstract class Provider extends Properties {
         if (!checkLegacy(key)) return null;
 
         Object o = super.computeIfAbsent(key, mappingFunction);
-        if (o instanceof String && key instanceof String) {
-            parseLegacy((String)key, (String)o, OPType.REPLACE);
+        if (o instanceof String so && key instanceof String sk) {
+            parseLegacy(sk, so, OPType.REPLACE);
         }
         return o;
     }
@@ -1031,8 +1031,8 @@ public abstract class Provider extends Properties {
         if (!checkLegacy(key)) return null;
 
         Object o = super.computeIfPresent(key, remappingFunction);
-        if (o instanceof String && key instanceof String) {
-            parseLegacy((String)key, (String)o, OPType.REPLACE);
+        if (o instanceof String so && key instanceof String sk) {
+            parseLegacy(sk, so, OPType.REPLACE);
         }
         return o;
     }
@@ -1041,8 +1041,8 @@ public abstract class Provider extends Properties {
         if (!checkLegacy(key)) return null;
 
         Object o = super.put(key, value);
-        if (key instanceof String && value instanceof String) {
-            parseLegacy((String)key, (String)value, OPType.REPLACE);
+        if (key instanceof String sk && value instanceof String sv) {
+            parseLegacy(sk, sv, OPType.REPLACE);
         }
         return o;
     }
@@ -1051,8 +1051,9 @@ public abstract class Provider extends Properties {
         if (!checkLegacy(key)) return null;
 
         Object o = super.putIfAbsent(key, value);
-        if (o == null && key instanceof String && value instanceof String) {
-            parseLegacy((String)key, (String)value, OPType.ADD);
+        if (o == null && key instanceof String sk &&
+                value instanceof String sv) {
+            parseLegacy(sk, sv, OPType.ADD);
         }
         return o;
     }

--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -191,6 +191,9 @@ public abstract class Provider extends Properties {
         this.versionStr = Double.toString(version);
         this.info = info;
         this.serviceMap = new ConcurrentHashMap<>();
+        this.legacyMap = new ConcurrentHashMap<>();
+        this.prngAlgos =
+                Collections.synchronizedSet(new LinkedHashSet<String>(6));
         putId();
         initialized = true;
     }
@@ -229,6 +232,9 @@ public abstract class Provider extends Properties {
         this.version = parseVersionStr(versionStr);
         this.info = info;
         this.serviceMap = new ConcurrentHashMap<>();
+        this.legacyMap = new ConcurrentHashMap<>();
+        this.prngAlgos =
+                Collections.synchronizedSet(new LinkedHashSet<String>(6));
         putId();
         initialized = true;
     }
@@ -354,7 +360,7 @@ public abstract class Provider extends Properties {
      * @since 1.2
      */
     @Override
-    public synchronized void clear() {
+    public void clear() {
         check("clearProviderProperties."+name);
         if (debug != null) {
             debug.println("Remove " + name + " provider properties");
@@ -371,7 +377,7 @@ public abstract class Provider extends Properties {
      * @see java.util.Properties#load
      */
     @Override
-    public synchronized void load(InputStream inStream) throws IOException {
+    public void load(InputStream inStream) throws IOException {
         check("putProviderProperty."+name);
         if (debug != null) {
             debug.println("Load " + name + " provider properties");
@@ -389,7 +395,7 @@ public abstract class Provider extends Properties {
      * @since 1.2
      */
     @Override
-    public synchronized void putAll(Map<?,?> t) {
+    public void putAll(Map<?,?> t) {
         check("putProviderProperty."+name);
         if (debug != null) {
             debug.println("Put all " + name + " provider properties");
@@ -405,7 +411,7 @@ public abstract class Provider extends Properties {
      * @since 1.2
      */
     @Override
-    public synchronized Set<Map.Entry<Object,Object>> entrySet() {
+    public Set<Map.Entry<Object,Object>> entrySet() {
         checkInitialized();
         if (entrySet == null) {
             if (entrySetCallCount++ == 0)  // Initial call
@@ -466,7 +472,7 @@ public abstract class Provider extends Properties {
      * @since 1.2
      */
     @Override
-    public synchronized Object put(Object key, Object value) {
+    public Object put(Object key, Object value) {
         check("putProviderProperty."+name);
         if (debug != null) {
             debug.println("Set " + name + " provider property [" +
@@ -493,7 +499,7 @@ public abstract class Provider extends Properties {
      * @since 1.8
      */
     @Override
-    public synchronized Object putIfAbsent(Object key, Object value) {
+    public Object putIfAbsent(Object key, Object value) {
         check("putProviderProperty."+name);
         if (debug != null) {
             debug.println("Set " + name + " provider property [" +
@@ -519,7 +525,7 @@ public abstract class Provider extends Properties {
      * @since 1.2
      */
     @Override
-    public synchronized Object remove(Object key) {
+    public Object remove(Object key) {
         check("removeProviderProperty."+name);
         if (debug != null) {
             debug.println("Remove " + name + " provider property " + key);
@@ -544,7 +550,7 @@ public abstract class Provider extends Properties {
      * @since 1.8
      */
     @Override
-    public synchronized boolean remove(Object key, Object value) {
+    public boolean remove(Object key, Object value) {
         check("removeProviderProperty."+name);
         if (debug != null) {
             debug.println("Remove " + name + " provider property " + key);
@@ -569,10 +575,8 @@ public abstract class Provider extends Properties {
      * @since 1.8
      */
     @Override
-    public synchronized boolean replace(Object key, Object oldValue,
-            Object newValue) {
+    public boolean replace(Object key, Object oldValue, Object newValue) {
         check("putProviderProperty." + name);
-
         if (debug != null) {
             debug.println("Replace " + name + " provider property " + key);
         }
@@ -596,9 +600,8 @@ public abstract class Provider extends Properties {
      * @since 1.8
      */
     @Override
-    public synchronized Object replace(Object key, Object value) {
+    public Object replace(Object key, Object value) {
         check("putProviderProperty." + name);
-
         if (debug != null) {
             debug.println("Replace " + name + " provider property " + key);
         }
@@ -624,10 +627,9 @@ public abstract class Provider extends Properties {
      * @since 1.8
      */
     @Override
-    public synchronized void replaceAll(BiFunction<? super Object,
-            ? super Object, ? extends Object> function) {
+    public void replaceAll(BiFunction<? super Object, ? super Object,
+            ? extends Object> function) {
         check("putProviderProperty." + name);
-
         if (debug != null) {
             debug.println("ReplaceAll " + name + " provider property ");
         }
@@ -653,11 +655,10 @@ public abstract class Provider extends Properties {
      * @since 1.8
      */
     @Override
-    public synchronized Object compute(Object key, BiFunction<? super Object,
+    public Object compute(Object key, BiFunction<? super Object,
             ? super Object, ? extends Object> remappingFunction) {
         check("putProviderProperty." + name);
         check("removeProviderProperty." + name);
-
         if (debug != null) {
             debug.println("Compute " + name + " provider property " + key);
         }
@@ -684,11 +685,10 @@ public abstract class Provider extends Properties {
      * @since 1.8
      */
     @Override
-    public synchronized Object computeIfAbsent(Object key, Function<? super Object,
+    public Object computeIfAbsent(Object key, Function<? super Object,
             ? extends Object> mappingFunction) {
         check("putProviderProperty." + name);
         check("removeProviderProperty." + name);
-
         if (debug != null) {
             debug.println("ComputeIfAbsent " + name + " provider property " +
                     key);
@@ -714,11 +714,10 @@ public abstract class Provider extends Properties {
      * @since 1.8
      */
     @Override
-    public synchronized Object computeIfPresent(Object key, BiFunction<? super Object,
+    public Object computeIfPresent(Object key, BiFunction<? super Object,
             ? super Object, ? extends Object> remappingFunction) {
         check("putProviderProperty." + name);
         check("removeProviderProperty." + name);
-
         if (debug != null) {
             debug.println("ComputeIfPresent " + name + " provider property " +
                     key);
@@ -747,11 +746,10 @@ public abstract class Provider extends Properties {
      * @since 1.8
      */
     @Override
-    public synchronized Object merge(Object key, Object value,  BiFunction<? super Object,
+    public Object merge(Object key, Object value,  BiFunction<? super Object,
             ? super Object, ? extends Object>  remappingFunction) {
         check("putProviderProperty." + name);
         check("removeProviderProperty." + name);
-
         if (debug != null) {
             debug.println("Merge " + name + " provider property " + key);
         }
@@ -768,7 +766,7 @@ public abstract class Provider extends Properties {
      * @since 1.8
      */
     @Override
-    public synchronized Object getOrDefault(Object key, Object defaultValue) {
+    public Object getOrDefault(Object key, Object defaultValue) {
         checkInitialized();
         return super.getOrDefault(key, defaultValue);
     }
@@ -777,7 +775,7 @@ public abstract class Provider extends Properties {
      * @since 1.8
      */
     @Override
-    public synchronized void forEach(BiConsumer<? super Object, ? super Object> action) {
+    public void forEach(BiConsumer<? super Object, ? super Object> action) {
         checkInitialized();
         super.forEach(action);
     }
@@ -817,13 +815,10 @@ public abstract class Provider extends Properties {
         }
     }
 
-    // legacy properties changed since last call to any services method?
-    private transient boolean legacyChanged;
+    // legacyMap changed since last call to getServices()
+    private transient volatile boolean legacyChanged;
     // serviceMap changed since last call to getServices()
     private transient volatile boolean servicesChanged;
-
-    // Map<String,String> used to keep track of legacy registration
-    private transient Map<String,String> legacyStrings;
 
     // Map<ServiceKey,Service>
     // used for services added via putService(), initialized on demand
@@ -832,6 +827,9 @@ public abstract class Provider extends Properties {
     // For backward compatibility, the registration ordering of
     // SecureRandom (RNG) algorithms needs to be preserved for
     // "new SecureRandom()" calls when this provider is used
+    // NOTE: may need extra mechanism for providers to indicate their
+    // preferred ordering of SecureRandom algorithms since registration
+    // ordering info is lost once serialized
     private transient Set<String> prngAlgos;
 
     // Map<ServiceKey,Service>
@@ -872,6 +870,7 @@ public abstract class Provider extends Properties {
         for (Map.Entry<Object,Object> entry : super.entrySet()) {
             copy.put(entry.getKey(), entry.getValue());
         }
+
         defaults = null;
         in.defaultReadObject();
         if (this.versionStr == null) {
@@ -882,21 +881,22 @@ public abstract class Provider extends Properties {
             this.version = parseVersionStr(this.versionStr);
         }
         this.serviceMap = new ConcurrentHashMap<>();
+        this.legacyMap = new ConcurrentHashMap<>();
+        this.prngAlgos =
+                Collections.synchronizedSet(new LinkedHashSet<String>(6));
         implClear();
         initialized = true;
         putAll(copy);
     }
 
-    // check whether to update 'legacyString' with the specified key
+    // returns false if the key is provider-related, i.e.name, version, info,
+    // and className
     private boolean checkLegacy(Object key) {
-        String keyString = (String)key;
-        if (keyString.startsWith("Provider.")) {
+        if (key instanceof String && ((String)key).startsWith("Provider.")) {
+            // ignore provider related updates
             return false;
-        }
-
-        legacyChanged = true;
-        if (legacyStrings == null) {
-            legacyStrings = new LinkedHashMap<>();
+        } else {
+            legacyChanged = true;
         }
         return true;
     }
@@ -913,149 +913,157 @@ public abstract class Provider extends Properties {
     }
 
     private Object implRemove(Object key) {
-        if (key instanceof String) {
-            if (!checkLegacy(key)) {
-                return null;
-            }
-            legacyStrings.remove((String)key);
+        if (!checkLegacy(key)) return null;
+
+        Object o = super.remove(key);
+        if (o != null && o instanceof String && key instanceof String) {
+            parseLegacy((String)key, (String)o, OPType.REMOVE);
         }
-        return super.remove(key);
+        return o;
     }
 
     private boolean implRemove(Object key, Object value) {
-        if (key instanceof String && value instanceof String) {
-            if (!checkLegacy(key)) {
-                return false;
-            }
-            legacyStrings.remove((String)key, (String)value);
+        if (!checkLegacy(key)) return false;
+
+        boolean result = super.remove(key, value);
+        if (result && key instanceof String && value instanceof String) {
+            parseLegacy((String)key, (String)value, OPType.REMOVE);
         }
-        return super.remove(key, value);
+        return result;
     }
 
     private boolean implReplace(Object key, Object oldValue, Object newValue) {
-        if ((key instanceof String) && (oldValue instanceof String) &&
-                (newValue instanceof String)) {
-            if (!checkLegacy(key)) {
-                return false;
+        if (!checkLegacy(key)) return false;
+
+        boolean result = super.replace(key, oldValue, newValue);
+        if (result && key instanceof String) {
+            if (newValue instanceof String) {
+                parseLegacy((String)key, (String)newValue, OPType.REPLACE);
+            } else if (oldValue instanceof String) {
+                parseLegacy((String)key, (String)oldValue, OPType.REMOVE);
             }
-            legacyStrings.replace((String)key, (String)oldValue,
-                    (String)newValue);
         }
-        return super.replace(key, oldValue, newValue);
+        return result;
     }
 
     private Object implReplace(Object key, Object value) {
-        if ((key instanceof String) && (value instanceof String)) {
-            if (!checkLegacy(key)) {
-                return null;
+        if (!checkLegacy(key)) return null;
+
+        Object o = super.replace(key, value);
+        if (key instanceof String) {
+            if (o != null && o instanceof String) {
+                if (value != null && value instanceof String) {
+                    parseLegacy((String)key, (String)value, OPType.REPLACE);
+                } else {
+                    parseLegacy((String)key, (String)o, OPType.REMOVE);
+                }
             }
-            legacyStrings.replace((String)key, (String)value);
         }
-        return super.replace(key, value);
+        return o;
     }
 
     @SuppressWarnings("unchecked") // Function must actually operate over strings
     private void implReplaceAll(BiFunction<? super Object, ? super Object,
             ? extends Object> function) {
-        legacyChanged = true;
-        if (legacyStrings == null) {
-            legacyStrings = new LinkedHashMap<>();
-        } else {
-            legacyStrings.replaceAll((BiFunction<? super String, ? super String,
-                    ? extends String>) function);
-        }
+
         super.replaceAll(function);
+        for (Map.Entry<Object, Object> entry : super.entrySet()) {
+            Object key = entry.getKey();
+            Object value = entry.getValue();
+            if ((key instanceof String) && (value instanceof String)) {
+                if (!checkLegacy(key)) {
+                    continue;
+                }
+                parseLegacy((String)key, (String)value, OPType.REPLACE);
+            }
+        }
     }
 
     @SuppressWarnings("unchecked") // Function must actually operate over strings
     private Object implMerge(Object key, Object value,
             BiFunction<? super Object, ? super Object, ? extends Object>
             remappingFunction) {
-        if ((key instanceof String) && (value instanceof String)) {
-            if (!checkLegacy(key)) {
-                return null;
+        if (!checkLegacy(key)) return null;
+
+        Object o = super.merge(key, value, remappingFunction);
+        if (key instanceof String) {
+            if (o == null) {
+                parseLegacy((String)key, (String)o, OPType.REMOVE);
+            } else if (o instanceof String) {
+                parseLegacy((String)key, (String)o, OPType.REPLACE);
             }
-            legacyStrings.merge((String)key, (String)value,
-                    (BiFunction<? super String, ? super String,
-                    ? extends String>) remappingFunction);
         }
-        return super.merge(key, value, remappingFunction);
+        return o;
     }
 
     @SuppressWarnings("unchecked") // Function must actually operate over strings
     private Object implCompute(Object key, BiFunction<? super Object,
             ? super Object, ? extends Object> remappingFunction) {
+
+        if (!checkLegacy(key)) return null;
+
+        Object o = super.compute(key, remappingFunction);
         if (key instanceof String) {
-            if (!checkLegacy(key)) {
-                return null;
+            if (o == null) {
+                parseLegacy((String)key, (String)o, OPType.REMOVE);
+            } else if (o instanceof String) {
+                parseLegacy((String)key, (String)o, OPType.REPLACE);
             }
-            legacyStrings.compute((String) key,
-                    (BiFunction<? super String,? super String,
-                    ? extends String>) remappingFunction);
         }
-        return super.compute(key, remappingFunction);
+        return o;
     }
 
     @SuppressWarnings("unchecked") // Function must actually operate over strings
     private Object implComputeIfAbsent(Object key, Function<? super Object,
             ? extends Object> mappingFunction) {
-        if (key instanceof String) {
-            if (!checkLegacy(key)) {
-                return null;
-            }
-            legacyStrings.computeIfAbsent((String) key,
-                    (Function<? super String, ? extends String>)
-                    mappingFunction);
+        if (!checkLegacy(key)) return null;
+
+        Object o = super.computeIfAbsent(key, mappingFunction);
+        if (o instanceof String && key instanceof String) {
+            parseLegacy((String)key, (String)o, OPType.REPLACE);
         }
-        return super.computeIfAbsent(key, mappingFunction);
+        return o;
     }
 
     @SuppressWarnings("unchecked") // Function must actually operate over strings
     private Object implComputeIfPresent(Object key, BiFunction<? super Object,
             ? super Object, ? extends Object> remappingFunction) {
-        if (key instanceof String) {
-            if (!checkLegacy(key)) {
-                return null;
-            }
-            legacyStrings.computeIfPresent((String) key,
-                    (BiFunction<? super String, ? super String,
-                    ? extends String>) remappingFunction);
+        if (!checkLegacy(key)) return null;
+
+        Object o = super.computeIfPresent(key, remappingFunction);
+        if (o instanceof String && key instanceof String) {
+            parseLegacy((String)key, (String)o, OPType.REPLACE);
         }
-        return super.computeIfPresent(key, remappingFunction);
+        return o;
     }
 
     private Object implPut(Object key, Object value) {
-        if ((key instanceof String) && (value instanceof String)) {
-            if (!checkLegacy(key)) {
-                return null;
-            }
-            legacyStrings.put((String)key, (String)value);
+        if (!checkLegacy(key)) return null;
+
+        Object o = super.put(key, value);
+        if (key instanceof String && value instanceof String) {
+            parseLegacy((String)key, (String)value, OPType.REPLACE);
         }
-        return super.put(key, value);
+        return o;
     }
 
     private Object implPutIfAbsent(Object key, Object value) {
-        if ((key instanceof String) && (value instanceof String)) {
-            if (!checkLegacy(key)) {
-                return null;
-            }
-            legacyStrings.putIfAbsent((String)key, (String)value);
+        if (!checkLegacy(key)) return null;
+
+        Object o = super.putIfAbsent(key, value);
+        if (o == null && key instanceof String && value instanceof String) {
+            parseLegacy((String)key, (String)value, OPType.ADD);
         }
-        return super.putIfAbsent(key, value);
+        return o;
     }
 
     private void implClear() {
-        if (legacyStrings != null) {
-            legacyStrings.clear();
-        }
-        if (legacyMap != null) {
-            legacyMap.clear();
-        }
+        legacyMap.clear();
         serviceMap.clear();
         legacyChanged = false;
         servicesChanged = false;
         serviceSet = null;
-        prngAlgos = null;
+        prngAlgos.clear();
         super.clear();
         putId();
     }
@@ -1085,27 +1093,9 @@ public abstract class Provider extends Properties {
         boolean matches(String type, String algorithm) {
             return (this.type == type) && (this.originalAlgorithm == algorithm);
         }
-    }
-
-    /**
-     * Ensure all the legacy String properties are fully parsed into
-     * service objects.
-     */
-    private void ensureLegacyParsed() {
-        if (legacyChanged == false || (legacyStrings == null)) {
-            return;
+        public String toString() {
+            return type + "." + algorithm;
         }
-        serviceSet = null;
-        if (legacyMap == null) {
-            legacyMap = new ConcurrentHashMap<>();
-        } else {
-            legacyMap.clear();
-        }
-        for (Map.Entry<String,String> entry : legacyStrings.entrySet()) {
-            parseLegacyPut(entry.getKey(), entry.getValue());
-        }
-        removeInvalidServices(legacyMap);
-        legacyChanged = false;
     }
 
     /**
@@ -1136,71 +1126,142 @@ public abstract class Provider extends Properties {
         return new String[] {type, alg};
     }
 
+    // utility method for getting a String with service type and algorithm
+    private static String getKey(Service s) {
+        return s.getType() + "." + s.getAlgorithm();
+    }
+
     private static final String ALIAS_PREFIX = "Alg.Alias.";
     private static final String ALIAS_PREFIX_LOWER = "alg.alias.";
     private static final int ALIAS_LENGTH = ALIAS_PREFIX.length();
 
-    private void parseLegacyPut(String name, String value) {
+    private static enum OPType {
+        ADD, REMOVE, REPLACE;
+    }
+
+    private void parseLegacy(String name, String value, OPType opType) {
+        // alias
         if (name.toLowerCase(ENGLISH).startsWith(ALIAS_PREFIX_LOWER)) {
             // e.g. put("Alg.Alias.MessageDigest.SHA", "SHA-1");
             // aliasKey ~ MessageDigest.SHA
-            String stdAlg = value;
-            String aliasKey = name.substring(ALIAS_LENGTH);
-            String[] typeAndAlg = getTypeAndAlgorithm(aliasKey);
+            String aliasKeyStr = name.substring(ALIAS_LENGTH);
+            String[] typeAndAlg = getTypeAndAlgorithm(aliasKeyStr);
             if (typeAndAlg == null) {
                 return;
             }
+            Objects.requireNonNull(value, "alias value should map to an alg");
             String type = getEngineName(typeAndAlg[0]);
             String aliasAlg = typeAndAlg[1].intern();
-            ServiceKey key = new ServiceKey(type, stdAlg, true);
-            Service s = legacyMap.get(key);
-            if (s == null) {
-                s = new Service(this, type, stdAlg);
-                legacyMap.put(key, s);
+            ServiceKey stdKey = new ServiceKey(type, value, true);
+            Service stdService = legacyMap.get(stdKey);
+            ServiceKey aliasKey = new ServiceKey(type, aliasAlg, true);
+            switch (opType) {
+                case ADD:
+                case REPLACE:
+                    if (opType == OPType.REPLACE) {
+                        Service prevAliasService = legacyMap.get(aliasAlg);
+                        if (prevAliasService != null) {
+                            prevAliasService.removeAlias(aliasAlg);
+                        }
+                    }
+                    if (stdService == null) {
+                        // add standard mapping in order to add alias
+                        stdService = new Service(this, type, value);
+                        legacyMap.put(stdKey, stdService);
+                    }
+                    stdService.addAlias(aliasAlg);
+                    legacyMap.put(aliasKey, stdService);
+                    break;
+                case REMOVE:
+                    if (stdService != null) {
+                        stdService.removeAlias(aliasAlg);
+                    }
+                    legacyMap.remove(aliasKey);
+                    break;
+                default:
+                    throw new AssertionError();
             }
-            legacyMap.put(new ServiceKey(type, aliasAlg, true), s);
-            s.addAlias(aliasAlg);
         } else {
             String[] typeAndAlg = getTypeAndAlgorithm(name);
             if (typeAndAlg == null) {
                 return;
             }
             int i = typeAndAlg[1].indexOf(' ');
+            // regular registration
             if (i == -1) {
                 // e.g. put("MessageDigest.SHA-1", "sun.security.provider.SHA");
                 String type = getEngineName(typeAndAlg[0]);
                 String stdAlg = typeAndAlg[1].intern();
-                String className = value;
-                ServiceKey key = new ServiceKey(type, stdAlg, true);
-                Service s = legacyMap.get(key);
-                if (s == null) {
-                    s = new Service(this, type, stdAlg);
-                    legacyMap.put(key, s);
+                ServiceKey stdKey = new ServiceKey(type, stdAlg, true);
+                Service stdService = legacyMap.get(stdKey);
+                switch (opType) {
+                    case ADD:
+                    case REPLACE:
+                        Objects.requireNonNull(value,
+                                "className can't be null");
+                        if (stdService == null) {
+                            stdService = new Service(this, type, stdAlg);
+                            legacyMap.put(stdKey, stdService);
+                        } else if ((opType == OPType.ADD) &&
+                                (stdService.className != null)) {
+                            // ignore subsequent registration for ADD
+                            return;
+                        }
+                        stdService.className = value;
+                        break;
+                    case REMOVE:
+                        // only remove if value also matches when non-null
+                        if (stdService != null) {
+                            if (value == null) {
+                                legacyMap.remove(stdKey);
+                            } else if (stdService.className.equals(value)) {
+                                legacyMap.remove(stdKey, stdService);
+                            }
+                            // remove all corresponding alias mappings
+                            for (String alias : stdService.getAliases()) {
+                                legacyMap.remove(new ServiceKey(type, alias,
+                                        true), stdService);
+                            }
+                        }
+                        break;
+                    default:
+                        throw new AssertionError();
                 }
-                s.className = className;
-
-                if (type.equals("SecureRandom")) {
-                    updateSecureRandomEntries(true, s.algorithm);
-                }
+                checkAndUpdateSecureRandom(type, stdAlg,
+                        (opType != OPType.REMOVE));
             } else { // attribute
                 // e.g. put("MessageDigest.SHA-1 ImplementedIn", "Software");
-                String attributeValue = value;
                 String type = getEngineName(typeAndAlg[0]);
-                String attributeString = typeAndAlg[1];
-                String stdAlg = attributeString.substring(0, i).intern();
-                String attributeName = attributeString.substring(i + 1);
+                String attrString = typeAndAlg[1];
+                String stdAlg = attrString.substring(0, i).intern();
+                String attrName = attrString.substring(i + 1);
                 // kill additional spaces
-                while (attributeName.startsWith(" ")) {
-                    attributeName = attributeName.substring(1);
+                while (attrName.startsWith(" ")) {
+                    attrName = attrName.substring(1);
                 }
-                attributeName = attributeName.intern();
-                ServiceKey key = new ServiceKey(type, stdAlg, true);
-                Service s = legacyMap.get(key);
-                if (s == null) {
-                    s = new Service(this, type, stdAlg);
-                    legacyMap.put(key, s);
+                attrName = attrName.intern();
+                ServiceKey stdKey = new ServiceKey(type, stdAlg, true);
+                Service stdService = legacyMap.get(stdKey);
+                switch (opType) {
+                    case ADD:
+                    case REPLACE:
+                        Objects.requireNonNull(value,
+                                "attribute value should not be null");
+
+                        if (stdService == null) {
+                            stdService = new Service(this, type, stdAlg);
+                            legacyMap.put(stdKey, stdService);
+                        }
+                        stdService.addAttribute(attrName, value);
+                        break;
+                    case REMOVE:
+                        if (stdService != null) {
+                            stdService.removeAttribute(attrName, value);
+                        }
+                        break;
+                default:
+                    throw new AssertionError();
                 }
-                s.addAttribute(attributeName, attributeValue);
             }
         }
     }
@@ -1227,25 +1288,29 @@ public abstract class Provider extends Properties {
      */
     public Service getService(String type, String algorithm) {
         checkInitialized();
-
         // avoid allocating a new ServiceKey object if possible
         ServiceKey key = previousKey;
         if (key.matches(type, algorithm) == false) {
             key = new ServiceKey(type, algorithm, false);
             previousKey = key;
         }
+
         if (!serviceMap.isEmpty()) {
             Service s = serviceMap.get(key);
             if (s != null) {
                 return s;
             }
         }
-        synchronized (this) {
-            ensureLegacyParsed();
-            if (legacyMap != null && !legacyMap.isEmpty()) {
-                return legacyMap.get(key);
+
+        if (!legacyMap.isEmpty()) {
+            Service s = legacyMap.get(key);
+            if (s != null && !s.isValid()) {
+                legacyMap.remove(key);
+            } else {
+                return s;
             }
         }
+
         return null;
     }
 
@@ -1267,18 +1332,14 @@ public abstract class Provider extends Properties {
      *
      * @since 1.5
      */
-    public synchronized Set<Service> getServices() {
+    public Set<Service> getServices() {
         checkInitialized();
-        if (legacyChanged || servicesChanged) {
-            serviceSet = null;
-        }
-        if (serviceSet == null) {
-            ensureLegacyParsed();
+        if (serviceSet == null || legacyChanged || servicesChanged) {
             Set<Service> set = new LinkedHashSet<>();
             if (!serviceMap.isEmpty()) {
                 set.addAll(serviceMap.values());
             }
-            if (legacyMap != null && !legacyMap.isEmpty()) {
+            if (!legacyMap.isEmpty()) {
                 set.addAll(legacyMap.values());
             }
             serviceSet = Collections.unmodifiableSet(set);
@@ -1337,46 +1398,37 @@ public abstract class Provider extends Properties {
             serviceMap.put(new ServiceKey(type, alias, true), s);
         }
         servicesChanged = true;
-        synchronized (this) {
-            putPropertyStrings(s);
-            if (type.equals("SecureRandom")) {
-                updateSecureRandomEntries(true, s.algorithm);
-            }
-        }
+        putPropertyStrings(s);
+
+        checkAndUpdateSecureRandom(type, algorithm, true);
     }
 
-    // keep tracks of the registered secure random algos and store them in order
-    private void updateSecureRandomEntries(boolean doAdd, String s) {
-        Objects.requireNonNull(s);
-        if (doAdd) {
-            if (prngAlgos == null) {
-                prngAlgos = new LinkedHashSet<String>();
+    private void checkAndUpdateSecureRandom(String type, String algo,
+            boolean doAdd) {
+        if (type.equalsIgnoreCase("SecureRandom")) {
+            if (doAdd) {
+                prngAlgos.add(algo);
+            } else {
+                prngAlgos.remove(algo);
             }
-            prngAlgos.add(s);
-        } else {
-            prngAlgos.remove(s);
-        }
-
-        if (debug != null) {
-            debug.println((doAdd? "Add":"Remove") + " SecureRandom algo " + s);
+            if (debug != null) {
+                debug.println((doAdd? "Add":"Remove") +
+                        " SecureRandom algo " + algo);
+            }
         }
     }
 
     // used by new SecureRandom() to find out the default SecureRandom
     // service for this provider
-    synchronized Service getDefaultSecureRandomService() {
+    Service getDefaultSecureRandomService() {
         checkInitialized();
 
-        if (legacyChanged) {
-            prngAlgos = null;
-            ensureLegacyParsed();
-        }
-
-        if (prngAlgos != null && !prngAlgos.isEmpty()) {
+        if (!prngAlgos.isEmpty()) {
+            String algo = prngAlgos.iterator().next();
             // IMPORTANT: use the Service obj returned by getService(...) call
             // as providers may override putService(...)/getService(...) and
             // return their own Service objects
-            return getService("SecureRandom", prngAlgos.iterator().next());
+            return getService("SecureRandom", algo);
         }
 
         return null;
@@ -1473,12 +1525,9 @@ public abstract class Provider extends Properties {
         for (String alias : s.getAliases()) {
             serviceMap.remove(new ServiceKey(type, alias, false));
         }
-        synchronized (this) {
-            removePropertyStrings(s);
-            if (type.equals("SecureRandom")) {
-                updateSecureRandomEntries(false, s.algorithm);
-            }
-        }
+
+        removePropertyStrings(s);
+        checkAndUpdateSecureRandom(type, algorithm, false);
     }
 
     // Wrapped String that behaves in a case insensitive way for equals/hashCode
@@ -1686,11 +1735,29 @@ public abstract class Provider extends Properties {
             aliases.add(alias);
         }
 
+        private void removeAlias(String alias) {
+            if (aliases.isEmpty()) {
+                return;
+            }
+            aliases.remove(alias);
+        }
+
         void addAttribute(String type, String value) {
             if (attributes.isEmpty()) {
                 attributes = new HashMap<>(8);
             }
             attributes.put(new UString(type), value);
+        }
+
+        void removeAttribute(String type, String value) {
+            if (attributes.isEmpty()) {
+                return;
+            }
+            if (value == null) {
+                attributes.remove(new UString(type));
+            } else {
+                attributes.remove(new UString(type), value);
+            }
         }
 
         /**

--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -1098,20 +1098,6 @@ public abstract class Provider extends Properties {
         }
     }
 
-    /**
-     * Remove all invalid services from the Map. Invalid services can only
-     * occur if the legacy properties are inconsistent or incomplete.
-     */
-    private void removeInvalidServices(Map<ServiceKey,Service> map) {
-        for (Iterator<Map.Entry<ServiceKey, Service>> t =
-                map.entrySet().iterator(); t.hasNext(); ) {
-            Service s = t.next().getValue();
-            if (s.isValid() == false) {
-                t.remove();
-            }
-        }
-    }
-
     private static String[] getTypeAndAlgorithm(String key) {
         int i = key.indexOf('.');
         if (i < 1) {

--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -232,8 +232,7 @@ public abstract class Provider extends Properties {
         this.info = info;
         this.serviceMap = new ConcurrentHashMap<>();
         this.legacyMap = new ConcurrentHashMap<>();
-        this.prngAlgos =
-                Collections.synchronizedSet(new LinkedHashSet<String>(6));
+        this.prngAlgos = new LinkedHashSet<String>(6);
         putId();
         initialized = true;
     }
@@ -885,8 +884,7 @@ public abstract class Provider extends Properties {
         }
         this.serviceMap = new ConcurrentHashMap<>();
         this.legacyMap = new ConcurrentHashMap<>();
-        this.prngAlgos =
-                Collections.synchronizedSet(new LinkedHashSet<String>(6));
+        this.prngAlgos = new LinkedHashSet<String>(6);
         implClear();
         initialized = true;
         putAll(copy);

--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -192,8 +192,7 @@ public abstract class Provider extends Properties {
         this.info = info;
         this.serviceMap = new ConcurrentHashMap<>();
         this.legacyMap = new ConcurrentHashMap<>();
-        this.prngAlgos =
-                Collections.synchronizedSet(new LinkedHashSet<String>(6));
+        this.prngAlgos = new LinkedHashSet<String>(6);
         putId();
         initialized = true;
     }
@@ -360,7 +359,7 @@ public abstract class Provider extends Properties {
      * @since 1.2
      */
     @Override
-    public void clear() {
+    public synchronized void clear() {
         check("clearProviderProperties."+name);
         if (debug != null) {
             debug.println("Remove " + name + " provider properties");
@@ -377,7 +376,7 @@ public abstract class Provider extends Properties {
      * @see java.util.Properties#load
      */
     @Override
-    public void load(InputStream inStream) throws IOException {
+    public synchronized void load(InputStream inStream) throws IOException {
         check("putProviderProperty."+name);
         if (debug != null) {
             debug.println("Load " + name + " provider properties");
@@ -395,7 +394,7 @@ public abstract class Provider extends Properties {
      * @since 1.2
      */
     @Override
-    public void putAll(Map<?,?> t) {
+    public synchronized void putAll(Map<?,?> t) {
         check("putProviderProperty."+name);
         if (debug != null) {
             debug.println("Put all " + name + " provider properties");
@@ -411,7 +410,7 @@ public abstract class Provider extends Properties {
      * @since 1.2
      */
     @Override
-    public Set<Map.Entry<Object,Object>> entrySet() {
+    public synchronized Set<Map.Entry<Object,Object>> entrySet() {
         checkInitialized();
         if (entrySet == null) {
             if (entrySetCallCount++ == 0)  // Initial call
@@ -472,7 +471,7 @@ public abstract class Provider extends Properties {
      * @since 1.2
      */
     @Override
-    public Object put(Object key, Object value) {
+    public synchronized Object put(Object key, Object value) {
         check("putProviderProperty."+name);
         if (debug != null) {
             debug.println("Set " + name + " provider property [" +
@@ -499,7 +498,7 @@ public abstract class Provider extends Properties {
      * @since 1.8
      */
     @Override
-    public Object putIfAbsent(Object key, Object value) {
+    public synchronized Object putIfAbsent(Object key, Object value) {
         check("putProviderProperty."+name);
         if (debug != null) {
             debug.println("Set " + name + " provider property [" +
@@ -525,7 +524,7 @@ public abstract class Provider extends Properties {
      * @since 1.2
      */
     @Override
-    public Object remove(Object key) {
+    public synchronized Object remove(Object key) {
         check("removeProviderProperty."+name);
         if (debug != null) {
             debug.println("Remove " + name + " provider property " + key);
@@ -550,7 +549,7 @@ public abstract class Provider extends Properties {
      * @since 1.8
      */
     @Override
-    public boolean remove(Object key, Object value) {
+    public synchronized boolean remove(Object key, Object value) {
         check("removeProviderProperty."+name);
         if (debug != null) {
             debug.println("Remove " + name + " provider property " + key);
@@ -575,7 +574,8 @@ public abstract class Provider extends Properties {
      * @since 1.8
      */
     @Override
-    public boolean replace(Object key, Object oldValue, Object newValue) {
+    public synchronized boolean replace(Object key, Object oldValue,
+            Object newValue) {
         check("putProviderProperty." + name);
         if (debug != null) {
             debug.println("Replace " + name + " provider property " + key);
@@ -600,7 +600,7 @@ public abstract class Provider extends Properties {
      * @since 1.8
      */
     @Override
-    public Object replace(Object key, Object value) {
+    public synchronized Object replace(Object key, Object value) {
         check("putProviderProperty." + name);
         if (debug != null) {
             debug.println("Replace " + name + " provider property " + key);
@@ -627,8 +627,8 @@ public abstract class Provider extends Properties {
      * @since 1.8
      */
     @Override
-    public void replaceAll(BiFunction<? super Object, ? super Object,
-            ? extends Object> function) {
+    public synchronized void replaceAll(BiFunction<? super Object,
+            ? super Object, ? extends Object> function) {
         check("putProviderProperty." + name);
         if (debug != null) {
             debug.println("ReplaceAll " + name + " provider property ");
@@ -655,7 +655,7 @@ public abstract class Provider extends Properties {
      * @since 1.8
      */
     @Override
-    public Object compute(Object key, BiFunction<? super Object,
+    public synchronized Object compute(Object key, BiFunction<? super Object,
             ? super Object, ? extends Object> remappingFunction) {
         check("putProviderProperty." + name);
         check("removeProviderProperty." + name);
@@ -685,8 +685,8 @@ public abstract class Provider extends Properties {
      * @since 1.8
      */
     @Override
-    public Object computeIfAbsent(Object key, Function<? super Object,
-            ? extends Object> mappingFunction) {
+    public synchronized Object computeIfAbsent(Object key,
+            Function<? super Object, ? extends Object> mappingFunction) {
         check("putProviderProperty." + name);
         check("removeProviderProperty." + name);
         if (debug != null) {
@@ -714,8 +714,9 @@ public abstract class Provider extends Properties {
      * @since 1.8
      */
     @Override
-    public Object computeIfPresent(Object key, BiFunction<? super Object,
-            ? super Object, ? extends Object> remappingFunction) {
+    public synchronized Object computeIfPresent(Object key,
+            BiFunction<? super Object, ? super Object, ? extends Object>
+            remappingFunction) {
         check("putProviderProperty." + name);
         check("removeProviderProperty." + name);
         if (debug != null) {
@@ -746,8 +747,9 @@ public abstract class Provider extends Properties {
      * @since 1.8
      */
     @Override
-    public Object merge(Object key, Object value,  BiFunction<? super Object,
-            ? super Object, ? extends Object>  remappingFunction) {
+    public synchronized Object merge(Object key, Object value,
+            BiFunction<? super Object, ? super Object, ? extends Object>
+            remappingFunction) {
         check("putProviderProperty." + name);
         check("removeProviderProperty." + name);
         if (debug != null) {
@@ -766,7 +768,7 @@ public abstract class Provider extends Properties {
      * @since 1.8
      */
     @Override
-    public Object getOrDefault(Object key, Object defaultValue) {
+    public synchronized Object getOrDefault(Object key, Object defaultValue) {
         checkInitialized();
         return super.getOrDefault(key, defaultValue);
     }
@@ -775,7 +777,8 @@ public abstract class Provider extends Properties {
      * @since 1.8
      */
     @Override
-    public void forEach(BiConsumer<? super Object, ? super Object> action) {
+    public synchronized void forEach(BiConsumer<? super Object, ? super Object>
+            action) {
         checkInitialized();
         super.forEach(action);
     }
@@ -1385,9 +1388,10 @@ public abstract class Provider extends Properties {
             serviceMap.put(new ServiceKey(type, alias, true), s);
         }
         servicesChanged = true;
-        putPropertyStrings(s);
-
-        checkAndUpdateSecureRandom(type, algorithm, true);
+        synchronized (this) {
+            putPropertyStrings(s);
+            checkAndUpdateSecureRandom(type, algorithm, true);
+        }
     }
 
     private void checkAndUpdateSecureRandom(String type, String algo,


### PR DESCRIPTION
It is observed that when running crypto benchmark with large number of threads, a lot of time is spent on the synchronized block inside the Provider.getService() method. The cause for this is that Provider.getService() method first uses the 'serviceMap' field to find the requested service. However, when the requested service is not supported by this provider, e.g. requesting Cipher.RSA from SUN provider, the impl continues to try searching the legacy registrations whose processing is guarded by the "synchronized" keyword. When apps use getInstance() calls without the provider argument, Provider class has to iterate through existing providers trying to find one that supports the requested service.

Now that the parent class of Provider no longer synchronizes all of its methods, Provider class should follow suit and de-synchronize its methods. Parsing of the legacy registration is done eagerly (at the time of put(...) calls) instead of lazily (at the time of getService(...) calls). This also makes "legacyStrings" redundant as the registration is parsed and stored directly into "legacyMap". 

The bug reporter has confirmed that the changes resolve the performance bottleneck and all regression tests pass.

Please review and thanks in advance,
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276660](https://bugs.openjdk.java.net/browse/JDK-8276660): Scalability bottleneck in java.security.Provider.getService()


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6513/head:pull/6513` \
`$ git checkout pull/6513`

Update a local copy of the PR: \
`$ git checkout pull/6513` \
`$ git pull https://git.openjdk.java.net/jdk pull/6513/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6513`

View PR using the GUI difftool: \
`$ git pr show -t 6513`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6513.diff">https://git.openjdk.java.net/jdk/pull/6513.diff</a>

</details>
