### PR TITLE
8258512: serviceability/sa/TestJmapCore.java timed out on macOS 10.13.6

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/TestJmapCore.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJmapCore.java
@@ -26,7 +26,7 @@
  * @summary Test verifies that jhsdb jmap could generate heap dump from core when heap is full
  * @requires vm.hasSA
  * @library /test/lib
- * @run driver/timeout=240 TestJmapCore run heap
+ * @run driver/timeout=480 TestJmapCore run heap
  */
 
 import java.io.File;


### PR DESCRIPTION
Increase the test timeout to 480 just to make sure we don't see this timeout anymore. This same change was already made to TestJmapCoreMetaspace.java a long time ago.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258512](https://bugs.openjdk.java.net/browse/JDK-8258512): serviceability/sa/TestJmapCore.java timed out on macOS 10.13.6


### Reviewers
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6676/head:pull/6676` \
`$ git checkout pull/6676`

Update a local copy of the PR: \
`$ git checkout pull/6676` \
`$ git pull https://git.openjdk.java.net/jdk pull/6676/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6676`

View PR using the GUI difftool: \
`$ git pr show -t 6676`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6676.diff">https://git.openjdk.java.net/jdk/pull/6676.diff</a>

</details>
