### PR TITLE
8277026: Remove blank lines remaining from snippet markup

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
@@ -401,6 +401,7 @@ public class TagletWriterImpl extends TagletWriter {
                 Element e = null;
                 String t = null;
                 boolean linkEncountered = false;
+                boolean markupEncountered = false;
                 Set<String> classes = new HashSet<>();
                 for (Style s : styles) {
                     if (s instanceof Style.Name n) {
@@ -414,6 +415,8 @@ public class TagletWriterImpl extends TagletWriter {
                             // TODO: diagnostic output
                         }
                     } else if (s instanceof Style.Markup) {
+                        markupEncountered = true;
+                        break;
                     } else {
                         // TODO: transform this if...else into an exhaustive
                         // switch over the sealed Style hierarchy when "Pattern
@@ -423,7 +426,9 @@ public class TagletWriterImpl extends TagletWriter {
                     }
                 }
                 Content c;
-                if (linkEncountered) {
+                if (markupEncountered) {
+                    return;
+                } else if (linkEncountered) {
                     assert e != null;
                     String line = sequence.toString();
                     String strippedLine = line.strip();

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
@@ -443,7 +443,7 @@ public class TagletWriterImpl extends TagletWriter {
                     c = new ContentBuilder(whitespace, htmlWriter.linkToContent(element, e, t, strippedLine));
                     // We don't care about trailing whitespace.
                 } else {
-                    c = HtmlTree.SPAN(Text.of(utils.normalizeNewlines(sequence)));
+                    c = HtmlTree.SPAN(Text.of(text));
                     classes.forEach(((HtmlTree) c)::addStyle);
                 }
                 code.add(c);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/snippet/Parser.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/snippet/Parser.java
@@ -139,6 +139,7 @@ public final class Parser {
             String rawLine = next.line();
             boolean addLineTerminator = iterator.hasNext() || trailingNewline;
             String line;
+            boolean hasMarkup = false;
             markedUpLine.reset(rawLine);
             if (!markedUpLine.matches()) { // (1)
                 line = rawLine + (addLineTerminator ? "\n" : "");
@@ -168,6 +169,7 @@ public final class Parser {
                     // TODO: log this with NOTICE;
                     line = rawLine + (addLineTerminator ? "\n" : "");
                 } else { // (3)
+                    hasMarkup = true;
                     String payload = rawLine.substring(0, markedUpLine.end("payload"));
                     line = payload + (addLineTerminator ? "\n" : "");
                 }
@@ -185,7 +187,7 @@ public final class Parser {
 
             thisLineTags.clear();
 
-            append(text, Set.of(), line);
+            append(text, line.isBlank() && hasMarkup ? Set.of(new Style.Markup()) : Set.of(), line);
             // TODO: mark up trailing whitespace!
             lineStart += line.length();
         }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/snippet/Style.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/snippet/Style.java
@@ -37,21 +37,21 @@ public sealed interface Style {
 
     /**
      * A style that describes a link. Characters of this style are typically
-     * processed by wrapping into an HTML {@code A} element pointing to the
+     * processed by being wrapped into an HTML {@code A} element pointing to the
      * provided target.
      */
     record Link(String target) implements Style { }
 
     /**
      * A named style. Characters of this style are typically processed by
-     * wrapping into an HTML {@code SPAN} element with the {@code class}
+     * being wrapped into an HTML {@code SPAN} element with the {@code class}
      * attribute which is obtained from the provided name.
      */
     record Name(String name) implements Style { }
 
     /**
      * A marker of belonging to markup. Characters of this style are typically
-     * processed by omitting from the output.
+     * processed by being omitted from the output.
      */
     record Markup() implements Style { }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/snippet/StyledText.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/snippet/StyledText.java
@@ -74,8 +74,8 @@ public class StyledText {
     }
 
     /*
-     * For each character of this text adds the provided objects to a set of
-     * objects associated with that character.
+     * For each character of this text adds the provided styles to a set of
+     * styles associated with that character.
      */
     public void addStyle(Set<? extends Style> additionalStyles) {
         styles.add(0, length(), additionalStyles);
@@ -87,7 +87,7 @@ public class StyledText {
 
     /*
      * Replaces all characters of this text with the provided sequence of
-     * characters, each of which is associated with all the provided objects.
+     * characters, each of which is associated with all the provided styles.
      */
     public void replace(Set<? extends Style> styles, CharSequence plaintext) {
         replace(0, length(), styles, plaintext);

--- a/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestLangProperties.java
+++ b/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestLangProperties.java
@@ -62,7 +62,6 @@ public class TestLangProperties extends SnippetTester {
                                     tea=black
                                     """.formatted(markup),
                             """
-
                                     <span class="bold">coffee=espresso
                                     </span>tea=black
                                     """);

--- a/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetMarkup.java
+++ b/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetMarkup.java
@@ -370,11 +370,132 @@ First line // @highlight :
         testPositive(base, testCases);
     }
 
-    // @replace on a blank line will not do anything bad!
+    /*
+     * These are corner cases. As such they are expected to rarely happen in
+     * practise. These tests merely capture what the results looked when
+     * the feature was integrated. This might help when refactoring
+     * and refreshing the feature, to better understand the impact of
+     * the proposed changes.
+     */
+    @Test
+    public void testPositiveInlineTagMarkup_ReplaceOnBlankLine(Path base) throws Exception {
+        var testCases = List.of(
+                // the complete line is being replaced
+                new TestCase("one",
+                        """
+                                // @start region=one @replace regex=".*" replacement="-----"
+                                one
+                                // @end
+                                """,
+                        """
+                                -----one
+                                """
+                ),
+                // the contents of the line, but not the line terminator is being replaced
+                new TestCase("two",
+                        """
+                                    // @start region=two @replace regex=".+" replacement="*****"
+                                two
+                                // @end
+                                """,
+                        """
+                                *****two
+                                """
+                ),
+                new TestCase(
+                        """
+                                // @replace regex="duke" replacement="duchess"
+                                """,
+                        """
+                                """
+                )
+        );
+        testPositive(base, testCases);
+    }
 
-    // What to do with a markup line that modifies blankness somehow? For example:
-    //
-    //    // @replace regex=.* replacement="hello"
+    @Test
+    public void testPositiveInlineTagMarkup_BlankLinesRegionEquivalence(Path base) throws Exception {
+        var testCases = List.of(
+                new TestCase("example1",
+                        """
+                                // @start region="example1"
+                                if (v.isPresent()) {
+                                    System.out.println("v: " + v.get());
+                                } // @end
+                                """,
+                        """
+                                if (v.isPresent()) {
+                                    System.out.println("v: " + v.get());
+                                }"""),
+                new TestCase("example2",
+                        """
+                                if (v.isPresent()) { // @start region="example2"
+                                    System.out.println("v: " + v.get());
+                                } // @end
+                                """,
+                        """
+                                if (v.isPresent()) {
+                                    System.out.println("v: " + v.get());
+                                }"""),
+                new TestCase("example3",
+                        """
+                                // @start region="example3" :
+                                if (v.isPresent()) {
+                                    System.out.println("v: " + v.get());
+                                // @end :
+                                }
+                                """,
+                        """
+                                if (v.isPresent()) {
+                                    System.out.println("v: " + v.get());
+                                }""")
+        );
+        testPositive(base, testCases);
+    }
+
+    @Test
+    public void testPositiveInlineTagMarkup_BlankLinesEquivalence(Path base) throws Exception {
+        var testCases = List.of(
+                new TestCase(
+                        """
+                                // @start region="example"
+                                if (v.isPresent()) {
+                                    System.out.println("v: " + v.get());
+                                }
+                                // @end
+                                """,
+                        """
+                                if (v.isPresent()) {
+                                    System.out.println("v: " + v.get());
+                                }
+                                """),
+                new TestCase(
+                        """
+                                if (v.isPresent()) { // @start region="example"
+                                    System.out.println("v: " + v.get());
+                                } // @end
+                                """,
+                        """
+                                if (v.isPresent()) {
+                                    System.out.println("v: " + v.get());
+                                }
+                                """),
+                new TestCase(
+                        """
+                                 // @start region="example" :
+                                if (v.isPresent()) {
+                                    System.out.println("v: " + v.get());
+                                // @end :
+                                }
+                                """,
+                        """
+                                if (v.isPresent()) {
+                                    System.out.println("v: " + v.get());
+                                }
+                                """)
+        );
+        testPositive(base, testCases);
+    }
 
     @Test
     public void testPositiveInlineTagMarkup_BlankLinesFromStartEnd(Path base) throws Exception {

--- a/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetMarkup.java
+++ b/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetMarkup.java
@@ -370,6 +370,118 @@ First line // @highlight :
         testPositive(base, testCases);
     }
 
+    // @replace on a blank line will not do anything bad!
+
+    // What to do with a markup line that modifies blankness somehow? For example:
+    //
+    //    // @replace regex=.* replacement="hello"
+
+    @Test
+    public void testPositiveInlineTagMarkup_BlankLinesFromStartEnd(Path base) throws Exception {
+        // A markup line that contains either @start or @end is removed.
+        var testCases = List.of(
+                new TestCase("""
+                        First line
+                          // @start region="a"
+                         Third line
+                          // @end
+                        Fifth line
+                        """,
+                        """
+                                First line
+                                 Third line
+                                Fifth line
+                                """),
+                new TestCase("""
+                        First line
+                          // @start region="a"
+                          // @start region="b"
+                         Third line
+                          // @end
+                        Fifth line
+                          // @end
+                        """,
+                        """
+                                First line
+                                 Third line
+                                Fifth line
+                                """),
+                // note incidental whitespace removal in test cases below
+                new TestCase("a", """
+                        First line
+                          // @start region="a"
+                         Third line
+                          // @end
+                        Fifth line
+                        """,
+
+                        """
+                                Third line
+                                """),
+                new TestCase("b", """
+                        First line
+                          // @start region="a"
+                          // @start region="b"
+                         Third line
+                          // @end
+                        Fifth line
+                          // @end
+                        """,
+                        """
+                                Third line
+                                """)
+        );
+        testPositive(base, testCases);
+    }
+
+    @Test
+    public void testPositiveInlineTagMarkup_BlankLinesFromNextLineMarkup(Path base) throws Exception {
+        // A markup line that refers to the next line is removed.
+        var testCases = List.of(
+                new TestCase("""
+                        First line
+                             // @highlight:
+                         Third line
+                        """,
+                        """
+                                First line
+                                <span class="bold"> Third line
+                                </span>"""),
+                new TestCase("""
+                        First line
+                             // @link target="Object#equals(Object)":
+                         Third line
+                        """,
+                        replace("""
+                                First line
+                                 link(Third line)
+                                """, "link\\((.+?)\\)", r -> link(true, "java.lang.Object#equals(Object)", r.group(1)))
+                ),
+                new TestCase("""
+                        First line
+                             // @replace regex=.+ replacement="x":
+                         Third line
+                        """,
+                        """
+                                First line
+                                x
+                                """),
+                new TestCase("""
+                        First line
+                             // @start region=a:
+                         Third line
+                             // @end:
+                           Fifth line
+                        """,
+                        """
+                                First line
+                                 Third line
+                                   Fifth line
+                                """)
+        );
+        testPositive(base, testCases);
+    }
+
     private static String link(boolean linkPlain,
                                String targetReference,
                                String content)

--- a/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetTag.java
@@ -278,7 +278,6 @@ public class TestSnippetTag extends SnippetTester {
         checkExit(Exit.OK);
         checkLinks();
         final var javaContent = """
-
                 System.out.println(msg);
                 """;
         final var propertiesContent = """


### PR DESCRIPTION
This PR proposes to omit lines from the snippet source if those lines consist only of markup and perhaps whitespace. For example, if this PR is integrated, these three snippets will result in the same output:
```
    // @start region="example1"
    if (v.isPresent()) {
        System.out.println("v: " + v.get());
    } // @end


    if (v.isPresent()) { // @start region="example2"
        System.out.println("v: " + v.get());
    } // @end


    // @start region="example3" :
    if (v.isPresent()) {
        System.out.println("v: " + v.get());
    // @end :
    }
```
While this change complicates the mental model for markup, it removes otherwise unavoidable inner blank lines in properties files, for example:
```
    coffee=espresso
    # @highlight:
    tea=ice
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277026](https://bugs.openjdk.java.net/browse/JDK-8277026): Remove blank lines remaining from snippet markup


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6623/head:pull/6623` \
`$ git checkout pull/6623`

Update a local copy of the PR: \
`$ git checkout pull/6623` \
`$ git pull https://git.openjdk.java.net/jdk pull/6623/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6623`

View PR using the GUI difftool: \
`$ git pr show -t 6623`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6623.diff">https://git.openjdk.java.net/jdk/pull/6623.diff</a>

</details>
