### PR TITLE
8247973: Javadoc incorrect for IdentityArrayList, IdentityLinkedList

### DIFF
--- a/doc/hotspot-style.html
+++ b/doc/hotspot-style.html
@@ -49,6 +49,7 @@
 <li><a href="#thread_local">thread_local</a></li>
 <li><a href="#nullptr">nullptr</a></li>
 <li><a href="#atomic">&lt;atomic&gt;</a></li>
+<li><a href="#uniform-initialization">Uniform Initialization</a></li>
 <li><a href="#additional-permitted-features">Additional Permitted Features</a></li>
 <li><a href="#excluded-features">Excluded Features</a></li>
 <li><a href="#undecided-features">Undecided Features</a></li>
@@ -275,6 +276,17 @@ while ( test_foo(args...) ) { // No, excess spaces around control</code></pre></
 <p>Do not use facilities provided by the <code>&lt;atomic&gt;</code> header (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2427.html">n2427</a>), (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2752.htm">n2752</a>); instead, use the HotSpot <code>Atomic</code> class and related facilities.</p>
 <p>Atomic operations in HotSpot code must have semantics which are consistent with those provided by the JDK's compilers for Java. There are platform-specific implementation choices that a C++ compiler might make or change that are outside the scope of the C++ Standard, and might differ from what the Java compilers implement.</p>
 <p>In addition, HotSpot <code>Atomic</code> has a concept of &quot;conservative&quot; memory ordering, which may differ from (may be stronger than) sequentially consistent. There are algorithms in HotSpot that are believed to rely on that ordering.</p>
+<h3 id="uniform-initialization">Uniform Initialization</h3>
+<p>The use of <em>uniform initialization</em> (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2672.htm">n2672</a>), also known as <em>brace initialization</em>, is permitted.</p>
+<p>Some relevant sections from cppreference.com:</p>
+<ul>
+<li><a href="https://en.cppreference.com/w/cpp/language/initialization">initialization</a></li>
+<li><a href="https://en.cppreference.com/w/cpp/language/value_initialization">value initialization</a></li>
+<li><a href="https://en.cppreference.com/w/cpp/language/direct_initialization">direct initialization</a></li>
+<li><a href="https://en.cppreference.com/w/cpp/language/list_initialization">list initialization</a></li>
+<li><a href="https://en.cppreference.com/w/cpp/language/aggregate_initialization">aggregate initialization</a></li>
+</ul>
+<p>Although related, the use of <code>std::initializer_list</code> remains forbidden, as part of the avoidance of the C++ Standard Library in HotSpot code.</p>
 <h3 id="additional-permitted-features">Additional Permitted Features</h3>
 <ul>
 <li><p><code>constexpr</code> (<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2235.pdf">n2235</a>) (<a href="https://isocpp.org/files/papers/N3652.html">n3652</a>)</p></li>

--- a/doc/hotspot-style.md
+++ b/doc/hotspot-style.md
@@ -681,6 +681,23 @@ ordering, which may differ from (may be stronger than) sequentially
 consistent.  There are algorithms in HotSpot that are believed to rely
 on that ordering.
 
+### Uniform Initialization
+
+The use of _uniform initialization_
+([n2672](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2672.htm)),
+also known as _brace initialization_, is permitted.
+
+Some relevant sections from cppreference.com:
+
+* [initialization](https://en.cppreference.com/w/cpp/language/initialization)
+* [value initialization](https://en.cppreference.com/w/cpp/language/value_initialization)
+* [direct initialization](https://en.cppreference.com/w/cpp/language/direct_initialization)
+* [list initialization](https://en.cppreference.com/w/cpp/language/list_initialization)
+* [aggregate initialization](https://en.cppreference.com/w/cpp/language/aggregate_initialization)
+
+Although related, the use of `std::initializer_list` remains forbidden, as
+part of the avoidance of the C++ Standard Library in HotSpot code.
+
 ### Additional Permitted Features
 
 * `constexpr`

--- a/src/java.desktop/share/classes/sun/awt/util/IdentityArrayList.java
+++ b/src/java.desktop/share/classes/sun/awt/util/IdentityArrayList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,7 +203,7 @@ public class IdentityArrayList<E> extends AbstractList<E>
      * Returns {@code true} if this list contains the specified element.
      * More formally, returns {@code true} if and only if this list contains
      * at least one element {@code e} such that
-     * {@code Objects.equals(o, e)}.
+     * {@code o == e}.
      *
      * @param o element whose presence in this list is to be tested
      * @return {@code true} if this list contains the specified element
@@ -216,8 +216,12 @@ public class IdentityArrayList<E> extends AbstractList<E>
      * Returns the index of the first occurrence of the specified element
      * in this list, or -1 if this list does not contain the element.
      * More formally, returns the lowest index {@code i} such that
-     * {@code Objects.equals(o, get(i))},
+     * {@code get(i)==o},
      * or -1 if there is no such index.
+     *
+     * @param o element to search for
+     * @return the index of the first occurrence of the specified element in
+     *         this list, or -1 if this list does not contain the element
      */
     public int indexOf(Object o) {
         for (int i = 0; i < size; i++) {
@@ -232,8 +236,12 @@ public class IdentityArrayList<E> extends AbstractList<E>
      * Returns the index of the last occurrence of the specified element
      * in this list, or -1 if this list does not contain the element.
      * More formally, returns the highest index {@code i} such that
-     * {@code Objects.equals(o, get(i))},
+     * {@code get(i)==o},
      * or -1 if there is no such index.
+     *
+     * @param o element to search for
+     * @return the index of the last occurrence of the specified element in
+     *         this list, or -1 if this list does not contain the element
      */
     public int lastIndexOf(Object o) {
         for (int i = size-1; i >= 0; i--) {
@@ -388,11 +396,11 @@ public class IdentityArrayList<E> extends AbstractList<E>
         return oldValue;
     }
 
-    /**
+     /**
      * Removes the first occurrence of the specified element from this list,
-     * if it is present.  If the list does not contain the element, it is
+     * if it is present.  If this list does not contain the element, it is
      * unchanged.  More formally, removes the element with the lowest index
-     * {@code i} such that {@code Objects.equals(o, get(i))}
+     * {@code i} such that {@code get(i)==o}
      * (if such an element exists).  Returns {@code true} if this list
      * contained the specified element (or equivalently, if this list
      * changed as a result of the call).

--- a/src/java.desktop/share/classes/sun/awt/util/IdentityLinkedList.java
+++ b/src/java.desktop/share/classes/sun/awt/util/IdentityLinkedList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -183,7 +183,7 @@ public class IdentityLinkedList<E>
      * Returns {@code true} if this list contains the specified element.
      * More formally, returns {@code true} if and only if this list contains
      * at least one element {@code e} such that
-     * {@code Objects.equals(o, e)}.
+     * {@code o == e}.
      *
      * @param o element whose presence in this list is to be tested
      * @return {@code true} if this list contains the specified element


### PR DESCRIPTION
The documentation for following methods used equals() for object equality:

sun.awt.util.IdentityLinkedList#contains
sun.awt.util.IdentityArrayList#contains
sun.awt.util.IdentityArrayList#indexOf
sun.awt.util.IdentityArrayList#lastIndexOf
sun.awt.util.IdentityArrayList#remove(java.lang.Object)

I have updated the comments to use "==" operator for object equality. Kindly review the changes for the same.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8247973](https://bugs.openjdk.java.net/browse/JDK-8247973): Javadoc incorrect for IdentityArrayList, IdentityLinkedList


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6694/head:pull/6694` \
`$ git checkout pull/6694`

Update a local copy of the PR: \
`$ git checkout pull/6694` \
`$ git pull https://git.openjdk.java.net/jdk pull/6694/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6694`

View PR using the GUI difftool: \
`$ git pr show -t 6694`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6694.diff">https://git.openjdk.java.net/jdk/pull/6694.diff</a>

</details>
