### PR TITLE
8278116: runtime/modules/LoadUnloadModuleStress.java has duplicate -Xmx

### DIFF
--- a/test/hotspot/jtreg/runtime/modules/LoadUnloadModuleStress.java
+++ b/test/hotspot/jtreg/runtime/modules/LoadUnloadModuleStress.java
@@ -30,7 +30,7 @@
  * @build sun.hotspot.WhiteBox
  * @compile/module=java.base java/lang/ModuleHelper.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xmx64m -Xmx64m LoadUnloadModuleStress 15000
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xms64m -Xmx64m LoadUnloadModuleStress 15000
  */
 
 import java.lang.ref.WeakReference;


### PR DESCRIPTION
Spotted by Andrey here:  https://github.com/openjdk/jdk/pull/6574#issuecomment-983959564

Seems to be that way since initial integration in JDK-8142968. 

Additional testing:
 - [x] Affected test still passes on Linux x86_64 fastdebug

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278116](https://bugs.openjdk.java.net/browse/JDK-8278116): runtime/modules/LoadUnloadModuleStress.java has duplicate -Xmx


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6660/head:pull/6660` \
`$ git checkout pull/6660`

Update a local copy of the PR: \
`$ git checkout pull/6660` \
`$ git pull https://git.openjdk.java.net/jdk pull/6660/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6660`

View PR using the GUI difftool: \
`$ git pr show -t 6660`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6660.diff">https://git.openjdk.java.net/jdk/pull/6660.diff</a>

</details>
