### PR TITLE
JDK-8278309: [windows] use of uninitialized OSThread::_state

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -675,6 +675,8 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
   if (osthread == NULL) {
     return false;
   }
+
+  // Initial state is ALLOCATED but not INITIALIZED
   osthread->set_state(ALLOCATED);
 
   // Initialize the JDK library's interrupt event.

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -780,7 +780,7 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
   osthread->set_thread_handle(thread_handle);
   osthread->set_thread_id(thread_id);
 
-  // Initial thread state is INITIALIZED, not SUSPENDED
+  // Thread state now is INITIALIZED, not SUSPENDED
   osthread->set_state(INITIALIZED);
 
   // The thread is returned suspended (in state INITIALIZED), and is started higher up in the call chain

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -675,6 +675,7 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
   if (osthread == NULL) {
     return false;
   }
+  osthread->set_state(ALLOCATED);
 
   // Initialize the JDK library's interrupt event.
   // This should really be done when OSThread is constructed,


### PR DESCRIPTION
May I have reviews for this trivial fix.

On Windows, we use `OSThread::_state` in `os::create_thread` before it has been initialized. This causes an assert to fire in `Thread::is_JavaThread_protected` (`assert(target->is_handshake_safe_for(current_thread)`)

This only happens if the following is true:
- We log os=info level, thereby firing the "Thread started.." log output the parent thread of a newly started child thread writes. Since JDK-8268773, we also print the thread name. `Thread::name()` uses `Thread::is_JavaThread_protected`, but on Windows, the thread state has not been set yet.
- This is an assert, so only debug, but in debug newly malloced memory is poisoned with "F1F1F1F1...", which hides the error since `Thread::is_JavaThread_protected` compares the thread state like this:
```
  if (target->osthread() == NULL || target->osthread()->get_state() <= INITIALIZED) {
    return true;
  }
```
and the compiler interprets the "F1F1F1F1" as a negative large value. Changing the init pattern to 0x01, or adding an explicit cast to unsigned, causes the assert to fire as soon as logging is switched on.

---

Musings:

I wondered whether we should change the thread state comparison to unsigned like this:
```
  if (target->osthread() == NULL || (unsigned)target->osthread()->get_state() <= INITIALIZED) {
```
which would have shown the error right away after JDK-8268773. This is matter of taste though since one could say that at this point we expect the enum to be filled correctly with one of its values, and guarding against uninitialized memory should belong somewhere else, maybe in a debug-only verify function.

--

Just my personal opinion, but `OSThread` could do with a bit of cleanup. E.g. using an initializer list to init its values, and possibly doing the per-platform-factoring out in a different way. That include-file-in-the-middle-of-class composition technique is terrible. It confuses IDEs and makes analyzing the code difficult, and the code is not really difficult in what it does.

----

Tests: GHAs (twice, once with experimentally set init word to 1 to see that the patch works)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278309](https://bugs.openjdk.java.net/browse/JDK-8278309): [windows] use of uninitialized OSThread::_state


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to f7e72498f5f227f283d1df01574e9d7f1ae8fb9e
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to e85638e2c8c33a18f1476e272a41a958729b9f90


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6734/head:pull/6734` \
`$ git checkout pull/6734`

Update a local copy of the PR: \
`$ git checkout pull/6734` \
`$ git pull https://git.openjdk.java.net/jdk pull/6734/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6734`

View PR using the GUI difftool: \
`$ git pr show -t 6734`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6734.diff">https://git.openjdk.java.net/jdk/pull/6734.diff</a>

</details>
