### PR TITLE
8277847: Support toolGuide tag in class-level documentation

### DIFF
--- a/make/jdk/src/classes/build/tools/taglet/ToolGuide.java
+++ b/make/jdk/src/classes/build/tools/taglet/ToolGuide.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,8 +31,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.lang.model.element.Element;
-import javax.lang.model.element.ModuleElement;
 import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
 
 import com.sun.source.doctree.DocTree;
 import com.sun.source.doctree.UnknownBlockTagTree;
@@ -75,7 +75,7 @@ public class ToolGuide implements Taglet {
      */
     @Override
     public Set<Location> getAllowedLocations() {
-        return EnumSet.of(MODULE, PACKAGE);
+        return EnumSet.of(MODULE, PACKAGE, TYPE);
     }
 
     @Override
@@ -151,6 +151,12 @@ public class ToolGuide implements Taglet {
                 return pe.getEnclosingElement() != null
                         ? "../" + pkgPart
                         : pkgPart;
+            case CLASS:
+                TypeElement te = (TypeElement)elem;
+                return te.getQualifiedName()
+                        .toString()
+                        .replace('.', '/')
+                        .replaceAll("[^/]+", "..");
 
             default:
                 throw new IllegalArgumentException(elem.getKind().toString());


### PR DESCRIPTION
This change adds support for the `@toolGuide` tag in class-level API documentation. 

(A use case is the jwebserver tool, where the com.sun.net.httpserver.SimpleFileServer class provides API points for extension and customization of the underlying server and its components. Linking to the tool's man page in the class-level documentation would be beneficial.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277847](https://bugs.openjdk.java.net/browse/JDK-8277847): Support toolGuide tag in class-level documentation


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6566/head:pull/6566` \
`$ git checkout pull/6566`

Update a local copy of the PR: \
`$ git checkout pull/6566` \
`$ git pull https://git.openjdk.java.net/jdk pull/6566/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6566`

View PR using the GUI difftool: \
`$ git pr show -t 6566`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6566.diff">https://git.openjdk.java.net/jdk/pull/6566.diff</a>

</details>
