### PR TITLE
8277878: Fix compiler tests after JDK-8275908

### DIFF
--- a/test/hotspot/jtreg/compiler/exceptions/OptimizeImplicitExceptions.java
+++ b/test/hotspot/jtreg/compiler/exceptions/OptimizeImplicitExceptions.java
@@ -32,7 +32,7 @@
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *                   -XX:+UseSerialGC -Xbatch -XX:-UseOnStackReplacement -XX:-TieredCompilation
+ *                   -Xbatch -XX:-UseOnStackReplacement -XX:-TieredCompilation
  *                   -XX:CompileCommand=compileonly,compiler.exceptions.OptimizeImplicitExceptions::throwImplicitException
  *                   compiler.exceptions.OptimizeImplicitExceptions
  */

--- a/test/hotspot/jtreg/compiler/uncommontrap/Decompile.java
+++ b/test/hotspot/jtreg/compiler/uncommontrap/Decompile.java
@@ -32,7 +32,7 @@
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *                   -XX:+UseSerialGC -Xbatch -XX:-UseOnStackReplacement -XX:-TieredCompilation
+ *                   -Xbatch -XX:-UseOnStackReplacement -XX:-TieredCompilation
  *                   -XX:CompileCommand=compileonly,compiler.uncommontrap.Decompile::uncommonTrap
  *                   -XX:CompileCommand=inline,compiler.uncommontrap.Decompile*::foo
  *                   compiler.uncommontrap.Decompile
@@ -54,7 +54,8 @@ public class Decompile {
     private static final int Tier0InvokeNotifyFreq = (int)Math.pow(2, WB.getIntxVMFlag("Tier0InvokeNotifyFreqLog"));
     // VM builds without JVMCI like x86_32 call the bimorphic inlining trap just 'bimorphic'
     // while all the other builds with JVMCI call it 'bimorphic_or_optimized_type_check'.
-    private static final boolean isJVMCISupported = WhiteBox.getWhiteBox().isJVMCISupportedByGC();
+    // Only builds with JVMCI have the "EnableJVMCI" flag.
+    private static final boolean isJVMCISupported = (WB.getBooleanVMFlag("EnableJVMCI") != null);
     private static final String bimorphicTrapName = isJVMCISupported ? "bimorphic_or_optimized_type_check" : "bimorphic";
 
     static class Base {


### PR DESCRIPTION
This is a quick fix for the two compiler tests introduced by JDK-8275908. The test explicitly added SerialGC in the parameter list which leads to a garbage collector conflict, if the tests are run with some other Garbage collector.

It was suggested to fix this by adding a `@requires vm.gc.Serial` tag but this is not necessary because the tests are actually GC-agnostic so I've removed the `-XX:+UseSerialGC` parameter from the test command line instead.

After the fix it was necessary to refine the check for whether the test JVM has JVMCI support built-in. Before the fix, I used  `WhiteBox.getWhiteBox().isJVMCISupportedByGC()` which worked fine if only running with SerialGC. Now that we can run with GCs which don't support JVMCI we have to use the more specific `(WB.getBooleanVMFlag("EnableJVMCI") != null)`.

Please let me know if you want me to push this instantly after it has been reviewed or if you first want to re-run your internal Tier3 tests before pushing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277878](https://bugs.openjdk.java.net/browse/JDK-8277878): Fix compiler tests after JDK-8275908


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6581/head:pull/6581` \
`$ git checkout pull/6581`

Update a local copy of the PR: \
`$ git checkout pull/6581` \
`$ git pull https://git.openjdk.java.net/jdk pull/6581/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6581`

View PR using the GUI difftool: \
`$ git pr show -t 6581`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6581.diff">https://git.openjdk.java.net/jdk/pull/6581.diff</a>

</details>
