### PR TITLE
8276241: JVM does not flag constant class entries ending in '/'

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -4525,7 +4525,6 @@ void ClassFileParser::verify_legal_class_modifiers(jint flags, TRAPS) const {
   const bool is_enum       = (flags & JVM_ACC_ENUM)       != 0;
   const bool is_annotation = (flags & JVM_ACC_ANNOTATION) != 0;
   const bool major_gte_1_5 = _major_version >= JAVA_1_5_VERSION;
-  const bool major_gte_14  = _major_version >= JAVA_14_VERSION;
 
   if ((is_abstract && is_final) ||
       (is_interface && !is_abstract) ||
@@ -4781,7 +4780,7 @@ bool ClassFileParser::verify_unqualified_name(const char* name,
 
 // Take pointer to a UTF8 byte string (not NUL-terminated).
 // Skip over the longest part of the string that could
-// be taken as a fieldname. Allow '/' if slash_ok is true.
+// be taken as a fieldname. Allow non-trailing '/'s if slash_ok is true.
 // Return a pointer to just past the fieldname.
 // Return NULL if no fieldname at all was found, or in the case of slash_ok
 // being true, we saw consecutive slashes (meaning we were looking for a
@@ -4855,7 +4854,7 @@ static const char* skip_over_field_name(const char* const name,
     }
     return (not_first_ch) ? old_p : NULL;
   }
-  return (not_first_ch) ? p : NULL;
+  return (not_first_ch && !last_is_slash) ? p : NULL;
 }
 
 // Take pointer to a UTF8 byte string (not NUL-terminated).

--- a/test/hotspot/jtreg/runtime/classFileParserBug/TrailingSlashTest.java
+++ b/test/hotspot/jtreg/runtime/classFileParserBug/TrailingSlashTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8276241
+ * @summary Throw ClassFormatError exception for an old class file whose name ends in a '/'.
+ * @run main/othervm -Xverify:remote TrailingSlashTest
+ */
+
+public class TrailingSlashTest extends ClassLoader {
+
+    @Override
+    public Class findClass(String fileName) throws ClassNotFoundException {
+        return defineClass(null, oldSlashClass, 0, oldSlashClass.length);
+    }
+
+    public static void main(String args[]) throws Throwable {
+        try {
+            TrailingSlashTest cl = new TrailingSlashTest();
+            cl.findClass("oldSlashClass");
+            throw new RuntimeException("Expected exception not thrown");
+        } catch (ClassFormatError e) {
+            if (!e.getMessage().contains("Illegal class name")) {
+               throw new RuntimeException("Wrong ClassFormatError exception: " + e.getMessage());
+            }
+        }
+    }
+
+
+    // This byte array comprises the compiled bytes of the following class.  Note that the class's
+    // name ends in a '/' and has a class file version of 45.3.
+    /*
+        package has;
+        public class slashe/ { }
+    */
+    public static byte[] oldSlashClass = {
+        (byte) 0xca, (byte) 0xfe, (byte) 0xba, (byte) 0xbe, (byte) 0x0, (byte) 0x3, (byte) 0x0, (byte) 0x2d,
+        (byte) 0x0, (byte) 0xd, (byte) 0xa, (byte) 0x0, (byte) 0x2, (byte) 0x0, (byte) 0x3, (byte) 0x7,
+        (byte) 0x0, (byte) 0x4, (byte) 0xc, (byte) 0x0, (byte) 0x5, (byte) 0x0, (byte) 0x6, (byte) 0x1,
+        (byte) 0x0, (byte) 0x10, (byte) 0x6a, (byte) 0x61, (byte) 0x76, (byte) 0x61, (byte) 0x2f, (byte) 0x6c,
+        (byte) 0x61, (byte) 0x6e, (byte) 0x67, (byte) 0x2f, (byte) 0x4f, (byte) 0x62, (byte) 0x6a, (byte) 0x65,
+        (byte) 0x63, (byte) 0x74, (byte) 0x1, (byte) 0x0, (byte) 0x6, (byte) 0x3c, (byte) 0x69, (byte) 0x6e,
+        (byte) 0x69, (byte) 0x74, (byte) 0x3e, (byte) 0x1, (byte) 0x0, (byte) 0x3, (byte) 0x28, (byte) 0x29,
+        (byte) 0x56, (byte) 0x7, (byte) 0x0, (byte) 0x8, (byte) 0x1, (byte) 0x0, (byte) 0xb, (byte) 0x68,
+        (byte) 0x61, (byte) 0x73, (byte) 0x2f, (byte) 0x73, (byte) 0x6c, (byte) 0x61, (byte) 0x73, (byte) 0x68,
+        (byte) 0x65, (byte) 0x2f, (byte) 0x1, (byte) 0x0, (byte) 0x4, (byte) 0x43, (byte) 0x6f, (byte) 0x64,
+        (byte) 0x65, (byte) 0x1, (byte) 0x0, (byte) 0xf, (byte) 0x4c, (byte) 0x69, (byte) 0x6e, (byte) 0x65,
+        (byte) 0x4e, (byte) 0x75, (byte) 0x6d, (byte) 0x62, (byte) 0x65, (byte) 0x72, (byte) 0x54, (byte) 0x61,
+        (byte) 0x62, (byte) 0x6c, (byte) 0x65, (byte) 0x1, (byte) 0x0, (byte) 0xa, (byte) 0x53, (byte) 0x6f,
+        (byte) 0x75, (byte) 0x72, (byte) 0x63, (byte) 0x65, (byte) 0x46, (byte) 0x69, (byte) 0x6c, (byte) 0x65,
+        (byte) 0x1, (byte) 0x0, (byte) 0xc, (byte) 0x73, (byte) 0x6c, (byte) 0x61, (byte) 0x73, (byte) 0x68,
+        (byte) 0x65, (byte) 0x73, (byte) 0x2e, (byte) 0x6a, (byte) 0x61, (byte) 0x76, (byte) 0x61, (byte) 0x0,
+        (byte) 0x21, (byte) 0x0, (byte) 0x7, (byte) 0x0, (byte) 0x2, (byte) 0x0, (byte) 0x0, (byte) 0x0,
+        (byte) 0x0, (byte) 0x0, (byte) 0x1, (byte) 0x0, (byte) 0x1, (byte) 0x0, (byte) 0x5, (byte) 0x0,
+        (byte) 0x6, (byte) 0x0, (byte) 0x1, (byte) 0x0, (byte) 0x9, (byte) 0x0, (byte) 0x0, (byte) 0x0,
+        (byte) 0x1d, (byte) 0x0, (byte) 0x1, (byte) 0x0, (byte) 0x1, (byte) 0x0, (byte) 0x0, (byte) 0x0,
+        (byte) 0x5, (byte) 0x2a, (byte) 0xb7, (byte) 0x0, (byte) 0x1, (byte) 0xb1, (byte) 0x0, (byte) 0x0,
+        (byte) 0x0, (byte) 0x1, (byte) 0x0, (byte) 0xa, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x6,
+        (byte) 0x0, (byte) 0x1, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x3, (byte) 0x0, (byte) 0x1,
+        (byte) 0x0, (byte) 0xb, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x2, (byte) 0x0, (byte) 0xc,
+    };
+
+}


### PR DESCRIPTION
Please review this small fix for JDK-8276241.  The fix ensures that a ClassFormatError exception gets thrown for classes whose name ends in a '/' and are class file version less than 49 (JDK 1.5).  (A CFE already gets thrown for newer class file versions.)  The regression test class was written using a byte array because neither jcod nor jasm could handle a class name ending in '/'.

The fix was tested by running JCK lang and VM tests on Linux x64, Mach5 tiers 1-2 on Linux, Mac OS, and Windows, and Mach5 tiers 3-5 on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8276241](https://bugs.openjdk.java.net/browse/JDK-8276241): JVM does not flag constant class entries ending in '/'
 * [JDK-8278448](https://bugs.openjdk.java.net/browse/JDK-8278448): JVM does not flag constant class entries ending in '/' (**CSR**)


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6678/head:pull/6678` \
`$ git checkout pull/6678`

Update a local copy of the PR: \
`$ git checkout pull/6678` \
`$ git pull https://git.openjdk.java.net/jdk pull/6678/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6678`

View PR using the GUI difftool: \
`$ git pr show -t 6678`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6678.diff">https://git.openjdk.java.net/jdk/pull/6678.diff</a>

</details>
