### PR TITLE
8277854: The upper bound of GCCardSizeInBytes should be limited to 512 for 32-bit platforms

### DIFF
--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -696,7 +696,7 @@
                                                                             \
   product(uint, GCCardSizeInBytes, 512,                                     \
           "Card table entry size (in bytes) for card based collectors")     \
-          range(128, 1024)                                                  \
+          range(128, NOT_LP64(512) LP64_ONLY(1024))                         \
           constraint(GCCardSizeInBytesConstraintFunc,AtParse)
   // end of GC_FLAGS
 


### PR DESCRIPTION
Hi all,

runtime/CommandLine/OptionsValidation/TestOptionsWithRanges.java crashes on linux/x86_32 with `-XX:GCCardSizeInBytes=1024`.

This is because if`-XX:GCCardSizeInBytes=1024` then `BOTConstants::N_words` [1] would be 256.
Then the guarantee [2] always fails due to _bot->offset_array(start_card), which is a u_char value, never equals to 256.

So for 32-bit platforms, the upper bound of `GCCardSizeInBytes` should be limited to 512.

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/gc/shared/blockOffsetTable.cpp#L45
[2] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp#L186

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277854](https://bugs.openjdk.java.net/browse/JDK-8277854): The upper bound of GCCardSizeInBytes should be limited to 512 for 32-bit platforms


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6569/head:pull/6569` \
`$ git checkout pull/6569`

Update a local copy of the PR: \
`$ git checkout pull/6569` \
`$ git pull https://git.openjdk.java.net/jdk pull/6569/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6569`

View PR using the GUI difftool: \
`$ git pr show -t 6569`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6569.diff">https://git.openjdk.java.net/jdk/pull/6569.diff</a>

</details>
