### PR TITLE
8277868: Use Comparable.compare() instead of surrogate code

### DIFF
--- a/src/java.base/share/classes/java/math/BigDecimal.java
+++ b/src/java.base/share/classes/java/math/BigDecimal.java
@@ -4405,7 +4405,7 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
             x = -x;
         if (y < 0)
             y = -y;
-        return (x < y) ? -1 : ((x == y) ? 0 : 1);
+        return Long.compare(x, y);
     }
 
     private static int saturateLong(long s) {

--- a/src/java.base/share/classes/java/net/CookieManager.java
+++ b/src/java.base/share/classes/java/net/CookieManager.java
@@ -447,13 +447,7 @@ public class CookieManager extends CookieHandler
             // Check creation time. Sort older first
             long creation1 = c1.getCreationTime();
             long creation2 = c2.getCreationTime();
-            if (creation1 < creation2) {
-                return -1;
-            }
-            if (creation1 > creation2) {
-                return 1;
-            }
-            return 0;
+            return Long.compare(creation1, creation2);
         }
     }
 }

--- a/src/java.base/share/classes/java/util/Calendar.java
+++ b/src/java.base/share/classes/java/util/Calendar.java
@@ -3417,7 +3417,7 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
 
     private int compareTo(long t) {
         long thisTime = getMillisOf(this);
-        return (thisTime > t) ? 1 : (thisTime == t) ? 0 : -1;
+        return Long.compare(thisTime, t);
     }
 
     private static long getMillisOf(Calendar calendar) {

--- a/src/java.base/share/classes/java/util/Calendar.java
+++ b/src/java.base/share/classes/java/util/Calendar.java
@@ -3416,8 +3416,7 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
     }
 
     private int compareTo(long t) {
-        long thisTime = getMillisOf(this);
-        return Long.compare(thisTime, t);
+        return Long.compare(getMillisOf(this), t);
     }
 
     private static long getMillisOf(Calendar calendar) {

--- a/src/java.base/share/classes/java/util/Date.java
+++ b/src/java.base/share/classes/java/util/Date.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,18 +26,13 @@
 package java.util;
 
 import java.text.DateFormat;
-import java.time.LocalDate;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.ObjectInputStream;
-import java.lang.ref.SoftReference;
 import java.time.Instant;
 import sun.util.calendar.BaseCalendar;
-import sun.util.calendar.CalendarDate;
 import sun.util.calendar.CalendarSystem;
 import sun.util.calendar.CalendarUtils;
-import sun.util.calendar.Era;
-import sun.util.calendar.Gregorian;
 import sun.util.calendar.ZoneInfo;
 
 /**
@@ -975,10 +970,11 @@ public class Date
      * @since   1.2
      * @throws    NullPointerException if {@code anotherDate} is null.
      */
+    @Override
     public int compareTo(Date anotherDate) {
         long thisTime = getMillisOf(this);
         long anotherTime = getMillisOf(anotherDate);
-        return (thisTime<anotherTime ? -1 : (thisTime==anotherTime ? 0 : 1));
+        return Long.compare(thisTime, anotherTime);
     }
 
     /**

--- a/src/java.base/share/classes/java/util/Date.java
+++ b/src/java.base/share/classes/java/util/Date.java
@@ -972,9 +972,7 @@ public class Date
      */
     @Override
     public int compareTo(Date anotherDate) {
-        long thisTime = getMillisOf(this);
-        long anotherTime = getMillisOf(anotherDate);
-        return Long.compare(thisTime, anotherTime);
+        return Long.compare(getMillisOf(this), getMillisOf(anotherDate));
     }
 
     /**

--- a/src/java.base/share/classes/java/util/UUID.java
+++ b/src/java.base/share/classes/java/util/UUID.java
@@ -504,8 +504,8 @@ public final class UUID implements java.io.Serializable, Comparable<UUID> {
      * @param  val
      *         {@code UUID} to which this {@code UUID} is to be compared
      *
-     * @return a negative integer, zero, or a positive integer as this {@code UUID}
-     *         is less than, equal to, or greater than {@code val}.
+     * @return  -1, 0 or 1 as this {@code UUID} is less than, equal to, or
+     *          greater than {@code val}
      *
      */
     @Override

--- a/src/java.base/share/classes/java/util/UUID.java
+++ b/src/java.base/share/classes/java/util/UUID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -514,8 +514,6 @@ public final class UUID implements java.io.Serializable, Comparable<UUID> {
         // can simply be numerically compared as two numbers
         return (this.mostSigBits < val.mostSigBits ? -1 :
                 (this.mostSigBits > val.mostSigBits ? 1 :
-                 (this.leastSigBits < val.leastSigBits ? -1 :
-                  (this.leastSigBits > val.leastSigBits ? 1 :
-                   0))));
+                 Long.compare(this.leastSigBits, val.leastSigBits)));
     }
 }

