### PR TITLE
8277850: C2: optimize mask checks in counted loops

### DIFF
--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -1746,7 +1746,7 @@ bool MulNode::AndIL_shift_and_mask(PhaseGVN* phase, Node* mask, Node* shift, Bas
   if ((1L << shift_con) > mask_t->hi_as_long() && mask_t->lo_as_long() >= 0) {
     return true;
   }
-  
+
   return false;
 }
 

--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -1747,7 +1747,7 @@ bool MulNode::AndIL_shift_and_mask(PhaseGVN* phase, Node* mask, Node* shift, Bas
   }
 
   jint shift_con = shift2_t->is_int()->get_con() & ((bt == T_INT ? BitsPerJavaInteger : BitsPerJavaLong) - 1);
-  if ((((long)1) << shift_con) > mask_t->hi_as_long() && mask_t->lo_as_long() >= 0) {
+  if ((((jlong)1) << shift_con) > mask_t->hi_as_long() && mask_t->lo_as_long() >= 0) {
     return true;
   }
 

--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -1747,7 +1747,7 @@ bool MulNode::AndIL_shift_and_mask(PhaseGVN* phase, Node* mask, Node* shift, Bas
   }
 
   jint shift_con = shift2_t->is_int()->get_con() & ((bt == T_INT ? BitsPerJavaInteger : BitsPerJavaLong) - 1);
-  if ((1L << shift_con) > mask_t->hi_as_long() && mask_t->lo_as_long() >= 0) {
+  if ((((long)1) << shift_con) > mask_t->hi_as_long() && mask_t->lo_as_long() >= 0) {
     return true;
   }
 

--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -505,6 +505,15 @@ const Type *AndINode::mul_ring( const Type *t0, const Type *t1 ) const {
   return TypeInt::INT;          // No constants to be had
 }
 
+const Type* AndINode::Value(PhaseGVN* phase) const {
+  // patterns similar to (v << 2) & 3
+  if (AndIL_shift_and_mask(phase, in(2), in(1), T_INT)) {
+    return TypeInt::ZERO;
+  }
+
+  return MulINode::Value(phase);
+}
+
 //------------------------------Identity---------------------------------------
 // Masking off the high bits of an unsigned load is not required
 Node* AndINode::Identity(PhaseGVN* phase) {
@@ -598,6 +607,12 @@ Node *AndINode::Ideal(PhaseGVN *phase, bool can_reshape) {
       phase->type(load->in(1)) == TypeInt::ZERO )
     return new AndINode( load->in(2), in(2) );
 
+  // pattern similar to (v1 + (v2 << 2)) & 3 transformed to v1 & 3
+  Node* progress = AndIL_add_shift_and_mask(phase, T_INT);
+  if (progress != NULL) {
+    return progress;
+  }
+
   return MulNode::Ideal(phase, can_reshape);
 }
 
@@ -627,6 +642,15 @@ const Type *AndLNode::mul_ring( const Type *t0, const Type *t1 ) const {
     return TypeLong::make(CONST64(0), r1->get_con(), widen);
 
   return TypeLong::LONG;        // No constants to be had
+}
+
+const Type* AndLNode::Value(PhaseGVN* phase) const {
+  // patterns similar to (v << 2) & 3
+  if (AndIL_shift_and_mask(phase, in(2), in(1), T_LONG)) {
+    return TypeLong::ZERO;
+  }
+
+  return MulLNode::Value(phase);
 }
 
 //------------------------------Identity---------------------------------------
@@ -675,7 +699,7 @@ Node *AndLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   const jlong mask = t2->get_con();
 
   Node* in1 = in(1);
-  uint op = in1->Opcode();
+  int op = in1->Opcode();
 
   // Are we masking a long that was converted from an int with a mask
   // that fits in 32-bits?  Commute them and use an AndINode.  Don't
@@ -703,6 +727,12 @@ Node *AndLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
         return new AndLNode(zshift, in(2));
       }
     }
