### PR TITLE
8272392 Lanai: SwingSet2. Black background on expanding tree node

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/EncoderManager.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/EncoderManager.m
@@ -42,6 +42,7 @@ const SurfaceRasterFlags defaultRasterFlags = { JNI_FALSE, JNI_TRUE };
 
 - (void)reset:(id<MTLTexture>)destination
          isAA:(jboolean)isAA
+       isText:(jboolean)isText
         isLCD:(jboolean)isLCD;
 
 - (void)updateEncoder:(id<MTLRenderCommandEncoder>)encoder

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/EncoderManager.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/EncoderManager.m
@@ -41,11 +41,8 @@ const SurfaceRasterFlags defaultRasterFlags = { JNI_FALSE, JNI_TRUE };
 - (void)dealloc;
 
 - (void)reset:(id<MTLTexture>)destination
-           isDstOpaque:(jboolean)isDstOpaque
-    isDstPremultiplied:(jboolean)isDstPremultiplied
-                  isAA:(jboolean)isAA
-                  isText:(jboolean)isText
-                  isLCD:(jboolean)isLCD;
+         isAA:(jboolean)isAA
+        isLCD:(jboolean)isLCD;
 
 - (void)updateEncoder:(id<MTLRenderCommandEncoder>)encoder
               context:(MTLContext *)mtlc
@@ -64,7 +61,6 @@ const SurfaceRasterFlags defaultRasterFlags = { JNI_FALSE, JNI_TRUE };
 
     // Persistent encoder properties
     id<MTLTexture> _destination;
-    SurfaceRasterFlags _dstFlags;
 
     jboolean _isAA;
     jboolean _isText;
@@ -123,14 +119,10 @@ const SurfaceRasterFlags defaultRasterFlags = { JNI_FALSE, JNI_TRUE };
 }
 
 - (void)reset:(id<MTLTexture>)destination
