### PR TITLE
8244602: Add JTREG_REPEAT_COUNT to repeat execution of a test

### DIFF
--- a/doc/testing.html
+++ b/doc/testing.html
@@ -194,6 +194,8 @@ TEST FAILURE</code></pre>
 <p>Generate AOT modules before testing for the specified module, or set of modules. If multiple modules are specified, they should be separated by space (or, to help avoid quoting issues, the special value <code>%20</code>).</p>
 <h4 id="retry_count">RETRY_COUNT</h4>
 <p>Retry failed tests up to a set number of times. Defaults to 0.</p>
+<h4 id="repeat_count">REPEAT_COUNT</h4>
+<p>Repeat the tests for a set number of times. Defaults to 0.</p>
 <h3 id="gtest-keywords">Gtest keywords</h3>
 <h4 id="repeat">REPEAT</h4>
 <p>The number of times to repeat the tests (<code>--gtest_repeat</code>).</p>

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -421,6 +421,10 @@ modules. If multiple modules are specified, they should be separated by space
 
 Retry failed tests up to a set number of times. Defaults to 0.
 
+#### REPEAT_COUNT
+
+Repeat the tests for a set number of times. Defaults to 0.
+
 ### Gtest keywords
 
 #### REPEAT

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -200,7 +200,7 @@ $(eval $(call SetTestOpt,FAILURE_HANDLER_TIMEOUT,JTREG))
 $(eval $(call ParseKeywordVariable, JTREG, \
     SINGLE_KEYWORDS := JOBS TIMEOUT_FACTOR FAILURE_HANDLER_TIMEOUT \
         TEST_MODE ASSERT VERBOSE RETAIN MAX_MEM RUN_PROBLEM_LISTS \
-        RETRY_COUNT MAX_OUTPUT $(CUSTOM_JTREG_SINGLE_KEYWORDS), \
+        RETRY_COUNT REPEAT_COUNT MAX_OUTPUT $(CUSTOM_JTREG_SINGLE_KEYWORDS), \
     STRING_KEYWORDS := OPTIONS JAVA_OPTIONS VM_OPTIONS KEYWORDS \
         EXTRA_PROBLEM_LISTS LAUNCHER_OPTIONS \
         $(CUSTOM_JTREG_STRING_KEYWORDS), \
@@ -745,6 +745,15 @@ define SetupRunJtregTestBody
   JTREG_RETAIN ?= fail,error
   JTREG_RUN_PROBLEM_LISTS ?= false
   JTREG_RETRY_COUNT ?= 0
+  JTREG_REPEAT_COUNT ?= 0
+
+  ifneq ($$(JTREG_RETRY_COUNT), 0)
+    ifneq ($$(JTREG_REPEAT_COUNT), 0)
+      $$(info Error: Cannot use both JTREG_RETRY_COUNT and JTREG_REPEAT_COUNT together.)
+      $$(info Please choose one or the other.)
+      $$(error Cannot continue)
+    endif
+  endif
 
   ifneq ($$(JTREG_LAUNCHER_OPTIONS), )
     $1_JTREG_LAUNCHER_OPTIONS += $$(JTREG_LAUNCHER_OPTIONS)
@@ -866,6 +875,18 @@ define SetupRunJtregTestBody
             break; \
           fi; \
           export JTREG_STATUS="-status:error,fail"; \
+        done
+  endif
+
+  ifneq ($$(JTREG_REPEAT_COUNT), 0)
+    $1_COMMAND_LINE := \
+        for i in {1..$$(JTREG_REPEAT_COUNT)}; do \
+          $$(PRINTF) "\nRepeating Jtreg run: $$$$i out of $$(JTREG_REPEAT_COUNT)\n"; \
+          $$($1_COMMAND_LINE); \
+          if [ "`$$(CAT) $$($1_EXITCODE)`" != "0" ]; then \
+            $$(PRINTF) "\nFailures detected, no more repeats.\n"; \
+            break; \
+          fi; \
         done
   endif
 


### PR DESCRIPTION
This adds the test repeat feature in the build system. This is convenient to follow-up on intermittently failing tests: the `REPEAT_COUNT > 0` would run the test multiple times, until we run out of repeats or the tests fail.

With this sample test:

```
/*
 * @test
 * @run driver IntermittentTest
 */
public class IntermittentTest {
    public static void main(String... args) {
        if (Math.random() < 0.05) {
            throw new IllegalStateException("Oops");
        }
    }
}
```

...a lucky run looks like this:

```
$ CONF=linux-x86_64-server-fastdebug make run-test TEST=sanity/IntermittentTest.java JTREG="REPEAT_COUNT=5"
Building target 'run-test' in configuration 'linux-x86_64-server-fastdebug'
Running tests using JTREG control variable 'REPEAT_COUNT=5'
Test selection 'sanity/IntermittentTest.java', will run:
* jtreg:test/hotspot/jtreg/sanity/IntermittentTest.java

Running test 'jtreg:test/hotspot/jtreg/sanity/IntermittentTest.java'

Repeating Jtreg run: 1 out of 5
Passed: sanity/IntermittentTest.java
Test results: passed: 1
Report written to ...
Results written to ...

Repeating Jtreg run: 2 out of 5
Passed: sanity/IntermittentTest.java
Test results: passed: 1
Report written to ...
Results written to ...

Repeating Jtreg run: 3 out of 5
Passed: sanity/IntermittentTest.java
Test results: passed: 1
Report written to ...
Results written to ...

Repeating Jtreg run: 4 out of 5
Passed: sanity/IntermittentTest.java
Test results: passed: 1
Report written to ...
Results written to ...

Repeating Jtreg run: 5 out of 5
Passed: sanity/IntermittentTest.java
Test results: passed: 1
Report written to ...
Results written to ...
Finished running test 'jtreg:test/hotspot/jtreg/sanity/IntermittentTest.java'
Test report is stored in ...

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/hotspot/jtreg/sanity/IntermittentTest.java
                                                         1     1     0     0   
==============================
TEST SUCCESS
```

...and unlucky run looks like this:

```
$ CONF=linux-x86_64-server-fastdebug make run-test TEST=sanity/IntermittentTest.java JTREG="REPEAT_COUNT=50"
Building target 'run-test' in configuration 'linux-x86_64-server-fastdebug'
Running tests using JTREG control variable 'REPEAT_COUNT=50'
Test selection 'sanity/IntermittentTest.java', will run:
* jtreg:test/hotspot/jtreg/sanity/IntermittentTest.java
...
Repeating Jtreg run: 9 out of 50
Passed: sanity/IntermittentTest.java
Test results: passed: 1
Report written to ...
Results written to ...

Repeating Jtreg run: 10 out of 50
--------------------------------------------------
TEST: sanity/IntermittentTest.java
TEST JDK: ...

...

STDERR:
java.lang.IllegalStateException: Oops
	at IntermittentTest.main(IntermittentTest.java:8)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:577)
	at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:312)
	at java.base/java.lang.Thread.run(Thread.java:833)

JavaTest Message: Test threw exception: java.lang.IllegalStateException
JavaTest Message: shutting down test


TEST RESULT: Failed. Execution failed: `main' threw exception: java.lang.IllegalStateException: Oops
--------------------------------------------------
Test results: failed: 1
Report written to ...
Results written to ...
Error: Some tests failed or other problems occurred.

Failures detected, no more repeats.
Finished running test 'jtreg:test/hotspot/jtreg/sanity/IntermittentTest.java'
Test report is stored in ...

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/hotspot/jtreg/sanity/IntermittentTest.java
>>                                                       1     0     1     0 <<
==============================
TEST FAILURE
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244602](https://bugs.openjdk.java.net/browse/JDK-8244602): Add JTREG_REPEAT_COUNT to repeat execution of a test


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6720/head:pull/6720` \
`$ git checkout pull/6720`

Update a local copy of the PR: \
`$ git checkout pull/6720` \
`$ git pull https://git.openjdk.java.net/jdk pull/6720/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6720`

View PR using the GUI difftool: \
`$ git pr show -t 6720`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6720.diff">https://git.openjdk.java.net/jdk/pull/6720.diff</a>

</details>
