### PR TITLE
8172065: javax/swing/JTree/4908142/bug4908142.java The selected index should be "aad"

### DIFF
--- a/test/jdk/javax/swing/JTree/4908142/bug4908142.java
+++ b/test/jdk/javax/swing/JTree/4908142/bug4908142.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,7 @@ public class bug4908142 {
             });
 
             robot.waitForIdle();
+            robot.delay(1000);
 
             SwingUtilities.invokeAndWait(new Runnable() {
 
@@ -70,7 +71,7 @@ public class bug4908142 {
             });
 
             robot.waitForIdle();
-
+            robot.delay(500);
 
             robot.keyPress(KeyEvent.VK_A);
             robot.keyRelease(KeyEvent.VK_A);
@@ -114,6 +115,7 @@ public class bug4908142 {
 
         JScrollPane sp = new JScrollPane(tree);
         fr.getContentPane().add(sp);
+        fr.setLocationRelativeTo(null);
         fr.setSize(200, 200);
         fr.setVisible(true);
     }

--- a/test/jdk/javax/swing/JTree/4908142/bug4908142.java
+++ b/test/jdk/javax/swing/JTree/4908142/bug4908142.java
@@ -75,8 +75,10 @@ public class bug4908142 {
 
             robot.keyPress(KeyEvent.VK_A);
             robot.keyRelease(KeyEvent.VK_A);
+            robot.waitForIdle();
             robot.keyPress(KeyEvent.VK_A);
             robot.keyRelease(KeyEvent.VK_A);
+            robot.waitForIdle();
             robot.keyPress(KeyEvent.VK_D);
             robot.keyRelease(KeyEvent.VK_D);
             robot.waitForIdle();


### PR DESCRIPTION
Test is failing in macosx-12 in aarch64 system. Added stability fixes of delay after frame is visible, making frame to center of screen to make the test stable in macos12-aarch64 system too.
Modified test passes in all CI platforms including osx-aarch64 system in osx11 and osx12.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8172065](https://bugs.openjdk.java.net/browse/JDK-8172065): javax/swing/JTree/4908142/bug4908142.java The selected index should be "aad"


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6661/head:pull/6661` \
`$ git checkout pull/6661`

Update a local copy of the PR: \
`$ git checkout pull/6661` \
`$ git pull https://git.openjdk.java.net/jdk pull/6661/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6661`

View PR using the GUI difftool: \
`$ git pr show -t 6661`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6661.diff">https://git.openjdk.java.net/jdk/pull/6661.diff</a>

</details>
