### PR TITLE
JDK-8277562 Remove dead method c1 If::swap_sux

### DIFF
--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1998,14 +1998,6 @@ LEAF(If, BlockEnd)
     _cond = mirror(_cond);
   }
 
-  void swap_sux() {
-    assert(number_of_sux() == 2, "wrong number of successors");
-    BlockList* s = sux();
-    BlockBegin* t = s->at(0); s->at_put(0, s->at(1)); s->at_put(1, t);
-    _cond = negate(_cond);
-    set_flag(UnorderedIsTrueFlag, !check_flag(UnorderedIsTrueFlag));
-  }
-
   void set_should_profile(bool value)             { set_flag(ProfileMDOFlag, value); }
   void set_profiled_method(ciMethod* method)      { _profiled_method = method; }
   void set_profiled_bci(int bci)                  { _profiled_bci = bci;       }


### PR DESCRIPTION
swap_sux in c1 is never used or referenced. Let's remove it. This will facilitate further refactorings.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277562](https://bugs.openjdk.java.net/browse/JDK-8277562): Remove dead method c1 If::swap_sux


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6517/head:pull/6517` \
`$ git checkout pull/6517`

Update a local copy of the PR: \
`$ git checkout pull/6517` \
`$ git pull https://git.openjdk.java.net/jdk pull/6517/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6517`

View PR using the GUI difftool: \
`$ git pr show -t 6517`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6517.diff">https://git.openjdk.java.net/jdk/pull/6517.diff</a>

</details>
