### PR TITLE
8276125: RunThese24H.java SIGSEGV in JfrThreadGroup::thread_group_id

### DIFF
--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrThreadGroup.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrThreadGroup.cpp
@@ -151,8 +151,12 @@ int JfrThreadGroupsHelper::populate_thread_group_hierarchy(const JavaThread* jt,
   assert(current != NULL, "invariant");
   assert(_thread_group_hierarchy != NULL, "invariant");
 
+  oop thread_oop = jt->threadObj();
+  if (thread_oop == nullptr) {
+    return 0;
+  }
   // immediate thread group
-  Handle thread_group_handle(current, java_lang_Thread::threadGroup(jt->threadObj()));
+  Handle thread_group_handle(current, java_lang_Thread::threadGroup(thread_oop));
   if (thread_group_handle == NULL) {
     return 0;
   }
@@ -167,7 +171,7 @@ int JfrThreadGroupsHelper::populate_thread_group_hierarchy(const JavaThread* jt,
   Handle parent_thread_group_handle(current, parent_thread_group_obj);
 
   // and check parents parents...
-  while (!(parent_thread_group_handle == NULL)) {
+  while (parent_thread_group_handle != nullptr) {
     const jweak parent_group_weak_ref = use_weak_handles ? JNIHandles::make_weak_global(parent_thread_group_handle) : NULL;
     thread_group_pointers = new JfrThreadGroupPointers(parent_thread_group_handle, parent_group_weak_ref);
     _thread_group_hierarchy->append(thread_group_pointers);


### PR DESCRIPTION
Greetings,

please help review this changeset.

Details are listed in the JIRA issue.

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276125](https://bugs.openjdk.java.net/browse/JDK-8276125): RunThese24H.java SIGSEGV in JfrThreadGroup::thread_group_id


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6702/head:pull/6702` \
`$ git checkout pull/6702`

Update a local copy of the PR: \
`$ git checkout pull/6702` \
`$ git pull https://git.openjdk.java.net/jdk pull/6702/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6702`

View PR using the GUI difftool: \
`$ git pr show -t 6702`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6702.diff">https://git.openjdk.java.net/jdk/pull/6702.diff</a>

</details>
