### PR TITLE
8277899: Parallel: Simplify PSVirtualSpace::initialize logic

### DIFF
--- a/src/hotspot/share/gc/parallel/objectStartArray.cpp
+++ b/src/hotspot/share/gc/parallel/objectStartArray.cpp
@@ -65,9 +65,7 @@ void ObjectStartArray::initialize(MemRegion reserved_region) {
   MemTracker::record_virtual_memory_type((address)backing_store.base(), mtGC);
 
   // We do not commit any memory initially
-  if (!_virtual_space.initialize(backing_store, 0)) {
-    vm_exit_during_initialization("Could not commit space for ObjectStartArray");
-  }
+  _virtual_space.initialize(backing_store);
 
   _raw_base = (jbyte*)_virtual_space.low_boundary();
 

--- a/src/hotspot/share/gc/parallel/psVirtualspace.cpp
+++ b/src/hotspot/share/gc/parallel/psVirtualspace.cpp
@@ -56,16 +56,10 @@ PSVirtualSpace::PSVirtualSpace():
 }
 
 // Deprecated.
-bool PSVirtualSpace::initialize(ReservedSpace rs,
-                                size_t commit_size) {
+void PSVirtualSpace::initialize(ReservedSpace rs) {
   set_reserved(rs);
   set_committed(reserved_low_addr(), reserved_low_addr());
-
-  // Commit to initial size.
-  assert(commit_size <= rs.size(), "commit_size too big");
-  bool result = commit_size > 0 ? expand_by(commit_size) : true;
   DEBUG_ONLY(verify());
-  return result;
 }
 
 PSVirtualSpace::~PSVirtualSpace() {

--- a/src/hotspot/share/gc/parallel/psVirtualspace.hpp
+++ b/src/hotspot/share/gc/parallel/psVirtualspace.hpp
@@ -73,7 +73,7 @@ class PSVirtualSpace : public CHeapObj<mtGC> {
     _special(false) {
   }
   PSVirtualSpace();
-  bool initialize(ReservedSpace rs, size_t commit_size);
+  void initialize(ReservedSpace rs);
 
   bool contains(void* p)      const;
 


### PR DESCRIPTION
Simple change of baking the static arg into `PSVirtualSpace::initialize`.

Test: hotspot_gc