### PR TITLE
8253860: PPC: Relocation::pd_set_data_value conflates compressed oops and klasses

### DIFF
--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -942,9 +942,10 @@ void LIR_Assembler::const2mem(LIR_Opr src, LIR_Opr dest, BasicType type, CodeEmi
       tmp = FrameMap::R0_opr;
       if (UseCompressedOops && !wide && c->as_jobject() != NULL) {
         AddressLiteral oop_addr = __ constant_oop_address(c->as_jobject());
-        __ lis(R0, oop_addr.value() >> 16); // Don't care about sign extend (will use stw).
+        // Don't care about sign extend (will use stw).
+        __ lis(R0, 0); // Will get patched.
         __ relocate(oop_addr.rspec(), /*compressed format*/ 1);
-        __ ori(R0, R0, oop_addr.value() & 0xffff);
+        __ ori(R0, R0, 0); // Will get patched.
       } else {
         jobject2reg(c->as_jobject(), R0);
       }

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -233,7 +233,7 @@ address MacroAssembler::patch_set_narrow_oop(address a, address bound, narrowOop
   return inst1_addr;
 }
 
-// Get compressed oop or klass constant.
+// Get compressed oop constant.
 narrowOop MacroAssembler::get_narrow_oop(address a, address bound) {
   assert(UseCompressedOops, "Should only patch compressed oops");
 

--- a/src/hotspot/cpu/ppc/nativeInst_ppc.hpp
+++ b/src/hotspot/cpu/ppc/nativeInst_ppc.hpp
@@ -257,7 +257,7 @@ class NativeMovConstReg: public NativeInstruction {
   // Patch the code stream and oop pool.
   void set_data(intptr_t x);
 
-  // Patch narrow oop constants. Use this also for narrow klass.
+  // Patch narrow oop constants.
   void set_narrow_oop(narrowOop data, CodeBlob *code = NULL);
 
   void verify() NOT_DEBUG_RETURN;

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -5967,7 +5967,7 @@ instruct loadConN_lo(iRegNdst dst, iRegNsrc src1, immN src2) %{
   size(4);
   ins_encode %{
     AddressLiteral addrlit = __ constant_oop_address((jobject)$src2$$constant);
-    __ relocate(addrlit.rspec(), 1);
+    __ relocate(addrlit.rspec(), /*compressed format*/ 1);
     __ ori($dst$$Register, $src1$$Register, 0); // Will get patched.
   %}
   ins_pipe(pipe_class_default);

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -5953,7 +5953,7 @@ instruct loadConN_hi(iRegNdst dst, immN src) %{
   format %{ "LIS     $dst, $src \t// narrow oop hi" %}
   size(4);
   ins_encode %{
-    __ lis($dst$$Register, (int)(short)(($src$$constant >> 16) & 0xffff));
+    __ lis($dst$$Register, 0); // Will get patched.
   %}
   ins_pipe(pipe_class_default);
 %}
@@ -5966,11 +5966,9 @@ instruct loadConN_lo(iRegNdst dst, iRegNsrc src1, immN src2) %{
   format %{ "ORI     $dst, $src1, $src2 \t// narrow oop lo" %}
   size(4);
   ins_encode %{
-    assert(__ oop_recorder() != NULL, "this assembler needs an OopRecorder");
-    int oop_index = __ oop_recorder()->find_index((jobject)$src2$$constant);
-    RelocationHolder rspec = oop_Relocation::spec(oop_index);
-    __ relocate(rspec, 1);
-    __ ori($dst$$Register, $src1$$Register, $src2$$constant & 0xffff);
+    AddressLiteral addrlit = __ constant_oop_address((jobject)$src2$$constant);
+    __ relocate(addrlit.rspec(), 1);
+    __ ori($dst$$Register, $src1$$Register, 0); // Will get patched.
   %}
   ins_pipe(pipe_class_default);
 %}
@@ -6085,12 +6083,9 @@ instruct loadConNKlass_lo(iRegNdst dst, immNKlass_NM src1, iRegNsrc src2) %{
   format %{ "ORI     $dst, $src1, $src2 \t// narrow klass lo" %}
   size(4);
   ins_encode %{
-    intptr_t Csrc = CompressedKlassPointers::encode((Klass *)$src1$$constant);
-    assert(__ oop_recorder() != NULL, "this assembler needs an OopRecorder");
-    int klass_index = __ oop_recorder()->find_index((Klass *)$src1$$constant);
-    RelocationHolder rspec = metadata_Relocation::spec(klass_index);
-
-    __ relocate(rspec, 1);
+    // Notify OOP recorder (don't need the relocation)
+    AddressLiteral md = __ constant_metadata_address((Klass*)$src1$$constant);
+    intptr_t Csrc = CompressedKlassPointers::encode((Klass*)md.value());
     __ ori($dst$$Register, $src2$$Register, Csrc & 0xffff);
   %}
   ins_pipe(pipe_class_default);

--- a/src/hotspot/cpu/ppc/relocInfo_ppc.cpp
+++ b/src/hotspot/cpu/ppc/relocInfo_ppc.cpp
@@ -33,34 +33,15 @@
 #include "runtime/safepoint.hpp"
 
 void Relocation::pd_set_data_value(address x, intptr_t o, bool verify_only) {
-  // The following comment is from the declaration of DataRelocation:
-  //
-  //  "The "o" (displacement) argument is relevant only to split relocations
-  //   on RISC machines.  In some CPUs (SPARC), the set-hi and set-lo ins'ns
-  //   can encode more than 32 bits between them.  This allows compilers to
-  //   share set-hi instructions between addresses that differ by a small
-  //   offset (e.g., different static variables in the same class).
-  //   On such machines, the "x" argument to set_value on all set-lo
-  //   instructions must be the same as the "x" argument for the
-  //   corresponding set-hi instructions.  The "o" arguments for the
-  //   set-hi instructions are ignored, and must not affect the high-half
-  //   immediate constant.  The "o" arguments for the set-lo instructions are
-  //   added into the low-half immediate constant, and must not overflow it."
-  //
-  // Currently we don't support splitting of relocations, so o must be
-  // zero:
+  // Currently we don't support splitting of relocations.
   assert(o == 0, "tried to split relocations");
 
   if (!verify_only) {
     if (format() != 1) {
       nativeMovConstReg_at(addr())->set_data_plain(((intptr_t)x), code());
     } else {
-      assert(type() == relocInfo::oop_type || type() == relocInfo::metadata_type,
-             "how to encode else?");
-      narrowOop no = (type() == relocInfo::oop_type) ?
-          CompressedOops::encode(cast_to_oop(x)) :
-          // Type punning compressed klass pointer as narrowOop.
-          CompressedOops::narrow_oop_cast(CompressedKlassPointers::encode((Klass*)x));
+      assert(type() == relocInfo::oop_type, "how to encode else?");
+      narrowOop no = CompressedOops::encode(cast_to_oop(x));
       nativeMovConstReg_at(addr())->set_narrow_oop(no, code());
     }
   } else {


### PR DESCRIPTION
Casting narrow Klass pointer to a narrow Oop is problematic. Note that `NativeMovConstReg::set_narrow_oop` only supports narrow Oops.
It turns out, that the problematic code is unused. We never patch narrow Klass pointers in the instruction stream on PPC64 (`metadata_Relocation::pd_fix_value` has an empty implementation). In contrast to that, narrow Oops in the instructions stream always get patched when the nmethod gets installed (by `fix_oop_relocations`). This makes sense as Metadata doesn't get relocated, but Oops may be moved by GC and the instructions need to get the current value during nmethod installation.
Note that the initial constants we were using for narrow Oops in the instruction stream were not correct (Oop compression missing, not updated by GC). So, I think it's better to use 0 to avoid confusion.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253860](https://bugs.openjdk.java.net/browse/JDK-8253860): PPC: Relocation::pd_set_data_value conflates compressed oops and klasses


### Reviewers
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)
 * [Richard Reingruber](https://openjdk.java.net/census#rrich) (@reinrich - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6716/head:pull/6716` \
`$ git checkout pull/6716`

Update a local copy of the PR: \
`$ git checkout pull/6716` \
`$ git pull https://git.openjdk.java.net/jdk pull/6716/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6716`

View PR using the GUI difftool: \
`$ git pr show -t 6716`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6716.diff">https://git.openjdk.java.net/jdk/pull/6716.diff</a>

</details>
