### PR TITLE
8276685: Malformed Javadoc inline tags in JDK source in /jdk/management/jfr/RecordingInfo.java

### DIFF
--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/RecordingInfo.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/RecordingInfo.java
@@ -300,10 +300,10 @@ public final class RecordingInfo {
 
     /**
      * Returns the desired duration, measured in seconds, of the recording
-     * associated with this {@link RecordingInfo}, or {code 0} if no duration
+     * associated with this {@link RecordingInfo}, or {@code 0} if no duration
      * has been set.
      *
-     * @return the desired duration, or {code 0} if no duration has been set
+     * @return the desired duration, or {@code 0} if no duration has been set
      *
      * @see Recording#getDuration()
      */


### PR DESCRIPTION
Hi, 

Could I have review of this Javadoc fix.

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276685](https://bugs.openjdk.java.net/browse/JDK-8276685): Malformed Javadoc inline tags in JDK source in /jdk/management/jfr/RecordingInfo.java


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6573/head:pull/6573` \
`$ git checkout pull/6573`

Update a local copy of the PR: \
`$ git checkout pull/6573` \
`$ git pull https://git.openjdk.java.net/jdk pull/6573/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6573`

View PR using the GUI difftool: \
`$ git pr show -t 6573`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6573.diff">https://git.openjdk.java.net/jdk/pull/6573.diff</a>

</details>
