### PR TITLE
8275721: Name of UTC timezone in a locale changes depending on previous code

### DIFF
--- a/src/java.base/share/classes/sun/util/cldr/CLDRTimeZoneNameProviderImpl.java
+++ b/src/java.base/share/classes/sun/util/cldr/CLDRTimeZoneNameProviderImpl.java
@@ -162,18 +162,6 @@ public class CLDRTimeZoneNameProviderImpl extends TimeZoneNameProviderImpl {
             }
         }
 
-        // Check if COMPAT can substitute the short name (CLDR does not provide most short names)
-        if (index % 2 == 0 && !exists(names, index) &&
-            LocaleProviderAdapter.getAdapterPreference().contains(Type.JRE)) {
-            String[] compatNames = (String[])LocaleProviderAdapter.forJRE()
-                .getLocaleResources(mapChineseLocale(locale))
-                .getTimeZoneNames(id);
-            if (compatNames != null) {
-                // Assumes COMPAT has no empty slots
-                names[index] = compatNames[index];
-            }
-        }
-
         // Region Fallback
         if (regionFormatFallback(names, index, locale)) {
             return;
@@ -182,6 +170,19 @@ public class CLDRTimeZoneNameProviderImpl extends TimeZoneNameProviderImpl {
         // Type Fallback
         if (noDST && typeFallback(names, index)) {
             return;
+        }
+
+        // Check if COMPAT can substitute the name
+        if (!exists(names, index) &&
+                LocaleProviderAdapter.getAdapterPreference().contains(Type.JRE)) {
+            String[] compatNames = (String[])LocaleProviderAdapter.forJRE()
+                    .getLocaleResources(mapChineseLocale(locale))
+                    .getTimeZoneNames(id);
+            if (compatNames != null) {
+                // Assumes COMPAT has no empty slots
+                names[index] = compatNames[index];
+                return;
+            }
         }
 
         // last resort

--- a/src/java.base/share/classes/sun/util/cldr/CLDRTimeZoneNameProviderImpl.java
+++ b/src/java.base/share/classes/sun/util/cldr/CLDRTimeZoneNameProviderImpl.java
@@ -28,6 +28,7 @@ package sun.util.cldr;
 import static sun.util.locale.provider.LocaleProviderAdapter.Type;
 
 import java.text.MessageFormat;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Objects;
@@ -91,7 +92,7 @@ public class CLDRTimeZoneNameProviderImpl extends TimeZoneNameProviderImpl {
                 case "":
                     // Fill in empty elements
                     deriveFallbackName(namesSuper, i, locale,
-                                       !TimeZone.getTimeZone(id).useDaylightTime());
+                                       TimeZone.getTimeZone(id).toZoneId().getRules().isFixedOffset());
                     break;
                 case NO_INHERITANCE_MARKER:
                     // CLDR's "no inheritance marker"
@@ -129,7 +130,7 @@ public class CLDRTimeZoneNameProviderImpl extends TimeZoneNameProviderImpl {
 
     // Derive fallback time zone name according to LDML's logic
     private void deriveFallbackNames(String[] names, Locale locale) {
-        boolean noDST = !TimeZone.getTimeZone(names[0]).useDaylightTime();
+        boolean noDST = TimeZone.getTimeZone(names[0]).toZoneId().getRules().isFixedOffset();
 
         for (int i = INDEX_STD_LONG; i <= INDEX_GEN_SHORT; i++) {
             deriveFallbackName(names, i, locale, noDST);

--- a/src/java.base/share/classes/sun/util/cldr/CLDRTimeZoneNameProviderImpl.java
+++ b/src/java.base/share/classes/sun/util/cldr/CLDRTimeZoneNameProviderImpl.java
@@ -28,7 +28,6 @@ package sun.util.cldr;
 import static sun.util.locale.provider.LocaleProviderAdapter.Type;
 
 import java.text.MessageFormat;
-import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Objects;

--- a/test/jdk/sun/util/resources/TimeZone/ChineseTimeZoneNameTest.java
+++ b/test/jdk/sun/util/resources/TimeZone/ChineseTimeZoneNameTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ /*
+ * @test
+ * @bug 8275721
+ * @modules jdk.localedata
+ * @summary Checks Chinese time zone names for `UTC` using CLDR are consistent
+ * @run testng/othervm -Djava.locale.providers=CLDR,COMPAT ChineseTimeZoneNameTest
+ * @run testng/othervm -Djava.locale.providers=CLDR ChineseTimeZoneNameTest
+ */
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+import static org.testng.Assert.assertEquals;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@Test
+public class ChineseTimeZoneNameTest {
+
+    private static final Locale SIMPLIFIED_CHINESE = Locale.forLanguageTag("zh-Hans");
+    private static final Locale TRADITIONAL_CHINESE = Locale.forLanguageTag("zh-Hant");
+    private static final ZonedDateTime EPOCH_UTC =
+        ZonedDateTime.ofInstant(Instant.ofEpochSecond (0), ZoneId.of ("UTC"));
+
+    @DataProvider(name="locales")
+    Object[][] data() {
+        return new Object[][] {
+            {Locale.CHINESE,                        SIMPLIFIED_CHINESE},
+            {Locale.SIMPLIFIED_CHINESE,             SIMPLIFIED_CHINESE},
+            {Locale.forLanguageTag("zh-SG"),        SIMPLIFIED_CHINESE},
+            {Locale.forLanguageTag("zh-Hans-TW"),   SIMPLIFIED_CHINESE},
+            {Locale.forLanguageTag("zh-HK"),        TRADITIONAL_CHINESE},
+            {Locale.forLanguageTag("zh-MO"),        TRADITIONAL_CHINESE},
+            {Locale.TRADITIONAL_CHINESE,            TRADITIONAL_CHINESE},
+            {Locale.forLanguageTag("zh-Hant-CN"),   TRADITIONAL_CHINESE},
+        };
+    }
+
+    @Test(dataProvider="locales")
+    public void test_ChineseTimeZoneNames(Locale testLoc, Locale resourceLoc) {
+        assertEquals(DateTimeFormatter.ofPattern("z", testLoc).format(EPOCH_UTC),
+                DateTimeFormatter.ofPattern("z", resourceLoc).format(EPOCH_UTC));
+        assertEquals(DateTimeFormatter.ofPattern("zzzz", testLoc).format(EPOCH_UTC),
+                DateTimeFormatter.ofPattern("zzzz", resourceLoc).format(EPOCH_UTC));
+    }
+}


### PR DESCRIPTION
Fixing time zone name provider for CLDR. In some cases, COMPAT's `UTC` display names were incorrectly substituted for CLDR. The reason it worked fine after `zh-Hant-HK` was that by loading names for `zh-Hant-HK`, the names for `zh-Hant` were cached and hit for the following `zh-MO` name retrieval.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275721](https://bugs.openjdk.java.net/browse/JDK-8275721): Name of UTC timezone in a locale changes depending on previous code


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6709/head:pull/6709` \
`$ git checkout pull/6709`

Update a local copy of the PR: \
`$ git checkout pull/6709` \
`$ git pull https://git.openjdk.java.net/jdk pull/6709/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6709`

View PR using the GUI difftool: \
`$ git pr show -t 6709`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6709.diff">https://git.openjdk.java.net/jdk/pull/6709.diff</a>

</details>
