### PR TITLE
8278174: runtime/cds/appcds/LambdaWithJavaAgent.java fails with release VMs

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/LambdaWithJavaAgent.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/LambdaWithJavaAgent.java
@@ -69,6 +69,7 @@ public class LambdaWithJavaAgent {
         CDSOptions opts = (new CDSOptions())
             .addPrefix("-XX:ExtraSharedClassListFile=" + classList,
                        "-cp", appJar,
+                       "-XX:+UnlockDiagnosticVMOptions",
                        "-XX:+AllowArchivingWithJavaAgent",
                        useJavaAgent,
                        "-Xlog:class+load,cds+class=debug,cds")
@@ -81,6 +82,7 @@ public class LambdaWithJavaAgent {
         // run with archive
         CDSOptions runOpts = (new CDSOptions())
             .addPrefix("-cp", appJar, "-Xlog:class+load,cds=debug",
+                       "-XX:+UnlockDiagnosticVMOptions",
                        "-XX:+AllowArchivingWithJavaAgent",
                        useJavaAgent)
             .setArchiveName(archiveName)


### PR DESCRIPTION
Hi all,

runtime/cds/appcds/LambdaWithJavaAgent.java fails with release VMs.
This is because VM option 'AllowArchivingWithJavaAgent' is diagnostic and must be enabled via -XX:+UnlockDiagnosticVMOptions.
So let's add -XX:+UnlockDiagnosticVMOptions to fix it.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278174](https://bugs.openjdk.java.net/browse/JDK-8278174): runtime/cds/appcds/LambdaWithJavaAgent.java fails with release VMs


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6684/head:pull/6684` \
`$ git checkout pull/6684`

Update a local copy of the PR: \
`$ git checkout pull/6684` \
`$ git pull https://git.openjdk.java.net/jdk pull/6684/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6684`

View PR using the GUI difftool: \
`$ git pr show -t 6684`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6684.diff">https://git.openjdk.java.net/jdk/pull/6684.diff</a>

</details>
