### PR TITLE
JDK-8278179: Enable all doclint warnings for build of java.naming

### DIFF
--- a/make/modules/java.naming/Java.gmk
+++ b/make/modules/java.naming/Java.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,6 @@
 # questions.
 #
 
-DOCLINT += -Xdoclint:all/protected,-accessibility \
+DOCLINT += -Xdoclint:all/protected \
     '-Xdoclint/package:java.*,javax.*'
 CLEAN += jndiprovider.properties


### PR DESCRIPTION
An exploratory build indicates that it is not necessary to disable the accessibility doclint check for the java.naming module.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278179](https://bugs.openjdk.java.net/browse/JDK-8278179): Enable all doclint warnings for build of java.naming


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6688/head:pull/6688` \
`$ git checkout pull/6688`

Update a local copy of the PR: \
`$ git checkout pull/6688` \
`$ git pull https://git.openjdk.java.net/jdk pull/6688/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6688`

View PR using the GUI difftool: \
`$ git pr show -t 6688`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6688.diff">https://git.openjdk.java.net/jdk/pull/6688.diff</a>

</details>
