### PR TITLE
8277860: PPC: Remove duplicate info != NULL check

### DIFF
--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -2733,12 +2733,10 @@ void LIR_Assembler::emit_load_klass(LIR_OpLoadKlass* op) {
 
   CodeEmitInfo* info = op->info();
   if (info != NULL) {
-    if (info != NULL) {
-      if (!os::zero_page_read_protected() || !ImplicitNullChecks) {
-        explicit_null_check(obj, info);
-      } else {
-        add_debug_info_for_null_check_here(info);
-      }
+    if (!os::zero_page_read_protected() || !ImplicitNullChecks) {
+      explicit_null_check(obj, info);
+    } else {
+      add_debug_info_for_null_check_here(info);
     }
   }
 


### PR DESCRIPTION
I made a mistake: I should have fixed the duplicated info != NULL check in LIR_Assembler::emit_load_klass() in c1_LIRAssembler_ppc.cpp but forgot until the second I sent the integrate command.

I have no access to PPC hardware, I am sending this blindly, relying only on GHA tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277860](https://bugs.openjdk.java.net/browse/JDK-8277860): PPC: Remove duplicate info != NULL check


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6571/head:pull/6571` \
`$ git checkout pull/6571`

Update a local copy of the PR: \
`$ git checkout pull/6571` \
`$ git pull https://git.openjdk.java.net/jdk pull/6571/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6571`

View PR using the GUI difftool: \
`$ git pr show -t 6571`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6571.diff">https://git.openjdk.java.net/jdk/pull/6571.diff</a>

</details>
