### PR TITLE
8277649 [BACKOUT] JDK-8277507 Add jlink.debug system property while launching jpackage tests to help diagonize recent intermittent failures

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/HelloApp.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/HelloApp.java
@@ -133,10 +133,6 @@ public final class HelloApp {
     }
 
     void addTo(JPackageCommand cmd) {
-        // set jlink.debug system property to allow the jlink process
-        // to print exception stacktraces on any failure
-        cmd.addArgument("-J-Djlink.debug=true");
-
         final String moduleName = appDesc.moduleName();
         final String qualifiedClassName = appDesc.className();
 


### PR DESCRIPTION
This reverts commit 12f08ba4d47cb70a0629b17bc3639ce170309f21.

The fix for JDK-8277507 is causing 38 failures per Tier2 job set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277649](https://bugs.openjdk.java.net/browse/JDK-8277649): [BACKOUT] JDK-8277507 Add jlink.debug system property while launching jpackage tests to help diagonize recent intermittent failures


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6523/head:pull/6523` \
`$ git checkout pull/6523`

Update a local copy of the PR: \
`$ git checkout pull/6523` \
`$ git pull https://git.openjdk.java.net/jdk pull/6523/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6523`

View PR using the GUI difftool: \
`$ git pr show -t 6523`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6523.diff">https://git.openjdk.java.net/jdk/pull/6523.diff</a>

</details>
