### PR TITLE
8278143: Remove unused "argc" from ConstantPool::copy_bootstrap_arguments_at_impl

### DIFF
--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -1178,7 +1178,6 @@ void ConstantPool::copy_bootstrap_arguments_at_impl(const constantPoolHandle& th
                                                     objArrayHandle info, int pos,
                                                     bool must_resolve, Handle if_not_available,
                                                     TRAPS) {
-  int argc;
   int limit = pos + end_arg - start_arg;
   // checks: index in range [0..this_cp->length),
   // tag at index, start..end in range [0..argc],
@@ -1187,7 +1186,7 @@ void ConstantPool::copy_bootstrap_arguments_at_impl(const constantPoolHandle& th
       !(this_cp->tag_at(index).is_invoke_dynamic()    ||
         this_cp->tag_at(index).is_dynamic_constant()) ||
       (0 > start_arg || start_arg > end_arg) ||
-      (end_arg > (argc = this_cp->bootstrap_argument_count_at(index))) ||
+      (end_arg > this_cp->bootstrap_argument_count_at(index)) ||
       (0 > pos       || pos > limit)         ||
       (info.is_null() || limit > info->length())) {
     // An index or something else went wrong; throw an error.

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -1180,7 +1180,7 @@ void ConstantPool::copy_bootstrap_arguments_at_impl(const constantPoolHandle& th
                                                     TRAPS) {
   int limit = pos + end_arg - start_arg;
   // checks: index in range [0..this_cp->length),
-  // tag at index, start..end in range [0..argc],
+  // tag at index, start..end in range [0..this_cp->bootstrap_argument_count],
   // info array non-null, pos..limit in [0..info.length]
   if ((0 >= index    || index >= this_cp->length())  ||
       !(this_cp->tag_at(index).is_invoke_dynamic()    ||


### PR DESCRIPTION
SonarCloud complains about variable initialization in large conditional statements. In that tower of if-expressions, it is not even clear to me that `argc` would be properly initialized. Seems better to clean that up.

Additional testing:
 - [x] Linux x86_64 fastdebug build
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278143](https://bugs.openjdk.java.net/browse/JDK-8278143): Remove unused "argc" from ConstantPool::copy_bootstrap_arguments_at_impl


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**) ⚠️ Review applies to 18fba172cd42b72e6a39f238c40054ac55bd3788
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6671/head:pull/6671` \
`$ git checkout pull/6671`

Update a local copy of the PR: \
`$ git checkout pull/6671` \
`$ git pull https://git.openjdk.java.net/jdk pull/6671/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6671`

View PR using the GUI difftool: \
`$ git pr show -t 6671`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6671.diff">https://git.openjdk.java.net/jdk/pull/6671.diff</a>

</details>
