### PR TITLE
8278289: Drop G1BlockOffsetTablePart::_object_can_span

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
@@ -75,7 +75,6 @@ void G1BlockOffsetTable::check_index(size_t index, const char* msg) const {
 
 G1BlockOffsetTablePart::G1BlockOffsetTablePart(G1BlockOffsetTable* array, HeapRegion* hr) :
   _next_offset_threshold(NULL),
-  DEBUG_ONLY(_object_can_span(false) COMMA)
   _bot(array),
   _hr(hr)
 {
@@ -330,12 +329,6 @@ void G1BlockOffsetTablePart::verify() const {
     }
   }
 }
-
-#ifdef ASSERT
-void G1BlockOffsetTablePart::set_object_can_span(bool can_span) {
-  _object_can_span = can_span;
-}
-#endif
 
 #ifndef PRODUCT
 void G1BlockOffsetTablePart::print_on(outputStream* out) {

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -114,9 +114,6 @@ private:
   // allocation boundary at which offset array must be updated
   HeapWord* _next_offset_threshold;
 
-  // Indicates if an object can span into this G1BlockOffsetTablePart.
-  debug_only(bool _object_can_span;)
-
   // This is the global BlockOffsetTable.
   G1BlockOffsetTable* _bot;
 
@@ -212,7 +209,6 @@ public:
   }
 
   void set_for_starts_humongous(HeapWord* obj_top, size_t fill_size);
-  void set_object_can_span(bool can_span) NOT_DEBUG_RETURN;
 
   void print_on(outputStream* out) PRODUCT_RETURN;
 };

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
@@ -113,9 +113,13 @@ inline size_t G1BlockOffsetTablePart::block_size(const HeapWord* p) const {
 }
 
 inline HeapWord* G1BlockOffsetTablePart::block_at_or_preceding(const void* addr) const {
-  assert(_object_can_span || _bot->offset_array(_bot->index_for(_hr->bottom())) == 0,
-         "Object crossed region boundary, found offset %u instead of 0",
-         (uint) _bot->offset_array(_bot->index_for(_hr->bottom())));
+#ifdef ASSERT
+  if (!_hr->is_continues_humongous()) {
+    // For non ContinuesHumongous regions, the first obj always starts from bottom.
+    u_char offset = _bot->offset_array(_bot->index_for(_hr->bottom()));
+    assert(offset == 0, "Found offset %u instead of 0", offset);
+  }
+#endif
 
   size_t index = _bot->index_for(addr);
 

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
@@ -115,9 +115,10 @@ inline size_t G1BlockOffsetTablePart::block_size(const HeapWord* p) const {
 inline HeapWord* G1BlockOffsetTablePart::block_at_or_preceding(const void* addr) const {
 #ifdef ASSERT
   if (!_hr->is_continues_humongous()) {
-    // For non ContinuesHumongous regions, the first obj always starts from bottom.
+    // For non-ContinuesHumongous regions, the first obj always starts from bottom.
     u_char offset = _bot->offset_array(_bot->index_for(_hr->bottom()));
-    assert(offset == 0, "Found offset %u instead of 0", offset);
+    assert(offset == 0, "Found offset %u instead of 0 for region %u %s",
+           offset, _hr->hrm_index(), _hr->get_short_type_str());
   }
 #endif
 

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -214,8 +214,6 @@ void HeapRegion::set_continues_humongous(HeapRegion* first_hr) {
   report_region_type_change(G1HeapRegionTraceType::ContinuesHumongous);
   _type.set_continues_humongous();
   _humongous_start_region = first_hr;
-
-  _bot_part.set_object_can_span(true);
 }
 
 void HeapRegion::clear_humongous() {
@@ -223,8 +221,6 @@ void HeapRegion::clear_humongous() {
 
   assert(capacity() == HeapRegion::GrainBytes, "pre-condition");
   _humongous_start_region = NULL;
-
-  _bot_part.set_object_can_span(false);
 }
 
 HeapRegion::HeapRegion(uint hrm_index,


### PR DESCRIPTION
Simple change of dropping a debug-only field. Instead, the assert logic queries for the region type directly.

Test: tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278289](https://bugs.openjdk.java.net/browse/JDK-8278289): Drop G1BlockOffsetTablePart::_object_can_span


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6718/head:pull/6718` \
`$ git checkout pull/6718`

Update a local copy of the PR: \
`$ git checkout pull/6718` \
`$ git pull https://git.openjdk.java.net/jdk pull/6718/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6718`

View PR using the GUI difftool: \
`$ git pr show -t 6718`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6718.diff">https://git.openjdk.java.net/jdk/pull/6718.diff</a>

</details>
