### PR TITLE
8277659: [TESTBUG] Microbenchmark ThreadOnSpinWaitProducerConsumer.java hangs

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/ThreadOnSpinWaitProducerConsumer.java
+++ b/test/micro/org/openjdk/bench/java/lang/ThreadOnSpinWaitProducerConsumer.java
@@ -193,6 +193,7 @@ public class ThreadOnSpinWaitProducerConsumer {
             }
         }
         threadConsumer.interrupt();
+        threadConsumer.join();
 
         if (producedDataCount != maxNum) {
             throw new RuntimeException("Produced: " + producedDataCount + ". Expected: " + maxNum);


### PR DESCRIPTION
Fix java/lang/ThreadOnSpinWaitProducerConsumer by waiting for consumer thread to finish before restarting trial method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277659](https://bugs.openjdk.java.net/browse/JDK-8277659): [TESTBUG] Microbenchmark ThreadOnSpinWaitProducerConsumer.java hangs


### Reviewers
 * @eastig (no known github.com user name / role)
 * [Ningsheng Jian](https://openjdk.java.net/census#njian) (@nsjian - Committer)
 * [Nick Gasson](https://openjdk.java.net/census#ngasson) (@nick-arm - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6560/head:pull/6560` \
`$ git checkout pull/6560`

Update a local copy of the PR: \
`$ git checkout pull/6560` \
`$ git pull https://git.openjdk.java.net/jdk pull/6560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6560`

View PR using the GUI difftool: \
`$ git pr show -t 6560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6560.diff">https://git.openjdk.java.net/jdk/pull/6560.diff</a>

</details>
