### PR TITLE
8278141: LIR_OpLoadKlass::_info shadows the field of the same name from LIR_Op

### DIFF
--- a/src/hotspot/share/c1/c1_LIR.hpp
+++ b/src/hotspot/share/c1/c1_LIR.hpp
@@ -1828,15 +1828,13 @@ class LIR_OpLoadKlass: public LIR_Op {
 
  private:
   LIR_Opr _obj;
-  CodeEmitInfo* _info;
  public:
   LIR_OpLoadKlass(LIR_Opr obj, LIR_Opr result, CodeEmitInfo* info)
-    : LIR_Op(lir_load_klass, result, NULL)
+    : LIR_Op(lir_load_klass, result, info)
     , _obj(obj)
-    , _info(info) {}
+    {}
 
   LIR_Opr obj()        const { return _obj;  }
-  CodeEmitInfo* info() const { return _info; }
 
   virtual LIR_OpLoadKlass* as_OpLoadKlass() { return this; }
   virtual void emit_code(LIR_Assembler* masm);


### PR DESCRIPTION
SonarCloud complains about code added in [JDK-8277417](https://bugs.openjdk.java.net/browse/JDK-8277417):
 Field "_info" shadows a field of the same name in base class "LIR_Op"

```
class LIR_OpLoadKlass: public LIR_Op {
  friend class LIR_OpVisitState;

 private:
  LIR_Opr _obj;
  CodeEmitInfo* _info; <--- here
```

From the look of it, it seems risky to have two inconsistent fields here. Depending on which base class we use to access it, we might have different `_info`-s referenced. @rkennke, that was not intentional, was it? I don't see the mentions of this oddity in the original PR.

The fix is to push `CodeEmitInfo` to super-class `LIR_Op`, and use it from there.

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1`
 - [x] Linux x86_64 fastdebug `tier2`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278141](https://bugs.openjdk.java.net/browse/JDK-8278141): LIR_OpLoadKlass::_info shadows the field of the same name from LIR_Op


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6669/head:pull/6669` \
`$ git checkout pull/6669`

Update a local copy of the PR: \
`$ git checkout pull/6669` \
`$ git pull https://git.openjdk.java.net/jdk pull/6669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6669`

View PR using the GUI difftool: \
`$ git pr show -t 6669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6669.diff">https://git.openjdk.java.net/jdk/pull/6669.diff</a>

</details>
