### PR TITLE
8278163: --with-cacerts-src variable resolved after GenerateCacerts recipe setup

### DIFF
--- a/make/modules/java.base/Gendata.gmk
+++ b/make/modules/java.base/Gendata.gmk
@@ -60,7 +60,11 @@ TARGETS += $(GENDATA_CURDATA)
 
 ################################################################################
 
-GENDATA_CACERTS_SRC := $(TOPDIR)/make/data/cacerts/
+ifneq ($(CACERTS_SRC), )
+  GENDATA_CACERTS_SRC := $(CACERTS_SRC)
+else
+  GENDATA_CACERTS_SRC := $(TOPDIR)/make/data/cacerts/
+endif
 GENDATA_CACERTS := $(SUPPORT_OUTPUTDIR)/modules_libs/java.base/security/cacerts
 
 $(GENDATA_CACERTS): $(BUILD_TOOLS_JDK) $(wildcard $(GENDATA_CACERTS_SRC)/*)
@@ -70,9 +74,6 @@ $(GENDATA_CACERTS): $(BUILD_TOOLS_JDK) $(wildcard $(GENDATA_CACERTS_SRC)/*)
 
 ifeq ($(CACERTS_FILE), )
   TARGETS += $(GENDATA_CACERTS)
-endif
-ifneq ($(CACERTS_SRC), )
-  GENDATA_CACERTS_SRC := $(CACERTS_SRC)
 endif
 
 ################################################################################


### PR DESCRIPTION
PR https://github.com/openjdk/jdk/pull/6647 resolved the GENDATA_CACERTS_SRC fir --with-cacerts-src after the recipe, which meant the dependencies were wrong.
This PR moves it before the recipe.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278163](https://bugs.openjdk.java.net/browse/JDK-8278163): --with-cacerts-src variable resolved after GenerateCacerts recipe setup


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6680/head:pull/6680` \
`$ git checkout pull/6680`

Update a local copy of the PR: \
`$ git checkout pull/6680` \
`$ git pull https://git.openjdk.java.net/jdk pull/6680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6680`

View PR using the GUI difftool: \
`$ git pr show -t 6680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6680.diff">https://git.openjdk.java.net/jdk/pull/6680.diff</a>

</details>
