### PR TITLE
8278339: ServerSocket::isClosed may return false after accept throws

### DIFF
--- a/src/java.base/share/classes/java/net/ServerSocket.java
+++ b/src/java.base/share/classes/java/net/ServerSocket.java
@@ -711,15 +711,12 @@ public class ServerSocket implements java.io.Closeable {
     public void close() throws IOException {
         synchronized (stateLock) {
             if (!closed) {
-                try {
-                    // close underlying socket if created
-                    if (created) {
-                        impl.close();
-                    }
-                } finally {
-                    closed = true;
-                }
+                closed = true;
 
+                // close underlying socket if created
+                if (created) {
+                    impl.close();
+                }
             }
         }
     }

--- a/test/jdk/java/net/ServerSocket/IsClosedAfterAsyncClose.java
+++ b/test/jdk/java/net/ServerSocket/IsClosedAfterAsyncClose.java
@@ -24,7 +24,7 @@
 /**
  * @test
  * @bug 8278339
- * @summary Test that ServerSocket::isClosed returns false after async close
+ * @summary Test that ServerSocket::isClosed returns true after async close
  */
 
 import java.io.IOException;

--- a/test/jdk/java/net/ServerSocket/IsClosedAfterAsyncClose.java
+++ b/test/jdk/java/net/ServerSocket/IsClosedAfterAsyncClose.java
@@ -69,7 +69,7 @@ public class IsClosedAfterAsyncClose {
                     }
                 } catch (IOException ioe) {
                     if (!listener.isClosed()) {
-                        throw new RuntimeException("isClosed returned true!!");
+                        throw new RuntimeException("isClosed returned false!!");
                     }
                 } finally {
                     closer.join();

--- a/test/jdk/java/net/ServerSocket/IsClosedAfterAsyncClose.java
+++ b/test/jdk/java/net/ServerSocket/IsClosedAfterAsyncClose.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8278339
+ * @summary Test that ServerSocket::isClosed returns false after async close
+ */
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+public class IsClosedAfterAsyncClose {
+
+    private static final int ITERATIONS = 100;
+
+    public static void main(String[] args) throws Exception {
+        for (int i = 0; i < ITERATIONS; i++) {
+            System.out.printf("Test %d...%n", i);
+
+            // create listener bound to the loopback address
+            ServerSocket listener = new ServerSocket();
+            InetAddress loopback = InetAddress.getLoopbackAddress();
+            listener.bind(new InetSocketAddress(loopback, 0));
+
+            // task to close listener after a delay
+            Runnable closeListener = () -> {
+                try {
+                    Thread.sleep(100);
+                    listener.close();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            };
+
+            // main thread blocks in accept. When listener is closed then accept
+            // should wakeup with an IOException and isClosed should be true.
+            try (listener) {
+                Thread closer = new Thread(closeListener);
+                closer.start();
+                try {
+                    while (true) {
+                        Socket s = listener.accept();
+                        // close spurious connection
+                        s.close();
+                    }
+                } catch (IOException ioe) {
+                    if (!listener.isClosed()) {
+                        throw new RuntimeException("isClosed returned true!!");
+                    }
+                } finally {
+                    closer.join();
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
JDK-8278270 introduces a small regression. If a ServerSocket is closed while another thread is blocked in the accept method then the other thread may observe isClosed returning false, i.e. code may catch IOException and check isClosed before the "closed" flag gets to true.

I've changed the close method to set the "closed" flag before closing the underlying impl. This is consistent with the network channels and also consistent with async close where the close completes on the thread that was blocked in accept. The change also prevents re-attempting the underlying impl in the unlikely event that it fails(an area that is completed unspecified). Overall I think this is preferable to have add synchronization to isClosed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278339](https://bugs.openjdk.java.net/browse/JDK-8278339): ServerSocket::isClosed may return false after accept throws


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6741/head:pull/6741` \
`$ git checkout pull/6741`

Update a local copy of the PR: \
`$ git checkout pull/6741` \
`$ git pull https://git.openjdk.java.net/jdk pull/6741/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6741`

View PR using the GUI difftool: \
`$ git pr show -t 6741`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6741.diff">https://git.openjdk.java.net/jdk/pull/6741.diff</a>

</details>
