### PR TITLE
8277194: applications/runthese/RunThese30M.java crashes with jfrSymbolTable.cpp:305 assert(_instance != null)

### DIFF
--- a/src/hotspot/share/jfr/periodic/jfrFinalizerStatisticsEvent.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrFinalizerStatisticsEvent.cpp
@@ -57,6 +57,9 @@ static void send_event(const FinalizerEntry* fe, const InstanceKlass* ik, const 
 }
 
 void JfrFinalizerStatisticsEvent::send_unload_event(const InstanceKlass* ik) {
+  if (!EventFinalizerStatistics::is_enabled()) {
+    return;
+  }
   Thread* const thread = Thread::current();
   ResourceMark rm(thread);
   send_event(FinalizerService::lookup(ik, thread), ik, JfrTicks::now(), thread);


### PR DESCRIPTION
Greetings,

please help review this change set to add a missing enabled check for the event EventFinalizerStatistics, lack of which is causing problems when code not running a JFR recording is accessing uninitialized data as part of class unloading.

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277194](https://bugs.openjdk.java.net/browse/JDK-8277194): applications/runthese/RunThese30M.java crashes with jfrSymbolTable.cpp:305 assert(_instance != null)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6611/head:pull/6611` \
`$ git checkout pull/6611`

Update a local copy of the PR: \
`$ git checkout pull/6611` \
`$ git pull https://git.openjdk.java.net/jdk pull/6611/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6611`

View PR using the GUI difftool: \
`$ git pr show -t 6611`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6611.diff">https://git.openjdk.java.net/jdk/pull/6611.diff</a>

</details>
