### PR TITLE
8277983: Remove unused fields from sun.net.www.protocol.jar.JarURLConnection

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/jar/JarURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/jar/JarURLConnection.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLConnection;
 import java.security.Permission;
 import java.util.List;
 import java.util.Map;
@@ -47,9 +46,6 @@ public class JarURLConnection extends java.net.JarURLConnection {
     /* the Jar file factory. It handles both retrieval and caching.
      */
     private static final JarFileFactory factory = JarFileFactory.getInstance();
-
-    /* the entry name, if any */
-    private String entryName;
 
     /* the JarEntry */
     private JarEntry jarEntry;
@@ -68,7 +64,6 @@ public class JarURLConnection extends java.net.JarURLConnection {
         // whether, or not, the embedded URL should use the cache will depend
         // on this instance's cache value
         jarFileURLConnection.setUseCaches(useCaches);
-        entryName = getEntryName();
     }
 
     public JarFile getJarFile() throws IOException {
@@ -103,7 +98,7 @@ public class JarURLConnection extends java.net.JarURLConnection {
     public void connect() throws IOException {
         if (!connected) {
             boolean useCaches = getUseCaches();
-            String entryName = this.entryName;
+            String entryName = getEntryName();
 
             /* the factory call will do the security checks */
             URL url = getJarFileURL();
@@ -159,6 +154,7 @@ public class JarURLConnection extends java.net.JarURLConnection {
 
         InputStream result = null;
 
+        String entryName = getEntryName();
         if (entryName == null) {
             throw new IOException("no entry name specified");
         } else {
@@ -199,7 +195,7 @@ public class JarURLConnection extends java.net.JarURLConnection {
         Object result = null;
 
         connect();
-        if (entryName == null) {
+        if (getEntryName() == null) {
             result = jarFile;
         } else {
             result = super.getContent();
@@ -209,6 +205,7 @@ public class JarURLConnection extends java.net.JarURLConnection {
 
     public String getContentType() {
         if (contentType == null) {
+            String entryName = getEntryName();
             if (entryName == null) {
                 contentType = "x-java/jar";
             } else {

--- a/src/java.base/share/classes/sun/net/www/protocol/jar/JarURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/jar/JarURLConnection.java
@@ -25,21 +25,18 @@
 
 package sun.net.www.protocol.jar;
 
-import java.io.InputStream;
-import java.io.IOException;
-import java.io.FileNotFoundException;
 import java.io.BufferedInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
-import java.net.MalformedURLException;
-import java.net.UnknownServiceException;
-import java.util.Enumeration;
-import java.util.Map;
+import java.security.Permission;
 import java.util.List;
+import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-import java.util.jar.Manifest;
-import java.security.Permission;
 
 /**
  * @author Benjamin Renaud
@@ -47,22 +44,9 @@ import java.security.Permission;
  */
 public class JarURLConnection extends java.net.JarURLConnection {
 
-    private static final boolean debug = false;
-
     /* the Jar file factory. It handles both retrieval and caching.
      */
     private static final JarFileFactory factory = JarFileFactory.getInstance();
-
-    /* the url for the Jar file */
-    private URL jarFileURL;
-
-    /* the permission to get this JAR file. This is the actual, ultimate,
-     * permission, returned by the jar file factory.
-     */
-    private Permission permission;
-
-    /* the url connection for the JAR file */
-    private URLConnection jarFileURLConnection;
 
     /* the entry name, if any */
     private String entryName;
@@ -80,8 +64,7 @@ public class JarURLConnection extends java.net.JarURLConnection {
     throws MalformedURLException, IOException {
         super(url);
 
-        jarFileURL = getJarFileURL();
-        jarFileURLConnection = jarFileURL.openConnection();
+        jarFileURLConnection = getJarFileURL().openConnection();
         // whether, or not, the embedded URL should use the cache will depend
         // on this instance's cache value
         jarFileURLConnection.setUseCaches(useCaches);


### PR DESCRIPTION
There are some fields that are unused in current implementation of `JarURLConnection`:
- debug
- jarFileURL
- permission
- jarFileURLConnection (inherited one can be used)
- entryName (can be taken from super-class)

They can be safely removed reducing object footprint. Before:
```
sun.net.www.protocol.jar.JarURLConnection object internals:
 OFFSET  SIZE                        TYPE DESCRIPTION                               VALUE
      0    12                             (object header)                           N/A
     12     4                         int URLConnection.connectTimeout              N/A
     16     8                        long URLConnection.ifModifiedSince             N/A
     24     4                         int URLConnection.readTimeout                 N/A
     28     1                     boolean URLConnection.doInput                     N/A
     29     1                     boolean URLConnection.doOutput                    N/A
     30     1                     boolean URLConnection.allowUserInteraction        N/A
     31     1                     boolean URLConnection.useCaches                   N/A
     32     1                     boolean URLConnection.connected                   N/A
     33     3                             (alignment/padding gap)                  
     36     4                java.net.URL URLConnection.url                         N/A
     40     4   sun.net.www.MessageHeader URLConnection.requests                    N/A
     44     4                java.net.URL JarURLConnection.jarFileURL               N/A
     48     4            java.lang.String JarURLConnection.entryName                N/A
     52     4      java.net.URLConnection JarURLConnection.jarFileURLConnection     N/A
     56     4                java.net.URL JarURLConnection.jarFileURL               N/A
     60     4    java.security.Permission JarURLConnection.permission               N/A
     64     4      java.net.URLConnection JarURLConnection.jarFileURLConnection     N/A
     68     4            java.lang.String JarURLConnection.entryName                N/A
     72     4      java.util.jar.JarEntry JarURLConnection.jarEntry                 N/A
     76     4       java.util.jar.JarFile JarURLConnection.jarFile                  N/A
     80     4            java.lang.String JarURLConnection.contentType              N/A
     84     4                             (loss due to the next object alignment)
Instance size: 88 bytes
Space losses: 3 bytes internal + 4 bytes external = 7 bytes total
```
After:
```
sun.net.www.protocol.jar.JarURLConnection object internals:
 OFFSET  SIZE                        TYPE DESCRIPTION                               VALUE
      0    12                             (object header)                           N/A
     12     4                         int URLConnection.connectTimeout              N/A
     16     8                        long URLConnection.ifModifiedSince             N/A
     24     4                         int URLConnection.readTimeout                 N/A
     28     1                     boolean URLConnection.doInput                     N/A
     29     1                     boolean URLConnection.doOutput                    N/A
     30     1                     boolean URLConnection.allowUserInteraction        N/A
     31     1                     boolean URLConnection.useCaches                   N/A
     32     1                     boolean URLConnection.connected                   N/A
     33     3                             (alignment/padding gap)                  
     36     4                java.net.URL URLConnection.url                         N/A
     40     4   sun.net.www.MessageHeader URLConnection.requests                    N/A
     44     4                java.net.URL JarURLConnection.jarFileURL               N/A
     48     4            java.lang.String JarURLConnection.entryName                N/A
     52     4      java.net.URLConnection JarURLConnection.jarFileURLConnection     N/A
     56     4      java.util.jar.JarEntry JarURLConnection.jarEntry                 N/A
     60     4       java.util.jar.JarFile JarURLConnection.jarFile                  N/A
     64     4            java.lang.String JarURLConnection.contentType              N/A
     68     4                             (loss due to the next object alignment)
Instance size: 72 bytes
Space losses: 3 bytes internal + 4 bytes external = 7 bytes total
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277983](https://bugs.openjdk.java.net/browse/JDK-8277983): Remove unused fields from sun.net.www.protocol.jar.JarURLConnection


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6649/head:pull/6649` \
`$ git checkout pull/6649`

Update a local copy of the PR: \
`$ git checkout pull/6649` \
`$ git pull https://git.openjdk.java.net/jdk pull/6649/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6649`

View PR using the GUI difftool: \
`$ git pr show -t 6649`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6649.diff">https://git.openjdk.java.net/jdk/pull/6649.diff</a>

</details>
