### PR TITLE
8275610: C2: Object field load floats above its null check resulting in a segfault

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1174,6 +1174,16 @@ bool PhaseIdealLoop::identical_backtoback_ifs(Node *n) {
   if (!n->in(0)->is_Region()) {
     return false;
   }
+
+  IfNode* n_if = n->as_If();
+  if (n_if->proj_out(0)->outcnt() > 1 || n_if->proj_out(1)->outcnt() > 1) {
+    // Removing the dominated If node by using the split-if optimization does not work if there are data dependencies.
+    // Some data dependencies depend on its immediate dominator If node and should not be separated from it (e.g. null
+    // checks, division by zero checks etc.). Bail out for now until data dependencies are correctly handled when
+    // optimizing back-to-back ifs.
+    return false;
+  }
+
   Node* region = n->in(0);
   Node* dom = idom(region);
   if (!dom->is_If() || dom->in(1) != n->in(1)) {

--- a/test/hotspot/jtreg/compiler/loopopts/TestEliminateNullCheckWithSplitIf.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestEliminateNullCheckWithSplitIf.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @key stress randomness
+ * @bug 8275610
+ * @summary Null check for field access of object floats above null check resulting in a segfault.
+ * @requires vm.compiler2.enabled
+ * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,compiler.loopopts.TestEliminateNullCheckWithSplitIf::test
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:StressSeed=42 compiler.loopopts.TestEliminateNullCheckWithSplitIf
+ * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,compiler.loopopts.TestEliminateNullCheckWithSplitIf::test
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+StressIGVN compiler.loopopts.TestEliminateNullCheckWithSplitIf
+ */
+
+package compiler.loopopts;
+
+public class TestEliminateNullCheckWithSplitIf {
+    public static int[] iArrFld = new int[20];
+    public static int[] iArrFld2 = new int[20];
+    public static int iFld = 10;
+    public static MyClass obj;
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 10000; i++) {
+            obj = (i % 100 == 0 ? null : new MyClass());
+            test();
+        }
+    }
+
+    // The field access obj.iFld requires a null check NC3 and adds a not-null CastPP node on the succeeded projection.
+    // In the first IGVN after parsing, the null check NC3 can be subsumed by the explicit null check NC2.
+    // (done in IfNode::simple_subsuming()). The Bool node of NC2 is also shared with the same null check NC1 earlier.
+    // However, C2 cannot remove the null check NC2, yet, because the IR in between the two checks are too complex
+    // (IfNode::search_identical() fails).
+    // Now, loopopts are applied:
+    // (1) First, the split if optimization is done. It recognizes that NC1 and NC2 are back to back null checks and removes
+    // the null check NC2 by splitting it through the region R which is removed afterwards. In this process, control dependent
+    // data nodes on the out projections of NC2 end up at the new regions R1/R2 created for each projection for R. They get
+    // the last nodes of the if and else block as input. For this example, R1 is a control input to the CastPP node which
+    // will merge both true projections.
+    // (2) Later in loop opts, the loop L is transformed into normal code and y will become a constant 1.
+    // After loopopts, another round of IGVN is done:
+    // (These steps also depend on the order in which they are applied in order to trigger the bug)
+    // (1) The region R is removed because one path is dead (a result of the split if optimization).
+    // (2) The new If node added by the above split if optimization is also folded. This rewires the CastPP node to
+    // the last control node in the If block which is the true projection of range check RC2. Up until now, the CastPP
+    // is still after the null check NC1.
+    // (3) The range check RC2 is removed because the range check RC1 already covers this range (see RangeCheck::Ideal()).
+    // All data nodes which are control dependent on RC2 will be rewired to the dominating range check RC1, including
+    // the non-null CastPP node - which now has a control input above the null check NC1. This also means that the field
+    // load obj.iFld now has the same early control as the CastPP (CastPP -> AddP -> LoadI). Using StressGCM can
+    // now schedule the obj.iFld load before the null check NC1 because the early control allows it which leads to a
+    // segmentation fault if obj is null.
+    public static void test() {
+        int x = iArrFld[17]; // Emits range check RC1
+        if (obj != null) { // Null check NC1
+            int y = 0;
+            for (int i = 0; i < 1; i++) { // Loop L
+                y++;
+            }
+            // Use additional loop to keep the rangecheck for iArrFld[y] in before loopopts.
+            // y will become constant 1 but only once the loop above is removed in loopopts.
+            x = iArrFld[y]; // Emits range check RC2
+        } else {
+            x = iArrFld2[18];
+        }
+        // Region R merging the if and else paths above.
+        if (obj != null) { // Null check NC2
+            x = iArrFld2[obj.iFld]; // Emits Null check NC3 for obj.iFld
+        }
+    }
+}
+
+class MyClass {
+    int iFld;
+}
+
+
+
+


