### PR TITLE
8277861: Terminally deprecate Thread.stop

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -922,7 +922,7 @@ public class Thread implements Runnable {
      *       <a href="{@docRoot}/java.base/java/lang/doc-files/threadPrimitiveDeprecation.html">Why
      *       are Thread.stop, Thread.suspend and Thread.resume Deprecated?</a>.
      */
-    @Deprecated(since="1.2")
+    @Deprecated(since="1.2", forRemoval=true)
     public final void stop() {
         @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();

--- a/src/java.base/share/classes/java/lang/ThreadGroup.java
+++ b/src/java.base/share/classes/java/lang/ThreadGroup.java
@@ -628,6 +628,7 @@ public class ThreadGroup implements Thread.UncaughtExceptionHandler {
      *     {@link Thread#stop} for details.
      */
     @Deprecated(since="1.2", forRemoval=true)
+    @SuppressWarnings("removal")
     public final void stop() {
         if (stopOrSuspend(false))
             Thread.currentThread().stop();


### PR DESCRIPTION
Thread.stop is inherently unsafe and has been deprecated since Java 1.2 (1998). It's time to terminally deprecate this method so it can be degraded and removed in the future.

This PR does not propose any changes to the JVM TI StopThread function (or the corresponding JDWP command or JDI method).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8277861](https://bugs.openjdk.java.net/browse/JDK-8277861): Terminally deprecate Thread.stop
 * [JDK-8277987](https://bugs.openjdk.java.net/browse/JDK-8277987): Terminally deprecate Thread.stop (**CSR**) ⚠️ Issue is not open.


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)
 * [Uwe Schindler](https://openjdk.java.net/census#uschindler) (@uschindler - Author)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6616/head:pull/6616` \
`$ git checkout pull/6616`

Update a local copy of the PR: \
`$ git checkout pull/6616` \
`$ git pull https://git.openjdk.java.net/jdk pull/6616/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6616`

View PR using the GUI difftool: \
`$ git pr show -t 6616`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6616.diff">https://git.openjdk.java.net/jdk/pull/6616.diff</a>

</details>
