### PR TITLE
8277948: AArch64: Print the correct native stack if -XX:+PreserveFramePointer when crash

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -464,9 +464,17 @@ frame frame::sender_for_interpreter_frame(RegisterMap* map) const {
 //------------------------------------------------------------------------------
 // frame::sender_for_compiled_frame
 frame frame::sender_for_compiled_frame(RegisterMap* map) const {
-  // we cannot rely upon the last fp having been saved to the thread
-  // in C2 code but it will have been pushed onto the stack. so we
-  // have to find it relative to the unextended sp
+  // When the sp of a compiled frame is correct, we can get the correct sender sp
+  // by unextended sp + frame size.
+  // For the following two scenarios, the sp of a compiled frame is correct:
+  //  a) This compiled frame is built from the anchor.
+  //  b) This compiled frame is built from a callee frame, and the callee frame can
+  //    calculate its sp correctly.
+  //
+  // For b), if the callee frame is a native code frame (such as leaf call), the sp of
+  // the compiled frame cannot be calculated correctly. There is currently no suitable
+  // solution to solve this problem perfectly. But when PreserveFramePointer is enabled,
+  // we can get the correct sender sp by fp + 2 (that is sender_sp()).
 
   assert(_cb->frame_size() >= 0, "must have non-zero frame size");
   intptr_t* l_sender_sp = (!PreserveFramePointer || _sp_is_trusted) ? unextended_sp() + _cb->frame_size()

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -358,6 +358,7 @@ frame frame::sender_for_entry_frame(RegisterMap* map) const {
   assert(map->include_argument_oops(), "should be set by clear");
   vmassert(jfa->last_Java_pc() != NULL, "not walkable");
   frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), jfa->last_Java_pc());
+  fr.set_from_anchor();
 
   return fr;
 }
@@ -468,7 +469,7 @@ frame frame::sender_for_compiled_frame(RegisterMap* map) const {
   // have to find it relative to the unextended sp
 
   assert(_cb->frame_size() >= 0, "must have non-zero frame size");
-  intptr_t* l_sender_sp = (!PreserveFramePointer || _from_thread) ? unextended_sp() + _cb->frame_size()
+  intptr_t* l_sender_sp = (!PreserveFramePointer || _from_anchor) ? unextended_sp() + _cb->frame_size()
                                                                   : sender_sp();
   intptr_t* unextended_sp = l_sender_sp;
 

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -358,7 +358,7 @@ frame frame::sender_for_entry_frame(RegisterMap* map) const {
   assert(map->include_argument_oops(), "should be set by clear");
   vmassert(jfa->last_Java_pc() != NULL, "not walkable");
   frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), jfa->last_Java_pc());
-  fr.set_from_anchor();
+  fr.set_sp_is_trusted();
 
   return fr;
 }
