### PR TITLE
8278247: KeyStoreSpi::engineGetAttributes does not throws KeyStoreException

### DIFF
--- a/src/java.base/share/classes/java/security/KeyStoreSpi.java
+++ b/src/java.base/share/classes/java/security/KeyStoreSpi.java
@@ -465,9 +465,6 @@ public abstract class KeyStoreSpi {
      *      {@link #engineGetEntry} and can be retrieved by calling
      *      the {@link Entry#getAttributes} method.
      *
-     * @throws KeyStoreException if the keystore has not been initialized
-     * (loaded).
-     *
      * @since 18
      */
     public Set<Entry.Attribute> engineGetAttributes(String alias) {


### PR DESCRIPTION
The specification wrongly claims there could be an exception thrown, but it's not true.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278247](https://bugs.openjdk.java.net/browse/JDK-8278247): KeyStoreSpi::engineGetAttributes does not throws KeyStoreException


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6706/head:pull/6706` \
`$ git checkout pull/6706`

Update a local copy of the PR: \
`$ git checkout pull/6706` \
`$ git pull https://git.openjdk.java.net/jdk pull/6706/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6706`

View PR using the GUI difftool: \
`$ git pr show -t 6706`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6706.diff">https://git.openjdk.java.net/jdk/pull/6706.diff</a>

</details>
