### PR TITLE
Consume less memory in reflection by introducing Executable.parameterType(int) and usage of Executable.getParamerterCount()/getSharedParameterTypes()

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleProxies.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleProxies.java
@@ -284,7 +284,7 @@ public class MethodHandleProxies {
                                && m.getParameterCount() == 0;
             case "equals"   -> m.getReturnType() == boolean.class
                                && m.getParameterCount() == 1
-                               && m.getParameterTypes()[0] == Object.class;
+                               && m.parameterType(0) == Object.class;
             default -> false;
         };
     }

--- a/src/java.base/share/classes/java/lang/reflect/Constructor.java
+++ b/src/java.base/share/classes/java/lang/reflect/Constructor.java
@@ -371,7 +371,7 @@ public final class Constructor<T> extends Executable {
         sb.append(getDeclaringClass().getTypeName());
         sb.append('(');
         StringJoiner sj = new StringJoiner(",");
-        for (Class<?> parameterType : getParameterTypes()) {
+        for (Class<?> parameterType : getSharedParameterTypes()) {
             sj.add(parameterType.getTypeName());
         }
         sb.append(sj);

--- a/src/java.base/share/classes/java/lang/reflect/Executable.java
+++ b/src/java.base/share/classes/java/lang/reflect/Executable.java
@@ -30,7 +30,6 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
-import java.util.stream.Stream;
 import java.util.stream.Collectors;
 
 import jdk.internal.access.SharedSecrets;
@@ -258,6 +257,16 @@ public abstract sealed class Executable extends AccessibleObject
     }
 
     /**
+     * Returns the parameter type at the specified index, within this method.
+     * @param index the index (zero-based) of the desired parameter type
+     * @return the selected parameter type
+     */
+    public Class<?> parameterType(int index) {
+        Objects.checkIndex(index, getParameterCount());
+        return getSharedParameterTypes()[index];
+    }
+
+    /**
      * Returns an array of {@code Type} objects that represent the
      * formal parameter types, in declaration order, of the executable
      * represented by this object. An array of length 0 is returned if the
@@ -311,11 +320,11 @@ public abstract sealed class Executable extends AccessibleObject
         // this case, we just return the result of
         // getParameterTypes().
         if (!genericInfo) {
-            return getParameterTypes();
+            return getSharedParameterTypes();
         } else {
             final boolean realParamData = hasRealParameterData();
             final Type[] genericParamTypes = getGenericParameterTypes();
-            final Type[] nonGenericParamTypes = getParameterTypes();
+            final Type[] nonGenericParamTypes = getSharedParameterTypes();
             // If we have real parameter data, then we use the
             // synthetic and mandate flags to our advantage.
             if (realParamData) {
@@ -326,7 +335,7 @@ public abstract sealed class Executable extends AccessibleObject
                     final Parameter param = params[i];
                     if (param.isSynthetic() || param.isImplicit()) {
                         // If we hit a synthetic or mandated parameter,
-                        // use the non generic parameter info.
+                        // use the non-generic parameter info.
                         out[i] = nonGenericParamTypes[i];
                     } else {
                         // Otherwise, use the generic parameter info.

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -431,7 +431,7 @@ public final class Method extends Executable {
 
     String toShortSignature() {
         StringJoiner sj = new StringJoiner(",", getName() + "(", ")");
-        for (Class<?> parameterType : getParameterTypes()) {
+        for (Class<?> parameterType : getSharedParameterTypes()) {
             sj.add(parameterType.getTypeName());
         }
         return sj.toString();

--- a/src/java.base/share/classes/java/lang/reflect/Parameter.java
+++ b/src/java.base/share/classes/java/lang/reflect/Parameter.java
@@ -219,7 +219,7 @@ public final class Parameter implements AnnotatedElement {
     public Class<?> getType() {
         Class<?> tmp = parameterClassCache;
         if (null == tmp) {
-            tmp = executable.getParameterTypes()[index];
+            tmp = executable.parameterType(index);
             parameterClassCache = tmp;
         }
         return tmp;

--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinTask.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinTask.java
@@ -550,10 +550,9 @@ public abstract class ForkJoinTask<V> implements Future<V>, Serializable {
             try {
                 Constructor<?> noArgCtor = null, oneArgCtor = null;
                 for (Constructor<?> c : ex.getClass().getConstructors()) {
-                    Class<?>[] ps = c.getParameterTypes();
-                    if (ps.length == 0)
+                    if (c.getParameterCount() == 0)
                         noArgCtor = c;
-                    else if (ps.length == 1 && ps[0] == Throwable.class) {
+                    else if (c.getParameterCount() == 1 && c.parameterType(0) == Throwable.class) {
                         oneArgCtor = c;
                         break;
                     }

--- a/src/java.base/share/classes/java/util/random/RandomGeneratorFactory.java
+++ b/src/java.base/share/classes/java/util/random/RandomGeneratorFactory.java
@@ -295,12 +295,12 @@ public final class RandomGeneratorFactory<T extends RandomGenerator> {
                         for (Constructor<?> ctorGeneric : ctors) {
                             @SuppressWarnings("unchecked")
                             Constructor<T> ctorSpecific = (Constructor<T>) ctorGeneric;
-                            final Class<?>[] parameterTypes = ctorSpecific.getParameterTypes();
+                            int ctorSpecificParameterCount = ctorSpecific.getParameterCount();
 
-                            if (parameterTypes.length == 0) {
+                            if (ctorSpecificParameterCount == 0) {
                                 tmpCtor = ctorSpecific;
-                            } else if (parameterTypes.length == 1) {
-                                Class<?> argType = parameterTypes[0];
+                            } else if (ctorSpecificParameterCount == 1) {
+                                Class<?> argType = ctorSpecific.parameterType(0);
 
                                 if (argType == long.class) {
                                     tmpCtorLong = ctorSpecific;

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleAccessorFactory.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleAccessorFactory.java
@@ -323,7 +323,7 @@ final class MethodHandleAccessorFactory {
         // the native accessor.
         int paramCount = member.getParameterCount();
         if (member.isVarArgs() &&
-                (paramCount == 0 || !(member.getParameterTypes()[paramCount-1].isArray()))) {
+                (paramCount == 0 || !(member.parameterType(paramCount-1).isArray()))) {
             return true;
         }
         // A method handle cannot be created if its type has an arity >= 255

--- a/src/java.base/share/classes/sun/reflect/annotation/AnnotationInvocationHandler.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/AnnotationInvocationHandler.java
@@ -64,7 +64,7 @@ class AnnotationInvocationHandler implements InvocationHandler, Serializable {
 
         // Handle Object and Annotation methods
         if (parameterCount == 1 && member == "equals" &&
-                method.getParameterTypes()[0] == Object.class) {
+                method.parameterType(0) == Object.class) {
             return equalsImpl(proxy, args[0]);
         }
         if (parameterCount != 0) {

--- a/src/java.desktop/share/classes/com/sun/beans/introspect/PropertyInfo.java
+++ b/src/java.desktop/share/classes/com/sun/beans/introspect/PropertyInfo.java
@@ -288,13 +288,13 @@ public final class PropertyInfo {
                         if (returnType.equals(void.class) && isPrefix(name, "set")) {
                             PropertyInfo info = getInfo(map, name.substring(3), false);
                             info.writeList = add(info.writeList, method, method.getGenericParameterTypes()[0]);
-                        } else if (!returnType.equals(void.class) && method.getParameterTypes()[0].equals(int.class) && isPrefix(name, "get")) {
+                        } else if (!returnType.equals(void.class) && method.parameterType(0).equals(int.class) && isPrefix(name, "get")) {
                             PropertyInfo info = getInfo(map, name.substring(3), true);
                             info.readList = add(info.readList, method, method.getGenericReturnType());
                         }
                         break;
                     case 2:
-                        if (returnType.equals(void.class) && method.getParameterTypes()[0].equals(int.class) && isPrefix(name, "set")) {
+                        if (returnType.equals(void.class) && method.parameterType(0).equals(int.class) && isPrefix(name, "set")) {
                             PropertyInfo info = getInfo(map, name.substring(3), true);
                             info.writeList = add(info.writeList, method, method.getGenericParameterTypes()[1]);
                         }

--- a/src/java.management/share/classes/com/sun/jmx/mbeanserver/DefaultMXBeanMappingFactory.java
+++ b/src/java.management/share/classes/com/sun/jmx/mbeanserver/DefaultMXBeanMappingFactory.java
@@ -1612,7 +1612,7 @@ public class DefaultMXBeanMappingFactory extends MXBeanMappingFactory {
         else if (name.startsWith("is") && m.getReturnType() == boolean.class)
             rest = name.substring(2);
         if (rest == null || rest.length() == 0
-            || m.getParameterTypes().length > 0
+            || m.getParameterCount() > 0
             || m.getReturnType() == void.class
             || name.equals("getClass"))
             return null;

--- a/src/java.management/share/classes/com/sun/jmx/mbeanserver/Introspector.java
+++ b/src/java.management/share/classes/com/sun/jmx/mbeanserver/Introspector.java
@@ -622,8 +622,7 @@ public class Introspector {
                 return false;
 
             String name = method.getName();
-            Class<?>[] paramTypes = method.getParameterTypes();
-            int paramCount = paramTypes.length;
+            int paramCount = method.getParameterCount();
 
             if (paramCount == 0 && name.length() > 2) {
                 // boolean isXXX()

--- a/src/java.management/share/classes/com/sun/jmx/mbeanserver/MBeanAnalyzer.java
+++ b/src/java.management/share/classes/com/sun/jmx/mbeanserver/MBeanAnalyzer.java
@@ -132,7 +132,7 @@ class MBeanAnalyzer<M> {
            us to give getter and setter together to visitAttribute. */
         for (Method m : methods) {
             final String name = m.getName();
-            final int nParams = m.getParameterTypes().length;
+            final int nParams = m.getParameterCount();
 
             final M cm = introspector.mFrom(m);
 

--- a/src/java.management/share/classes/com/sun/jmx/mbeanserver/MBeanIntrospector.java
+++ b/src/java.management/share/classes/com/sun/jmx/mbeanserver/MBeanIntrospector.java
@@ -287,7 +287,7 @@ abstract class MBeanIntrospector<M> {
     }
 
     static boolean isValidParameter(Method m, Object value, int paramNo) {
-        Class<?> c = m.getParameterTypes()[paramNo];
+        Class<?> c = m.parameterType(paramNo);
         try {
             // Following is expensive but we only call this method to determine
             // if an exception is due to an incompatible parameter type.

--- a/src/java.management/share/classes/javax/management/MBeanAttributeInfo.java
+++ b/src/java.management/share/classes/javax/management/MBeanAttributeInfo.java
@@ -321,7 +321,7 @@ public class MBeanAttributeInfo extends MBeanFeatureInfo implements Cloneable {
         Class<?> type = null;
 
         if (getter != null) {
-            if (getter.getParameterTypes().length != 0) {
+            if (getter.getParameterCount() != 0) {
                 throw new IntrospectionException("bad getter arg count");
             }
             type = getter.getReturnType();

--- a/src/java.management/share/classes/javax/management/MBeanInfo.java
+++ b/src/java.management/share/classes/javax/management/MBeanInfo.java
@@ -588,7 +588,7 @@ public class MBeanInfo implements Cloneable, Serializable, DescriptorRead {
                 Method method = methods[i];
                 String methodName = method.getName();
                 if (methodName.startsWith("get") &&
-                        method.getParameterTypes().length == 0 &&
+                        method.getParameterCount() == 0 &&
                         method.getReturnType().isArray()) {
                     try {
                         Method submethod =

--- a/src/java.management/share/classes/javax/management/MBeanServerInvocationHandler.java
+++ b/src/java.management/share/classes/javax/management/MBeanServerInvocationHandler.java
@@ -416,7 +416,7 @@ public class MBeanServerInvocationHandler implements InvocationHandler {
     private boolean shouldDoLocally(Object proxy, Method method) {
         final String methodName = method.getName();
         if ((methodName.equals("hashCode") || methodName.equals("toString"))
-            && method.getParameterTypes().length == 0
+            && method.getParameterCount() == 0
             && isLocal(proxy, method))
             return true;
         if (methodName.equals("equals")
@@ -425,7 +425,7 @@ public class MBeanServerInvocationHandler implements InvocationHandler {
             && isLocal(proxy, method))
             return true;
         if (methodName.equals("finalize")
-            && method.getParameterTypes().length == 0) {
+            && method.getParameterCount() == 0) {
             return true;
         }
         return false;

--- a/src/java.management/share/classes/javax/management/openmbean/CompositeDataInvocationHandler.java
+++ b/src/java.management/share/classes/javax/management/openmbean/CompositeDataInvocationHandler.java
@@ -160,7 +160,7 @@ public class CompositeDataInvocationHandler implements InvocationHandler {
             else if (methodName.equals("hashCode") && args == null)
                 return compositeData.hashCode() + 0x43444948;
             else if (methodName.equals("equals") && args.length == 1
-                && method.getParameterTypes()[0] == Object.class)
+                && method.parameterType(0) == Object.class)
                 return equals(proxy, args[0]);
             else {
                 /* Either someone is calling invoke by hand, or

--- a/src/java.management/share/classes/sun/management/MappedMXBeanType.java
+++ b/src/java.management/share/classes/sun/management/MappedMXBeanType.java
@@ -665,7 +665,7 @@ public abstract class MappedMXBeanType {
                     }
 
                     if (rest.isEmpty() ||
-                        method.getParameterTypes().length > 0 ||
+                        method.getParameterCount() > 0 ||
                         type == void.class ||
                         rest.equals("Class")) {
 


### PR DESCRIPTION
Currently in JDK code and in frameworks vastly utilizing reflection (Spring, Hibernate, ASM) we have one common anti-pattern:
```java
Class<?> firstParam = Method.getParameterTypes()[0];
```
In order to get a type of method's param we need to clone underlying array which is redundant. I suggest to add into `Executable` a method allowing to access method's param by index:
```java
/**
 * Returns the parameter type at the specified index, within this method.
 * @param index the index (zero-based) of the desired parameter type
 * @return the selected parameter type
 */
public Class<?> parameterType(int index) {
    Objects.checkIndex(index, getParameterCount());
    return getSharedParameterTypes()[index];
}
```
The method will allow to reduce copying in patterns like this one:
```java
public static Type[] getArgumentTypes(final Method method) {
    Class<?>[] classes = method.getParameterTypes();
    Type[] types = new Type[classes.length];
    for (int i = classes.length - 1; i >= 0; --i) {
        types[i] = getType(classes[i]);
    }
    return types;
}
```
Instead of calling `Method.getParameterTypes()` and iterating over array copy it'd be possible to call `Method.getParameterCount()` and access each param in counting loop:
```java
/**
 * Returns the parameter type at the specified index, within this method.
 * @param index the index (zero-based) of the desired parameter type
 * @return the selected parameter type
 */
public Class<?> parameterType(int index) {
    Objects.checkIndex(index, getParameterCount());
    return getSharedParameterTypes()[index];
}
```
Additionally we can use `getSharedParameterTypes()` instead of `getParameterTypes()` inside of `java.lang.reflect` package.

If the change seems reasonable then let me know, I'll file an issue for this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6742/head:pull/6742` \
`$ git checkout pull/6742`

Update a local copy of the PR: \
`$ git checkout pull/6742` \
`$ git pull https://git.openjdk.java.net/jdk pull/6742/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6742`

View PR using the GUI difftool: \
`$ git pr show -t 6742`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6742.diff">https://git.openjdk.java.net/jdk/pull/6742.diff</a>

</details>
