### PR TITLE
8278240: ProblemList containers/docker/TestJcmd.java on linux-aarch64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -106,6 +106,8 @@ runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
 
 applications/jcstress/copy.java 8229852 linux-all
 
+containers/docker/TestJcmd.java 8278102 linux-aarch64
+
 #############################################################################
 
 # :hotspot_serviceability


### PR DESCRIPTION
A trivial fix to ProblemList containers/docker/TestJcmd.java on linux-aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278240](https://bugs.openjdk.java.net/browse/JDK-8278240): ProblemList containers/docker/TestJcmd.java on linux-aarch64


### Reviewers
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6705/head:pull/6705` \
`$ git checkout pull/6705`

Update a local copy of the PR: \
`$ git checkout pull/6705` \
`$ git pull https://git.openjdk.java.net/jdk pull/6705/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6705`

View PR using the GUI difftool: \
`$ git pr show -t 6705`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6705.diff">https://git.openjdk.java.net/jdk/pull/6705.diff</a>

</details>
