### PR TITLE
8277803: vmTestbase/nsk/jdi/TypeComponent/isSynthetic/issynthetic001 fails with "Synthetic fields not found"

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -149,7 +149,6 @@ vmTestbase/nsk/monitoring/ThreadMXBean/ThreadInfo/Deadlock/JavaDeadlock001/TestD
 
 vmTestbase/nsk/jdi/HiddenClass/events/events001.java                 8257705 generic-all
 vmTestbase/nsk/jdi/ThreadReference/stop/stop001/TestDescription.java 7034630 generic-all
-vmTestbase/nsk/jdi/TypeComponent/isSynthetic/issynthetic001/TestDescription.java 8277803 generic-all
 
 vmTestbase/metaspace/gc/firstGC_10m/TestDescription.java 8208250 generic-all
 vmTestbase/metaspace/gc/firstGC_50m/TestDescription.java 8208250 generic-all

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/isSynthetic/issynthetic001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/isSynthetic/issynthetic001a.java
@@ -27,6 +27,7 @@ package nsk.jdi.TypeComponent.isSynthetic;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
+import java.util.Objects;
 
 
 public class issynthetic001a {
@@ -94,5 +95,10 @@ class ClassToCheck {
         protected Inter ER0,        ER1[]={ER0}, ER2[][]={ER1};
         transient Inter ET0,        ET1[]={ET0}, ET2[][]={ET1};
         volatile  Inter EV0,        EV1[]={EV0}, EV2[][]={EV1};
+
+        {
+          // access enclosing instance so this$0 field is generated
+          Objects.requireNonNull(ClassToCheck.this);
+        }
     }
 }


### PR DESCRIPTION
This change fixes `vmTestbase/nsk/jdi/TypeComponent/isSynthetic/issynthetic001` after [JDK-8271623](https://bugs.openjdk.java.net/browse/JDK-8271623).

[JDK-8271623](https://bugs.openjdk.java.net/browse/JDK-8271623) causes javac to omit a synthetic field from inner classes that do not reference their enclosing instance. The test was specifically checking for the presence of the synthetic field. To fix the test, this change adds an explicit reference to the enclosing instance of an inner class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277803](https://bugs.openjdk.java.net/browse/JDK-8277803): vmTestbase/nsk/jdi/TypeComponent/isSynthetic/issynthetic001 fails with "Synthetic fields not found"


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6601/head:pull/6601` \
`$ git checkout pull/6601`

Update a local copy of the PR: \
`$ git checkout pull/6601` \
`$ git pull https://git.openjdk.java.net/jdk pull/6601/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6601`

View PR using the GUI difftool: \
`$ git pr show -t 6601`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6601.diff">https://git.openjdk.java.net/jdk/pull/6601.diff</a>

</details>
