### PR TITLE
8279669: test/jdk/com/sun/jdi/TestScaffold.java uses wrong condition

### DIFF
--- a/test/jdk/com/sun/jdi/TestScaffold.java
+++ b/test/jdk/com/sun/jdi/TestScaffold.java
@@ -535,16 +535,15 @@ abstract public class TestScaffold extends TargetAdapter {
                         Location loc = ((Locatable)event).location();
                         ReferenceType rt = loc.declaringType();
                         String name = rt.name();
-                        if (name.startsWith("java.") &&
-                                       !name.startsWith("sun.") &&
-                                       !name.startsWith("com.")) {
+                        if (name.startsWith("java.")
+                            || name.startsWith("sun.")
+                            || name.startsWith("com.")
+                            || name.startsWith("jdk.")) {
                             if (mainStartClass != null) {
                                 redefine(mainStartClass);
                             }
                         } else {
-                            if (!name.startsWith("jdk.")) {
-                                redefine(rt);
-                            }
+                            redefine(rt);
                         }
                     }
                 }


### PR DESCRIPTION
Condition is obviously wrong, because if name starts with "java." other 2 conditions are always true. Intent, as I understand it, was to redefine class where debug event took place (in case of test classes), unless it took place in class of jdk itself, in which case redefine test's main class (if redefineAtEvents is true of course). Check for class names starting with "jdk." was added with later commit [1], not touching that wrong condition (check for classes belonging to jdk) and putting check to else branch instead (therefore not doing any redefinition in case name starts with "jdk.").

Actually fix is done to be then backported to jdk8u, where com/sun/jdi/RedefineCrossEvent.java test stared failing after recent backport [2], due to missing check for classes starting with "jdk." [3]:
...
Redefining class jdk.internal.misc.TerminatingThreadLocal (no class loader)
FAIL: redefine - unexpected exception: java.io.FileNotFoundException: /home/tester/test.1638289866/jdk/JTwork/classes/com/sun/jdi/jdk/internal/misc/TerminatingThreadLocal.class (No such file or directory)
...

This test actually passes for (latest) jdk. However fixing this condition before doing backport, rather than backporting it in current form seems like right thing to do. I tested this locally and jdi tests are passing with this change for latest jdk (and also for jdk8u).

[1]  https://github.com/zzambers/jdk/commit/426873751c710061d0f9bc713a0de47373e51418#diff-778880449f85966d3c6b219b8ceb41fdbbe7acc5e520d2aa27aada3f33bf1eab
[2] https://bugs.openjdk.java.net/browse/JDK-8273772
[3] https://github.com/openjdk/jdk8u/blob/7d3c0bede34930cadd76644e58bf56f2a83c3d01/jdk/test/com/sun/jdi/TestScaffold.java#L535

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279669](https://bugs.openjdk.java.net/browse/JDK-8279669): test/jdk/com/sun/jdi/TestScaffold.java uses wrong condition


### Reviewers
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6652/head:pull/6652` \
`$ git checkout pull/6652`

Update a local copy of the PR: \
`$ git checkout pull/6652` \
`$ git pull https://git.openjdk.java.net/jdk pull/6652/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6652`

View PR using the GUI difftool: \
`$ git pr show -t 6652`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6652.diff">https://git.openjdk.java.net/jdk/pull/6652.diff</a>

</details>
