### PR TITLE
8277986: Typo in javadoc of java.util.zip.ZipEntry#setTime

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipEntry.java
+++ b/src/java.base/share/classes/java/util/zip/ZipEntry.java
@@ -153,7 +153,7 @@ public class ZipEntry implements ZipConstants, Cloneable {
      * be stored into the {@code date and time fields} of the zip file
      * entry and encoded in standard {@code MS-DOS date and time format}.
      * The {@link java.util.TimeZone#getDefault() default TimeZone} is
-     * used to convert the epoch time to the MS-DOS data and time.
+     * used to convert the epoch time to the MS-DOS date and time.
      *
      * @param  time
      *         The last modification time of the entry in milliseconds


### PR DESCRIPTION
Can I please get a review for this change which fixes a typo in the javadoc of `java.util.zip.ZipEntry.setTime()` method?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277986](https://bugs.openjdk.java.net/browse/JDK-8277986): Typo in javadoc of java.util.zip.ZipEntry#setTime


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6615/head:pull/6615` \
`$ git checkout pull/6615`

Update a local copy of the PR: \
`$ git checkout pull/6615` \
`$ git pull https://git.openjdk.java.net/jdk pull/6615/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6615`

View PR using the GUI difftool: \
`$ git pr show -t 6615`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6615.diff">https://git.openjdk.java.net/jdk/pull/6615.diff</a>

</details>
