### PR TITLE
8275908: Record null_check traps for calls and array_check traps in the interpreter

### DIFF
--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -831,7 +831,7 @@ void InterpreterRuntime::resolve_invoke(JavaThread* current, Bytecodes::Code byt
                                  last_frame.get_index_u2_cpcache(bytecode), bytecode,
                                  THREAD);
 
-    if(HAS_PENDING_EXCEPTION) {
+    if (HAS_PENDING_EXCEPTION) {
       if (ProfileTraps && PENDING_EXCEPTION->klass()->name() == vmSymbols::java_lang_NullPointerException()) {
         // Preserve the original exception across the call to note_trap()
         PreserveExceptionMark pm(current);

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -407,7 +407,11 @@ JRT_ENTRY(void, InterpreterRuntime::create_klass_exception(JavaThread* current, 
   // lookup exception klass
   TempNewSymbol s = SymbolTable::new_symbol(name);
   if (ProfileTraps) {
-    note_trap(current, Deoptimization::Reason_class_check);
+    if (s == vmSymbols::java_lang_ArrayStoreException()) {
+      note_trap(current, Deoptimization::Reason_array_check);
+    } else {
+      note_trap(current, Deoptimization::Reason_class_check);
+    }
   }
   // create exception, with klass name as detail message
   Handle exception = Exceptions::new_exception(current, s, klass_name);
@@ -825,7 +829,18 @@ void InterpreterRuntime::resolve_invoke(JavaThread* current, Bytecodes::Code byt
     JavaThread* THREAD = current; // For exception macros.
     LinkResolver::resolve_invoke(info, receiver, pool,
                                  last_frame.get_index_u2_cpcache(bytecode), bytecode,
-                                 CHECK);
+                                 THREAD);
+
+    if(HAS_PENDING_EXCEPTION) {
+      if (ProfileTraps && PENDING_EXCEPTION->klass()->name() == vmSymbols::java_lang_NullPointerException()) {
+        // Preserve the original exception across the call to note_trap()
+        PreserveExceptionMark pm(current);
+        // Recording the trap will help the compiler to potentially recognize this exception as "hot"
+        note_trap(current, Deoptimization::Reason_null_check);
+      }
+      return;
+    }
+
     if (JvmtiExport::can_hotswap_or_post_breakpoint() && info.resolved_method()->is_old()) {
       resolved_method = methodHandle(current, info.resolved_method()->get_new_method());
     } else {

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -580,11 +580,10 @@ void GraphKit::builtin_throw(Deoptimization::DeoptReason reason, Node* arg) {
       ex_obj = env()->ArrayIndexOutOfBoundsException_instance();
       break;
     case Deoptimization::Reason_class_check:
-      if (java_bc() == Bytecodes::_aastore) {
-        ex_obj = env()->ArrayStoreException_instance();
-      } else {
-        ex_obj = env()->ClassCastException_instance();
-      }
+      ex_obj = env()->ClassCastException_instance();
+      break;
+    case Deoptimization::Reason_array_check:
+      ex_obj = env()->ArrayStoreException_instance();
       break;
     default:
       break;
@@ -3340,7 +3339,10 @@ Node* GraphKit::gen_checkcast(Node *obj, Node* superklass,
         // It needs a null check because a null will *pass* the cast check.
         // A non-null value will always produce an exception.
         if (!objtp->maybe_null()) {
-          builtin_throw(Deoptimization::Reason_class_check, makecon(TypeKlassPtr::make(objtp->klass())));
+          bool aastore = (java_bc() == Bytecodes::_aastore);
+          Deoptimization::DeoptReason reason = aastore ?
+            Deoptimization::Reason_array_check : Deoptimization::Reason_class_check;
+          builtin_throw(reason, makecon(TypeKlassPtr::make(objtp->klass())));
           return top();
         } else if (!too_many_traps_or_recompiles(Deoptimization::Reason_null_assert)) {
           return null_assert(obj);
@@ -3422,7 +3424,10 @@ Node* GraphKit::gen_checkcast(Node *obj, Node* superklass,
       if (not_subtype_ctrl != top()) { // If failure is possible
         PreserveJVMState pjvms(this);
         set_control(not_subtype_ctrl);
-        builtin_throw(Deoptimization::Reason_class_check, load_object_klass(not_null_obj));
+        bool aastore = (java_bc() == Bytecodes::_aastore);
+        Deoptimization::DeoptReason reason = aastore ?
+          Deoptimization::Reason_array_check : Deoptimization::Reason_class_check;
+        builtin_throw(reason, load_object_klass(not_null_obj));
       }
     } else {
       (*failure_control) = not_subtype_ctrl;

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3339,8 +3339,8 @@ Node* GraphKit::gen_checkcast(Node *obj, Node* superklass,
         // It needs a null check because a null will *pass* the cast check.
         // A non-null value will always produce an exception.
         if (!objtp->maybe_null()) {
-          bool aastore = (java_bc() == Bytecodes::_aastore);
-          Deoptimization::DeoptReason reason = aastore ?
+          bool is_aastore = (java_bc() == Bytecodes::_aastore);
+          Deoptimization::DeoptReason reason = is_aastore ?
             Deoptimization::Reason_array_check : Deoptimization::Reason_class_check;
           builtin_throw(reason, makecon(TypeKlassPtr::make(objtp->klass())));
           return top();
@@ -3424,8 +3424,8 @@ Node* GraphKit::gen_checkcast(Node *obj, Node* superklass,
       if (not_subtype_ctrl != top()) { // If failure is possible
         PreserveJVMState pjvms(this);
         set_control(not_subtype_ctrl);
-        bool aastore = (java_bc() == Bytecodes::_aastore);
-        Deoptimization::DeoptReason reason = aastore ?
+        bool is_aastore = (java_bc() == Bytecodes::_aastore);
+        Deoptimization::DeoptReason reason = is_aastore ?
           Deoptimization::Reason_array_check : Deoptimization::Reason_class_check;
         builtin_throw(reason, load_object_klass(not_null_obj));
       }

--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -298,3 +298,4 @@ void Parse::dump_map_adr_mem() const {
 }
 
 #endif
+

--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -298,4 +298,3 @@ void Parse::dump_map_adr_mem() const {
 }
 
 #endif
-

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -955,6 +955,72 @@ WB_ENTRY(void, WB_MakeMethodNotCompilable(JNIEnv* env, jobject o, jobject method
   }
 WB_END
 
+WB_ENTRY(jint, WB_GetMethodDecompileCount(JNIEnv* env, jobject o, jobject method))
+  jmethodID jmid = reflected_method_to_jmid(thread, env, method);
+  CHECK_JNI_EXCEPTION_(env, 0);
+  methodHandle mh(THREAD, Method::checked_resolve_jmethod_id(jmid));
+  uint cnt = 0;
+  MethodData* mdo = mh->method_data();
+  if (mdo != NULL) {
+    cnt = mdo->decompile_count();
+  }
+  return cnt;
+WB_END
+
+// Get the trap count of a method for a specific reason. If the trap count for
+// that reason did overflow, this includes the overflow trap count of the method.
+// If 'reason' is NULL, the sum of the traps for all reasons will be returned.
+// This number includes the overflow trap count if the trap count for any reason
+// did overflow.
+WB_ENTRY(jint, WB_GetMethodTrapCount(JNIEnv* env, jobject o, jobject method, jstring reason_obj))
+  jmethodID jmid = reflected_method_to_jmid(thread, env, method);
+  CHECK_JNI_EXCEPTION_(env, 0);
+  methodHandle mh(THREAD, Method::checked_resolve_jmethod_id(jmid));
+  uint cnt = 0;
+  MethodData* mdo = mh->method_data();
+  if (mdo != NULL) {
+    ResourceMark rm(THREAD);
+    char* reason_str = (reason_obj == NULL) ?
+      NULL : java_lang_String::as_utf8_string(JNIHandles::resolve_non_null(reason_obj));
+    bool overflow = false;
+    for (uint reason = 0; reason < mdo->trap_reason_limit(); reason++) {
+      if (reason_str != NULL && !strcmp(reason_str, Deoptimization::trap_reason_name(reason))) {
+        cnt = mdo->trap_count(reason);
+        // Count in the overflow trap count on overflow
+        if (cnt == (uint)-1) {
+          cnt = mdo->trap_count_limit() + mdo->overflow_trap_count();
+        }
+        break;
+      } else if (reason_str == NULL) {
+        uint c = mdo->trap_count(reason);
+        if (c == (uint)-1) {
+          c = mdo->trap_count_limit();
+          if (!overflow) {
+            // Count overflow trap count just once
+            overflow = true;
+            c += mdo->overflow_trap_count();
+          }
+        }
+        cnt += c;
+      }
+    }
+  }
+  return cnt;
+WB_END
+
+WB_ENTRY(jint, WB_GetDeoptCount(JNIEnv* env, jobject o, jstring reason_obj, jstring action_obj))
+  if (reason_obj == NULL && action_obj == NULL) {
+    return Deoptimization::total_deoptimization_count();
+  }
+  ResourceMark rm(THREAD);
+  const char *reason_str = (reason_obj == NULL) ?
+    NULL : java_lang_String::as_utf8_string(JNIHandles::resolve_non_null(reason_obj));
+  const char *action_str = (action_obj == NULL) ?
+    NULL : java_lang_String::as_utf8_string(JNIHandles::resolve_non_null(action_obj));
+
+  return Deoptimization::deoptimization_count(reason_str, action_str);
+WB_END
+
 WB_ENTRY(jint, WB_GetMethodEntryBci(JNIEnv* env, jobject o, jobject method))
   jmethodID jmid = reflected_method_to_jmid(thread, env, method);
   CHECK_JNI_EXCEPTION_(env, InvocationEntryBci);
@@ -2527,6 +2593,13 @@ static JNINativeMethod methods[] = {
       CC"(Ljava/lang/reflect/Executable;Z)Z",         (void*)&WB_TestSetDontInlineMethod},
   {CC"getMethodCompilationLevel0",
       CC"(Ljava/lang/reflect/Executable;Z)I",         (void*)&WB_GetMethodCompilationLevel},
+  {CC"getMethodDecompileCount0",
+      CC"(Ljava/lang/reflect/Executable;)I",          (void*)&WB_GetMethodDecompileCount},
+  {CC"getMethodTrapCount0",
+      CC"(Ljava/lang/reflect/Executable;Ljava/lang/String;)I",
+                                                      (void*)&WB_GetMethodTrapCount},
+  {CC"getDeoptCount0",
+      CC"(Ljava/lang/String;Ljava/lang/String;)I",    (void*)&WB_GetDeoptCount},
   {CC"getMethodEntryBci0",
       CC"(Ljava/lang/reflect/Executable;)I",          (void*)&WB_GetMethodEntryBci},
   {CC"getCompileQueueSize",

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -2608,6 +2608,30 @@ jint Deoptimization::total_deoptimization_count() {
   return _deoptimization_hist[Reason_none][0][0];
 }
 
+// Get the deopt count for a specific reason and a specific action. If either
+// one of 'reason' or 'action' is null, the method returns the sum of all
+// deoptimizations with the specific 'action' or 'reason' respectively.
+// If both arguments are null, the method returns the total deopt count.
+jint Deoptimization::deoptimization_count(const char *reason_str, const char *action_str) {
+  if (reason_str == NULL && action_str == NULL) {
+    return total_deoptimization_count();
+  }
+  juint counter = 0;
+  for (int reason = 0; reason < Reason_LIMIT; reason++) {
+    if (reason_str == NULL || !strcmp(reason_str, trap_reason_name(reason))) {
+      for (int action = 0; action < Action_LIMIT; action++) {
+        if (action_str == NULL || !strcmp(action_str, trap_action_name(action))) {
+          juint* cases = _deoptimization_hist[reason][1+action];
+          for (int bc_case = 0; bc_case < BC_CASE_LIMIT; bc_case++) {
+            counter += cases[bc_case] >> LSB_BITS;
+          }
+        }
+      }
+    }
+  }
+  return counter;
+}
+
 void Deoptimization::print_statistics() {
   juint total = total_deoptimization_count();
   juint account = total;
@@ -2659,6 +2683,14 @@ bool Deoptimization::trap_state_is_recompiled(int trap_state) {
 
 const char* Deoptimization::trap_reason_name(int reason) {
   return "unknown";
+}
+
+jint Deoptimization::total_deoptimization_count() {
+  return 0;
+}
+
+jint Deoptimization::deoptimization_count(const char *reason_str, const char *action_str) {
+  return 0;
 }
 
 void Deoptimization::print_statistics() {

--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -433,7 +433,7 @@ class Deoptimization : AllStatic {
                                          int trap_request);
 
   static jint total_deoptimization_count();
-  static jint deoptimization_count(const char *reason_str, const char *action_str);
+  static jint deoptimization_count(const char* reason_str, const char* action_str);
 
   // JVMTI PopFrame support
 

--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -433,6 +433,7 @@ class Deoptimization : AllStatic {
                                          int trap_request);
 
   static jint total_deoptimization_count();
+  static jint deoptimization_count(const char *reason_str, const char *action_str);
 
   // JVMTI PopFrame support
 

--- a/test/hotspot/jtreg/compiler/exceptions/OptimizeImplicitExceptions.java
+++ b/test/hotspot/jtreg/compiler/exceptions/OptimizeImplicitExceptions.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ /*
+ * @test
+ * @bug 8275908
+ * @summary Record null_check traps for calls and array_check traps in the interpreter
+ *
+ * @requires vm.compiler2.enabled & vm.compMode != "Xcomp"
+ *
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:+UseSerialGC -Xbatch -XX:-UseOnStackReplacement -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,compiler.exceptions.OptimizeImplicitExceptions::throwImplicitException
+ *                   compiler.exceptions.OptimizeImplicitExceptions
+ */
+
+package compiler.exceptions;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+
+import jdk.test.lib.Asserts;
+import jdk.test.whitebox.WhiteBox;
+
+public class OptimizeImplicitExceptions {
+    // ImplicitException represents the various implicit (aka. 'built-in') exceptions
+    // which can be thrown implicitely by the JVM when executing bytecodes.
+    public enum ImplicitException {
+        // NullPointerException during field access
+        NULL_POINTER_EXCEPTION("null_check"),
+        // NullPointerException during invoke
+        INVOKE_NULL_POINTER_EXCEPTION("null_check"),
+        ARITHMETIC_EXCEPTION("div0_check"),
+        ARRAY_INDEX_OUT_OF_BOUNDS_EXCEPTION("range_check"),
+        ARRAY_STORE_EXCEPTION("array_check"),
+        CLASS_CAST_EXCEPTION("class_check");
+        private final String reason;
+        ImplicitException(String reason) {
+            this.reason = reason;
+        }
+        public String getReason() {
+            return reason;
+        }
+    }
+    // TestMode represents a specific combination of the OmitStackTraceInFastThrow command line options.
+    // They will be set up in 'setFlags(TestMode testMode)' before a new test run starts.
+    public enum TestMode {
+        OMIT_STACKTRACES_IN_FASTTHROW,
+        STACKTRACES_IN_FASTTHROW
+    }
+
+    private static final WhiteBox WB = WhiteBox.getWhiteBox();
+    // The number of deoptimizations after which a method will be made not-entrant
+    private static final int PerBytecodeTrapLimit = WB.getIntxVMFlag("PerBytecodeTrapLimit").intValue();
+    // The number of interpreter invocations after which a decompiled method will be re-compiled.
+    private static final int Tier0InvokeNotifyFreq = (int)Math.pow(2, WB.getIntxVMFlag("Tier0InvokeNotifyFreqLog"));
+    // The following variables are used to track the value of the global deopt counters between the various test phases.
+    private static int oldDeoptCount = 0;
+    private static HashMap<String, Integer> oldDeoptCountReason = new HashMap<String, Integer>(ImplicitException.values().length);
+    // The following two objects are declared statically to simplify the test method.
+    private static String[] string_a = new String[1];
+    private static final Object o = new Object();
+
+    // This is the main test method. It will repeatedly called with the same ImplicitException 'type' to
+    // JIT-compile it, deoptimized it, re-compile it again and do various checks on the way.
+    // This process will be repeated then for each kind of ImplicitException 'type'.
+    public static Object throwImplicitException(ImplicitException type, Object[] object_a) {
+        switch (type) {
+            case NULL_POINTER_EXCEPTION: {
+                return object_a.length;
+            }
+            case INVOKE_NULL_POINTER_EXCEPTION: {
+                return object_a.hashCode();
+            }
+            case ARITHMETIC_EXCEPTION: {
+                return ((42 / (object_a.length - 1)) > 2) ? null : object_a[0];
+            }
+            case ARRAY_INDEX_OUT_OF_BOUNDS_EXCEPTION: {
+                return object_a[5];
+            }
+            case ARRAY_STORE_EXCEPTION: {
+                return (object_a[0] = o);
+            }
+            case CLASS_CAST_EXCEPTION: {
+                return (ImplicitException[])object_a;
+            }
+        }
+        return null;
+    }
+
+    // Completely unload (i.e. make "not-entrant"->"zombie"->"unload/free") a JIT-compiled
+    // version of a method and clear the method's profiling counters.
+    private static void unloadAndClean(Method m) {
+        WB.deoptimizeMethod(m);  // Makes the nmethod "not entrant".
+        WB.forceNMethodSweep();  // Makes all "not entrant" nmethods "zombie". This requires
+        WB.forceNMethodSweep();  // two sweeps, see 'nmethod::can_convert_to_zombie()' for why.
+        WB.forceNMethodSweep();  // Need third sweep to actually unload/free all "zombie" nmethods.
+        System.gc();
+        WB.clearMethodState(m);
+    }
+
+    // Set '-XX' flags according to 'TestMode'
+    private static void setFlags(TestMode testMode) {
+        if (testMode == TestMode.OMIT_STACKTRACES_IN_FASTTHROW) {
+            WB.setBooleanVMFlag("OmitStackTraceInFastThrow", true);
+        } else {
+            WB.setBooleanVMFlag("OmitStackTraceInFastThrow", false);
+        }
+
+        System.out.println("==========================================================");
+        System.out.println("testMode=" + testMode +
+                           " OmitStackTraceInFastThrow=" + WB.getBooleanVMFlag("OmitStackTraceInFastThrow"));
+        System.out.println("==========================================================");
+    }
+
+    private static void printCounters(TestMode testMode, ImplicitException impExcp, Method throwImplicitException_m, int invocations) {
+        System.out.println("testMode=" + testMode + " exception=" + impExcp + " invocations=" + invocations + "\n" +
+                           "decompilecount=" + WB.getMethodDecompileCount(throwImplicitException_m) + " " +
+                           "trapCount=" + WB.getMethodTrapCount(throwImplicitException_m) + " " +
+                           "trapCount(" + impExcp.getReason() + ")=" +
+                           WB.getMethodTrapCount(throwImplicitException_m, impExcp.getReason()) + " " +
+                           "globalDeoptCount=" + WB.getDeoptCount() + " " +
+                           "globalDeoptCount(" + impExcp.getReason() + ")=" + WB.getDeoptCount(impExcp.getReason(), null));
+        System.out.println("method compiled=" + WB.isMethodCompiled(throwImplicitException_m));
+    }
+
+    // Checks after the test method has been JIT-compiled but before the compiled version has been invoked.
+    private static void checkOne(TestMode testMode, ImplicitException impExcp, Exception ex, Method throwImplicitException_m, int invocations) {
+
+        printCounters(testMode, impExcp, throwImplicitException_m, invocations);
+        // At this point, throwImplicitException() has been compiled but the compiled version has not been invoked yet.
+        Asserts.assertEQ(WB.getMethodCompilationLevel(throwImplicitException_m), 4, "Method should be compiled at level 4.");
+
+        int trapCount = WB.getMethodTrapCount(throwImplicitException_m);
+        int trapCountSpecific = WB.getMethodTrapCount(throwImplicitException_m, impExcp.getReason());
+        Asserts.assertEQ(trapCount, invocations, "Trap count must much invocation count.");
+        Asserts.assertEQ(trapCountSpecific, invocations, "Trap count must much invocation count.");
+        Asserts.assertNotNull(ex.getMessage(), "Exceptions thrown in the interpreter should have a message.");
+    }
+
+    // Checks after the JIT-compiled test method has been invoked 'PerBytecodeTrapLimit' times.
+    private static void checkTwo(TestMode testMode, ImplicitException impExcp, Exception ex, Method throwImplicitException_m, int invocations) {
+
+        printCounters(testMode, impExcp, throwImplicitException_m, invocations);
+        // At this point, the compiled version of 'throwImplicitException()' has been invoked 'PerBytecodeTrapLimit' times.
+        Asserts.assertEQ(WB.getMethodCompilationLevel(throwImplicitException_m), 4, "Method should be compiled at level 4.");
+        int deoptCount = WB.getDeoptCount();
+        int deoptCountReason = WB.getDeoptCount(impExcp.getReason(), null/*action*/);
+        if (testMode == TestMode.OMIT_STACKTRACES_IN_FASTTHROW) {
+            // No deoptimizations for '-XX:+OmitStackTraceInFastThrow'
+            Asserts.assertEQ(oldDeoptCount, deoptCount, "Wrong number of deoptimizations.");
+            Asserts.assertEQ(oldDeoptCountReason.get(impExcp.getReason()), deoptCountReason, "Wrong number of deoptimizations.");
+            // '-XX:+OmitStackTraceInFastThrow' never has message because it is using a global singleton exception.
+            Asserts.assertNull(ex.getMessage(), "Optimized exceptions have no message.");
+        } else if (testMode == TestMode.STACKTRACES_IN_FASTTHROW) {
+            // We always deoptimize for '-XX:-OmitStackTraceInFastThrow
+            Asserts.assertEQ(oldDeoptCount + PerBytecodeTrapLimit, deoptCount, "Wrong number of deoptimizations.");
+            Asserts.assertEQ(oldDeoptCountReason.get(impExcp.getReason()) + PerBytecodeTrapLimit, deoptCountReason, "Wrong number of deoptimizations.");
+            Asserts.assertNotNull(ex.getMessage(), "Exceptions thrown in the interpreter should have a message.");
+        } else {
+            Asserts.fail("Unknown test mode.");
+        }
+        oldDeoptCount = deoptCount;
+        oldDeoptCountReason.put(impExcp.getReason(), deoptCountReason);
+    }
+
+    // Checks after the test method has been invoked 'Tier0InvokeNotifyFreq' more times.
+    private static void checkThree(TestMode testMode, ImplicitException impExcp, Exception ex, Method throwImplicitException_m, int invocations) {
+
+        printCounters(testMode, impExcp, throwImplicitException_m, invocations);
+        // At this point, throwImplicitException() has been invoked 'Tier0InvokeNotifyFreq' more times.
+        Asserts.assertEQ(WB.getMethodCompilationLevel(throwImplicitException_m), 4, "Method should be compiled at level 4.");
+        int deoptCount = WB.getDeoptCount();
+        int deoptCountReason = WB.getDeoptCount(impExcp.getReason(), null/*action*/);
+        if (testMode == TestMode.OMIT_STACKTRACES_IN_FASTTHROW) {
+            // No deoptimizations for '-XX:+OmitStackTraceInFastThrow'
+            Asserts.assertEQ(oldDeoptCount, deoptCount, "Wrong number of deoptimizations.");
+            Asserts.assertEQ(oldDeoptCountReason.get(impExcp.getReason()), deoptCountReason, "Wrong number of deoptimizations.");
+        } else if (testMode == TestMode.STACKTRACES_IN_FASTTHROW) {
+            Asserts.assertEQ(oldDeoptCount + Tier0InvokeNotifyFreq, deoptCount, "Wrong number of deoptimizations.");
+            Asserts.assertEQ(oldDeoptCountReason.get(impExcp.getReason()) + Tier0InvokeNotifyFreq, deoptCountReason, "Wrong number of deoptimizations.");
+            Asserts.assertNotNull(ex.getMessage(), "Exceptions thrown in the interpreter should have a message.");
+        } else {
+            Asserts.fail("Unknown test mode.");
+        }
+        oldDeoptCount = deoptCount;
+        oldDeoptCountReason.put(impExcp.getReason(), deoptCountReason);
+    }
+
+    // Checks after the test method has been invoked 'PerBytecodeTrapLimit' more times.
+    private static void checkFour(TestMode testMode, ImplicitException impExcp, Exception ex, Method throwImplicitException_m, int invocations) {
+
+        printCounters(testMode, impExcp, throwImplicitException_m, invocations);
+        // At this point, the compiled (or re-compiled) version of throwImplicitException() has been invoked 'PerBytecodeTrapLimit' more times.
+        Asserts.assertEQ(WB.getMethodCompilationLevel(throwImplicitException_m), 4, "Method should be compiled at level 4.");
+        int deoptCount = WB.getDeoptCount();
+        int deoptCountReason = WB.getDeoptCount(impExcp.getReason(), null/*action*/);
+        if (testMode == TestMode.OMIT_STACKTRACES_IN_FASTTHROW) {
+            // No deoptimizations for '-XX:+OmitStackTraceInFastThrow'
+            Asserts.assertEQ(oldDeoptCount, deoptCount, "Wrong number of deoptimizations.");
+            Asserts.assertEQ(oldDeoptCountReason.get(impExcp.getReason()), deoptCountReason, "Wrong number of deoptimizations.");
+            // '-XX:+OmitStackTraceInFastThrow' never has message because it is using a global singleton exception.
+            Asserts.assertNull(ex.getMessage(), "Optimized exceptions have no message.");
+        } else if (testMode == TestMode.STACKTRACES_IN_FASTTHROW) {
+            // We always deoptimize for '-XX:-OmitStackTraceInFastThrow'
+            Asserts.assertEQ(oldDeoptCount + PerBytecodeTrapLimit, deoptCount, "Wrong number of deoptimizations.");
+            Asserts.assertEQ(oldDeoptCountReason.get(impExcp.getReason()) + PerBytecodeTrapLimit, deoptCountReason, "Wrong number of deoptimizations.");
+        } else {
+            Asserts.fail("Unknown test mode.");
+        }
+        oldDeoptCount = deoptCount;
+        oldDeoptCountReason.put(impExcp.getReason(), deoptCountReason);
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        if (!WB.getBooleanVMFlag("ProfileTraps")) {
+            // The fast-throw optimzation only works if we're running with -XX:+ProfileTraps
+            return;
+        }
+
+        // Initialize global deopt counts to zero.
+        for (ImplicitException impExcp : ImplicitException.values()) {
+            oldDeoptCountReason.put(impExcp.getReason(), 0);
+        }
+        // Get a handle of the test method for usage with the WhiteBox API.
+        Method throwImplicitException_m = OptimizeImplicitExceptions.class
+            .getDeclaredMethod("throwImplicitException", new Class[] { ImplicitException.class, Object[].class});
+
+        for (TestMode testMode : TestMode.values()) {
+            setFlags(testMode);
+            for (ImplicitException impExcp : ImplicitException.values()) {
+                int invocations = 0;
+                Exception lastException = null;
+
+                // Warmup and compile, but don't invoke compiled code.
+                while(!WB.isMethodCompiled(throwImplicitException_m)) {
+                    invocations++;
+                    try {
+                        throwImplicitException(impExcp, impExcp.getReason().equals("null_check") ? null : string_a);
+                    } catch (Exception catchedExcp) {
+                        lastException = catchedExcp;
+                        continue;
+                    }
+                    throw new Exception("Should not happen");
+                }
+
+                checkOne(testMode, impExcp, lastException, throwImplicitException_m, invocations);
+
+                // Invoke compiled code 'PerBytecodeTrapLimit' times.
+                for (int i = 0; i < PerBytecodeTrapLimit; i++) {
+                    invocations++;
+                    try {
+                        throwImplicitException(impExcp, impExcp.getReason().equals("null_check") ? null : string_a);
+                    } catch (Exception catchedExcp) {
+                        lastException = catchedExcp;
+                        continue;
+                    }
+                    throw new Exception("Should not happen");
+                }
+
+                checkTwo(testMode, impExcp, lastException, throwImplicitException_m, invocations);
+
+                // Invoke compiled (or interpreted if JDK-8275908 isn't fixed) code 'Tier0InvokeNotifyFreq' times.
+                // If the method was de-compiled before, this will re-compile it again.
+                for (int i = 0; i < Tier0InvokeNotifyFreq; i++) {
+                    invocations++;
+                    try {
+                        throwImplicitException(impExcp, impExcp.getReason().equals("null_check") ? null : string_a);
+                    } catch (Exception catchedExcp) {
+                        lastException = catchedExcp;
+                        continue;
+                    }
+                    throw new Exception("Should not happen");
+                }
+
+                checkThree(testMode, impExcp, lastException, throwImplicitException_m, invocations);
+
+                // Invoke compiled code 'PerBytecodeTrapLimit' times.
+                for (int i = 0; i < PerBytecodeTrapLimit; i++) {
+                    invocations++;
+                    try {
+                        throwImplicitException(impExcp, impExcp.getReason().equals("null_check") ? null : string_a);
+                    } catch (Exception catchedExcp) {
+                        lastException = catchedExcp;
+                        continue;
+                    }
+                    throw new Exception("Should not happen");
+                }
+
+                checkFour(testMode, impExcp, lastException, throwImplicitException_m, invocations);
+
+                System.out.println("------------------------------------------------------------------");
+
+                unloadAndClean(throwImplicitException_m);
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/uncommontrap/Decompile.java
+++ b/test/hotspot/jtreg/compiler/uncommontrap/Decompile.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ /*
+ * @test
+ * @bug 8275908
+ * @summary Quick test for the new WhiteBox methods of JDK-8275908
+ *
+ * @requires vm.compiler2.enabled & vm.compMode != "Xcomp"
+ *
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:+UseSerialGC -Xbatch -XX:-UseOnStackReplacement -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,compiler.uncommontrap.Decompile::uncommonTrap
+ *                   -XX:CompileCommand=inline,compiler.uncommontrap.Decompile*::foo
+ *                   compiler.uncommontrap.Decompile
+ */
+
+package compiler.uncommontrap;
+
+import java.lang.reflect.Method;
+
+import jdk.test.lib.Asserts;
+import jdk.test.whitebox.WhiteBox;
+
+public class Decompile {
+
+    private static final WhiteBox WB = WhiteBox.getWhiteBox();
+    // The number of deoptimizations after which a method will be made not-entrant
+    private static final int PerBytecodeTrapLimit = WB.getIntxVMFlag("PerBytecodeTrapLimit").intValue();
+    // The number of interpreter invocations after which a decompiled method will be re-compiled.
+    private static final int Tier0InvokeNotifyFreq = (int)Math.pow(2, WB.getIntxVMFlag("Tier0InvokeNotifyFreqLog"));
+
+    static class Base {
+        void foo() {}
+    }
+    static class X extends Base {
+        void foo() {}
+    }
+    static class Y extends Base {
+        void foo() {}
+    }
+
+    static void uncommonTrap(Base t) {
+        t.foo();
+    }
+
+    private static void printCounters(Method uncommonTrap_m, int invocations) {
+        System.out.println("-----------------------------------------------------------------");
+        System.out.println("invocations=" + invocations + " " +
+                           "method compiled=" + WB.isMethodCompiled(uncommonTrap_m) + " " +
+                           "decompileCount=" + WB.getMethodDecompileCount(uncommonTrap_m) + "\n" +
+                           "trapCount=" + WB.getMethodTrapCount(uncommonTrap_m) + " " +
+                           "trapCount(class_check)=" + WB.getMethodTrapCount(uncommonTrap_m, "class_check") + " " +
+                           "trapCount(bimorphic_or_optimized_type_check)=" +
+                           WB.getMethodTrapCount(uncommonTrap_m, "bimorphic_or_optimized_type_check") + "\n" +
+                           "globalDeoptCount=" + WB.getDeoptCount() + " " +
+                           "globalDeoptCount(class_check)=" + WB.getDeoptCount("class_check", null) + " " +
+                           "globalDeoptCount(bimorphic_or_optimized_type_check)=" +
+                           WB.getDeoptCount("bimorphic_or_optimized_type_check", null));
+        System.out.println("-----------------------------------------------------------------");
+    }
+
+    private static void check(Method uncommonTrap_m, int invocations, boolean isCompiled, int decompileCount,
+                              int trapCount, int trapCountClassCheck, int trapCountBimorphic,
+                              int deoptCount, int deoptCountClassCheck, int deoptCountBimorphic) {
+
+        printCounters(uncommonTrap_m, invocations);
+
+        Asserts.assertEQ(isCompiled, WB.isMethodCompiled(uncommonTrap_m),
+                         "Wrong compilation status.");
+        Asserts.assertEQ(decompileCount, WB.getMethodDecompileCount(uncommonTrap_m),
+                         "Wrong number of decompilations.");
+        Asserts.assertEQ(trapCount, WB.getMethodTrapCount(uncommonTrap_m),
+                         "Wrong number of traps.");
+        Asserts.assertEQ(trapCountClassCheck, WB.getMethodTrapCount(uncommonTrap_m, "class_check"),
+                         "Wrong number of traps.");
+        Asserts.assertEQ(trapCountBimorphic, WB.getMethodTrapCount(uncommonTrap_m, "bimorphic_or_optimized_type_check"),
+                         "Wrong number of traps.");
+        Asserts.assertEQ(deoptCount, WB.getDeoptCount(),
+                         "Wrong number of deoptimizations.");
+        Asserts.assertEQ(deoptCountClassCheck, WB.getDeoptCount("class_check", null),
+                         "Wrong number of class_check deoptimizations.");
+        Asserts.assertEQ(deoptCountBimorphic, WB.getDeoptCount("bimorphic_or_optimized_type_check", null),
+                         "Wrong number of bimorphic_or_optimized_type_checkdeoptimizations.");
+    }
+    public static void main(String[] args) throws Exception {
+
+        // Get a handle of the test method for usage with the WhiteBox API.
+        Method uncommonTrap_m = Decompile.class
+            .getDeclaredMethod("uncommonTrap", new Class[] { Base.class });
+
+        int invocations = 0;
+        Base b = new Base();
+        // This is a little tricky :) We have to define 'x' already here otherwise
+        // the class 'X' won't be loaded and 'uncommonTrap()' will be compiled without
+        // a class check but a CHA dependency that class 'B' has no subtypes.
+        X x = new X();
+        Y y = new Y();
+
+        // Warmup and compile with an object of type 'Base' as receiver, but don't invoke compiled code.
+        while(!WB.isMethodCompiled(uncommonTrap_m)) {
+            invocations++;
+            uncommonTrap(b);
+        }
+        check(uncommonTrap_m, invocations, true /* is_compiled */, 0 /* decompileCount */,
+              0 /* trapCount  */, 0 /* trapCountClassCheck  */, 0 /* trapCountBimorphic  */,
+              0 /* deoptCount */, 0 /* deoptCountClassCheck */, 0 /* deoptCountBimorphic */);
+
+        // Invoke compiled code 'PerBytecodeTrapLimit' times with an receiver object of type 'X'.
+        // This should deoptimize 'PerBytecodeTrapLimit' times and finally decompile the method.
+        for (int i = 0; i < PerBytecodeTrapLimit; i++) {
+            invocations++;
+            uncommonTrap(x);
+        }
+        check(uncommonTrap_m, invocations, false /* is_compiled */, 1 /* decompileCount */,
+              PerBytecodeTrapLimit /* trapCount  */, PerBytecodeTrapLimit /* trapCountClassCheck  */, 0 /* trapCountBimorphic  */,
+              PerBytecodeTrapLimit /* deoptCount */, PerBytecodeTrapLimit /* deoptCountClassCheck */, 0 /* deoptCountBimorphic */);
+
+        // Invoke the method 'Tier0InvokeNotifyFreq' more times with an receiver object of type 'X'.
+        // This should re-compile the method again with bimorphic inlining for receiver types 'Base' and 'X'.
+        for (int i = 0; i < Tier0InvokeNotifyFreq; i++) {
+            invocations++;
+            uncommonTrap(x);
+        }
+        check(uncommonTrap_m, invocations, true /* is_compiled */, 1 /* decompileCount */,
+              PerBytecodeTrapLimit /* trapCount  */, PerBytecodeTrapLimit /* trapCountClassCheck  */, 0 /* trapCountBimorphic  */,
+              PerBytecodeTrapLimit /* deoptCount */, PerBytecodeTrapLimit /* deoptCountClassCheck */, 0 /* deoptCountBimorphic */);
+
+        // Invoke compiled code 'PerBytecodeTrapLimit' times with an receiver object of type 'Y'.
+        // This should deoptimize 'PerBytecodeTrapLimit' times and finally decompile the method.
+        for (int i = 0; i < PerBytecodeTrapLimit; i++) {
+            invocations++;
+            uncommonTrap(y);
+        }
+        check(uncommonTrap_m, invocations, false /* is_compiled */, 2 /* decompileCount */,
+              2*PerBytecodeTrapLimit /* trapCount  */, PerBytecodeTrapLimit /* trapCountClassCheck  */, PerBytecodeTrapLimit /* trapCountBimorphic  */,
+              2*PerBytecodeTrapLimit /* deoptCount */, PerBytecodeTrapLimit /* deoptCountClassCheck */, PerBytecodeTrapLimit /* deoptCountBimorphic */);
+    }
+}

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -317,6 +317,36 @@ public class WhiteBox {
     Objects.requireNonNull(method);
     return getMethodCompilationLevel0(method, isOsr);
   }
+  public         int     getMethodDecompileCount(Executable method) {
+    Objects.requireNonNull(method);
+    return getMethodDecompileCount0(method);
+  }
+  private native int     getMethodDecompileCount0(Executable method);
+  // Get the total trap count of a method. If the trap count for a specific reason
+  // did overflow, this includes the overflow trap count of the method.
+  public         int     getMethodTrapCount(Executable method) {
+    Objects.requireNonNull(method);
+    return getMethodTrapCount0(method, null);
+  }
+  // Get the trap count of a method for a specific reason. If the trap count for
+  // that reason did overflow, this includes the overflow trap count of the method.
+  public         int     getMethodTrapCount(Executable method, String reason) {
+    Objects.requireNonNull(method);
+    return getMethodTrapCount0(method, reason);
+  }
+  private native int     getMethodTrapCount0(Executable method, String reason);
+  // Get the total deopt count.
+  public         int     getDeoptCount() {
+    return getDeoptCount0(null, null);
+  }
+  // Get the deopt count for a specific reason and a specific action. If either
+  // one of 'reason' or 'action' is null, the method returns the sum of all
+  // deoptimizations with the specific 'action' or 'reason' respectively.
+  // If both arguments are null, the method returns the total deopt count.
+  public         int     getDeoptCount(String reason, String action) {
+    return getDeoptCount0(reason, action);
+  }
+  private native int     getDeoptCount0(String reason, String action);
   private native boolean testSetDontInlineMethod0(Executable method, boolean value);
   public         boolean testSetDontInlineMethod(Executable method, boolean value) {
     Objects.requireNonNull(method);

--- a/test/lib/sun/hotspot/WhiteBox.java
+++ b/test/lib/sun/hotspot/WhiteBox.java
@@ -318,6 +318,36 @@ public class WhiteBox {
     Objects.requireNonNull(method);
     return getMethodCompilationLevel0(method, isOsr);
   }
+  public         int     getMethodDecompileCount(Executable method) {
+    Objects.requireNonNull(method);
+    return getMethodDecompileCount0(method);
+  }
+  private native int     getMethodDecompileCount0(Executable method);
+  // Get the total trap count of a method. If the trap count for a specific reason
+  // did overflow, this includes the overflow trap count of the method.
+  public         int     getMethodTrapCount(Executable method) {
+    Objects.requireNonNull(method);
+    return getMethodTrapCount0(method, null);
+  }
+  // Get the trap count of a method for a specific reason. If the trap count for
+  // that reason did overflow, this includes the overflow trap count of the method.
+  public         int     getMethodTrapCount(Executable method, String reason) {
+    Objects.requireNonNull(method);
+    return getMethodTrapCount0(method, reason);
+  }
+  private native int     getMethodTrapCount0(Executable method, String reason);
+  // Get the total deopt count.
+  public         int     getDeoptCount() {
+    return getDeoptCount0(null, null);
+  }
+  // Get the deopt count for a specific reason and a specific action. If either
+  // one of 'reason' or 'action' is null, the method returns the sum of all
+  // deoptimizations with the specific 'action' or 'reason' respectively.
+  // If both arguments are null, the method returns the total deopt count.
+  public         int     getDeoptCount(String reason, String action) {
+    return getDeoptCount0(reason, action);
+  }
+  private native int     getDeoptCount0(String reason, String action);
   private native boolean testSetDontInlineMethod0(Executable method, boolean value);
   public         boolean testSetDontInlineMethod(Executable method, boolean value) {
     Objects.requireNonNull(method);


### PR DESCRIPTION
`null_checks` occurring at invoke bytecodes are currently not recorded by the profiler. This leads to unnecessary uncommon traps, deoptimizations and recompilations for exceptions which already occurred before the compilation (i.e. are "hot"). This change fixes the problem in the interpreter.

`array_checks` are currently recorded as `class_checks` in the interpreter and therefore not recognized by the compiler. This again leads to uncommon traps, deoptimizations and recompilations. This change unifies the handling of `array_checks` in the interpreter and compiler and prevents unnecessary recompilation.

The test is a stripped down version of a test which was developed for [JDK-8273563: Improve performance of implicit exceptions with -XX:-OmitStackTraceInFastThrow](https://bugs.openjdk.java.net/browse/JDK-8273563) (still [under review](https://github.com/openjdk/jdk/pull/5488)). It introduces an extension to the Whitebox API to expose the decompile, deopt and trap counters which is also required for testing [JDK-8273563](https://bugs.openjdk.java.net/browse/JDK-8273563). I think (and hope) it will also be helpful for others in the future.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275908](https://bugs.openjdk.java.net/browse/JDK-8275908): Record null_check traps for calls and array_check traps in the interpreter


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6541/head:pull/6541` \
`$ git checkout pull/6541`

Update a local copy of the PR: \
`$ git checkout pull/6541` \
`$ git pull https://git.openjdk.java.net/jdk pull/6541/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6541`

View PR using the GUI difftool: \
`$ git pr show -t 6541`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6541.diff">https://git.openjdk.java.net/jdk/pull/6541.diff</a>

</details>
