### PR TITLE
JDK-8276683: Malformed Javadoc inline tags in JDK source in com/sun/tools/javac/util/RawDiagnosticFormatter.java

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/RawDiagnosticFormatter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/RawDiagnosticFormatter.java
@@ -59,8 +59,8 @@ public final class RawDiagnosticFormatter extends AbstractDiagnosticFormatter {
 
     /**
      * Helper class to generate stable positions for AST nodes occurring in diagnostic arguments.
-     * If the AST node appears in the same line number as the main diagnostic, the line is information is omitted.
-     * Otherwise, both line and column information is included, using the format {@code line:col}".
+     * If the AST node appears in the same line number as the main diagnostic, the line information is omitted.
+     * Otherwise, both line and column information is included, using the format {@code line:col}.
      *
      * Note: since subdiagnostics can be created without a diagnostic source, a position helper
      * should always refer to the toplevel diagnostic source.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/RawDiagnosticFormatter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/RawDiagnosticFormatter.java
@@ -60,7 +60,7 @@ public final class RawDiagnosticFormatter extends AbstractDiagnosticFormatter {
     /**
      * Helper class to generate stable positions for AST nodes occurring in diagnostic arguments.
      * If the AST node appears in the same line number as the main diagnostic, the line is information is omitted.
-     * Otherwise both line and column information is included, using the format @{code line:col}".
+     * Otherwise, both line and column information is included, using the format {@code line:col}".
      *
      * Note: since subdiagnostics can be created without a diagnostic source, a position helper
      * should always refer to the toplevel diagnostic source.
@@ -85,7 +85,7 @@ public final class RawDiagnosticFormatter extends AbstractDiagnosticFormatter {
 
     /**
      * Create a formatter based on the supplied options.
-     * @param options
+     * @param options the compiler options
      */
     public RawDiagnosticFormatter(Options options) {
         super(null, new SimpleConfiguration(options,


### PR DESCRIPTION
Please review a trivial patch to fix up some minor issues in doc comments in internal API.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276683](https://bugs.openjdk.java.net/browse/JDK-8276683): Malformed Javadoc inline tags in JDK source in com/sun/tools/javac/util/RawDiagnosticFormatter.java


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to 9af2d503ad2b58b1f76e32287cd253cc2562f97a
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6602/head:pull/6602` \
`$ git checkout pull/6602`

Update a local copy of the PR: \
`$ git checkout pull/6602` \
`$ git pull https://git.openjdk.java.net/jdk pull/6602/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6602`

View PR using the GUI difftool: \
`$ git pr show -t 6602`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6602.diff">https://git.openjdk.java.net/jdk/pull/6602.diff</a>

</details>
