### PR TITLE
8278050: Armenian text isn't rendered on macOS if text layout is performed

### DIFF
--- a/src/java.desktop/macosx/classes/sun/font/CFont.java
+++ b/src/java.desktop/macosx/classes/sun/font/CFont.java
@@ -206,7 +206,7 @@ public final class CFont extends PhysicalFont implements FontSubstitution {
 
         // In some italic cases the standard Mac cascade list is missing Arabic.
         listOfString.add("GeezaPro");
-        FontManager fm = FontManagerFactory.getInstance();
+        CFontManager fm = (CFontManager) FontManagerFactory.getInstance();
         int numFonts = 1 + listOfString.size();
         PhysicalFont[] fonts = new PhysicalFont[numFonts];
         fonts[0] = this;
@@ -222,7 +222,7 @@ public final class CFont extends PhysicalFont implements FontSubstitution {
                 // Don't know why we get the weird name above .. replace.
                 s = "AppleSymbols";
             }
-            Font2D f2d = fm.findFont2D(s, Font.PLAIN, FontManager.NO_FALLBACK);
+            Font2D f2d = fm.getOrCreateFallbackFont(s);
             if (f2d == null || f2d == this) {
                 continue;
             }

--- a/src/java.desktop/macosx/classes/sun/font/CFontManager.java
+++ b/src/java.desktop/macosx/classes/sun/font/CFontManager.java
@@ -33,8 +33,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Locale;
+import java.util.Map;
 import java.util.TreeMap;
 import java.util.Vector;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.swing.plaf.FontUIResource;
 
@@ -45,6 +47,7 @@ import sun.lwawt.macosx.*;
 
 public final class CFontManager extends SunFontManager {
     private static Hashtable<String, Font2D> genericFonts = new Hashtable<String, Font2D>();
+    private final Map<String, Font2D> fallbackFonts = new ConcurrentHashMap<>();
 
     @Override
     protected FontConfiguration createFontConfiguration() {
@@ -321,4 +324,17 @@ public final class CFontManager extends SunFontManager {
     @Override
     protected void populateFontFileNameMap(HashMap<String, String> fontToFileMap, HashMap<String, String> fontToFamilyNameMap,
             HashMap<String, ArrayList<String>> familyToFontListMap, Locale locale) {}
+
+    Font2D getOrCreateFallbackFont(String fontName) {
+        Font2D font2D = findFont2D(fontName, Font.PLAIN, FontManager.NO_FALLBACK);
+        if (font2D != null || fontName.startsWith(".")) {
+            return font2D;
+        } else {
+            // macOS doesn't list some system fonts in [NSFontManager availableFontFamilies] output,
+            // so they are not registered in font manager as part of 'loadNativeFonts'.
+            // These fonts are present in [NSFontManager availableFonts] output though,
+            // and can be accessed in the same way as other system fonts.
+            return fallbackFonts.computeIfAbsent(fontName, name -> new CFont(name, null));
+        }
+    }
 }


### PR DESCRIPTION
The problem is related to the implementation of font fallback on macOS, specifically to the path used when text layout
is performed, i.e. the one using `FontSubstitution` and cascade lists. `CTFontCopyDefaultCascadeListForLanguages`'s output contains an entry for the font, able to render Armenian text ('NotoSansArmenian-Regular'), but `CFont.createCompositeFont` cannot find this font amongst registered fonts, and the entry is skipped, resulting in broken rendering.
System font loading (performed by `CFontManager.loadNativeFonts`) relies on `[NSFontManager availableFontFamilies]`, but its output doesn't contain 'Noto Sans Armenian' (which is a family for 'NotoSansArmenian-Regular' font). 'Noto Sans Armenian' is recognized by `[NSFontManager availableMembersOfFontFamily:]` though, 'NotoSansArmenian-Regular' is contained in `[NSFontManager availableFonts]` output, and the font can be created and used normally, just like any other system font. Not sure why its family is 'hidden', maybe macOS developers wanted to limit the number of options
displayed in font selection drop-downs.
For reference, another cascade list item, ignored in similar way is 'NotoSansZawgyi-Regular'.

Proposed fix is to create `CFont` objects for cascade list items explicitly, if corresponding fonts are not registered. These objects are re-used between different fonts as their fallback components (to enable caching of char-to-glyph mapping), but are not made available to public font APIs.
I've considered an alternative solution - using `[NSFontManager availableFonts]` instead of
`[NSFontManager availableFontFamilies]` to load system fonts. Two factors complicate it though - `loadNativeFonts` will
take more time (on my machine about 170 additional fonts will be loaded) and the order of font loading will change (which
impacts the selection of 'preferred' plain/bold/italic/bolditalic components in `FontFamily` class). Both factors can be
dealt with, but they make the solution more complicated and prone to regressions. For now, it seems not worth it.

I've not created a test, as it would rely on macOS providing a fallback font for Armenian script, which is not guaranteed.
Existing tests pass fine with the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278050](https://bugs.openjdk.java.net/browse/JDK-8278050): Armenian text isn't rendered on macOS if text layout is performed


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6633/head:pull/6633` \
`$ git checkout pull/6633`

Update a local copy of the PR: \
`$ git checkout pull/6633` \
`$ git pull https://git.openjdk.java.net/jdk pull/6633/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6633`

View PR using the GUI difftool: \
`$ git pr show -t 6633`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6633.diff">https://git.openjdk.java.net/jdk/pull/6633.diff</a>

</details>