--- a/src/java.base/share/classes/java/util/UUID.java
+++ b/src/java.base/share/classes/java/util/UUID.java
@@ -512,8 +512,7 @@ public final class UUID implements java.io.Serializable, Comparable<UUID> {
     public int compareTo(UUID val) {
         // The ordering is intentionally set up so that the UUIDs
         // can simply be numerically compared as two numbers
-        return (this.mostSigBits < val.mostSigBits ? -1 :
-                (this.mostSigBits > val.mostSigBits ? 1 :
-                 Long.compare(this.leastSigBits, val.leastSigBits)));
+        int mostSigBits = Long.compare(this.mostSigBits, val.mostSigBits);
+        return mostSigBits != 0 ? mostSigBits : Long.compare(this.leastSigBits, val.leastSigBits);
     }
 }

--- a/src/java.base/share/classes/java/util/UUID.java
+++ b/src/java.base/share/classes/java/util/UUID.java
@@ -504,8 +504,8 @@ public final class UUID implements java.io.Serializable, Comparable<UUID> {
      * @param  val
      *         {@code UUID} to which this {@code UUID} is to be compared
      *
-     * @return  -1, 0 or 1 as this {@code UUID} is less than, equal to, or
-     *          greater than {@code val}
+     * @return a negative integer, zero, or a positive integer as this {@code UUID}
+     *         is less than, equal to, or greater than {@code val}.
      *
      */
     @Override

--- a/src/java.desktop/share/classes/java/awt/font/NumericShaper.java
+++ b/src/java.desktop/share/classes/java/awt/font/NumericShaper.java
@@ -1533,12 +1533,7 @@ public final class NumericShaper implements java.io.Serializable {
         rangeArray = rangeSet.toArray(new Range[rangeSet.size()]);
         if (rangeArray.length > BSEARCH_THRESHOLD) {
             // sort rangeArray for binary search
-            Arrays.sort(rangeArray,
-                        new Comparator<Range>() {
-                            public int compare(Range s1, Range s2) {
-                                return s1.base > s2.base ? 1 : s1.base == s2.base ? 0 : -1;
-                            }
-                        });
+            Arrays.sort(rangeArray, Comparator.comparingInt(s -> s.base));
         }
     }
 

--- a/src/java.desktop/share/classes/java/awt/geom/Line2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Line2D.java
@@ -112,7 +112,7 @@ public abstract class Line2D implements Shape, Cloneable {
          * @since 1.2
          */
         public double getX1() {
-            return x1;
+            return (double) x1;
         }
 
         /**
@@ -120,7 +120,7 @@ public abstract class Line2D implements Shape, Cloneable {
          * @since 1.2
          */
         public double getY1() {
-            return y1;
+            return (double) y1;
         }
 
         /**
@@ -136,7 +136,7 @@ public abstract class Line2D implements Shape, Cloneable {
          * @since 1.2
          */
         public double getX2() {
-            return x2;
+            return (double) x2;
         }
 
         /**
@@ -144,7 +144,7 @@ public abstract class Line2D implements Shape, Cloneable {
          * @since 1.2
          */
         public double getY2() {
-            return y2;
+            return (double) y2;
         }
 
         /**

--- a/src/java.desktop/share/classes/java/awt/geom/Line2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Line2D.java
@@ -112,7 +112,7 @@ public abstract class Line2D implements Shape, Cloneable {
          * @since 1.2
          */
         public double getX1() {
-            return (double) x1;
+            return x1;
         }
 
         /**
@@ -120,7 +120,7 @@ public abstract class Line2D implements Shape, Cloneable {
          * @since 1.2
          */
         public double getY1() {
-            return (double) y1;
+            return y1;
         }
 
         /**
@@ -136,7 +136,7 @@ public abstract class Line2D implements Shape, Cloneable {
          * @since 1.2
          */
         public double getX2() {
-            return (double) x2;
+            return x2;
         }
 
         /**
@@ -144,7 +144,7 @@ public abstract class Line2D implements Shape, Cloneable {
          * @since 1.2
          */
         public double getY2() {
-            return (double) y2;
+            return y2;
         }
 
         /**
@@ -532,7 +532,7 @@ public abstract class Line2D implements Shape, Cloneable {
                 }
             }
         }
-        return (ccw < 0.0) ? -1 : ((ccw > 0.0) ? 1 : 0);
+        return java.lang.Double.compare(ccw, 0.0);
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,16 +27,11 @@ package javax.swing.plaf.basic;
 
 import java.awt.*;
 import java.awt.datatransfer.*;
-import java.awt.dnd.*;
 import java.awt.event.*;
 import java.util.Enumeration;
-import java.util.EventObject;
-import java.util.Hashtable;
-import java.util.TooManyListenersException;
 import javax.swing.*;
 import javax.swing.event.*;
 import javax.swing.plaf.*;
-import javax.swing.text.*;
 import javax.swing.table.*;
 import javax.swing.plaf.basic.DragRecognitionSupport.BeforeDrag;
 import sun.swing.SwingUtilities2;
@@ -251,7 +246,7 @@ public class BasicTableUI extends TableUI
         }
 
         private static int sign(int num) {
-            return (num < 0) ? -1 : ((num == 0) ? 0 : 1);
+            return Integer.compare(num, 0);
         }
 
         /**

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableUI.java
@@ -216,8 +216,8 @@ public class BasicTableUI extends TableUI
                 this.inSelection = true;
 
                 // look at the sign of dx and dy only
-                dx = sign(dx);
-                dy = sign(dy);
+                dx = Integer.signum(dx);
+                dy = Integer.signum(dy);
 
                 // make sure one is zero, but not both
                 assert (dx == 0 || dy == 0) && !(dx == 0 && dy == 0);
@@ -243,10 +243,6 @@ public class BasicTableUI extends TableUI
         private void moveWithinTableRange(JTable table, int dx, int dy) {
             leadRow = clipToRange(leadRow+dy, 0, table.getRowCount());
             leadColumn = clipToRange(leadColumn+dx, 0, table.getColumnCount());
-        }
-
-        private static int sign(int num) {
-            return Integer.compare(num, 0);
         }
 
         /**

--- a/src/java.desktop/share/classes/javax/swing/text/GapContent.java
+++ b/src/java.desktop/share/classes/javax/swing/text/GapContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -504,13 +504,7 @@ public class GapContent extends GapVector implements AbstractDocument.Content, S
      * @return < 0 if o1 < o2, 0 if the same, > 0 if o1 > o2
      */
     final int compare(MarkData o1, MarkData o2) {
-        if (o1.index < o2.index) {
-            return -1;
-        } else if (o1.index > o2.index) {
-            return 1;
-        } else {
-            return 0;
-        }
+      return Integer.compare(o1.index, o2.index);
     }
 
     /**

--- a/src/java.desktop/share/classes/sun/awt/geom/Curve.java
+++ b/src/java.desktop/share/classes/sun/awt/geom/Curve.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -730,13 +730,7 @@ public abstract class Curve {
     }
 
     public static int orderof(double x1, double x2) {
-        if (x1 < x2) {
-            return -1;
-        }
-        if (x1 > x2) {
-            return 1;
-        }
-        return 0;
+      return Double.compare(x1, x2);
     }
 
     public static long signeddiffbits(double y1, double y2) {

--- a/src/java.desktop/share/classes/sun/java2d/Spans.java
+++ b/src/java.desktop/share/classes/sun/java2d/Spans.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -315,19 +315,11 @@ public class Spans {
          * position. The end position is ignored
          * in this ranking.
          */
+        @Override
         public int compareTo(Span otherSpan) {
             float otherStart = otherSpan.getStart();
-            int result;
 
-            if (mStart < otherStart) {
-                result = -1;
-            } else if (mStart > otherStart) {
-                result = 1;
-            } else {
-                result = 0;
-            }
-
-            return result;
+            return Float.compare(mStart, otherStart);
         }
 
         public String toString() {

--- a/src/java.desktop/share/classes/sun/java2d/Spans.java
+++ b/src/java.desktop/share/classes/sun/java2d/Spans.java
@@ -317,9 +317,7 @@ public class Spans {
          */
         @Override
         public int compareTo(Span otherSpan) {
-            float otherStart = otherSpan.getStart();
-
-            return Float.compare(mStart, otherStart);
+            return Float.compare(mStart, otherSpan.getStart());
         }
 
         public String toString() {

--- a/src/java.desktop/share/classes/sun/java2d/loops/GraphicsPrimitiveMgr.java
+++ b/src/java.desktop/share/classes/sun/java2d/loops/GraphicsPrimitiveMgr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,7 +79,7 @@ public final class GraphicsPrimitiveMgr {
             int id1 = o1.getUniqueID();
             int id2 = o2.getUniqueID();
 
-            return (id1 == id2 ? 0 : (id1 < id2 ? -1 : 1));
+            return Integer.compare(id1, id2);
         }
     };
 
@@ -88,7 +88,7 @@ public final class GraphicsPrimitiveMgr {
             int id1 = ((GraphicsPrimitive) o1).getUniqueID();
             int id2 = ((PrimitiveSpec) o2).uniqueID;
 
-            return (id1 == id2 ? 0 : (id1 < id2 ? -1 : 1));
+            return Integer.compare(id1, id2);
         }
     };
 


### PR DESCRIPTION
Instead of something like
```java
long x;
long y;
return (x < y) ? -1 : ((x == y) ? 0 : 1);
```
we can use `return Long.compare(x, y);`

All replacements are done with IDE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277868](https://bugs.openjdk.java.net/browse/JDK-8277868): Use Comparable.compare() instead of surrogate code


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to 6744a5627ed56f2e6dfaf071dd9aa86365457e23
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6575/head:pull/6575` \
`$ git checkout pull/6575`

Update a local copy of the PR: \
`$ git checkout pull/6575` \
`$ git pull https://git.openjdk.java.net/jdk pull/6575/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6575`

View PR using the GUI difftool: \
`$ git pr show -t 6575`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6575.diff">https://git.openjdk.java.net/jdk/pull/6575.diff</a>

</details>
