### PR TITLE
8273175: Add @since tags to the DocTree.Kind enum constants

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/source/doctree/DocTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/doctree/DocTree.java
@@ -38,56 +38,42 @@ public interface DocTree {
         /**
          * Used for instances of {@link AttributeTree}
          * representing an attribute in an HTML element or tag.
-         *
-         * @since 1.8
          */
         ATTRIBUTE,
 
         /**
          * Used for instances of {@link AuthorTree}
          * representing an {@code @author} tag.
-         *
-         * @since 1.8
          */
         AUTHOR("author"),
 
         /**
          * Used for instances of {@link LiteralTree}
          * representing an {@code @code} tag.
-         *
-         * @since 1.8
          */
         CODE("code"),
 
         /**
          * Used for instances of {@link CommentTree}
          * representing an HTML comment.
-         *
-         * @since 1.8
          */
         COMMENT,
 
         /**
          * Used for instances of {@link DeprecatedTree}
          * representing an {@code @deprecated} tag.
-         *
-         * @since 1.8
          */
         DEPRECATED("deprecated"),
 
         /**
          * Used for instances of {@link DocCommentTree}
          * representing a complete doc comment.
-         *
-         * @since 1.8
          */
         DOC_COMMENT,
 
         /**
          * Used for instances of {@link DocRootTree}
          * representing an {@code @docRoot} tag.
-         *
-         * @since 1.8
          */
         DOC_ROOT("docRoot"),
 
@@ -102,48 +88,36 @@ public interface DocTree {
         /**
          * Used for instances of {@link EndElementTree}
          * representing the end of an HTML element.
-         *
-         * @since 1.8
          */
         END_ELEMENT,
 
         /**
          * Used for instances of {@link EntityTree}
          * representing an HTML entity.
-         *
-         * @since 1.8
          */
         ENTITY,
 
         /**
          * Used for instances of {@link ErroneousTree}
          * representing some invalid text.
-         *
-         * @since 1.8
          */
         ERRONEOUS,
 
         /**
          * Used for instances of {@link ThrowsTree}
          * representing an {@code @exception} tag.
-         *
-         * @since 1.8
          */
         EXCEPTION("exception"),
 
         /**
          * Used for instances of {@link HiddenTree}
          * representing an {@code @hidden} tag.
-         *
-         * @since 1.8
          */
         HIDDEN("hidden"),
 
         /**
          * Used for instances of {@link IdentifierTree}
          * representing an identifier.
-         *
-         * @since 1.8
          */
         IDENTIFIER,
 
@@ -158,40 +132,30 @@ public interface DocTree {
         /**
          * Used for instances of {@link InheritDocTree}
          * representing an {@code @inheritDoc} tag.
-         *
-         * @since 1.8
          */
         INHERIT_DOC("inheritDoc"),
 
         /**
          * Used for instances of {@link LinkTree}
          * representing an {@code @link} tag.
-         *
-         * @since 1.8
          */
         LINK("link"),
 
         /**
          * Used for instances of {@link LinkTree}
          * representing an {@code @linkplain} tag.
-         *
-         * @since 1.8
          */
         LINK_PLAIN("linkplain"),
 
         /**
          * Used for instances of {@link LiteralTree}
          * representing an {@code @literal} tag.
-         *
-         * @since 1.8
          */
         LITERAL("literal"),
 
         /**
          * Used for instances of {@link ParamTree}
          * representing an {@code @param} tag.
-         *
-         * @since 1.8
          */
         PARAM("param"),
 
@@ -207,56 +171,42 @@ public interface DocTree {
          * Used for instances of {@link ReferenceTree}
          * representing a reference to an element in the
          * Java programming language.
-         *
-         * @since 1.8
          */
         REFERENCE,
 
         /**
          * Used for instances of {@link ReturnTree}
          * representing an {@code @return} tag.
-         *
-         * @since 1.8
          */
         RETURN("return"),
 
         /**
          * Used for instances of {@link SeeTree}
          * representing an {@code @see} tag.
-         *
-         * @since 1.8
          */
         SEE("see"),
 
         /**
          * Used for instances of {@link SerialTree}
          * representing an {@code @serial} tag.
-         *
-         * @since 1.8
          */
         SERIAL("serial"),
 
         /**
          * Used for instances of {@link SerialDataTree}
          * representing an {@code @serialData} tag.
-         *
-         * @since 1.8
          */
         SERIAL_DATA("serialData"),
 
         /**
          * Used for instances of {@link SerialFieldTree}
          * representing an {@code @serialField} tag.
-         *
-         * @since 1.8
          */
         SERIAL_FIELD("serialField"),
 
         /**
          * Used for instances of {@link SinceTree}
          * representing an {@code @since} tag.
-         *
-         * @since 1.8
          */
         SINCE("since"),
 
@@ -271,8 +221,6 @@ public interface DocTree {
         /**
          * Used for instances of {@link EndElementTree}
          * representing the start of an HTML element.
-         *
-         * @since 1.8
          */
         START_ELEMENT,
 
@@ -295,32 +243,24 @@ public interface DocTree {
         /**
          * Used for instances of {@link TextTree}
          * representing some documentation text.
-         *
-         * @since 1.8
          */
         TEXT,
 
         /**
          * Used for instances of {@link ThrowsTree}
          * representing an {@code @throws} tag.
-         *
-         * @since 1.8
          */
         THROWS("throws"),
 
         /**
          * Used for instances of {@link UnknownBlockTagTree}
          * representing an unknown block tag.
-         *
-         * @since 1.8
          */
         UNKNOWN_BLOCK_TAG,
 
         /**
          * Used for instances of {@link UnknownInlineTagTree}
          * representing an unknown inline tag.
-         *
-         * @since 1.8
          */
         UNKNOWN_INLINE_TAG,
 
@@ -335,24 +275,18 @@ public interface DocTree {
         /**
          * Used for instances of {@link ValueTree}
          * representing an {@code @value} tag.
-         *
-         * @since 1.8
          */
         VALUE("value"),
 
         /**
          * Used for instances of {@link VersionTree}
          * representing an {@code @version} tag.
-         *
-         * @since 1.8
          */
         VERSION("version"),
 
         /**
          * An implementation-reserved node. This is not the node
          * you are looking for.
-         *
-         * @since 1.8
          */
         OTHER;
 

--- a/src/jdk.compiler/share/classes/com/sun/source/doctree/DocTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/doctree/DocTree.java
@@ -38,126 +38,168 @@ public interface DocTree {
         /**
          * Used for instances of {@link AttributeTree}
          * representing an attribute in an HTML element or tag.
+         *
+         * @since 1.8
          */
         ATTRIBUTE,
 
         /**
          * Used for instances of {@link AuthorTree}
          * representing an {@code @author} tag.
+         *
+         * @since 1.8
          */
         AUTHOR("author"),
 
         /**
          * Used for instances of {@link LiteralTree}
          * representing an {@code @code} tag.
+         *
+         * @since 1.8
          */
         CODE("code"),
 
         /**
          * Used for instances of {@link CommentTree}
          * representing an HTML comment.
+         *
+         * @since 1.8
          */
         COMMENT,
 
         /**
          * Used for instances of {@link DeprecatedTree}
          * representing an {@code @deprecated} tag.
+         *
+         * @since 1.8
          */
         DEPRECATED("deprecated"),
 
         /**
          * Used for instances of {@link DocCommentTree}
          * representing a complete doc comment.
+         *
+         * @since 1.8
          */
         DOC_COMMENT,
 
         /**
          * Used for instances of {@link DocRootTree}
          * representing an {@code @docRoot} tag.
+         *
+         * @since 1.8
          */
         DOC_ROOT("docRoot"),
 
         /**
          * Used for instances of {@link DocTypeTree}
          * representing an HTML DocType declaration.
+         *
+         * @since 10
          */
         DOC_TYPE,
 
         /**
          * Used for instances of {@link EndElementTree}
          * representing the end of an HTML element.
+         *
+         * @since 1.8
          */
         END_ELEMENT,
 
         /**
          * Used for instances of {@link EntityTree}
          * representing an HTML entity.
+         *
+         * @since 1.8
          */
         ENTITY,
 
         /**
          * Used for instances of {@link ErroneousTree}
          * representing some invalid text.
+         *
+         * @since 1.8
          */
         ERRONEOUS,
 
         /**
          * Used for instances of {@link ThrowsTree}
          * representing an {@code @exception} tag.
+         *
+         * @since 1.8
          */
         EXCEPTION("exception"),
 
         /**
          * Used for instances of {@link HiddenTree}
          * representing an {@code @hidden} tag.
+         *
+         * @since 1.8
          */
         HIDDEN("hidden"),
 
         /**
          * Used for instances of {@link IdentifierTree}
          * representing an identifier.
+         *
+         * @since 1.8
          */
         IDENTIFIER,
 
         /**
          * Used for instances of {@link IndexTree}
          * representing an {@code @index} tag.
+         *
+         * @since 9
          */
         INDEX("index"),
 
         /**
          * Used for instances of {@link InheritDocTree}
          * representing an {@code @inheritDoc} tag.
+         *
+         * @since 1.8
          */
         INHERIT_DOC("inheritDoc"),
 
         /**
          * Used for instances of {@link LinkTree}
          * representing an {@code @link} tag.
+         *
+         * @since 1.8
          */
         LINK("link"),
 
         /**
          * Used for instances of {@link LinkTree}
          * representing an {@code @linkplain} tag.
+         *
+         * @since 1.8
          */
         LINK_PLAIN("linkplain"),
 
         /**
          * Used for instances of {@link LiteralTree}
          * representing an {@code @literal} tag.
+         *
+         * @since 1.8
          */
         LITERAL("literal"),
 
         /**
          * Used for instances of {@link ParamTree}
          * representing an {@code @param} tag.
+         *
+         * @since 1.8
          */
         PARAM("param"),
 
         /**
          * Used for instances of {@link ProvidesTree}
          * representing an {@code @provides} tag.
+         *
+         * @since 9
          */
         PROVIDES("provides"),
 
@@ -165,114 +207,152 @@ public interface DocTree {
          * Used for instances of {@link ReferenceTree}
          * representing a reference to an element in the
          * Java programming language.
+         *
+         * @since 1.8
          */
         REFERENCE,
 
         /**
          * Used for instances of {@link ReturnTree}
          * representing an {@code @return} tag.
+         *
+         * @since 1.8
          */
         RETURN("return"),
 
         /**
          * Used for instances of {@link SeeTree}
          * representing an {@code @see} tag.
+         *
+         * @since 1.8
          */
         SEE("see"),
 
         /**
          * Used for instances of {@link SerialTree}
          * representing an {@code @serial} tag.
+         *
+         * @since 1.8
          */
         SERIAL("serial"),
 
         /**
          * Used for instances of {@link SerialDataTree}
          * representing an {@code @serialData} tag.
+         *
+         * @since 1.8
          */
         SERIAL_DATA("serialData"),
 
         /**
          * Used for instances of {@link SerialFieldTree}
          * representing an {@code @serialField} tag.
+         *
+         * @since 1.8
          */
         SERIAL_FIELD("serialField"),
 
         /**
          * Used for instances of {@link SinceTree}
          * representing an {@code @since} tag.
+         *
+         * @since 1.8
          */
         SINCE("since"),
 
         /**
          * Used for instances of {@link SnippetTree}
          * representing an {@code @snippet} tag.
+         *
+         * @since 18
          */
         SNIPPET("snippet"),
 
         /**
          * Used for instances of {@link EndElementTree}
          * representing the start of an HTML element.
+         *
+         * @since 1.8
          */
         START_ELEMENT,
 
         /**
          * Used for instances of {@link SystemPropertyTree}
          * representing an {@code @systemProperty} tag.
+         *
+         * @since 12
          */
         SYSTEM_PROPERTY("systemProperty"),
 
         /**
          * Used for instances of {@link SummaryTree}
          * representing an {@code @summary} tag.
+         *
+         * @since 10
          */
         SUMMARY("summary"),
 
         /**
          * Used for instances of {@link TextTree}
          * representing some documentation text.
+         *
+         * @since 1.8
          */
         TEXT,
 
         /**
          * Used for instances of {@link ThrowsTree}
          * representing an {@code @throws} tag.
+         *
+         * @since 1.8
          */
         THROWS("throws"),
 
         /**
          * Used for instances of {@link UnknownBlockTagTree}
          * representing an unknown block tag.
+         *
+         * @since 1.8
          */
         UNKNOWN_BLOCK_TAG,
 
         /**
          * Used for instances of {@link UnknownInlineTagTree}
          * representing an unknown inline tag.
+         *
+         * @since 1.8
          */
         UNKNOWN_INLINE_TAG,
 
         /**
          * Used for instances of {@link UsesTree}
          * representing an {@code @uses} tag.
+         *
+         * @since 9
          */
         USES("uses"),
 
         /**
          * Used for instances of {@link ValueTree}
          * representing an {@code @value} tag.
+         *
+         * @since 1.8
          */
         VALUE("value"),
 
         /**
          * Used for instances of {@link VersionTree}
          * representing an {@code @version} tag.
+         *
+         * @since 1.8
          */
         VERSION("version"),
 
         /**
          * An implementation-reserved node. This is not the node
          * you are looking for.
+         *
+         * @since 1.8
          */
         OTHER;
 


### PR DESCRIPTION
Please review this trivial change to update `@since` tags.

Here are the links that I used for comparison; you might also find them useful when reviewing:

  1. https://docs.oracle.com/javase/8/docs/api/index.html (DocTree.Kind was not documented in JDK 8)
  2. https://docs.oracle.com/javase/9/docs/api/com/sun/source/doctree/DocTree.Kind.html
  3. https://docs.oracle.com/javase/10/docs/api/com/sun/source/doctree/DocTree.Kind.html
  4. https://docs.oracle.com/en/java/javase/11/docs/api/jdk.compiler/com/sun/source/doctree/DocTree.Kind.html (for control, to ensure that nothing has changed since JDK 10)
  5. https://docs.oracle.com/en/java/javase/12/docs/api/jdk.compiler/com/sun/source/doctree/DocTree.Kind.html
  6. https://download.java.net/java/early_access/jdk18/docs/api/jdk.compiler/com/sun/source/doctree/DocTree.Kind.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273175](https://bugs.openjdk.java.net/browse/JDK-8273175): Add @since tags to the DocTree.Kind enum constants


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6743/head:pull/6743` \
`$ git checkout pull/6743`

Update a local copy of the PR: \
`$ git checkout pull/6743` \
`$ git pull https://git.openjdk.java.net/jdk pull/6743/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6743`

View PR using the GUI difftool: \
`$ git pr show -t 6743`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6743.diff">https://git.openjdk.java.net/jdk/pull/6743.diff</a>

</details>
