### PR TITLE
8277497 Last column cell in the JTAble row is read as empty cell

### DIFF
--- a/src/java.desktop/share/classes/com/sun/accessibility/internal/resources/accessibility.properties
+++ b/src/java.desktop/share/classes/com/sun/accessibility/internal/resources/accessibility.properties
@@ -53,6 +53,7 @@ glasspane=glass pane
 filechooser=file chooser
 filler=filler
 frame=frame
+image=image
 internalframe=internal frame
 label=label
 layeredpane=layered pane

--- a/src/java.desktop/share/classes/com/sun/accessibility/internal/resources/accessibility.properties
+++ b/src/java.desktop/share/classes/com/sun/accessibility/internal/resources/accessibility.properties
@@ -53,7 +53,6 @@ glasspane=glass pane
 filechooser=file chooser
 filler=filler
 frame=frame
-image=image
 internalframe=internal frame
 label=label
 layeredpane=layered pane

--- a/src/java.desktop/share/classes/javax/swing/JLabel.java
+++ b/src/java.desktop/share/classes/javax/swing/JLabel.java
@@ -39,6 +39,8 @@ import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.Serial;
 import java.text.BreakIterator;
+import java.util.Locale;
+import java.util.ResourceBundle;
 
 import javax.accessibility.Accessible;
 import javax.accessibility.AccessibleContext;
@@ -1075,6 +1077,10 @@ public class JLabel extends JComponent implements SwingConstants, Accessible
          * @see AccessibleContext#setAccessibleName
          */
         public String getAccessibleName() {
+            return getAccessibleNameCheckIcon(getAccessibleNameImpl());
+        }
+
+        private String getAccessibleNameImpl() {
             String name = accessibleName;
 
             if (name == null) {
@@ -1089,6 +1095,25 @@ public class JLabel extends JComponent implements SwingConstants, Accessible
             return name;
         }
 
+        private String getAccessibleNameCheckIcon(String name) {
+            // If an icon is set but no text is set,
+            // the screen reader will say "image".
+            // cc jdk-8277497
+            if (((name == null) || name.isEmpty()) &&
+                    (JLabel.this.getIcon() != null)) {
+                if (JLabel.this.getIcon() instanceof Accessible) {
+                    AccessibleContext ac = ((Accessible) JLabel.this.getIcon()).getAccessibleContext();
+                    if (ac != null) {
+                        name = ac.getAccessibleName();
+                    }
+                }
+                if ((name == null) || name.isEmpty()) {
+                    name = ResourceBundle.getBundle("com.sun.accessibility.internal.resources.accessibility", Locale.getDefault()).getString("image");
+                }
+            }
+            return name;
+        }
+
         /**
          * Get the role of this object.
          *
@@ -1097,6 +1122,11 @@ public class JLabel extends JComponent implements SwingConstants, Accessible
          * @see AccessibleRole
          */
         public AccessibleRole getAccessibleRole() {
+            String name = getAccessibleNameImpl();
+            if (((name == null) || name.isEmpty()) &&
+                    (JLabel.this.getIcon() != null)) {
+                return AccessibleRole.ICON;
+            }
             return AccessibleRole.LABEL;
         }
 

--- a/src/java.desktop/share/classes/javax/swing/JLabel.java
+++ b/src/java.desktop/share/classes/javax/swing/JLabel.java
@@ -39,8 +39,6 @@ import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.Serial;
 import java.text.BreakIterator;
-import java.util.Locale;
-import java.util.ResourceBundle;
 
 import javax.accessibility.Accessible;
 import javax.accessibility.AccessibleContext;
@@ -1096,9 +1094,6 @@ public class JLabel extends JComponent implements SwingConstants, Accessible
         }
 
         private String getAccessibleNameCheckIcon(String name) {
-            // If an icon is set but no text is set,
-            // the screen reader will say "image".
-            // cc jdk-8277497
             if (((name == null) || name.isEmpty()) &&
                     (JLabel.this.getIcon() != null)) {
                 if (JLabel.this.getIcon() instanceof Accessible) {
@@ -1106,9 +1101,6 @@ public class JLabel extends JComponent implements SwingConstants, Accessible
                     if (ac != null) {
                         name = ac.getAccessibleName();
                     }
-                }
-                if ((name == null) || name.isEmpty()) {
-                    name = ResourceBundle.getBundle("com.sun.accessibility.internal.resources.accessibility", Locale.getDefault()).getString("image");
                 }
             }
             return name;


### PR DESCRIPTION
Testing https://bugs.openjdk.java.net/browse/JDK-8271071 
Step to reproduce 
1) Run SwingSet2 in JDK 18 ( I used b24 ) 
2) Enable Voiceover. 
3) Select JTable demo 
4) Click any row in the table or select the first row . Observe that row is selected & VoiceOver reads the column values or navigate the columns one by one by pressing tab key. When the focus reaches the last column ( Favourite Food ) Observe that column value is read as null. If you hear the same then the bug is reproduced.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277497](https://bugs.openjdk.java.net/browse/JDK-8277497): Last column cell in the JTable row is read as empty cell


### Reviewers
 * [Anton Tarasov](https://openjdk.java.net/census#ant) (@forantar - **Reviewer**)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**) ⚠️ Review applies to 2199bd53a4f324b7398e48dc6a3972427a1db611
 * pbansal - **Reviewer** ⚠️ Added manually

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6538/head:pull/6538` \
`$ git checkout pull/6538`

Update a local copy of the PR: \
`$ git checkout pull/6538` \
`$ git pull https://git.openjdk.java.net/jdk pull/6538/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6538`

View PR using the GUI difftool: \
`$ git pr show -t 6538`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6538.diff">https://git.openjdk.java.net/jdk/pull/6538.diff</a>

</details>
