### PR TITLE
8277864: Compilation error thrown while doing a boxing conversion on selector expression

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -347,8 +347,9 @@ public class TransPatterns extends TreeTranslator {
                 }
             }
             selector = translate(selector);
-            statements.append(make.at(tree.pos).VarDef(temp, !hasNullCase ? attr.makeNullCheck(selector)
-                                                                          : selector));
+            boolean needsNullCheck = !hasNullCase && !seltype.isPrimitive();
+            statements.append(make.at(tree.pos).VarDef(temp, needsNullCheck ? attr.makeNullCheck(selector)
+                                                                            : selector));
             VarSymbol index = new VarSymbol(Flags.SYNTHETIC,
                     names.fromString(tree.pos + target.syntheticNameChar() + "index"),
                     syms.intType,

--- a/test/langtools/tools/javac/patterns/Switches.java
+++ b/test/langtools/tools/javac/patterns/Switches.java
@@ -28,7 +28,7 @@ import java.util.function.Function;
 
 /*
  * @test
- * @bug 8262891 8268333 8268896 8269802 8269808 8270151 8269113
+ * @bug 8262891 8268333 8268896 8269802 8269808 8270151 8269113 8277864
  * @summary Check behavior of pattern switches.
  * @compile --enable-preview -source ${jdk.version} Switches.java
  * @run main/othervm --enable-preview Switches
@@ -85,6 +85,9 @@ public class Switches {
         assertEquals(2, switchOverNull1());
         assertEquals(2, switchOverNull2());
         assertEquals(2, switchOverNull3());
+        assertEquals(5, switchOverPrimitiveInt(0));
+        assertEquals(7, switchOverPrimitiveInt(1));
+        assertEquals(9, switchOverPrimitiveInt(2));
     }
 
     void run(Function<Object, Integer> mapper) {
@@ -588,6 +591,14 @@ public class Switches {
         return switch (null) {
             case null -> 2;
             case Object o -> 1;
+        };
+    }
+
+    private int switchOverPrimitiveInt(Integer i) {
+        return switch (i) {
+            case 0 -> 5 + 0;
+            case Integer j && j == 1 -> 6 + j;
+            case Integer j -> 7 + j;
         };
     }
 


### PR DESCRIPTION
Consider a switch whose selector type is a primitive type (e.g. an integer). This may still be a pattern matching switch, if it has a case with a pattern label. But, as the selector type is primitive, TransPatterns must not attempt to generate a null check, so this patch avoids it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277864](https://bugs.openjdk.java.net/browse/JDK-8277864): Compilation error thrown while doing a boxing conversion on selector expression


### Reviewers
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**)
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6695/head:pull/6695` \
`$ git checkout pull/6695`

Update a local copy of the PR: \
`$ git checkout pull/6695` \
`$ git pull https://git.openjdk.java.net/jdk pull/6695/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6695`

View PR using the GUI difftool: \
`$ git pr show -t 6695`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6695.diff">https://git.openjdk.java.net/jdk/pull/6695.diff</a>

</details>
