### PR TITLE
8277631: ZGC: CriticalMetaspaceAllocation asserts

### DIFF
--- a/src/hotspot/share/memory/metaspaceCriticalAllocation.cpp
+++ b/src/hotspot/share/memory/metaspaceCriticalAllocation.cpp
@@ -113,10 +113,12 @@ void MetaspaceCriticalAllocation::remove(MetadataAllocationRequest* request) {
 }
 
 bool MetaspaceCriticalAllocation::try_allocate_critical(MetadataAllocationRequest* request) {
-  MutexLocker ml(MetaspaceCritical_lock, Mutex::_no_safepoint_check_flag);
-  if (_requests_head == request) {
-    // The first request can't opportunistically ride on a previous GC
-    return false;
+  {
+    MutexLocker ml(MetaspaceCritical_lock, Mutex::_no_safepoint_check_flag);
+    if (_requests_head == request) {
+      // The first request can't opportunistically ride on a previous GC
+      return false;
+    }
   }
   // Try to ride on a previous GC and hope for early satisfaction
   wait_for_purge(request);
@@ -124,8 +126,12 @@ bool MetaspaceCriticalAllocation::try_allocate_critical(MetadataAllocationReques
 }
 
 void MetaspaceCriticalAllocation::wait_for_purge(MetadataAllocationRequest* request) {
-  while (!request->has_result()) {
+  for (;;) {
     ThreadBlockInVM tbivm(JavaThread::current());
+    MutexLocker ml(MetaspaceCritical_lock, Mutex::_no_safepoint_check_flag);
+    if (request->has_result()) {
+      break;
+    }
     MetaspaceCritical_lock->wait_without_safepoint_check();
   }
 }

--- a/src/hotspot/share/memory/metaspaceCriticalAllocation.cpp
+++ b/src/hotspot/share/memory/metaspaceCriticalAllocation.cpp
@@ -126,9 +126,9 @@ bool MetaspaceCriticalAllocation::try_allocate_critical(MetadataAllocationReques
 }
 
 void MetaspaceCriticalAllocation::wait_for_purge(MetadataAllocationRequest* request) {
+  ThreadBlockInVM tbivm(JavaThread::current());
+  MutexLocker ml(MetaspaceCritical_lock, Mutex::_no_safepoint_check_flag);
   for (;;) {
-    ThreadBlockInVM tbivm(JavaThread::current());
-    MutexLocker ml(MetaspaceCritical_lock, Mutex::_no_safepoint_check_flag);
     if (request->has_result()) {
       break;
     }

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/LoadUnloadGC/LoadUnloadGC.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/LoadUnloadGC/LoadUnloadGC.java
@@ -45,6 +45,30 @@
  *      gc.gctests.LoadUnloadGC.LoadUnloadGC
  */
 
+/*
+ * @test
+ * @key stress
+ *
+ * @summary converted from VM Testbase gc/gctests/LoadUnloadGC.
+ * VM Testbase keywords: [gc, stress, stressopt, nonconcurrent, monitoring]
+ * VM Testbase readme:
+ * In this test a 1000 classes are loaded and unloaded in a loop.
+ * Class0 gets loaded which results in Class1 getting loaded and so on all
+ * the way uptill class1000.  The classes should be unloaded whenever a
+ * garbage collection takes place because their classloader is made unreachable
+ * at the end of the each loop iteration. The loop is repeated 1000 times.
+ *
+ * @requires vm.opt.final.ClassUnloading
+ * @library /vmTestbase
+ *          /test/lib
+ * @build nsk.share.gc.ClassChain
+ * @run main/othervm
+ *      -XX:MaxMetaspaceSize=64M
+ *      -XX:MetaspaceSize=64M
+ *      -XX:CompressedClassSpaceSize=32M
+ *      gc.gctests.LoadUnloadGC.LoadUnloadGC
+ */
+
 package gc.gctests.LoadUnloadGC;
 
 import nsk.share.test.*;

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/LoadUnloadGC/LoadUnloadGC.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/LoadUnloadGC/LoadUnloadGC.java
@@ -28,11 +28,11 @@
  * @summary converted from VM Testbase gc/gctests/LoadUnloadGC.
  * VM Testbase keywords: [gc, stress, stressopt, nonconcurrent, monitoring]
  * VM Testbase readme:
- * In this test a 1000 classes are loaded and unloaded in a loop.
+ * In this test 1000 classes are loaded and unloaded in a loop.
  * Class0 gets loaded which results in Class1 getting loaded and so on all
- * the way uptill class1000.  The classes should be unloaded whenever a
+ * the way up to class1000.  The classes should be unloaded whenever a
  * garbage collection takes place because their classloader is made unreachable
- * at the end of the each loop iteration. The loop is repeated 1000 times.
+ * at the end of each loop iteration. The loop is repeated 1000 times.
  *
  * @requires vm.opt.final.ClassUnloading
  * @library /vmTestbase
@@ -52,11 +52,11 @@
  * @summary converted from VM Testbase gc/gctests/LoadUnloadGC.
  * VM Testbase keywords: [gc, stress, stressopt, nonconcurrent, monitoring]
  * VM Testbase readme:
- * In this test a 1000 classes are loaded and unloaded in a loop.
+ * In this test 1000 classes are loaded and unloaded in a loop.
  * Class0 gets loaded which results in Class1 getting loaded and so on all
- * the way uptill class1000.  The classes should be unloaded whenever a
+ * the way up to class1000.  The classes should be unloaded whenever a
  * garbage collection takes place because their classloader is made unreachable
- * at the end of the each loop iteration. The loop is repeated 1000 times.
+ * at the end of each loop iteration. The loop is repeated 1000 times.
  *
  * @requires vm.opt.final.ClassUnloading
  * @library /vmTestbase


### PR DESCRIPTION
The MetaspaceCritical_lock is a non-safepoint checking lock. That implies that the allow VM block flag is true. That implies that taking that lock takes a NoSafepointVerifier. That causes an assert to fire when MetaspaceCriticalAllocation::wait_for_purge transitions to blocked with ThreadBlockInVM while holding the lock. The fix is to move the locker inside of the ThreadBlockInVM.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277631](https://bugs.openjdk.java.net/browse/JDK-8277631): ZGC: CriticalMetaspaceAllocation asserts


### Reviewers
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**) ⚠️ Review applies to ec93bede572406cb57a461804e0659dc37fe00a7
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to ec93bede572406cb57a461804e0659dc37fe00a7
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to ec93bede572406cb57a461804e0659dc37fe00a7


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6520/head:pull/6520` \
`$ git checkout pull/6520`

Update a local copy of the PR: \
`$ git checkout pull/6520` \
`$ git pull https://git.openjdk.java.net/jdk pull/6520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6520`

View PR using the GUI difftool: \
`$ git pr show -t 6520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6520.diff">https://git.openjdk.java.net/jdk/pull/6520.diff</a>

</details>
