### PR TITLE
JDK-8278175: Enable all doclint warnings for build of java.desktop

### DIFF
--- a/make/modules/java.desktop/Java.gmk
+++ b/make/modules/java.desktop/Java.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 # questions.
 #
 
-DOCLINT += -Xdoclint:all/protected,-reference,-missing \
+DOCLINT += -Xdoclint:all/protected \
     '-Xdoclint/package:java.*,javax.*'
 COPY += .gif .png .wav .txt .xml .css .pf
 CLEAN += iio-plugin.properties cursors.properties

--- a/src/java.desktop/share/classes/java/awt/BufferCapabilities.java
+++ b/src/java.desktop/share/classes/java/awt/BufferCapabilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ package java.awt;
  * @author Michael Martak
  * @since 1.4
  */
+@SuppressWarnings("doclint:missing")
 public class BufferCapabilities implements Cloneable {
 
     private ImageCapabilities frontCaps;

--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -214,6 +214,7 @@ import static sun.java2d.pipe.hw.ExtendedBufferCapabilities.VSyncType.VSYNC_ON;
  * @author      Arthur van Hoff
  * @author      Sami Shaio
  */
+@SuppressWarnings("doclint:missing")
 public abstract class Component implements ImageObserver, MenuContainer,
                                            Serializable
 {

--- a/src/java.desktop/share/classes/java/awt/event/KeyEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/KeyEvent.java
@@ -151,6 +151,7 @@ import sun.awt.AWTAccessor;
  *
  * @since 1.1
  */
+@SuppressWarnings("doclint:missing")
 public class KeyEvent extends InputEvent {
 
     /**

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesSupport.java
@@ -54,7 +54,7 @@ import java.util.TooManyListenersException;
  * @author Laurence P. G. Cable
  * @since 1.2
  */
-
+@SuppressWarnings("doclint:missing")
 public class      BeanContextServicesSupport extends BeanContextSupport
        implements BeanContextServices {
 

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
@@ -59,6 +59,7 @@ import java.util.Map;
  * @author Laurence P. G. Cable
  * @since 1.2
  */
+@SuppressWarnings("doclint:missing")
 public class      BeanContextSupport extends BeanContextChildSupport
        implements BeanContext,
                   Serializable,

--- a/src/java.desktop/share/classes/javax/swing/DefaultListSelectionModel.java
+++ b/src/java.desktop/share/classes/javax/swing/DefaultListSelectionModel.java
@@ -50,7 +50,8 @@ import javax.swing.event.*;
  * @see ListSelectionModel
  * @since 1.2
  */
-@SuppressWarnings("serial") // Same-version serialization only
+@SuppressWarnings({"serial", // Same-version serialization only
+                   "doclint:missing"})
 public class DefaultListSelectionModel implements ListSelectionModel, Cloneable, Serializable
 {
     private static final int MIN = -1;

--- a/src/java.desktop/share/classes/javax/swing/JApplet.java
+++ b/src/java.desktop/share/classes/javax/swing/JApplet.java
@@ -99,7 +99,8 @@ import javax.accessibility.AccessibleContext;
 @Deprecated(since = "9", forRemoval = true)
 @JavaBean(defaultProperty = "JMenuBar", description = "Swing's Applet subclass.")
 @SwingContainer(delegate = "getContentPane")
-@SuppressWarnings({"serial", "removal"}) // Same-version serialization only
+@SuppressWarnings({"serial", "removal", // Same-version serialization only
+                   "doclint:missing"})
 public class JApplet extends Applet implements Accessible,
                                                RootPaneContainer,
                                TransferHandler.HasGetTransferHandler

--- a/src/java.desktop/share/classes/javax/swing/JDialog.java
+++ b/src/java.desktop/share/classes/javax/swing/JDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,7 +95,8 @@ import javax.accessibility.*;
  */
 @JavaBean(defaultProperty = "JMenuBar", description = "A toplevel window for creating dialog boxes.")
 @SwingContainer(delegate = "getContentPane")
-@SuppressWarnings("serial") // Same-version serialization only
+@SuppressWarnings({"serial", // Same-version serialization only
+                   "doclint:missing"})
 public class JDialog extends Dialog implements WindowConstants,
                                                Accessible,
                                                RootPaneContainer,

--- a/src/java.desktop/share/classes/javax/swing/JScrollBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JScrollBar.java
@@ -83,7 +83,8 @@ import javax.swing.plaf.ScrollBarUI;
  */
 @JavaBean(defaultProperty = "UI", description = "A component that helps determine the visible content range of an area.")
 @SwingContainer(false)
-@SuppressWarnings("serial") // Same-version serialization only
+@SuppressWarnings({"serial",  // Same-version serialization only
+                   "doclint:missing"})
 public class JScrollBar extends JComponent implements Adjustable, Accessible
 {
     /**

--- a/src/java.desktop/share/classes/javax/swing/filechooser/FileSystemView.java
+++ b/src/java.desktop/share/classes/javax/swing/filechooser/FileSystemView.java
@@ -65,7 +65,7 @@ import sun.awt.shell.ShellFolder;
 // PENDING(jeff) - need to provide a specification for
 // how Mac/OS2/BeOS/etc file systems can modify FileSystemView
 // to handle their particular type of file system.
-
+@SuppressWarnings("doclint:missing")
 public abstract class FileSystemView {
 
     static FileSystemView windowsFileSystemView = null;

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuItemUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuItemUI.java
@@ -45,6 +45,7 @@ import sun.swing.*;
  * @author Arnaud Weber
  * @author Fredrik Lagerblad
  */
+@SuppressWarnings("doclint:missing")
 public class BasicMenuItemUI extends MenuItemUI
 {
     /**

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,6 +46,7 @@ import java.util.ArrayList;
  * @author David Karlton
  * @author Arnaud Weber
  */
+@SuppressWarnings("doclint:missing")
 public class BasicMenuUI extends BasicMenuItemUI
 {
     /**

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalBorders.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalBorders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ import sun.swing.SwingUtilities2;
  * Factory object that can vend Borders appropriate for the metal L &amp; F.
  * @author Steve Wilson
  */
-
+@SuppressWarnings("doclint:missing")
 public class MetalBorders {
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/text/LayeredHighlighter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/LayeredHighlighter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ import java.awt.Shape;
  * @author  Timothy Prinzing
  * @see     Highlighter
  */
+@SuppressWarnings("doclint:missing")
 public abstract class LayeredHighlighter implements Highlighter {
     /**
      * Constructor for subclasses to call.

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTML.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTML.java
@@ -43,6 +43,7 @@ import javax.swing.text.StyleContext;
  * @author  Sunita Mani
  *
  */
+@SuppressWarnings("doclint:missing")
 public class HTML {
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
@@ -216,7 +216,8 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
  *
  * @author  Timothy Prinzing
  */
-@SuppressWarnings("serial") // Same-version serialization only
+@SuppressWarnings({"serial", // Same-version serialization only
+                   "doclint:missing"})
 public class HTMLEditorKit extends StyledEditorKit implements Accessible {
 
     private JEditorPane theEditor;

--- a/src/java.desktop/share/classes/javax/swing/text/html/parser/AttributeList.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/parser/AttributeList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,8 @@ import java.io.*;
  * @author      Arthur Van Hoff
  *
  */
-@SuppressWarnings("serial") // Same-version serialization only
+@SuppressWarnings({"serial", // Same-version serialization only
+                   "doclint:missing"})
 public final
 class AttributeList implements DTDConstants, Serializable {
 

--- a/src/java.desktop/share/classes/javax/swing/text/html/parser/Parser.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/parser/Parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,6 +75,7 @@ import java.net.URL;
  * @author Arthur van Hoff
  * @author Sunita Mani
  */
+@SuppressWarnings("doclint:missing")
 public
 class Parser implements DTDConstants {
 

--- a/src/java.desktop/share/classes/javax/swing/undo/UndoableEditSupport.java
+++ b/src/java.desktop/share/classes/javax/swing/undo/UndoableEditSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ import java.util.*;
  *
  * @author Ray Ryan
  */
+@SuppressWarnings("doclint:missing")
 public class UndoableEditSupport {
     /**
      * The update level.


### PR DESCRIPTION
In JDK 18, JDK-8189591 added the ability to suppress doclint warnings. Therefore, it is now possible to enable the full doclint checks for the java.desktop module if the instances of warnings are suppressed. This patch does this; it would be preferable to address the doc warnings directly, but that is beyond what I'm attempting to do here.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278175](https://bugs.openjdk.java.net/browse/JDK-8278175): Enable all doclint warnings for build of java.desktop


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6687/head:pull/6687` \
`$ git checkout pull/6687`

Update a local copy of the PR: \
`$ git checkout pull/6687` \
`$ git pull https://git.openjdk.java.net/jdk pull/6687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6687`

View PR using the GUI difftool: \
`$ git pr show -t 6687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6687.diff">https://git.openjdk.java.net/jdk/pull/6687.diff</a>

</details>
