### PR TITLE
8278270: ServerSocket is not thread safe

### DIFF
--- a/src/java.base/share/classes/java/net/ServerSocket.java
+++ b/src/java.base/share/classes/java/net/ServerSocket.java
@@ -78,17 +78,17 @@ import sun.net.PlatformSocketImpl;
  */
 public class ServerSocket implements java.io.Closeable {
     /**
-     * Various states of this socket.
+     * The underlying SocketImpl
      */
-    private boolean created = false;
-    private boolean bound = false;
-    private boolean closed = false;
-    private Object closeLock = new Object();
+    private final SocketImpl impl;
 
     /**
-     * The implementation of this Socket.
+     * Various states of this socket, need stateLock to change.
      */
-    private SocketImpl impl;
+    private volatile boolean created;   // impl.create(boolean) called
+    private volatile boolean bound;
+    private volatile boolean closed;
+    private final Object stateLock = new Object();
 
     /**
      * Creates a server socket with a user-specified {@code SocketImpl}.
@@ -124,7 +124,7 @@ public class ServerSocket implements java.io.Closeable {
      * @revised 1.4
      */
     public ServerSocket() throws IOException {
-        setImpl();
+        this.impl = createImpl();
     }
 
     /**
@@ -264,18 +264,15 @@ public class ServerSocket implements java.io.Closeable {
      * @since   1.1
      */
     public ServerSocket(int port, int backlog, InetAddress bindAddr) throws IOException {
-        setImpl();
         if (port < 0 || port > 0xFFFF)
-            throw new IllegalArgumentException(
-                       "Port value out of range: " + port);
+            throw new IllegalArgumentException("Port value out of range: " + port);
         if (backlog < 1)
-          backlog = 50;
+            backlog = 50;
+
+        this.impl = createImpl();
         try {
             bind(new InetSocketAddress(bindAddr, port), backlog);
-        } catch(SecurityException e) {
-            close();
-            throw e;
-        } catch(IOException e) {
+        } catch (IOException | SecurityException e) {
             close();
             throw e;
         }
@@ -289,35 +286,36 @@ public class ServerSocket implements java.io.Closeable {
      * @throws SocketException if creation fails.
      * @since 1.4
      */
-    SocketImpl getImpl() throws SocketException {
-        if (!created)
-            createImpl();
+    private SocketImpl getImpl() throws SocketException {
+        if (!created) {
+            synchronized (stateLock) {
+                if (!created) {
+                    if (closed) {
+                        throw new SocketException("Socket is closed");
+                    }
+                    try {
+                        impl.create(true);
+                    } catch (SocketException e) {
+                        throw e;
+                    } catch (IOException e) {
+                        throw new SocketException(e.getMessage());
+                    }
+                    created = true;
+                }
+            }
+        }
         return impl;
     }
 
-    private void setImpl() {
+    /**
+     * Create a SocketImpl for a server socket.
+     */
+    private static SocketImpl createImpl() {
         SocketImplFactory factory = ServerSocket.factory;
         if (factory != null) {
-            impl = factory.createSocketImpl();
+            return factory.createSocketImpl();
         } else {
-            impl = SocketImpl.createPlatformSocketImpl(true);
-        }
-    }
-
-    /**
-     * Creates the socket implementation.
-     *
-     * @throws SocketException if creation fails
-     * @since 1.4
-     */
-    void createImpl() throws SocketException {
-        if (impl == null)
-            setImpl();
-        try {
-            impl.create(true);
-            created = true;
-        } catch (IOException e) {
-            throw new SocketException(e.getMessage());
+            return SocketImpl.createPlatformSocketImpl(true);
         }
     }
 
@@ -379,21 +377,21 @@ public class ServerSocket implements java.io.Closeable {
         if (epoint.isUnresolved())
             throw new SocketException("Unresolved address");
         if (backlog < 1)
-          backlog = 50;
-        try {
-            @SuppressWarnings("removal")
-            SecurityManager security = System.getSecurityManager();
-            if (security != null)
-                security.checkListen(epoint.getPort());
+            backlog = 50;
+        
+        @SuppressWarnings("removal")
+        SecurityManager security = System.getSecurityManager();
+        if (security != null)
+            security.checkListen(epoint.getPort());
+
+        synchronized (stateLock) {
+            if (closed)
+                throw new SocketException("Socket is closed");
+            if (bound)
+                throw new SocketException("Already bound");
             getImpl().bind(epoint.getAddress(), epoint.getPort());
             getImpl().listen(backlog);
             bound = true;
-        } catch(SecurityException e) {
-            bound = false;
-            throw e;
-        } catch(IOException e) {
-            bound = false;
-            throw e;
         }
     }
 
@@ -711,12 +709,18 @@ public class ServerSocket implements java.io.Closeable {
      * @revised 1.4
      */
     public void close() throws IOException {
-        synchronized(closeLock) {
-            if (isClosed())
-                return;
-            if (created)
-                impl.close();
-            closed = true;
+        synchronized (stateLock) {
+            if (!closed) {
+                try {
+                    // close underlying socket if created
+                    if (created) {
+                        impl.close();
+                    }
+                } finally {
+                    closed = true;
+                }
+
+            }
         }
     }
 
@@ -760,9 +764,7 @@ public class ServerSocket implements java.io.Closeable {
      * @since 1.4
      */
     public boolean isClosed() {
-        synchronized(closeLock) {
-            return closed;
-        }
+        return closed;
     }
 
     /**
@@ -783,7 +785,7 @@ public class ServerSocket implements java.io.Closeable {
      * @since   1.1
      * @see #getSoTimeout()
      */
-    public synchronized void setSoTimeout(int timeout) throws SocketException {
+    public void setSoTimeout(int timeout) throws SocketException {
         if (isClosed())
             throw new SocketException("Socket is closed");
         if (timeout < 0)
@@ -799,7 +801,7 @@ public class ServerSocket implements java.io.Closeable {
      * @since   1.1
      * @see #setSoTimeout(int)
      */
-    public synchronized int getSoTimeout() throws IOException {
+    public int getSoTimeout() throws IOException {
         if (isClosed())
             throw new SocketException("Socket is closed");
         Object o = getImpl().getOption(SocketOptions.SO_TIMEOUT);
@@ -984,7 +986,7 @@ public class ServerSocket implements java.io.Closeable {
      * @since 1.4
      * @see #getReceiveBufferSize
      */
-     public synchronized void setReceiveBufferSize (int size) throws SocketException {
+     public void setReceiveBufferSize (int size) throws SocketException {
         if (!(size > 0)) {
             throw new IllegalArgumentException("negative receive size");
         }
@@ -1007,8 +1009,7 @@ public class ServerSocket implements java.io.Closeable {
      * @see #setReceiveBufferSize(int)
      * @since 1.4
      */
-    public synchronized int getReceiveBufferSize()
-    throws SocketException{
+    public int getReceiveBufferSize() throws SocketException {
         if (isClosed())
             throw new SocketException("Socket is closed");
         int result = 0;

--- a/src/java.base/share/classes/java/net/ServerSocket.java
+++ b/src/java.base/share/classes/java/net/ServerSocket.java
@@ -378,7 +378,7 @@ public class ServerSocket implements java.io.Closeable {
             throw new SocketException("Unresolved address");
         if (backlog < 1)
             backlog = 50;
-        
+
         @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null)


### PR DESCRIPTION
There are several thread safety issues in java.net.ServerSocket, issues that go back to at least JDK 1.4.

The issue of most concern is async close of a ServerSocket that is initially created unbound and where close may be called at or around the time the underlying SocketImpl is created or the socket is bound.

The summary of the changes are:

1. The "impl" field is changed to be final field.
2. The closeLock is renamed to stateLock and is required to change the (now volatile) created, bound or closed fields.
3. The needless synchronization has been removed from xxxSoTimeout and xxxReceiveBufferSize.

There are many redundant checks for isClosed() and other state that could be removed. Removing them would subtle change the exception thrown when there are two or more failure conditions. So they are left as is.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278270](https://bugs.openjdk.java.net/browse/JDK-8278270): ServerSocket is not thread safe


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6712/head:pull/6712` \
`$ git checkout pull/6712`

Update a local copy of the PR: \
`$ git checkout pull/6712` \
`$ git pull https://git.openjdk.java.net/jdk pull/6712/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6712`

View PR using the GUI difftool: \
`$ git pr show -t 6712`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6712.diff">https://git.openjdk.java.net/jdk/pull/6712.diff</a>

</details>
