### PR TITLE
8278341: Liveness check for global scope is not as fast as it could be

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
@@ -217,6 +217,11 @@ public abstract non-sealed class ResourceScopeImpl implements ResourceScope, Seg
         void addInternal(ResourceList.ResourceCleanup resource) {
             // do nothing
         }
+
+        @Override
+        public boolean isAlive() {
+            return true;
+        }
     }
 
     public static final ResourceScopeImpl GLOBAL = new GlobalScopeImpl(null);


### PR DESCRIPTION
When doing some unrelated performance measurements, I realized that segments backed by global scope were still paying a relatively high cost for liveness checks - that's because GlobalScopeImpl extends from SharedScopeImpl, and does not override the `isAlive` method. This means that when checking for liveness, we will still do (in some cases - e.g. when calling `checkValidStateSlow`) a volatile VH get on the scope state - which is useless in this case.

This simple patch adds the missing override.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278341](https://bugs.openjdk.java.net/browse/JDK-8278341): Liveness check for global scope is not as fast as it could be


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6744/head:pull/6744` \
`$ git checkout pull/6744`

Update a local copy of the PR: \
`$ git checkout pull/6744` \
`$ git pull https://git.openjdk.java.net/jdk pull/6744/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6744`

View PR using the GUI difftool: \
`$ git pr show -t 6744`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6744.diff">https://git.openjdk.java.net/jdk/pull/6744.diff</a>

</details>
