### PR TITLE
8277652: SIGSEGV in ShenandoahBarrierC2Support::verify_raw_mem for malformed control flow graph

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
@@ -1920,6 +1920,10 @@ void ShenandoahBarrierC2Support::verify_raw_mem(RootNode* root) {
         Node *m = controls.at(next2);
         for (DUIterator_Fast imax, i = m->fast_outs(imax); i < imax; i++) {
           Node* u = m->fast_out(i);
+          if (u->is_Region() && u->unique_ctrl_out() == NULL) {
+              // Malformed control flow detected. So return early.
+              return;
+          }
           if (u->is_CFG() && !u->is_Root() &&
               !(u->Opcode() == Op_CProj && u->in(0)->Opcode() == Op_NeverBranch && u->as_Proj()->_con == 1) &&
               !(u->is_Region() && u->unique_ctrl_out()->Opcode() == Op_Halt)) {

--- a/test/hotspot/jtreg/compiler/vectorapi/TestIntrinsicBailOut.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestIntrinsicBailOut.java
@@ -35,6 +35,15 @@ import java.nio.ByteOrder;
  *                   -XX:-TieredCompilation compiler.vectorapi.TestIntrinsicBailOut
  */
 
+/*
+ * @test
+ * @bug 8277652
+ * @summary ShenandoahBarrierC2Support::verify_raw_mem testing with malformed control flow graph
+ * @modules jdk.incubator.vector
+ * @requires vm.gc.Shenandoah
+ * @run main/othervm -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:UseAVX=1 -XX:+UseShenandoahGC
+ *                   -XX:-TieredCompilation compiler.vectorapi.TestIntrinsicBailOut
+ */
 
 public class TestIntrinsicBailOut {
   static final VectorSpecies<Double> SPECIES256 = DoubleVector.SPECIES_256;


### PR DESCRIPTION
Hi all,

`ShenandoahBarrierC2Support::verify_raw_mem` crashes due to `u->unique_ctrl_out()` [1] returns NULL for malformed control flow graph.
It can be reproduced by running `compiler/vectorapi/TestIntrinsicBailOut.java` with `-XX:+UseShenandoahGC`.
It would be better to fix it.

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp#L1925

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8277652](https://bugs.openjdk.java.net/browse/JDK-8277652): SIGSEGV in ShenandoahBarrierC2Support::verify_raw_mem for malformed control flow graph


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6525/head:pull/6525` \
`$ git checkout pull/6525`

Update a local copy of the PR: \
`$ git checkout pull/6525` \
`$ git pull https://git.openjdk.java.net/jdk pull/6525/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6525`

View PR using the GUI difftool: \
`$ git pr show -t 6525`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6525.diff">https://git.openjdk.java.net/jdk/pull/6525.diff</a>

</details>
