### PR TITLE
6462028: MaskFormatter API documentation refers to getDisplayValue

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/table/TableCellEditor.java
+++ b/src/java.desktop/share/classes/javax/swing/table/TableCellEditor.java
@@ -31,7 +31,8 @@ import javax.swing.*;
 
 /**
  * This interface defines the method any object that would like to be
- * an editor of values for the component <code>JTable</code> that
+ * an editor of values for components such as <code>JListBox</code>,
+ * <code>JComboBox</code>, <code>JTree</code>, or <code>JTable</code>
  * needs to implement.
  *
  * @author Alan Chung

--- a/src/java.desktop/share/classes/javax/swing/table/TableCellEditor.java
+++ b/src/java.desktop/share/classes/javax/swing/table/TableCellEditor.java
@@ -31,8 +31,7 @@ import javax.swing.*;
 
 /**
  * This interface defines the method any object that would like to be
- * an editor of values for components such as <code>JListBox</code>,
- * <code>JComboBox</code>, <code>JTree</code>, or <code>JTable</code>
+ * an editor of values for the component <code>JTable</code> that
  * needs to implement.
  *
  * @author Alan Chung

--- a/src/java.desktop/share/classes/javax/swing/text/MaskFormatter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/MaskFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,13 @@
 
 package javax.swing.text;
 
-import javax.swing.JFormattedTextField;
-import javax.swing.text.DefaultFormatter;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serial;
 import java.text.ParseException;
 import java.util.ArrayList;
+import javax.swing.JFormattedTextField;
+import javax.swing.text.DefaultFormatter;
 
 /**
  * <code>MaskFormatter</code> is used to format and edit strings. The behavior

--- a/src/java.desktop/share/classes/javax/swing/text/MaskFormatter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/MaskFormatter.java
@@ -100,6 +100,7 @@ import javax.swing.*;
  * <pre>
  *   MaskFormatter formatter = new MaskFormatter("###-####");
  *   formatter.setPlaceholderCharacter('_');
+ *   System.out.println(formatter.valueToString("123"));
  * </pre>
  * <p>
  * Would result in the string '123-____'. If

--- a/src/java.desktop/share/classes/javax/swing/text/MaskFormatter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/MaskFormatter.java
@@ -100,7 +100,6 @@ import javax.swing.*;
  * <pre>
  *   MaskFormatter formatter = new MaskFormatter("###-####");
  *   formatter.setPlaceholderCharacter('_');
- *   formatter.getDisplayValue(tf, "123");
  * </pre>
  * <p>
  * Would result in the string '123-____'. If

--- a/src/java.desktop/share/classes/javax/swing/text/MaskFormatter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/MaskFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,13 @@
 
 package javax.swing.text;
 
-import java.io.*;
-import java.text.*;
-import java.util.*;
-import javax.swing.*;
+import javax.swing.JFormattedTextField;
+import javax.swing.text.DefaultFormatter;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serial;
+import java.text.ParseException;
+import java.util.ArrayList;
 
 /**
  * <code>MaskFormatter</code> is used to format and edit strings. The behavior


### PR DESCRIPTION
MaskFormatter API doesn't have getDisplayValue method, hence removed from Documentation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-6462028](https://bugs.openjdk.java.net/browse/JDK-6462028): MaskFormatter API documentation refers to getDisplayValue


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**) ⚠️ Review applies to dbdc7b1b982973f35153029099df0656b67e18fa
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6556/head:pull/6556` \
`$ git checkout pull/6556`

Update a local copy of the PR: \
`$ git checkout pull/6556` \
`$ git pull https://git.openjdk.java.net/jdk pull/6556/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6556`

View PR using the GUI difftool: \
`$ git pr show -t 6556`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6556.diff">https://git.openjdk.java.net/jdk/pull/6556.diff</a>

</details>