-           isDstOpaque:(jboolean)isDstOpaque
-    isDstPremultiplied:(jboolean)isDstPremultiplied
-                  isAA:(jboolean)isAA
-                  isText:(jboolean)isText
-                  isLCD:(jboolean)isLCD {
+         isAA:(jboolean)isAA
+       isText:(jboolean)isText
+        isLCD:(jboolean)isLCD {
     _destination = destination;
-    _dstFlags.isOpaque = isDstOpaque;
-    _dstFlags.isPremultiplied = isDstPremultiplied;
     _isAA = isAA;
     _isText = isText;
     _isLCD = isLCD;
@@ -288,20 +280,20 @@ const SurfaceRasterFlags defaultRasterFlags = { JNI_FALSE, JNI_TRUE };
 
 - (id<MTLRenderCommandEncoder> _Nonnull)getAARenderEncoder:(const BMTLSDOps * _Nonnull)dstOps {
   id<MTLTexture> dstTxt = dstOps->pTexture;
-  RenderOptions roptions = {JNI_FALSE, JNI_TRUE, INTERPOLATION_NEAREST_NEIGHBOR, defaultRasterFlags, {dstOps->isOpaque, JNI_TRUE}, JNI_FALSE, JNI_FALSE, JNI_FALSE};
+  RenderOptions roptions = {JNI_FALSE, JNI_TRUE, INTERPOLATION_NEAREST_NEIGHBOR, defaultRasterFlags, JNI_FALSE, JNI_FALSE, JNI_FALSE};
   return [self getEncoder:dstTxt renderOptions:&roptions];
 }
 
 - (id<MTLRenderCommandEncoder> _Nonnull)getAAShaderRenderEncoder:(const BMTLSDOps * _Nonnull)dstOps
 {
-    RenderOptions roptions = {JNI_FALSE, JNI_FALSE, INTERPOLATION_NEAREST_NEIGHBOR, defaultRasterFlags, {dstOps->isOpaque, JNI_TRUE}, JNI_FALSE, JNI_FALSE, JNI_TRUE};
+    RenderOptions roptions = {JNI_FALSE, JNI_FALSE, INTERPOLATION_NEAREST_NEIGHBOR, defaultRasterFlags, JNI_FALSE, JNI_FALSE, JNI_TRUE};
     return [self getEncoder:dstOps->pTexture renderOptions:&roptions];
 }
 
 - (id<MTLRenderCommandEncoder> _Nonnull)getRenderEncoder:(id<MTLTexture> _Nonnull)dest
                                              isDstOpaque:(bool)isOpaque
 {
-    RenderOptions roptions = {JNI_FALSE, JNI_FALSE, INTERPOLATION_NEAREST_NEIGHBOR, defaultRasterFlags, {isOpaque, JNI_TRUE}, JNI_FALSE, JNI_FALSE, JNI_FALSE};
+    RenderOptions roptions = {JNI_FALSE, JNI_FALSE, INTERPOLATION_NEAREST_NEIGHBOR, defaultRasterFlags, JNI_FALSE, JNI_FALSE, JNI_FALSE};
     return [self getEncoder:dest renderOptions:&roptions];
 }
 
@@ -329,7 +321,7 @@ const SurfaceRasterFlags defaultRasterFlags = { JNI_FALSE, JNI_TRUE };
                                                isSrcOpaque:(bool)isSrcOpaque
                                                isDstOpaque:(bool)isDstOpaque
 {
-    RenderOptions roptions = {JNI_TRUE, JNI_FALSE, INTERPOLATION_NEAREST_NEIGHBOR, {isSrcOpaque, JNI_TRUE }, {isDstOpaque, JNI_TRUE}, JNI_FALSE, JNI_TRUE, JNI_FALSE};
+    RenderOptions roptions = {JNI_TRUE, JNI_FALSE, INTERPOLATION_NEAREST_NEIGHBOR, {isSrcOpaque, JNI_TRUE }, JNI_FALSE, JNI_TRUE, JNI_FALSE};
     return [self getEncoder:dest renderOptions:&roptions];
 }
 
@@ -339,7 +331,7 @@ const SurfaceRasterFlags defaultRasterFlags = { JNI_FALSE, JNI_TRUE };
                                     interpolation:(int)interpolation
                                              isAA:(jboolean)isAA
 {
-    RenderOptions roptions = {JNI_TRUE, isAA, interpolation, { isSrcOpaque, JNI_TRUE }, {isDstOpaque, JNI_TRUE}, JNI_FALSE, JNI_FALSE, JNI_FALSE};
+    RenderOptions roptions = {JNI_TRUE, isAA, interpolation, { isSrcOpaque, JNI_TRUE }, JNI_FALSE, JNI_FALSE, JNI_FALSE};
     return [self getEncoder:dest renderOptions:&roptions];
 }
 
@@ -354,7 +346,8 @@ const SurfaceRasterFlags defaultRasterFlags = { JNI_FALSE, JNI_TRUE };
 - (id<MTLRenderCommandEncoder> _Nonnull) getTextEncoder:(const BMTLSDOps * _Nonnull)dstOps
                                       isSrcOpaque:(bool)isSrcOpaque
 {
-    RenderOptions roptions = {JNI_TRUE, JNI_FALSE, INTERPOLATION_NEAREST_NEIGHBOR, { isSrcOpaque, JNI_TRUE }, {dstOps->isOpaque, JNI_TRUE}, JNI_TRUE, JNI_FALSE, JNI_FALSE};
+    RenderOptions roptions = {JNI_TRUE, JNI_FALSE, INTERPOLATION_NEAREST_NEIGHBOR, { isSrcOpaque, JNI_TRUE },
+                              JNI_TRUE, JNI_FALSE, JNI_FALSE};
     return [self getEncoder:dstOps->pTexture renderOptions:&roptions];
 }
 
@@ -437,11 +430,9 @@ const SurfaceRasterFlags defaultRasterFlags = { JNI_FALSE, JNI_TRUE };
     _encoder = [[cbw getCommandBuffer] renderCommandEncoderWithDescriptor:rpd];
 
     [_encoderStates reset:dest
-               isDstOpaque:renderOptions->dstFlags.isOpaque
-        isDstPremultiplied:YES
-                      isAA:renderOptions->isAA
-                      isText:renderOptions->isText
-                      isLCD:renderOptions->isLCD];
+                     isAA:renderOptions->isAA
+                   isText:renderOptions->isText
+                    isLCD:renderOptions->isLCD];
   }
 
   //

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
@@ -595,8 +595,9 @@ MTLBlitLoops_Blit(JNIEnv *env,
             }
 
 #ifdef TRACE_BLIT
