### PR TITLE
8278115: gc/stress/gclocker/TestGCLockerWithSerial.java has duplicate -Xmx

### DIFF
--- a/test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithSerial.java
+++ b/test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithSerial.java
@@ -30,7 +30,7 @@ package gc.stress.gclocker;
  * @requires vm.gc.Serial
  * @requires vm.flavor != "minimal"
  * @summary Stress Serial's GC locker by calling GetPrimitiveArrayCritical while concurrently filling up old gen.
- * @run main/native/othervm/timeout=200 -Xlog:gc*=info -Xmx1500m -Xmx1500m -XX:+UseSerialGC gc.stress.gclocker.TestGCLockerWithSerial
+ * @run main/native/othervm/timeout=200 -Xlog:gc*=info -Xms1500m -Xmx1500m -XX:+UseSerialGC gc.stress.gclocker.TestGCLockerWithSerial
  */
 public class TestGCLockerWithSerial {
     public static void main(String[] args) {


### PR DESCRIPTION
Spotted by Andrey here:
 https://github.com/openjdk/jdk/pull/6574#issuecomment-983959564

Seems to be that way all the way back to JDK-8177968. Should be -Xms, like other GCLocker tests. 

Additional testing:
 - [x] Affected test still passes on Linux x86_64 fastdebug

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278115](https://bugs.openjdk.java.net/browse/JDK-8278115): gc/stress/gclocker/TestGCLockerWithSerial.java has duplicate -Xmx


### Reviewers
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6659/head:pull/6659` \
`$ git checkout pull/6659`

Update a local copy of the PR: \
`$ git checkout pull/6659` \
`$ git pull https://git.openjdk.java.net/jdk pull/6659/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6659`

View PR using the GUI difftool: \
`$ git pr show -t 6659`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6659.diff">https://git.openjdk.java.net/jdk/pull/6659.diff</a>

</details>
