### PR TITLE
8277793: Support vector F2I and D2L cast operations for X86

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -2060,12 +2060,27 @@ void Assembler::vcvtpd2ps(XMMRegister dst, XMMRegister src, int vector_len) {
   emit_int16(0x5A, (0xC0 | encode));
 }
 
+void Assembler::vcvttps2dq(XMMRegister dst, XMMRegister src, int vector_len) {
+  assert(vector_len <= AVX_256bit ? VM_Version::supports_avx() : VM_Version::supports_evex(), "");
+  InstructionAttr attributes(vector_len, /* rex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
+  int encode = vex_prefix_and_encode(dst->encoding(), 0, src->encoding(), VEX_SIMD_F3, VEX_OPCODE_0F, &attributes);
+  emit_int16(0x5B, (0xC0 | encode));
+}
+
 void Assembler::evcvtqq2ps(XMMRegister dst, XMMRegister src, int vector_len) {
   assert(UseAVX > 2 && VM_Version::supports_avx512dq(), "");
   InstructionAttr attributes(vector_len, /* rex_w */ true, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
   attributes.set_is_evex_instruction();
   int encode = vex_prefix_and_encode(dst->encoding(), 0, src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
   emit_int16(0x5B, (0xC0 | encode));
+}
+
+void Assembler::evcvttpd2qq(XMMRegister dst, XMMRegister src, int vector_len) {
+  assert(UseAVX > 2 && VM_Version::supports_avx512dq(), "");
+  InstructionAttr attributes(vector_len, /* rex_w */ true, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
+  attributes.set_is_evex_instruction();
+  int encode = vex_prefix_and_encode(dst->encoding(), 0, src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
+  emit_int16(0x7A, (0xC0 | encode));
 }
 
 void Assembler::evcvtqq2pd(XMMRegister dst, XMMRegister src, int vector_len) {

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -1168,9 +1168,15 @@ private:
   void vcvtps2pd(XMMRegister dst, XMMRegister src, int vector_len);
   void vcvtpd2ps(XMMRegister dst, XMMRegister src, int vector_len);
 
+  // Convert vector float and int
+  void vcvttps2dq(XMMRegister dst, XMMRegister src, int vector_len);
+
   // Convert vector long to vector FP
   void evcvtqq2ps(XMMRegister dst, XMMRegister src, int vector_len);
   void evcvtqq2pd(XMMRegister dst, XMMRegister src, int vector_len);
+
+  // Convert vector double to long
+  void evcvttpd2qq(XMMRegister dst, XMMRegister src, int vector_len);
 
   // Evex casts with truncation
   void evpmovwb(XMMRegister dst, XMMRegister src, int vector_len);

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -4070,8 +4070,8 @@ void C2_MacroAssembler::masked_op(int ideal_opc, int mask_len, KRegister dst,
  */
 
 void C2_MacroAssembler::vector_castD2L_evex(XMMRegister dst, XMMRegister src, XMMRegister xtmp1, XMMRegister xtmp2,
-                                            KRegister ktmp1, AddressLiteral double_sign_flip,
-                                            AddressLiteral max_long, Register scratch, int vec_enc) {
+                                            KRegister ktmp1, KRegister ktmp2, AddressLiteral double_sign_flip,
+                                            Register scratch, int vec_enc) {
   Label done;
   evcvttpd2qq(dst, src, vec_enc);
   evmovdqul(xtmp1, k0, double_sign_flip, true, vec_enc, scratch);
@@ -4080,43 +4080,44 @@ void C2_MacroAssembler::vector_castD2L_evex(XMMRegister dst, XMMRegister src, XM
   jccb(Assembler::equal, done);
 
   vpxor(xtmp2, xtmp2, xtmp2, vec_enc);
-  evcmppd(ktmp1, k0, src, src, Assembler::UNORD_Q, vec_enc);
-  evblendmpd(dst, ktmp1, dst, xtmp2, true, vec_enc);
+  evcmppd(ktmp2, k0, src, src, Assembler::UNORD_Q, vec_enc);
+  evmovdquq(dst, ktmp2, xtmp2, true, vec_enc);
 
-  evpcmpeqq(ktmp1, xtmp1, dst, vec_enc);
+  kxorwl(ktmp1, ktmp1, ktmp2);
   evcmppd(ktmp1, ktmp1, src, xtmp2, Assembler::NLT_US, vec_enc);
-  evmovdquq(xtmp1, max_long, vec_enc, scratch);
-  evblendmpd(dst, ktmp1, dst, xtmp1, true, vec_enc);
+  vpternlogq(xtmp2, 0x11, xtmp1, xtmp1, vec_enc);
+  evmovdquq(dst, ktmp1, xtmp2, true, vec_enc);
   bind(done);
 }
 
 void C2_MacroAssembler::vector_castF2I_avx(XMMRegister dst, XMMRegister src, XMMRegister xtmp1,
-                                           XMMRegister xtmp2, XMMRegister xtmp3, AddressLiteral float_sign_flip,
-                                           AddressLiteral max_int, Register scratch, int vec_enc) {
+                                           XMMRegister xtmp2, XMMRegister xtmp3, XMMRegister xtmp4,
+                                           AddressLiteral float_sign_flip, Register scratch, int vec_enc) {
   Label done;
   vcvttps2dq(dst, src, vec_enc);
   vmovdqu(xtmp1, float_sign_flip, scratch);
   vpcmpeqd(xtmp2, dst, xtmp1, vec_enc);
-  vpmovmskb(scratch, xtmp2, vec_enc);
-  testl(scratch, scratch);
+  vptest(xtmp2, xtmp2, vec_enc);
   jccb(Assembler::equal, done);
 
-  vpxor(xtmp2, xtmp2, xtmp2, vec_enc);
+  vpxor(xtmp4, xtmp4, xtmp4, vec_enc);
   vcmpps(xtmp3, src, src, Assembler::UNORD_Q, vec_enc);
-  vblendvps(dst, dst, xtmp2, xtmp3, vec_enc);
+  vblendvps(dst, dst, xtmp4, xtmp3, vec_enc);
 
-  vpcmpeqd(xtmp1, dst, xtmp1, vec_enc);
-  vpand(xtmp2, xtmp1, src, vec_enc);
-  vpxor(xtmp3, xtmp2, xtmp1, vec_enc);
-  vpand(xtmp3, xtmp3, xtmp1, vec_enc);
-  vmovdqu(xtmp1, max_int, scratch);
+  vpxor(xtmp2, xtmp2, xtmp3, vec_enc);
+  vpand(xtmp4, xtmp2, src, vec_enc);
+  vpxor(xtmp3, xtmp2, xtmp4, vec_enc);
+
+  vpcmpeqd(xtmp4, xtmp4, xtmp4, vec_enc);
+  vpxor(xtmp1, xtmp1, xtmp4, vec_enc);
+
   vblendvps(dst, dst, xtmp1, xtmp3, vec_enc);
   bind(done);
 }
 
 void C2_MacroAssembler::vector_castF2I_evex(XMMRegister dst, XMMRegister src, XMMRegister xtmp1, XMMRegister xtmp2,
-                                            KRegister ktmp1, AddressLiteral float_sign_flip,
-                                            AddressLiteral max_int, Register scratch, int vec_enc) {
+                                            KRegister ktmp1, KRegister ktmp2, AddressLiteral float_sign_flip,
+                                            Register scratch, int vec_enc) {
   Label done;
   vcvttps2dq(dst, src, vec_enc);
   evmovdqul(xtmp1, k0, float_sign_flip, false, vec_enc, scratch);
@@ -4125,13 +4126,13 @@ void C2_MacroAssembler::vector_castF2I_evex(XMMRegister dst, XMMRegister src, XM
   jccb(Assembler::equal, done);
 
   vpxor(xtmp2, xtmp2, xtmp2, vec_enc);
-  evcmpps(ktmp1, k0, src, src, Assembler::UNORD_Q, vec_enc);
-  evblendmps(dst, ktmp1, dst, xtmp2, true, vec_enc);
+  evcmpps(ktmp2, k0, src, src, Assembler::UNORD_Q, vec_enc);
+  evmovdqul(dst, ktmp2, xtmp2, true, vec_enc);
 
-  Assembler::evpcmpeqd(ktmp1, k0, xtmp1, dst, vec_enc);
+  kxorwl(ktmp1, ktmp1, ktmp2);
   evcmpps(ktmp1, ktmp1, src, xtmp2, Assembler::NLT_US, vec_enc);
-  evmovdquq(xtmp1, max_int, vec_enc, scratch);
-  evblendmps(dst, ktmp1, dst, xtmp1, true, vec_enc);
+  vpternlogd(xtmp2, 0x11, xtmp1, xtmp1, vec_enc);
+  evmovdqul(dst, ktmp1, xtmp2, true, vec_enc);
   bind(done);
 }
 

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -4074,7 +4074,7 @@ void C2_MacroAssembler::vector_castD2L_evex(XMMRegister dst, XMMRegister src, XM
                                             Register scratch, int vec_enc) {
   Label done;
   evcvttpd2qq(dst, src, vec_enc);
-  evmovdqul(xtmp1, k0, double_sign_flip, true, vec_enc, scratch);
+  evmovdqul(xtmp1, k0, double_sign_flip, false, vec_enc, scratch);
   evpcmpeqq(ktmp1, xtmp1, dst, vec_enc);
   kortestwl(ktmp1, ktmp1);
   jccb(Assembler::equal, done);
@@ -4134,7 +4134,7 @@ void C2_MacroAssembler::vector_castF2I_evex(XMMRegister dst, XMMRegister src, XM
   evmovdqul(dst, ktmp2, xtmp2, true, vec_enc);
 
   kxorwl(ktmp1, ktmp1, ktmp2);
-  evcmpps(ktmp1, ktmp1, src, xtmp2, Assembler::NLT_US, vec_enc);
+  evcmpps(ktmp1, ktmp1, src, xtmp2, Assembler::NLT_UQ, vec_enc);
   vpternlogd(xtmp2, 0x11, xtmp1, xtmp1, vec_enc);
   evmovdqul(dst, ktmp1, xtmp2, true, vec_enc);
   bind(done);

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -288,4 +288,16 @@ public:
 
   void masked_op(int ideal_opc, int mask_len, KRegister dst,
                  KRegister src1, KRegister src2);
+
+  void vector_castF2I_avx(XMMRegister dst, XMMRegister src, XMMRegister xtmp1,
+                          XMMRegister xtmp2, XMMRegister xtmp3, AddressLiteral float_sign_flip,
+                          AddressLiteral max_int, Register scratch, int vec_enc);
+
+  void vector_castF2I_evex(XMMRegister dst, XMMRegister src, XMMRegister xtmp1, XMMRegister xtmp2,
+                           KRegister ktmp1, AddressLiteral float_sign_flip,
+                           AddressLiteral max_int, Register scratch, int vec_enc);
+
+  void vector_castD2L_evex(XMMRegister dst, XMMRegister src, XMMRegister xtmp1, XMMRegister xtmp2,
+                           KRegister ktmp1, AddressLiteral double_sign_flip,
+                           AddressLiteral max_long, Register scratch, int vec_enc);
 #endif // CPU_X86_C2_MACROASSEMBLER_X86_HPP

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -290,14 +290,14 @@ public:
                  KRegister src1, KRegister src2);
 
   void vector_castF2I_avx(XMMRegister dst, XMMRegister src, XMMRegister xtmp1,
-                          XMMRegister xtmp2, XMMRegister xtmp3, AddressLiteral float_sign_flip,
-                          AddressLiteral max_int, Register scratch, int vec_enc);
+                          XMMRegister xtmp2, XMMRegister xtmp3, XMMRegister xtmp4,
+                          AddressLiteral float_sign_flip, Register scratch, int vec_enc);
 
   void vector_castF2I_evex(XMMRegister dst, XMMRegister src, XMMRegister xtmp1, XMMRegister xtmp2,
-                           KRegister ktmp1, AddressLiteral float_sign_flip,
-                           AddressLiteral max_int, Register scratch, int vec_enc);
+                           KRegister ktmp1, KRegister ktmp2, AddressLiteral float_sign_flip,
+                           Register scratch, int vec_enc);
 
   void vector_castD2L_evex(XMMRegister dst, XMMRegister src, XMMRegister xtmp1, XMMRegister xtmp2,
-                           KRegister ktmp1, AddressLiteral double_sign_flip,
-                           AddressLiteral max_long, Register scratch, int vec_enc);
+                           KRegister ktmp1, KRegister ktmp2, AddressLiteral double_sign_flip,
+                           Register scratch, int vec_enc);
 #endif // CPU_X86_C2_MACROASSEMBLER_X86_HPP

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2546,6 +2546,15 @@ void MacroAssembler::vmovdqu(XMMRegister dst, AddressLiteral src, Register scrat
   }
 }
 
+void MacroAssembler::vmovdqu(XMMRegister dst, AddressLiteral src, Register scratch_reg, int vector_len) {
+  assert(vector_len <= AVX_256bit, "AVX2 vector length");
+  if (vector_len == AVX_256bit) {
+    vmovdqu(dst, src, scratch_reg);
+  } else {
+    movdqu(dst, src, scratch_reg);
+  }
+}
+
 void MacroAssembler::kmov(KRegister dst, Address src) {
   if (VM_Version::supports_avx512bw()) {
     kmovql(dst, src);
@@ -9034,5 +9043,6 @@ void MacroAssembler::get_thread(Register thread) {
     pop(rax);
   }
 }
+
 
 #endif // !WIN32 || _LP64

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -1117,6 +1117,8 @@ public:
   void vmovdqu(XMMRegister dst, Address src);
   void vmovdqu(XMMRegister dst, XMMRegister src);
   void vmovdqu(XMMRegister dst, AddressLiteral src, Register scratch_reg = rscratch1);
+  void vmovdqu(XMMRegister dst, AddressLiteral src, Register scratch_reg, int vector_len);
+
 
   // AVX512 Unaligned
   void evmovdqu(BasicType type, KRegister kmask, Address dst, XMMRegister src, int vector_len);

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1382,6 +1382,10 @@ Assembler::Width widthForType(BasicType bt) {
   static address vector_long_shufflemask() { return StubRoutines::x86::vector_long_shuffle_mask(); }
   static address vector_32_bit_mask() { return StubRoutines::x86::vector_32_bit_mask(); }
   static address vector_64_bit_mask() { return StubRoutines::x86::vector_64_bit_mask(); }
+  static address vector_float_signflip() { return StubRoutines::x86::vector_float_sign_flip();}
+  static address vector_double_signflip() { return StubRoutines::x86::vector_double_sign_flip();}
+  static address vector_float_signmask() { return StubRoutines::x86::vector_float_sign_mask();}
+  static address vector_double_signmask() { return StubRoutines::x86::vector_double_sign_mask();}
 
 //=============================================================================
 const bool Matcher::match_rule_supported(int opcode) {
@@ -1792,13 +1796,19 @@ const bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType 
         return false;
       }
       break;
-    case Op_VectorCastF2X:
     case Op_VectorCastD2X:
-      if (is_integral_type(bt)) {
-        // Casts from FP to integral types require special fixup logic not easily
-        // implementable with vectors.
-        return false; // Implementation limitation
+      if (is_subword_type(bt) || bt == T_INT) {
+        return false;
       }
+      if (bt == T_LONG && !VM_Version::supports_avx512dq()) {
+        return false;
+      }
+      break;
+    case Op_VectorCastF2X:
+      if (is_subword_type(bt) || bt == T_LONG) {
+        return false;
+      }
+      break;
     case Op_MulReductionVI:
       if (bt == T_BYTE && size_in_bits == 512 && !VM_Version::supports_avx512bw()) {
         return false;
@@ -7157,10 +7167,42 @@ instruct vcastLtoX_evex(vec dst, vec src) %{
 instruct vcastFtoD_reg(vec dst, vec src) %{
   predicate(Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (VectorCastF2X src));
-  format %{ "vector_cast_f2x  $dst,$src\t!" %}
+  format %{ "vector_cast_f2d  $dst,$src\t!" %}
   ins_encode %{
     int vlen_enc = vector_length_encoding(this);
     __ vcvtps2pd($dst$$XMMRegister, $src$$XMMRegister, vlen_enc);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct vcastFtoI_reg_avx(vec dst, vec src, vec xtmp1, vec xtmp2, vec xtmp3, rRegP scratch, rFlagsReg cr) %{
+  predicate(!VM_Version::supports_avx512vl() &&
+            Matcher::vector_length_in_bytes(n) < 64 &&
+            Matcher::vector_element_basic_type(n) == T_INT);
+  match(Set dst (VectorCastF2X src));
+  effect(TEMP dst, TEMP xtmp1, TEMP xtmp2, TEMP xtmp3, TEMP scratch, KILL cr);
+  format %{ "vector_cast_f2i $dst,$src\t! using $xtmp1, $xtmp2 and $xtmp3 as TEMP" %}
+  ins_encode %{
+    int vlen_enc = vector_length_encoding(this);
+    __ vector_castF2I_avx($dst$$XMMRegister, $src$$XMMRegister, $xtmp1$$XMMRegister,
+                          $xtmp2$$XMMRegister, $xtmp3$$XMMRegister, ExternalAddress(vector_float_signflip()),
+                          ExternalAddress(vector_float_signmask()), $scratch$$Register, vlen_enc);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct vcastFtoI_reg_evex(vec dst, vec src, vec xtmp1, vec xtmp2, kReg ktmp1, rRegP scratch, rFlagsReg cr) %{
+  predicate((VM_Version::supports_avx512vl() ||
+             Matcher::vector_length_in_bytes(n) == 64) &&
+             Matcher::vector_element_basic_type(n) == T_INT);
+  match(Set dst (VectorCastF2X src));
+  effect(TEMP dst, TEMP xtmp1, TEMP xtmp2, TEMP ktmp1, TEMP scratch, KILL cr);
+  format %{ "vector_cast_f2i $dst,$src\t! using $xtmp1, $xtmp2 and $ktmp1 as TEMP" %}
+  ins_encode %{
+    int vlen_enc = vector_length_encoding(this);
+    __ vector_castF2I_evex($dst$$XMMRegister, $src$$XMMRegister, $xtmp1$$XMMRegister,
+                           $xtmp2$$XMMRegister, $ktmp1$$KRegister, ExternalAddress(vector_float_signflip()),
+                           ExternalAddress(vector_float_signmask()), $scratch$$Register, vlen_enc);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -7172,6 +7214,20 @@ instruct vcastDtoF_reg(vec dst, vec src) %{
   ins_encode %{
     int vlen_enc = vector_length_encoding(this, $src);
     __ vcvtpd2ps($dst$$XMMRegister, $src$$XMMRegister, vlen_enc);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct vcastDtoL_reg_evex(vec dst, vec src, vec xtmp1, vec xtmp2, kReg ktmp1, rRegP scratch, rFlagsReg cr) %{
+  predicate(Matcher::vector_element_basic_type(n) == T_LONG);
+  match(Set dst (VectorCastD2X src));
+  effect(TEMP dst, TEMP xtmp1, TEMP xtmp2, TEMP ktmp1, TEMP scratch, KILL cr);
+  format %{ "vector_cast_d2l $dst,$src\t! using $xtmp1, $xtmp2 and $ktmp1 as TEMP" %}
+  ins_encode %{
+    int vlen_enc = vector_length_encoding(this);
+    __ vector_castD2L_evex($dst$$XMMRegister, $src$$XMMRegister, $xtmp1$$XMMRegister,
+                           $xtmp2$$XMMRegister, $ktmp1$$KRegister, ExternalAddress(vector_double_signflip()),
+                           ExternalAddress(vector_double_signmask()), $scratch$$Register, vlen_enc);
   %}
   ins_pipe( pipe_slow );
 %}

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1384,8 +1384,6 @@ Assembler::Width widthForType(BasicType bt) {
   static address vector_64_bit_mask() { return StubRoutines::x86::vector_64_bit_mask(); }
   static address vector_float_signflip() { return StubRoutines::x86::vector_float_sign_flip();}
   static address vector_double_signflip() { return StubRoutines::x86::vector_double_sign_flip();}
-  static address vector_float_signmask() { return StubRoutines::x86::vector_float_sign_mask();}
-  static address vector_double_signmask() { return StubRoutines::x86::vector_double_sign_mask();}
 
 //=============================================================================
 const bool Matcher::match_rule_supported(int opcode) {
@@ -7175,34 +7173,34 @@ instruct vcastFtoD_reg(vec dst, vec src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vcastFtoI_reg_avx(vec dst, vec src, vec xtmp1, vec xtmp2, vec xtmp3, rRegP scratch, rFlagsReg cr) %{
+instruct vcastFtoI_reg_avx(vec dst, vec src, vec xtmp1, vec xtmp2, vec xtmp3, vec xtmp4, rRegP scratch, rFlagsReg cr) %{
   predicate(!VM_Version::supports_avx512vl() &&
             Matcher::vector_length_in_bytes(n) < 64 &&
             Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst (VectorCastF2X src));
-  effect(TEMP dst, TEMP xtmp1, TEMP xtmp2, TEMP xtmp3, TEMP scratch, KILL cr);
-  format %{ "vector_cast_f2i $dst,$src\t! using $xtmp1, $xtmp2 and $xtmp3 as TEMP" %}
+  effect(TEMP dst, TEMP xtmp1, TEMP xtmp2, TEMP xtmp3, TEMP xtmp4, TEMP scratch, KILL cr);
+  format %{ "vector_cast_f2i $dst,$src\t! using $xtmp1, $xtmp2, $xtmp3 and $xtmp4 as TEMP" %}
   ins_encode %{
     int vlen_enc = vector_length_encoding(this);
     __ vector_castF2I_avx($dst$$XMMRegister, $src$$XMMRegister, $xtmp1$$XMMRegister,
-                          $xtmp2$$XMMRegister, $xtmp3$$XMMRegister, ExternalAddress(vector_float_signflip()),
-                          ExternalAddress(vector_float_signmask()), $scratch$$Register, vlen_enc);
+                          $xtmp2$$XMMRegister, $xtmp3$$XMMRegister, $xtmp4$$XMMRegister,
+                          ExternalAddress(vector_float_signflip()), $scratch$$Register, vlen_enc);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct vcastFtoI_reg_evex(vec dst, vec src, vec xtmp1, vec xtmp2, kReg ktmp1, rRegP scratch, rFlagsReg cr) %{
+instruct vcastFtoI_reg_evex(vec dst, vec src, vec xtmp1, vec xtmp2, kReg ktmp1, kReg ktmp2, rRegP scratch, rFlagsReg cr) %{
   predicate((VM_Version::supports_avx512vl() ||
              Matcher::vector_length_in_bytes(n) == 64) &&
              Matcher::vector_element_basic_type(n) == T_INT);
   match(Set dst (VectorCastF2X src));
-  effect(TEMP dst, TEMP xtmp1, TEMP xtmp2, TEMP ktmp1, TEMP scratch, KILL cr);
-  format %{ "vector_cast_f2i $dst,$src\t! using $xtmp1, $xtmp2 and $ktmp1 as TEMP" %}
+  effect(TEMP dst, TEMP xtmp1, TEMP xtmp2, TEMP ktmp1, TEMP ktmp2, TEMP scratch, KILL cr);
+  format %{ "vector_cast_f2i $dst,$src\t! using $xtmp1, $xtmp2, $ktmp1 and $ktmp2 as TEMP" %}
   ins_encode %{
     int vlen_enc = vector_length_encoding(this);
     __ vector_castF2I_evex($dst$$XMMRegister, $src$$XMMRegister, $xtmp1$$XMMRegister,
-                           $xtmp2$$XMMRegister, $ktmp1$$KRegister, ExternalAddress(vector_float_signflip()),
-                           ExternalAddress(vector_float_signmask()), $scratch$$Register, vlen_enc);
+                           $xtmp2$$XMMRegister, $ktmp1$$KRegister, $ktmp2$$KRegister,
+                           ExternalAddress(vector_float_signflip()), $scratch$$Register, vlen_enc);
   %}
   ins_pipe( pipe_slow );
 %}
@@ -7218,16 +7216,16 @@ instruct vcastDtoF_reg(vec dst, vec src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vcastDtoL_reg_evex(vec dst, vec src, vec xtmp1, vec xtmp2, kReg ktmp1, rRegP scratch, rFlagsReg cr) %{
+instruct vcastDtoL_reg_evex(vec dst, vec src, vec xtmp1, vec xtmp2, kReg ktmp1, kReg ktmp2, rRegP scratch, rFlagsReg cr) %{
   predicate(Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (VectorCastD2X src));
-  effect(TEMP dst, TEMP xtmp1, TEMP xtmp2, TEMP ktmp1, TEMP scratch, KILL cr);
-  format %{ "vector_cast_d2l $dst,$src\t! using $xtmp1, $xtmp2 and $ktmp1 as TEMP" %}
+  effect(TEMP dst, TEMP xtmp1, TEMP xtmp2, TEMP ktmp1, TEMP ktmp2, TEMP scratch, KILL cr);
+  format %{ "vector_cast_d2l $dst,$src\t! using $xtmp1, $xtmp2, $ktmp1 and $ktmp2 as TEMP" %}
   ins_encode %{
     int vlen_enc = vector_length_encoding(this);
     __ vector_castD2L_evex($dst$$XMMRegister, $src$$XMMRegister, $xtmp1$$XMMRegister,
-                           $xtmp2$$XMMRegister, $ktmp1$$KRegister, ExternalAddress(vector_double_signflip()),
-                           ExternalAddress(vector_double_signmask()), $scratch$$Register, vlen_enc);
+                           $xtmp2$$XMMRegister, $ktmp1$$KRegister, $ktmp2$$KRegister,
+                           ExternalAddress(vector_double_signflip()), $scratch$$Register, vlen_enc);
   %}
   ins_pipe( pipe_slow );
 %}


### PR DESCRIPTION
- JDK-8275317 extended auto-vectorizer to infer Vector Cast operations if source and destination primitive type have same size.
- This patch adds the backend support for vector CastF2I and CaseD2L on X86 AVX512 and legacy targets.

Following are the performance measurements of an existing JMH benchmark (test/micro/org/openjdk/bench/vm/compiler/TypeVectorOperations.java)

System Configuration :  Intel(R) Xeon(R) Platinum 8380 CPU @ 2.30GHz (40C 2S Icelake Server)

BENCHMARK | SIZE | BASELINE (AVX3) ns/op | WithOpt (AVX3) ns/op | Gain AVX3(baseline/opt) | BASELINE (AVX2) ns/op | WithOpt (AVX2) ns/op | Gain AVX2 (baseline/opt)
-- | -- | -- | -- | -- | -- | -- | --
TypeVectorOperations.TypeVectorOperationsSuperWord.convert_d2l | 512.00 | 256.26 | 77.50 | 3.31 | 275.49 | 275.65 | 1.00
TypeVectorOperations.TypeVectorOperationsSuperWord.convert_d2l | 1024.00 | 501.87 | 150.35 | 3.34 | 540.47 | 541.22 | 1.00
TypeVectorOperations.TypeVectorOperationsSuperWord.convert_d2l | 2048.00 | 993.05 | 293.23 | 3.39 | 1070.56 | 1070.14 | 1.00
TypeVectorOperations.TypeVectorOperationsSuperWord.convert_f2i | 512.00 | 227.83 | 39.36 | 5.79 | 248.25 | 45.01 | 5.52
TypeVectorOperations.TypeVectorOperationsSuperWord.convert_f2i | 1024.00 | 449.70 | 77.88 | 5.77 | 487.33 | 86.15 | 5.66
TypeVectorOperations.TypeVectorOperationsSuperWord.convert_f2i | 2048.00 | 884.95 | 149.58 | 5.92 | 956.58 | 152.45 | 6.27

Kindly review and share your feedback.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277793](https://bugs.openjdk.java.net/browse/JDK-8277793): Support vector F2I and D2L cast operations for X86


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**) ⚠️ Review applies to 9f784eb9107244857a2bd0e5bcf490e492684ad5
 * [Sandhya Viswanathan](https://openjdk.java.net/census#sviswanathan) (@sviswa7 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6544/head:pull/6544` \
`$ git checkout pull/6544`

Update a local copy of the PR: \
`$ git checkout pull/6544` \
`$ git pull https://git.openjdk.java.net/jdk pull/6544/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6544`

View PR using the GUI difftool: \
`$ git pr show -t 6544`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6544.diff">https://git.openjdk.java.net/jdk/pull/6544.diff</a>

</details>
