### PR TITLE
8277628: Spec for InetAddressResolverProvider::get() throwing error or exception could be clearer

### DIFF
--- a/src/java.base/share/classes/java/net/spi/InetAddressResolverProvider.java
+++ b/src/java.base/share/classes/java/net/spi/InetAddressResolverProvider.java
@@ -66,7 +66,8 @@ import java.util.ServiceLoader;
  *
  * <p> If instantiating a custom resolver from a provider discovered in
  * step 1 throws an error or exception, the system-wide resolver will not be
- * set and the error or exception will be propagated to the calling thread.
+ * set and the error or exception will be propagated to the caller of the method
+ * that triggered the lookup operation.
  * Otherwise, any lookup operation will be performed using the
  * <i>system-wide resolver</i>.
  *
@@ -85,7 +86,7 @@ public abstract class InetAddressResolverProvider {
      *
      * <p> Any error or exception thrown by this method is considered as
      * a failure of {@code InetAddressResolver} instantiation and will be propagated to
-     * the calling thread.
+     * the caller of the method that triggered the lookup operation.
      * @param configuration a {@link Configuration} instance containing platform built-in address
      *                     resolution configuration.
      * @return the resolver provided by this provider


### PR DESCRIPTION
The following fix clarifies spec for `InetAddressResolverProvider.get(Configuration)` method to state that an error or exception thrown by this method will be propagated to to the caller of the method that triggered the lookup operation.  

The `InetAddressResolverProvider#system-wide-resolver` class-level javadoc section has been updated to state the same.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277628](https://bugs.openjdk.java.net/browse/JDK-8277628): Spec for InetAddressResolverProvider::get() throwing error or exception could be clearer


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6725/head:pull/6725` \
`$ git checkout pull/6725`

Update a local copy of the PR: \
`$ git checkout pull/6725` \
`$ git pull https://git.openjdk.java.net/jdk pull/6725/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6725`

View PR using the GUI difftool: \
`$ git pr show -t 6725`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6725.diff">https://git.openjdk.java.net/jdk/pull/6725.diff</a>

</details>
