### PR TITLE
8278037: Clean up PPC32 related code in C1

### DIFF
--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -132,17 +132,15 @@ void LIR_Opr::validate_type() const {
              size_field() == double_size, "must match");
       break;
     case T_FLOAT:
-      // FP return values can be also in CPU registers on ARM and PPC32 (softfp ABI)
+      // FP return values can be also in CPU registers on ARM (softfp ABI)
       assert((kindfield == fpu_register || kindfield == stack_value
-             ARM_ONLY(|| kindfield == cpu_register)
-             PPC32_ONLY(|| kindfield == cpu_register) ) &&
+             ARM_ONLY(|| kindfield == cpu_register) &&
              size_field() == single_size, "must match");
       break;
     case T_DOUBLE:
-      // FP return values can be also in CPU registers on ARM and PPC32 (softfp ABI)
+      // FP return values can be also in CPU registers on ARM (softfp ABI)
       assert((kindfield == fpu_register || kindfield == stack_value
-             ARM_ONLY(|| kindfield == cpu_register)
-             PPC32_ONLY(|| kindfield == cpu_register) ) &&
+             ARM_ONLY(|| kindfield == cpu_register) &&
              size_field() == double_size, "must match");
       break;
     case T_BOOLEAN:

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -497,10 +497,6 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
       assert(opConvert->_info == NULL, "must be");
       if (opConvert->_opr->is_valid())       do_input(opConvert->_opr);
       if (opConvert->_result->is_valid())    do_output(opConvert->_result);
-#ifdef PPC32
-      if (opConvert->_tmp1->is_valid())      do_temp(opConvert->_tmp1);
-      if (opConvert->_tmp2->is_valid())      do_temp(opConvert->_tmp2);
-#endif
       do_stub(opConvert->_stub);
 
       break;
