### PR TITLE
8278137: JFR: PrettyWriter uses incorrect year specifier

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
@@ -59,7 +59,7 @@ import jdk.jfr.internal.Utils;
  */
 public final class PrettyWriter extends EventPrintWriter {
     private static final String TYPE_OLD_OBJECT = Type.TYPES_PREFIX + "OldObject";
-    private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss.SSS (YYYY-MM-dd)");
+    private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss.SSS (yyyy-MM-dd)");
     private static final Long ZERO = 0L;
     private boolean showIds;
     private RecordedEvent currentEvent;


### PR DESCRIPTION
Found by SonarCloud, actually. For this commit: https://github.com/openjdk/jdk/commit/ee3576a48b700df3d8ad4bd447346d4102b20818 -- it says:

> Week Year ("YYYY") should not be used for date formatting
> 
> Few developers are aware of the difference between Y for "Week year" and y for Year when formatting and parsing a date with SimpleDateFormat or DateTimeFormatter. That's likely because for most dates, Week year and Year are the same, so testing at any time other than the first or last week of the year will yield the same value for both y and Y. But in the last week of December and the first week of January, you may get unexpected results.

See also ErrorProne rule: https://errorprone.info/bugpattern/MisusedWeekYear

A nice end-of-the-year time-bomb, that :)

Additional testing:
 - [x] Linux x86_64 fastdebug `jdk_jfr`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278137](https://bugs.openjdk.java.net/browse/JDK-8278137): JFR: PrettyWriter uses incorrect year specifier


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6665/head:pull/6665` \
`$ git checkout pull/6665`

Update a local copy of the PR: \
`$ git checkout pull/6665` \
`$ git pull https://git.openjdk.java.net/jdk pull/6665/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6665`

View PR using the GUI difftool: \
`$ git pr show -t 6665`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6665.diff">https://git.openjdk.java.net/jdk/pull/6665.diff</a>

</details>
