### PR TITLE
8277353: java/security/MessageDigest/ThreadSafetyTest.java test times out

### DIFF
--- a/test/jdk/java/security/MessageDigest/ThreadSafetyTest.java
+++ b/test/jdk/java/security/MessageDigest/ThreadSafetyTest.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8241960 8277353
  * @summary Confirm that java.security.MessageDigest is thread-safe after clone.
- * @run main/othervm/timeout=120 ThreadSafetyTest 5 4
+ * @run main/othervm/timeout=200 ThreadSafetyTest 5 4
  */
 
 import java.security.MessageDigest;

--- a/test/jdk/java/security/MessageDigest/ThreadSafetyTest.java
+++ b/test/jdk/java/security/MessageDigest/ThreadSafetyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Azul Systems, Inc. All rights reserved.
+ * Copyright (c) 2020, 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,9 @@
 
 /*
  * @test
- * @bug 8241960
+ * @bug 8241960 8277353
  * @summary Confirm that java.security.MessageDigest is thread-safe after clone.
- * @run main/othervm ThreadSafetyTest 5 4
+ * @run main/othervm/timeout=120 ThreadSafetyTest 5 4
  */
 
 import java.security.MessageDigest;

--- a/test/jdk/java/security/MessageDigest/ThreadSafetyTest.java
+++ b/test/jdk/java/security/MessageDigest/ThreadSafetyTest.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8241960 8277353
  * @summary Confirm that java.security.MessageDigest is thread-safe after clone.
- * @run main/othervm/timeout=200 ThreadSafetyTest 5 4
+ * @run main ThreadSafetyTest 4 2
  */
 
 import java.security.MessageDigest;
@@ -56,7 +56,7 @@ public class ThreadSafetyTest {
             duration = Integer.parseInt(args[1]);
         }
         int nProcessors = Runtime.getRuntime().availableProcessors();
-        int nTasks = nProcessors * threadsFactor;
+        int nTasks = Math.min(nProcessors, 4) * threadsFactor;
 
         System.out.println("Testing with " + nTasks + " threads on " +
                            nProcessors + " processors for " + duration +


### PR DESCRIPTION
This Test gets timeout during low cpu availability. It is modified to support extended timeout period during JTREG execution.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277353](https://bugs.openjdk.java.net/browse/JDK-8277353): java/security/MessageDigest/ThreadSafetyTest.java test times out


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6626/head:pull/6626` \
`$ git checkout pull/6626`

Update a local copy of the PR: \
`$ git checkout pull/6626` \
`$ git pull https://git.openjdk.java.net/jdk pull/6626/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6626`

View PR using the GUI difftool: \
`$ git pr show -t 6626`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6626.diff">https://git.openjdk.java.net/jdk/pull/6626.diff</a>

</details>
