### PR TITLE
8277789: G1: G1CardSetConfiguration prefixes num_ and max_ used interchangeably

### DIFF
--- a/src/hotspot/share/gc/g1/g1Arguments.cpp
+++ b/src/hotspot/share/gc/g1/g1Arguments.cpp
@@ -135,8 +135,8 @@ void G1Arguments::initialize_card_set_configuration() {
   uint region_size_log_mb = (uint)MAX2(HeapRegion::LogOfHRGrainBytes - LOG_M, 0);
 
   if (FLAG_IS_DEFAULT(G1RemSetArrayOfCardsEntries)) {
-    uint num_cards_in_inline_ptr = G1CardSetConfiguration::num_cards_in_inline_ptr(HeapRegion::LogOfHRGrainBytes - CardTable::card_shift);
-    FLAG_SET_ERGO(G1RemSetArrayOfCardsEntries, MAX2(num_cards_in_inline_ptr * 2,
+    uint max_cards_in_inline_ptr = G1CardSetConfiguration::max_cards_in_inline_ptr(HeapRegion::LogOfHRGrainBytes - CardTable::card_shift);
+    FLAG_SET_ERGO(G1RemSetArrayOfCardsEntries, MAX2(max_cards_in_inline_ptr * 2,
                                                     G1RemSetArrayOfCardsEntriesBase * (1u << (region_size_log_mb + 1))));
   }
 

--- a/src/hotspot/share/gc/g1/g1CardSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.hpp
@@ -94,7 +94,7 @@ public:
   static uint max_cards_in_inline_ptr(uint bits_per_card);
 
   // Array of Cards configuration
-  // Number of cards in "Array of Cards" set; 0 to disable.
+  // Maximum number of cards in "Array of Cards" set; 0 to disable.
   // Always coarsen to next level if full, so no specific threshold.
   uint max_cards_in_array() const { return _max_cards_in_array; }
 

--- a/src/hotspot/share/gc/g1/g1CardSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.hpp
@@ -50,13 +50,13 @@ class G1CardSetConfiguration {
   // regions covered by this card set.
   uint _inline_ptr_bits_per_card;
 
-  uint _num_cards_in_array;
+  uint _max_cards_in_array;
   uint _num_buckets_in_howl;
   uint _max_cards_in_card_set;
   uint _cards_in_howl_threshold;
-  uint _num_cards_in_howl_bitmap;
+  uint _max_cards_in_howl_bitmap;
   uint _cards_in_howl_bitmap_threshold;
-  uint _log2_num_cards_in_howl_bitmap;
+  uint _log2_max_cards_in_howl_bitmap;
   size_t _bitmap_hash_mask;
   uint _log2_card_regions_per_heap_region;
   uint _log2_cards_per_card_region;
@@ -64,7 +64,7 @@ class G1CardSetConfiguration {
   G1CardSetAllocOptions* _card_set_alloc_options;
 
   G1CardSetConfiguration(uint inline_ptr_bits_per_card,
-                         uint num_cards_in_array,
+                         uint max_cards_in_array,
                          double cards_in_bitmap_threshold_percent,
                          uint num_buckets_in_howl,
                          double cards_in_howl_threshold_percent,
@@ -79,7 +79,7 @@ public:
   G1CardSetConfiguration();
   // Initialize card set configuration from parameters.
   // Testing only.
-  G1CardSetConfiguration(uint num_cards_in_array,
+  G1CardSetConfiguration(uint max_cards_in_array,
                          double cards_in_bitmap_threshold_percent,
                          uint max_buckets_in_howl,
                          double cards_in_howl_threshold_percent,
@@ -90,21 +90,19 @@ public:
 
   // Inline pointer configuration
   uint inline_ptr_bits_per_card() const { return _inline_ptr_bits_per_card; }
-  uint num_cards_in_inline_ptr() const;
-  static uint num_cards_in_inline_ptr(uint bits_per_card);
+  uint max_cards_in_inline_ptr() const;
+  static uint max_cards_in_inline_ptr(uint bits_per_card);
 
   // Array of Cards configuration
-  bool use_cards_in_array() const { return _num_cards_in_array != 0; } // Unused for now
   // Number of cards in "Array of Cards" set; 0 to disable.
   // Always coarsen to next level if full, so no specific threshold.
-  uint num_cards_in_array() const { return _num_cards_in_array; }
+  uint max_cards_in_array() const { return _max_cards_in_array; }
 
   // Bitmap within Howl card set container configuration
-  bool use_cards_in_howl_bitmap() const { return _num_cards_in_howl_bitmap != 0; } // Unused for now
-  uint num_cards_in_howl_bitmap() const { return _num_cards_in_howl_bitmap; }
+  uint max_cards_in_howl_bitmap() const { return _max_cards_in_howl_bitmap; }
   // (Approximate) Number of cards in bitmap to coarsen Howl Bitmap to Howl Full.
   uint cards_in_howl_bitmap_threshold() const { return _cards_in_howl_bitmap_threshold; }
-  uint log2_num_cards_in_howl_bitmap() const {return _log2_num_cards_in_howl_bitmap;}
+  uint log2_max_cards_in_howl_bitmap() const {return _log2_max_cards_in_howl_bitmap;}
 
   // Howl card set container configuration
   uint num_buckets_in_howl() const { return _num_buckets_in_howl; }
@@ -112,7 +110,7 @@ public:
   uint cards_in_howl_threshold() const { return _cards_in_howl_threshold; }
   uint howl_bitmap_offset(uint card_idx) const { return card_idx & _bitmap_hash_mask; }
   // Given a card index, return the bucket in the array of card sets.
-  uint howl_bucket_index(uint card_idx) { return card_idx >> _log2_num_cards_in_howl_bitmap; }
+  uint howl_bucket_index(uint card_idx) { return card_idx >> _log2_max_cards_in_howl_bitmap; }
 
   // Full card configuration
   // Maximum number of cards in a non-full card set for a single region. Card sets

--- a/test/hotspot/gtest/gc/g1/test_g1CardSet.cpp
+++ b/test/hotspot/gtest/gc/g1/test_g1CardSet.cpp
@@ -343,17 +343,17 @@ void G1CardSetTest::cardset_basic_test() {
       ASSERT_TRUE(count == card_set.occupied());
     }
 
-    G1AddCardResult res = card_set.add_card(99, config.num_cards_in_howl_bitmap() - 1);
+    G1AddCardResult res = card_set.add_card(99, config.max_cards_in_howl_bitmap() - 1);
     // Adding above card should have coarsened Bitmap -> Full.
     ASSERT_TRUE(res == Added);
-    ASSERT_TRUE(config.num_cards_in_howl_bitmap() == card_set.occupied());
+    ASSERT_TRUE(config.max_cards_in_howl_bitmap() == card_set.occupied());
 
-    res = card_set.add_card(99, config.num_cards_in_howl_bitmap() - 2);
+    res = card_set.add_card(99, config.max_cards_in_howl_bitmap() - 2);
     ASSERT_TRUE(res == Found);
 
     uint threshold = config.cards_in_howl_threshold();
     uint adjusted_threshold = config.cards_in_howl_bitmap_threshold() * config.num_buckets_in_howl();
-    i = config.num_cards_in_howl_bitmap();
+    i = config.max_cards_in_howl_bitmap();
     count = i;
     for (; i <  threshold; i++) {
       G1AddCardResult res = card_set.add_card(99, i);


### PR DESCRIPTION
Hi all,

Please review this small refactoring to consistently use prefix `max_` for variable names where the variable represents a limit in G1CardSetConfiguration.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277789](https://bugs.openjdk.java.net/browse/JDK-8277789): G1: G1CardSetConfiguration prefixes num_ and max_ used interchangeably


### Reviewers
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**) ⚠️ Review applies to ceb50a6a5262b80ce990fc16303bedbedb46b4d4
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to ceb50a6a5262b80ce990fc16303bedbedb46b4d4


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6567/head:pull/6567` \
`$ git checkout pull/6567`

Update a local copy of the PR: \
`$ git checkout pull/6567` \
`$ git pull https://git.openjdk.java.net/jdk pull/6567/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6567`

View PR using the GUI difftool: \
`$ git pr show -t 6567`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6567.diff">https://git.openjdk.java.net/jdk/pull/6567.diff</a>

</details>
