### PR TITLE
8278268 - (ch) InputStream returned by Channels.newInputStream should have fast path for FileChannel targets

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/channels/Channels/TransferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo.java
@@ -21,12 +21,10 @@
  * questions.
  */
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.IllegalBlockingModeException;
@@ -36,27 +34,14 @@ import java.nio.channels.SelectableChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
-import java.util.Arrays;
-import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import jdk.test.lib.RandomFactory;
-
-import static java.lang.String.format;
-import static java.nio.file.StandardOpenOption.*;
-
-import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
-import static org.testng.Assert.assertTrue;
 
 /*
  * @test
@@ -68,40 +53,39 @@ import static org.testng.Assert.assertTrue;
  *          InputStream.transferTo specification
  * @key randomness
  */
-public class TransferTo {
-    private static final int MIN_SIZE      = 10_000;
-    private static final int MAX_SIZE_INCR = 100_000_000 - MIN_SIZE;
-
-    private static final int ITERATIONS = 10;
-
-    private static final int NUM_WRITES = 3*1024;
-    private static final int BYTES_PER_WRITE = 1024*1024;
-    private static final long BYTES_WRITTEN = (long) NUM_WRITES*BYTES_PER_WRITE;
-
-    private static final Random RND = RandomFactory.getRandom();
-
-    private static final Path CWD = Path.of(".");
+public class TransferTo extends TransferToBase {
 
     /*
      * Provides test scenarios, i.e., combinations of input and output streams
      * to be tested.
      */
     @DataProvider
-    public static Object[][] streamCombinations() throws Exception {
+    public static Object[][] streamCombinations() {
         return new Object[][] {
             // tests FileChannel.transferTo(FileChannel) optimized case
-            { fileChannelInput(), fileChannelOutput() },
+            {fileChannelInput(), fileChannelOutput()},
 
             // tests FileChannel.transferTo(SelectableChannelOutput)
             // optimized case
-            { fileChannelInput(), selectableChannelOutput() },
+            {fileChannelInput(), selectableChannelOutput()},
 
-            // tests FileChannel.transferTo(WritableChannelOutput)
+            // tests FileChannel.transferTo(WritableByteChannelOutput)
             // optimized case
-            { fileChannelInput(), writableByteChannelOutput() },
+            {fileChannelInput(), writableByteChannelOutput()},
 
             // tests InputStream.transferTo(OutputStream) default case
-            { readableByteChannelInput(), defaultOutput() }
+            {readableByteChannelInput(), defaultOutput()}
+        };
+    }
+
+    /*
+     * Input streams to be tested.
+     */
+    @DataProvider
+    public static Object[][] inputStreamProviders() {
+        return new Object[][] {
+                {fileChannelInput()},
+                {readableByteChannelInput()}
         };
     }
 
@@ -109,9 +93,8 @@ public class TransferTo {
      * Testing API compliance: input stream must throw NullPointerException
      * when parameter "out" is null.
      */
-    @Test(dataProvider = "streamCombinations")
-    public void testNullPointerException(InputStreamProvider inputStreamProvider,
-            OutputStreamProvider outputStreamProvider) throws Exception {
+    @Test(dataProvider = "inputStreamProviders")
+    public void testNullPointerException(InputStreamProvider inputStreamProvider) {
         // tests empty input stream
         assertThrows(NullPointerException.class, () -> inputStreamProvider.input().transferTo(null));
 
@@ -156,73 +139,7 @@ public class TransferTo {
     }
 
     /*
-     * Special test for file-to-file transfer of more than 2 GB. This test
-     * covers multiple iterations of FileChannel.transerTo(FileChannel),
-     * which ChannelInputStream.transferTo() only applies in this particular
-     * case, and cannot get tested using a single byte[] due to size limitation
-     * of arrays.
-     */
-    @Test
-    public void testMoreThanTwoGB() throws IOException {
-        // prepare two temporary files to be compared at the end of the test
-        // set the source file name
-        String sourceName = String.format("test3GBSource%s.tmp",
-            String.valueOf(RND.nextInt(Integer.MAX_VALUE)));
-        Path sourceFile = CWD.resolve(sourceName);
-
-        try {
-            // set the target file name
-            String targetName = String.format("test3GBTarget%s.tmp",
-                String.valueOf(RND.nextInt(Integer.MAX_VALUE)));
-            Path targetFile = CWD.resolve(targetName);
-
-            try {
-                // calculate initial position to be just short of 2GB
-                final long initPos = 2047*BYTES_PER_WRITE;
-
-                // create the source file with a hint to be sparse
-                try (FileChannel fc = FileChannel.open(sourceFile, CREATE_NEW, SPARSE, WRITE, APPEND);) {
-                    // set initial position to avoid writing nearly 2GB
-                    fc.position(initPos);
-
-                    // fill the remainder of the file with random bytes
-                    int nw = (int)(NUM_WRITES - initPos/BYTES_PER_WRITE);
-                    for (int i = 0; i < nw; i++) {
-                        byte[] rndBytes = createRandomBytes(BYTES_PER_WRITE, 0);
-                        ByteBuffer src = ByteBuffer.wrap(rndBytes);
-                        fc.write(src);
-                    }
-                }
-
-                // create the target file with a hint to be sparse
-                try (FileChannel fc = FileChannel.open(targetFile, CREATE_NEW, WRITE, SPARSE);) {
-                }
-
-                // perform actual transfer, effectively by multiple invocations
-                // of Filechannel.transferTo(FileChannel)
-                try (InputStream inputStream = Channels.newInputStream(FileChannel.open(sourceFile));
-                     OutputStream outputStream = Channels.newOutputStream(FileChannel.open(targetFile, WRITE))) {
-                    long count = inputStream.transferTo(outputStream);
-
-                    // compare reported transferred bytes, must be 3 GB
-                    // less the value of the initial position
-                    assertEquals(count, BYTES_WRITTEN - initPos);
-                }
-
-                // compare content of both files, failing if different
-                assertEquals(Files.mismatch(sourceFile, targetFile), -1);
-
-            } finally {
-                 Files.delete(targetFile);
-            }
-        } finally {
-            Files.delete(sourceFile);
-        }
-    }
-
-    /*
-     * Special test of whether selectable channel based transfer throws blocking
-     * mode exception.
+     * Special test whether selectable channel based transfer throws blocking mode exception.
      */
     @Test
     public void testIllegalBlockingMode() throws IOException {
@@ -257,69 +174,13 @@ public class TransferTo {
     }
 
     /*
-     * Asserts that the transferred content is correct, i.e., compares the bytes
-     * actually transferred to those expected. The position of the input and
-     * output streams before the transfer are zero (BOF).
-     */
-    private static void checkTransferredContents(InputStreamProvider inputStreamProvider,
-            OutputStreamProvider outputStreamProvider, byte[] inBytes) throws Exception {
-        checkTransferredContents(inputStreamProvider, outputStreamProvider, inBytes, 0, 0);
-    }
-
-    /*
-     * Asserts that the transferred content is correct, i. e. compares the bytes
-     * actually transferred to those expected. The positions of the input and
-     * output streams before the transfer are provided by the caller.
-     */
-    private static void checkTransferredContents(InputStreamProvider inputStreamProvider,
-            OutputStreamProvider outputStreamProvider, byte[] inBytes, int posIn, int posOut) throws Exception {
-        AtomicReference<Supplier<byte[]>> recorder = new AtomicReference<>();
-        try (InputStream in = inputStreamProvider.input(inBytes);
-            OutputStream out = outputStreamProvider.output(recorder::set)) {
-            // skip bytes until starting position
-            in.skipNBytes(posIn);
-            out.write(new byte[posOut]);
-
-            long reported = in.transferTo(out);
-            int count = inBytes.length - posIn;
-
-            assertEquals(reported, count, format("reported %d bytes but should report %d", reported, count));
-
-            byte[] outBytes = recorder.get().get();
-            assertTrue(Arrays.equals(inBytes, posIn, posIn + count, outBytes, posOut, posOut + count),
-                format("inBytes.length=%d, outBytes.length=%d", count, outBytes.length));
-        }
-    }
-
-    /*
-     * Creates an array of random size (between min and min + maxRandomAdditive)
-     * filled with random bytes
-     */
-    private static byte[] createRandomBytes(int min, int maxRandomAdditive) {
-        byte[] bytes = new byte[min + (maxRandomAdditive == 0 ? 0 : RND.nextInt(maxRandomAdditive))];
-        RND.nextBytes(bytes);
-        return bytes;
-    }
-
-    private interface InputStreamProvider {
-        InputStream input(byte... bytes) throws Exception;
-    }
-
-    private interface OutputStreamProvider {
-        OutputStream output(Consumer<Supplier<byte[]>> spy) throws Exception;
-    }
-
-    /*
      * Creates a provider for an output stream which does not wrap a channel
      */
     private static OutputStreamProvider defaultOutput() {
-        return new OutputStreamProvider() {
-            @Override
-            public OutputStream output(Consumer<Supplier<byte[]>> spy) {
-                ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-                spy.accept(outputStream::toByteArray);
-                return outputStream;
-            }
+        return spy -> {
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            spy.accept(outputStream::toByteArray);
+            return outputStream;
         };
     }
 
@@ -327,83 +188,50 @@ public class TransferTo {
      * Creates a provider for an input stream which wraps a file channel
      */
     private static InputStreamProvider fileChannelInput() {
-        return new InputStreamProvider() {
-            @Override
-            public InputStream input(byte... bytes) throws Exception {
-                Path path = Files.createTempFile(CWD, "fileChannelInput", null);
-                Files.write(path, bytes);
-                FileChannel fileChannel = FileChannel.open(path);
-                return Channels.newInputStream(fileChannel);
-            }
+        return bytes -> {
+            Path path = Files.createTempFile(CWD, "fileChannelInput", null);
+            Files.write(path, bytes);
+            FileChannel fileChannel = FileChannel.open(path);
+            return Channels.newInputStream(fileChannel);
         };
     }
 
     /*
-     * Creates a provider for an input stream which wraps a readable byte
-     * channel but is not a file channel
+     * Creates a provider for an output stream which wraps a selectable channel
      */
-    private static InputStreamProvider readableByteChannelInput() {
-        return new InputStreamProvider() {
-            @Override
-            public InputStream input(byte... bytes) throws Exception {
-                return Channels.newInputStream(Channels.newChannel(new ByteArrayInputStream(bytes)));
-            }
+    private static OutputStreamProvider selectableChannelOutput() {
+        return spy -> {
+            Pipe pipe = Pipe.open();
+            Future<byte[]> bytes = CompletableFuture.supplyAsync(() -> {
+                try {
+                    InputStream is = Channels.newInputStream(pipe.source());
+                    return is.readAllBytes();
+                } catch (IOException e) {
+                    throw new AssertionError("Exception while asserting content", e);
+                }
+            });
+            final OutputStream os = Channels.newOutputStream(pipe.sink());
+            spy.accept(() -> {
+                try {
+                    os.close();
+                    return bytes.get();
+                } catch (IOException | InterruptedException | ExecutionException e) {
+                    throw new AssertionError("Exception while asserting content", e);
+                }
+            });
+            return os;
         };
     }
 
     /*
-     * Creates a provider for an output stream which wraps a file channel
+     * Creates a provider for an output stream which wraps a writable byte channel but is not a file channel
      */
-    private static OutputStreamProvider fileChannelOutput() {
-        return new OutputStreamProvider() {
-            public OutputStream output(Consumer<Supplier<byte[]>> spy) throws Exception {
-                Path path = Files.createTempFile(CWD, "fileChannelOutput", null);
-                FileChannel fileChannel = FileChannel.open(path, WRITE);
-                spy.accept(() -> {
-                    try {
-                        return Files.readAllBytes(path);
-                    } catch (IOException e) {
-                        throw new AssertionError("Failed to verify output file", e);
-                    }
-                });
-                return Channels.newOutputStream(fileChannel);
-            }
-        };
-    }
-
-    private static OutputStreamProvider selectableChannelOutput() throws IOException {
-        return new OutputStreamProvider() {
-            public OutputStream output(Consumer<Supplier<byte[]>> spy) throws Exception {
-                Pipe pipe = Pipe.open();
-                Future<byte[]> bytes = CompletableFuture.supplyAsync(() -> {
-                    try {
-                        InputStream is = Channels.newInputStream(pipe.source());
-                        return is.readAllBytes();
-                    } catch (IOException e) {
-                        throw new AssertionError("Exception while asserting content", e);
-                    }
-                });
-                final OutputStream os = Channels.newOutputStream(pipe.sink());
-                spy.accept(() -> {
-                    try {
-                        os.close();
-                        return bytes.get();
-                    } catch (IOException | InterruptedException | ExecutionException e) {
-                        throw new AssertionError("Exception while asserting content", e);
-                    }
-                });
-                return os;
-            }
-        };
-    }
-
     private static OutputStreamProvider writableByteChannelOutput() {
-        return new OutputStreamProvider() {
-            public OutputStream output(Consumer<Supplier<byte[]>> spy) throws Exception {
-                ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-                spy.accept(outputStream::toByteArray);
-                return Channels.newOutputStream(Channels.newChannel(outputStream));
-            }
+        return spy -> {
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            spy.accept(outputStream::toByteArray);
+            return Channels.newOutputStream(Channels.newChannel(outputStream));
         };
     }
+
 }

--- a/test/jdk/java/nio/channels/Channels/TransferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/channels/Channels/TransferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo.java
@@ -105,30 +105,7 @@ public class TransferTo extends TransferToBase {
     @Test(dataProvider = "streamCombinations")
     public void testStreamContents(InputStreamProvider inputStreamProvider,
             OutputStreamProvider outputStreamProvider) throws Exception {
-        // tests empty input stream
-        checkTransferredContents(inputStreamProvider, outputStreamProvider, new byte[0]);
-
-        // tests input stream with a length between 1k and 4k
-        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(1024, 4096));
-
-        // tests input stream with several data chunks, as 16k is more than a
-        // single chunk can hold
-        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(16384, 16384));
-
-        // tests randomly chosen starting positions within source and
-        // target stream
-        for (int i = 0; i < ITERATIONS; i++) {
-            byte[] inBytes = createRandomBytes(MIN_SIZE, MAX_SIZE_INCR);
-            int posIn = RND.nextInt(inBytes.length);
-            int posOut = RND.nextInt(MIN_SIZE);
-            checkTransferredContents(inputStreamProvider, outputStreamProvider, inBytes, posIn, posOut);
-        }
-
-        // tests reading beyond source EOF (must not transfer any bytes)
-        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(4096, 0), 4096, 0);
-
-        // tests writing beyond target EOF (must extend output stream)
-        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(4096, 0), 0, 4096);
+        assertStreamContents(inputStreamProvider, outputStreamProvider);
     }
 
     /*

--- a/test/jdk/java/nio/channels/Channels/TransferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo.java
@@ -95,14 +95,7 @@ public class TransferTo extends TransferToBase {
      */
     @Test(dataProvider = "inputStreamProviders")
     public void testNullPointerException(InputStreamProvider inputStreamProvider) {
-        // tests empty input stream
-        assertThrows(NullPointerException.class, () -> inputStreamProvider.input().transferTo(null));
-
-        // tests single-byte input stream
-        assertThrows(NullPointerException.class, () -> inputStreamProvider.input((byte) 1).transferTo(null));
-
-        // tests dual-byte input stream
-        assertThrows(NullPointerException.class, () -> inputStreamProvider.input((byte) 1, (byte) 2).transferTo(null));
+        assertNullPointerException(inputStreamProvider);
     }
 
     /*

--- a/test/jdk/java/nio/channels/Channels/TransferTo2.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo2.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.OutputStream;
+import java.io.IOException;
+import java.nio.channels.Channels;
+import java.nio.channels.Pipe;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static java.lang.String.format;
+
+import static org.testng.Assert.assertThrows;
+
+/*
+ * @test
+ * @library /test/lib
+ * @build jdk.test.lib.RandomFactory
+ * @run testng/othervm/timeout=180 TransferTo2
+ * @bug 8278268
+ * @summary Tests FileChannel.transferFrom() optimized case
+ * @key randomness
+ */
+public class TransferTo2 extends TransferToBase {
+
+    /*
+     * Provides test scenarios, i.e., combinations of input and output streams
+     * to be tested.
+     */
+    @DataProvider
+    public static Object[][] streamCombinations() {
+        return new Object[][] {
+            // tests FileChannel.transferFrom(SelectableChannelOutput) optimized case
+            {selectableChannelInput(), fileChannelOutput()},
+
+            // tests FileChannel.transferFrom(ReadableByteChannelInput) optimized case
+            {readableByteChannelInput(), fileChannelOutput()},
+        };
+    }
+
+    /*
+     * Input streams to be tested.
+     */
+    @DataProvider
+    public static Object[][] inputStreamProviders() {
+        return new Object[][] {
+            {selectableChannelInput()},
+            {readableByteChannelInput()}
+        };
+    }
+
+    /*
+     * Testing API compliance: input stream must throw NullPointerException
+     * when parameter "out" is null.
+     */
+    @Test(dataProvider = "inputStreamProviders")
+    public void testNullPointerException(InputStreamProvider inputStreamProvider) {
+        // tests empty input stream
+        assertThrows(NullPointerException.class, () -> inputStreamProvider.input().transferTo(null));
+
+        // tests single-byte input stream
+        assertThrows(NullPointerException.class, () -> inputStreamProvider.input((byte) 1).transferTo(null));
+
+        // tests dual-byte input stream
+        assertThrows(NullPointerException.class, () -> inputStreamProvider.input((byte) 1, (byte) 2).transferTo(null));
+    }
+
+    /*
+     * Testing API compliance: complete content of input stream must be
+     * transferred to output stream.
+     */
+    @Test(dataProvider = "streamCombinations")
+    public void testStreamContents(InputStreamProvider inputStreamProvider,
+            OutputStreamProvider outputStreamProvider) throws Exception {
+        // tests empty input stream
+        checkTransferredContents(inputStreamProvider, outputStreamProvider, new byte[0]);
+
+        // tests input stream with a length between 1k and 4k
+        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(1024, 4096));
+
+        // tests input stream with several data chunks, as 16k is more than a
+        // single chunk can hold
+        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(16384, 16384));
+
+        // tests randomly chosen starting positions within source and
+        // target stream
+        for (int i = 0; i < ITERATIONS; i++) {
+            byte[] inBytes = createRandomBytes(MIN_SIZE, MAX_SIZE_INCR);
+            int posIn = RND.nextInt(inBytes.length);
+            int posOut = RND.nextInt(MIN_SIZE);
+            checkTransferredContents(inputStreamProvider, outputStreamProvider, inBytes, posIn, posOut);
+        }
+
+        // tests reading beyond source EOF (must not transfer any bytes)
+        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(4096, 0), 4096, 0);
+
+        // tests writing beyond target EOF (must extend output stream)
+        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(4096, 0), 0, 4096);
+    }
+
+    /*
+     * Creates a provider for an input stream which wraps a selectable channel
+     */
+    private static InputStreamProvider selectableChannelInput() {
+        return bytes -> {
+            Pipe pipe = Pipe.open();
+            new Thread(() -> {
+                try (OutputStream os = Channels.newOutputStream(pipe.sink())) {
+                    os.write(bytes);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }).start();
+            return Channels.newInputStream(pipe.source());
+        };
+    }
+
+}

--- a/test/jdk/java/nio/channels/Channels/TransferTo2.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/channels/Channels/TransferTo2.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo2.java
@@ -31,8 +31,6 @@ import org.testng.annotations.Test;
 
 import static java.lang.String.format;
 
-import static org.testng.Assert.assertThrows;
-
 /*
  * @test
  * @library /test/lib
@@ -76,14 +74,7 @@ public class TransferTo2 extends TransferToBase {
      */
     @Test(dataProvider = "inputStreamProviders")
     public void testNullPointerException(InputStreamProvider inputStreamProvider) {
-        // tests empty input stream
-        assertThrows(NullPointerException.class, () -> inputStreamProvider.input().transferTo(null));
-
-        // tests single-byte input stream
-        assertThrows(NullPointerException.class, () -> inputStreamProvider.input((byte) 1).transferTo(null));
-
-        // tests dual-byte input stream
-        assertThrows(NullPointerException.class, () -> inputStreamProvider.input((byte) 1, (byte) 2).transferTo(null));
+        assertNullPointerException(inputStreamProvider);
     }
 
     /*

--- a/test/jdk/java/nio/channels/Channels/TransferTo2.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo2.java
@@ -84,30 +84,7 @@ public class TransferTo2 extends TransferToBase {
     @Test(dataProvider = "streamCombinations")
     public void testStreamContents(InputStreamProvider inputStreamProvider,
             OutputStreamProvider outputStreamProvider) throws Exception {
-        // tests empty input stream
-        checkTransferredContents(inputStreamProvider, outputStreamProvider, new byte[0]);
-
-        // tests input stream with a length between 1k and 4k
-        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(1024, 4096));
-
-        // tests input stream with several data chunks, as 16k is more than a
-        // single chunk can hold
-        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(16384, 16384));
-
-        // tests randomly chosen starting positions within source and
-        // target stream
-        for (int i = 0; i < ITERATIONS; i++) {
-            byte[] inBytes = createRandomBytes(MIN_SIZE, MAX_SIZE_INCR);
-            int posIn = RND.nextInt(inBytes.length);
-            int posOut = RND.nextInt(MIN_SIZE);
-            checkTransferredContents(inputStreamProvider, outputStreamProvider, inBytes, posIn, posOut);
-        }
-
-        // tests reading beyond source EOF (must not transfer any bytes)
-        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(4096, 0), 4096, 0);
-
-        // tests writing beyond target EOF (must extend output stream)
-        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(4096, 0), 0, 4096);
+        assertStreamContents(inputStreamProvider, outputStreamProvider);
     }
 
     /*

--- a/test/jdk/java/nio/channels/Channels/TransferToBase.java
+++ b/test/jdk/java/nio/channels/Channels/TransferToBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/channels/Channels/TransferToBase.java
+++ b/test/jdk/java/nio/channels/Channels/TransferToBase.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import jdk.test.lib.RandomFactory;
+
+import static java.lang.String.format;
+import static java.nio.file.StandardOpenOption.*;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+class TransferToBase {
+    static final int MIN_SIZE      = 10_000;
+    static final int MAX_SIZE_INCR = 100_000_000 - MIN_SIZE;
+
+    static final int ITERATIONS = 10;
+
+    static final int NUM_WRITES = 3*1024;
+    static final int BYTES_PER_WRITE = 1024*1024;
+    static final long BYTES_WRITTEN = (long) NUM_WRITES*BYTES_PER_WRITE;
+
+    static final Random RND = RandomFactory.getRandom();
+
+    static final Path CWD = Path.of(".");
+
+    /*
+     * Asserts that the transferred content is correct, i.e., compares the bytes
+     * actually transferred to those expected. The position of the input and
+     * output streams before the transfer are zero (BOF).
+     */
+    static void checkTransferredContents(InputStreamProvider inputStreamProvider,
+            OutputStreamProvider outputStreamProvider, byte[] inBytes) throws Exception {
+        checkTransferredContents(inputStreamProvider, outputStreamProvider, inBytes, 0, 0);
+    }
+
+    /*
+     * Asserts that the transferred content is correct, i.e. compares the bytes
+     * actually transferred to those expected. The positions of the input and
+     * output streams before the transfer are provided by the caller.
+     */
+    static void checkTransferredContents(InputStreamProvider inputStreamProvider,
+            OutputStreamProvider outputStreamProvider, byte[] inBytes, int posIn, int posOut) throws Exception {
+        AtomicReference<Supplier<byte[]>> recorder = new AtomicReference<>();
+        try (InputStream in = inputStreamProvider.input(inBytes);
+            OutputStream out = outputStreamProvider.output(recorder::set)) {
+            // skip bytes until starting position
+            in.skipNBytes(posIn);
+            out.write(new byte[posOut]);
+
+            long reported = in.transferTo(out);
+            int count = inBytes.length - posIn;
+
+            assertEquals(reported, count, format("reported %d bytes but should report %d", reported, count));
+
+            byte[] outBytes = recorder.get().get();
+            assertTrue(Arrays.equals(inBytes, posIn, posIn + count, outBytes, posOut, posOut + count),
+                format("inBytes.length=%d, outBytes.length=%d", count, outBytes.length));
+        }
+    }
+
+    /*
+     * Creates an array of random size (between min and min + maxRandomAdditive)
+     * filled with random bytes
+     */
+    static byte[] createRandomBytes(int min, int maxRandomAdditive) {
+        byte[] bytes = new byte[min + (maxRandomAdditive == 0 ? 0 : RND.nextInt(maxRandomAdditive))];
+        RND.nextBytes(bytes);
+        return bytes;
+    }
+
+    interface InputStreamProvider {
+        InputStream input(byte... bytes) throws Exception;
+    }
+
+    interface OutputStreamProvider {
+        OutputStream output(Consumer<Supplier<byte[]>> spy) throws Exception;
+    }
+
+    /*
+     * Creates a provider for an input stream which wraps a readable byte
+     * channel but is not a file channel
+     */
+    static InputStreamProvider readableByteChannelInput() {
+        return bytes -> Channels.newInputStream(Channels.newChannel(new ByteArrayInputStream(bytes)));
+    }
+
+    /*
+     * Creates a provider for an output stream which wraps a file channel
+     */
+    static OutputStreamProvider fileChannelOutput() {
+        return spy -> {
+            Path path = Files.createTempFile(CWD, "fileChannelOutput", null);
+            FileChannel fileChannel = FileChannel.open(path, WRITE);
+            spy.accept(() -> {
+                try {
+                    return Files.readAllBytes(path);
+                } catch (IOException e) {
+                    throw new AssertionError("Failed to verify output file", e);
+                }
+            });
+            return Channels.newOutputStream(fileChannel);
+        };
+    }
+
+}

--- a/test/jdk/java/nio/channels/Channels/TransferToBase.java
+++ b/test/jdk/java/nio/channels/Channels/TransferToBase.java
@@ -215,11 +215,14 @@ class TransferToBase {
                     fc.position(initPos);
 
                     // Add random bytes to the remainder of the file
-                    int nw = (int)(NUM_WRITES - initPos/BYTES_PER_WRITE);
-                    for (int i = 0; i < nw; i++) {
-                        byte[] rndBytes = createRandomBytes(BYTES_PER_WRITE, 0);
+                    long pos = initPos;
+                    while (pos < BYTES_WRITTEN) {
+                        int len = Math.toIntExact(BYTES_WRITTEN - pos);
+                        if (len > BYTES_PER_WRITE)
+                            len = BYTES_PER_WRITE;
+                        byte[] rndBytes = createRandomBytes(len, 0);
                         ByteBuffer src = ByteBuffer.wrap(rndBytes);
-                        fc.write(src);
+                        pos += fc.write(src);
                     }
                 }
 

--- a/test/jdk/java/nio/channels/Channels/TransferToBase.java
+++ b/test/jdk/java/nio/channels/Channels/TransferToBase.java
@@ -41,6 +41,7 @@ import static java.lang.String.format;
 import static java.nio.file.StandardOpenOption.*;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 class TransferToBase {
@@ -134,6 +135,21 @@ class TransferToBase {
             });
             return Channels.newOutputStream(fileChannel);
         };
+    }
+
+    /*
+     * Testing API compliance: input stream must throw NullPointerException
+     * when parameter "out" is null.
+     */
+    static void assertNullPointerException(InputStreamProvider inputStreamProvider) {
+        // tests empty input stream
+        assertThrows(NullPointerException.class, () -> inputStreamProvider.input().transferTo(null));
+
+        // tests single-byte input stream
+        assertThrows(NullPointerException.class, () -> inputStreamProvider.input((byte) 1).transferTo(null));
+
+        // tests dual-byte input stream
+        assertThrows(NullPointerException.class, () -> inputStreamProvider.input((byte) 1, (byte) 2).transferTo(null));
     }
 
 }

--- a/test/jdk/java/nio/channels/Channels/TransferToBase.java
+++ b/test/jdk/java/nio/channels/Channels/TransferToBase.java
@@ -152,4 +152,36 @@ class TransferToBase {
         assertThrows(NullPointerException.class, () -> inputStreamProvider.input((byte) 1, (byte) 2).transferTo(null));
     }
 
+    /*
+     * Testing API compliance: complete content of input stream must be
+     * transferred to output stream.
+     */
+    static void assertStreamContents(InputStreamProvider inputStreamProvider,
+            OutputStreamProvider outputStreamProvider) throws Exception {
+        // tests empty input stream
+        checkTransferredContents(inputStreamProvider, outputStreamProvider, new byte[0]);
+
+        // tests input stream with a length between 1k and 4k
+        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(1024, 4096));
+
+        // tests input stream with several data chunks, as 16k is more than a
+        // single chunk can hold
+        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(16384, 16384));
+
+        // tests randomly chosen starting positions within source and
+        // target stream
+        for (int i = 0; i < ITERATIONS; i++) {
+            byte[] inBytes = createRandomBytes(MIN_SIZE, MAX_SIZE_INCR);
+            int posIn = RND.nextInt(inBytes.length);
+            int posOut = RND.nextInt(MIN_SIZE);
+            checkTransferredContents(inputStreamProvider, outputStreamProvider, inBytes, posIn, posOut);
+        }
+
+        // tests reading beyond source EOF (must not transfer any bytes)
+        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(4096, 0), 4096, 0);
+
+        // tests writing beyond target EOF (must extend output stream)
+        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(4096, 0), 0, 4096);
+    }
+
 }

