### PR TITLE
8275233: Incorrect line number reported in exception stack trace thrown from a lambda expression

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -165,9 +165,14 @@ public class LambdaToMethod extends TreeTranslator {
         dumpLambdaToMethodStats = options.isSet("debug.dumpLambdaToMethodStats");
         attr = Attr.instance(context);
         forceSerializable = options.isSet("forceSerializable");
-        debugLinesOrVars = options.isSet(Option.G)
-                || options.isSet(Option.G_CUSTOM, "lines")
-                || options.isSet(Option.G_CUSTOM, "vars");
+        boolean lineDebugInfo =
+            options.isUnset(Option.G_CUSTOM) ||
+            options.isSet(Option.G_CUSTOM, "lines");
+        boolean varDebugInfo =
+            options.isUnset(Option.G_CUSTOM)
+            ? options.isSet(Option.G)
+            : options.isSet(Option.G_CUSTOM, "vars");
+        debugLinesOrVars = lineDebugInfo || varDebugInfo;
         verboseDeduplication = options.isSet("debug.dumpLambdaToMethodDeduplication");
         deduplicateLambdas = options.getBoolean("deduplicateLambdas", true);
         nestmateLambdas = Target.instance(context).runtimeUseNestAccess();

--- a/test/langtools/tools/javac/diags/examples/LambdaDeduplicate.java
+++ b/test/langtools/tools/javac/diags/examples/LambdaDeduplicate.java
@@ -23,7 +23,7 @@
 
 
 // key: compiler.note.verbose.l2m.deduplicate
-// options: --debug=dumpLambdaToMethodDeduplication
+// options: -g:none --debug=dumpLambdaToMethodDeduplication
 
 import java.util.function.Function;
 

--- a/test/langtools/tools/javac/lambda/deduplication/DeduplicationDebugInfo.java
+++ b/test/langtools/tools/javac/lambda/deduplication/DeduplicationDebugInfo.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, Google LLC. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test 8275233
+ * @summary Incorrect line number reported in exception stack trace thrown from a lambda expression
+ * @compile/ref=DeduplicationDebugInfo.out           -XDrawDiagnostics -XDdebug.dumpLambdaToMethodDeduplication -g:none        DeduplicationDebugInfo.java
+ * @compile/ref=DeduplicationDebugInfo_none.out      -XDrawDiagnostics -XDdebug.dumpLambdaToMethodDeduplication                DeduplicationDebugInfo.java
+ * @compile/ref=DeduplicationDebugInfo_none.out      -XDrawDiagnostics -XDdebug.dumpLambdaToMethodDeduplication -g:lines       DeduplicationDebugInfo.java
+ * @compile/ref=DeduplicationDebugInfo_none.out      -XDrawDiagnostics -XDdebug.dumpLambdaToMethodDeduplication -g:vars        DeduplicationDebugInfo.java
+ * @compile/ref=DeduplicationDebugInfo_none.out      -XDrawDiagnostics -XDdebug.dumpLambdaToMethodDeduplication -g:lines,vars  DeduplicationDebugInfo.java
+ */
+
+import java.util.function.Function;
+
+class DeduplicationDebugInfoTest {
+    void f() {
+        Function<Object, Integer> f = x -> x.hashCode();
+        Function<Object, Integer> g = x -> x.hashCode();
+    }
+}

--- a/test/langtools/tools/javac/lambda/deduplication/DeduplicationDebugInfo.out
+++ b/test/langtools/tools/javac/lambda/deduplication/DeduplicationDebugInfo.out
@@ -1,0 +1,1 @@
+DeduplicationDebugInfo.java:39:39: compiler.note.verbose.l2m.deduplicate: lambda$f$0(java.lang.Object)

--- a/test/langtools/tools/javac/lambda/deduplication/DeduplicationTest.java
+++ b/test/langtools/tools/javac/lambda/deduplication/DeduplicationTest.java
@@ -93,6 +93,7 @@ public class DeduplicationTest {
                         Arrays.asList(
                                 "-d",
                                 ".",
+                                "-g:none",
                                 "-XDdebug.dumpLambdaToMethodDeduplication",
                                 "-XDdebug.dumpLambdaToMethodStats"),
                         null,


### PR DESCRIPTION
This change fixes a bug introduced in [JDK-8200301](https://bugs.openjdk.java.net/browse/JDK-8200301), which tries to check if line or variable debug info is generated, but fails to consider that line debug info is generated if no `-g` or `-g:` options are passed.

The new check is consistent with the handling of lines in e.g.

* https://github.com/openjdk/jdk/blob/17ceef97c3df2326d585b2a298e5daa5dcfe3d99/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java#L421-L422
* https://github.com/openjdk/jdk/blob/fe89dd3b0d47807c7dbfe24d17f6aca152fc8908/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java#L118-L120

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275233](https://bugs.openjdk.java.net/browse/JDK-8275233): Incorrect line number reported in exception stack trace thrown from a lambda expression


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6733/head:pull/6733` \
`$ git checkout pull/6733`

Update a local copy of the PR: \
`$ git checkout pull/6733` \
`$ git pull https://git.openjdk.java.net/jdk pull/6733/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6733`

View PR using the GUI difftool: \
`$ git pr show -t 6733`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6733.diff">https://git.openjdk.java.net/jdk/pull/6733.diff</a>

</details>
