### PR TITLE
8277806: 4 tools/jar failures per platform after JDK-8272728

### DIFF
--- a/test/jdk/tools/jar/modularJar/Basic.java
+++ b/test/jdk/tools/jar/modularJar/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1093,9 +1093,6 @@ public class Basic {
     {
 
         List<String> commands = new ArrayList<>();
-        if (!TOOL_VM_OPTIONS.isEmpty()) {
-            commands.addAll(Arrays.asList(TOOL_VM_OPTIONS.split("\\s+", -1)));
-        }
         commands.add("-d");
         commands.add(dest.toString());
         if (dest.toString().contains("bar")) {

--- a/test/jdk/tools/jar/multiRelease/MRTestBase.java
+++ b/test/jdk/tools/jar/multiRelease/MRTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,7 +108,6 @@ public class MRTestBase {
         if (!opts.isEmpty()) {
             commands.addAll(Arrays.asList(opts.split(" +")));
         }
-        commands.addAll(Utils.getForwardVmOptions());
         commands.add("-d");
         commands.add(dest.toString());
         Stream.of(sourceFiles)


### PR DESCRIPTION
HI all,

Attached is a patch for 4 failing MR tests due the issue that was resolved via JDK-8272728

Best
Lance

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277806](https://bugs.openjdk.java.net/browse/JDK-8277806): 4 tools/jar failures per platform after JDK-8272728


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6546/head:pull/6546` \
`$ git checkout pull/6546`

Update a local copy of the PR: \
`$ git checkout pull/6546` \
`$ git pull https://git.openjdk.java.net/jdk pull/6546/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6546`

View PR using the GUI difftool: \
`$ git pr show -t 6546`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6546.diff">https://git.openjdk.java.net/jdk/pull/6546.diff</a>

</details>
