### PR TITLE
8278139: G1: Refactor G1BlockOffsetTablePart::block_at_or_preceding

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
@@ -119,20 +119,18 @@ inline HeapWord* G1BlockOffsetTablePart::block_at_or_preceding(const void* addr)
 
   size_t index = _bot->index_for(addr);
 
-  HeapWord* q = _bot->address_for_index(index);
-
   uint offset = _bot->offset_array(index);  // Extend u_char to uint.
   while (offset >= BOTConstants::N_words) {
     // The excess of the offset from N_words indicates a power of Base
     // to go back by.
     size_t n_cards_back = BOTConstants::entry_to_cards_back(offset);
-    q -= (BOTConstants::N_words * n_cards_back);
     index -= n_cards_back;
     offset = _bot->offset_array(index);
   }
   assert(offset < BOTConstants::N_words, "offset too large");
-  q -= offset;
-  return q;
+
+  HeapWord* q = _bot->address_for_index(index);
+  return q - offset;
 }
 
 inline HeapWord* G1BlockOffsetTablePart::forward_to_block_containing_addr(HeapWord* q, HeapWord* n,


### PR DESCRIPTION
Simple change of removing some redundant calculation.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278139](https://bugs.openjdk.java.net/browse/JDK-8278139): G1: Refactor G1BlockOffsetTablePart::block_at_or_preceding


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6666/head:pull/6666` \
`$ git checkout pull/6666`

Update a local copy of the PR: \
`$ git checkout pull/6666` \
`$ git pull https://git.openjdk.java.net/jdk pull/6666/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6666`

View PR using the GUI difftool: \
`$ git pr show -t 6666`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6666.diff">https://git.openjdk.java.net/jdk/pull/6666.diff</a>

</details>
