### PR TITLE
8278071: typos in MemorySegment::set, MemorySegment::setAtIndex javadoc

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -1051,6 +1051,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      * @throws IllegalStateException if the scope associated with this segment has been closed, or if access occurs from
      * a thread other than the thread owning that scope.
      * @throws IndexOutOfBoundsException when the dereference operation falls outside the <em>spatial bounds</em> of the
+     * memory segment.
      */
     @ForceInline
     default void set(ValueLayout.OfByte layout, long offset, byte value) {
@@ -1084,6 +1085,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      * @throws IllegalStateException if the scope associated with this segment has been closed, or if access occurs from
      * a thread other than the thread owning that scope.
      * @throws IndexOutOfBoundsException when the dereference operation falls outside the <em>spatial bounds</em> of the
+     * memory segment.
      */
     @ForceInline
     default void set(ValueLayout.OfBoolean layout, long offset, boolean value) {
@@ -1117,6 +1119,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      * @throws IllegalStateException if the scope associated with this segment has been closed, or if access occurs from
      * a thread other than the thread owning that scope.
      * @throws IndexOutOfBoundsException when the dereference operation falls outside the <em>spatial bounds</em> of the
+     * memory segment.
      */
     @ForceInline
     default void set(ValueLayout.OfChar layout, long offset, char value) {
@@ -1150,6 +1153,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      * @throws IllegalStateException if the scope associated with this segment has been closed, or if access occurs from
      * a thread other than the thread owning that scope.
      * @throws IndexOutOfBoundsException when the dereference operation falls outside the <em>spatial bounds</em> of the
+     * memory segment.
      */
     @ForceInline
     default void set(ValueLayout.OfShort layout, long offset, short value) {
@@ -1183,6 +1187,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      * @throws IllegalStateException if the scope associated with this segment has been closed, or if access occurs from
      * a thread other than the thread owning that scope.
      * @throws IndexOutOfBoundsException when the dereference operation falls outside the <em>spatial bounds</em> of the
+     * memory segment.
      */
     @ForceInline
     default void set(ValueLayout.OfInt layout, long offset, int value) {
@@ -1216,6 +1221,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      * @throws IllegalStateException if the scope associated with this segment has been closed, or if access occurs from
      * a thread other than the thread owning that scope.
      * @throws IndexOutOfBoundsException when the dereference operation falls outside the <em>spatial bounds</em> of the
+     * memory segment.
      */
     @ForceInline
     default void set(ValueLayout.OfFloat layout, long offset, float value) {
@@ -1249,6 +1255,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      * @throws IllegalStateException if the scope associated with this segment has been closed, or if access occurs from
      * a thread other than the thread owning that scope.
      * @throws IndexOutOfBoundsException when the dereference operation falls outside the <em>spatial bounds</em> of the
+     * memory segment.
      */
     @ForceInline
     default void set(ValueLayout.OfLong layout, long offset, long value) {
@@ -1282,6 +1289,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      * @throws IllegalStateException if the scope associated with this segment has been closed, or if access occurs from
      * a thread other than the thread owning that scope.
      * @throws IndexOutOfBoundsException when the dereference operation falls outside the <em>spatial bounds</em> of the
+     * memory segment.
      */
     @ForceInline
     default void set(ValueLayout.OfDouble layout, long offset, double value) {
@@ -1315,6 +1323,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      * @throws IllegalStateException if the scope associated with this segment has been closed, or if access occurs from
      * a thread other than the thread owning that scope.
      * @throws IndexOutOfBoundsException when the dereference operation falls outside the <em>spatial bounds</em> of the
+     * memory segment.
      */
     @ForceInline
     default void set(ValueLayout.OfAddress layout, long offset, Addressable value) {
@@ -1348,6 +1357,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      * @throws IllegalStateException if the scope associated with this segment has been closed, or if access occurs from
      * a thread other than the thread owning that scope.
      * @throws IndexOutOfBoundsException when the dereference operation falls outside the <em>spatial bounds</em> of the
+     * memory segment.
      */
     @ForceInline
     default void setAtIndex(ValueLayout.OfChar layout, long index, char value) {
@@ -1381,6 +1391,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      * @throws IllegalStateException if the scope associated with this segment has been closed, or if access occurs from
      * a thread other than the thread owning that scope.
      * @throws IndexOutOfBoundsException when the dereference operation falls outside the <em>spatial bounds</em> of the
+     * memory segment.
      */
     @ForceInline
     default void setAtIndex(ValueLayout.OfShort layout, long index, short value) {
@@ -1414,6 +1425,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      * @throws IllegalStateException if the scope associated with this segment has been closed, or if access occurs from
      * a thread other than the thread owning that scope.
      * @throws IndexOutOfBoundsException when the dereference operation falls outside the <em>spatial bounds</em> of the
+     * memory segment.
      */
     @ForceInline
     default void setAtIndex(ValueLayout.OfInt layout, long index, int value) {
@@ -1447,6 +1459,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      * @throws IllegalStateException if the scope associated with this segment has been closed, or if access occurs from
      * a thread other than the thread owning that scope.
      * @throws IndexOutOfBoundsException when the dereference operation falls outside the <em>spatial bounds</em> of the
+     * memory segment.
      */
     @ForceInline
     default void setAtIndex(ValueLayout.OfFloat layout, long index, float value) {
@@ -1480,6 +1493,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      * @throws IllegalStateException if the scope associated with this segment has been closed, or if access occurs from
      * a thread other than the thread owning that scope.
      * @throws IndexOutOfBoundsException when the dereference operation falls outside the <em>spatial bounds</em> of the
+     * memory segment.
      */
     @ForceInline
     default void setAtIndex(ValueLayout.OfLong layout, long index, long value) {
@@ -1513,6 +1527,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      * @throws IllegalStateException if the scope associated with this segment has been closed, or if access occurs from
      * a thread other than the thread owning that scope.
      * @throws IndexOutOfBoundsException when the dereference operation falls outside the <em>spatial bounds</em> of the
+     * memory segment.
      */
     @ForceInline
     default void setAtIndex(ValueLayout.OfDouble layout, long index, double value) {
@@ -1546,6 +1561,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      * @throws IllegalStateException if the scope associated with this segment has been closed, or if access occurs from
      * a thread other than the thread owning that scope.
      * @throws IndexOutOfBoundsException when the dereference operation falls outside the <em>spatial bounds</em> of the
+     * memory segment.
      */
     @ForceInline
     default void setAtIndex(ValueLayout.OfAddress layout, long index, Addressable value) {


### PR DESCRIPTION
There are some truncated statements in MemorySegment::get/MemorySegment::getAtIndex javadoc, more specifically in the `@throws` for `IndexOutOfBoundsException`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278071](https://bugs.openjdk.java.net/browse/JDK-8278071): typos in MemorySegment::set, MemorySegment::setAtIndex javadoc


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6635/head:pull/6635` \
`$ git checkout pull/6635`

Update a local copy of the PR: \
`$ git checkout pull/6635` \
`$ git pull https://git.openjdk.java.net/jdk pull/6635/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6635`

View PR using the GUI difftool: \
`$ git pr show -t 6635`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6635.diff">https://git.openjdk.java.net/jdk/pull/6635.diff</a>

</details>