### PR DESCRIPTION
In the test case, a field load of an object floats above the object null check due to a `CastPP` that gets separated from its null check `If` node. C2 then schedules the field load before the object null check which results in a segfault.

The problem can be traced back to the elimination of identical back-to-back ifs [(JDK-8143542)](https://bugs.openjdk.java.net/browse/JDK-8143542). This is done in split-if where we detect identical back-to-back ifs in `PhaseIdealLoop::identical_backtoback_ifs()`. We then replace the boolean node of the dominated `If` by a phi to use the split-if optimization to nicely fold away the dominated `If` later in IGVN. This, however, does not update any data nodes that were dependent on the dominated `If` projections. 

In the test case, we have the following graph right before splitting `313 If` (`NC 2`) through `190 Region`:

![Screenshot from 2021-12-03 14-08-31](https://user-images.githubusercontent.com/17833009/144608863-a1185bf8-dfa3-4bd5-a0c2-284ea2b27606.png)
`313 If` is dominated by the identical (= both share `308 Bool`) `309 If` (`NC 1`). The bool input for `313 If` is replaced by a phi and the split-if optimization is applied. However, the data nodes dependent on the out projections of the dominated `313 If` (`261 CastPP` in this case) are not processed separately and just end up at the newly inserted regions in split-if. In the test case, we get the following graph where `261 CastPP` ends up at the new `334 Region`:

![Screenshot from 2021-12-03 14-08-59](https://user-images.githubusercontent.com/17833009/144608891-48adf7a3-9b04-4e6d-bc26-310757b3d596.png)
Loopopts are applied and can remove the `325 CountedLoop` and we find that the `171 RangeCheck` (`RC 2`) is applied on a constant array index 1.

Now at IGVN, the order in which the nodes are processed is important in order to trigger the segfault:
1. `334 Region` with `332 If` and `333 If` are removed because of the special split-if setup we used to remove the identical `313 If`. The control input of `261 CastPP` is therefore updated to `172 IfTrue`.
2. Applying `RangeCheck::Ideal()` for `171 RangeCheck` finds that `305 RangeCheck` (`RC 1`) already covers it and we remove `171 RangeCheck`. In this process, we rewire `261 CastPP` to the dominating `305 RangeCheck` and we have the following graph:

![Screenshot from 2021-12-03 14-09-21](https://user-images.githubusercontent.com/17833009/144608917-f5159b21-40b2-41c8-afab-fa495433217a.png)
`261 CastPP` - and also the field `263 LoadI` - have now `306 IfFalse` as early control. GCM is then scheduling `263 LoadI` before the null check `309 If` and we get a segfault.

An easy fix is not straight forward. What we actually would want to do is rewiring `261 CastPP` from `334 Region` to `311 IfTrue` in the second graph after split-if to not separate it from the null check. But that's not possible because we would create a bad graph: The early control `311 IfTrue` of `261 CastPP` does not dominate its late control further down after `334 Region` because of the not yet removed `334 Region`. We would need to already clean the regions up and then do the rewiring. But then the question arises why to use the split-if optimization in the first place when we do not want to rely on IGVN to clean it up.

I therefore suggest to go with an easy bailout fix for JDK 18 where we do not apply this identical back-to-back if removal optimization if there are data dependencies and rework this in an RFE for JDK 19. Roland already has some ideas how to do that.

I ran some standard benchmarks and did not see any performance regressions with this fix.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275610](https://bugs.openjdk.java.net/browse/JDK-8275610): C2: Object field load floats above its null check resulting in a segfault


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6701/head:pull/6701` \
`$ git checkout pull/6701`

Update a local copy of the PR: \
`$ git checkout pull/6701` \
`$ git pull https://git.openjdk.java.net/jdk pull/6701/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6701`

View PR using the GUI difftool: \
`$ git pr show -t 6701`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6701.diff">https://git.openjdk.java.net/jdk/pull/6701.diff</a>

</details>
