### PR TITLE
8277654: Shenandoah: Don't produce new memory state in C2 LRB runtime call

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.hpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.hpp
@@ -61,7 +61,7 @@ private:
   static void test_null(Node*& ctrl, Node* val, Node*& null_ctrl, PhaseIdealLoop* phase);
   static void test_gc_state(Node*& ctrl, Node* raw_mem, Node*& heap_stable_ctrl,
                             PhaseIdealLoop* phase, int flags);
-  static void call_lrb_stub(Node*& ctrl, Node*& val, Node* load_addr, Node*& result_mem, Node* raw_mem,
+  static void call_lrb_stub(Node*& ctrl, Node*& val, Node* load_addr,
                             DecoratorSet decorators, PhaseIdealLoop* phase);
   static void test_in_cset(Node*& ctrl, Node*& not_cset_ctrl, Node* val, Node* raw_mem, PhaseIdealLoop* phase);
   static void move_gc_state_test_out_of_loop(IfNode* iff, PhaseIdealLoop* phase);

--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.hpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.hpp
@@ -50,7 +50,6 @@ private:
 
   static bool verify_helper(Node* in, Node_Stack& phis, VectorSet& visited, verify_type t, bool trace, Unique_Node_List& barriers_used);
   static void report_verify_failure(const char* msg, Node* n1 = NULL, Node* n2 = NULL);
-  static void verify_raw_mem(RootNode* root);
 #endif
   static Node* dom_mem(Node* mem, Node* ctrl, int alias, Node*& mem_ctrl, PhaseIdealLoop* phase);
   static Node* no_branches(Node* c, Node* dom, bool allow_one_proj, PhaseIdealLoop* phase);


### PR DESCRIPTION
The runtime call in expanded Shenandoah LRB doesn't need to produce (and consume) raw memory state. I believe this is a left-over from when the LRB (or WB) allocated from TLABs, and would mess with TLAB pointers, when not ordered correctly. (Also, we used to require ordering with RBs back when we had them, but we already removed that memory dependency on -8 offset)

Testing:
 - [x] hotspot_gc_shenandoah
 - [x] specjvm -XX:+UseShenandoahGC
 - [x] tier1
 - [x] tier2
 - [x] tier3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277654](https://bugs.openjdk.java.net/browse/JDK-8277654): Shenandoah: Don't produce new memory state in C2 LRB runtime call


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6526/head:pull/6526` \
`$ git checkout pull/6526`

Update a local copy of the PR: \
`$ git checkout pull/6526` \
`$ git pull https://git.openjdk.java.net/jdk pull/6526/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6526`

View PR using the GUI difftool: \
`$ git pr show -t 6526`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6526.diff">https://git.openjdk.java.net/jdk/pull/6526.diff</a>

</details>
