### PR TITLE
8278099: two sun/security/pkcs11/Signature tests failed with AssertionError

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/CK_MECHANISM.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/CK_MECHANISM.java
@@ -164,7 +164,6 @@ public class CK_MECHANISM {
     // CK_MECHANISM(long) constructor and setParameter(CK_RSA_PKCS_PSS_PARAMS)
     // methods instead of creating yet another constructor
     public void setParameter(CK_RSA_PKCS_PSS_PARAMS params) {
-        assert(this.mechanism == CKM_RSA_PKCS_PSS);
         assert(params != null);
         if (this.pParameter != null && this.pParameter.equals(params)) {
             return;


### PR DESCRIPTION
Can someone help reviewing this trivial one-line fix? The assert check in CK_MECHANISM.java is too strict and fail unexpectedly when digest-specific PSS signature mechanisms are supported by the underlying PKCS#11 library. The fix is to remove this assert check. No new regression test added with this fix as this is already covered by existing regression tests.

Thanks,
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278099](https://bugs.openjdk.java.net/browse/JDK-8278099): two sun/security/pkcs11/Signature tests failed with AssertionError


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6656/head:pull/6656` \
`$ git checkout pull/6656`

Update a local copy of the PR: \
`$ git checkout pull/6656` \
`$ git pull https://git.openjdk.java.net/jdk pull/6656/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6656`

View PR using the GUI difftool: \
`$ git pr show -t 6656`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6656.diff">https://git.openjdk.java.net/jdk/pull/6656.diff</a>

</details>
