### PR TITLE
8278049: G1: add precondition to set_remainder_to_point_to_start

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
@@ -97,14 +97,7 @@ void G1BlockOffsetTablePart::update() {
 // The arguments follow the normal convention of denoting
 // a right-open interval: [start, end)
 void G1BlockOffsetTablePart:: set_remainder_to_point_to_start(HeapWord* start, HeapWord* end) {
-
-  if (start >= end) {
-    // The start address is equal to the end address (or to
-    // the right of the end address) so there are not cards
-    // that need to be updated..
-    return;
-  }
-
+  assert(start < end, "precondition");
   // Write the backskip value for each region.
   //
   //    offset
@@ -149,9 +142,7 @@ void G1BlockOffsetTablePart:: set_remainder_to_point_to_start(HeapWord* start, H
 // a closed, inclusive interval: [start_card, end_card], cf set_remainder_to_point_to_start()
 // above.
 void G1BlockOffsetTablePart::set_remainder_to_point_to_start_incl(size_t start_card, size_t end_card) {
-  if (start_card > end_card) {
-    return;
-  }
+  assert(start_card <= end_card, "precondition");
   assert(start_card > _bot->index_for(_hr->bottom()), "Cannot be first card");
   assert(_bot->offset_array(start_card-1) <= BOTConstants::N_words,
          "Offset card has an unexpected value");


### PR DESCRIPTION
Simple change of converting always-false conditions to assertions.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278049](https://bugs.openjdk.java.net/browse/JDK-8278049): G1: add precondition to set_remainder_to_point_to_start


### Reviewers
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**) ⚠️ Review applies to 9cc3bd7ca46f04970d92bd2eb25b34128c5330db
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6630/head:pull/6630` \
`$ git checkout pull/6630`

Update a local copy of the PR: \
`$ git checkout pull/6630` \
`$ git pull https://git.openjdk.java.net/jdk pull/6630/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6630`

View PR using the GUI difftool: \
`$ git pr show -t 6630`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6630.diff">https://git.openjdk.java.net/jdk/pull/6630.diff</a>

</details>
