### PR TITLE
8277657: OptimizedEntryBlob does not pass the correct header size to RuntimeBlob

### DIFF
--- a/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
+++ b/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
@@ -629,7 +629,6 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
 
   int frame_size = frame_bottom_offset;
   frame_size = align_up(frame_size, StackAlignmentInBytes);
-  int frame_size_slots = frame_size >> LogBytesPerInt;
 
   // Ok The space we have allocated will look like:
   //
@@ -667,7 +666,6 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
   }
   // allocate frame (frame_size is also aligned, so stack is still aligned)
   __ subptr(rsp, frame_size);
-  int frame_complete = __ pc() - start;
 
   // we have to always spill args since we need to do a call to get the thread
   // (and maybe attach it).
@@ -779,8 +777,6 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
   OptimizedEntryBlob* blob
     = OptimizedEntryBlob::create(name,
                                  &buffer,
-                                 frame_complete,
-                                 frame_size_slots,
                                  exception_handler_offset,
                                  receiver,
                                  in_ByteSize(frame_data_offset));

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -760,6 +760,10 @@ JavaFrameAnchor* OptimizedEntryBlob::jfa_for_frame(const frame& frame) const {
   return &frame_data_for_frame(frame)->jfa;
 }
 
+void OptimizedEntryBlob::preserve_callee_argument_oops(frame fr, const RegisterMap* reg_map, OopClosure* f) {
+  // do nothing for now
+}
+
 void OptimizedEntryBlob::verify() {
   // unimplemented
 }

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -719,10 +719,10 @@ void DeoptimizationBlob::print_value_on(outputStream* st) const {
 
 // Implementation of OptimizedEntryBlob
 
-OptimizedEntryBlob::OptimizedEntryBlob(const char* name, CodeBuffer* cb, int size, int frame_complete, int frame_size,
+OptimizedEntryBlob::OptimizedEntryBlob(const char* name, CodeBuffer* cb, int size,
                                        intptr_t exception_handler_offset,
                                        jobject receiver, ByteSize frame_data_offset) :
-  RuntimeBlob(name, cb, sizeof(OptimizedEntryBlob), size, frame_complete, frame_size,
+  RuntimeBlob(name, cb, sizeof(OptimizedEntryBlob), size, CodeOffsets::frame_never_safe, no_frame_size,
               /* oop_maps */ nullptr, /* caller should gc arguments */ false),
   _exception_handler_offset(exception_handler_offset),
   _receiver(receiver),
@@ -734,7 +734,7 @@ void* OptimizedEntryBlob::operator new(size_t s, unsigned size) throw() {
   return CodeCache::allocate(size, CodeBlobType::NonNMethod);
 }
 
-OptimizedEntryBlob* OptimizedEntryBlob::create(const char* name, CodeBuffer* cb, int frame_complete, int frame_size,
+OptimizedEntryBlob* OptimizedEntryBlob::create(const char* name, CodeBuffer* cb,
                                                intptr_t exception_handler_offset,
                                                jobject receiver, ByteSize frame_data_offset) {
   ThreadInVMfromUnknown __tiv;  // get to VM state in case we block on CodeCache_lock
@@ -743,7 +743,7 @@ OptimizedEntryBlob* OptimizedEntryBlob::create(const char* name, CodeBuffer* cb,
   unsigned int size = CodeBlob::allocation_size(cb, sizeof(OptimizedEntryBlob));
   {
     MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
-    blob = new (size) OptimizedEntryBlob(name, cb, size, frame_complete, frame_size,
+    blob = new (size) OptimizedEntryBlob(name, cb, size,
                                          exception_handler_offset, receiver, frame_data_offset);
   }
   // Track memory usage statistic after releasing CodeCache_lock

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -747,7 +747,7 @@ class OptimizedEntryBlob: public RuntimeBlob {
   jobject _receiver;
   ByteSize _frame_data_offset;
 
-  OptimizedEntryBlob(const char* name, CodeBuffer* cb, int size, int frame_complete, int frame_size,
+  OptimizedEntryBlob(const char* name, CodeBuffer* cb, int size,
                      intptr_t exception_handler_offset,
                      jobject receiver, ByteSize frame_data_offset);
 
@@ -769,7 +769,7 @@ class OptimizedEntryBlob: public RuntimeBlob {
   FrameData* frame_data_for_frame(const frame& frame) const;
  public:
   // Creation
-  static OptimizedEntryBlob* create(const char* name, CodeBuffer* cb, int frame_complete, int frame_size,
+  static OptimizedEntryBlob* create(const char* name, CodeBuffer* cb,
                                     intptr_t exception_handler_offset,
                                     jobject receiver, ByteSize frame_data_offset);
 


### PR DESCRIPTION
OptimizedEntryBlob currently extends BufferBlob.

However, the BufferBlob constructor directly passes `sizeof(BufferBlob)` as a header_size to the RuntimeBlob constructor, resulting in the wrong header size for OptimizedEntryBlobs, which has fields as opposed to other sub classes of BufferBlob. This can lead to the header overwriting some of the code in the code buffer, which leads to SIGSEGV and SIGILL. (Currently this doesn't happen, but it starts happening when trying to fix other issues like: https://bugs.openjdk.java.net/browse/JDK-8277601, or when implementing OptimizedEntryBlobs on AArch64)

The original fix in the panama-foreign repo was to forward the right header size through the BufferBlob constructor, but I think OptimizedEntryBlob should instead extend RuntimeBlob directly, so that we don't end up accidentally inheriting behavior like this from BufferBlob that is not appropriate for OptimizedEntryBlob.

This patch implements that, and at the same time now passes the right header size (`sizeof(OptimizedEntryBlob)`) to the constructor of RuntimeBlob.

Thanks,
Jorn

Testing: run-test-jdk_foreign on Linux x64 (only test suite that uses OptimizedEntryBlob).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8277657](https://bugs.openjdk.java.net/browse/JDK-8277657): OptimizedEntryBlob does not pass the correct header size to RuntimeBlob


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6528/head:pull/6528` \
`$ git checkout pull/6528`

Update a local copy of the PR: \
`$ git checkout pull/6528` \
`$ git pull https://git.openjdk.java.net/jdk pull/6528/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6528`

View PR using the GUI difftool: \
`$ git pr show -t 6528`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6528.diff">https://git.openjdk.java.net/jdk/pull/6528.diff</a>

</details>
