### PR TITLE
8277928: Fix compilation on macosx-aarch64 after 8276108

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -479,7 +479,7 @@ class Address {
           size = 0b100;
         }
         assert(offset_ok_for_immed(_offset, size),
-               "must be, was: %ld, %d", _offset, size);
+               "must be, was: " INT64_FORMAT ", %d", _offset, size);
         unsigned mask = (1 << size) - 1;
         if (_offset < 0 || _offset & mask) {
           i->f(0b00, 25, 24);


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that uses a wrong format specifier for int64 which makes osx/aarch64 builds fail.
```
[2021-11-29T10:42:32,638Z] .../src/hotspot/cpu/aarch64/assembler_aarch64.hpp:482:41: error: format specifies type 'long' but the argument has type 'int64_t' (aka 'long long') [-Werror,-Wformat]
[2021-11-29T10:42:32,638Z]                "must be, was: %ld, %d", _offset, size);
[2021-11-29T10:42:32,638Z]                               ~~~       ^~~~~~~
[2021-11-29T10:42:32,638Z]                               %lld
[2021-11-29T10:42:32,638Z] .../debug.hpp:65:36: note: expanded from macro 'assert'
```

Instead of the hardcoded `%ld` the change uses `INT64_FORMAT`.

Testing: tier1 running, Gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277928](https://bugs.openjdk.java.net/browse/JDK-8277928): Fix compilation on macosx-aarch64 after 8276108


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6590/head:pull/6590` \
`$ git checkout pull/6590`

Update a local copy of the PR: \
`$ git checkout pull/6590` \
`$ git pull https://git.openjdk.java.net/jdk pull/6590/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6590`

View PR using the GUI difftool: \
`$ git pr show -t 6590`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6590.diff">https://git.openjdk.java.net/jdk/pull/6590.diff</a>

</details>
