### PR TITLE
8268575: Annotations not visible on model elements before they are generated

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
@@ -345,7 +345,7 @@ public class Annotate {
 
             Assert.checkNonNull(c, "Failed to create annotation");
 
-            if (a.type.tsym.isAnnotationType()) {
+            if (a.type.isErroneous() || a.type.tsym.isAnnotationType()) {
                 if (annotated.containsKey(a.type.tsym)) {
                     if (!allowRepeatedAnnos) {
                         log.error(DiagnosticFlag.SOURCE_LEVEL, a.pos(), Feature.REPEATED_ANNOTATIONS.error(sourceName));

--- a/test/langtools/tools/javac/processing/8268575/Processor.java
+++ b/test/langtools/tools/javac/processing/8268575/Processor.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.io.Writer;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.tools.Diagnostic.Kind;
+import javax.tools.JavaFileObject;
+import java.util.List;
+
+@SupportedAnnotationTypes("*")
+public class Processor extends AbstractProcessor {
+
+  @Override
+  public SourceVersion getSupportedSourceVersion() {
+    return SourceVersion.latestSupported();
+  }
+
+  int round = 1;
+
+  @Override
+  public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+    processingEnv.getMessager().printMessage(Kind.NOTE, "round " + round);
+    Element t = processingEnv.getElementUtils().getTypeElement("T8268575");
+    for (Element e : t.getEnclosedElements()) {
+      if (e instanceof ExecutableElement) {
+        for (VariableElement p : ((ExecutableElement) e).getParameters()) {
+            List<? extends AnnotationMirror> annos = p.getAnnotationMirrors();
+            if (annos.size() != 1) {
+                throw new RuntimeException("Missing annotation in round " + round);
+            }
+        }
+      }
+    }
+    if (round == 1) {
+      String name = "A";
+      try {
+        JavaFileObject jfo = processingEnv.getFiler().createSourceFile(name);
+        try (Writer w = jfo.openWriter()) {
+          w.write("@interface " + name + " {}");
+        }
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+    round++;
+    return false;
+  }
+}

--- a/test/langtools/tools/javac/processing/8268575/T8268575.java
+++ b/test/langtools/tools/javac/processing/8268575/T8268575.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug     8268575
+ * @summary Annotations not visible on model elements before they are generated
+ * @build   Processor
+ * @compile -processor Processor T8268575.java
+ */
+
+class T8268575 {
+  void f(@A int x) {}
+}


### PR DESCRIPTION
As an inadvertant side effect of JDK-8206325, the model was failing to expose a missing annotation type. Address this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8268575](https://bugs.openjdk.java.net/browse/JDK-8268575): Annotations not visible on model elements before they are generated
 * [JDK-8278121](https://bugs.openjdk.java.net/browse/JDK-8278121): Annotations not visible on model elements before they are generated (**CSR**)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6662/head:pull/6662` \
`$ git checkout pull/6662`

Update a local copy of the PR: \
`$ git checkout pull/6662` \
`$ git pull https://git.openjdk.java.net/jdk pull/6662/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6662`

View PR using the GUI difftool: \
`$ git pr show -t 6662`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6662.diff">https://git.openjdk.java.net/jdk/pull/6662.diff</a>

</details>
