### PR TITLE
8266839: Enable pandoc on macosx-aarch64 at Oracle

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -450,7 +450,7 @@ var getJibProfilesProfiles = function (input, common, data) {
         "macosx-aarch64": {
             target_os: "macosx",
             target_cpu: "aarch64",
-            dependencies: ["devkit", "gtest"],
+            dependencies: ["devkit", "gtest", "pandoc"],
             configure_args: concat(common.configure_args_64bit, "--with-zlib=system",
                 "--with-macosx-version-max=11.00.00"),
         },
@@ -1100,6 +1100,17 @@ var getJibProfilesDependencies = function (input, common) {
         environment_path: common.boot_jdk_home + "/bin"
     }
 
+    var pandoc_version;
+    if (input.build_cpu == "aarch64") {
+        if (input.build_os == "macosx") {
+            pandoc_version = "2.14.0.2+1.0";
+        } else {
+            pandoc_version = "2.5+1.0";
+        }
+    } else {
+        pandoc_version = "2.3.1+1.0";
+    }
+
     var makeBinDir = (input.build_os == "windows"
         ? input.get("gnumake", "install_path") + "/cygwin/bin"
         : input.get("gnumake", "install_path") + "/bin");
@@ -1212,7 +1223,7 @@ var getJibProfilesDependencies = function (input, common) {
         pandoc: {
             organization: common.organization,
             ext: "tar.gz",
-            revision: (input.build_cpu == 'aarch64' ? "2.5+1.0" : "2.3.1+1.0"),
+            revision: pandoc_version,
             module: "pandoc-" + input.build_platform,
             configure_args: "PANDOC=" + input.get("pandoc", "install_path") + "/pandoc/pandoc",
             environment_path: input.get("pandoc", "install_path") + "/pandoc"


### PR DESCRIPTION
Enabling pandoc on macosx-aarch64 at Oracle to produce man pages etc.

Testing:

* Passes tier1
* Verified that the product bundle includes man pages as expected
* Sampling a few of the man pages they look as expected

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266839](https://bugs.openjdk.java.net/browse/JDK-8266839): Enable pandoc on macosx-aarch64 at Oracle


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6650/head:pull/6650` \
`$ git checkout pull/6650`

Update a local copy of the PR: \
`$ git checkout pull/6650` \
`$ git pull https://git.openjdk.java.net/jdk pull/6650/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6650`

View PR using the GUI difftool: \
`$ git pr show -t 6650`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6650.diff">https://git.openjdk.java.net/jdk/pull/6650.diff</a>

</details>