+  }
+
+  // pattern similar to (v1 + (v2 << 2)) & 3 transformed to v1 & 3
+  Node* progress = AndIL_add_shift_and_mask(phase, T_LONG);
+  if (progress != NULL) {
+    return progress;
   }
 
   return MulNode::Ideal(phase, can_reshape);
@@ -1682,4 +1712,59 @@ const Type* RotateRightNode::Value(PhaseGVN* phase) const {
     }
     return TypeLong::LONG;
   }
+}
+
+bool MulNode::AndIL_shift_and_mask(PhaseGVN* phase, Node* mask, Node* shift, BasicType bt) const {
+  if (mask == NULL || shift == NULL) {
+    return false;
+  }
+  const TypeInteger* mask_t = phase->type(mask)->isa_integer(bt);
+  const TypeInteger* shift_t = phase->type(shift)->isa_integer(bt);
+  if (mask_t == NULL || shift_t == NULL) {
+    return false;
+  }
+  if (bt == T_LONG && shift != NULL && shift->Opcode() == Op_ConvI2L) {
+    bt = T_INT;
+    shift = shift->in(1);
+    if (shift == NULL) {
+      return false;
+    }
+  }
+  if (shift->Opcode() != Op_LShift(bt)) {
+    return false;
+  }
+  Node* shift2 = shift->in(2);
+  if (shift2 == NULL) {
+    return false;
+  }
+  const Type* shift2_t = phase->type(shift2);
+  if (!shift2_t->isa_int() || !shift2_t->is_int()->is_con()) {
+    return false;
+  }
+
+  jint shift_con = shift2_t->is_int()->get_con() & ((bt == T_INT ? BitsPerJavaInteger : BitsPerJavaLong) - 1);
+  if ((1L << shift_con) > mask_t->hi_as_long() && mask_t->lo_as_long() >= 0) {
+    return true;
+  }
+  
+  return false;
+}
+
+Node* MulNode::AndIL_add_shift_and_mask(PhaseGVN* phase, BasicType bt) {
+  Node* in1 = in(1);
+  Node* in2 = in(2);
+  if (in1 != NULL && in2 != NULL && in1->Opcode() == Op_Add(bt)) {
+    Node* add1 = in1->in(1);
+    Node* add2 = in1->in(2);
+    if (add1 != NULL && add2 != NULL) {
+      if (AndIL_shift_and_mask(phase, in2, add1, bt)) {
+        set_req_X(1, add2, phase);
+        return this;
+      } else if (AndIL_shift_and_mask(phase, in2, add2, bt)) {
+        set_req_X(1, add1, phase);
+        return this;
+      }
+    }
+  }
+  return NULL;
 }

--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -511,7 +511,7 @@ const Type* AndINode::Value(PhaseGVN* phase) const {
     return TypeInt::ZERO;
   }
 
-  return MulINode::Value(phase);
+  return MulNode::Value(phase);
 }
 
 //------------------------------Identity---------------------------------------
@@ -650,7 +650,7 @@ const Type* AndLNode::Value(PhaseGVN* phase) const {
     return TypeLong::ZERO;
   }
 
-  return MulLNode::Value(phase);
+  return MulNode::Value(phase);
 }
 
 //------------------------------Identity---------------------------------------
@@ -1714,7 +1714,11 @@ const Type* RotateRightNode::Value(PhaseGVN* phase) const {
   }
 }
 
