### PR TITLE
8277842: IGV: Add jvms property to know where a node came from

### DIFF
--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -418,6 +418,14 @@ void IdealGraphPrinter::visit_node(Node *n, bool edges, VectorSet* temp_set) {
         break;
     }
 
+    Node_Notes* nn = C->node_notes_at(node->_idx);
+    if (nn != NULL && !nn->is_clear() && nn->jvms() != NULL) {
+      buffer[0] = 0;
+      stringStream ss(buffer, sizeof(buffer) - 1);
+      nn->jvms()->dump_spec(&ss);
+      print_prop("jvms", buffer);
+    }
+
     const jushort flags = node->flags();
     if (flags & Node::Flag_is_Copy) {
       print_prop("is_copy", "true");


### PR DESCRIPTION
When dumping a node with `node->dump()`, it also prints the JVM state which tells us to which bci and inlinee method the node belongs to:
```
 38  StoreI  ===  5  7  37  35  [[ 15 ]]  @java/lang/Class:exact+116 *, name=y, idx=5;  Memory: @java/lang/Class:exact+116 *, name=y, idx=5; !jvms: Test::inlinee @ bci:1 (line 16) Test::test @ bci:4 (line 12)
```
IGV only shows the line and bci information with which it is sometimes hard to tell where exactly the node came from, especially with deep inlining. This patch adds the entire JVM state as a `jvms` property field to IGV: 

![Screenshot from 2021-11-25 15-21-53](https://user-images.githubusercontent.com/17833009/143460385-baf5ee3a-31b0-4693-bfa4-0de91c3c4822.png)

This helps to better analyze a graph.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277842](https://bugs.openjdk.java.net/browse/JDK-8277842): IGV: Add jvms property to know where a node came from


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6563/head:pull/6563` \
`$ git checkout pull/6563`

Update a local copy of the PR: \
`$ git checkout pull/6563` \
`$ git pull https://git.openjdk.java.net/jdk pull/6563/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6563`

View PR using the GUI difftool: \
`$ git pr show -t 6563`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6563.diff">https://git.openjdk.java.net/jdk/pull/6563.diff</a>

</details>
