### PR TITLE
8277786: G1: Rename log2_card_region_per_heap_region used in G1CardSet

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.cpp
@@ -45,14 +45,14 @@
 G1CardSet::CardSetPtr G1CardSet::FullCardSet = (G1CardSet::CardSetPtr)-1;
 
 static uint default_log2_card_region_per_region() {
-  uint log2_card_region_per_heap_region = 0;
+  uint log2_card_regions_per_heap_region = 0;
 
   const uint card_container_limit = G1CardSetContainer::LogCardsPerRegionLimit;
   if (card_container_limit < (uint)HeapRegion::LogCardsPerRegion) {
-    log2_card_region_per_heap_region = (uint)HeapRegion::LogCardsPerRegion - card_container_limit;
+    log2_card_regions_per_heap_region = (uint)HeapRegion::LogCardsPerRegion - card_container_limit;
   }
 
-  return log2_card_region_per_heap_region;
+  return log2_card_regions_per_heap_region;
 }
 
 G1CardSetConfiguration::G1CardSetConfiguration() :
@@ -64,7 +64,7 @@ G1CardSetConfiguration::G1CardSetConfiguration() :
                          (uint)HeapRegion::CardsPerRegion,                          /* max_cards_in_cardset */
                          default_log2_card_region_per_region())                     /* log2_card_region_per_region */
 {
-  assert((_log2_card_region_per_heap_region + _log2_cards_per_card_region) == (uint)HeapRegion::LogCardsPerRegion,
+  assert((_log2_card_regions_per_heap_region + _log2_cards_per_card_region) == (uint)HeapRegion::LogCardsPerRegion,
          "inconsistent heap region virtualization setup");
 }
 
@@ -91,7 +91,7 @@ G1CardSetConfiguration::G1CardSetConfiguration(uint inline_ptr_bits_per_card,
                                                uint num_buckets_in_howl,
                                                double cards_in_howl_threshold_percent,
                                                uint max_cards_in_card_set,
-                                               uint log2_card_region_per_heap_region) :
+                                               uint log2_card_regions_per_heap_region) :
   _inline_ptr_bits_per_card(inline_ptr_bits_per_card),
   _num_cards_in_array(num_cards_in_array),
   _num_buckets_in_howl(num_buckets_in_howl),
@@ -101,8 +101,8 @@ G1CardSetConfiguration::G1CardSetConfiguration(uint inline_ptr_bits_per_card,
   _cards_in_howl_bitmap_threshold(_num_cards_in_howl_bitmap * cards_in_bitmap_threshold_percent),
   _log2_num_cards_in_howl_bitmap(log2i_exact(_num_cards_in_howl_bitmap)),
   _bitmap_hash_mask(~(~(0) << _log2_num_cards_in_howl_bitmap)),
-  _log2_card_region_per_heap_region(log2_card_region_per_heap_region),
-  _log2_cards_per_card_region(log2i_exact(_max_cards_in_card_set) - _log2_card_region_per_heap_region) {
+  _log2_card_regions_per_heap_region(log2_card_regions_per_heap_region),
+  _log2_cards_per_card_region(log2i_exact(_max_cards_in_card_set) - _log2_card_regions_per_heap_region) {
 
   assert(is_power_of_2(_max_cards_in_card_set),
          "max_cards_in_card_set must be a power of 2: %u", _max_cards_in_card_set);
@@ -134,7 +134,7 @@ void G1CardSetConfiguration::log_configuration() {
                           num_cards_in_array(), G1CardSetArray::size_in_bytes(num_cards_in_array()),
                           num_buckets_in_howl(), cards_in_howl_threshold(),
                           num_cards_in_howl_bitmap(), G1CardSetBitMap::size_in_bytes(num_cards_in_howl_bitmap()), cards_in_howl_bitmap_threshold(),
-                          (uint)1 << log2_card_region_per_heap_region(),
+                          (uint)1 << log2_card_regions_per_heap_region(),
                           (uint)1 << log2_cards_per_card_region());
 }
 

--- a/src/hotspot/share/gc/g1/g1CardSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.hpp
@@ -58,7 +58,7 @@ class G1CardSetConfiguration {
   uint _cards_in_howl_bitmap_threshold;
   uint _log2_num_cards_in_howl_bitmap;
   size_t _bitmap_hash_mask;
-  uint _log2_card_region_per_heap_region;
+  uint _log2_card_regions_per_heap_region;
   uint _log2_cards_per_card_region;
 
   G1CardSetAllocOptions* _card_set_alloc_options;
@@ -69,7 +69,7 @@ class G1CardSetConfiguration {
                          uint num_buckets_in_howl,
                          double cards_in_howl_threshold_percent,
                          uint max_cards_in_card_set,
-                         uint log2_card_region_per_heap_region);
+                         uint log2_card_regions_per_heap_region);
   void init_card_set_alloc_options();
 
   void log_configuration();
@@ -127,8 +127,8 @@ public:
   // The next two members give information about how many card regions are there
   // per area (heap region) and how many cards each card region has.
 
-  // The log2 of the amount of card regions per heap region configured.
-  uint log2_card_region_per_heap_region() const { return _log2_card_region_per_heap_region; }
+  // The log2 of the number of card regions per heap region configured.
+  uint log2_card_regions_per_heap_region() const { return _log2_card_regions_per_heap_region; }
   // The log2 of the number of cards per card region. This is calculated from max_cards_in_region()
   // and above.
   uint log2_cards_per_card_region() const { return _log2_cards_per_card_region; }

--- a/src/hotspot/share/gc/g1/heapRegionRemSet.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.inline.hpp
@@ -110,7 +110,7 @@ template <class CardOrRangeVisitor>
 inline void HeapRegionRemSet::iterate_for_merge(CardOrRangeVisitor& cl) {
   G1HeapRegionRemSetMergeCardClosure<CardOrRangeVisitor, G1ContainerCardsOrRanges> cl2(&_card_set,
                                                                                        cl,
-                                                                                       _card_set.config()->log2_card_region_per_heap_region(),
+                                                                                       _card_set.config()->log2_card_regions_per_heap_region(),
                                                                                        _card_set.config()->log2_cards_per_card_region());
   _card_set.iterate_containers(&cl2, true /* at_safepoint */);
 }


### PR DESCRIPTION
Hi all,

Please review this small change to  rename log2_card_region_per_heap_region to log2_card_regions_per_heap_region in order to improve readability.

//

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277786](https://bugs.openjdk.java.net/browse/JDK-8277786): G1: Rename log2_card_region_per_heap_region used in G1CardSet


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6539/head:pull/6539` \
`$ git checkout pull/6539`

Update a local copy of the PR: \
`$ git checkout pull/6539` \
`$ git pull https://git.openjdk.java.net/jdk pull/6539/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6539`

View PR using the GUI difftool: \
`$ git pr show -t 6539`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6539.diff">https://git.openjdk.java.net/jdk/pull/6539.diff</a>

</details>
