### PR TITLE
JDK-8154011: Make TraceDeoptimization a diagnostic flag

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1280,7 +1280,7 @@ const intx ObjectAlignmentInBytes = 8;
           constraint(AllocatePrefetchInstrConstraintFunc, AfterMemoryInit)  \
                                                                             \
   /* deoptimization */                                                      \
-  develop(bool, TraceDeoptimization, false,                                 \
+  product(bool, TraceDeoptimization, false, DIAGNOSTIC,                     \
           "Trace deoptimization")                                           \
                                                                             \
   develop(bool, PrintDeoptimizationDetails, false,                          \


### PR DESCRIPTION
Make TraceDeoptimization available in a product build.

I checked that performance is not affected on Aurora.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8154011](https://bugs.openjdk.java.net/browse/JDK-8154011): Make TraceDeoptimization a diagnostic flag


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6703/head:pull/6703` \
`$ git checkout pull/6703`

Update a local copy of the PR: \
`$ git checkout pull/6703` \
`$ git pull https://git.openjdk.java.net/jdk pull/6703/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6703`

View PR using the GUI difftool: \
`$ git pr show -t 6703`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6703.diff">https://git.openjdk.java.net/jdk/pull/6703.diff</a>

</details>
