### PR TITLE
8277529: SIGSEGV in C2 CompilerThread Node::rematerialize() compiling Packet::readUnsignedTrint

### DIFF
--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -555,6 +555,7 @@ class Invariance : public StackObj {
   Node_List _old_new; // map of old to new (clone)
   IdealLoopTree* _lpt;
   PhaseIdealLoop* _phase;
+  Node* _data_dependency_on; // The projection into the loop on which data nodes are dependent or NULL otherwise
 
   // Helper function to set up the invariance for invariance computation
   // If n is a known invariant, set up directly. Otherwise, look up the
@@ -656,7 +657,8 @@ class Invariance : public StackObj {
     _visited(area), _invariant(area),
     _stack(area, 10 /* guess */),
     _clone_visited(area), _old_new(area),
-    _lpt(lpt), _phase(lpt->_phase)
+    _lpt(lpt), _phase(lpt->_phase),
+    _data_dependency_on(NULL)
   {
     LoopNode* head = _lpt->_head->as_Loop();
     Node* entry = head->skip_strip_mined()->in(LoopNode::EntryControl);
@@ -664,7 +666,12 @@ class Invariance : public StackObj {
       // If a node is pinned between the predicates and the loop
       // entry, we won't be able to move any node in the loop that
       // depends on it above it in a predicate. Mark all those nodes
-      // as non loop invariatnt.
+      // as non-loop-invariant.
+      // Loop predication could create new nodes for which the below
+      // invariant information is missing. Mark the 'entry' node to
+      // later check again if a node needs to be treated as non-loop-
+      // invariant as well.
+      _data_dependency_on = entry;
       Unique_Node_List wq;
       wq.push(entry);
       for (uint next = 0; next < wq.size(); ++next) {
@@ -681,6 +688,12 @@ class Invariance : public StackObj {
         }
       }
     }
+  }
+
+  // Did we explicitly mark some nodes non-loop-invariant? If so, return the entry node on which some data nodes
+  // are dependent that prevent loop predication. Otherwise, return NULL.
+  Node* data_dependency_on() {
+    return _data_dependency_on;
   }
 
   // Map old to n for invariance computation and clone
@@ -757,12 +770,25 @@ bool IdealLoopTree::is_range_check_if(IfNode *iff, PhaseIdealLoop *phase, Invari
   Node* offset = NULL;
   jlong scale = 0;
   Node* iv = _head->as_BaseCountedLoop()->phi();
+  Compile* C = Compile::current();
+  const uint old_unique_idx = C->unique();
   if (is_range_check_if(iff, phase, T_INT, iv, range, offset, scale)) {
     if (!invar.is_invariant(range)) {
       return false;
     }
-    if (offset && !invar.is_invariant(offset)) { // offset must be invariant
-      return false;
+    if (offset != NULL) {
+      if (!invar.is_invariant(offset)) { // offset must be invariant
+        return false;
+      }
+      Node* data_dependency_on = invar.data_dependency_on();
+      if (data_dependency_on != NULL && old_unique_idx < C->unique()) {
+        // 'offset' node was newly created in is_range_check_if(). Check that it does not depend on the entry projection
+        // into the loop. If it does, we cannot perform loop predication (see Invariant::Invariant()).
+        assert(!offset->is_CFG(), "offset must be a data node");
+        if (_phase->get_ctrl(offset) == data_dependency_on) {
+          return false;
+        }
+      }
     }
 #ifdef ASSERT
     if (offset && phase->has_ctrl(offset)) {

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1627,14 +1627,7 @@ Node *LoadNode::split_through_phi(PhaseGVN *phase) {
       the_clone = x;            // Remember for possible deletion.
       // Alter data node to use pre-phi inputs
       if (this->in(0) == region) {
-        if (mem->is_Phi() && (mem->in(0) == region) && mem->in(i)->in(0) != NULL &&
-            MemNode::all_controls_dominate(address, region)) {
-          // Enable other optimizations such as loop predication which does not work
-          // if we directly pin the node to node `in`
-          x->set_req(0, mem->in(i)->in(0)); // Use same control as memory
-        } else {
-          x->set_req(0, in);
-        }
+        x->set_req(0, in);
       } else {
         x->set_req(0, NULL);
       }

--- a/test/hotspot/jtreg/compiler/loopopts/TestDepBetweenLoopAndPredicate.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestDepBetweenLoopAndPredicate.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8277529
+ * @summary RangeCheck should not be moved out of a loop if a node on the data input chain for the bool is dependent
+ *          on the projection into the loop (after the predicates).
+ * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,compiler.loopopts.TestDepBetweenLoopAndPredicate::test*
+ *                   compiler.loopopts.TestDepBetweenLoopAndPredicate
+ */
+
+package compiler.loopopts;
+
+public class TestDepBetweenLoopAndPredicate {
+    static int x, y, z;
+    static boolean flag;
+    static int[] iArrFld = new int[25];
+    static int[] iArrFld2 = new int[5];
+    static int limit = 5;
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10000; i++) {
+            flag = !flag;
+            test();
+        }
+
+        for (int i = 0; i < 5000; i++) {
+            flag = !flag;
+            test2();
+            test3();
+            test4();
+            test5();
+        }
+    }
+
+    public static void test()  {
+        int[] iArr = new int[20];
+        System.arraycopy(iArrFld, x, iArr, y, 18);
+
+        if (flag) {
+            return;
+        }
+
+        for (int i = 0; i < limit; i++) {
+            iArr[19]++;
+        }
+    }
+
+    public static void test2() {
+        for (int i = 0; i < limit; i++) {
+            int[] iArr = new int[20];
+            System.arraycopy(iArrFld, x, iArr, y, 18);
+
+            if (flag) {
+                return;
+            }
+
+            for (int j = i; j < limit; j++) {
+                x = iArrFld[iArr[19]]; // No new offset node created
+                iArr[19]++;
+            }
+        }
+    }
+
+    public static void test3() {
+        for (int i = 0; i < limit; i++) {
+            int[] iArr = new int[20];
+            System.arraycopy(iArrFld, x, iArr, y, 18);
+
+            if (flag) {
+                return;
+            }
+
+            for (int j = i + 1; j < limit; j++) {
+                x = iArrFld[iArr[19]]; // New offset node created
+                iArr[19]++;
+            }
+        }
+    }
+
+    public static void test4() {
+        for (int i = 0; i < limit; i++) {
+            int[] iArr = new int[20];
+            System.arraycopy(iArrFld, x, iArr, y, 18);
+
+            if (flag) {
+                return;
+            }
+
+            for (int j = i + 1 + z; j < limit; j++) {
+                x = iArrFld[iArr[19]]; // New offset node created
+                iArr[19]++;
+            }
+        }
+    }
+
+    public static void test5() {
+        for (int i = 0; i < limit; i++) {
+            int[] iArr = new int[20];
+            System.arraycopy(iArrFld, x, iArr, y, 18);
+
+            if (flag) {
+                return;
+            }
+
+            for (int j = i + 1 + z; j < limit; j++) {
+                x = iArrFld[iArr[19]]; // New offset node created
+                iArr[19]++;
+                y += iArrFld2[3]; // Range check removed because not dependent on projection into the loop
+            }
+        }
+    }
+}


### PR DESCRIPTION
This bug was found in internal testing for 17.0.2 after the backport of [JDK-8272574](https://bugs.openjdk.java.net/browse/JDK-8272574). The fix rewires a control input of a split load node through a phi to the same control input as the corresponding memory input into the phi node:
https://github.com/openjdk/jdk/blob/e002bfec8cb815b551c9b0f851a8a5b288e8360d/src/hotspot/share/opto/memnode.cpp#L1629-L1637

This can lead to an illegal control input for the new load if `mem->in(i)` is a projection. This situation occurs in the test case: `mem->in(i)` is a projection of an `ArrayCopy` node. Having an `ArrayCopy` node as control input is unexpected and we later fail with an assertion (in product we crash with a segfault).

My initial thought was to just not apply the improved rewiring for memory projections and fall back to the else case on L1636. However, this also does not work as we could then wrongly move a range check out of a loop and creating a cyclic dependency (case described in the [review of JDK-8272574](https://github.com/openjdk/jdk/pull/5142)) and reproduced with `test2()` where we hit:
https://github.com/openjdk/jdk/blob/e002bfec8cb815b551c9b0f851a8a5b288e8360d/src/hotspot/share/opto/loopPredicate.cpp#L777-L778

During this analysis I came across the [fix for JDK-8146792](http://hg.openjdk.java.net/jdk9/jdk9/hotspot/rev/2748d975045f) which should actually prevent loop predication if we have a data dependency on the projection into a loop. But this does not seem to work correctly as shown in the test case found for JDK-8272574. In the review of JDK-8272574, it was missed that the actual problem could have been traced back to JDK-8146792 and instead we went for an improvement for loads split through phis to not end up with cases supposed to be fixed by JDK-8146972 (which now also causes other problems). But the root problem is still there to be fixed.

I therefore propose to completely undo the fix for JDK-8272574 for now and go for a fix on top of JDK-8146972 to fix JDK-8272574 and also prevent this bug. The assertion code added by JDK-8272574 is still good to have. I suggest to revisit the improved rewiring for loads done with JDK-8272574 in an RFE. I think it should still be beneficial but requires some more careful checking (to avoid the problems reported in this bug).


Explanation of JDK-8272574 with regard to JDK-8146972 (covered by `test2-5()`):

When deciding if we can apply loop predication to a check inside the loop, we call `IdealLoopTree::is_range_check()`. This method calls `PhaseIdealLoop::is_scaled_iv_plus_offset()` which can create new nodes for the offset:
https://github.com/openjdk/jdk/blob/b79554bb5cef14590d427543a40efbcc60c66548/src/hotspot/share/opto/loopTransform.cpp#L2586-L2588
`get_ctrl()` of these new nodes could also be the incoming projection into a loop. But these nodes are not marked as non-loop-invariant as done for the other nodes in `Invariant::Invariant()`:
https://github.com/openjdk/jdk/blob/b79554bb5cef14590d427543a40efbcc60c66548/src/hotspot/share/opto/loopPredicate.cpp#L663-L667

The proposed fix keeps track when above code was applied (`data_dependency_on` is set) and does an additional checking for `get_ctrl()` accordingly if a new node was created for the offset in `PhaseIdealLoop::is_scaled_iv_plus_offset()`. This should be fine as we are not using the newly created `offset` node anymore after doing that check.

In discussions with Roland, we think that we should revisit this fix and the fix of JDK-8146972 and clean them up to directly do the invariant checks in `compute_invariance()/visit()` without special handling in the constructor. But given the deadline of 17.0.2 and the fork soon coming up for 18, we think it's the most safe way to go with the proposed fix - if others agree.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277529](https://bugs.openjdk.java.net/browse/JDK-8277529): SIGSEGV in C2 CompilerThread Node::rematerialize() compiling Packet::readUnsignedTrint


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to 3102d7ada2098215ff74db1bc681119db54e8ea2
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6670/head:pull/6670` \
`$ git checkout pull/6670`

Update a local copy of the PR: \
`$ git checkout pull/6670` \
`$ git pull https://git.openjdk.java.net/jdk pull/6670/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6670`

View PR using the GUI difftool: \
`$ git pr show -t 6670`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6670.diff">https://git.openjdk.java.net/jdk/pull/6670.diff</a>

</details>