-bool MulNode::AndIL_shift_and_mask(PhaseGVN* phase, Node* mask, Node* shift, BasicType bt) const {
+// Helper method to transform:
+// patterns similar to (v << 2) & 3 to 0
+// and
+// patterns similar to (v1 + (v2 << 2)) & 3 transformed to v1 & 3
+bool MulNode::AndIL_shift_and_mask(PhaseGVN* phase, Node* mask, Node* shift, BasicType bt) {
   if (mask == NULL || shift == NULL) {
     return false;
   }
@@ -1750,6 +1754,8 @@ bool MulNode::AndIL_shift_and_mask(PhaseGVN* phase, Node* mask, Node* shift, Bas
   return false;
 }
 
+// Helper method to transform:
+// patterns similar to (v1 + (v2 << 2)) & 3 to v1 & 3
 Node* MulNode::AndIL_add_shift_and_mask(PhaseGVN* phase, BasicType bt) {
   Node* in1 = in(1);
   Node* in2 = in(2);

--- a/src/hotspot/share/opto/mulnode.hpp
+++ b/src/hotspot/share/opto/mulnode.hpp
@@ -82,6 +82,9 @@ public:
   virtual int min_opcode() const = 0;
 
   static MulNode* make(Node* in1, Node* in2, BasicType bt);
+
+  bool AndIL_shift_and_mask(PhaseGVN* phase, Node* mask, Node* shift, BasicType bt) const;
+  Node* AndIL_add_shift_and_mask(PhaseGVN* phase, BasicType bt);
 };
 
 //------------------------------MulINode---------------------------------------
@@ -189,6 +192,7 @@ public:
   virtual int Opcode() const;
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
   virtual Node* Identity(PhaseGVN* phase);
+  virtual const Type* Value(PhaseGVN* phase) const;
   virtual const Type *mul_ring( const Type *, const Type * ) const;
   const Type *mul_id() const { return TypeInt::MINUS_1; }
   const Type *add_id() const { return TypeInt::ZERO; }
@@ -208,6 +212,7 @@ public:
   virtual int Opcode() const;
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
   virtual Node* Identity(PhaseGVN* phase);
+  virtual const Type* Value(PhaseGVN* phase) const;
   virtual const Type *mul_ring( const Type *, const Type * ) const;
   const Type *mul_id() const { return TypeLong::MINUS_1; }
   const Type *add_id() const { return TypeLong::ZERO; }

--- a/src/hotspot/share/opto/mulnode.hpp
+++ b/src/hotspot/share/opto/mulnode.hpp
@@ -83,7 +83,7 @@ public:
 
   static MulNode* make(Node* in1, Node* in2, BasicType bt);
 
-  bool AndIL_shift_and_mask(PhaseGVN* phase, Node* mask, Node* shift, BasicType bt) const;
+  static bool AndIL_shift_and_mask(PhaseGVN* phase, Node* mask, Node* shift, BasicType bt);
   Node* AndIL_add_shift_and_mask(PhaseGVN* phase, BasicType bt);
 };
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestShiftAndMask.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestShiftAndMask.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug JDK-8277850
+ * @summary C2: optimize mask checks in counted loops
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.TestShiftAndMask
+ */
+
+public class TestShiftAndMask {
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    @Test
+    @Arguments(Argument.RANDOM_EACH)
+    @IR(failOn = { IRNode.AND_I, IRNode.LSHIFT_I })
+    public static int shiftMaskInt(int i) {
+        return (i << 2) & 3; // transformed to: return 0;
+    }
+
+    @Test
+    @Arguments(Argument.RANDOM_EACH)
+    @IR(failOn = { IRNode.AND_L, IRNode.LSHIFT_L })
+    public static long shiftMaskLong(long i) {
+        return (i << 2) & 3; // transformed to: return 0;
+    }
+
+    @Test
+    @Arguments({Argument.RANDOM_EACH, Argument.RANDOM_EACH})
+    @IR(counts = { IRNode.AND_I, "1" })
+    @IR(failOn = { IRNode.ADD_I, IRNode.LSHIFT_I })
+    public static int addShiftMaskInt(int i, int j) {
+        return (j + (i << 2)) & 3; // transformed to: return j & 3;
+    }
+
+    @Test
+    @Arguments({Argument.RANDOM_EACH, Argument.RANDOM_EACH})
+    @IR(counts = { IRNode.AND_L, "1" })
+    @IR(failOn = { IRNode.ADD_L, IRNode.LSHIFT_L })
+    public static long addShiftMaskLong(long i, long j) {
+        return (j + (i << 2)) & 3; // transformed to: return j & 3;
+    }
+
+    @Test
+    @Arguments({Argument.RANDOM_EACH, Argument.RANDOM_EACH})
+    @IR(failOn = { IRNode.AND_I, IRNode.ADD_I, IRNode.LSHIFT_I })
+    public static int addShiftMaskInt2(int i, int j) {
+        return ((j << 2) + (i << 2)) & 3; // transformed to: return 0;
+    }
+
+    @Test
+    @Arguments({Argument.RANDOM_EACH, Argument.RANDOM_EACH})
+    @IR(failOn = { IRNode.AND_L, IRNode.ADD_L, IRNode.LSHIFT_L })
+    public static long addShiftMaskLong2(long i, long j) {
+        return ((j << 2) + (i << 2)) & 3; // transformed to: return 0;
+    }
+
+    @Test
+    @Arguments(Argument.RANDOM_EACH)
+    @IR(failOn = { IRNode.AND_L, IRNode.LSHIFT_I })
+    public static long shiftConvMask(int i) {
+        return ((long)(i << 2)) & 3; // transformed to: return 0;
+    }
+
+    @Test
+    @Arguments({Argument.RANDOM_EACH, Argument.RANDOM_EACH})
+    @IR(counts = { IRNode.AND_L, "1" })
+    @IR(failOn = { IRNode.ADD_L, IRNode.LSHIFT_I, IRNode.CONV_I2L })
+    public static long addShiftConvMask(int i, long j) {
+        return (j + (i << 2)) & 3; // transformed to: return j & 3;
+    }
+
+    @Test
+    @Arguments({Argument.RANDOM_EACH, Argument.RANDOM_EACH})
+    @IR(failOn = { IRNode.AND_L, IRNode.ADD_L, IRNode.LSHIFT_L })
+    public static long addShiftConvMask2(int i, int j) {
+        return (((long)(j << 2)) + ((long)(i << 2))) & 3; // transformed to: return 0;
+    }
+
+}
+

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestShiftAndMask.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestShiftAndMask.java
@@ -27,7 +27,7 @@ import compiler.lib.ir_framework.*;
 
 /*
  * @test
- * @bug JDK-8277850
+ * @bug 8277850
  * @summary C2: optimize mask checks in counted loops
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestShiftAndMask

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -133,6 +133,14 @@ public class IRNode {
     public static final String SCOPE_OBJECT = "(.*# ScObj.*" + END;
     public static final String MEMBAR = START + "MemBar" + MID + END;
 
+    public static final String AND_I = START + "AndI" + MID + END;
+    public static final String AND_L = START + "AndL" + MID + END;
+    public static final String LSHIFT_I = START + "LShiftI" + MID + END;
+    public static final String LSHIFT_L = START + "LShiftL" + MID + END;
+    public static final String ADD_I = START + "AddI" + MID + END;
+    public static final String ADD_L = START + "AddL" + MID + END;
+    public static final String CONV_I2L = START + "ConvI2L" + MID + END;
+
     /**
      * Called by {@link IRMatcher} to merge special composite nodes together with additional user-defined input.
      */


### PR DESCRIPTION
This is another fix that addresses a performance issue with panama and that was brought up by Maurizio. The pattern to optimize is:
if ((base + (offset << 2)) & 3) != 0) {
}

where base is loop independent but offset depends on a loop variable. This can be transformed to:

if ((base & 3) != 0) {

That check becomes loop independent and be optimized by loop predication (or I suppose loop unswitching but that wasn't the case of the micro benchmark I worked on).

This change also optimizes the pattern:

(offset << 2) & 3

to return 0.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277850](https://bugs.openjdk.java.net/browse/JDK-8277850): C2: optimize mask checks in counted loops


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to 94b6869354c7164c05fc6b75ace9f2df31f739ed


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6697/head:pull/6697` \
`$ git checkout pull/6697`

Update a local copy of the PR: \
`$ git checkout pull/6697` \
`$ git pull https://git.openjdk.java.net/jdk pull/6697/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6697`

View PR using the GUI difftool: \
`$ git pr show -t 6697`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6697.diff">https://git.openjdk.java.net/jdk/pull/6697.diff</a>

</details>
