### PR TITLE
8277843: [Vector API] scalar2vector generates incorrect type info for mask operations if Op_MaskAll is unavailable

### DIFF
--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -837,16 +837,6 @@ bool LibraryCallKit::inline_vector_broadcast_coerced() {
     return false; // not supported
   }
 
-  // Op_MaskAll is required in VectorNode::scalar2vector for mask operations.
-  // So bail out if Op_MaskAll is unavailable.
-  if (is_vector_mask(vbox_klass) && !Matcher::match_rule_supported_vector(Op_MaskAll, num_elem, elem_bt)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: arity=0 op=broadcast vlen=%d etype=%s ismask=1 due to Op_MaskAll is unavailable",
-                    num_elem, type2name(elem_bt));
-    }
-    return false; // not supported
-  }
-
   Node* bits = argument(3); // long
   Node* elem = NULL;
   switch (elem_bt) {

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -837,6 +837,16 @@ bool LibraryCallKit::inline_vector_broadcast_coerced() {
     return false; // not supported
   }
 
+  // Op_MaskAll is required in VectorNode::scalar2vector for mask operations.
+  // So bail out if Op_MaskAll is unavailable.
+  if (is_vector_mask(vbox_klass) && !Matcher::match_rule_supported_vector(Op_MaskAll, num_elem, elem_bt)) {
+    if (C->print_intrinsics()) {
+      tty->print_cr("  ** not supported: arity=0 op=broadcast vlen=%d etype=%s ismask=1 due to Op_MaskAll is unavailable",
+                    num_elem, type2name(elem_bt));
+    }
+    return false; // not supported
+  }
+
   Node* bits = argument(3); // long
   Node* elem = NULL;
   switch (elem_bt) {

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -596,14 +596,13 @@ VectorNode* VectorNode::make(int opc, Node* n1, Node* n2, Node* n3, uint vlen, B
 // Scalar promotion
 VectorNode* VectorNode::scalar2vector(Node* s, uint vlen, const Type* opd_t, bool is_mask) {
   BasicType bt = opd_t->array_element_basic_type();
-  const TypeVect* vt = opd_t->singleton() ? TypeVect::make(opd_t, vlen, is_mask)
-                                          : TypeVect::make(bt, vlen, is_mask);
-
-  if (is_mask) {
-    guarantee(Matcher::match_rule_supported_vector(Op_MaskAll, vlen, bt), "must be");
+  if (is_mask && Matcher::match_rule_supported_vector(Op_MaskAll, vlen, bt)) {
+    const TypeVect* vt = TypeVect::make(opd_t, vlen, true);
     return new MaskAllNode(s, vt);
   }
 
+  const TypeVect* vt = opd_t->singleton() ? TypeVect::make(opd_t, vlen)
+                                          : TypeVect::make(bt, vlen);
   switch (bt) {
   case T_BOOLEAN:
   case T_BYTE:

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -599,7 +599,8 @@ VectorNode* VectorNode::scalar2vector(Node* s, uint vlen, const Type* opd_t, boo
   const TypeVect* vt = opd_t->singleton() ? TypeVect::make(opd_t, vlen, is_mask)
                                           : TypeVect::make(bt, vlen, is_mask);
 
-  if (is_mask && Matcher::match_rule_supported_vector(Op_MaskAll, vlen, bt)) {
+  if (is_mask) {
+    guarantee(Matcher::match_rule_supported_vector(Op_MaskAll, vlen, bt), "must be");
     return new MaskAllNode(s, vt);
   }
 


### PR DESCRIPTION
Hi all,

This bug was first observed on x86_32/AVX512.
It caused 62 vector api test failures.
```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR
>> jtreg:test/jdk/jdk/incubator/vector                  74    12    62     0 <<
==============================
```

You can easily reproduce this bug on an AVX512 machine with x86_32.
Or you can also reproduce it on an AVX512 machine with x86_64 if you disable `Op_MaskAll` like this.
```
diff --git a/src/hotspot/cpu/x86/x86.ad b/src/hotspot/cpu/x86/x86.ad
index 3f6d5a44b0d..d5a751b310d 100644
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1819,6 +1819,7 @@ const bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType
       }
       break;
     case Op_MaskAll:
+      return false;
       if (!is_LP64 || !VM_Version::supports_evex()) {
         return false;
       }
```

The failure reason is that `VectorNode::scalar2vector` generate incorrect IR for mask operations if `Op_MaskAll` is unavailable.
So it shouldn't be used for mask operations if `Op_MaskAll` is unavailable.

Testing (with two more bug fixes https://github.com/openjdk/jdk/pull/6535 and https://github.com/openjdk/jdk/pull/6533):
 - vector api tests on {x86_64, x86_32}/{AVX512, AVX256}, all passed
 - vector api tests on aarch64, all passed

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277843](https://bugs.openjdk.java.net/browse/JDK-8277843): [Vector API] scalar2vector generates incorrect type info for mask operations if Op_MaskAll is unavailable


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * jbhateja - Committer ⚠️ Added manually

### Contributors
 * Jatin Bhateja `<jbhateja@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6562/head:pull/6562` \
`$ git checkout pull/6562`

Update a local copy of the PR: \
`$ git checkout pull/6562` \
`$ git pull https://git.openjdk.java.net/jdk pull/6562/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6562`

View PR using the GUI difftool: \
`$ git pr show -t 6562`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6562.diff">https://git.openjdk.java.net/jdk/pull/6562.diff</a>

</details>
