### PR TITLE
8210558: serviceability/sa/TestJhsdbJstackLock.java fails to find '^\s+- waiting to lock <0x[0-9a-f]+> \(a java\.lang\.Class ...'

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/LingeredAppWithLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/LingeredAppWithLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,6 +46,19 @@ public class LingeredAppWithLock extends LingeredApp {
         classLock2.start();
         objectLock.start();
         primitiveLock.start();
+
+        // Wait until all threads have reached their blocked or timed wait state
+        while ((classLock1.getState() != Thread.State.BLOCKED &&
+                classLock1.getState() != Thread.State.TIMED_WAITING) ||
+               (classLock2.getState() != Thread.State.BLOCKED &&
+                classLock2.getState() != Thread.State.TIMED_WAITING) ||
+               (objectLock.getState() != Thread.State.TIMED_WAITING) ||
+               (primitiveLock.getState() != Thread.State.TIMED_WAITING)) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException ex) {
+            }
+        }
 
         LingeredApp.main(args);
     }


### PR DESCRIPTION
The issue appears to be due to running jstack before allowing the 4 threads created by `LingeredAppWithLock` to fully start up and reach their blocking or timed wait state. With this fix `LingeredAppWithLock.main()` now waits until the threads have reached the blocking or timed wait state before calling into `LingeredApp.main()`. 

Tests that use `LingeredAppWithLock` call `LingeredApp.startApp()`, which will first launch `LingeredAppWithLock` and then block until the lock file is touched. This blocking/waiting is done the call to `waitAppReady()`, which will be called before `LingeredApp.startApp()` returns. The lock file is not touched until `LingeredApp.main()` is called, and it is not called until after `LingeredAppWithBloc.main()` has already verified the state of all the threads. Thus by the time `LingeredApp.startApp()` returns, we can be sure that the threads started by `LingeredAppWithLock.main()` are in the desired state.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8210558](https://bugs.openjdk.java.net/browse/JDK-8210558): serviceability/sa/TestJhsdbJstackLock.java fails to find '^\s+- waiting to lock <0x[0-9a-f]+> \(a java\.lang\.Class ...'


### Reviewers
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6689/head:pull/6689` \
`$ git checkout pull/6689`

Update a local copy of the PR: \
`$ git checkout pull/6689` \
`$ git pull https://git.openjdk.java.net/jdk pull/6689/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6689`

View PR using the GUI difftool: \
`$ git pr show -t 6689`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6689.diff">https://git.openjdk.java.net/jdk/pull/6689.diff</a>

</details>
