### PR TITLE
8278031: MultiThreadedRefCounter should not use relaxed atomic decrement

### DIFF
--- a/src/hotspot/share/jfr/utilities/jfrRefCountPointer.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrRefCountPointer.hpp
@@ -116,7 +116,11 @@ class MultiThreadedRefCounter {
   }
 
   bool dec() const {
-    return 0 == Atomic::sub(&_refs, 1, memory_order_relaxed);
+    if (0 == Atomic::sub(&_refs, 1, memory_order_release)) {
+      OrderAccess::acquire();
+      return true;
+    }
+    return false;
   }
 
   intptr_t current() const {


### PR DESCRIPTION
Greetings,

please help review this small adjustment to the reference counter memory order.

Tests: jdk_jfr

Thanks to @kimbarrett for bringing this to attention.

Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278031](https://bugs.openjdk.java.net/browse/JDK-8278031): MultiThreadedRefCounter should not use relaxed atomic decrement


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6699/head:pull/6699` \
`$ git checkout pull/6699`

Update a local copy of the PR: \
`$ git checkout pull/6699` \
`$ git pull https://git.openjdk.java.net/jdk pull/6699/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6699`

View PR using the GUI difftool: \
`$ git pr show -t 6699`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6699.diff">https://git.openjdk.java.net/jdk/pull/6699.diff</a>

</details>
