### PR TITLE
8275687: runtime/CommandLine/PrintTouchedMethods test shouldn't catch RuntimeException

### DIFF
--- a/test/hotspot/jtreg/runtime/CommandLine/PrintTouchedMethodsJcmd.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/PrintTouchedMethodsJcmd.java
@@ -41,10 +41,6 @@ public class PrintTouchedMethodsJcmd {
       var pb = new ProcessBuilder();
       pb.command(new String[] {JDKToolFinder.getJDKTool("jcmd"), pid, "VM.print_touched_methods"});
       var output = new OutputAnalyzer(pb.start());
-      try {
-        output.shouldContain("PrintTouchedMethodsJcmd.main:([Ljava/lang/String;)V");
-      } catch (RuntimeException e) {
-        output.shouldContain("Unknown diagnostic command");
-      }
-  }
+      output.shouldContain("PrintTouchedMethodsJcmd.main:([Ljava/lang/String;)V");
+    }
 }


### PR DESCRIPTION
During the review of https://github.com/openjdk/jdk/pull/5231#pullrequestreview-784995993 
It was suggested by @iklam in the test case Runtime exception is not required for the reason TouchedMethodsDCmd is always enabled as long as the current JVM has INCLUDE_SERVICES is true.

Igor has agreed to capture this in separate RFE (current) to handle this scenario.

This is trivial, please review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275687](https://bugs.openjdk.java.net/browse/JDK-8275687): runtime/CommandLine/PrintTouchedMethods test shouldn't catch RuntimeException


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6536/head:pull/6536` \
`$ git checkout pull/6536`

Update a local copy of the PR: \
`$ git checkout pull/6536` \
`$ git pull https://git.openjdk.java.net/jdk pull/6536/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6536`

View PR using the GUI difftool: \
`$ git pr show -t 6536`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6536.diff">https://git.openjdk.java.net/jdk/pull/6536.diff</a>

</details>
