### PR TITLE
JDK-8278318: Create {@index} entries for key LangTools terms

### DIFF
--- a/src/java.compiler/share/classes/module-info.java
+++ b/src/java.compiler/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/module-info.java
+++ b/src/java.compiler/share/classes/module-info.java
@@ -24,7 +24,9 @@
  */
 
 /**
- * Defines the Language Model, Annotation Processing, and Java Compiler APIs.
+ * Defines the {@index "Language Model"}, {@index "Annotation Processing"}, and
+ * {@index "Java Compiler"} APIs.
+ *
  * <p>
  * These APIs model declarations and types of the Java programming language,
  * and define interfaces for tools such as compilers which can be invoked

--- a/src/jdk.compiler/share/classes/module-info.java
+++ b/src/jdk.compiler/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/module-info.java
+++ b/src/jdk.compiler/share/classes/module-info.java
@@ -28,6 +28,10 @@
  * {@linkplain javax.tools.ToolProvider#getSystemJavaCompiler system Java compiler}
  * and its command line equivalent, <em>{@index javac javac tool}</em>.
  *
+ * <p>The {@code com.sun.source.*} packages provide the {@index "Compiler Tree API"}:
+ * an API for accessing the abstract trees (ASTs) representing Java source code
+ * and documentation comments, used by <em>javac</em>, <em>javadoc</em> and related tools.
+ *
  * <h2 style="font-family:'DejaVu Sans Mono', monospace; font-style:italic">javac</h2>
  *
  * <p>


### PR DESCRIPTION
Please review a small update to the `jdk.compiler` and `java.compiler` module declarations, to index the names of some key compiler-related APIs.

There are no API changes, so no CSR is required.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8278318](https://bugs.openjdk.java.net/browse/JDK-8278318): Create {@index} entries for key LangTools terms
 * [JDK-8278319](https://bugs.openjdk.java.net/browse/JDK-8278319): Create {@index} entries for key LangTools terms (**CSR**)


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to 2cc1c3e4b82940ed875f62edba04b80b2f407d39


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6729/head:pull/6729` \
`$ git checkout pull/6729`

Update a local copy of the PR: \
`$ git checkout pull/6729` \
`$ git pull https://git.openjdk.java.net/jdk pull/6729/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6729`

View PR using the GUI difftool: \
`$ git pr show -t 6729`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6729.diff">https://git.openjdk.java.net/jdk/pull/6729.diff</a>

</details>