--- a/test/jdk/java/nio/channels/Channels/TransferToBase.java
+++ b/test/jdk/java/nio/channels/Channels/TransferToBase.java
@@ -25,6 +25,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
@@ -32,8 +33,10 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.function.ToLongBiFunction;
 
 import jdk.test.lib.RandomFactory;
 
@@ -182,6 +185,68 @@ class TransferToBase {
 
         // tests writing beyond target EOF (must extend output stream)
         checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(4096, 0), 0, 4096);
+    }
+
+    /*
+     * Special test for stream-to-file / file-to-stream transfer of more than 2 GB.
+     */
+    static void testMoreThanTwoGB(String direction, BiFunction<Path, Path, InputStream> inputStreamProvider,
+            BiFunction<Path, Path, OutputStream> outputStreamProvider,
+            ToLongBiFunction<InputStream, OutputStream> transfer) throws IOException {
+        // prepare two temporary files to be compared at the end of the test
+        // set the source file name
+        String sourceName = String.format("test3GBSource_transfer%s%s.tmp", direction,
+            RND.nextInt(Integer.MAX_VALUE));
+        Path sourceFile = CWD.resolve(sourceName);
+
+        try {
+            // set the target file name
+            String targetName = String.format("test3GBTarget_transfer%s%s.tmp", direction,
+                RND.nextInt(Integer.MAX_VALUE));
+            Path targetFile = CWD.resolve(targetName);
+
+            try {
+                // calculate initial position to be just short of 2GB
+                final long initPos = 2047*BYTES_PER_WRITE;
+
+                // create the source file with a hint to be sparse
+                try (FileChannel fc = FileChannel.open(sourceFile, CREATE_NEW, SPARSE, WRITE, APPEND)) {
+                    // set initial position to avoid writing nearly 2GB
+                    fc.position(initPos);
+
+                    // Add random bytes to the remainder of the file
+                    int nw = (int)(NUM_WRITES - initPos/BYTES_PER_WRITE);
+                    for (int i = 0; i < nw; i++) {
+                        byte[] rndBytes = createRandomBytes(BYTES_PER_WRITE, 0);
+                        ByteBuffer src = ByteBuffer.wrap(rndBytes);
+                        fc.write(src);
+                    }
+                }
+
+                // create the target file with a hint to be sparse
+                try (FileChannel fc = FileChannel.open(targetFile, CREATE_NEW, WRITE, SPARSE)) {
+                }
+
+                // performing actual transfer, effectively by multiple invocations of
+                // FileChannel.transferFrom(ReadableByteChannel) / FileChannel.transferTo(WritableByteChannel)
+                try (InputStream inputStream = inputStreamProvider.apply(sourceFile, targetFile);
+                     OutputStream outputStream = outputStreamProvider.apply(sourceFile, targetFile)) {
+                    long count = transfer.applyAsLong(inputStream, outputStream);
+
+                    // compare reported transferred bytes, must be 3 GB
+                    // less the value of the initial position
+                    assertEquals(count, BYTES_WRITTEN - initPos);
+                }
+
+                // compare content of both files, failing if different
+                assertEquals(Files.mismatch(sourceFile, targetFile), -1);
+
+            } finally {
+                 Files.delete(targetFile);
+            }
+        } finally {
+            Files.delete(sourceFile);
+        }
     }
 
 }

