### PR TITLE
8278158: jwebserver should set request timeout

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/JWebServer.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/JWebServer.java
@@ -28,11 +28,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Programmatic entry point to start the jwebserver tool.
- *
- * <p><b> This is NOT part of any supported API.
- * If you write code that depends on this, you do so at your own risk.
- * This code and its internal interface are subject to change or deletion
- * without notice.</b>
  */
 public class JWebServer {
 
@@ -51,16 +46,32 @@ public class JWebServer {
      * or an I/O error occurs, the server is not started and this method invokes
      * System::exit with an appropriate exit code.
      *
+     * <p> If the system property "sun.net.httpserver.maxReqTime" has not been
+     * set by the user, it is set to a value of 5 seconds. This is to prevent
+     * the server from hanging indefinitely, for example in the case of an HTTPS
+     * request.
+     *
      * @param args the command-line options
      * @throws NullPointerException if {@code args} is {@code null}, or if there
      *         are any {@code null} values in the {@code args} array
      */
     public static void main(String... args) {
+        setMaxReqTime();
+
         int ec = SimpleFileServerImpl.start(new PrintWriter(System.out, true, UTF_8), "jwebserver", args);
         if (ec != 0) {
             System.exit(ec);
         }  // otherwise, the server has either been started successfully and
            // runs in another non-daemon thread, or -h or -version have been
            // passed and the main thread has exited normally.
+    }
+
+    public static final String MAXREQTIME_KEY = "sun.net.httpserver.maxReqTime";
+    public static final String MAXREQTIME_VAL = "5";
+
+    private static void setMaxReqTime() {
+        if (System.getProperty(MAXREQTIME_KEY) == null) {
+            System.setProperty(MAXREQTIME_KEY, MAXREQTIME_VAL);
+        }
     }
 }

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/Main.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/Main.java
@@ -28,11 +28,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Programmatic entry point to start "java -m jdk.httpserver".
- *
- * <p><b> This is NOT part of any supported API.
- * If you write code that depends on this, you do so at your own risk.
- * This code and its internal interface are subject to change or deletion
- * without notice.</b>
  */
 public class Main {
 
@@ -51,16 +46,32 @@ public class Main {
      * or an I/O error occurs, the server is not started and this method invokes
      * System::exit with an appropriate exit code.
      *
+     * <p> If the system property "sun.net.httpserver.maxReqTime" has not been
+     * set by the user, it is set to a value of 5 seconds. This is to prevent
+     * the server from hanging indefinitely, for example in the case of an HTTPS
+     * request.
+     *
      * @param args the command-line options
      * @throws NullPointerException if {@code args} is {@code null}, or if there
      *         are any {@code null} values in the {@code args} array
      */
     public static void main(String... args) {
+        setMaxReqTime();
+
         int ec = SimpleFileServerImpl.start(new PrintWriter(System.out, true, UTF_8), "java", args);
         if (ec != 0) {
             System.exit(ec);
         }  // otherwise, the server has either been started successfully and
            // runs in another non-daemon thread, or -h or -version have been
            // passed and the main thread has exited normally.
+    }
+
+    public static final String MAXREQTIME_KEY = "sun.net.httpserver.maxReqTime";
+    public static final String MAXREQTIME_VAL = "5";
+
+    private static void setMaxReqTime() {
+        if (System.getProperty(MAXREQTIME_KEY) == null) {
+            System.setProperty(MAXREQTIME_KEY, MAXREQTIME_VAL);
+        }
     }
 }


### PR DESCRIPTION
This change sets a maximum request time for the `jwebserver` (and `java -m jdk.httpserver`), unless it has already been set. 

While here, I removed a comment from the implementation classes, a left-over from the pre-module era that is not needed and should not have been included in the first place.

Testing: tier 1-3, and manual testing to confirm a request fails after the given time, e.g.:
```
$ curl https://127.0.0.1:8000
curl: (35) LibreSSL SSL_connect: SSL_ERROR_SYSCALL in connection to 127.0.0.1:8000
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278158](https://bugs.openjdk.java.net/browse/JDK-8278158): jwebserver should set request timeout


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Michael McMahon](https://openjdk.java.net/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6737/head:pull/6737` \
`$ git checkout pull/6737`

Update a local copy of the PR: \
`$ git checkout pull/6737` \
`$ git pull https://git.openjdk.java.net/jdk pull/6737/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6737`

View PR using the GUI difftool: \
`$ git pr show -t 6737`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6737.diff">https://git.openjdk.java.net/jdk/pull/6737.diff</a>

</details>
