### PR TITLE
8278205: jlink plugins should dump .class file in debug mode

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JlinkTask.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/JlinkTask.java
@@ -78,7 +78,7 @@ import jdk.internal.module.ModuleResolution;
  * ## Should use jdk.joptsimple some day.
  */
 public class JlinkTask {
-    static final boolean DEBUG = Boolean.getBoolean("jlink.debug");
+    public static final boolean DEBUG = Boolean.getBoolean("jlink.debug");
 
     // jlink API ignores by default. Remove when signing is implemented.
     static final boolean IGNORE_SIGNING_DEFAULT = true;

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/IncludeLocalesPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/IncludeLocalesPlugin.java
@@ -158,7 +158,7 @@ public final class IncludeLocalesPlugin extends AbstractPlugin implements Resour
                 if (resource != null &&
                     resource.type().equals(ResourcePoolEntry.Type.CLASS_OR_RESOURCE)) {
                     byte[] bytes = resource.contentBytes();
-                    ClassReader cr = new ClassReader(bytes);
+                    ClassReader cr = newClassReader(path, bytes);
                     if (Arrays.stream(cr.getInterfaces())
                         .anyMatch(i -> i.contains(METAINFONAME)) &&
                         stripUnsupportedLocales(bytes, cr)) {

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/StripJavaDebugAttributesPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/StripJavaDebugAttributesPlugin.java
@@ -59,7 +59,7 @@ public final class StripJavaDebugAttributesPlugin extends AbstractPlugin {
                     if (path.endsWith("module-info.class")) {
                         // XXX. Do we have debug info? Is Asm ready for module-info?
                     } else {
-                        ClassReader reader = new ClassReader(resource.contentBytes());
+                        ClassReader reader = newClassReader(path, resource.contentBytes());
                         ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
                         reader.accept(writer, ClassReader.SKIP_DEBUG);
                         byte[] content = writer.toByteArray();

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/VersionPropsPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/VersionPropsPlugin.java
@@ -96,9 +96,9 @@ abstract class VersionPropsPlugin extends AbstractPlugin {
 
     private boolean redefined = false;
 
-    private byte[] redefine(byte[] classFile) {
+    private byte[] redefine(String path, byte[] classFile) {
 
-        var cr = new ClassReader(classFile);
+        var cr = newClassReader(path, classFile);
         var cw = new ClassWriter(0);
 
         cr.accept(new ClassVisitor(Opcodes.ASM7, cw) {
@@ -189,7 +189,7 @@ abstract class VersionPropsPlugin extends AbstractPlugin {
         in.transformAndCopy(res -> {
                 if (res.type().equals(ResourcePoolEntry.Type.CLASS_OR_RESOURCE)) {
                     if (res.path().equals(VERSION_PROPS_CLASS)) {
-                        return res.copyWithContent(redefine(res.contentBytes()));
+                        return res.copyWithContent(redefine(res.path(), res.contentBytes()));
                     }
                 }
                 return res;


### PR DESCRIPTION
jlink plugins dump .class files in debug mode. jpackage tests already set jlink.debug property to true.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278205](https://bugs.openjdk.java.net/browse/JDK-8278205): jlink plugins should dump .class file in debug mode


### Reviewers
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6696/head:pull/6696` \
`$ git checkout pull/6696`

Update a local copy of the PR: \
`$ git checkout pull/6696` \
`$ git pull https://git.openjdk.java.net/jdk pull/6696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6696`

View PR using the GUI difftool: \
`$ git pr show -t 6696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6696.diff">https://git.openjdk.java.net/jdk/pull/6696.diff</a>

</details>
