### PR TITLE
8278207: G1: Tighten verification in G1ResetSkipCompactingClosure

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
@@ -56,7 +56,8 @@ public:
       bool is_empty = (_collector->live_words(r->hrm_index()) == 0);
       assert(!is_empty, "should contain at least one live obj");
     } else if (r->is_closed_archive()) {
-      // nothing to assert
+      // should early-return above
+      ShouldNotReachHere();
     } else {
       assert(_collector->live_words(region_index) > _collector->scope()->region_compaction_threshold(),
              "should be quite full");

--- a/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
@@ -46,13 +46,22 @@ public:
     uint region_index = r->hrm_index();
     // Only for skip-compaction regions; early return otherwise.
     if (!_collector->is_skip_compacting(region_index)) {
-
       return false;
     }
-    assert(_collector->live_words(region_index) > _collector->scope()->region_compaction_threshold() ||
-         !r->is_starts_humongous() ||
-         _collector->mark_bitmap()->is_marked(cast_to_oop(r->bottom())),
-         "must be, otherwise reclaimed earlier");
+#ifdef ASSERT
+    if (r->is_humongous()) {
+      oop obj = cast_to_oop(r->humongous_start_region()->bottom());
+      assert(_collector->mark_bitmap()->is_marked(obj), "must be live");
+    } else if (r->is_open_archive()) {
+      bool is_empty = (_collector->live_words(r->hrm_index()) == 0);
+      assert(!is_empty, "should contain at least one live obj");
+    } else if (r->is_closed_archive()) {
+      // nothing to assert
+    } else {
+      assert(_collector->live_words(region_index) > _collector->scope()->region_compaction_threshold(),
+             "should be quite full");
+    }
+#endif
     r->reset_skip_compacting_after_full_gc();
     return false;
   }


### PR DESCRIPTION
Simple change of expanding the verification logic to mirror its source.

Test: tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278207](https://bugs.openjdk.java.net/browse/JDK-8278207): G1: Tighten verification in G1ResetSkipCompactingClosure


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6698/head:pull/6698` \
`$ git checkout pull/6698`

Update a local copy of the PR: \
`$ git checkout pull/6698` \
`$ git pull https://git.openjdk.java.net/jdk pull/6698/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6698`

View PR using the GUI difftool: \
`$ git pr show -t 6698`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6698.diff">https://git.openjdk.java.net/jdk/pull/6698.diff</a>

</details>