--- a/test/jdk/java/nio/channels/Channels/TransferTo_2GB_transferFrom.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo_2GB_transferFrom.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.BufferedInputStream;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.testng.annotations.Test;
+
+import static java.lang.String.format;
+import static java.nio.file.StandardOpenOption.*;
+
+import static org.testng.Assert.assertEquals;
+
+/*
+ * @test
+ * @library /test/lib
+ * @build jdk.test.lib.RandomFactory
+ * @run testng/othervm/timeout=180 TransferTo_2GB_transferFrom
+ * @bug 8278268
+ * @summary Tests if ChannelInputStream.transferFrom correctly
+ *     transfers 2GB+ using FileChannel.transferFrom(ReadableByteChannel).
+ * @key randomness
+ */
+public class TransferTo_2GB_transferFrom extends TransferToBase {
+
+    /*
+     * Special test for stream-to-file transfer of more than 2 GB. This test
+     * covers multiple iterations of FileChannel.transferFrom(ReadableByteChannel),
+     * which ChannelInputStream.transferFrom() only applies in this particular
+     * case, and cannot get tested using a single byte[] due to size limitation
+     * of arrays.
+     */
+    @Test
+    public void testMoreThanTwoGB() throws IOException {
+        // prepare two temporary files to be compared at the end of the test
+        // set the source file name
+        String sourceName = String.format("test3GBSource_transferFrom%s.tmp",
+            RND.nextInt(Integer.MAX_VALUE));
+        Path sourceFile = CWD.resolve(sourceName);
+
+        try {
+            // set the target file name
+            String targetName = String.format("test3GBTarget_transferFrom%s.tmp",
+                RND.nextInt(Integer.MAX_VALUE));
+            Path targetFile = CWD.resolve(targetName);
+
+            try {
+                // calculate initial position to be just short of 2GB
+                final long initPos = 2047*BYTES_PER_WRITE;
+
+                // create the source file with a hint to be sparse
+                try (FileChannel fc = FileChannel.open(sourceFile, CREATE_NEW, SPARSE, WRITE, APPEND)) {
+                    // set initial position to avoid writing nearly 2GB
+                    fc.position(initPos);
+
+                    // Add random bytes to the remainder of the file
+                    int nw = (int)(NUM_WRITES - initPos/BYTES_PER_WRITE);
+                    for (int i = 0; i < nw; i++) {
+                        byte[] rndBytes = createRandomBytes(BYTES_PER_WRITE, 0);
+                        ByteBuffer src = ByteBuffer.wrap(rndBytes);
+                        fc.write(src);
+                    }
+                }
+
+                // create the target file with a hint to be sparse
+                try (FileChannel fc = FileChannel.open(targetFile, CREATE_NEW, WRITE, SPARSE)) {
+                }
+
+                // performing actual transfer, effectively by multiple invocations of
+                // FileChannel.transferFrom(ReadableByteChannel)
+                try (InputStream inputStream = Channels.newInputStream(Channels.newChannel(
+                        new BufferedInputStream(Files.newInputStream(sourceFile))));
+                     OutputStream outputStream = Channels.newOutputStream(FileChannel.open(targetFile, WRITE))) {
+                    long count = inputStream.transferTo(outputStream);
+
+                    // compare reported transferred bytes, must be 3 GB
+                    // less the value of the initial position
+                    assertEquals(count, BYTES_WRITTEN - initPos);
+                }
+
+                // compare content of both files, failing if different
+                assertEquals(Files.mismatch(sourceFile, targetFile), -1);
+
+            } finally {
+                 Files.delete(targetFile);
+            }
+        } finally {
+            Files.delete(sourceFile);
+        }
+    }
+
+}

