### PR TITLE
8277659: [TESTBUG] ThreadOnSpinWaitProducerConsumer hangs

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/ThreadOnSpinWaitProducerConsumer.java
+++ b/test/micro/org/openjdk/bench/java/lang/ThreadOnSpinWaitProducerConsumer.java
@@ -193,6 +193,7 @@ public class ThreadOnSpinWaitProducerConsumer {
             }
         }
         threadConsumer.interrupt();
+        threadConsumer.join();
 
         if (producedDataCount != maxNum) {
             throw new RuntimeException("Produced: " + producedDataCount + ". Expected: " + maxNum);


### PR DESCRIPTION
Fix java/lang/ThreadOnSpinWaitProducerConsumer by waiting for consumer thread to finish before restarting trial method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8277659](https://bugs.openjdk.java.net/browse/JDK-8277659)

### Issue
 * [JDK-8277659](https://bugs.openjdk.java.net/browse/JDK-8277659): Microbenchmark ThreadOnSpinWaitProducerConsumer.java hangs ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6559/head:pull/6559` \
`$ git checkout pull/6559`

Update a local copy of the PR: \
`$ git checkout pull/6559` \
`$ git pull https://git.openjdk.java.net/jdk pull/6559/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6559`

View PR using the GUI difftool: \
`$ git pr show -t 6559`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6559.diff">https://git.openjdk.java.net/jdk/pull/6559.diff</a>

</details>