-            J2dTraceImpl(J2D_TRACE_VERBOSE, JNI_FALSE,
-                    "MTLBlitLoops_Blit [tx=%d, xf=%d, AC=%s]: bdst=%s, src=%p (%dx%d) O=%d premul=%d | (%d, %d, %d, %d)->(%1.2f, %1.2f, %1.2f, %1.2f)",
+            J2dTraceImpl(J2D_TRACE_VERBOSE, JNI_TRUE,
+                    "MTLBlitLoops_Blit srctype=%d [tx=%d, xf=%d, AC=%s]: bdst=%s, src=%p (%dx%d) O=%d premul=%d | (%d, "
+                    "%d, %d, %d)->(%1.2f, %1.2f, %1.2f, %1.2f)", srctype,
                     texture, xform, [mtlc getCompositeDescription].cString,
                     getSurfaceDescription(dstOps).cString, srcOps,
                     sx2 - sx1, sy2 - sy1,

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLClip.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLClip.m
@@ -58,7 +58,6 @@ static void initTemplatePipelineDescriptors() {
     BMTLSDOps*  _dstOps;
     BOOL _stencilMaskGenerationInProgress;
     BOOL _stencilMaskGenerationStarted;
-    BOOL _clipReady;
     MTLOrigin _clipShapeOrigin;
     MTLSize _clipShapeSize;
 }
@@ -73,7 +72,6 @@ static void initTemplatePipelineDescriptors() {
         _dstOps = NULL;
         _stencilMaskGenerationInProgress = NO;
         _stencilMaskGenerationStarted = NO;
-        _clipReady = NO;
     }
     return self;
 }
@@ -189,7 +187,6 @@ static void initTemplatePipelineDescriptors() {
     _stencilMaskGenerationStarted = NO;
     _dstOps = dstOps;
     _clipType = SHAPE_CLIP;
-    _clipReady = NO;
 }
 
 - (void)setMaskGenerationPipelineState:(id<MTLRenderCommandEncoder>)encoder

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPaints.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPaints.m
@@ -56,7 +56,7 @@ static MTLRenderPipelineDescriptor * templateLCDPipelineDesc = nil;
 static MTLRenderPipelineDescriptor * templateAAPipelineDesc = nil;
 static void
 setTxtUniforms(MTLContext *mtlc, int color, id <MTLRenderCommandEncoder> encoder, int interpolation, bool repeat,
-               jfloat extraAlpha, const SurfaceRasterFlags *srcFlags, const SurfaceRasterFlags *dstFlags, int mode);
+               jfloat extraAlpha, const SurfaceRasterFlags *srcFlags, int mode);
 
 static void initTemplatePipelineDescriptors() {
     if (templateRenderPipelineDesc != nil && templateTexturePipelineDesc != nil &&
@@ -228,8 +228,8 @@ jint _color;
             rpDesc = [[templateLCDPipelineDesc copy] autorelease];
         }
         setTxtUniforms(mtlc, _color, encoder,
-                       renderOptions->interpolation, NO, [mtlc.composite getExtraAlpha], &renderOptions->srcFlags,
-                       &renderOptions->dstFlags, 1);
+                       renderOptions->interpolation, NO, [mtlc.composite getExtraAlpha],
+                       &renderOptions->srcFlags, 1);
     } else if (renderOptions->isAAShader) {
         vertShader = @"vert_col_aa";
         fragShader = @"frag_col_aa";
@@ -270,7 +270,7 @@ jint _color;
 
         setTxtUniforms(mtlc, col, encoder,
                        renderOptions->interpolation, NO, [mtlc.composite getExtraAlpha],
-                       &renderOptions->srcFlags, &renderOptions->dstFlags, 1);
+                       &renderOptions->srcFlags, 1);
         [encoder setFragmentBytes:&xorColor length:sizeof(xorColor) atIndex:0];
 
         [encoder setFragmentTexture:dstOps->pTexture atIndex:1];
@@ -809,9 +809,8 @@ jint _color;
         [encoder setFragmentTexture:_paintTexture atIndex:0];
     }
     const SurfaceRasterFlags srcFlags = {_isOpaque, renderOptions->srcFlags.isPremultiplied};
