### PR TITLE
8235876: Misleading warning message in java source-file mode

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/Main.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/Main.java
@@ -354,6 +354,7 @@ public class Main {
         javacOpts.add("-Xdiags:verbose");
         javacOpts.add("-Xlint:deprecation");
         javacOpts.add("-Xlint:unchecked");
+        javacOpts.add("-Xlint:-options");
         return javacOpts;
     }
 

--- a/test/langtools/tools/javac/launcher/SourceLauncherTest.java
+++ b/test/langtools/tools/javac/launcher/SourceLauncherTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8192920 8204588 8246774 8248843 8268869
+ * @bug 8192920 8204588 8246774 8248843 8268869 8235876
  * @summary Test source launcher
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -627,6 +627,20 @@ public class SourceLauncherTest extends TestRunner {
         Result r = run(base.resolve("NoRecompile.java"), Collections.emptyList(), Collections.emptyList());
         if (r.stdErr.contains("recompile with")) {
             error("Unexpected recompile suggestions in error output: " + r.stdErr);
+        }
+    }
+
+    @Test
+    public void testNoOptionsWarnings(Path base) throws IOException {
+        tb.writeJavaFiles(base, "public class Main { public static void main(String... args) {System.out.println(\"coto\");}}");
+        String log = new JavaTask(tb)
+                .vmOptions("--source", "7")
+                .className(base.resolve("Main.java").toString())
+                .run(Task.Expect.SUCCESS)
+                .getOutput(Task.OutputKind.STDERR);
+
+        if (log.contains("warning: [options]")) {
+            error("Unexpected options warning in error output: " + log);
         }
     }
 

--- a/test/langtools/tools/javac/launcher/SourceLauncherTest.java
+++ b/test/langtools/tools/javac/launcher/SourceLauncherTest.java
@@ -632,7 +632,7 @@ public class SourceLauncherTest extends TestRunner {
 
     @Test
     public void testNoOptionsWarnings(Path base) throws IOException {
-        tb.writeJavaFiles(base, "public class Main { public static void main(String... args) {System.out.println(\"coto\");}}");
+        tb.writeJavaFiles(base, "public class Main { public static void main(String... args) {}}");
         String log = new JavaTask(tb)
                 .vmOptions("--source", "7")
                 .className(base.resolve("Main.java").toString())


### PR DESCRIPTION
Execution of  `java --source 7 Test.java` displays following warning: 
`warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.` 

However use of `-Xlint:-options` is not allowed and so it proposes an invalid suggestion.

This is yet another case of "too much information" provided to user in source-file mode. 
Target audience of source-file mode are Java beginners with very simple cases.
Many options are not available in source-file mode and so this patch disables also related options warnings.

The case is similar to JDK-8268869

Patch adds `-Xlint:-options` into the list of default javac options in source-file mode.
Relevant test is also provided.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8235876](https://bugs.openjdk.java.net/browse/JDK-8235876): Misleading warning message in java source-file mode


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6537/head:pull/6537` \
`$ git checkout pull/6537`

Update a local copy of the PR: \
`$ git checkout pull/6537` \
`$ git pull https://git.openjdk.java.net/jdk pull/6537/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6537`

View PR using the GUI difftool: \
`$ git pr show -t 6537`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6537.diff">https://git.openjdk.java.net/jdk/pull/6537.diff</a>

</details>
