### PR TITLE
8278087: Deserialization filter and filter factory property error reporting under specified

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputFilter.java
+++ b/src/java.base/share/classes/java/io/ObjectInputFilter.java
@@ -524,12 +524,12 @@ public interface ObjectInputFilter {
      * {@code jdk.serialFilter} is defined then it is used to configure the filter.
      * The filter is created as if {@link #createFilter(String) createFilter} is called,
      * if the filter string is invalid the initialization fails and subsequent attempts to
-     * {@linkplain Config#getSerialFilter() get the filter}, {@link Config#setSerialFilter set a filter},
-     * or create an {@link ObjectInputStream#ObjectInputStream(InputStream) ObjectInputStream}
+     * {@linkplain Config#getSerialFilter() get the filter}, {@linkplain Config#setSerialFilter set a filter},
+     * or create an {@linkplain ObjectInputStream#ObjectInputStream(InputStream) ObjectInputStream}
      * throw {@link IllegalStateException}. Deserialization is not possible with an
      * invalid serial filter.
      * If the system property {@code jdk.serialFilter} or the {@link java.security.Security}
-     * property is not set the filter can be set with
+     * property {@code jdk.serialFilter} is not set the filter can be set with
      * {@link #setSerialFilter(ObjectInputFilter) Config.setSerialFilter}.
      * Setting the {@code jdk.serialFilter} with {@link System#setProperty(String, String)
      * System.setProperty} <em>does not set the filter</em>.
@@ -718,7 +718,7 @@ public interface ObjectInputFilter {
          *
          * @return the static JVM-wide deserialization filter or {@code null} if not configured
          * @throws IllegalStateException if the initialization of the filter from the
-         *      commandline property {@code jdk.serialFilter} or
+         *      system property {@code jdk.serialFilter} or
          *      the security property {@code jdk.serialFilter} fails.
          */
         public static ObjectInputFilter getSerialFilter() {
@@ -735,7 +735,7 @@ public interface ObjectInputFilter {
          * @throws SecurityException if there is security manager and the
          *       {@code SerializablePermission("serialFilter")} is not granted
          * @throws IllegalStateException if the filter has already been set or the initialization
-         *       of the filter from the commandline property {@code jdk.serialFilter} or
+         *       of the filter from the system property {@code jdk.serialFilter} or
          *       the security property {@code jdk.serialFilter} fails.
          */
         public static void setSerialFilter(ObjectInputFilter filter) {
@@ -745,11 +745,12 @@ public interface ObjectInputFilter {
             if (sm != null) {
                 sm.checkPermission(ObjectStreamConstants.SERIAL_FILTER_PERMISSION);
             }
+            if (invalidFilterMessage != null) {
+                throw new IllegalStateException(invalidFilterMessage);
+            }
             synchronized (serialFilterLock) {
                 if (serialFilter != null) {
                     throw new IllegalStateException("Serial filter can only be set once");
-                } else if (invalidFilterMessage != null) {
-                    throw new IllegalStateException(invalidFilterMessage);
                 }
                 serialFilter = filter;
             }

--- a/src/java.base/share/classes/java/io/ObjectInputFilter.java
+++ b/src/java.base/share/classes/java/io/ObjectInputFilter.java
@@ -27,7 +27,6 @@ package java.io;
 
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.util.StaticProperty;
-import sun.security.action.GetBooleanAction;
 
 import java.lang.reflect.InvocationTargetException;
 import java.security.AccessController;
@@ -523,10 +522,15 @@ public interface ObjectInputFilter {
      * {@systemProperty jdk.serialFilter}, its value is used to configure the filter.
      * If the system property is not defined, and the {@link java.security.Security} property
      * {@code jdk.serialFilter} is defined then it is used to configure the filter.
-     * The filter is created as if {@link #createFilter(String) createFilter} is called;
-     * if the filter string is invalid, an {@link ExceptionInInitializerError} is thrown.
-     * Otherwise, the filter is not configured during initialization and
-     * can be set with {@link #setSerialFilter(ObjectInputFilter) Config.setSerialFilter}.
+     * The filter is created as if {@link #createFilter(String) createFilter} is called,
+     * if the filter string is invalid the initialization fails and subsequent attempts to
+     * {@linkplain Config#getSerialFilter() get the filter}, {@link Config#setSerialFilter set a filter},
+     * or create an {@link ObjectInputStream#ObjectInputStream(InputStream) ObjectInputStream}
+     * throw {@link IllegalStateException}. Deserialization is not possible with an
+     * invalid serial filter.
+     * If the system property {@code jdk.serialFilter} or the {@link java.security.Security}
+     * property is not set the filter can be set with
+     * {@link #setSerialFilter(ObjectInputFilter) Config.setSerialFilter}.
      * Setting the {@code jdk.serialFilter} with {@link System#setProperty(String, String)
      * System.setProperty} <em>does not set the filter</em>.
      * The syntax for the property value is the same as for the
@@ -545,9 +549,12 @@ public interface ObjectInputFilter {
      * <p>The class must be public, must have a public zero-argument constructor, implement the
      * {@link BinaryOperator {@literal BinaryOperator<ObjectInputFilter>}} interface, provide its implementation and
      * be accessible via the {@linkplain ClassLoader#getSystemClassLoader() application class loader}.
-     * If the filter factory constructor is not invoked successfully, an {@link ExceptionInInitializerError}
-     * is thrown and subsequent use of the filter factory for deserialization fails with
-     * {@link IllegalStateException}.
+     * If the filter factory constructor is not invoked successfully subsequent attempts to
+     * {@linkplain Config#getSerialFilterFactory() get the factory},
+     * {@linkplain Config#setSerialFilterFactory(BinaryOperator) set the factory}, or create an
+     * {@link ObjectInputStream#ObjectInputStream(InputStream) ObjectInputStream}
+     * throw {@link IllegalStateException}. Deserialization is not possible with an
+     * invalid serial filter factory.
      * The filter factory configured using the system or security property during initialization
      * can NOT be replaced with {@link #setSerialFilterFactory(BinaryOperator) Config.setSerialFilterFactory}.
      * This ensures that a filter factory set on the command line is not overridden accidentally
@@ -583,10 +590,20 @@ public interface ObjectInputFilter {
         private static volatile ObjectInputFilter serialFilter;
 
         /**
+         * Saved message if the jdk.serialFilter property is invalid.
+         */
+        private static final String invalidFilterMessage;
+
+        /**
          * Current serial filter factory.
          * @see Config#setSerialFilterFactory(BinaryOperator)
          */
         private static volatile BinaryOperator<ObjectInputFilter> serialFilterFactory;
+
+        /**
+         * Saved message if the jdk.serialFilterFactory property is invalid.
+         */
+        private static final String invalidFactoryMessage;
 
         /**
          * Boolean to indicate that the filter factory can not be set or replaced.
@@ -630,23 +647,24 @@ public interface ObjectInputFilter {
                         Security.getProperty(SERIAL_FILTER_PROPNAME));
 
             // Initialize the static filter if the jdk.serialFilter is present
-            ObjectInputFilter filter = null;
+            String filterMessage = null;
             if (filterString != null) {
                 configLog.log(DEBUG,
                         "Creating deserialization filter from {0}", filterString);
                 try {
-                    filter = createFilter(filterString);
+                    serialFilter = createFilter(filterString);
                 } catch (RuntimeException re) {
                     configLog.log(ERROR,
                             "Error configuring filter: {0}", (Object) re);
-                    // Do not continue if configuration not initialized
-                    throw re;
+                    // serialFilter remains null
+                    filterMessage = "Invalid jdk.serialFilter: " +  re.getMessage();
                 }
             }
-            serialFilter = filter;
+            invalidFilterMessage = filterMessage;
 
             // Initialize the filter factory if the jdk.serialFilterFactory is defined
             // otherwise use the builtin filter factory.
+            String factoryMessage = null;
             if (factoryClassName == null) {
                 serialFilterFactory = new BuiltinFilterFactory();
             } else {
@@ -671,10 +689,13 @@ public interface ObjectInputFilter {
                     Throwable th = (ex instanceof InvocationTargetException ite) ? ite.getCause() : ex;
                     configLog.log(ERROR,
                             "Error configuring filter factory: {0}", (Object)th);
-                    // Do not continue if configuration not initialized
-                    throw new ExceptionInInitializerError(th);
+                    // Configuration not initialized
+                    // serialFilterFactory remains null and filterFactoryNoReplace == true;
+                    factoryMessage = "invalid jdk.serialFilterFactory: " +
+                            factoryClassName + ": " + th.getClass().getName() + ": " + th.getMessage();
                 }
             }
+            invalidFactoryMessage = factoryMessage;
             // Setup shared secrets for RegistryImpl to use.
             SharedSecrets.setJavaObjectInputFilterAccess(Config::createFilter2);
         }
@@ -696,8 +717,14 @@ public interface ObjectInputFilter {
          * Returns the static JVM-wide deserialization filter or {@code null} if not configured.
          *
          * @return the static JVM-wide deserialization filter or {@code null} if not configured
+         * @throws IllegalStateException if the initialization of the filter from the
+         *      commandline property {@code jdk.serialFilter} or
+         *      the security property {@code jdk.serialFilter} fails.
          */
         public static ObjectInputFilter getSerialFilter() {
+            if (invalidFilterMessage != null) {
+                throw new IllegalStateException(invalidFilterMessage);
+            }
             return serialFilter;
         }
 
@@ -707,7 +734,9 @@ public interface ObjectInputFilter {
          * @param filter the deserialization filter to set as the JVM-wide filter; not null
          * @throws SecurityException if there is security manager and the
          *       {@code SerializablePermission("serialFilter")} is not granted
-         * @throws IllegalStateException if the filter has already been set
+         * @throws IllegalStateException if the filter has already been set or the initialization
+         *       of the filter from the commandline property {@code jdk.serialFilter} or
+         *       the security property {@code jdk.serialFilter} fails.
          */
         public static void setSerialFilter(ObjectInputFilter filter) {
             Objects.requireNonNull(filter, "filter");
@@ -719,6 +748,8 @@ public interface ObjectInputFilter {
             synchronized (serialFilterLock) {
                 if (serialFilter != null) {
                     throw new IllegalStateException("Serial filter can only be set once");
+                } else if (invalidFilterMessage != null) {
+                    throw new IllegalStateException(invalidFilterMessage);
                 }
                 serialFilter = filter;
             }
@@ -749,8 +780,10 @@ public interface ObjectInputFilter {
          * @since 17
          */
         public static BinaryOperator<ObjectInputFilter> getSerialFilterFactory() {
-            if (serialFilterFactory == null)
-                throw new IllegalStateException("Serial filter factory initialization incomplete");
+            if (serialFilterFactory == null) {
+                // If initializing the factory failed or not yet complete, throw with the message
+                throw new IllegalStateException(invalidFilterFactoryMessage());
+            }
             return serialFilterFactory;
         }
 
@@ -812,13 +845,24 @@ public interface ObjectInputFilter {
             }
             if (filterFactoryNoReplace.getAndSet(true)) {
                 final String msg = serialFilterFactory != null
-                        ? serialFilterFactory.getClass().getName()
-                        : "initialization incomplete";
-                throw new IllegalStateException("Cannot replace filter factory: " + msg);
+                        ? "Cannot replace filter factory: " + serialFilterFactory.getClass().getName()
+                        : invalidFilterFactoryMessage();
+                throw new IllegalStateException(msg);
             }
             configLog.log(DEBUG,
                     "Setting deserialization filter factory to {0}", filterFactory.getClass().getName());
             serialFilterFactory = filterFactory;
+        }
+
+        /*
+         * Return message for an invalid filter factory configuration saved from the static init.
+         * It can be called before the static initializer is complete and has set the message/null.
+         */
+        private static String invalidFilterFactoryMessage() {
+            assert serialFilterFactory == null;     // undefined if a filter factory has been set
+            return (invalidFactoryMessage != null)
+                ? invalidFactoryMessage
+                : "Serial filter factory initialization incomplete";
         }
 
         /**

--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -384,6 +384,8 @@ public class ObjectInputStream
      * <p>The constructor initializes the deserialization filter to the filter returned
      * by invoking the {@link Config#getSerialFilterFactory()} with {@code null} for the current filter
      * and the {@linkplain Config#getSerialFilter() static JVM-wide filter} for the requested filter.
+     * If the serial filter or serial filter factory properties are invalid
+     * an {@link IllegalStateException} is thrown.
      *
      * <p>If a security manager is installed, this constructor will check for
      * the "enableSubclassImplementation" SerializablePermission when invoked
@@ -396,6 +398,8 @@ public class ObjectInputStream
      * @throws  IOException if an I/O error occurs while reading stream header
      * @throws  SecurityException if untrusted subclass illegally overrides
      *          security-sensitive methods
+     * @throws  IllegalStateException if the initialization of {@link ObjectInputFilter.Config}
+     *          fails due to invalid serial filter or serial filter factory properties.
      * @throws  NullPointerException if {@code in} is {@code null}
      * @see     ObjectInputStream#ObjectInputStream()
      * @see     ObjectInputStream#readFields()
@@ -421,6 +425,8 @@ public class ObjectInputStream
      * <p>The constructor initializes the deserialization filter to the filter returned
      * by invoking the {@link Config#getSerialFilterFactory()} with {@code null} for the current filter
      * and the {@linkplain Config#getSerialFilter() static JVM-wide filter} for the requested filter.
+     * If the serial filter or serial filter factory properties are invalid
+     * an {@link IllegalStateException} is thrown.
      *
      * <p>If there is a security manager installed, this method first calls the
      * security manager's {@code checkPermission} method with the
@@ -431,6 +437,8 @@ public class ObjectInputStream
      *          {@code checkPermission} method denies enabling
      *          subclassing.
      * @throws  IOException if an I/O error occurs while creating this stream
+     * @throws  IllegalStateException if the initialization of {@link ObjectInputFilter.Config}
+     *      fails due to invalid serial filter or serial filter factory properties.
      * @see SecurityManager#checkPermission
      * @see java.io.SerializablePermission
      */

--- a/test/jdk/java/io/Serializable/serialFilter/InvalidGlobalFilterTest.java
+++ b/test/jdk/java/io/Serializable/serialFilter/InvalidGlobalFilterTest.java
@@ -26,16 +26,14 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.ObjectInputFilter;
 import java.io.ObjectInputStream;
 import java.util.Map;
 
 /*
  * @test
- * @bug 8269336
+ * @bug 8278087
  * @summary Test that an invalid pattern value for the jdk.serialFilter system property causes an
  * exception to be thrown when an attempt is made to use the filter or deserialize.
  * A subset of invalid filter patterns is tested.

--- a/test/jdk/java/io/Serializable/serialFilter/InvalidGlobalFilterTest.java
+++ b/test/jdk/java/io/Serializable/serialFilter/InvalidGlobalFilterTest.java
@@ -21,67 +21,102 @@
  * questions.
  */
 
-import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.process.ProcessTools;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.ObjectInputFilter;
+import java.io.ObjectInputStream;
+import java.util.Map;
 
 /*
  * @test
  * @bug 8269336
  * @summary Test that an invalid pattern value for the jdk.serialFilter system property causes an
- * exception to be thrown in the class initialization of java.io.ObjectInputFilter.Config class
- * @library /test/lib
- * @run driver InvalidGlobalFilterTest
+ * exception to be thrown when an attempt is made to use the filter or deserialize.
+ * A subset of invalid filter patterns is tested.
+ * @run testng/othervm -Djdk.serialFilter=.* InvalidGlobalFilterTest
+ * @run testng/othervm -Djdk.serialFilter=! InvalidGlobalFilterTest
+ * @run testng/othervm -Djdk.serialFilter=/ InvalidGlobalFilterTest
+ *
  */
+@Test
 public class InvalidGlobalFilterTest {
     private static final String serialPropName = "jdk.serialFilter";
+    private static final String serialFilter = System.getProperty(serialPropName);
+
+    static {
+        // Enable logging
+        System.setProperty("java.util.logging.config.file",
+                System.getProperty("test.src", ".") + "/logging.properties");
+    }
 
     /**
-     * Launches multiple instances of a Java program by passing each instance an invalid value
-     * for the {@code jdk.serialFilter} system property. The launched program then triggers the
-     * class initialization of {@code ObjectInputFilter.Config} class to have it parse the (invalid)
-     * value of the system property. The launched program is expected to propagate the exception
-     * raised by the {@code ObjectInputFilter.Config} initialization and the test asserts that the
-     * launched program did indeed fail with this expected exception.
+     * Map of invalid patterns to the expected exception message.
      */
-    public static void main(final String[] args) throws Exception {
-        final String[] invalidPatterns = {".*", ".**", "!", "/java.util.Hashtable", "java.base/", "/"};
-        for (final String invalidPattern : invalidPatterns) {
-            final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
-                    "-D" + serialPropName + "=" + invalidPattern,
-                    "-Djava.util.logging.config.file=" + System.getProperty("test.src")
-                            + File.separator + "logging.properties",
-                    ObjectInputFilterConfigLoader.class.getName());
-            // launch a process by passing it an invalid value for -Djdk.serialFilter
-            final OutputAnalyzer outputAnalyzer = ProcessTools.executeProcess(processBuilder);
-            try {
-                // we expect the JVM launch to fail
-                outputAnalyzer.shouldNotHaveExitValue(0);
-                // do an additional check to be sure it failed for the right reason
-                outputAnalyzer.stderrShouldContain("java.lang.ExceptionInInitializerError");
-            } finally {
-                // fail or pass, we print out the generated output from the launched program
-                // for any debugging
-                System.err.println("Diagnostics from process " + outputAnalyzer.pid() + ":");
-                // print out any stdout/err that was generated in the launched program
-                outputAnalyzer.reportDiagnosticSummary();
-            }
+    private static final Map<String, String> invalidMessages =
+            Map.of(".*", "Invalid jdk.serialFilter: package missing in: \".*\"",
+                    ".**", "Invalid jdk.serialFilter: package missing in: \".**\"",
+                    "!", "Invalid jdk.serialFilter: class or package missing in: \"!\"",
+                    "/java.util.Hashtable", "Invalid jdk.serialFilter: module name is missing in: \"/java.util.Hashtable\"",
+                    "java.base/", "Invalid jdk.serialFilter: class or package missing in: \"java.base/\"",
+                    "/", "Invalid jdk.serialFilter: module name is missing in: \"/\"");
+
+    @DataProvider(name = "MethodsToCall")
+    private Object[][] cases() {
+        return new Object[][] {
+                {serialFilter, "getSerialFilter", (Assert.ThrowingRunnable) () -> ObjectInputFilter.Config.getSerialFilter()},
+                {serialFilter, "setSerialFilter", (Assert.ThrowingRunnable) () -> ObjectInputFilter.Config.setSerialFilter(new NoopFilter())},
+                {serialFilter, "new ObjectInputStream(is)", (Assert.ThrowingRunnable) () -> new ObjectInputStream(new ByteArrayInputStream(new byte[0]))},
+                {serialFilter, "new OISSubclass()", (Assert.ThrowingRunnable) () -> new OISSubclass()},
+        };
+    }
+
+    /**
+     * Test each method that should throw IllegalStateException based on
+     * the invalid arguments it was launched with.
+     */
+    @Test(dataProvider = "MethodsToCall")
+    public void initFaultTest(String pattern, String method, Assert.ThrowingRunnable runnable) {
+
+        IllegalStateException ex = Assert.expectThrows(IllegalStateException.class,
+                runnable);
+
+        String expected = invalidMessages.get(serialFilter);
+        if (expected == null) {
+            Assert.fail("No expected message for filter: " + serialFilter);
+        }
+        System.out.println(ex.getMessage());
+        Assert.assertEquals(ex.getMessage(), expected, "wrong message");
+    }
+
+    private static class NoopFilter implements ObjectInputFilter {
+        /**
+         * Returns UNDECIDED.
+         *
+         * @param filter the FilterInfo
+         * @return Status.UNDECIDED
+         */
+        public ObjectInputFilter.Status checkInput(FilterInfo filter) {
+             return ObjectInputFilter.Status.UNDECIDED;
+        }
+
+        public String toString() {
+            return "NoopFilter";
         }
     }
 
-    // A main() class which just triggers the class initialization of ObjectInputFilter.Config
-    private static final class ObjectInputFilterConfigLoader {
+    /**
+     * Subclass of ObjectInputStream to test subclassing constructor.
+     */
+    private static class OISSubclass extends ObjectInputStream {
 
-        public static void main(final String[] args) throws Exception {
-            System.out.println("JVM was launched with " + serialPropName
-                    + " system property set to " + System.getProperty(serialPropName));
-            // this call is expected to fail and we aren't interested in the result.
-            // we just let the exception propagate out of this call and fail the
-            // launched program. The test which launched this main, then asserts
-            // that the exception was indeed thrown.
-            ObjectInputFilter.Config.getSerialFilter();
+        protected OISSubclass() throws IOException {
         }
     }
+
 }

--- a/test/jdk/java/io/Serializable/serialFilter/SerialFactoryFaults.java
+++ b/test/jdk/java/io/Serializable/serialFilter/SerialFactoryFaults.java
@@ -22,10 +22,14 @@
  */
 
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.ObjectInputFilter;
 import java.io.ObjectInputFilter.Config;
+import java.io.ObjectInputStream;
 import java.util.function.BinaryOperator;
 
 /* @test
@@ -39,33 +43,47 @@ import java.util.function.BinaryOperator;
 @Test
 public class SerialFactoryFaults {
 
+    // Sample the serial factory class name
+    private static final String factoryName = System.getProperty("jdk.serialFilterFactory");
+
     static {
         // Enable logging
         System.setProperty("java.util.logging.config.file",
                 System.getProperty("test.src", ".") + "/logging.properties");
     }
 
-    public void initFaultTest() {
-        String factoryName = System.getProperty("jdk.serialFilterFactory");
-        ExceptionInInitializerError ex = Assert.expectThrows(ExceptionInInitializerError.class,
-                () -> Config.getSerialFilterFactory());
-        Throwable cause = ex.getCause();
+    @DataProvider(name = "MethodsToCall")
+    private Object[][] cases() {
+        return new Object[][] {
+                {"getSerialFilterFactory", (Assert.ThrowingRunnable) () -> Config.getSerialFilterFactory()},
+                {"setSerialFilterFactory", (Assert.ThrowingRunnable) () -> Config.setSerialFilterFactory(new NoopFactory())},
+                {"new ObjectInputStream(is)", (Assert.ThrowingRunnable) () -> new ObjectInputStream(new ByteArrayInputStream(new byte[0]))},
+                {"new OISSubclass()", (Assert.ThrowingRunnable) () -> new OISSubclass()},
+        };
+    }
+
+    /**
+     * Test each method that should throw IllegalStateException based on
+     * the invalid arguments it was launched with.
+     */
+    @Test(dataProvider = "MethodsToCall")
+    public void initFaultTest(String name, Assert.ThrowingRunnable runnable) {
+        IllegalStateException ex = Assert.expectThrows(IllegalStateException.class,
+                runnable);
+        final String msg = ex.getMessage();
 
         if (factoryName.equals("ForcedError_NoSuchClass")) {
-            Assert.assertEquals(cause.getClass(),
-                    ClassNotFoundException.class, "wrong exception");
+            Assert.assertEquals(msg,
+                    "invalid jdk.serialFilterFactory: ForcedError_NoSuchClass: java.lang.ClassNotFoundException: ForcedError_NoSuchClass", "wrong exception");
         } else if (factoryName.equals("SerialFactoryFaults$NoPublicConstructor")) {
-            Assert.assertEquals(cause.getClass(),
-                    NoSuchMethodException.class, "wrong exception");
+            Assert.assertEquals(msg,
+                    "invalid jdk.serialFilterFactory: SerialFactoryFaults$NoPublicConstructor: java.lang.NoSuchMethodException: SerialFactoryFaults$NoPublicConstructor.<init>()", "wrong exception");
         } else if (factoryName.equals("SerialFactoryFaults$ConstructorThrows")) {
-            Assert.assertEquals(cause.getClass(),
-                    IllegalStateException.class, "wrong exception");
+            Assert.assertEquals(msg,
+                    "invalid jdk.serialFilterFactory: SerialFactoryFaults$ConstructorThrows: java.lang.RuntimeException: constructor throwing a runtime exception", "wrong exception");
         } else if (factoryName.equals("SerialFactoryFaults$FactorySetsFactory")) {
-            Assert.assertEquals(cause.getClass(),
-                    IllegalStateException.class, "wrong exception");
-            Assert.assertEquals(cause.getMessage(),
-                    "Cannot replace filter factory: initialization incomplete",
-                    "wrong message");
+            Assert.assertEquals(msg,
+                    "invalid jdk.serialFilterFactory: SerialFactoryFaults$FactorySetsFactory: java.lang.IllegalStateException: Serial filter factory initialization incomplete", "wrong exception");
         } else {
             Assert.fail("No test for filter factory: " + factoryName);
         }
@@ -90,7 +108,7 @@ public class SerialFactoryFaults {
     public static final class ConstructorThrows
             implements BinaryOperator<ObjectInputFilter> {
         public ConstructorThrows() {
-            throw new IllegalStateException("SerialFactoryFaults$ConstructorThrows");
+            throw new RuntimeException("constructor throwing a runtime exception");
         }
 
         public ObjectInputFilter apply(ObjectInputFilter curr, ObjectInputFilter next) {
@@ -109,6 +127,23 @@ public class SerialFactoryFaults {
 
         public ObjectInputFilter apply(ObjectInputFilter curr, ObjectInputFilter next) {
             throw new RuntimeException("NYI");
+        }
+    }
+
+    public static final class NoopFactory implements BinaryOperator<ObjectInputFilter> {
+        public NoopFactory() {}
+
+        public ObjectInputFilter apply(ObjectInputFilter curr, ObjectInputFilter next) {
+            throw new RuntimeException("NYI");
+        }
+    }
+
+    /**
+     * Subclass of ObjectInputStream to test subclassing constructor.
+     */
+    private static class OISSubclass extends ObjectInputStream {
+
+        protected OISSubclass() throws IOException {
         }
     }
 


### PR DESCRIPTION
The effects of invalid values of `jdk.serialFilter` and `jdk.serialFilterFactory` properties are 
incompletely specified. The behavior for invalid values of the properties is different and
use an unconventional exception type, `ExceptionInInitializerError` and leave the `OIF.Config` class
uninitialized. 

The exceptions in the `ObjectInputFilter.Config` class initialization caused by invalid values of the two properties, 
either by system properties supplied on the command line or security properties are logged.
The `Config` class marks either or both the filter and filter factory values as unusable
and remembers the exception message.

Subsequent calls to the methods that get or set the filter or filter factory or create 
an `ObjectInputStream` throw `java.lang.IllegalStateException` with the remembered exception message.
Constructing an `ObjectInputStream` calls both `Config.getSerialFilter` and `Config.getSerialFilterFactory`.
The nature of the invalid property is reported as an `IllegalStateException` on first use.

This PR supercedes https://github.com/openjdk/jdk/pull/6508 Document that setting an invalid property jdk.serialFilter disables deserialization

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8278087](https://bugs.openjdk.java.net/browse/JDK-8278087): Deserialization filter and filter factory property error reporting under specified
 * [JDK-8278088](https://bugs.openjdk.java.net/browse/JDK-8278088): Deserialization filter and filter factory property error reporting under specified (**CSR**)


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6645/head:pull/6645` \
`$ git checkout pull/6645`

Update a local copy of the PR: \
`$ git checkout pull/6645` \
`$ git pull https://git.openjdk.java.net/jdk pull/6645/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6645`

View PR using the GUI difftool: \
`$ git pr show -t 6645`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6645.diff">https://git.openjdk.java.net/jdk/pull/6645.diff</a>

</details>
