### PR TITLE
8278154: SimpleFileServer#createFileServer() should specify that the returned server is not started

### DIFF
--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/SimpleFileServer.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/SimpleFileServer.java
@@ -164,14 +164,15 @@ public final class SimpleFileServer {
     }
 
     /**
-     * Creates a <i>file server</i> the serves files from a given path.
+     * Creates a <i>file server</i> that serves files from a given path.
      *
      * <p> The server is configured with an initial context that maps the
      * URI {@code path} to a <i>file handler</i>. The <i>file handler</i> is
      * created as if by an invocation of
      * {@link #createFileHandler(Path) createFileHandler(rootDirectory)}, and is
      * associated to a context created as if by an invocation of
-     * {@link HttpServer#createContext(String) createContext("/")}.
+     * {@link HttpServer#createContext(String) createContext("/")}. The returned
+     * server is not started.
      *
      * <p> An output level can be given to print log messages relating to the
      * exchanges handled by the server. The log messages, if any, are printed to


### PR DESCRIPTION
This doc-only change amends the method-level documentation of SimpleFileServer#createFileServer() to specify the state of the returned server.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8278154](https://bugs.openjdk.java.net/browse/JDK-8278154): SimpleFileServer#createFileServer() should specify that the returned server is not started
 * [JDK-8278159](https://bugs.openjdk.java.net/browse/JDK-8278159): SimpleFileServer#createFileServer() should specify that the returned server is not started (**CSR**)


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6674/head:pull/6674` \
`$ git checkout pull/6674`

Update a local copy of the PR: \
`$ git checkout pull/6674` \
`$ git pull https://git.openjdk.java.net/jdk pull/6674/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6674`

View PR using the GUI difftool: \
`$ git pr show -t 6674`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6674.diff">https://git.openjdk.java.net/jdk/pull/6674.diff</a>

</details>
