### PR TITLE
8277361: java/nio/channels/Channels/ReadXBytes.java fails with OOM error

### DIFF
--- a/test/jdk/java/nio/channels/Channels/ReadXBytes.java
+++ b/test/jdk/java/nio/channels/Channels/ReadXBytes.java
@@ -88,7 +88,7 @@ public class ReadXBytes {
     static Path createFile(long length) throws IOException {
         Path path = createFilePath();
         path.toFile().deleteOnExit();
-        try (FileChannel fc = FileChannel.open(path, CREATE_NEW, SPARSE, WRITE);) {
+        try (FileChannel fc = FileChannel.open(path, CREATE_NEW, SPARSE, WRITE)) {
             if (length > 0) {
                 fc.position(length - 1);
                 fc.write(ByteBuffer.wrap(new byte[] {27}));
@@ -102,6 +102,7 @@ public class ReadXBytes {
         Path file = createFile(length);
         try (FileChannel fc = FileChannel.open(file, WRITE);) {
             long pos = 0L;
+            // if the length exceeds 2 GB, skip the first 2 GB - 1 MB bytes
             if (length >= 2L*1024*1024*1024) {
                 // write the last (length - 2GB - 1MB) bytes
                 pos = 2047L*1024*1024;

--- a/test/jdk/java/nio/channels/Channels/ReadXBytes.java
+++ b/test/jdk/java/nio/channels/Channels/ReadXBytes.java
@@ -25,12 +25,12 @@
  * @test
  * @bug 8268435 8274780
  * @summary Verify ChannelInputStream methods readAllBytes and readNBytes
- * @requires vm.bits == 64
+ * @requires (sun.arch.data.model == "64" & os.maxMemory >= 16g)
  * @library ..
  * @library /test/lib
  * @build jdk.test.lib.RandomFactory
  * @modules java.base/jdk.internal.util
- * @run testng/othervm/timeout=900 -Xmx8G ReadXBytes
+ * @run testng/othervm/timeout=900 -Xmx12G ReadXBytes
  * @key randomness
  */
 import java.io.File;
@@ -38,7 +38,7 @@ import java.io.FileInputStream;
 import java.io.FilterInputStream;
 import java.io.InputStream;
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 import java.nio.channels.Channel;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
@@ -46,10 +46,11 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import static java.nio.file.StandardOpenOption.READ;
 import java.util.List;
 import java.util.Random;
 import jdk.internal.util.ArraysSupport;
+
+import static java.nio.file.StandardOpenOption.*;
 
 import jdk.test.lib.RandomFactory;
 
@@ -72,30 +73,50 @@ public class ReadXBytes {
     // A length greater than a 32-bit integer can accommodate
     private static final long HUGE_LENGTH = Integer.MAX_VALUE + 27L;
 
+    // Current directory
+    private static final Path DIR = Path.of(System.getProperty("test.dir", "."));
+
     // --- Framework ---
+
+    // Create a temporary file path
+    static Path createFilePath() {
+        String name = String.format("ReadXBytes%d.tmp", System.nanoTime());
+        return DIR.resolve(name);
+    }
 
     // Creates a temporary file of a specified length with undefined content
     static Path createFile(long length) throws IOException {
-        File file = File.createTempFile("foo", ".bar");
-        file.deleteOnExit();
-        try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
-            raf.setLength(length);
+        Path path = createFilePath();
+        path.toFile().deleteOnExit();
+        try (FileChannel fc = FileChannel.open(path, CREATE_NEW, SPARSE, WRITE);) {
+            if (length > 0) {
+                fc.position(length - 1);
+                fc.write(ByteBuffer.wrap(new byte[] {27}));
+            }
         }
-        return file.toPath();
+        return path;
     }
 
     // Creates a temporary file of a specified length with random content
     static Path createFileWithRandomContent(long length) throws IOException {
         Path file = createFile(length);
-        try (RandomAccessFile raf = new RandomAccessFile(file.toFile(), "rw")) {
-            long written = 0L;
-            int bufLength = Math.min(32768, (int)Math.min(length, BIG_LENGTH));
+        try (FileChannel fc = FileChannel.open(file, WRITE);) {
+            long pos = 0L;
+            if (length >= 2L*1024*1024*1024) {
+                // write the last (length - 2GB - 1MB) bytes
+                pos = 2047L*1024*1024;
+            } else if (length > 0) {
+                // write either the first or last bytes only
+                long p = Math.min(Math.abs(RAND.nextLong()), length - 1);
+                pos = RAND.nextBoolean() ? p : length - 1 - p;
+            }
+            fc.position(pos);
+            int bufLength = Math.min(32768, (int)Math.min(length - pos, BIG_LENGTH));
             byte[] buf = new byte[bufLength];
-            while (written < length) {
+            while (pos < length) {
                 RAND.nextBytes(buf);
-                int len = (int)Math.min(bufLength, length - written);
-                raf.write(buf, 0, len);
-                written += len;
+                int len = (int)Math.min(bufLength, length - pos);
+                pos += fc.write(ByteBuffer.wrap(buf, 0, len));
             }
         }
         return file;


### PR DESCRIPTION
This request would increase the amount of heap memory that the test can use, and decrease execution time by not writing the entirety of test files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277361](https://bugs.openjdk.java.net/browse/JDK-8277361): java/nio/channels/Channels/ReadXBytes.java   fails with OOM error


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to f606ce8cd32dd805c06ad6e2ff4399deff63f7d2
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to f606ce8cd32dd805c06ad6e2ff4399deff63f7d2


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6732/head:pull/6732` \
`$ git checkout pull/6732`

Update a local copy of the PR: \
`$ git checkout pull/6732` \
`$ git pull https://git.openjdk.java.net/jdk pull/6732/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6732`

View PR using the GUI difftool: \
`$ git pr show -t 6732`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6732.diff">https://git.openjdk.java.net/jdk/pull/6732.diff</a>

</details>
