### PR TITLE
6465404: some problems in CellEditor related API docs

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/table/TableCellEditor.java
+++ b/src/java.desktop/share/classes/javax/swing/table/TableCellEditor.java
@@ -30,8 +30,8 @@ import javax.swing.CellEditor;
 import javax.swing.JTable;
 
 /**
- * This interface defines the method any object that would like to be
- * an editor of values for the {@code JTable} component needs to implement.
+ * This interface must be implemented to provide an editor of cell values
+ * for a {@code JTable}.
  *
  * @author Alan Chung
  */

--- a/src/java.desktop/share/classes/javax/swing/table/TableCellEditor.java
+++ b/src/java.desktop/share/classes/javax/swing/table/TableCellEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/table/TableCellEditor.java
+++ b/src/java.desktop/share/classes/javax/swing/table/TableCellEditor.java
@@ -31,8 +31,7 @@ import javax.swing.*;
 
 /**
  * This interface defines the method any object that would like to be
- * an editor of values for the component <code>JTable</code> that
- * needs to implement.
+ * an editor of values for the {@code JTable} component needs to implement.
  *
  * @author Alan Chung
  */

--- a/src/java.desktop/share/classes/javax/swing/table/TableCellEditor.java
+++ b/src/java.desktop/share/classes/javax/swing/table/TableCellEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 1999, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/table/TableCellEditor.java
+++ b/src/java.desktop/share/classes/javax/swing/table/TableCellEditor.java
@@ -31,8 +31,7 @@ import javax.swing.*;
 
 /**
  * This interface defines the method any object that would like to be
- * an editor of values for components such as <code>JListBox</code>,
- * <code>JComboBox</code>, <code>JTree</code>, or <code>JTable</code>
+ * an editor of values for the component <code>JTable</code> that
  * needs to implement.
  *
  * @author Alan Chung

--- a/src/java.desktop/share/classes/javax/swing/table/TableCellEditor.java
+++ b/src/java.desktop/share/classes/javax/swing/table/TableCellEditor.java
@@ -27,7 +27,7 @@ package javax.swing.table;
 
 import java.awt.Component;
 import javax.swing.CellEditor;
-import javax.swing.*;
+import javax.swing.JTable;
 
 /**
  * This interface defines the method any object that would like to be


### PR DESCRIPTION
JListBox is invalid component. CellTableEditor Interface doesn't support JComboBox and JTree components. Hence its removed from Documentation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-6465404](https://bugs.openjdk.java.net/browse/JDK-6465404): some problems in CellEditor related API docs
 * [JDK-8279421](https://bugs.openjdk.java.net/browse/JDK-8279421): some problems in CellEditor related API docs (**CSR**)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**) ⚠️ Review applies to fb13cfdab49cd828811f6a06b630bffdb02735bf
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6608/head:pull/6608` \
`$ git checkout pull/6608`

Update a local copy of the PR: \
`$ git checkout pull/6608` \
`$ git pull https://git.openjdk.java.net/jdk pull/6608/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6608`

View PR using the GUI difftool: \
`$ git pr show -t 6608`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6608.diff">https://git.openjdk.java.net/jdk/pull/6608.diff</a>

</details>
