### PR TITLE
8277328: jdk/jshell/CommandCompletionTest.java failures on Windows

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
@@ -254,7 +254,7 @@ public class JShellTool implements MessageHandler {
             Pattern.compile(OPTION_PRE_PATTERN.pattern() + "(?<dd>-??)(?<flag>-([a-z][a-z\\-]*)?)");
     // match an option flag and a (possibly missing or incomplete) value
     private static final Pattern OPTION_VALUE_PATTERN =
-            Pattern.compile(OPTION_PATTERN.pattern() + "\\s+(?<val>\\S*)");
+            Pattern.compile(OPTION_PATTERN.pattern() + "\\s+(?<val>(\\S|\\\\ )*)");
 
     // Tool id (tid) mapping: the three name spaces
     NameSpace mainNamespace;
@@ -1561,13 +1561,13 @@ public class JShellTool implements MessageHandler {
     private static CompletionProvider fileCompletions(Predicate<Path> accept) {
         return (code, cursor, anchor) -> {
             int lastSlash = code.lastIndexOf('/');
-            String path = code.substring(0, lastSlash + 1);
-            String prefix = lastSlash != (-1) ? code.substring(lastSlash + 1) : code;
+            String path = code.substring(0, lastSlash + 1).replace("\\ ", " ");
+            String prefix = (lastSlash != (-1) ? code.substring(lastSlash + 1) : code).replace("\\ ", " ");
             Path current = toPathResolvingUserHome(path);
             List<Suggestion> result = new ArrayList<>();
             try (Stream<Path> dir = Files.list(current)) {
                 dir.filter(f -> accept.test(f) && f.getFileName().toString().startsWith(prefix))
-                   .map(f -> new ArgSuggestion(f.getFileName() + (Files.isDirectory(f) ? "/" : "")))
+                   .map(f -> new ArgSuggestion(f.getFileName().toString().replace(" ", "\\ ") + (Files.isDirectory(f) ? "/" : "")))
                    .forEach(result::add);
             } catch (IOException ex) {
                 //ignore...


### PR DESCRIPTION
The `CommandCompletionTest.java#testUserHome` test picks an existing file or directory in the user's home directory, and uses it to validate the behavior of completion after '~/'. The test fails if the test picks a directory with space.

This is not solely a problem in the test - JShell does not handle paths with spaces. The proposed solution is to allow spaces in paths to be escaped with '\', and adjust tests accordingly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277328](https://bugs.openjdk.java.net/browse/JDK-8277328): jdk/jshell/CommandCompletionTest.java failures on Windows


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6578/head:pull/6578` \
`$ git checkout pull/6578`

Update a local copy of the PR: \
`$ git checkout pull/6578` \
`$ git pull https://git.openjdk.java.net/jdk pull/6578/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6578`

View PR using the GUI difftool: \
`$ git pr show -t 6578`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6578.diff">https://git.openjdk.java.net/jdk/pull/6578.diff</a>

</details>
