### PR TITLE
8266435: WBMPImageReader.read() should not truncate the input stream

### DIFF
--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/wbmp/WBMPImageReader.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/wbmp/WBMPImageReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -244,8 +244,8 @@ public class WBMPImageReader extends ImageReader {
             }
 
             // If noTransform is necessary, read the data.
-            iis.read(((DataBufferByte)tile.getDataBuffer()).getData(),
-                     0, height*sm.getScanlineStride());
+            iis.readFully(((DataBufferByte)tile.getDataBuffer()).getData(),
+                          0, height*sm.getScanlineStride());
             processImageUpdate(bi,
                                0, 0,
                                width, height, 1, 1,
@@ -280,7 +280,7 @@ public class WBMPImageReader extends ImageReader {
 
                 if (abortRequested())
                     break;
-                iis.read(buf, 0, len);
+                iis.readFully(buf, 0, len);
                 for (int i = 0; i < destinationRegion.width; i++) {
                     //get the bit and assign to the data buffer of the raster
                     int v = (buf[srcPos[i]] >> srcOff[i]) & 1;

--- a/test/jdk/javax/imageio/plugins/wbmp/WBMPStreamTruncateTest.java
+++ b/test/jdk/javax/imageio/plugins/wbmp/WBMPStreamTruncateTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug     8266435
+ * @summary Test verifies that WBMPImageReader doesnt truncate
+ *          the stream and reads it fully
+ * @run     main WBMPStreamTruncateTest
+ */
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import javax.imageio.ImageIO;
+import javax.imageio.stream.ImageInputStreamImpl;
+
+public class WBMPStreamTruncateTest
+{
+    static final int LIMIT = 100;
+    static final int width = 100;
+    static final int height = 100;
+    public static void main(String[] args) throws IOException
+    {
+        String sep = System.getProperty("file.separator");
+        String dir = System.getProperty("test.src", ".");
+        String filePath = dir+sep;
+        BufferedImage srcImage = new
+                BufferedImage(width, height, BufferedImage.TYPE_BYTE_BINARY);
+        Graphics2D g = (Graphics2D) srcImage.getGraphics();
+        g.setBackground(Color.WHITE);
+        g.fillRect(0, 0, srcImage.getWidth(), srcImage.getHeight());
+        g.dispose();
+        // create WBMP image
+        File imageFile = File.
+                createTempFile("test", ".wbmp", new File(filePath));
+        imageFile.deleteOnExit();
+        ImageIO.write(srcImage, "wbmp", imageFile);
+        BufferedImage testImg =
+                ImageIO.read(new LimitedImageInputStream(imageFile, LIMIT));
+        for (int x = 0; x < testImg.getWidth(); ++x)
+        {
+            for (int y = 0; y < testImg.getHeight(); ++y)
+            {
+                int i1 = testImg.getRGB(x, y);
+                int i2 = srcImage.getRGB(x, y);
+                if (i1 != i2)
+                {
+                    throw new RuntimeException("Stream is decoded only until "
+                    + "the limit specified");
+                }
+            }
+        }
+    }
+
+    static class LimitedImageInputStream extends ImageInputStreamImpl
+    {
+        private final RandomAccessFile raf;
+        private final int limit;
+
+        public LimitedImageInputStream(File file, int limit)
+                throws FileNotFoundException
+        {
+            raf = new RandomAccessFile(file, "r");
+            this.limit = limit;
+        }
+
+        @Override
+        public int read() throws IOException
+        {
+            return raf.read();
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException
+        {
+            return raf.read(b, off, Math.min(limit, len));
+        }
+
+        @Override
+        public void close() throws IOException
+        {
+            super.close();
+            raf.close();
+        }
+
+        @Override
+        public void seek(long pos) throws IOException
+        {
+            super.seek(pos);
+            raf.seek(pos);
+        }
+    }
+}


### PR DESCRIPTION
If we use a custom stream and specify limit on stream.read() length, WBMPImageReader.read() doesnt verify whether we are decoded complete data or not. We can check the length of data decoded and rerun the stream.read() or use readFully(). In case of other decoders like BMP we are using readFully(), so i have updated WBMPImageReader.read() to use readFully().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266435](https://bugs.openjdk.java.net/browse/JDK-8266435): WBMPImageReader.read() should not truncate the input stream


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6518/head:pull/6518` \
`$ git checkout pull/6518`

Update a local copy of the PR: \
`$ git checkout pull/6518` \
`$ git pull https://git.openjdk.java.net/jdk pull/6518/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6518`

View PR using the GUI difftool: \
`$ git pr show -t 6518`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6518.diff">https://git.openjdk.java.net/jdk/pull/6518.diff</a>

</details>
