### PR TITLE
8277797: Remove undefined/unused SharedRuntime::trampoline_size()

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -384,8 +384,6 @@ class SharedRuntime: AllStatic {
                                        uint num_bits,
                                        uint total_args_passed);
 
-  static size_t trampoline_size();
-
   // Generate I2C and C2I adapters. These adapters are simple argument marshalling
   // blobs. Unlike adapters in the tiger and earlier releases the code in these
   // blobs does not create a new frame and are therefore virtually invisible


### PR DESCRIPTION
A trivial patch to remove undefined and unused `SharedRuntime::trampoline_size()`, a leftover from [JDK-8263002](https://bugs.openjdk.java.net/browse/JDK-8263002).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277797](https://bugs.openjdk.java.net/browse/JDK-8277797): Remove undefined/unused SharedRuntime::trampoline_size()


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6540/head:pull/6540` \
`$ git checkout pull/6540`

Update a local copy of the PR: \
`$ git checkout pull/6540` \
`$ git pull https://git.openjdk.java.net/jdk pull/6540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6540`

View PR using the GUI difftool: \
`$ git pr show -t 6540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6540.diff">https://git.openjdk.java.net/jdk/pull/6540.diff</a>

</details>
