### PR TITLE
8275771: JDK source code contains redundant boolean operations in jdk.compiler and langtools

### DIFF
--- a/make/langtools/tools/compileproperties/CompileProperties.java
+++ b/make/langtools/tools/compileproperties/CompileProperties.java
@@ -183,7 +183,8 @@ public class CompileProperties {
                         log.error("cannot close " + filename, e);
                     }
                 }
-                if ( ok && contents != null ) {
+                ok = true;
+                if ( contents != null ) {
                     String tokens[] = (new String(contents)).split("\\s+");
                     if ( tokens.length > 0 ) {
                         ok = parseOptions(tokens);

--- a/make/langtools/tools/compileproperties/CompileProperties.java
+++ b/make/langtools/tools/compileproperties/CompileProperties.java
@@ -183,7 +183,7 @@ public class CompileProperties {
                         log.error("cannot close " + filename, e);
                     }
                 }
-                if ( ok = true && contents != null ) {
+                if ( ok && contents != null ) {
                     String tokens[] = (new String(contents)).split("\\s+");
                     if ( tokens.length > 0 ) {
                         ok = parseOptions(tokens);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -1312,7 +1312,9 @@ public class Resolve {
 
                 @Override
                 public void visitReference(JCMemberReference tree) {
-                    if (tRet.hasTag(VOID)) {
+                    if (sRet.hasTag(VOID)) {
+                        // do nothing
+                    } else if (tRet.hasTag(VOID)) {
                         result = false;
                     } else if (tRet.isPrimitive() != sRet.isPrimitive()) {
                         boolean retValIsPrimitive =
@@ -1332,7 +1334,9 @@ public class Resolve {
 
                 @Override
                 public void visitLambda(JCLambda tree) {
-                    if (tRet.hasTag(VOID)) {
+                    if (sRet.hasTag(VOID)) {
+                        // do nothing
+                    } else if (tRet.hasTag(VOID)) {
                         result = false;
                     } else {
                         List<JCExpression> lambdaResults = lambdaResults(tree);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -1301,7 +1301,7 @@ public class Resolve {
 
                 @Override
                 void skip(JCTree tree) {
-                    result &= false;
+                    result = false;
                 }
 
                 @Override
@@ -1313,9 +1313,9 @@ public class Resolve {
                 @Override
                 public void visitReference(JCMemberReference tree) {
                     if (sRet.hasTag(VOID)) {
-                        result &= true;
+                        result = true;
                     } else if (tRet.hasTag(VOID)) {
-                        result &= false;
+                        result = false;
                     } else if (tRet.isPrimitive() != sRet.isPrimitive()) {
                         boolean retValIsPrimitive =
                                 tree.refPolyKind == PolyKind.STANDALONE &&
@@ -1335,9 +1335,9 @@ public class Resolve {
                 @Override
                 public void visitLambda(JCLambda tree) {
                     if (sRet.hasTag(VOID)) {
-                        result &= true;
+                        result = true;
                     } else if (tRet.hasTag(VOID)) {
-                        result &= false;
+                        result = false;
                     } else {
                         List<JCExpression> lambdaResults = lambdaResults(tree);
                         if (!lambdaResults.isEmpty() && unrelatedFunctionalInterfaces(tRet, sRet)) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -1312,9 +1312,7 @@ public class Resolve {
 
                 @Override
                 public void visitReference(JCMemberReference tree) {
-                    if (sRet.hasTag(VOID)) {
-                        result = true;
-                    } else if (tRet.hasTag(VOID)) {
+                    if (tRet.hasTag(VOID)) {
                         result = false;
                     } else if (tRet.isPrimitive() != sRet.isPrimitive()) {
                         boolean retValIsPrimitive =
@@ -1334,9 +1332,7 @@ public class Resolve {
 
                 @Override
                 public void visitLambda(JCLambda tree) {
-                    if (sRet.hasTag(VOID)) {
-                        result = true;
-                    } else if (tRet.hasTag(VOID)) {
+                    if (tRet.hasTag(VOID)) {
                         result = false;
                     } else {
                         List<JCExpression> lambdaResults = lambdaResults(tree);


### PR DESCRIPTION
Hi,

Please review this PR which is basically rewriting some redundant boolean expressions in the compiler.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275771](https://bugs.openjdk.java.net/browse/JDK-8275771): JDK source code contains redundant boolean operations in jdk.compiler and langtools


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6599/head:pull/6599` \
`$ git checkout pull/6599`

Update a local copy of the PR: \
`$ git checkout pull/6599` \
`$ git pull https://git.openjdk.java.net/jdk pull/6599/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6599`

View PR using the GUI difftool: \
`$ git pr show -t 6599`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6599.diff">https://git.openjdk.java.net/jdk/pull/6599.diff</a>

</details>
