### PR TITLE
8277981: String Deduplication table is never cleaned up due to bad dead_factor_for_cleanup

### DIFF
--- a/src/hotspot/share/gc/shared/stringdedup/stringDedupConfig.cpp
+++ b/src/hotspot/share/gc/shared/stringdedup/stringDedupConfig.cpp
@@ -161,6 +161,6 @@ void StringDedup::Config::initialize() {
   _load_factor_for_shrink = StringDeduplicationShrinkTableLoad;
   _load_factor_target = StringDeduplicationTargetTableLoad;
   _minimum_dead_for_cleanup = StringDeduplicationCleanupDeadMinimum;
-  _dead_factor_for_cleanup = percent_of(StringDeduplicationCleanupDeadPercent, 100);
+  _dead_factor_for_cleanup = StringDeduplicationCleanupDeadPercent / 100.0;
   _hash_seed = initial_hash_seed();
 }


### PR DESCRIPTION
See the reproducer and analysis in the bug. 

The root cause for this problem is that `percent_of` returns `0..100` (percent) value of `nominator / denominator`. Which means if we feed `percent` and `100` there, this is an identity operation, returning the same value. And we wanted the conversion from percent to factor instead.

The default value for `StringDeduplicationCleanupDeadPercent` is `5`, which means (assuming `dead_count <= entry_count`) this erroneous conversion makes this condition always `false`:

```
bool StringDedup::Config::should_cleanup_table(size_t entry_count, size_t dead_count) {
  return (dead_count > _minimum_dead_for_cleanup) &&
         (dead_count > (entry_count * _dead_factor_for_cleanup));
}
```

Additional testing:
 - [x] Reproducer stress test does not leak anymore
 - [x] Linux x86_64 fastdebug tier1, `-XX:+UseStringDeduplication`
 - [x] Linux x86_64 fastdebug tier2, `-XX:+UseStringDeduplication`
 - [x] Linux x86_64 fastdebug tier3, `-XX:+UseStringDeduplication`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277981](https://bugs.openjdk.java.net/browse/JDK-8277981): String Deduplication table is never cleaned up due to bad dead_factor_for_cleanup


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6613/head:pull/6613` \
`$ git checkout pull/6613`

Update a local copy of the PR: \
`$ git checkout pull/6613` \
`$ git pull https://git.openjdk.java.net/jdk pull/6613/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6613`

View PR using the GUI difftool: \
`$ git pr show -t 6613`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6613.diff">https://git.openjdk.java.net/jdk/pull/6613.diff</a>

</details>
