### PR TITLE
JDK-8277496 Remove duplication in c1 Block successor lists

### DIFF
--- a/src/hotspot/share/c1/c1_CFGPrinter.cpp
+++ b/src/hotspot/share/c1/c1_CFGPrinter.cpp
@@ -231,9 +231,7 @@ void CFGPrinterOutput::print_LIR(BlockBegin* block) {
 
 void CFGPrinterOutput::print_block(BlockBegin* block) {
   print_begin("block");
-
   print("name \"B%d\"", block->block_id());
-
   print("from_bci %d", block->bci());
   print("to_bci %d", (block->end() == NULL ? -1 : block->end()->printable_bci()));
 
@@ -246,9 +244,13 @@ void CFGPrinterOutput::print_block(BlockBegin* block) {
   output()->cr();
 
   output()->indent();
-  output()->print("successors ");
-  for (i = 0; i < block->number_of_sux(); i++) {
-    output()->print("\"B%d\" ", block->sux_at(i)->block_id());
+  if (block->end() != NULL) {
+    output()->print("successors ");
+    for (i = 0; i < block->number_of_sux(); i++) {
+      output()->print("\"B%d\" ", block->sux_at(i)->block_id());
+    }
+  } else {
+    output()->print("(block has no end, cannot print successors)");
   }
   output()->cr();
 

--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -152,26 +152,6 @@ void Compilation::build_hir() {
   {
     PhaseTraceTime timeit(_t_hir_parse);
     _hir = new IR(this, method(), osr_bci());
-
-    /////////////////
-    // This is to assert that no block reachable from start has _end == NULL
-    BlockList processed;
-    BlockList to_go;
-    to_go.append(_hir->start());
-    while(to_go.length() > 0) {
-      BlockBegin* current = to_go.pop();
-      assert(current != NULL, "dont expect null");
-      assert(current->end() != NULL, "an end is NULL...");
-      processed.append(current);
-      for(int i = 0; i < current->number_of_sux(); i++) {
-        BlockBegin* s = current->sux_at(i);
-        if (!processed.contains(s)) {
-          to_go.append(s);
-        }
-      }
-    }
-    // Interesting, this passes...
-    //////////////
   }
   if (log)  log->done("parse");
   if (!_hir->is_valid()) {
@@ -214,21 +194,6 @@ void Compilation::build_hir() {
   // compute block ordering for code generation
   // the control flow must not be changed from here on
   _hir->compute_code();
-
-  /////////////////
-  // This is to verify that all the blocks in code have _end != NULL
-  // Are all the blockbegin _end pointers nonnull here?
-  bool all_ends = true;
-  // Unsure if code is the rightone but oh well
-  assert(_hir->code() != NULL, "has code, right? JANIUK");
-  for(int i = 0; i < _hir->code()->length(); i++) {
-    BlockBegin* b = _hir->code()->at(i);
-
-    if (b == NULL) continue;
-    if (b->end() == NULL) all_ends = false;
-  }
-  assert(all_ends, "checking in after compute code");
-  //////////////
 
   if (UseGlobalValueNumbering) {
     // No resource mark here! LoopInvariantCodeMotion can allocate ValueStack objects.

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -109,22 +109,19 @@ class BlockListBuilder {
 int BlockListBuilder::local_block_number_of_successors(BlockBegin* block)
 {
   assert(_bci2block_successors.length() > block->bci(), "sux must exist");
-  assert(block->number_of_sux_from_local() == _bci2block_successors.at(block->bci()).length(), "same answer?");
-  return block->number_of_sux_from_local();
+  return _bci2block_successors.at(block->bci()).length();
 }
 
 BlockBegin* BlockListBuilder::local_block_successor_at(BlockBegin* block, int i)
 {
   assert(_bci2block_successors.length() > block->bci(), "sux must exist");
-  assert(block->sux_at_from_local(i) == _bci2block_successors.at(block->bci()).at(i), "same answer?");
-  return block->sux_at_from_local(i);
+  return _bci2block_successors.at(block->bci()).at(i);
 }
 
 void BlockListBuilder::local_block_add_successor(BlockBegin* block, BlockBegin* sux)
 {
   assert(_bci2block_successors.length() > block->bci(), "sux must exist");
   _bci2block_successors.at(block->bci()).append(sux);
-  block->add_successor_local(sux);
 }
 
 BlockListBuilder::BlockListBuilder(Compilation* compilation, IRScope* scope, int osr_bci)
@@ -230,7 +227,7 @@ void BlockListBuilder::handle_exceptions(BlockBegin* current, int cur_bci) {
       assert(entry->is_set(BlockBegin::exception_entry_flag), "flag must be set");
 
       // add each exception handler only once
-      if (!current->is_successor(entry)) {
+      if(!_bci2block_successors.at(current->bci()).contains(entry)) {
         local_block_add_successor(current, entry);
         entry->increment_total_preds();
       }

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -124,6 +124,8 @@ BlockListBuilder::BlockListBuilder(Compilation* compilation, IRScope* scope, int
   mark_loops();
   NOT_PRODUCT(if (PrintInitialBlockList) print());
 
+  // _bci2block still contains blocks with _end == null and > 0 sux in _bci2block_successors.
+
 #ifndef PRODUCT
   if (PrintCFGToFile) {
     stringStream title;

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -3393,10 +3393,6 @@ GraphBuilder::GraphBuilder(Compilation* compilation, IRScope* scope)
 #ifndef PRODUCT
   if (PrintCompilation && Verbose) tty->print_cr("Created %d Instructions", _instruction_count);
 #endif
-
-  // JANIUK: If we iterate all the blocks in _blocks, some of them have end NULL.
-  // But the ones reachable from start don't, we saw that earlier.
-  // Ah! So a lot of BlockBegins get discarded. The only ones that survive are the ones reachable from start at the end.
 }
 
 

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -117,7 +117,7 @@ BlockBegin* BlockListBuilder::local_block_successor_at(BlockBegin* block, int i)
 
 void BlockListBuilder::local_block_add_successor(BlockBegin* block, BlockBegin* sux)
 {
-  block->add_successor(sux);
+  block->add_successor_local(sux);
 }
 
 BlockListBuilder::BlockListBuilder(Compilation* compilation, IRScope* scope, int osr_bci)
@@ -497,7 +497,7 @@ void BlockListBuilder::print() {
     tty->print(cur->is_set(BlockBegin::subroutine_entry_flag)        ? " sr" : "   ");
     tty->print(cur->is_set(BlockBegin::parser_loop_header_flag)      ? " lh" : "   ");
 
-    if (cur->number_of_sux_from_local() > 0) {
+    if (local_block_number_of_successors(cur) > 0) {
       tty->print("    sux: ");
       for (int j = 0; j < local_block_number_of_successors(cur); j++) {
         BlockBegin* sux = local_block_successor_at(cur, j);

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -93,6 +93,7 @@ class BlockListBuilder {
   int number_of_successors(BlockBegin* block);
   BlockBegin* successor_at(BlockBegin* block, int i);
   void add_successor(BlockBegin* block, BlockBegin* sux);
+  bool is_successor(BlockBegin* block, BlockBegin* sux);
 
  public:
   // creation
@@ -210,7 +211,7 @@ void BlockListBuilder::handle_exceptions(BlockBegin* current, int cur_bci) {
       assert(entry->is_set(BlockBegin::exception_entry_flag), "flag must be set");
 
       // add each exception handler only once
-      if(!_bci2block_successors.at(current->bci()).contains(entry)) {
+      if(!is_successor(current, entry)) {
         add_successor(current, entry);
         entry->increment_total_preds();
       }
@@ -477,6 +478,11 @@ inline void BlockListBuilder::add_successor(BlockBegin* block, BlockBegin* sux)
 {
   assert(_bci2block_successors.length() > block->bci(), "sux must exist");
   _bci2block_successors.at(block->bci()).append(sux);
+}
+
+inline bool BlockListBuilder::is_successor(BlockBegin* block, BlockBegin* sux) {
+  assert(_bci2block_successors.length() > block->bci(), "sux must exist");
+  return _bci2block_successors.at(block->bci()).contains(sux);
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1261,6 +1261,16 @@ void IR::print(bool cfg_only, bool live_only) {
   }
 }
 
+class EndNotNullValidator : public BlockClosure {
+ public:
+  EndNotNullValidator(IR* hir) {
+    hir->start()->iterate_postorder(this);
+  }
+
+  void block_do(BlockBegin* block) {
+    assert(block->end() != NULL, "Expect block end to exist.");
+  }
+};
 
 typedef GrowableArray<BlockList*> BlockListList;
 
@@ -1363,6 +1373,7 @@ public:
 void IR::verify() {
 #ifdef ASSERT
   PredecessorValidator pv(this);
+  EndNotNullValidator(this);
   VerifyBlockBeginField verifier;
   this->iterate_postorder(&verifier);
 #endif

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -568,10 +568,6 @@ void BlockBegin::disconnect_edge(BlockBegin* from, BlockBegin* to) {
   }
 }
 
-BlockList* BlockBegin::successors() {
-  assert(_end != NULL, "need end");
-  return _end->sux();
-} // TODO temporary accessor, remove
 
 void BlockBegin::substitute_sux(BlockBegin* old_sux, BlockBegin* new_sux) {
   // modify predecessors before substituting successors

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -544,10 +544,10 @@ void BlockBegin::set_end(BlockEnd* end) {
 
 
   // Now reset successors list based on BlockEnd
-  clear_sux();
+  clear_sux(); // Cannot remove yet
   for (int i = 0; i < end->number_of_sux(); i++) {
     BlockBegin* sux = end->sux_at(i);
-    add_successor(sux);
+    add_successor_local(sux);
     sux->_predecessors.append(this);
   }
 
@@ -570,7 +570,8 @@ void BlockBegin::disconnect_edge(BlockBegin* from, BlockBegin* to) {
       if (index >= 0) {
         sux->_predecessors.remove_at(index);
       }
-      from->remove_sux_at(s);
+      assert(from->successors() == from->end()->sux(), "must match janiuk");
+      from->end()->remove_sux_at(s);
     } else {
       s++;
     }

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -532,22 +532,26 @@ void BlockBegin::set_end(BlockEnd* end) {
 
   // remove this block as predecessor of its current successors
   if (_end != NULL) {
-    for (int i1 = 0; i1 < _successors.length(); i1++) {
-      _successors.at(i1)->remove_predecessor(this);
+    for (int i1 = 0; i1 < number_of_sux(); i1++) {
+      sux_at(i1)->remove_predecessor(this);
     }
     _end = NULL;
+  } else {
+    // What confuses me is, in this case, the successors can still have content, but we are just ignoring it...
+    // Ok. Let's take it at face value. If _end is null, then for some reason, we dont need to deregister predecessors.
+    // We are gonna clear _successors anyways so.
   }
 
 
   // Now reset successors list based on BlockEnd
-  _successors.clear();
+  clear_sux();
   for (int i = 0; i < end->number_of_sux(); i++) {
     BlockBegin* sux = end->sux_at(i);
-    _successors.append(sux);
+    add_successor(sux);
     sux->_predecessors.append(this);
   }
 
-  end->set_sux(&_successors);
+  end->set_sux(successors());
   _end = end;
 }
 
@@ -566,7 +570,7 @@ void BlockBegin::disconnect_edge(BlockBegin* from, BlockBegin* to) {
       if (index >= 0) {
         sux->_predecessors.remove_at(index);
       }
-      from->_successors.remove_at(s);
+      from->remove_sux_at(s);
     } else {
       s++;
     }

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -587,6 +587,7 @@ void BlockBegin::disconnect_from_graph() {
   // disconnect this block from all other blocks
   for (int p = 0; p < number_of_preds(); p++) {
     BlockBegin *receiver = pred_at(p);
+    assert(receiver->end() != NULL, "End should not be null");
     int idx;
     while ((idx = receiver->_successors.find(this)) >= 0) {
       receiver->_successors.remove_at(idx);
@@ -952,6 +953,7 @@ void BlockList::print(bool cfg_only, bool live_only) {
 void BlockEnd::set_begin(BlockBegin* begin) {
   BlockList* sux = NULL;
   if (begin != NULL) {
+    assert(begin->end() != NULL, "Using successors, need end");
     sux = begin->successors();
   } else if (this->begin() != NULL) {
     // copy our sux list

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -542,17 +542,12 @@ void BlockBegin::set_end(BlockEnd* end) {
     // We are gonna clear _successors anyways so.
   }
 
+  _end = end;
 
-  // Now reset successors list based on BlockEnd
-  clear_sux(); // Cannot remove yet
-  for (int i = 0; i < end->number_of_sux(); i++) {
-    BlockBegin* sux = end->sux_at(i);
-    add_successor_local(sux);
+  for (int i = 0; i < number_of_sux(); i++) {
+    BlockBegin* sux = sux_at(i);
     sux->_predecessors.append(this);
   }
-
-  end->set_sux(successors());
-  _end = end;
 }
 
 
@@ -570,13 +565,17 @@ void BlockBegin::disconnect_edge(BlockBegin* from, BlockBegin* to) {
       if (index >= 0) {
         sux->_predecessors.remove_at(index);
       }
-      assert(from->successors() == from->end()->sux(), "must match janiuk");
       from->end()->remove_sux_at(s);
     } else {
       s++;
     }
   }
 }
+
+BlockList* BlockBegin::successors() {
+  assert(_end != NULL, "need end");
+  return _end->sux();
+} // TODO temporary accessor, remove
 
 void BlockBegin::substitute_sux(BlockBegin* old_sux, BlockBegin* new_sux) {
   // modify predecessors before substituting successors

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -958,15 +958,15 @@ void BlockEnd::set_sux_from_begin(BlockBegin* begin) {
 
 
 void BlockEnd::clear_begin() {
-    BlockList* sux = NULL;
     if (this->begin() != NULL) {
       // copy our sux list
       BlockList* sux = new BlockList(this->begin()->number_of_sux());
       for (int i = 0; i < this->begin()->number_of_sux(); i++) {
         sux->append(this->begin()->sux_at(i));
       }
+      // NB the copy is completely worhless
     }
-    _sux = sux;
+    _sux = NULL;
 }
 
 

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -536,10 +536,6 @@ void BlockBegin::set_end(BlockEnd* end) {
       sux_at(i1)->remove_predecessor(this);
     }
     _end = NULL;
-  } else {
-    // What confuses me is, in this case, the successors can still have content, but we are just ignoring it...
-    // Ok. Let's take it at face value. If _end is null, then for some reason, we dont need to deregister predecessors.
-    // We are gonna clear _successors anyways so.
   }
 
   _end = end;

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -573,22 +573,6 @@ void BlockBegin::disconnect_edge(BlockBegin* from, BlockBegin* to) {
   }
 }
 
-
-void BlockBegin::disconnect_from_graph() {
-  // disconnect this block from all other blocks
-  for (int p = 0; p < number_of_preds(); p++) {
-    BlockBegin *receiver = pred_at(p);
-    assert(receiver->end() != NULL, "End should not be null");
-    int idx;
-    while ((idx = receiver->_successors.find(this)) >= 0) {
-      receiver->_successors.remove_at(idx);
-    }
-  }
-  for (int s = 0; s < number_of_sux(); s++) {
-    sux_at(s)->remove_predecessor(this);
-  }
-}
-
 void BlockBegin::substitute_sux(BlockBegin* old_sux, BlockBegin* new_sux) {
   // modify predecessors before substituting successors
   for (int i = 0; i < number_of_sux(); i++) {

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -538,6 +538,7 @@ void BlockBegin::set_end(BlockEnd* end) {
     _end = NULL;
   }
 
+
   // Now reset successors list based on BlockEnd
   _successors.clear();
   for (int i = 0; i < end->number_of_sux(); i++) {
@@ -940,16 +941,9 @@ void BlockList::print(bool cfg_only, bool live_only) {
 
 // Implementation of BlockEnd
 
-void BlockEnd::set_sux_from_begin(BlockBegin* begin) {
-  assert(begin->end() != NULL, "Using successors, need end");
-  _sux = begin->successors();
-}
-
-
 void BlockEnd::substitute_sux(BlockBegin* old_sux, BlockBegin* new_sux) {
   substitute(*_sux, old_sux, new_sux);
 }
-
 
 // Implementation of Phi
 

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -586,7 +586,11 @@ void BlockBegin::disconnect_edge(BlockBegin* from, BlockBegin* to) {
 void BlockBegin::disconnect_from_graph() {
   // disconnect this block from all other blocks
   for (int p = 0; p < number_of_preds(); p++) {
-    pred_at(p)->remove_successor(this);
+    BlockBegin *receiver = pred_at(p);
+    int idx;
+    while ((idx = receiver->_successors.find(this)) >= 0) {
+      receiver->_successors.remove_at(idx);
+    }
   }
   for (int s = 0; s < number_of_sux(); s++) {
     sux_at(s)->remove_predecessor(this);
@@ -666,14 +670,6 @@ BlockBegin* BlockBegin::insert_block_between(BlockBegin* sux) {
   }
   assert(assigned == true, "should have assigned at least once");
   return new_sux;
-}
-
-
-void BlockBegin::remove_successor(BlockBegin* pred) {
-  int idx;
-  while ((idx = _successors.find(pred)) >= 0) {
-    _successors.remove_at(idx);
-  }
 }
 
 

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -534,14 +534,15 @@ void BlockBegin::set_end(BlockEnd* end) {
   // Set the new end
   _end = end;
 
+  // Copy successors from newEnd to here
   _successors.clear();
-  // Now reset successors list based on BlockEnd
   for (int i = 0; i < end->number_of_sux(); i++) {
     BlockBegin* sux = end->sux_at(i);
     _successors.append(sux);
     sux->_predecessors.append(this);
   }
-  _end->set_begin(this);
+
+  _end->set_sux_from_begin(this);
 }
 
 
@@ -550,7 +551,7 @@ void BlockBegin::clear_end() {
   // BlockEnd's notion.
   if (_end != NULL) {
     // disconnect from the old end
-    _end->set_begin(NULL);
+    _end->clear_begin();
 
     // disconnect this block from it's current successors
     for (int i = 0; i < _successors.length(); i++) {
@@ -950,19 +951,22 @@ void BlockList::print(bool cfg_only, bool live_only) {
 
 // Implementation of BlockEnd
 
-void BlockEnd::set_begin(BlockBegin* begin) {
-  BlockList* sux = NULL;
-  if (begin != NULL) {
-    assert(begin->end() != NULL, "Using successors, need end");
-    sux = begin->successors();
-  } else if (this->begin() != NULL) {
-    // copy our sux list
-    BlockList* sux = new BlockList(this->begin()->number_of_sux());
-    for (int i = 0; i < this->begin()->number_of_sux(); i++) {
-      sux->append(this->begin()->sux_at(i));
+void BlockEnd::set_sux_from_begin(BlockBegin* begin) {
+  assert(begin->end() != NULL, "Using successors, need end");
+  _sux = begin->successors();
+}
+
+
+void BlockEnd::clear_begin() {
+    BlockList* sux = NULL;
+    if (this->begin() != NULL) {
+      // copy our sux list
+      BlockList* sux = new BlockList(this->begin()->number_of_sux());
+      for (int i = 0; i < this->begin()->number_of_sux(); i++) {
+        sux->append(this->begin()->sux_at(i));
+      }
     }
-  }
-  _sux = sux;
+    _sux = sux;
 }
 
 

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -549,16 +549,15 @@ void BlockBegin::set_end(BlockEnd* end) {
 void BlockBegin::clear_end() {
   // Must make the predecessors/successors match up with the
   // BlockEnd's notion.
-  if (_end != NULL) {
-    // disconnect from the old end
-    _end->clear_begin();
+  if (_end == NULL) return;
 
-    // disconnect this block from it's current successors
-    for (int i = 0; i < _successors.length(); i++) {
-      _successors.at(i)->remove_predecessor(this);
-    }
-    _end = NULL;
+  // We dont need to do anything with the old end, it will just be forgotten
+
+  // disconnect this block from its current successors
+  for (int i = 0; i < _successors.length(); i++) {
+    _successors.at(i)->remove_predecessor(this);
   }
+  _end = NULL;
 }
 
 
@@ -954,19 +953,6 @@ void BlockList::print(bool cfg_only, bool live_only) {
 void BlockEnd::set_sux_from_begin(BlockBegin* begin) {
   assert(begin->end() != NULL, "Using successors, need end");
   _sux = begin->successors();
-}
-
-
-void BlockEnd::clear_begin() {
-    if (this->begin() != NULL) {
-      // copy our sux list
-      BlockList* sux = new BlockList(this->begin()->number_of_sux());
-      for (int i = 0; i < this->begin()->number_of_sux(); i++) {
-        sux->append(this->begin()->sux_at(i));
-      }
-      // NB the copy is completely worhless
-    }
-    _sux = NULL;
 }
 
 

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -524,25 +524,21 @@ Constant::CompareResult Constant::compare(Instruction::Condition cond, Value rig
 
 // Implementation of BlockBegin
 
-void BlockBegin::set_end(BlockEnd* end) {
-  assert(end != NULL, "should not reset block end to NULL");
-  if (end == _end) {
-    return;
-  }
+void BlockBegin::set_end(BlockEnd* new_end) { // Assumes that no predecessor of new_end still has it as its successor
+  assert(new_end != NULL, "Should not reset block new_end to NULL");
+  if (new_end == _end) return;
 
-  // remove this block as predecessor of its current successors
-  if (_end != NULL) {
-    for (int i1 = 0; i1 < number_of_sux(); i1++) {
-      sux_at(i1)->remove_predecessor(this);
-    }
-    _end = NULL;
-  }
-
-  _end = end;
-
+  // Remove this block as predecessor of its current successors
+  if (_end != NULL)
   for (int i = 0; i < number_of_sux(); i++) {
-    BlockBegin* sux = sux_at(i);
-    sux->_predecessors.append(this);
+    sux_at(i)->remove_predecessor(this);
+  }
+
+  _end = new_end;
+
+  // Add this block as predecessor of its new successors
+  for (int i = 0; i < number_of_sux(); i++) {
+    sux_at(i)->add_predecessor(this);
   }
 }
 

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -529,12 +529,16 @@ void BlockBegin::set_end(BlockEnd* end) {
   if (end == _end) {
     return;
   }
-  clear_end();
 
-  // Set the new end
-  _end = end;
+  // remove this block as predecessor of its current successors
+  if (_end != NULL) {
+    for (int i1 = 0; i1 < _successors.length(); i1++) {
+      _successors.at(i1)->remove_predecessor(this);
+    }
+    _end = NULL;
+  }
 
-  // Copy successors from newEnd to here
+  // Now reset successors list based on BlockEnd
   _successors.clear();
   for (int i = 0; i < end->number_of_sux(); i++) {
     BlockBegin* sux = end->sux_at(i);
@@ -542,22 +546,8 @@ void BlockBegin::set_end(BlockEnd* end) {
     sux->_predecessors.append(this);
   }
 
-  _end->set_sux_from_begin(this);
-}
-
-
-void BlockBegin::clear_end() {
-  // Must make the predecessors/successors match up with the
-  // BlockEnd's notion.
-  if (_end == NULL) return;
-
-  // We dont need to do anything with the old end, it will just be forgotten
-
-  // disconnect this block from its current successors
-  for (int i = 0; i < _successors.length(); i++) {
-    _successors.at(i)->remove_predecessor(this);
-  }
-  _end = NULL;
+  end->set_sux(&_successors);
+  _end = end;
 }
 
 

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1595,7 +1595,6 @@ LEAF(BlockBegin, StateSplit)
   ResourceBitMap _stores_to_locals;              // bit is set when a local variable is stored in the block
 
   // SSA specific fields: (factor out later)
-  BlockList   _successors;                       // the successors of this block
   BlockList   _predecessors;                     // the predecessors of this block
   BlockList   _dominates;                        // list of blocks that are dominated by this block
   BlockBegin* _dominator;                        // the dominator of this block
@@ -1649,7 +1648,6 @@ LEAF(BlockBegin, StateSplit)
   , _flags(0)
   , _total_preds(0)
   , _stores_to_locals()
-  , _successors(2)
   , _predecessors(2)
   , _dominates(2)
   , _dominator(NULL)
@@ -1676,7 +1674,6 @@ LEAF(BlockBegin, StateSplit)
   // accessors
   int block_id() const                           { return _block_id; }
   int bci() const                                { return _bci; }
-  BlockList* successors();
   BlockList* dominates()                         { return &_dominates; }
   BlockBegin* dominator() const                  { return _dominator; }
   int loop_depth() const                         { return _loop_depth; }

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1706,7 +1706,6 @@ LEAF(BlockBegin, StateSplit)
   void set_linear_scan_number(int lsn)           { _linear_scan_number = lsn; }
   void set_end(BlockEnd* end);
 
-  void disconnect_from_graph();
   static void disconnect_edge(BlockBegin* from, BlockBegin* to);
   BlockBegin* insert_block_between(BlockBegin* sux);
   void substitute_sux(BlockBegin* old_sux, BlockBegin* new_sux);

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1730,6 +1730,9 @@ LEAF(BlockBegin, StateSplit)
   int number_of_sux_from_local() const;
   BlockBegin* sux_at(int i) const;
   BlockBegin* sux_at_from_local(int i) const;
+  void remove_sux_at(int i);
+  int find_sux(BlockBegin* sux);
+  void clear_sux();
   void add_successor(BlockBegin* sux);
   bool is_successor(BlockBegin* sux) const       { return _successors.contains(sux); }
 
@@ -1798,9 +1801,6 @@ LEAF(BlockBegin, StateSplit)
 BASE(BlockEnd, StateSplit)
  private:
   BlockList*  _sux;
-
- protected:
-  BlockList* sux() const                         { return _sux; }
 
  public:
   void set_sux(BlockList* sux) {
@@ -2440,6 +2440,9 @@ inline int         BlockBegin::number_of_sux() const            { assert(_end !=
 inline int         BlockBegin::number_of_sux_from_local() const { assert(_end == NULL, "should only be used when _end is null");                     return _successors.length(); }
 inline BlockBegin* BlockBegin::sux_at(int i) const              { assert(_end != NULL && _end->sux_at(i) == _successors.at(i), "mismatch");          return _successors.at(i); }
 inline BlockBegin* BlockBegin::sux_at_from_local(int i) const   { assert(_end == NULL, "should only be used when _end is null");                     return _successors.at(i); }
+inline void BlockBegin::remove_sux_at(int i) {_successors.remove_at(i);}
+inline int BlockBegin::find_sux(BlockBegin* sux) {return _successors.find(sux);}
+inline void BlockBegin::clear_sux() {_successors.clear();}
 inline void        BlockBegin::add_successor(BlockBegin* sux)   { assert(_end == NULL, "Would create mismatch with successors of BlockEnd");         _successors.append(sux); }
 
 #undef ASSERT_VALUES

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1827,7 +1827,6 @@ BASE(BlockEnd, StateSplit)
 
   // manipulation
   void set_sux_from_begin(BlockBegin* begin);
-  void clear_begin();
 
   // successors
   int number_of_sux() const                      { return _sux != NULL ? _sux->length() : 0; }

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1723,14 +1723,7 @@ LEAF(BlockBegin, StateSplit)
 
   // successors and predecessors
   int number_of_sux() const;
-  int number_of_sux_from_local() const;
   BlockBegin* sux_at(int i) const;
-  BlockBegin* sux_at_from_local(int i) const;
-  void remove_sux_at(int i);
-  int find_sux(BlockBegin* sux);
-  void clear_sux();
-  void add_successor_local(BlockBegin* sux);
-
   void add_predecessor(BlockBegin* pred);
   void remove_predecessor(BlockBegin* pred);
   bool is_predecessor(BlockBegin* pred) const    { return _predecessors.contains(pred); }
@@ -1810,7 +1803,6 @@ BASE(BlockEnd, StateSplit)
   }
 
  public:
-
   // creation
   BlockEnd(ValueType* type, ValueStack* state_before, bool is_safepoint)
   : StateSplit(type, state_before)
@@ -1827,14 +1819,11 @@ BASE(BlockEnd, StateSplit)
   // manipulation
   inline void remove_sux_at(int i) { _sux->remove_at(i);}
   inline int find_sux(BlockBegin* sux) {return _sux->find(sux);}
-  void clear_sux() {_sux->clear();}
 
   // successors
   int number_of_sux() const                      { return _sux != NULL ? _sux->length() : 0; }
   BlockBegin* sux_at(int i) const                { return _sux->at(i); }
   BlockBegin* default_sux() const                { return sux_at(number_of_sux() - 1); }
-  BlockBegin** addr_sux_at(int i) const          { return _sux->adr_at(i); }
-  int sux_index(BlockBegin* sux) const           { return _sux->find(sux); }
   void substitute_sux(BlockBegin* old_sux, BlockBegin* new_sux);
 };
 

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1732,7 +1732,6 @@ LEAF(BlockBegin, StateSplit)
   BlockBegin* sux_at(int i) const;
   BlockBegin* sux_at_from_local(int i) const;
   void add_successor(BlockBegin* sux);
-  void remove_successor(BlockBegin* pred);
   bool is_successor(BlockBegin* sux) const       { return _successors.contains(sux); }
 
   void add_predecessor(BlockBegin* pred);

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1701,8 +1701,7 @@ LEAF(BlockBegin, StateSplit)
   void set_dominator_depth(int d)                { _dominator_depth = d; }
   void set_depth_first_number(int dfn)           { _depth_first_number = dfn; }
   void set_linear_scan_number(int lsn)           { _linear_scan_number = lsn; }
-  void set_end(BlockEnd* end);
-
+  void set_end(BlockEnd* new_end);
   static void disconnect_edge(BlockBegin* from, BlockBegin* to);
   BlockBegin* insert_block_between(BlockBegin* sux);
   void substitute_sux(BlockBegin* old_sux, BlockBegin* new_sux);
@@ -1791,6 +1790,7 @@ LEAF(BlockBegin, StateSplit)
   // debugging
   void print_block()                             PRODUCT_RETURN;
   void print_block(InstructionPrinter& ip, bool live_only = false) PRODUCT_RETURN;
+
 };
 
 

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1705,7 +1705,7 @@ LEAF(BlockBegin, StateSplit)
   void set_depth_first_number(int dfn)           { _depth_first_number = dfn; }
   void set_linear_scan_number(int lsn)           { _linear_scan_number = lsn; }
   void set_end(BlockEnd* end);
-  void clear_end();
+
   void disconnect_from_graph();
   static void disconnect_edge(BlockBegin* from, BlockBegin* to);
   BlockBegin* insert_block_between(BlockBegin* sux);
@@ -1803,6 +1803,7 @@ BASE(BlockEnd, StateSplit)
  protected:
   BlockList* sux() const                         { return _sux; }
 
+ public:
   void set_sux(BlockList* sux) {
 #ifdef ASSERT
     assert(sux != NULL, "sux must exist");
@@ -1811,7 +1812,6 @@ BASE(BlockEnd, StateSplit)
     _sux = sux;
   }
 
- public:
   // creation
   BlockEnd(ValueType* type, ValueStack* state_before, bool is_safepoint)
   : StateSplit(type, state_before)

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1798,7 +1798,7 @@ BASE(BlockEnd, StateSplit)
  private:
   BlockList*  _sux;
 
- public:
+ protected:
   BlockList* sux() const                         { return _sux; }
 
   void set_sux(BlockList* sux) {
@@ -1808,6 +1808,8 @@ BASE(BlockEnd, StateSplit)
 #endif
     _sux = sux;
   }
+
+ public:
 
   // creation
   BlockEnd(ValueType* type, ValueStack* state_before, bool is_safepoint)

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1728,7 +1728,9 @@ LEAF(BlockBegin, StateSplit)
 
   // successors and predecessors
   int number_of_sux() const;
+  int number_of_sux_from_local() const;
   BlockBegin* sux_at(int i) const;
+  BlockBegin* sux_at_from_local(int i) const;
   void add_successor(BlockBegin* sux);
   void remove_successor(BlockBegin* pred);
   bool is_successor(BlockBegin* sux) const       { return _successors.contains(sux); }
@@ -2439,8 +2441,10 @@ class BlockPair: public CompilationResourceObj {
 
 typedef GrowableArray<BlockPair*> BlockPairList;
 
-inline int         BlockBegin::number_of_sux() const            { assert(_end == NULL || _end->number_of_sux() == _successors.length(), "mismatch"); return _successors.length(); }
-inline BlockBegin* BlockBegin::sux_at(int i) const              { assert(_end == NULL || _end->sux_at(i) == _successors.at(i), "mismatch");          return _successors.at(i); }
+inline int         BlockBegin::number_of_sux() const            { assert(_end != NULL && _end->number_of_sux() == _successors.length(), "mismatch"); return _successors.length(); }
+inline int         BlockBegin::number_of_sux_from_local() const { assert(_end == NULL, "should only be used when _end is null");                     return _successors.length(); }
+inline BlockBegin* BlockBegin::sux_at(int i) const              { assert(_end != NULL && _end->sux_at(i) == _successors.at(i), "mismatch");          return _successors.at(i); }
+inline BlockBegin* BlockBegin::sux_at_from_local(int i) const   { assert(_end == NULL, "should only be used when _end is null");                     return _successors.at(i); }
 inline void        BlockBegin::add_successor(BlockBegin* sux)   { assert(_end == NULL, "Would create mismatch with successors of BlockEnd");         _successors.append(sux); }
 
 #undef ASSERT_VALUES

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1825,9 +1825,6 @@ BASE(BlockEnd, StateSplit)
   // For compatibility with old code, for new code use block()
   BlockBegin* begin() const                      { return _block; }
 
-  // manipulation
-  void set_sux_from_begin(BlockBegin* begin);
-
   // successors
   int number_of_sux() const                      { return _sux != NULL ? _sux->length() : 0; }
   BlockBegin* sux_at(int i) const                { return _sux->at(i); }

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1826,7 +1826,8 @@ BASE(BlockEnd, StateSplit)
   BlockBegin* begin() const                      { return _block; }
 
   // manipulation
-  void set_begin(BlockBegin* begin);
+  void set_sux_from_begin(BlockBegin* begin);
+  void clear_begin();
 
   // successors
   int number_of_sux() const                      { return _sux != NULL ? _sux->length() : 0; }

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1676,7 +1676,7 @@ LEAF(BlockBegin, StateSplit)
   // accessors
   int block_id() const                           { return _block_id; }
   int bci() const                                { return _bci; }
-  BlockList* successors()                        { return &_successors; }
+  BlockList* successors();
   BlockList* dominates()                         { return &_dominates; }
   BlockBegin* dominator() const                  { return _dominator; }
   int loop_depth() const                         { return _loop_depth; }
@@ -1734,7 +1734,6 @@ LEAF(BlockBegin, StateSplit)
   int find_sux(BlockBegin* sux);
   void clear_sux();
   void add_successor_local(BlockBegin* sux);
-  bool is_successor(BlockBegin* sux) const       { return _successors.contains(sux); }
 
   void add_predecessor(BlockBegin* pred);
   void remove_predecessor(BlockBegin* pred);
@@ -2443,12 +2442,8 @@ class BlockPair: public CompilationResourceObj {
 
 typedef GrowableArray<BlockPair*> BlockPairList;
 
-inline int         BlockBegin::number_of_sux() const            { assert(_end != NULL && _end->number_of_sux() == _successors.length(), "mismatch"); return _end->number_of_sux(); }
-inline BlockBegin* BlockBegin::sux_at(int i) const              { assert(_end != NULL && _end->sux_at(i) == _successors.at(i), "mismatch");          return _end->sux_at(i); }
-inline int         BlockBegin::number_of_sux_from_local() const { assert(_end == NULL, "should only be used when _end is null");                     return _successors.length(); }
-inline BlockBegin* BlockBegin::sux_at_from_local(int i) const   { assert(_end == NULL, "should only be used when _end is null");                     return _successors.at(i); }
-inline void        BlockBegin::add_successor_local(BlockBegin* sux)   { assert(_end == NULL, "Would create mismatch with successors of BlockEnd");         _successors.append(sux); }
-inline void BlockBegin::clear_sux() {_successors.clear();}
+inline int         BlockBegin::number_of_sux() const            { assert(_end != NULL, "need end"); return _end->number_of_sux(); }
+inline BlockBegin* BlockBegin::sux_at(int i) const              { assert(_end != NULL , "need end"); return _end->sux_at(i); }
 
 #undef ASSERT_VALUES
 

--- a/src/hotspot/share/c1/c1_InstructionPrinter.cpp
+++ b/src/hotspot/share/c1/c1_InstructionPrinter.cpp
@@ -613,6 +613,7 @@ void InstructionPrinter::do_BlockBegin(BlockBegin* x) {
   }
 
   // print predecessors and successors
+  assert(x->end() != NULL, "gonna touch successors");
   if (x->successors()->length() > 0) {
     output()->print(" sux:");
     for (int i = 0; i < x->successors()->length(); i ++) {

--- a/src/hotspot/share/c1/c1_InstructionPrinter.cpp
+++ b/src/hotspot/share/c1/c1_InstructionPrinter.cpp
@@ -614,10 +614,10 @@ void InstructionPrinter::do_BlockBegin(BlockBegin* x) {
 
   // print predecessors and successors
   assert(x->end() != NULL, "gonna touch successors");
-  if (x->successors()->length() > 0) {
+  if (x->number_of_sux() > 0) {
     output()->print(" sux:");
-    for (int i = 0; i < x->successors()->length(); i ++) {
-      output()->print(" B%d", x->successors()->at(i)->block_id());
+    for (int i = 0; i < x->number_of_sux(); i ++) {
+      output()->print(" B%d", x->sux_at(i)->block_id());
     }
   }
 

--- a/src/hotspot/share/c1/c1_InstructionPrinter.cpp
+++ b/src/hotspot/share/c1/c1_InstructionPrinter.cpp
@@ -612,15 +612,7 @@ void InstructionPrinter::do_BlockBegin(BlockBegin* x) {
     output()->print(" dom B%d", x->dominator()->block_id());
   }
 
-  // print predecessors and successors
-  assert(x->end() != NULL, "gonna touch successors");
-  if (x->number_of_sux() > 0) {
-    output()->print(" sux:");
-    for (int i = 0; i < x->number_of_sux(); i ++) {
-      output()->print(" B%d", x->sux_at(i)->block_id());
-    }
-  }
-
+  // print predecessors
   if (x->number_of_preds() > 0) {
     output()->print(" pred:");
     for (int i = 0; i < x->number_of_preds(); i ++) {

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -1586,6 +1586,7 @@ static void print_block(BlockBegin* x) {
     }
   }
 
+  if (end != NULL)
   if (x->number_of_sux() > 0) {
     tty->print("sux: ");
     for (int i = 0; i < x->number_of_sux(); i ++) {

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -1586,8 +1586,7 @@ static void print_block(BlockBegin* x) {
     }
   }
 
-  if (end != NULL)
-  if (x->number_of_sux() > 0) {
+  if (end != NULL && x->number_of_sux() > 0) {
     tty->print("sux: ");
     for (int i = 0; i < x->number_of_sux(); i ++) {
       tty->print("B%d ", x->sux_at(i)->block_id());

--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -385,8 +385,8 @@ class BlockMerger: public BlockClosure {
       BlockBegin *receiver1 = receiver->pred_at(p);
       assert(receiver1->end() != NULL, "End should not be null.");
       int idx;
-      while ((idx = receiver1->successors()->find(receiver)) >= 0) {
-        receiver1->successors()->remove_at(idx);
+      while ((idx = receiver1->find_sux(receiver)) >= 0) {
+        receiver1->remove_sux_at(idx);
       }
     }
     for (int s = 0; s < receiver->number_of_sux(); s++) {

--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -383,11 +383,8 @@ class BlockMerger: public BlockClosure {
     BlockBegin *receiver = sux;// disconnect this block from all other blocks
     for (int p = 0; p < receiver->number_of_preds(); p++) {
       BlockBegin *receiver1 = receiver->pred_at(p);
-      assert(receiver1->end() != NULL, "End should not be null.");
-      assert(receiver1->successors() == receiver1->end()->sux(), "must match janiuk");
       int idx;
       while ((idx = receiver1->end()->find_sux(receiver)) >= 0) {
-        assert(receiver1->successors() == receiver1->end()->sux(), "must match janiuk");
         receiver1->end()->remove_sux_at(idx);
       }
     }

--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -380,18 +380,21 @@ class BlockMerger: public BlockClosure {
     assert(prev->as_BlockEnd() == NULL, "must not be a BlockEnd");
     prev->set_next(next);
     prev->fixup_block_pointers();
-    BlockBegin *receiver = sux;// disconnect this block from all other blocks
-    for (int p = 0; p < receiver->number_of_preds(); p++) {
-      BlockBegin *receiver1 = receiver->pred_at(p);
+
+    // disconnect this block from all other blocks
+    for (int p = 0; p < sux->number_of_preds(); p++) {
+      BlockBegin* pred = sux->pred_at(p);
       int idx;
-      while ((idx = receiver1->end()->find_sux(receiver)) >= 0) {
-        receiver1->end()->remove_sux_at(idx);
+      while ((idx = pred->end()->find_sux(sux)) >= 0) {
+        pred->end()->remove_sux_at(idx);
       }
     }
-    for (int s = 0; s < receiver->number_of_sux(); s++) {
-      receiver->sux_at(s)->remove_predecessor(receiver);
+    for (int s = 0; s < sux->number_of_sux(); s++) {
+      sux->sux_at(s)->remove_predecessor(sux);
     }
     block->set_end(sux->end());
+
+    // TODO Should this be done in set_end universally?
     // add exception handlers of deleted block, if any
     for (int k = 0; k < sux->number_of_exception_handlers(); k++) {
       BlockBegin* xhandler = sux->exception_handler_at(k);

--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -384,9 +384,11 @@ class BlockMerger: public BlockClosure {
     for (int p = 0; p < receiver->number_of_preds(); p++) {
       BlockBegin *receiver1 = receiver->pred_at(p);
       assert(receiver1->end() != NULL, "End should not be null.");
+      assert(receiver1->successors() == receiver1->end()->sux(), "must match janiuk");
       int idx;
-      while ((idx = receiver1->find_sux(receiver)) >= 0) {
-        receiver1->remove_sux_at(idx);
+      while ((idx = receiver1->end()->find_sux(receiver)) >= 0) {
+        assert(receiver1->successors() == receiver1->end()->sux(), "must match janiuk");
+        receiver1->end()->remove_sux_at(idx);
       }
     }
     for (int s = 0; s < receiver->number_of_sux(); s++) {


### PR DESCRIPTION
Remove `BlockBegin::_successors`, leaving `BlockEnd::_sux` as the SSOT for the successors of a block. Prior to this PR, these two lists were both tracking the same list of successors of the same block. This necessitated a lot of syncing and verification code.

With this PR, as long as a block has its end pointer assigned, its successors can always be reached by querying the `BlockEnd`.  `BlockEnd::_sux` becomes the single place where the list of successors is maintained. When modified, the successor list no longer needs to be synchronized in two places, reducing complexity and confusion. Asserts on the two lists corresponding no longer need to be made.

While being created in `GraphBuilder`, `BlockBegin`s don't have a `BlockEnd` assigned yet. To temporarily track block successors in this small interval, add a lookup structure `BlockListBuilder::_bci2block_successors`. 

This PR affects debug printing code. If the end pointer of a `BlockBegin `is NULL for some reason, then the successor list can no longer be printed (for obious reasons).

This PR introduces an additional check to IR::verify to check that `BlockBegin::_end` is not set to null.

This PR also performs some minor refactoring, polishing, inlining, and removing of dead code around the affected areas. 

The commit history has been polished to attempt to guide the reader through the changes.

hs-tier1 and hs-tier2 tests pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277496](https://bugs.openjdk.java.net/browse/JDK-8277496): Remove duplication in c1 Block successor lists


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6614/head:pull/6614` \
`$ git checkout pull/6614`

Update a local copy of the PR: \
`$ git checkout pull/6614` \
`$ git pull https://git.openjdk.java.net/jdk pull/6614/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6614`

View PR using the GUI difftool: \
`$ git pr show -t 6614`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6614.diff">https://git.openjdk.java.net/jdk/pull/6614.diff</a>

</details>
