### PR TITLE
8277932: Subject:callAs() not throwing NPE when action is null

### DIFF
--- a/src/java.base/share/classes/javax/security/auth/Subject.java
+++ b/src/java.base/share/classes/javax/security/auth/Subject.java
@@ -402,6 +402,7 @@ public final class Subject implements java.io.Serializable {
      */
     public static <T> T callAs(final Subject subject,
             final Callable<T> action) throws CompletionException {
+        Objects.requireNonNull(action);
         if (USE_TL) {
             Subject oldSubject = SUBJECT_THREAD_LOCAL.get();
             SUBJECT_THREAD_LOCAL.set(subject);


### PR DESCRIPTION
Add null check. I must have thought the NPE will be thrown anyway but the `catch Exception` block swallows it.

I added a noreg-trivial label. If you think differently can add one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277932](https://bugs.openjdk.java.net/browse/JDK-8277932): Subject:callAs() not throwing NPE when action is null


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6728/head:pull/6728` \
`$ git checkout pull/6728`

Update a local copy of the PR: \
`$ git checkout pull/6728` \
`$ git pull https://git.openjdk.java.net/jdk pull/6728/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6728`

View PR using the GUI difftool: \
`$ git pr show -t 6728`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6728.diff">https://git.openjdk.java.net/jdk/pull/6728.diff</a>

</details>