-    setTxtUniforms(mtlc, 0, encoder,
-                   renderOptions->interpolation, YES, [mtlc.composite getExtraAlpha],
-                   &srcFlags, &renderOptions->dstFlags, 0);
+    setTxtUniforms(mtlc, 0, encoder, renderOptions->interpolation, YES, [mtlc.composite getExtraAlpha],
+                   &srcFlags, 0);
 
     id <MTLRenderPipelineState> pipelineState = [pipelineStateStorage getPipelineState:rpDesc
                                                                         vertexShaderId:vertShader
@@ -893,8 +892,8 @@ jint _color;
 
 static void
 setTxtUniforms(MTLContext *mtlc, int color, id <MTLRenderCommandEncoder> encoder, int interpolation, bool repeat,
-               jfloat extraAlpha, const SurfaceRasterFlags *srcFlags, const SurfaceRasterFlags *dstFlags, int mode) {
-    struct TxtFrameUniforms uf = {RGBA_TO_V4(color), mode, srcFlags->isOpaque, dstFlags->isOpaque, extraAlpha};
+               jfloat extraAlpha, const SurfaceRasterFlags *srcFlags, int mode) {
+    struct TxtFrameUniforms uf = {RGBA_TO_V4(color), mode, srcFlags->isOpaque, extraAlpha};
     [encoder setFragmentBytes:&uf length:sizeof(uf) atIndex:FrameUniformBuffer];
     [mtlc.samplerManager setSamplerWithEncoder:encoder interpolation:interpolation repeat:repeat];
 }
@@ -956,8 +955,7 @@ setTxtUniforms(MTLContext *mtlc, int color, id <MTLRenderCommandEncoder> encoder
         } else {
             setTxtUniforms(mtlc, 0, encoder,
                            renderOptions->interpolation, NO, [mtlc.composite getExtraAlpha],
-                           &renderOptions->srcFlags,
-                           &renderOptions->dstFlags, 0);
+                           &renderOptions->srcFlags, 0);
 
         }
         id <MTLRenderPipelineState> pipelineState = [pipelineStateStorage getPipelineState:rpDesc
@@ -998,7 +996,7 @@ setTxtUniforms(MTLContext *mtlc, int color, id <MTLRenderCommandEncoder> encoder
         const int col = 0 ^ xorColor;
         setTxtUniforms(mtlc, col, encoder,
                        renderOptions->interpolation, NO, [mtlc.composite getExtraAlpha],
-                       &renderOptions->srcFlags, &renderOptions->dstFlags, 0);
+                       &renderOptions->srcFlags, 0);
         [encoder setFragmentBytes:&xorColor length:sizeof(xorColor) atIndex: 0];
 
         BMTLSDOps *dstOps = MTLRenderQueue_GetCurrentDestination();
@@ -1006,8 +1004,7 @@ setTxtUniforms(MTLContext *mtlc, int color, id <MTLRenderCommandEncoder> encoder
 
         setTxtUniforms(mtlc, 0, encoder,
                        renderOptions->interpolation, NO, [mtlc.composite getExtraAlpha],
-                       &renderOptions->srcFlags,
-                       &renderOptions->dstFlags, 0);
+                       &renderOptions->srcFlags, 0);
 
         id <MTLRenderPipelineState> pipelineState = [pipelineStateStorage getPipelineState:rpDesc
                                                                             vertexShaderId:vertShader

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/RenderOptions.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/RenderOptions.h
@@ -35,7 +35,6 @@ typedef struct {
     jboolean isAA;
     int interpolation;
     SurfaceRasterFlags srcFlags;
-    SurfaceRasterFlags dstFlags;
     jboolean isText;
     jboolean isLCD;
     jboolean isAAShader;

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/common.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/common.h
@@ -114,7 +114,6 @@ struct TxtFrameUniforms {
     vector_float4 color;
     int mode; // NOTE: consider to use bit fields
     int isSrcOpaque;
-    int isDstOpaque;
     float extraAlpha;
 };
 


### PR DESCRIPTION
Removed creation of the separate encoder depending on destination properties as we don't use this info to customize the encoder properties

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272392](https://bugs.openjdk.java.net/browse/JDK-8272392): Lanai: SwingSet2. Black background on expanding tree node


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - Committer)
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6529/head:pull/6529` \
`$ git checkout pull/6529`

Update a local copy of the PR: \
`$ git checkout pull/6529` \
`$ git pull https://git.openjdk.java.net/jdk pull/6529/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6529`

View PR using the GUI difftool: \
`$ git pr show -t 6529`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6529.diff">https://git.openjdk.java.net/jdk/pull/6529.diff</a>

</details>
