### PR TITLE
8277866: gc/epsilon/TestMemoryMXBeans.java failed with wrong initial heap size

### DIFF
--- a/test/hotspot/jtreg/gc/epsilon/TestMemoryMXBeans.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestMemoryMXBeans.java
@@ -36,7 +36,7 @@ package gc.epsilon;
  *                   gc.epsilon.TestMemoryMXBeans
  *                   -1 256
  *
- * @run main/othervm -Xmx256m -Xmx256m
+ * @run main/othervm -Xms256m -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   gc.epsilon.TestMemoryMXBeans
  *                   256 256


### PR DESCRIPTION
I would like to fix the bug reported in JDK-8277866.  
There is a typo in test/hotspot/jtreg/gc/epsilon/TestMemoryMXBeans.java as suggested in the issue.  
The second test case is expected to run with -Xms in addition to -Xmx option. However, -Xmx option appears twice in the test.  
This typo causes a failure of the test, and after fixing this typo, the test successfully passed.  
Although ProblemList contains TestMemoryMXBeans.java, this typo should be fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277866](https://bugs.openjdk.java.net/browse/JDK-8277866): gc/epsilon/TestMemoryMXBeans.java failed with wrong initial heap size


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6574/head:pull/6574` \
`$ git checkout pull/6574`

Update a local copy of the PR: \
`$ git checkout pull/6574` \
`$ git pull https://git.openjdk.java.net/jdk pull/6574/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6574`

View PR using the GUI difftool: \
`$ git pr show -t 6574`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6574.diff">https://git.openjdk.java.net/jdk/pull/6574.diff</a>

</details>