@@ -1874,12 +1870,6 @@ void LIR_OpConvert::print_instr(outputStream* out) const {
   print_bytecode(out, bytecode());
   in_opr()->print(out);                  out->print(" ");
   result_opr()->print(out);              out->print(" ");
-#ifdef PPC32
-  if(tmp1()->is_valid()) {
-    tmp1()->print(out); out->print(" ");
-    tmp2()->print(out); out->print(" ");
-  }
-#endif
 }
 
 void LIR_OpConvert::print_bytecode(outputStream* out, Bytecodes::Code code) {

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -134,13 +134,13 @@ void LIR_Opr::validate_type() const {
     case T_FLOAT:
       // FP return values can be also in CPU registers on ARM (softfp ABI)
       assert((kindfield == fpu_register || kindfield == stack_value
-             ARM_ONLY(|| kindfield == cpu_register) &&
+             ARM_ONLY(|| kindfield == cpu_register) ) &&
              size_field() == single_size, "must match");
       break;
     case T_DOUBLE:
       // FP return values can be also in CPU registers on ARM (softfp ABI)
       assert((kindfield == fpu_register || kindfield == stack_value
-             ARM_ONLY(|| kindfield == cpu_register) &&
+             ARM_ONLY(|| kindfield == cpu_register) ) &&
              size_field() == double_size, "must match");
       break;
     case T_BOOLEAN:

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -2142,11 +2142,7 @@ LIR_Opr LinearScan::calc_operand_for_interval(const Interval* interval) {
 #ifdef _LP64
         return LIR_OprFact::double_cpu(assigned_reg, assigned_reg);
 #else
-#if defined(PPC32)
-        return LIR_OprFact::double_cpu(assigned_regHi, assigned_reg);
-#else
         return LIR_OprFact::double_cpu(assigned_reg, assigned_regHi);
-#endif // PPC32
 #endif // LP64
       }
 
@@ -2788,9 +2784,6 @@ int LinearScan::append_scope_value_for_operand(LIR_Opr opr, GrowableArray<ScopeV
 #endif
 #ifdef ARM32
       assert(opr->fpu_regnrHi() == opr->fpu_regnrLo() + 1, "assumed in calculation (only fpu_regnrLo is used)");
-#endif
-#ifdef PPC32
-      assert(opr->fpu_regnrLo() == opr->fpu_regnrHi(), "assumed in calculation (only fpu_regnrHi is used)");
 #endif
 
 #ifdef VM_LITTLE_ENDIAN

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -243,9 +243,6 @@ void Runtime1::generate_blob_for(BufferBlob* buffer_blob, StubID id) {
   case fpu2long_stub_id:
   case unwind_exception_id:
   case counter_overflow_id:
-#if defined(PPC32)
-  case handle_exception_nofpu_id:
-#endif
     expect_oop_map = false;
     break;
   default:
@@ -1179,40 +1176,6 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_
           ShouldNotReachHere();
         }
 
-#if defined(PPC32)
-        if (load_klass_or_mirror_patch_id ||
-            stub_id == Runtime1::load_appendix_patching_id) {
-          // Update the location in the nmethod with the proper
-          // metadata.  When the code was generated, a NULL was stuffed
-          // in the metadata table and that table needs to be update to
-          // have the right value.  On intel the value is kept
-          // directly in the instruction instead of in the metadata
-          // table, so set_data above effectively updated the value.
-          nmethod* nm = CodeCache::find_nmethod(instr_pc);
-          assert(nm != NULL, "invalid nmethod_pc");
-          RelocIterator mds(nm, copy_buff, copy_buff + 1);
-          bool found = false;
-          while (mds.next() && !found) {
-            if (mds.type() == relocInfo::oop_type) {
-              assert(stub_id == Runtime1::load_mirror_patching_id ||
-                     stub_id == Runtime1::load_appendix_patching_id, "wrong stub id");
-              oop_Relocation* r = mds.oop_reloc();
-              oop* oop_adr = r->oop_addr();
-              *oop_adr = stub_id == Runtime1::load_mirror_patching_id ? mirror() : appendix();
-              r->fix_oop_relocation();
-              found = true;
-            } else if (mds.type() == relocInfo::metadata_type) {
-              assert(stub_id == Runtime1::load_klass_patching_id, "wrong stub id");
-              metadata_Relocation* r = mds.metadata_reloc();
-              Metadata** metadata_adr = r->metadata_addr();
-              *metadata_adr = load_klass;
-              r->fix_metadata_relocation();
-              found = true;
-            }
-          }
-          assert(found, "the metadata must exist!");
-        }
-#endif
         if (do_patch) {
           // replace instructions
           // first replace the tail, then the call
@@ -1270,13 +1233,6 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_
             RelocIterator iter(nm, (address)instr_pc, (address)(instr_pc + 1));
             relocInfo::change_reloc_info_for_address(&iter, (address) instr_pc,
                                                      relocInfo::none, rtype);
-#ifdef PPC32
-          { address instr_pc2 = instr_pc + NativeMovConstReg::lo_offset;
-            RelocIterator iter2(nm, instr_pc2, instr_pc2 + 1);
-            relocInfo::change_reloc_info_for_address(&iter2, (address) instr_pc2,
-                                                     relocInfo::none, rtype);
-          }
-#endif
           }
 
         } else {


### PR DESCRIPTION
`_tmp1` and `_tmp2` were [removed](https://hg.openjdk.java.net/jdk9/jdk9/hotspot/rev/faaed259df37#l13.173) in [JDK-8160245](https://bugs.openjdk.java.net/browse/JDK-8160245), but they are still used.

This should cause a build error. I don't have a ppc32 machine for the test. It's also not found at https://builds.shipilev.net. Is ppc32 a supported compiler1 platform?

Update: PPC32 C1 is not supported. Clean up PPC32 related code in C1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278037](https://bugs.openjdk.java.net/browse/JDK-8278037): Clean up PPC32 related code in C1


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to 90f402a6f521fb7fa805018e78a83401f5391714
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6625/head:pull/6625` \
`$ git checkout pull/6625`

Update a local copy of the PR: \
`$ git checkout pull/6625` \
`$ git pull https://git.openjdk.java.net/jdk pull/6625/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6625`

View PR using the GUI difftool: \
`$ git pr show -t 6625`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6625.diff">https://git.openjdk.java.net/jdk/pull/6625.diff</a>

</details>
