### PR TITLE
JDK-8278130: Failure in jdk/javadoc/tool/CheckManPageOptions.java after JDK-8274639

### DIFF
--- a/test/langtools/jdk/javadoc/tool/CheckManPageOptions.java
+++ b/test/langtools/jdk/javadoc/tool/CheckManPageOptions.java
@@ -60,10 +60,11 @@ public class CheckManPageOptions {
 
     static final PrintStream out = System.err;
 
-    // FIXME: JDK-8274295, JDK-8266666
+    // FIXME: JDK-8274295, JDK-8266666, JDK-8278077
     List<String> MISSING_IN_MAN_PAGE = List.of(
             "--add-script",
             "--legal-notices",
+            "--link-modularity-mismatch",
             "--link-platform-properties",
             "--no-platform-links",
             "--since",


### PR DESCRIPTION
Please review a simple fix in `CheckManPageOptions.java` that adds "--link-modularity-mismatch" to the group of javadoc options missing in the man page.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278130](https://bugs.openjdk.java.net/browse/JDK-8278130): Failure in jdk/javadoc/tool/CheckManPageOptions.java after JDK-8274639


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6664/head:pull/6664` \
`$ git checkout pull/6664`

Update a local copy of the PR: \
`$ git checkout pull/6664` \
`$ git pull https://git.openjdk.java.net/jdk pull/6664/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6664`

View PR using the GUI difftool: \
`$ git pr show -t 6664`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6664.diff">https://git.openjdk.java.net/jdk/pull/6664.diff</a>

</details>
