### PR TITLE
8277865: G1: Change integer division to floating point division

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -770,7 +770,7 @@ public:
   double worker_cost() const override {
     // The work done per region is very small, therefore we choose this magic number to cap the number
     // of threads used when there are few regions.
-    const uint regions_per_thread = 1000;
+    const double regions_per_thread = 1000;
     return _claimer.n_regions() / regions_per_thread;
   }
 


### PR DESCRIPTION
In the class G1PreConcurrentStartTask::NoteStartOfMarkTask the method `worker_cost` returns a cost of type double, unfortunately the return value is calculated using an integer division:

`return _claimer.n_regions() / regions_per_thread;`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277865](https://bugs.openjdk.java.net/browse/JDK-8277865): G1: Change integer division to floating point division


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6577/head:pull/6577` \
`$ git checkout pull/6577`

Update a local copy of the PR: \
`$ git checkout pull/6577` \
`$ git pull https://git.openjdk.java.net/jdk pull/6577/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6577`

View PR using the GUI difftool: \
`$ git pr show -t 6577`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6577.diff">https://git.openjdk.java.net/jdk/pull/6577.diff</a>

</details>
