### PR TITLE
8277904: G1: Remove G1CardSetArray::max_entries

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
@@ -227,7 +227,7 @@ public:
   template <class CardVisitor>
   void iterate(CardVisitor& found);
 
-  size_t max_entries() const { return _size; }
+  size_t num_entries() const { return _num_entries & EntryMask; }
 
   static size_t header_size_in_bytes() { return header_size_in_bytes_internal<G1CardSetArray>(); }
 

--- a/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
@@ -227,9 +227,6 @@ public:
   template <class CardVisitor>
   void iterate(CardVisitor& found);
 
-  size_t num_entries() const { return _num_entries & EntryMask; }
-  size_t max_entries() const { return _size; }
-
   static size_t header_size_in_bytes() { return header_size_in_bytes_internal<G1CardSetArray>(); }
 
   static size_t size_in_bytes(size_t num_cards) {

--- a/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
@@ -227,6 +227,8 @@ public:
   template <class CardVisitor>
   void iterate(CardVisitor& found);
 
+  size_t max_entries() const { return _size; }
+
   static size_t header_size_in_bytes() { return header_size_in_bytes_internal<G1CardSetArray>(); }
 
   static size_t size_in_bytes(size_t num_cards) {


### PR DESCRIPTION
Trivial change of removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277904](https://bugs.openjdk.java.net/browse/JDK-8277904): G1: Remove G1CardSetArray::max_entries


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6587/head:pull/6587` \
`$ git checkout pull/6587`

Update a local copy of the PR: \
`$ git checkout pull/6587` \
`$ git pull https://git.openjdk.java.net/jdk pull/6587/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6587`

View PR using the GUI difftool: \
`$ git pr show -t 6587`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6587.diff">https://git.openjdk.java.net/jdk/pull/6587.diff</a>

</details>
