### PR TITLE
JDK-8276837: [macos]: Error when signing the additional launcher

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/IOUtils.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/IOUtils.java
@@ -190,14 +190,24 @@ public class IOUtils {
     static void exec(ProcessBuilder pb, boolean testForPresenceOnly,
             PrintStream consumer, boolean writeOutputToFile, long timeout)
             throws IOException {
+        exec(pb, testForPresenceOnly, consumer, writeOutputToFile,
+                Executor.INFINITE_TIMEOUT, false);
+    }
+
+    static void exec(ProcessBuilder pb, boolean testForPresenceOnly,
+            PrintStream consumer, boolean writeOutputToFile,
+            long timeout, boolean quiet) throws IOException {
         List<String> output = new ArrayList<>();
-        Executor exec = Executor.of(pb).setWriteOutputToFile(writeOutputToFile)
-                .setTimeout(timeout).setOutputConsumer(lines -> {
-            lines.forEach(output::add);
-            if (consumer != null) {
-                output.forEach(consumer::println);
-            }
-        });
+        Executor exec = Executor.of(pb)
+                .setWriteOutputToFile(writeOutputToFile)
+                .setTimeout(timeout)
+                .setQuiet(quiet)
+                .setOutputConsumer(lines -> {
+                    lines.forEach(output::add);
+                    if (consumer != null) {
+                        output.forEach(consumer::println);
+                    }
+                });
 
         if (testForPresenceOnly) {
             exec.execute();

--- a/test/jdk/tools/jpackage/macosx/SigningAppImageTest.java
+++ b/test/jdk/tools/jpackage/macosx/SigningAppImageTest.java
@@ -66,31 +66,19 @@ public class SigningAppImageTest {
         cmd.addArguments("--mac-sign", "--mac-signing-key-user-name",
                 SigningBase.DEV_NAME, "--mac-signing-keychain",
                 SigningBase.KEYCHAIN);
+
+        AdditionalLauncher testAL = new AdditionalLauncher("testAL");
+        testAL.applyTo(cmd);
         cmd.executeAndAssertHelloAppImageCreated();
 
         Path launcherPath = cmd.appLauncherPath();
         SigningBase.verifyCodesign(launcherPath, true);
+
+        Path testALPath = launcherPath.getParent().resolve("testAL");
+        SigningBase.verifyCodesign(testALPath, true);
 
         Path appImage = cmd.outputBundle();
         SigningBase.verifyCodesign(appImage, true);
         SigningBase.verifySpctl(appImage, "exec");
-    }
-
-    @Test
-    public static void testAdditionalLauncher() throws Exception {
-        SigningCheck.checkCertificates();
-
-        JPackageCommand cmd = JPackageCommand.helloAppImage();
-        cmd.addArguments("--mac-sign", "--mac-signing-key-user-name",
-                SigningBase.DEV_NAME, "--mac-signing-keychain",
-                SigningBase.KEYCHAIN);
-        AdditionalLauncher testAL = new AdditionalLauncher("testAL");
-        testAL.applyTo(cmd);
-
-        cmd.executeAndAssertHelloAppImageCreated();
-        Path launcherPath = cmd.appLauncherPath();
-        Path testALPath = launcherPath.getParent().resolve("testAL");
-        SigningBase.verifyCodesign(launcherPath, true);
-        SigningBase.verifyCodesign(testALPath, true);
     }
 }

--- a/test/jdk/tools/jpackage/macosx/SigningAppImageTest.java
+++ b/test/jdk/tools/jpackage/macosx/SigningAppImageTest.java
@@ -24,6 +24,7 @@
 import java.nio.file.Path;
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.Annotations.Test;
+import jdk.jpackage.test.AdditionalLauncher;
 
 /**
  * Tests generation of app image with --mac-sign and related arguments. Test will
@@ -73,5 +74,23 @@ public class SigningAppImageTest {
         Path appImage = cmd.outputBundle();
         SigningBase.verifyCodesign(appImage, true);
         SigningBase.verifySpctl(appImage, "exec");
+    }
+
+    @Test
+    public static void testAdditionalLauncher() throws Exception {
+        SigningCheck.checkCertificates();
+
+        JPackageCommand cmd = JPackageCommand.helloAppImage();
+        cmd.addArguments("--mac-sign", "--mac-signing-key-user-name",
+                SigningBase.DEV_NAME, "--mac-signing-keychain",
+                SigningBase.KEYCHAIN);
+        AdditionalLauncher testAL = new AdditionalLauncher("testAL");
+        testAL.applyTo(cmd);
+
+        cmd.executeAndAssertHelloAppImageCreated();
+        Path launcherPath = cmd.appLauncherPath();
+        Path testALPath = launcherPath.getParent().resolve("testAL");
+        SigningBase.verifyCodesign(launcherPath, true);
+        SigningBase.verifyCodesign(testALPath, true);
     }
 }


### PR DESCRIPTION
- We need to unsign all executables and libraries in the app-image before signing. (not just those in the runtime).
 - Clean up excessive output by executing the individual file sign and unsigning commands in quiet mode.
 - Add conditions in SigningAppImageTest to test signing of additional launchers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276837](https://bugs.openjdk.java.net/browse/JDK-8276837): [macos]: Error when signing the additional launcher


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6654/head:pull/6654` \
`$ git checkout pull/6654`

Update a local copy of the PR: \
`$ git checkout pull/6654` \
`$ git pull https://git.openjdk.java.net/jdk pull/6654/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6654`

View PR using the GUI difftool: \
`$ git pr show -t 6654`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6654.diff">https://git.openjdk.java.net/jdk/pull/6654.diff</a>

</details>
