### PR TITLE
8264485: build.tools.depend.Depend.toString(byte[]) creates malformed hex strings

### DIFF
--- a/make/jdk/src/classes/build/tools/depend/Depend.java
+++ b/make/jdk/src/classes/build/tools/depend/Depend.java
@@ -37,6 +37,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -156,13 +157,7 @@ public class Depend implements Plugin {
     }
 
     private String toString(byte[] digest) {
-        StringBuilder result = new StringBuilder();
-
-        for (byte b : digest) {
-            result.append(String.format("%X", b));
-        }
-
-        return result.toString();
+        return HexFormat.of().withUpperCase().formatHex(digest);
     }
 
     private static final class APIVisitor implements ElementVisitor<Void, Void>,


### PR DESCRIPTION
make/jdk/src/classes/build/tools/depend/Depend.java method toString(byte[]) constructs hex string out of the given byte array.
Actual implementation is using custom conversion code, which does not pad byte values <16 with leading zero.
Resulting hex string is invalid and for example sequence of bytes 1 and 0 generates the same hex string as a single byte 16.

Proposed patch is delegating hex conversion to java.util.HexFormat instead.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264485](https://bugs.openjdk.java.net/browse/JDK-8264485): build.tools.depend.Depend.toString(byte[]) creates malformed hex strings


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6610/head:pull/6610` \
`$ git checkout pull/6610`

Update a local copy of the PR: \
`$ git checkout pull/6610` \
`$ git pull https://git.openjdk.java.net/jdk pull/6610/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6610`

View PR using the GUI difftool: \
`$ git pr show -t 6610`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6610.diff">https://git.openjdk.java.net/jdk/pull/6610.diff</a>

</details>
