### PR TITLE
8272395: Bad HTML in JVMTI man page

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -6861,7 +6861,7 @@ class C2 extends C1 implements I2 {
         <ul>
         <li>By loading and deriving a class from a <code>class</code> file representation
             using a class loader (see <vmspec chapter="5.3"/>).</li>
-        <li>By invoking <externallink id="../api/java.base/java/lang/invoke/MethodHandles.Lookup.html#defineHiddenClass(byte[],boolean,java.lang.invoke.MethodHandles.Lookup.ClassOption...)">Lookup::defineHiddenClass</externallink>
+        <li>By invoking <externallink id="../api/java.base/java/lang/invoke/MethodHandles.Lookup.html#defineHiddenClass(byte%5B%5D,boolean,java.lang.invoke.MethodHandles.Lookup.ClassOption...)">Lookup::defineHiddenClass</externallink>
             that creates a hidden class or interface from a <code>class</code> file representation.</li>
         <li>By invoking methods in certain Java SE Platform APIs such as reflection.</li>
          </ul>
@@ -6923,7 +6923,7 @@ class C2 extends C1 implements I2 {
         <code>class_count_ptr</code>, and the array itself via
         <code>classes_ptr</code>.
         <p/>
-        See <externallink id="../api/java.base/java/lang/invoke/MethodHandles.Lookup.html#defineHiddenClass(byte[],boolean,java.lang.invoke.MethodHandles.Lookup.ClassOption...)">Lookup::defineHiddenClass</externallink>.
+        See <externallink id="../api/java.base/java/lang/invoke/MethodHandles.Lookup.html#defineHiddenClass(byte%5B%5D,boolean,java.lang.invoke.MethodHandles.Lookup.ClassOption...)">Lookup::defineHiddenClass</externallink>.
       </description>
       <origin>jvmdi</origin>
       <capabilities>
@@ -6973,7 +6973,7 @@ class C2 extends C1 implements I2 {
           <code>"L" + N + "." +  S + ";"</code>
           where <code>N</code> is the binary name encoded in internal form (JVMS 4.2.1)
           indicated by the <code>class</code> file passed to
-          <externallink id="../api/java.base/java/lang/invoke/MethodHandles.Lookup.html#defineHiddenClass(byte[],boolean,java.lang.invoke.MethodHandles.Lookup.ClassOption...)">Lookup::defineHiddenClass</externallink>,
+          <externallink id="../api/java.base/java/lang/invoke/MethodHandles.Lookup.html#defineHiddenClass(byte%5B%5D,boolean,java.lang.invoke.MethodHandles.Lookup.ClassOption...)">Lookup::defineHiddenClass</externallink>,
           and <code>S</code> is an unqualified name.
           The returned name is not a type descriptor and does not conform to JVMS 4.3.2.
           For example, com.foo.Foo/AnySuffix is "Lcom/foo/Foo.AnySuffix;"


### PR DESCRIPTION
This fix adds escaping of invalid characters '[]' for 3 URLs defined in the jvmti.xml.
This file is a base to generate the jvmti.html.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272395](https://bugs.openjdk.java.net/browse/JDK-8272395): Bad HTML in JVMTI man page


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6730/head:pull/6730` \
`$ git checkout pull/6730`

Update a local copy of the PR: \
`$ git checkout pull/6730` \
`$ git pull https://git.openjdk.java.net/jdk pull/6730/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6730`

View PR using the GUI difftool: \
`$ git pr show -t 6730`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6730.diff">https://git.openjdk.java.net/jdk/pull/6730.diff</a>

</details>
