### PR TITLE
8278302: [s390] Implement fast-path for ASCII-compatible CharsetEncoders

### DIFF
--- a/src/hotspot/cpu/s390/c2_MacroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c2_MacroAssembler_s390.cpp
@@ -83,6 +83,7 @@ unsigned int C2_MacroAssembler::string_compress(Register result, Register src, R
     }
   } else {
     BLOCK_COMMENT("string_compress {");
+    assert(!toASCII, "Can't compress strings to 7-bit ASCII");
   }
   int  block_start = offset();
 

--- a/src/hotspot/cpu/s390/c2_MacroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c2_MacroAssembler_s390.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/s390/c2_MacroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/c2_MacroAssembler_s390.hpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/s390/c2_MacroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/c2_MacroAssembler_s390.hpp
@@ -38,7 +38,7 @@
   //   Early clobber: result.
   //   Boolean precise controls accuracy of result value.
   unsigned int string_compress(Register result, Register src, Register dst, Register cnt,
-                               Register tmp,    bool precise);
+                               Register tmp,    bool precise, bool toASCII);
 
   // Inflate byte[] to char[].
   unsigned int string_inflate_trot(Register src, Register dst, Register cnt, Register tmp);

--- a/src/hotspot/cpu/s390/matcher_s390.hpp
+++ b/src/hotspot/cpu/s390/matcher_s390.hpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/s390/matcher_s390.hpp
+++ b/src/hotspot/cpu/s390/matcher_s390.hpp
@@ -153,6 +153,6 @@
   }
 
   // Implements a variant of EncodeISOArrayNode that encode ASCII only
-  static const bool supports_encode_ascii_array = false;
+  static const bool supports_encode_ascii_array = true;
 
 #endif // CPU_S390_MATCHER_S390_HPP

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -1,6 +1,6 @@
 //
-// Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
-// Copyright (c) 2017, 2020 SAP SE. All rights reserved.
+// Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2017, 2022 SAP SE. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -10230,7 +10230,7 @@ instruct string_compress(iRegP src, iRegP dst, iRegI result, iRegI len, iRegI tm
   format %{ "String Compress $src->$dst($len) -> $result" %}
   ins_encode %{
     __ string_compress($result$$Register, $src$$Register, $dst$$Register, $len$$Register,
-                       $tmp$$Register, false);
+                       $tmp$$Register, false, false);
   %}
   ins_pipe(pipe_class_dummy);
 %}
@@ -10291,10 +10291,24 @@ instruct encode_iso_array(iRegP src, iRegP dst, iRegI result, iRegI len, iRegI t
   match(Set result (EncodeISOArray src (Binary dst len)));
   effect(TEMP_DEF result, TEMP tmp, KILL cr); // R0, R1 are killed, too.
   ins_cost(300);
-  format %{ "Encode array $src->$dst($len) -> $result" %}
+  format %{ "Encode iso array $src->$dst($len) -> $result" %}
   ins_encode %{
     __ string_compress($result$$Register, $src$$Register, $dst$$Register, $len$$Register,
-                       $tmp$$Register, true);
+                       $tmp$$Register, true, false);
+  %}
+  ins_pipe(pipe_class_dummy);
+%}
+
+// encode char[] to byte[] in ASCII
+instruct encode_ascii_array(iRegP src, iRegP dst, iRegI result, iRegI len, iRegI tmp, flagsReg cr) %{
+  predicate(((EncodeISOArrayNode*)n)->is_ascii());
+  match(Set result (EncodeISOArray src (Binary dst len)));
+  effect(TEMP_DEF result, TEMP tmp, KILL cr); // R0, R1 are killed, too.
+  ins_cost(300);
+  format %{ "Encode ascii array $src->$dst($len) -> $result" %}
+  ins_encode %{
+    __ string_compress($result$$Register, $src$$Register, $dst$$Register, $len$$Register,
+                       $tmp$$Register, true, true);
   %}
   ins_pipe(pipe_class_dummy);
 %}


### PR DESCRIPTION
This pull request contains the s390x variant of the fast-path for ASCII-compatible CharsetEncoders. 

The intrinsic implementation is pretty much similar to that of PPC64. Compared to the previously existing intrinsic implementation, changes to program logic are minimal. There is a new match rule for ascii strings and the bit mask used to detect invalid bits in the string characters is set depending on the target charset: 0xff00 for ISO, 0xff80 for ascii.

**Request:** SAP does not maintain a full build and test infrastructure for s390x anymore. Could somebody please test this PR on s390x? At least build and tier1 tests, the more the better. Thank you!

With my private testing (some microbenchmarks, some SPEC benchmarks) I could not find any issues. With the fast-path active I see a 2x, sometime 2.5x, improvement of CharsetEncodeDecode.encode. 

**Without the fast-path patch:**
```
CharsetEncodeDecode.encode   16384        UTF-8  avgt   30  16.350 ± 0.067  us/op
CharsetEncodeDecode.encode   16384         BIG5  avgt   30  15.972 ± 0.136  us/op
CharsetEncodeDecode.encode   16384  ISO-8859-15  avgt   30  14.372 ± 0.110  us/op
CharsetEncodeDecode.encode   16384        ASCII  avgt   30  14.287 ± 0.051  us/op
```

**With the fast-path patch:**
```
CharsetEncodeDecode.encode   16384        UTF-8  avgt   30   6.833 ± 0.064  us/op
CharsetEncodeDecode.encode   16384         BIG5  avgt   30   8.195 ± 0.059  us/op
CharsetEncodeDecode.encode   16384  ISO-8859-15  avgt   30   6.387 ± 0.149  us/op
CharsetEncodeDecode.encode   16384        ASCII  avgt   30   6.321 ± 0.049  us/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278302](https://bugs.openjdk.java.net/browse/JDK-8278302): [s390] Implement fast-path for ASCII-compatible CharsetEncoders


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to 4326bf93de4dd76edd78cee044e2a2b44a2822d2
 * @backwaterred (no known github.com user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6738/head:pull/6738` \
`$ git checkout pull/6738`

Update a local copy of the PR: \
`$ git checkout pull/6738` \
`$ git pull https://git.openjdk.java.net/jdk pull/6738/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6738`

View PR using the GUI difftool: \
`$ git pr show -t 6738`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6738.diff">https://git.openjdk.java.net/jdk/pull/6738.diff</a>

</details>
