### PR TITLE
8262901: Fix aarch64 jvmci calling convention

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.aarch64/src/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotJVMCIBackendFactory.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.aarch64/src/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotJVMCIBackendFactory.java
@@ -94,7 +94,7 @@ public class AArch64HotSpotJVMCIBackendFactory implements HotSpotJVMCIBackendFac
         // and Darwin use it for such. Linux doesn't assign it and thus r18 can
         // be used as an additional register.
         boolean canUsePlatformRegister = config.linuxOs;
-        return new AArch64HotSpotRegisterConfig(target, config.useCompressedOops, canUsePlatformRegister);
+        return new AArch64HotSpotRegisterConfig(target, config.useCompressedOops, canUsePlatformRegister, config.macOs);
     }
 
     protected HotSpotCodeCacheProvider createCodeCache(HotSpotJVMCIRuntime runtime, TargetDescription target, RegisterConfig regConfig) {

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.aarch64/src/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.aarch64/src/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotVMConfig.java
@@ -38,6 +38,7 @@ class AArch64HotSpotVMConfig extends HotSpotVMConfigAccess {
     }
 
     final boolean linuxOs = Services.getSavedProperty("os.name", "").startsWith("Linux");
+    final boolean macOs = Services.getSavedProperty("os.name", "").startsWith("Mac");
 
     final boolean useCompressedOops = getFlag("UseCompressedOops", Boolean.class);
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -46,7 +46,6 @@
 compiler/ciReplay/TestSAServer.java 8029528 generic-all
 compiler/compilercontrol/jcmd/ClearDirectivesFileStackTest.java 8225370 generic-all
 compiler/jvmci/compilerToVM/GetFlagValueTest.java 8204459 generic-all
-compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java 8262901 macosx-aarch64
 compiler/tiered/LevelTransitionTest.java 8067651 generic-all
 
 compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java 8190680 generic-all


### PR DESCRIPTION
This is the fix of aarch64 jvmci calling convention.

On MacOS/aarch64 "Function arguments may consume slots on the stack that are not multiples of 8 bytes" [1], but current approach uses only wordsize or bigger slots, which is incorrect (that is why tests were failing https://bugs.openjdk.java.net/browse/JDK-8262901). Now arguments consume the right amount of bytes.

Another problem is that current approach don't make 16-byte alignment of Stack Pointer [1][2][3]. However, tests not fail on Linux/aarch64 and Windows/aarch64. They pass because in this tests all functions have even number of argumets, that is why 16-byte alignment comes automatically. But if you try to add or delete one argumets, tests will fail with SIGBUS.

I've tested this patch on MacOS/aarch64 and Linux/aarch64, all tests have passed.

Also I don't understand, why current tests (NativeCallTest) use only int, long, float and double as arguments types. Is it possible to add functions with another types like byte or short? I tried, but it fails on every platform.

[1] https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms
[2] https://github.com/ARM-software/abi-aa/blob/main/aapcs64/aapcs64.rst#the-stack
[3] https://docs.microsoft.com/en-us/cpp/build/arm64-windows-abi-conventions?view=msvc-160#stack