### PR TITLE
8277977: Incorrect references to --enable-reproducible-builds in docs

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -891,7 +891,7 @@ spawn failed</code></pre>
 <ul>
 <li>Turn on build system support for reproducible builds</li>
 </ul>
-<p>Add the flag <code>--enable-reproducible-builds</code> to your <code>configure</code> command line. This will turn on support for reproducible builds where it could otherwise be lacking.</p>
+<p>Add the flag <code>--enable-reproducible-build</code> to your <code>configure</code> command line. This will turn on support for reproducible builds where it could otherwise be lacking.</p>
 <ul>
 <li>Do not rely on <code>configure</code>'s default adhoc version strings</li>
 </ul>

--- a/doc/building.md
+++ b/doc/building.md
@@ -1518,7 +1518,7 @@ non-determinism and make a larger part of the build reproducible:
 
   * Turn on build system support for reproducible builds
 
-Add the flag `--enable-reproducible-builds` to your `configure` command line.
+Add the flag `--enable-reproducible-build` to your `configure` command line.
 This will turn on support for reproducible builds where it could otherwise be
 lacking.
 

--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -702,7 +702,7 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_REPRODUCIBLE_BUILD],
   if test "x$OPENJDK_BUILD_OS" = xwindows && \
       test "x$ALLOW_ABSOLUTE_PATHS_IN_OUTPUT" = xfalse && \
       test "x$ENABLE_REPRODUCIBLE_BUILD" = xfalse; then
-    AC_MSG_NOTICE([On Windows it is not possible to combine  --disable-reproducible-builds])
+    AC_MSG_NOTICE([On Windows it is not possible to combine  --disable-reproducible-build])
     AC_MSG_NOTICE([with --disable-absolute-paths-in-output.])
     AC_MSG_ERROR([Cannot continue])
   fi


### PR DESCRIPTION
Corrects spelling mistakes in the documentation and one configure script message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277977](https://bugs.openjdk.java.net/browse/JDK-8277977): Incorrect references to --enable-reproducible-builds in docs


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6609/head:pull/6609` \
`$ git checkout pull/6609`

Update a local copy of the PR: \
`$ git checkout pull/6609` \
`$ git pull https://git.openjdk.java.net/jdk pull/6609/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6609`

View PR using the GUI difftool: \
`$ git pr show -t 6609`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6609.diff">https://git.openjdk.java.net/jdk/pull/6609.diff</a>

</details>
