### PR TITLE
8277824: Remove empty RefProcSubPhasesWorkerTimeTracker destructor

### DIFF
--- a/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
@@ -104,9 +104,6 @@ RefProcSubPhasesWorkerTimeTracker::RefProcSubPhasesWorkerTimeTracker(ReferencePr
   RefProcWorkerTimeTracker(phase_times->sub_phase_worker_time_sec(phase), worker_id) {
 }
 
-RefProcSubPhasesWorkerTimeTracker::~RefProcSubPhasesWorkerTimeTracker() {
-}
-
 RefProcPhaseTimeBaseTracker::RefProcPhaseTimeBaseTracker(const char* title,
                                                          ReferenceProcessor::RefProcPhases phase_number,
                                                          ReferenceProcessorPhaseTimes* phase_times) :

--- a/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
@@ -101,7 +101,7 @@ RefProcWorkerTimeTracker::~RefProcWorkerTimeTracker() {
 RefProcSubPhasesWorkerTimeTracker::RefProcSubPhasesWorkerTimeTracker(ReferenceProcessor::RefProcSubPhases phase,
                                                                      ReferenceProcessorPhaseTimes* phase_times,
                                                                      uint worker_id) :
-  RefProcWorkerTimeTracker(phase_times->sub_phase_worker_time_sec(phase), worker_id) {
+  _tracker(phase_times->sub_phase_worker_time_sec(phase), worker_id) {
 }
 
 RefProcPhaseTimeBaseTracker::RefProcPhaseTimeBaseTracker(const char* title,

--- a/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.hpp
@@ -114,7 +114,8 @@ public:
 };
 
 // Updates working time of each worker thread for a given sub phase.
-class RefProcSubPhasesWorkerTimeTracker : public RefProcWorkerTimeTracker {
+class RefProcSubPhasesWorkerTimeTracker : public StackObj {
+  RefProcWorkerTimeTracker _tracker;
 public:
   RefProcSubPhasesWorkerTimeTracker(ReferenceProcessor::RefProcSubPhases phase,
                                     ReferenceProcessorPhaseTimes* phase_times,

--- a/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.hpp
@@ -103,14 +103,14 @@ public:
   void print_all_references(uint base_indent = 0, bool print_total = true) const;
 };
 
-class RefProcWorkerTimeTracker : public CHeapObj<mtGC> {
+class RefProcWorkerTimeTracker : public StackObj {
 protected:
   WorkerDataArray<double>* _worker_time;
   double                   _start_time;
   uint                     _worker_id;
 public:
   RefProcWorkerTimeTracker(WorkerDataArray<double>* worker_time, uint worker_id);
-  virtual ~RefProcWorkerTimeTracker();
+  ~RefProcWorkerTimeTracker();
 };
 
 // Updates working time of each worker thread for a given sub phase.
@@ -119,7 +119,6 @@ public:
   RefProcSubPhasesWorkerTimeTracker(ReferenceProcessor::RefProcSubPhases phase,
                                     ReferenceProcessorPhaseTimes* phase_times,
                                     uint worker_id);
-  ~RefProcSubPhasesWorkerTimeTracker();
 };
 
 class RefProcPhaseTimeBaseTracker : public StackObj {


### PR DESCRIPTION
Simple change removing effectively dead code, and some general cleanup.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277824](https://bugs.openjdk.java.net/browse/JDK-8277824): Remove empty RefProcSubPhasesWorkerTimeTracker destructor


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Contributors
 * Kim Barrett `<kbarrett@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6555/head:pull/6555` \
`$ git checkout pull/6555`

Update a local copy of the PR: \
`$ git checkout pull/6555` \
`$ git pull https://git.openjdk.java.net/jdk pull/6555/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6555`

View PR using the GUI difftool: \
`$ git pr show -t 6555`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6555.diff">https://git.openjdk.java.net/jdk/pull/6555.diff</a>

</details>
