### PR TITLE
8278068: Fix next-line modifier (snippet markup)

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets.properties
@@ -373,6 +373,8 @@ doclet.snippet.contents.mismatch=\
 doclet.snippet.markup=\
  snippet markup: {0}
 
+doclet.snippet.markup.spurious=\
+  spurious markup
 doclet.snippet.markup.attribute.absent=\
   missing attribute "{0}"
 doclet.snippet.markup.attribute.simultaneous.use=\

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SnippetTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SnippetTaglet.java
@@ -269,7 +269,7 @@ public class SnippetTaglet extends BaseTaglet {
         StyledText externalSnippet = null;
 
         try {
-            Diag d = (text, pos) -> {
+            Diags d = (text, pos) -> {
                 var path = writer.configuration().utils.getCommentHelper(holder)
                         .getDocTreePath(snippetTag.getBody());
                 writer.configuration().getReporter().print(Diagnostic.Kind.WARNING,
@@ -291,7 +291,7 @@ public class SnippetTaglet extends BaseTaglet {
 
         try {
             var finalFileObject = fileObject;
-            Diag d = (text, pos) -> writer.configuration().getMessages().warning(finalFileObject, pos, pos, pos, text);
+            Diags d = (text, pos) -> writer.configuration().getMessages().warning(finalFileObject, pos, pos, pos, text);
             if (externalContent != null) {
                 externalSnippet = parse(writer.configuration().getDocResources(), d, language, externalContent);
             }
@@ -371,13 +371,13 @@ public class SnippetTaglet extends BaseTaglet {
                """.formatted(inline, external);
     }
 
-    private StyledText parse(Resources resources, Diag diag, Optional<Language> language, String content) throws ParseException {
-        Parser.Result result = new Parser(resources).parse(diag, language, content);
+    private StyledText parse(Resources resources, Diags diags, Optional<Language> language, String content) throws ParseException {
+        Parser.Result result = new Parser(resources).parse(diags, language, content);
         result.actions().forEach(Action::perform);
         return result.text();
     }
 
-    public interface Diag {
+    public interface Diags {
         void warn(String text, int pos);
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SnippetTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SnippetTaglet.java
@@ -269,8 +269,14 @@ public class SnippetTaglet extends BaseTaglet {
         StyledText externalSnippet = null;
 
         try {
+            Diag d = (text, pos) -> {
+                var path = writer.configuration().utils.getCommentHelper(holder)
+                        .getDocTreePath(snippetTag.getBody());
+                writer.configuration().getReporter().print(Diagnostic.Kind.WARNING,
+                        path, pos, pos, pos, text);
+            };
             if (inlineContent != null) {
-                inlineSnippet = parse(writer.configuration().getDocResources(), language, inlineContent);
+                inlineSnippet = parse(writer.configuration().getDocResources(), d, language, inlineContent);
             }
         } catch (ParseException e) {
             var path = writer.configuration().utils.getCommentHelper(holder)
@@ -284,8 +290,10 @@ public class SnippetTaglet extends BaseTaglet {
         }
 
         try {
+            var finalFileObject = fileObject;
+            Diag d = (text, pos) -> writer.configuration().getMessages().warning(finalFileObject, pos, pos, pos, text);
             if (externalContent != null) {
-                externalSnippet = parse(writer.configuration().getDocResources(), language, externalContent);
+                externalSnippet = parse(writer.configuration().getDocResources(), d, language, externalContent);
             }
         } catch (ParseException e) {
             assert fileObject != null;
@@ -363,10 +371,14 @@ public class SnippetTaglet extends BaseTaglet {
                """.formatted(inline, external);
     }
 
-    private StyledText parse(Resources resources, Optional<Language> language, String content) throws ParseException {
-        Parser.Result result = new Parser(resources).parse(language, content);
+    private StyledText parse(Resources resources, Diag diag, Optional<Language> language, String content) throws ParseException {
+        Parser.Result result = new Parser(resources).parse(diag, language, content);
         result.actions().forEach(Action::perform);
         return result.text();
+    }
+
+    public interface Diag {
+        void warn(String text, int pos);
     }
 
     private static String stringValueOf(AttributeTree at) throws BadSnippetException {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/snippet/Parser.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/snippet/Parser.java
@@ -94,19 +94,19 @@ public final class Parser {
         this.markupParser = new MarkupParser(resources);
     }
 
-    public Result parse(SnippetTaglet.Diag d, Optional<SnippetTaglet.Language> language, String source) throws ParseException {
+    public Result parse(SnippetTaglet.Diags diags, Optional<SnippetTaglet.Language> language, String source) throws ParseException {
         SnippetTaglet.Language lang = language.orElse(SnippetTaglet.Language.JAVA);
         var p = switch (lang) {
             case JAVA -> JAVA_COMMENT;
             case PROPERTIES -> PROPERTIES_COMMENT;
         };
-        return parse(d, p, source);
+        return parse(diags, p, source);
     }
 
     /*
      * Newline characters in the returned text are of the \n form.
      */
-    private Result parse(SnippetTaglet.Diag d, Pattern commentPattern, String source) throws ParseException {
+    private Result parse(SnippetTaglet.Diags diags, Pattern commentPattern, String source) throws ParseException {
         Objects.requireNonNull(commentPattern);
         Objects.requireNonNull(source);
 
@@ -166,7 +166,7 @@ public final class Parser {
                     }
                 }
                 if (parsedTags.isEmpty()) { // (2)
-                    d.warn(resources.getText("doclet.snippet.markup.spurious"), next.offset() + markedUpLine.start("markup"));
+                    diags.warn(resources.getText("doclet.snippet.markup.spurious"), next.offset() + markedUpLine.start("markup"));
                     line = rawLine + (addLineTerminator ? "\n" : "");
                 } else { // (3)
                     hasMarkup = true;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/snippet/Parser.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/snippet/Parser.java
@@ -94,19 +94,19 @@ public final class Parser {
         this.markupParser = new MarkupParser(resources);
     }
 
-    public Result parse(Optional<SnippetTaglet.Language> language, String source) throws ParseException {
+    public Result parse(SnippetTaglet.Diag d, Optional<SnippetTaglet.Language> language, String source) throws ParseException {
         SnippetTaglet.Language lang = language.orElse(SnippetTaglet.Language.JAVA);
         var p = switch (lang) {
             case JAVA -> JAVA_COMMENT;
             case PROPERTIES -> PROPERTIES_COMMENT;
         };
-        return parse(p, source);
+        return parse(d, p, source);
     }
 
     /*
      * Newline characters in the returned text are of the \n form.
      */
-    private Result parse(Pattern commentPattern, String source) throws ParseException {
+    private Result parse(SnippetTaglet.Diag d, Pattern commentPattern, String source) throws ParseException {
         Objects.requireNonNull(commentPattern);
         Objects.requireNonNull(source);
 
@@ -166,7 +166,7 @@ public final class Parser {
                     }
                 }
                 if (parsedTags.isEmpty()) { // (2)
-                    // TODO: log this with NOTICE;
+                    d.warn(resources.getText("doclet.snippet.markup.spurious"), next.offset() + markedUpLine.start("markup"));
                     line = rawLine + (addLineTerminator ? "\n" : "");
                 } else { // (3)
                     hasMarkup = true;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/snippet/Parser.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/snippet/Parser.java
@@ -150,7 +150,7 @@ public final class Parser {
                     parsedTags = markupParser.parse(maybeMarkup);
                 } catch (ParseException e) {
                     // translate error position from markup to file line
-                    throw new ParseException(e::getMessage, markedUpLine.start("markup") + e.getPosition());
+                    throw new ParseException(e::getMessage, next.offset() + markedUpLine.start("markup") + e.getPosition());
                 }
                 for (Tag t : parsedTags) {
                     t.lineSourceOffset = next.offset();

--- a/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetTag.java
@@ -2418,11 +2418,12 @@ error: snippet markup: invalid attribute value
                 /* ---------------------- */
                 new TestCase("""
 {@snippet :
-    hello // @highlight substring="
+    hello
+    there // @highlight substring="
 }""",
                              """
 error: snippet markup: unterminated attribute value
-    hello // @highlight substring="
+    there // @highlight substring="
                                   ^
                              """),
                 new TestCase("""


### PR DESCRIPTION
This PR fixes three interrelated issues:

  * https://bugs.openjdk.java.net/browse/JDK-8277027
  * https://bugs.openjdk.java.net/browse/JDK-8278068
  * An accidentally found bug in markup diagnostics

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8278068](https://bugs.openjdk.java.net/browse/JDK-8278068): Fix next-line modifier (snippet markup)
 * [JDK-8277027](https://bugs.openjdk.java.net/browse/JDK-8277027): Treat unrecognized markup as snippet text, but warn about it


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6739/head:pull/6739` \
`$ git checkout pull/6739`

Update a local copy of the PR: \
`$ git checkout pull/6739` \
`$ git pull https://git.openjdk.java.net/jdk pull/6739/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6739`

View PR using the GUI difftool: \
`$ git pr show -t 6739`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6739.diff">https://git.openjdk.java.net/jdk/pull/6739.diff</a>

</details>
