### PR TITLE
6465404: some problems in CellEditor related API docs

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/table/TableCellEditor.java
+++ b/src/java.desktop/share/classes/javax/swing/table/TableCellEditor.java
@@ -31,8 +31,7 @@ import javax.swing.*;
 
 /**
  * This interface defines the method any object that would like to be
- * an editor of values for components such as <code>JListBox</code>,
- * <code>JComboBox</code>, <code>JTree</code>, or <code>JTable</code>
+ * an editor of values for the component <code>JTable</code> that
  * needs to implement.
  *
  * @author Alan Chung

--- a/src/java.desktop/share/classes/javax/swing/text/MaskFormatter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/MaskFormatter.java
@@ -100,7 +100,6 @@ import javax.swing.*;
  * <pre>
  *   MaskFormatter formatter = new MaskFormatter("###-####");
  *   formatter.setPlaceholderCharacter('_');
- *   formatter.getDisplayValue(tf, "123");
  * </pre>
  * <p>
  * Would result in the string '123-____'. If


### PR DESCRIPTION
JListBox is invalid component. CellTableEditor Interface doesn't support JComboBox and JTree components. Hence its removed from Documentation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-6465404](https://bugs.openjdk.java.net/browse/JDK-6465404): some problems in CellEditor related API docs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6558/head:pull/6558` \
`$ git checkout pull/6558`

Update a local copy of the PR: \
`$ git checkout pull/6558` \
`$ git pull https://git.openjdk.java.net/jdk pull/6558/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6558`

View PR using the GUI difftool: \
`$ git pr show -t 6558`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6558.diff">https://git.openjdk.java.net/jdk/pull/6558.diff</a>

</details>