--- a/test/jdk/java/nio/channels/Channels/TransferTo_2GB_transferFrom.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo_2GB_transferFrom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/channels/Channels/TransferTo_2GB_transferFrom.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo_2GB_transferFrom.java
@@ -22,21 +22,15 @@
  */
 
 import java.io.BufferedInputStream;
-import java.io.InputStream;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.ByteBuffer;
+import java.io.UncheckedIOException;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
-import java.nio.file.Path;
 
-import org.testng.annotations.Test;
-
-import static java.lang.String.format;
 import static java.nio.file.StandardOpenOption.*;
 
-import static org.testng.Assert.assertEquals;
+import org.testng.annotations.Test;
 
 /*
  * @test
@@ -59,61 +53,30 @@ public class TransferTo_2GB_transferFrom extends TransferToBase {
      */
     @Test
     public void testMoreThanTwoGB() throws IOException {
-        // prepare two temporary files to be compared at the end of the test
-        // set the source file name
-        String sourceName = String.format("test3GBSource_transferFrom%s.tmp",
-            RND.nextInt(Integer.MAX_VALUE));
-        Path sourceFile = CWD.resolve(sourceName);
-
-        try {
-            // set the target file name
-            String targetName = String.format("test3GBTarget_transferFrom%s.tmp",
-                RND.nextInt(Integer.MAX_VALUE));
-            Path targetFile = CWD.resolve(targetName);
-
-            try {
-                // calculate initial position to be just short of 2GB
-                final long initPos = 2047*BYTES_PER_WRITE;
-
-                // create the source file with a hint to be sparse
-                try (FileChannel fc = FileChannel.open(sourceFile, CREATE_NEW, SPARSE, WRITE, APPEND)) {
-                    // set initial position to avoid writing nearly 2GB
-                    fc.position(initPos);
-
-                    // Add random bytes to the remainder of the file
-                    int nw = (int)(NUM_WRITES - initPos/BYTES_PER_WRITE);
-                    for (int i = 0; i < nw; i++) {
-                        byte[] rndBytes = createRandomBytes(BYTES_PER_WRITE, 0);
-                        ByteBuffer src = ByteBuffer.wrap(rndBytes);
-                        fc.write(src);
+        testMoreThanTwoGB("From",
+                (sourceFile, targetFile) -> {
+                    try {
+                        return Channels.newInputStream(
+                            Channels.newChannel(new BufferedInputStream(Files.newInputStream(sourceFile))));
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                },
+                (sourceFile, targetFile) -> {
+                    try {
+                        return Channels.newOutputStream(FileChannel.open(targetFile, WRITE));
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                },
+                (inputStream, outputStream) -> {
+                    try {
+                        return inputStream.transferTo(outputStream);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
                     }
                 }
-
-                // create the target file with a hint to be sparse
-                try (FileChannel fc = FileChannel.open(targetFile, CREATE_NEW, WRITE, SPARSE)) {
-                }
-
-                // performing actual transfer, effectively by multiple invocations of
-                // FileChannel.transferFrom(ReadableByteChannel)
-                try (InputStream inputStream = Channels.newInputStream(Channels.newChannel(
-                        new BufferedInputStream(Files.newInputStream(sourceFile))));
-                     OutputStream outputStream = Channels.newOutputStream(FileChannel.open(targetFile, WRITE))) {
-                    long count = inputStream.transferTo(outputStream);
-
-                    // compare reported transferred bytes, must be 3 GB
-                    // less the value of the initial position
-                    assertEquals(count, BYTES_WRITTEN - initPos);
-                }
-
-                // compare content of both files, failing if different
-                assertEquals(Files.mismatch(sourceFile, targetFile), -1);
-
-            } finally {
-                 Files.delete(targetFile);
-            }
-        } finally {
-            Files.delete(sourceFile);
-        }
+        );
     }
 
 }

--- a/test/jdk/java/nio/channels/Channels/TransferTo_2GB_transferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo_2GB_transferTo.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.testng.annotations.Test;
+
+import static java.lang.String.format;
+import static java.nio.file.StandardOpenOption.*;
+
+import static org.testng.Assert.assertEquals;
+
+/*
+ * @test
+ * @library /test/lib
+ * @build jdk.test.lib.RandomFactory
+ * @run testng/othervm/timeout=180 TransferTo_2GB_transferTo
+ * @bug 8265891
+ * @summary Tests if ChannelInputStream.transferTo correctly
+ *     transfers 2GB+ using FileChannel.transferTo(WritableByteChannel).
+ * @key randomness
+ */
+public class TransferTo_2GB_transferTo extends TransferToBase {
+
+    /*
+     * Special test for file-to-stream transfer of more than 2 GB. This test
+     * covers multiple iterations of FileChannel.transferTo(WritableByteChannel),
+     * which ChannelInputStream.transferTo() only applies in this particular
+     * case, and cannot get tested using a single byte[] due to size limitation
+     * of arrays.
+     */
+    @Test
+    public void testMoreThanTwoGB() throws IOException {
+        // prepare two temporary files to be compared at the end of the test
+        // set the source file name
+        String sourceName = String.format("test3GBSource_transferTo%s.tmp",
+            RND.nextInt(Integer.MAX_VALUE));
+        Path sourceFile = CWD.resolve(sourceName);
+
+        try {
+            // set the target file name
+            String targetName = String.format("test3GBTarget_transferTo%s.tmp",
+                RND.nextInt(Integer.MAX_VALUE));
+            Path targetFile = CWD.resolve(targetName);
+
+            try {
+                // calculate initial position to be just short of 2GB
+                final long initPos = 2047*BYTES_PER_WRITE;
+
+                // create the source file with a hint to be sparse
+                try (FileChannel fc = FileChannel.open(sourceFile, CREATE_NEW, SPARSE, WRITE, APPEND)) {
+                    // set initial position to avoid writing nearly 2GB
+                    fc.position(initPos);
+
+                    // Add random bytes to the remainder of the file
+                    int nw = (int)(NUM_WRITES - initPos/BYTES_PER_WRITE);
+                    for (int i = 0; i < nw; i++) {
+                        byte[] rndBytes = createRandomBytes(BYTES_PER_WRITE, 0);
+                        ByteBuffer src = ByteBuffer.wrap(rndBytes);
+                        fc.write(src);
+                    }
+                }
+
+                // create the target file with a hint to be sparse
+                try (FileChannel fc = FileChannel.open(targetFile, CREATE_NEW, WRITE, SPARSE)) {
+                }
+
+                // perform actual transfer, effectively by multiple invocations
+                // of FileChannel.transferTo(WritableByteChannel)
+                try (InputStream inputStream = Channels.newInputStream(FileChannel.open(sourceFile));
+                     OutputStream outputStream = Channels.newOutputStream(FileChannel.open(targetFile, WRITE))) {
+                    long count = inputStream.transferTo(outputStream);
+
+                    // compare reported transferred bytes, must be 3 GB
+                    // less the value of the initial position
+                    assertEquals(count, BYTES_WRITTEN - initPos);
+                }
+
+                // compare content of both files, failing if different
+                assertEquals(Files.mismatch(sourceFile, targetFile), -1);
+
+            } finally {
+                 Files.delete(targetFile);
+            }
+        } finally {
+            Files.delete(sourceFile);
+        }
+    }
+
+}

--- a/test/jdk/java/nio/channels/Channels/TransferTo_2GB_transferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo_2GB_transferTo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/channels/Channels/TransferTo_2GB_transferTo.java
+++ b/test/jdk/java/nio/channels/Channels/TransferTo_2GB_transferTo.java
@@ -21,21 +21,15 @@
  * questions.
  */
 
-import java.io.InputStream;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.ByteBuffer;
+import java.io.UncheckedIOException;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
-import java.nio.file.Path;
 
-import org.testng.annotations.Test;
-
-import static java.lang.String.format;
 import static java.nio.file.StandardOpenOption.*;
 
-import static org.testng.Assert.assertEquals;
+import org.testng.annotations.Test;
 
 /*
  * @test
@@ -58,60 +52,29 @@ public class TransferTo_2GB_transferTo extends TransferToBase {
      */
     @Test
     public void testMoreThanTwoGB() throws IOException {
-        // prepare two temporary files to be compared at the end of the test
-        // set the source file name
-        String sourceName = String.format("test3GBSource_transferTo%s.tmp",
-            RND.nextInt(Integer.MAX_VALUE));
-        Path sourceFile = CWD.resolve(sourceName);
-
-        try {
-            // set the target file name
-            String targetName = String.format("test3GBTarget_transferTo%s.tmp",
-                RND.nextInt(Integer.MAX_VALUE));
-            Path targetFile = CWD.resolve(targetName);
-
-            try {
-                // calculate initial position to be just short of 2GB
-                final long initPos = 2047*BYTES_PER_WRITE;
-
-                // create the source file with a hint to be sparse
-                try (FileChannel fc = FileChannel.open(sourceFile, CREATE_NEW, SPARSE, WRITE, APPEND)) {
-                    // set initial position to avoid writing nearly 2GB
-                    fc.position(initPos);
-
-                    // Add random bytes to the remainder of the file
-                    int nw = (int)(NUM_WRITES - initPos/BYTES_PER_WRITE);
-                    for (int i = 0; i < nw; i++) {
-                        byte[] rndBytes = createRandomBytes(BYTES_PER_WRITE, 0);
-                        ByteBuffer src = ByteBuffer.wrap(rndBytes);
-                        fc.write(src);
-                    }
+        testMoreThanTwoGB("To",
+            (sourceFile, targetFile) -> {
+                try {
+                    return Channels.newInputStream(FileChannel.open(sourceFile));
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
                 }
-
-                // create the target file with a hint to be sparse
-                try (FileChannel fc = FileChannel.open(targetFile, CREATE_NEW, WRITE, SPARSE)) {
+            },
+            (sourceFile, targetFile) -> {
+                try {
+                    return Channels.newOutputStream(FileChannel.open(targetFile, WRITE));
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
                 }
-
-                // perform actual transfer, effectively by multiple invocations
-                // of FileChannel.transferTo(WritableByteChannel)
-                try (InputStream inputStream = Channels.newInputStream(FileChannel.open(sourceFile));
-                     OutputStream outputStream = Channels.newOutputStream(FileChannel.open(targetFile, WRITE))) {
-                    long count = inputStream.transferTo(outputStream);
-
-                    // compare reported transferred bytes, must be 3 GB
-                    // less the value of the initial position
-                    assertEquals(count, BYTES_WRITTEN - initPos);
+            },
+            (inputStream, outputStream) -> {
+                try {
+                    return inputStream.transferTo(outputStream);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
                 }
-
-                // compare content of both files, failing if different
-                assertEquals(Files.mismatch(sourceFile, targetFile), -1);
-
-            } finally {
-                 Files.delete(targetFile);
             }
-        } finally {
-            Files.delete(sourceFile);
-        }
+        );
     }
 
 }


### PR DESCRIPTION
This sub-issue defines the work to be done to implement JDK-8265891 solely for the particular case of FileChannel.transferFrom(ReadableByteChannel), including special treatment of SelectableByteChannel.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278268](https://bugs.openjdk.org/browse/JDK-8278268): (ch) InputStream returned by Channels.newInputStream should have fast path for FileChannel targets


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/6711/head:pull/6711` \
`$ git checkout pull/6711`

Update a local copy of the PR: \
`$ git checkout pull/6711` \
`$ git pull https://git.openjdk.org/jdk.git pull/6711/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6711`

View PR using the GUI difftool: \
`$ git pr show -t 6711`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/6711.diff">https://git.openjdk.org/jdk/pull/6711.diff</a>

</details>
