### PR TITLE
8277825: Remove unused ReferenceProcessorPhaseTimes::_sub_phases_total_time_ms

### DIFF
--- a/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
@@ -200,7 +200,6 @@ void ReferenceProcessorPhaseTimes::set_phase_time_ms(ReferenceProcessor::RefProc
 void ReferenceProcessorPhaseTimes::reset() {
   for (int i = 0; i < ReferenceProcessor::RefSubPhaseMax; i++) {
     _sub_phases_worker_time_sec[i]->reset();
-    _sub_phases_total_time_ms[i] = uninitialized();
   }
 
   for (int i = 0; i < ReferenceProcessor::RefPhaseMax; i++) {
@@ -225,17 +224,6 @@ ReferenceProcessorPhaseTimes::~ReferenceProcessorPhaseTimes() {
     delete _sub_phases_worker_time_sec[i];
   }
   delete _soft_weak_final_refs_phase_worker_time_sec;
-}
-
-double ReferenceProcessorPhaseTimes::sub_phase_total_time_ms(ReferenceProcessor::RefProcSubPhases sub_phase) const {
-  ASSERT_SUB_PHASE(sub_phase);
-  return _sub_phases_total_time_ms[sub_phase];
-}
-
-void ReferenceProcessorPhaseTimes::set_sub_phase_total_phase_time_ms(ReferenceProcessor::RefProcSubPhases sub_phase,
-                                                                     double time_ms) {
-  ASSERT_SUB_PHASE(sub_phase);
-  _sub_phases_total_time_ms[sub_phase] = time_ms;
 }
 
 void ReferenceProcessorPhaseTimes::add_ref_cleared(ReferenceType ref_type, size_t count) {

--- a/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.hpp
@@ -41,8 +41,6 @@ class ReferenceProcessorPhaseTimes : public CHeapObj<mtGC> {
 
   // Records per thread time information of each sub phase.
   WorkerDataArray<double>* _sub_phases_worker_time_sec[ReferenceProcessor::RefSubPhaseMax];
-  // Total time of each sub phase.
-  double                   _sub_phases_total_time_ms[ReferenceProcessor::RefSubPhaseMax];
 
   // Records total elapsed time for each phase.
   double                   _phases_time_ms[ReferenceProcessor::RefPhaseMax];
@@ -62,7 +60,6 @@ class ReferenceProcessorPhaseTimes : public CHeapObj<mtGC> {
   GCTimer*                 _gc_timer;
 
   double phase_time_ms(ReferenceProcessor::RefProcPhases phase) const;
-  double sub_phase_total_time_ms(ReferenceProcessor::RefProcSubPhases sub_phase) const;
 
   double total_time_ms() const { return _total_time_ms; }
 
@@ -83,8 +80,6 @@ public:
   WorkerDataArray<double>* soft_weak_final_refs_phase_worker_time_sec() const { return _soft_weak_final_refs_phase_worker_time_sec; }
   WorkerDataArray<double>* sub_phase_worker_time_sec(ReferenceProcessor::RefProcSubPhases phase) const;
   void set_phase_time_ms(ReferenceProcessor::RefProcPhases phase, double par_phase_time_ms);
-
-  void set_sub_phase_total_phase_time_ms(ReferenceProcessor::RefProcSubPhases sub_phase, double ref_proc_time_ms);
 
   void set_total_time_ms(double total_time_ms) { _total_time_ms = total_time_ms; }
 


### PR DESCRIPTION
Simple change of removing effectively dead code.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277825](https://bugs.openjdk.java.net/browse/JDK-8277825): Remove unused ReferenceProcessorPhaseTimes::_sub_phases_total_time_ms


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6557/head:pull/6557` \
`$ git checkout pull/6557`

Update a local copy of the PR: \
`$ git checkout pull/6557` \
`$ git pull https://git.openjdk.java.net/jdk pull/6557/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6557`

View PR using the GUI difftool: \
`$ git pr show -t 6557`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6557.diff">https://git.openjdk.java.net/jdk/pull/6557.diff</a>

</details>
