### PR TITLE
8277931: Parallel: Remove unused PSVirtualSpace::expand_into

### DIFF
--- a/src/hotspot/share/gc/parallel/psVirtualspace.hpp
+++ b/src/hotspot/share/gc/parallel/psVirtualspace.hpp
@@ -95,7 +95,6 @@ class PSVirtualSpace : public CHeapObj<mtGC> {
   inline  void   set_committed(char* low_addr, char* high_addr);
   virtual bool   expand_by(size_t bytes);
   virtual bool   shrink_by(size_t bytes);
-  virtual size_t expand_into(PSVirtualSpace* space, size_t bytes);
   void           release();
 
 #ifndef PRODUCT


### PR DESCRIPTION
Trivial change of removing dead code.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277931](https://bugs.openjdk.java.net/browse/JDK-8277931): Parallel: Remove unused PSVirtualSpace::expand_into


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6593/head:pull/6593` \
`$ git checkout pull/6593`

Update a local copy of the PR: \
`$ git checkout pull/6593` \
`$ git pull https://git.openjdk.java.net/jdk pull/6593/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6593`

View PR using the GUI difftool: \
`$ git pr show -t 6593`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6593.diff">https://git.openjdk.java.net/jdk/pull/6593.diff</a>

</details>
