### PR TITLE
8278291: compiler/uncommontrap/TraceDeoptimizationNoRealloc.java fails with release VMs after JDK-8154011

### DIFF
--- a/test/hotspot/jtreg/compiler/uncommontrap/TraceDeoptimizationNoRealloc.java
+++ b/test/hotspot/jtreg/compiler/uncommontrap/TraceDeoptimizationNoRealloc.java
@@ -27,7 +27,7 @@
  * @summary -XX:+TraceDeoptimization tries to print realloc'ed objects even when there are none
  *
  * @run main/othervm -XX:-BackgroundCompilation -XX:-UseOnStackReplacement
- *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+TraceDeoptimization
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+TraceDeoptimization
  *                   compiler.uncommontrap.TraceDeoptimizationNoRealloc
  */
 

--- a/test/hotspot/jtreg/compiler/uncommontrap/TraceDeoptimizationNoRealloc.java
+++ b/test/hotspot/jtreg/compiler/uncommontrap/TraceDeoptimizationNoRealloc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary -XX:+TraceDeoptimization tries to print realloc'ed objects even when there are none
  *
  * @run main/othervm -XX:-BackgroundCompilation -XX:-UseOnStackReplacement
- *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+TraceDeoptimization
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+TraceDeoptimization
  *                   compiler.uncommontrap.TraceDeoptimizationNoRealloc
  */
 


### PR DESCRIPTION
Hi all,

compiler/uncommontrap/TraceDeoptimizationNoRealloc.java fails with release VMs after JDK-8154011 due 'TraceDeoptimization' is diagnostic and must be enabled via -XX:+UnlockDiagnosticVMOptions.
Let's add `-XX:+UnlockDiagnosticVMOptions` to fix it.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278291](https://bugs.openjdk.java.net/browse/JDK-8278291): compiler/uncommontrap/TraceDeoptimizationNoRealloc.java fails with release VMs after JDK-8154011


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6721/head:pull/6721` \
`$ git checkout pull/6721`

Update a local copy of the PR: \
`$ git checkout pull/6721` \
`$ git pull https://git.openjdk.java.net/jdk pull/6721/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6721`

View PR using the GUI difftool: \
`$ git pr show -t 6721`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6721.diff">https://git.openjdk.java.net/jdk/pull/6721.diff</a>

</details>
