### PR TITLE
JDK-8248863: Add feature to trigger search via URI fragment

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HelpWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HelpWriter.java
@@ -197,7 +197,8 @@ public class HelpWriter extends HtmlDocletWriter {
             for (String[] example : SEARCH_EXAMPLES) {
                 searchExamples.add(HtmlTree.LI(
                         getContent("doclet.help.search.example",
-                                HtmlTree.CODE(Text.of(example[0])), example[1])));
+                                HtmlTree.CODE(HtmlTree.A("#!search=" + example[0], Text.of(example[0]))),
+                                example[1])));
             }
             Content searchSpecLink = HtmlTree.A(
                     resources.getText("doclet.help.search.spec.url", configuration.getDocletVersion().feature()),

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js.template
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js.template
@@ -278,6 +278,14 @@ function doSearch(request, response) {
     }
     response(result);
 }
+function hashSearch() {
+    var searchKey = "!search=";
+    var hash = location.hash;
+    if (hash && hash.indexOf(searchKey) > -1) {
+        var queryString = decodeURI(hash.substring(hash.indexOf(searchKey) + searchKey.length));
+        $("#search-input").val(queryString).catcomplete("search", queryString);
+    }
+}
 $(function() {
     var expanded = false;
     var windowWidth;
@@ -308,6 +316,7 @@ $(function() {
     $(window).on("orientationchange", collapse).on("resize", function(e) {
         if (expanded && windowWidth !== window.innerWidth) collapse();
     });
+    $(window).on("hashchange", hashSearch);
     $("#search-input").catcomplete({
         minLength: 1,
         delay: 300,
@@ -368,4 +377,5 @@ $(function() {
             }
         }
     });
+    hashSearch();
 });

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
@@ -320,7 +320,7 @@ doclet.help.search.intro=You can search for definitions of modules, packages, ty
     system properties and other terms defined in the API, using some or all of the name, optionally \
     using "camelCase" abbreviations. For example:
 # Used to list search examples, {0} is a search term and {1} the matching result
-doclet.help.search.example={0} will match {1}
+doclet.help.search.example={0} matches {1}
 # {0} contains a link to the current Javadoc Search Specification
 doclet.help.search.refer=Refer to the {0} for a full description of search features.
 # The URL for the Javadoc Search Specification. {0} will be replaced by the JDK version number

--- a/test/langtools/jdk/javadoc/lib/javadoc/tester/LinkChecker.java
+++ b/test/langtools/jdk/javadoc/lib/javadoc/tester/LinkChecker.java
@@ -351,7 +351,7 @@ public class LinkChecker extends HtmlChecker {
 
         void addReference(String name, Path from, int line) {
             if (checked) {
-                if (name != null) {
+                if (isOrdinaryId(name)) {
                     ID id = map.get(name);
                     if (id == null || !id.declared) {
                         error(from, line, "id not found: " + this.name + "#" + name);
@@ -368,7 +368,7 @@ public class LinkChecker extends HtmlChecker {
 
         void check() {
             map.forEach((name, id) -> {
-                if (name != null && !id.declared) {
+                if (isOrdinaryId(name) && !id.declared) {
                     //log.error(currFile, 0, "id not declared: " + name);
                     for (Position ref : id.references) {
                         error(ref.path, ref.line, "id not found: " + this.name + "#" + name);
@@ -377,6 +377,11 @@ public class LinkChecker extends HtmlChecker {
                 }
             });
             checked = true;
+        }
+
+        boolean isOrdinaryId(String id) {
+            // Fragment #!search=x is used to trigger search for "x"
+            return id != null && !id.startsWith("!search=");
         }
     }
 


### PR DESCRIPTION
Please review a new feature to trigger a javadoc search on any javadoc page through a specially encoded URI fragment. 

This allows the search feature to be triggered "locally" in the currently viewed page by clicking on a link to the search fragment, or "remotely" by linking to a page whose URI includes a search fragment. The search fragment uses the following syntax to make it differ from normal page anchors:

    #!search=search_term

Although fragments are most commonly used to target elements by their `id` attribute in HTML documents they are by no means limited to this. The [URI specification] defines the fragment in very generic terms as additional information identifying some secondary resource within the primary resource identified by the URI. There are also many examples of [proposed and existing uses] of fragment identifiers for similar tasks.

[URI specification]: https://datatracker.ietf.org/doc/html/rfc3986#section-3.5
[proposed and existing uses]: https://en.wikipedia.org/wiki/URI_fragment#Proposals

I considered other mechanisms such as query strings or javascript links, but they all have significant drawbacks compared to URI fragments. Query strings are usually associated with server side processing and cannot be opened without reloading the page. Javascript links on the other hand cannot be triggered remotely as part of the primary URI, and there are security issues associated with them. I think URI fragments are the right tool for the task.

The new feature is deployed in the [Help page] with the search examples, which should help to popularize the feature. Additionally it  should be documented in the javadoc search spec, for which I'll file a separate JBS issue. 

[Help page]: http://cr.openjdk.java.net/~hannesw/8248863/api.00/help-doc.html

Below are the URIs for the search examples in the Help page as well as a few other examples:

http://cr.openjdk.java.net/~hannesw/8248863/api.00/help-doc.html#!search=j.l.obj
http://cr.openjdk.java.net/~hannesw/8248863/api.00/help-doc.html#!search=InpStr
http://cr.openjdk.java.net/~hannesw/8248863/api.00/help-doc.html#!search=HM.cK
http://cr.openjdk.java.net/~hannesw/8248863/api.00/index.html#!search=stringbuilder.append
http://cr.openjdk.java.net/~hannesw/8248863/api.00/index.html#!search=java%20collection%20framework

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ The change requires a CSR request to be approved.

### Issue
 * [JDK-8248863](https://bugs.openjdk.java.net/browse/JDK-8248863): Add feature to trigger search via URI fragment


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6524/head:pull/6524` \
`$ git checkout pull/6524`

Update a local copy of the PR: \
`$ git checkout pull/6524` \
`$ git pull https://git.openjdk.java.net/jdk pull/6524/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6524`

View PR using the GUI difftool: \
`$ git pr show -t 6524`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6524.diff">https://git.openjdk.java.net/jdk/pull/6524.diff</a>

</details>
