### PR TITLE
8277965: Enclosing instance optimization affects serialization

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -2279,28 +2279,11 @@ public class Lower extends TreeTranslator {
         // Enclosing instance field is used
         return true;
       }
-      if (rs.isSerializable(sym.type) && !hasSerialVersionUID(sym)) {
-        // Class is serializable and does not have a stable serialVersionUID
+      if (rs.isSerializable(sym.type)) {
+        // Class is serializable
         return true;
       }
       return false;
-    }
-
-    private boolean hasSerialVersionUID(ClassSymbol sym) {
-      VarSymbol svuid = (VarSymbol) sym.members().findFirst(names.serialVersionUID, f -> f.kind == VAR);
-      if (svuid == null) {
-        return false;
-      }
-      if ((svuid.flags() & (STATIC | FINAL)) != (STATIC | FINAL)) {
-        return false;
-      }
-      if (!svuid.type.hasTag(LONG)) {
-        return false;
-      }
-      if (svuid.getConstValue() == null) {
-        return false;
-      }
-      return true;
     }
 
     List<JCTree> generateMandatedAccessors(JCClassDecl tree) {

--- a/test/langtools/tools/javac/optimizeOuterThis/OptimizeOuterThis.java
+++ b/test/langtools/tools/javac/optimizeOuterThis/OptimizeOuterThis.java
@@ -64,7 +64,7 @@ public class OptimizeOuterThis extends InnerClasses {
         checkInner(N0.N1.N2.N3.N4.N5.class, false);
 
         checkInner(SerializableCapture.class, true);
-        checkInner(SerializableWithSerialVersionUID.class, false);
+        checkInner(SerializableWithSerialVersionUID.class, true);
         checkInner(SerializableWithInvalidSerialVersionUIDType.class, true);
         checkInner(SerializableWithInvalidSerialVersionUIDNonFinal.class, true);
         checkInner(SerializableWithInvalidSerialVersionUIDNonStatic.class, true);


### PR DESCRIPTION
This change disables the optimization introduced in [JDK-8271623](https://bugs.openjdk.java.net/browse/JDK-8277965) for all serializable classes, to avoid potential serialization compatibility issues.

As discussed in [JDK-8277965](https://bugs.openjdk.java.net/browse/JDK-8277965) the serialization spec notes that serializing inner classes is 'strongly discouraged' and that the 'synthetic fields generated by javac ... to implement inner classes are implementation dependent and may vary between compilers', which may allow the new behaviour.

This change is intended as an expedient way to restore the previous behaviour and provide more time to discuss the compatibility impact of this part of the change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8277965](https://bugs.openjdk.java.net/browse/JDK-8277965): Enclosing instance optimization affects serialization
 * [JDK-8278042](https://bugs.openjdk.java.net/browse/JDK-8278042): Enclosing instance optimization affects serialization (**CSR**) ⚠️ Issue is not open.


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6604/head:pull/6604` \
`$ git checkout pull/6604`

Update a local copy of the PR: \
`$ git checkout pull/6604` \
`$ git pull https://git.openjdk.java.net/jdk pull/6604/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6604`

View PR using the GUI difftool: \
`$ git pr show -t 6604`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6604.diff">https://git.openjdk.java.net/jdk/pull/6604.diff</a>

</details>
