### PR TITLE
8277985: G1: Compare max_parallel_refinement_threads to UINT_MAX

### DIFF
--- a/src/hotspot/share/gc/g1/g1Arguments.cpp
+++ b/src/hotspot/share/gc/g1/g1Arguments.cpp
@@ -243,7 +243,7 @@ void G1Arguments::initialize() {
   // the refcount in G1CardSetContainer.
   uint max_parallel_refinement_threads = G1ConcRefinementThreads + G1DirtyCardQueueSet::num_par_ids();
   uint const divisor = 3;  // Safe divisor; we increment by 2 for each claim, but there is a small initial value.
-  if (max_parallel_refinement_threads > UINTPTR_MAX / divisor) {
+  if (max_parallel_refinement_threads > UINT_MAX / divisor) {
     vm_exit_during_initialization("Too large parallelism for remembered sets.");
   }
 }


### PR DESCRIPTION
The max_parallel_refinement_threads comparison will never be larger than UINTPTR_MAX / divisor on platforms where pointers are larger than unsigned,   Use the intended UINT_MAX instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277985](https://bugs.openjdk.java.net/browse/JDK-8277985): G1: Compare max_parallel_refinement_threads to UINT_MAX


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6617/head:pull/6617` \
`$ git checkout pull/6617`

Update a local copy of the PR: \
`$ git checkout pull/6617` \
`$ git pull https://git.openjdk.java.net/jdk pull/6617/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6617`

View PR using the GUI difftool: \
`$ git pr show -t 6617`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6617.diff">https://git.openjdk.java.net/jdk/pull/6617.diff</a>

</details>
