### PR TITLE
8180622: gc/stress/gclocker/TestGCLockerWithParallel.java: fails with OOME Java heap space

### DIFF
--- a/test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithG1.java
+++ b/test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithG1.java
@@ -29,11 +29,11 @@ package gc.stress.gclocker;
  * @library /
  * @requires vm.gc.G1
  * @summary Stress G1's GC locker by calling GetPrimitiveArrayCritical while concurrently filling up old gen.
- * @run main/native/othervm/timeout=200 -Xlog:gc*=info -Xms1500m -Xmx1500m -XX:+UseG1GC gc.stress.gclocker.TestGCLockerWithG1
+ * @run main/native/othervm/timeout=260 -Xlog:gc*=info -Xms1500m -Xmx1500m -XX:+UseG1GC gc.stress.gclocker.TestGCLockerWithG1
  */
 public class TestGCLockerWithG1 {
     public static void main(String[] args) {
-        String[] testArgs = {"2", "G1 Old Gen"};
+        String[] testArgs = {"3", "G1 Old Gen"};
         TestGCLocker.main(testArgs);
     }
 }


### PR DESCRIPTION
Could you please review the JDK-8180622 fix?

I would like to modify the test to free up Filler objects when the usage reached 1000.
In addition, I changed the rate of freeing objects from one-fifth to three-fifths of the Java heap in this case.
I explain the reason for the change below.

TestGCLockerWithG1 runs for 2 minutes under GC load.
In my environment, an OutOfMeomryError occurs in about 7 seconds.

The environment:
  Red Hat Enterprise Linux Server release 7.7
  Intel Core Processor (Broadwell, IBRS) 2GHz 2core, 4GB memory

I added some print statements for debugging in shouldFreeUpSpace() to see the internal behavior of the test.

load() frees up one-fifth of the Java heap, if shouldFreeUpSpace() returns true.
But actually it returns false and becomes OOME.
And I found that the test repeats shouldFreeUpSpace() 30 times after the usage has reached 1000 before it becomes OOME.

Because minFreeCriticalWaitMS, minFreeWaitElapsedMS, and minGCWaitMS do not meet the conditions for freeing up.
Therefore, even if GC occurs, the test continues to allocate Filler objects without freeing up them.

It is not desirable to simply compare the elapsed time with the threshold,
since the speed of object allocations depends on the machine performance.
This is the reason to change the test to free up Filler objects when the usage reached 1000.

The test frees up one-fifth of objects, but G1GC cannot keep up with the allocation speed.
Because G1GC is region based and the stop the world is short.
The next log shows that G1GC was not able to collect objects enough regardless of one-fifth release.

[8.090s][info   ][gc          ] GC(65) Pause Young (Normal) (GCLocker Initiated GC) 1493M->1490M(1500M) 10.235ms

This is the reason to change the rate from one-fifth to three-fifths.
Instead, I changed the running time from 2 minutes to 3 minutes to prolong the high GC load.

With this fix, the frequency of 'GCLocker Initiated GC' is 799 times per 180 secs (4.4 times/sec), 
which means that the GC load is sufficient compared with other GC types.

TestGCLockerWithParallel : 288 times per 120 secs (2.4 times/sec)
TestGCLockerWithSerial : 244 times per 120 sec (2.0 times/sec)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ 8180622 is used in problem lists: [test/hotspot/jtreg/ProblemList.txt]

### Issue
 * [JDK-8180622](https://bugs.openjdk.java.net/browse/JDK-8180622): gc/stress/gclocker/TestGCLockerWithParallel.java: fails with OOME Java heap space


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6692/head:pull/6692` \
`$ git checkout pull/6692`

Update a local copy of the PR: \
`$ git checkout pull/6692` \
`$ git pull https://git.openjdk.java.net/jdk pull/6692/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6692`

View PR using the GUI difftool: \
`$ git pr show -t 6692`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6692.diff">https://git.openjdk.java.net/jdk/pull/6692.diff</a>

</details>
