### PR TITLE
8274883: (se) Selector.open throws IAE when the default file system provider is changed to a custom provider

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
@@ -700,11 +700,11 @@ class SocketChannelImpl
     private SocketAddress unixBind(SocketAddress local) throws IOException {
         UnixDomainSockets.checkPermission();
         if (local == null) {
-            return UnixDomainSockets.UNNAMED;
+            return UnixDomainSockets.getUNNAMED();
         } else {
             Path path = UnixDomainSockets.checkAddress(local).getPath();
             if (path.toString().isEmpty()) {
-                return UnixDomainSockets.UNNAMED;
+                return UnixDomainSockets.getUNNAMED();
             } else {
                 // bind to non-empty path
                 UnixDomainSockets.bind(fd, path);

--- a/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
@@ -700,11 +700,11 @@ class SocketChannelImpl
     private SocketAddress unixBind(SocketAddress local) throws IOException {
         UnixDomainSockets.checkPermission();
         if (local == null) {
-            return UnixDomainSockets.getUNNAMED();
+            return UnixDomainSockets.unnamed();
         } else {
             Path path = UnixDomainSockets.checkAddress(local).getPath();
             if (path.toString().isEmpty()) {
-                return UnixDomainSockets.getUNNAMED();
+                return UnixDomainSockets.unnamed();
             } else {
                 // bind to non-empty path
                 UnixDomainSockets.bind(fd, path);

--- a/src/java.base/share/classes/sun/nio/ch/UnixDomainSockets.java
+++ b/src/java.base/share/classes/sun/nio/ch/UnixDomainSockets.java
@@ -44,7 +44,9 @@ import sun.nio.fs.AbstractFileSystemProvider;
 class UnixDomainSockets {
     private UnixDomainSockets() { }
 
-    static final UnixDomainSocketAddress UNNAMED = UnixDomainSocketAddress.of("");
+    private static class UNNAMEDHolder {
+        static final UnixDomainSocketAddress UNNAMED = UnixDomainSocketAddress.of("");
+    }
 
     private static final boolean supported;
 
@@ -71,7 +73,7 @@ class UnixDomainSockets {
             // Security check passed
         } catch (SecurityException e) {
             // Return unnamed address only if security check fails
-            addr = UNNAMED;
+            addr = getUNNAMED();
         }
         return addr;
     }
@@ -137,6 +139,8 @@ class UnixDomainSockets {
             return UnixDomainSocketAddress.of(path);
         } catch (InvalidPathException e) {
             throw new BindException("Invalid temporary directory");
+        } catch (IllegalArgumentException e) {
+            throw new UnsupportedOperationException("Unix Domain Sockets not supported on non-default file system");
         }
     }
 
@@ -177,5 +181,9 @@ class UnixDomainSockets {
         // Load all required native libs
         IOUtil.load();
         supported = init();
+    }
+
+    static UnixDomainSocketAddress getUNNAMED() {
+        return UNNAMEDHolder.UNNAMED;
     }
 }

--- a/test/jdk/java/nio/channels/Selector/CustomFileSystem.java
+++ b/test/jdk/java/nio/channels/Selector/CustomFileSystem.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, JetBrains s.r.o.. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -23,16 +24,14 @@
 
 /**
  * @test
- * @summary Verifies that an attempt to call SelectorProvider.provider().openSelector()
- *          on a non-default file system succeeds.
- * @library /test/lib
- * @build TestProvider UnixSocketInNonDefaultFS
- * @run main/othervm -Djava.nio.file.spi.DefaultFileSystemProvider=TestProvider UnixSocketInNonDefaultFS
+ * @summary Verifies that an attempt to call Selector.open() on a non-default
+ *          file system succeeds.
+ * @build CustomFileSystem CustomFileSystemProvider
+ * @run main/othervm -Djava.nio.file.spi.DefaultFileSystemProvider=CustomFileSystemProvider CustomFileSystem
  */
-import java.nio.channels.spi.SelectorProvider;
 
-public class UnixSocketInNonDefaultFS {
+public class CustomFileSystem {
     public static void main(String args[]) throws java.io.IOException {
-        SelectorProvider.provider().openSelector();
+        java.nio.channels.Selector.open();
     }
 }

--- a/test/jdk/java/nio/channels/Selector/CustomFileSystemProvider.java
+++ b/test/jdk/java/nio/channels/Selector/CustomFileSystemProvider.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, JetBrains s.r.o.. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.channels.FileChannel;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.AccessMode;
+import java.nio.file.CopyOption;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileStore;
+import java.nio.file.FileSystem;
+import java.nio.file.LinkOption;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.ReadOnlyFileSystemException;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.FileAttributeView;
+import java.nio.file.attribute.UserPrincipalLookupService;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+public class CustomFileSystemProvider extends FileSystemProvider {
+
+    private final FileSystemProvider defaultProvider;
+
+    public CustomFileSystemProvider(FileSystemProvider defaultProvider) {
+        this.defaultProvider = defaultProvider;
+    }
+
+    FileSystemProvider defaultProvider() {
+        return defaultProvider;
+    }
+
+    @Override
+    public String getScheme() {
+        return "file";
+    }
+
+    @Override
+    public FileSystem newFileSystem(URI uri, Map<String,?> env) throws IOException {
+        return defaultProvider.newFileSystem(uri, env);
+    }
+
+    @Override
+    public FileSystem getFileSystem(URI uri) {
+        return defaultProvider.getFileSystem(uri);
+    }
+
+    @Override
+    public Path getPath(URI uri) {
+        return defaultProvider.getPath(uri);
+    }
+
+    @Override
+    public void setAttribute(Path file, String attribute, Object value,
+                             LinkOption... options)
+        throws IOException
+    {
+        throw new RuntimeException("not implemented");
+    }
+
+    @Override
+    public Map<String,Object> readAttributes(Path file, String attributes,
+                                             LinkOption... options)
+        throws IOException
+    {
+        throw new RuntimeException("not implemented");
+    }
+
+    @Override
+    public <A extends BasicFileAttributes> A readAttributes(Path file,
+                                                            Class<A> type,
+                                                            LinkOption... options)
+        throws IOException
+    {
+        throw new RuntimeException("not implemented");
+    }
+
+    @Override
+    public <V extends FileAttributeView> V getFileAttributeView(Path file,
+                                                                Class<V> type,
+                                                                LinkOption... options)
+    {
+        throw new RuntimeException("not implemented");
+    }
+
+    @Override
+    public boolean isHidden(Path file) throws IOException {
+        throw new ReadOnlyFileSystemException();
+    }
+
+    @Override
+    public boolean isSameFile(Path file, Path other) throws IOException {
+        throw new RuntimeException("not implemented");
+    }
+
+    @Override
+    public void checkAccess(Path file, AccessMode... modes)
+        throws IOException
+    {
+        throw new RuntimeException("not implemented");
+    }
+
+    @Override
+    public void copy(Path source, Path target, CopyOption... options)
+        throws IOException
+    {
+        throw new RuntimeException("not implemented");
+    }
+
+    @Override
+    public void move(Path source, Path target, CopyOption... options)
+        throws IOException
+    {
+        throw new RuntimeException("not implemented");
+    }
+
+    @Override
+    public void delete(Path file) throws IOException {
+        throw new RuntimeException("not implemented");
+    }
+
+    @Override
+    public void createSymbolicLink(Path link, Path target, FileAttribute<?>... attrs)
+        throws IOException
+    {
+        throw new RuntimeException("not implemented");
+    }
+
+    @Override
+    public void createLink(Path link, Path existing) throws IOException {
+        throw new RuntimeException("not implemented");
+    }
+
+    @Override
+    public Path readSymbolicLink(Path link) throws IOException {
+        throw new RuntimeException("not implemented");
+    }
+
+    @Override
+    public void createDirectory(Path dir, FileAttribute<?>... attrs)
+        throws IOException
+    {
+        throw new RuntimeException("not implemented");
+    }
+
+    @Override
+    public DirectoryStream<Path> newDirectoryStream(Path dir,
+                                                    DirectoryStream.Filter<? super Path> filter)
+        throws IOException
+    {
+        throw new RuntimeException("not implemented");
+    }
+
+    @Override
+    public SeekableByteChannel newByteChannel(Path file,
+                                              Set<? extends OpenOption> options,
+                                              FileAttribute<?>... attrs)
+        throws IOException
+    {
+        throw new RuntimeException("not implemented");
+    }
+
+    @Override
+    public FileChannel newFileChannel(Path file,
+                                      Set<? extends OpenOption> options,
+                                      FileAttribute<?>... attrs)
+        throws IOException
+    {
+        throw new RuntimeException("not implemented");
+    }
+
+    @Override
+    public FileStore getFileStore(Path file) throws IOException {
+        throw new RuntimeException("not implemented");
+    }
+}

--- a/test/jdk/java/nio/file/spi/UnixSocketInNonDefaultFS.java
+++ b/test/jdk/java/nio/file/spi/UnixSocketInNonDefaultFS.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021, JetBrains s.r.o.. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Verifies that an attempt to call SelectorProvider.provider().openSelector()
+ *          on a non-default file system succeeds.
+ * @library /test/lib
+ * @build TestProvider UnixSocketInNonDefaultFS
+ * @run main/othervm -Djava.nio.file.spi.DefaultFileSystemProvider=TestProvider UnixSocketInNonDefaultFS
+ */
+import java.nio.channels.spi.SelectorProvider;
+
+public class UnixSocketInNonDefaultFS {
+    public static void main(String args[]) throws java.io.IOException {
+        SelectorProvider.provider().openSelector();
+    }
+}


### PR DESCRIPTION
The gist of the problem: when a file system is specified via `-Djava.nio.file.spi.DefaultFileSystemProvider`, a call to `SelectorProvider.provider().openSelector()` ends with a throw on Windows.

There are two distinct components to the problem:

1. `ExceptionInInitializerError` is thrown during the static initialization of the `UnixDomainSockets.UNNAMED` field even though it isn't used on this code path (see `UnixDomainSocketAddress.of()` that throws `IllegalArgumentException` if invoked on a path from a non-default file system). 
This is fixed by lazy-initializing the static member `UNNAMED` of `UnixDomainSockets` so that this initialization doesn't throw unless actually used.

2. `IllegalArgumentException` is thrown by `UnixDomainSocketAddress.of()`  later on when `ServerSocketChannel` tries to use Windows version of `PipeImpl` and its method `createListener()` specifically. That `PipeImpl` probes for the availability of Unix Domain Sockets by trying to bind to a unique temporary name. That call throws `IAE` when a non-default Java file system is installed while the probing code (`PipeImpl.createListener()`) only expects `UnsupportedOperationException` or `IOException`.
The fix is to re-throw `UOE` instead of `IAE` in `UnixDomainSockets.genrateTempName()`. This is more consistent with the definition of the exception purpose ("requested operation is not supported"). So with this change, a loopback network socket will be used to implement a pipe on a non-default Java file system. Also, pipes do not rely on the default Java file system on other platforms (Linux, MacOS) as well.

Tested by running `jtreg:test/jdk/java/nio` on Window, MacOS, and Linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274883](https://bugs.openjdk.java.net/browse/JDK-8274883): (se) Selector.open throws IAE when the default file system provider is changed to a custom provider


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Michael McMahon](https://openjdk.java.net/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6722/head:pull/6722` \
`$ git checkout pull/6722`

Update a local copy of the PR: \
`$ git checkout pull/6722` \
`$ git pull https://git.openjdk.java.net/jdk pull/6722/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6722`

View PR using the GUI difftool: \
`$ git pr show -t 6722`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6722.diff">https://git.openjdk.java.net/jdk/pull/6722.diff</a>

</details>
