### PR TITLE
8278172: java/nio/channels/FileChannel/BlockDeviceSize.java should only run on Linux

### DIFF
--- a/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
+++ b/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 8054029
+ * @requires (os.family == "linux")
  * @summary Block devices should not report size=0 on Linux
  */
 


### PR DESCRIPTION
Please review this simple change which merely adds `@requires (os.family == "linux")` to the test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278172](https://bugs.openjdk.java.net/browse/JDK-8278172): java/nio/channels/FileChannel/BlockDeviceSize.java should only run on Linux


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6681/head:pull/6681` \
`$ git checkout pull/6681`

Update a local copy of the PR: \
`$ git checkout pull/6681` \
`$ git pull https://git.openjdk.java.net/jdk pull/6681/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6681`

View PR using the GUI difftool: \
`$ git pr show -t 6681`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6681.diff">https://git.openjdk.java.net/jdk/pull/6681.diff</a>

</details>
