### PR TITLE
8278276: G1: Refine naming of G1GCParPhaseTimesTracker::_must_record

### DIFF
--- a/src/hotspot/share/gc/g1/g1GCParPhaseTimesTracker.hpp
+++ b/src/hotspot/share/gc/g1/g1GCParPhaseTimesTracker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1GCParPhaseTimesTracker.hpp
+++ b/src/hotspot/share/gc/g1/g1GCParPhaseTimesTracker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,10 @@ protected:
   G1GCPhaseTimes* _phase_times;
   uint _worker_id;
   EventGCPhaseParallel _event;
-  bool _must_record;
+  bool _initial_record;
 
 public:
-  G1GCParPhaseTimesTracker(G1GCPhaseTimes* phase_times, G1GCPhaseTimes::GCParPhases phase, uint worker_id, bool must_record = true);
+  G1GCParPhaseTimesTracker(G1GCPhaseTimes* phase_times, G1GCPhaseTimes::GCParPhases phase, uint worker_id, bool initial_record = true);
   virtual ~G1GCParPhaseTimesTracker();
 };
 

--- a/src/hotspot/share/gc/g1/g1GCParPhaseTimesTracker.hpp
+++ b/src/hotspot/share/gc/g1/g1GCParPhaseTimesTracker.hpp
@@ -36,10 +36,10 @@ protected:
   G1GCPhaseTimes* _phase_times;
   uint _worker_id;
   EventGCPhaseParallel _event;
-  bool _initial_record;
+  bool _allow_multiple_record;
 
 public:
-  G1GCParPhaseTimesTracker(G1GCPhaseTimes* phase_times, G1GCPhaseTimes::GCParPhases phase, uint worker_id, bool initial_record = true);
+  G1GCParPhaseTimesTracker(G1GCPhaseTimes* phase_times, G1GCPhaseTimes::GCParPhases phase, uint worker_id, bool allow_multiple_record = false);
   virtual ~G1GCParPhaseTimesTracker();
 };
 

--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
@@ -578,8 +578,8 @@ void G1EvacPhaseWithTrimTimeTracker::stop() {
   _stopped = true;
 }
 
-G1GCParPhaseTimesTracker::G1GCParPhaseTimesTracker(G1GCPhaseTimes* phase_times, G1GCPhaseTimes::GCParPhases phase, uint worker_id, bool must_record) :
-  _start_time(), _phase(phase), _phase_times(phase_times), _worker_id(worker_id), _event(), _must_record(must_record) {
+G1GCParPhaseTimesTracker::G1GCParPhaseTimesTracker(G1GCPhaseTimes* phase_times, G1GCPhaseTimes::GCParPhases phase, uint worker_id, bool initial_record) :
+  _start_time(), _phase(phase), _phase_times(phase_times), _worker_id(worker_id), _event(), _initial_record(initial_record) {
   if (_phase_times != NULL) {
     _start_time = Ticks::now();
   }
@@ -587,7 +587,7 @@ G1GCParPhaseTimesTracker::G1GCParPhaseTimesTracker(G1GCPhaseTimes* phase_times, 
 
 G1GCParPhaseTimesTracker::~G1GCParPhaseTimesTracker() {
   if (_phase_times != NULL) {
-    if (_must_record) {
+    if (_initial_record) {
       _phase_times->record_time_secs(_phase, _worker_id, (Ticks::now() - _start_time).seconds());
     } else {
       _phase_times->record_or_add_time_secs(_phase, _worker_id, (Ticks::now() - _start_time).seconds());

--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
@@ -578,8 +578,8 @@ void G1EvacPhaseWithTrimTimeTracker::stop() {
   _stopped = true;
 }
 
-G1GCParPhaseTimesTracker::G1GCParPhaseTimesTracker(G1GCPhaseTimes* phase_times, G1GCPhaseTimes::GCParPhases phase, uint worker_id, bool initial_record) :
-  _start_time(), _phase(phase), _phase_times(phase_times), _worker_id(worker_id), _event(), _initial_record(initial_record) {
+G1GCParPhaseTimesTracker::G1GCParPhaseTimesTracker(G1GCPhaseTimes* phase_times, G1GCPhaseTimes::GCParPhases phase, uint worker_id, bool allow_multiple_record) :
+  _start_time(), _phase(phase), _phase_times(phase_times), _worker_id(worker_id), _event(), _allow_multiple_record(allow_multiple_record) {
   if (_phase_times != NULL) {
     _start_time = Ticks::now();
   }
@@ -587,10 +587,10 @@ G1GCParPhaseTimesTracker::G1GCParPhaseTimesTracker(G1GCPhaseTimes* phase_times, 
 
 G1GCParPhaseTimesTracker::~G1GCParPhaseTimesTracker() {
   if (_phase_times != NULL) {
-    if (_initial_record) {
-      _phase_times->record_time_secs(_phase, _worker_id, (Ticks::now() - _start_time).seconds());
-    } else {
+    if (_allow_multiple_record) {
       _phase_times->record_or_add_time_secs(_phase, _worker_id, (Ticks::now() - _start_time).seconds());
+    } else {
+      _phase_times->record_time_secs(_phase, _worker_id, (Ticks::now() - _start_time).seconds());
     }
     _event.commit(GCId::current(), _worker_id, G1GCPhaseTimes::phase_name(_phase));
   }

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1423,7 +1423,7 @@ public:
 
     // Merge remembered sets of current candidates.
     {
-      G1GCParPhaseTimesTracker x(p, merge_remset_phase, worker_id, _initial_evacuation /* must_record */);
+      G1GCParPhaseTimesTracker x(p, merge_remset_phase, worker_id, !_initial_evacuation /* allow_multiple_record */);
       G1MergeCardSetStats stats;
       {
         G1MergeCardSetClosure cl(_scan_state);


### PR DESCRIPTION
This is a trivial improvement to refine the naming of G1GCParPhaseTimesTracker::_must_record to _initial_record.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278276](https://bugs.openjdk.java.net/browse/JDK-8278276): G1: Refine naming of G1GCParPhaseTimesTracker::_must_record


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to fee8048903a6836117775bcf5b9eb5f824b2c7e5
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to fee8048903a6836117775bcf5b9eb5f824b2c7e5


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6714/head:pull/6714` \
`$ git checkout pull/6714`

Update a local copy of the PR: \
`$ git checkout pull/6714` \
`$ git pull https://git.openjdk.java.net/jdk pull/6714/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6714`

View PR using the GUI difftool: \
`$ git pr show -t 6714`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6714.diff">https://git.openjdk.java.net/jdk/pull/6714.diff</a>

</details>
