### PR TITLE
8277992: Add fast jdk_svc subtests to jdk:tier3

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -74,7 +74,9 @@ tier3 = \
     :build \
     :jdk_vector \
     :jdk_rmi \
-    :jdk_jfr_tier3
+    :jdk_svc \
+   -:jdk_svc_sanity \
+   -:svc_tools
 
 # Everything not in other tiers
 tier4 = \
@@ -282,9 +284,6 @@ jdk_tools = \
 
 jdk_jfr = \
     jdk/jfr
-
-jdk_jfr_tier3 = \
-    jdk/jfr/event/metadata/TestLookForUntestedEvents.java
 
 #
 # Catch-all for other areas with a small number of tests


### PR DESCRIPTION
OpenJDK tiered tests definitions have the catch-all `tier4` that runs all tests not defined in the lower tiers. `hotspot:tier4` has lots of them, mostly long-running vmTestbase tests, which take many hours even on a very parallel machines.

This, unfortunately, has a chilling effect on `jdk:tier4`, which is seldom run by contributors, because `hotspot:tier4` is in the way. But, there are plenty of fast and stable tests in `jdk:tier4` that can be run in `jdk:tier3`. `jdk_svc` is the example of such tests: management features (including but not limited to JFR) are important to keep from regressions, and significant subset of them runs pretty fast.

So, it makes sense to move some `jdk_svc` tests to `jdk:tier3` to expose it to more contributors. I think the only group we don't want to run is `svc_tools`, which includes lots of non-parallel tests that are rather slow.

Sample run before:

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/jdk:tier3                                174   174     0     0   
==============================
TEST SUCCESS

Finished building target 'run-test' in configuration 'linux-x86_64-server-fastdebug'

real	2m38.242s
user	80m7.216s
sys	2m13.846s


==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
>> jtreg:test/jdk:tier4                               2904  2901     3     0 <<
==============================
TEST FAILURE

real	18m13.933s
user	546m50.556s
sys	25m7.086s
```

Sample run after:

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/jdk:tier3                               1296  1296     0     0   
==============================
TEST SUCCESS

Finished building target 'run-test' in configuration 'linux-x86_64-server-fastdebug'

real	7m49.017s
user	287m30.943s
sys	13m20.060s

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
>> jtreg:test/jdk:tier4                               1783  1780     3     0 <<
==============================
TEST FAILURE


real	12m19.973s
user	351m48.561s
sys	14m51.566s
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277992](https://bugs.openjdk.java.net/browse/JDK-8277992): Add fast jdk_svc subtests to jdk:tier3


### Reviewers
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6619/head:pull/6619` \
`$ git checkout pull/6619`

Update a local copy of the PR: \
`$ git checkout pull/6619` \
`$ git pull https://git.openjdk.java.net/jdk pull/6619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6619`

View PR using the GUI difftool: \
`$ git pr show -t 6619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6619.diff">https://git.openjdk.java.net/jdk/pull/6619.diff</a>

</details>
