### PR TITLE
8276657: XSLT compiler tries to define a class with empty name

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/XSLTC.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/XSLTC.java
@@ -58,7 +58,7 @@ import org.xml.sax.XMLReader;
  * @author G. Todd Miller
  * @author Morten Jorgensen
  * @author John Howard (johnh@schemasoft.com)
- * @LastModified: May 2021
+ * @LastModified: Nov 2021
  */
 public final class XSLTC {
 
@@ -461,7 +461,10 @@ public final class XSLTC {
                     setClassName(name);
                 }
                 else if (systemId != null && !systemId.equals("")) {
-                    setClassName(Util.baseName(systemId));
+                    String clsName = Util.baseName(systemId);
+                    if (clsName != null && !clsName.equals("")) {
+                        setClassName(clsName);
+                    }
                 }
 
                 // Ensure we have a non-empty class name at this point

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/XSLTC.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/XSLTC.java
@@ -460,9 +460,9 @@ public final class XSLTC {
                 if (name != null) {
                     setClassName(name);
                 }
-                else if (systemId != null && !systemId.equals("")) {
+                else if (systemId != null && !systemId.isEmpty()) {
                     String clsName = Util.baseName(systemId);
-                    if (clsName != null && !clsName.equals("")) {
+                    if (clsName != null && !clsName.isEmpty()) {
                         setClassName(clsName);
                     }
                 }


### PR DESCRIPTION
The result of Util.baseName(systemId) can be empty, causing the compiler to set an empty classname. Add a check to make sure it will not set the empty classname.

Alternatively, it may report an error, but that would be disruptive. As the transform can proceed without the provided classname (by using the default), adding a check is better than reporting an error.

I've verified the patch with the proposed fix for JDK-8276241. Harold has also confirmed it fixes the tests in his builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276657](https://bugs.openjdk.java.net/browse/JDK-8276657): XSLT compiler tries to define a class with empty name


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to ef0e6b889bc16d32d575b4137a265440c2363c28


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6620/head:pull/6620` \
`$ git checkout pull/6620`

Update a local copy of the PR: \
`$ git checkout pull/6620` \
`$ git pull https://git.openjdk.java.net/jdk pull/6620/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6620`

View PR using the GUI difftool: \
`$ git pr show -t 6620`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6620.diff">https://git.openjdk.java.net/jdk/pull/6620.diff</a>

</details>