@@ -469,8 +469,8 @@ frame frame::sender_for_compiled_frame(RegisterMap* map) const {
   // have to find it relative to the unextended sp
 
   assert(_cb->frame_size() >= 0, "must have non-zero frame size");
-  intptr_t* l_sender_sp = (!PreserveFramePointer || _from_anchor) ? unextended_sp() + _cb->frame_size()
-                                                                  : sender_sp();
+  intptr_t* l_sender_sp = (!PreserveFramePointer || _sp_is_trusted) ? unextended_sp() + _cb->frame_size()
+                                                                    : sender_sp();
   intptr_t* unextended_sp = l_sender_sp;
 
   // the return_address is always the word on the stack

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -468,7 +468,8 @@ frame frame::sender_for_compiled_frame(RegisterMap* map) const {
   // have to find it relative to the unextended sp
 
   assert(_cb->frame_size() >= 0, "must have non-zero frame size");
-  intptr_t* l_sender_sp = unextended_sp() + _cb->frame_size();
+  intptr_t* l_sender_sp = (!PreserveFramePointer || _from_thread) ? unextended_sp() + _cb->frame_size()
+                                                                  : sender_sp();
   intptr_t* unextended_sp = l_sender_sp;
 
   // the return_address is always the word on the stack

--- a/src/hotspot/cpu/aarch64/frame_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/aarch64/frame_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.hpp
@@ -124,7 +124,10 @@
   intptr_t*     _unextended_sp;
   void adjust_unextended_sp();
 
-  bool _from_anchor;
+  // true means _sp value is correct and we can use it to get the sender's sp
+  // of the compiled frame, otherwise, _sp value may be invalid and we can use
+  // _fp to get the sender's sp if PreserveFramePointer is enabled.
+  bool _sp_is_trusted;
 
   intptr_t* ptr_at_addr(int offset) const {
     return (intptr_t*) addr_at(offset);
@@ -167,6 +170,6 @@
   // returns the sending frame, without applying any barriers
   frame sender_raw(RegisterMap* map) const;
 
-  void set_from_anchor() { _from_anchor = true; }
+  void set_sp_is_trusted() { _sp_is_trusted = true; }
 
 #endif // CPU_AARCH64_FRAME_AARCH64_HPP

--- a/src/hotspot/cpu/aarch64/frame_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.hpp
@@ -124,7 +124,7 @@
   intptr_t*     _unextended_sp;
   void adjust_unextended_sp();
 
-  bool _from_thread;
+  bool _from_anchor;
 
   intptr_t* ptr_at_addr(int offset) const {
     return (intptr_t*) addr_at(offset);
@@ -167,6 +167,6 @@
   // returns the sending frame, without applying any barriers
   frame sender_raw(RegisterMap* map) const;
 
-  void set_from_thread() { _from_thread = true; }
+  void set_from_anchor() { _from_anchor = true; }
 
 #endif // CPU_AARCH64_FRAME_AARCH64_HPP

--- a/src/hotspot/cpu/aarch64/frame_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.hpp
@@ -124,6 +124,8 @@
   intptr_t*     _unextended_sp;
   void adjust_unextended_sp();
 
+  bool _from_thread;
+
   intptr_t* ptr_at_addr(int offset) const {
     return (intptr_t*) addr_at(offset);
   }
@@ -164,5 +166,7 @@
 
   // returns the sending frame, without applying any barriers
   frame sender_raw(RegisterMap* map) const;
+
+  void set_from_thread() { _from_thread = true; }
 
 #endif // CPU_AARCH64_FRAME_AARCH64_HPP

--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -41,7 +41,7 @@ inline frame::frame() {
   _fp = NULL;
   _cb = NULL;
   _deopt_state = unknown;
-  _from_thread = false;
+  _from_anchor = false;
 }
 
 static int spin;
@@ -65,7 +65,7 @@ inline void frame::init(intptr_t* sp, intptr_t* fp, address pc) {
   } else {
     _deopt_state = not_deoptimized;
   }
-  _from_thread = false;
+  _from_anchor = false;
 }
 
 inline frame::frame(intptr_t* sp, intptr_t* fp, address pc) {
@@ -93,7 +93,7 @@ inline frame::frame(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, address
   } else {
     _deopt_state = not_deoptimized;
   }
-  _from_thread = false;
+  _from_anchor = false;
 }
 
 inline frame::frame(intptr_t* sp, intptr_t* fp) {
@@ -125,7 +125,7 @@ inline frame::frame(intptr_t* sp, intptr_t* fp) {
   } else {
     _deopt_state = not_deoptimized;
   }
-  _from_thread = false;
+  _from_anchor = false;
 }
 
 // Accessors

--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -41,7 +41,7 @@ inline frame::frame() {
   _fp = NULL;
   _cb = NULL;
   _deopt_state = unknown;
-  _from_anchor = false;
+  _sp_is_trusted = false;
 }
 
 static int spin;
@@ -65,7 +65,7 @@ inline void frame::init(intptr_t* sp, intptr_t* fp, address pc) {
   } else {
     _deopt_state = not_deoptimized;
   }
-  _from_anchor = false;
+  _sp_is_trusted = false;
 }
 
 inline frame::frame(intptr_t* sp, intptr_t* fp, address pc) {
@@ -93,7 +93,7 @@ inline frame::frame(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, address
   } else {
     _deopt_state = not_deoptimized;
   }
-  _from_anchor = false;
+  _sp_is_trusted = false;
 }
 
 inline frame::frame(intptr_t* sp, intptr_t* fp) {
@@ -125,7 +125,7 @@ inline frame::frame(intptr_t* sp, intptr_t* fp) {
   } else {
     _deopt_state = not_deoptimized;
   }
-  _from_anchor = false;
+  _sp_is_trusted = false;
 }
 
 // Accessors

--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -41,6 +41,7 @@ inline frame::frame() {
   _fp = NULL;
   _cb = NULL;
   _deopt_state = unknown;
+  _from_thread = false;
 }
 
 static int spin;
@@ -64,6 +65,7 @@ inline void frame::init(intptr_t* sp, intptr_t* fp, address pc) {
   } else {
     _deopt_state = not_deoptimized;
   }
+  _from_thread = false;
 }
 
 inline frame::frame(intptr_t* sp, intptr_t* fp, address pc) {
@@ -91,6 +93,7 @@ inline frame::frame(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, address
   } else {
     _deopt_state = not_deoptimized;
   }
+  _from_thread = false;
 }
 
 inline frame::frame(intptr_t* sp, intptr_t* fp) {
@@ -122,6 +125,7 @@ inline frame::frame(intptr_t* sp, intptr_t* fp) {
   } else {
     _deopt_state = not_deoptimized;
   }
+  _from_thread = false;
 }
 
 // Accessors

--- a/src/hotspot/os_cpu/linux_aarch64/thread_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/thread_linux_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/os_cpu/linux_aarch64/thread_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/thread_linux_aarch64.cpp
@@ -30,7 +30,7 @@
 frame JavaThread::pd_last_frame() {
   assert(has_last_Java_frame(), "must have last_Java_sp() when suspended");
   frame f = frame(_anchor.last_Java_sp(), _anchor.last_Java_fp(), _anchor.last_Java_pc());
-  f.set_from_anchor();
+  f.set_sp_is_trusted();
   return f;
 }
 

--- a/src/hotspot/os_cpu/linux_aarch64/thread_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/thread_linux_aarch64.cpp
@@ -30,7 +30,7 @@
 frame JavaThread::pd_last_frame() {
   assert(has_last_Java_frame(), "must have last_Java_sp() when suspended");
   frame f = frame(_anchor.last_Java_sp(), _anchor.last_Java_fp(), _anchor.last_Java_pc());
-  f.set_from_thread();
+  f.set_from_anchor();
   return f;
 }
 

--- a/src/hotspot/os_cpu/linux_aarch64/thread_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/thread_linux_aarch64.cpp
@@ -29,7 +29,9 @@
 
 frame JavaThread::pd_last_frame() {
   assert(has_last_Java_frame(), "must have last_Java_sp() when suspended");
-  return frame(_anchor.last_Java_sp(), _anchor.last_Java_fp(), _anchor.last_Java_pc());
+  frame f = frame(_anchor.last_Java_sp(), _anchor.last_Java_fp(), _anchor.last_Java_pc());
+  f.set_from_thread();
+  return f;
 }
 
 // For Forte Analyzer AsyncGetCallTrace profiling support - thread is


### PR DESCRIPTION
Hi,

I found that the native stack frames in the hs log are not accurate sometimes on AArch64, not sure if this is a known issue or an issue worth fixing.

The following steps can quick reproduce the problem:

1. apply the diff(comment the dtrace_object_alloc call in interpreter and make a crash on SharedRuntime::dtrace_object_alloc)
```
  index 39e99bdd5ed..4fc768e94aa 100644
  --- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
  +++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
  @@ -3558,6 +3558,7 @@ void TemplateTable::_new() {
       __ store_klass_gap(r0, zr);  // zero klass gap for compressed oops
       __ store_klass(r0, r4);      // store klass last

  +/**
       {
         SkipIfEqual skip(_masm, &DTraceAllocProbes, false);
         // Trigger dtrace event for fastpath
  @@ -3567,6 +3568,7 @@ void TemplateTable::_new() {
         __ pop(atos); // restore the return value

       }
  +*/
       __ b(done);
     }

  diff --git a/src/hotspot/cpu/x86/templateTable_x86.cpp b/src/hotspot/cpu/x86/templateTable_x86.cpp
  index 19530b7c57c..15b0509da4c 100644
  --- a/src/hotspot/cpu/x86/templateTable_x86.cpp
  +++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
  @@ -4033,6 +4033,7 @@ void TemplateTable::_new() {
       Register tmp_store_klass = LP64_ONLY(rscratch1) NOT_LP64(noreg);
       __ store_klass(rax, rcx, tmp_store_klass);  // klass

  +/**
       {
         SkipIfEqual skip_if(_masm, &DTraceAllocProbes, 0);
         // Trigger dtrace event for fastpath
  @@ -4041,6 +4042,7 @@ void TemplateTable::_new() {
              CAST_FROM_FN_PTR(address, static_cast<int (*)(oopDesc*)>(SharedRuntime::dtrace_object_alloc)), rax);
         __ pop(atos);
       }
  +*/

       __ jmp(done);
     }
  diff --git a/src/hotspot/share/runtime/sharedRuntime.cpp b/src/hotspot/share/runtime/sharedRuntime.cpp
  index a5de65ea5ab..60b4bd3bcc8 100644
  --- a/src/hotspot/share/runtime/sharedRuntime.cpp
  +++ b/src/hotspot/share/runtime/sharedRuntime.cpp
  @@ -1002,6 +1002,7 @@ jlong SharedRuntime::get_java_tid(Thread* thread) {
    * 6254741.  Once that is fixed we can remove the dummy return value.
    */
   int SharedRuntime::dtrace_object_alloc(oopDesc* o) {
  +  *(int*)0 = 1;
     return dtrace_object_alloc(Thread::current(), o, o->size());
   }
```

2. `java -XX:+DTraceAllocProbes -Xcomp -XX:-PreserveFramePointer -version`

On x86_64, the native stack in hs log is complete, but on AArch64, the native stack is incorrect.

In the beginning, I thought it might be the influence of PreserveFramePointer. Later, I found that no matter whether PreserveFramePointer is enabled or not, in the hs log of x86_64, the native stack is always correct, and aarch64 is wrong.

After some investigation, I found that this problem is related to the layout of the stack.

On x86_64, whether it is C/C++, interpreter, or JIT, `callee` will always put the `return address` and `fp` of the `caller` at the bottom of the stack.
Hence, `callee` can always get the `caller sp`(aka `sender sp`) by `fp + 2`, and if `caller` is a compiled method, `caller sp` is the key to getting the `caller`'s `caller` since `caller fp` may be invalid.(see frame::sender_for_compiled_frame).

```
push   %rbp
mov    %rsp,%rbp

         _ _ _ _ _ _
        |           |
        |           |               |
        |_ _ _ _ _ _|               |
        |           |               |
 caller |           | <- caller sp  |
 _ _ _  |_ _ _ _ _ _|               | expand
        |           |               |
        | ret addr  |               | direction
 callee |_ _ _ _ _ _|               |
        |           |               V
        | caller fp | <- fp
        |_ _ _ _ _ _|

```

But for AArch64, the C/C++ code doesn't put the `return address` and `fp` of the `caller` at the bottom of the stack.
Hence, we cannot use `fp + 2` to calculate the proper `caller sp`(although it is still implemented this way).

When `caller` is a C1/C2 method A, and `callee` is a C/C++ method B, we cannot get the `caller` of A since we cannot get the proper sp value of it.

```
stp x29, x30, [sp, #-N]!
mov x29, sp

         _ _ _ _ _ _
        |           |
        |           |               |
        |_ _ _ _ _ _|               |
        |           |               |
 caller |           | <- caller sp  |
 _ _ _  |_ _ _ _ _ _|     -         | expand
                          |         |
          . . . . .       |         | direction
         _ _ _ _ _ _      |         |
        |           |     | N       |
        | ret addr  |     |         |
 callee |_ _ _ _ _ _|     |         |
        |           |     -         V
        | caller fp | <- fp
        |_ _ _ _ _ _|

```

I am not very familiar with AArch64 and have no idea how to fix this issue perfectly at current.

Based on my understanding of the implementation, we can get the correct stack trace when PreserveFramePointer is enabled.

Although PreserveFramePointer is disabled by default, I found that some real applications will enable it in the production environment.
Therefore, in my opinion, this fix can help troubleshoot crash issues in applications that enable PreserveFramePointer on AArch64 platform.

This patch changes the logic of l_sender_sp calculation, uses sender_sp() as the value of l_sender_sp when PreserveFramePointer is enabled.

Any input is appreciated.

Thanks,
Denghui

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277948](https://bugs.openjdk.java.net/browse/JDK-8277948): AArch64: Print the correct native stack if -XX:+PreserveFramePointer when crash


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**) ⚠️ Review applies to 3674f719d1876bf5b3869c84fdcda9d8ace9e675
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6597/head:pull/6597` \
`$ git checkout pull/6597`

Update a local copy of the PR: \
`$ git checkout pull/6597` \
`$ git pull https://git.openjdk.java.net/jdk pull/6597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6597`

View PR using the GUI difftool: \
`$ git pr show -t 6597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6597.diff">https://git.openjdk.java.net/jdk/pull/6597.diff</a>

</details>
