### PR TITLE
8278368: ProblemList tools/jpackage/share/MultiNameTwoPhaseTest.java on macosx-x64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -833,6 +833,8 @@ jdk/jfr/api/consumer/streaming/TestLatestEvent.java             8268297 windows-
 
 # jdk_jpackage
 
+tools/jpackage/share/MultiNameTwoPhaseTest.java 8278233 macosx-x64
+
 ############################################################################
 
 # Client manual tests


### PR DESCRIPTION
A trivial fix to ProblemList tools/jpackage/share/MultiNameTwoPhaseTest.java on macosx-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278368](https://bugs.openjdk.java.net/browse/JDK-8278368): ProblemList tools/jpackage/share/MultiNameTwoPhaseTest.java on macosx-x64


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6750/head:pull/6750` \
`$ git checkout pull/6750`

Update a local copy of the PR: \
`$ git checkout pull/6750` \
`$ git pull https://git.openjdk.java.net/jdk pull/6750/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6750`

View PR using the GUI difftool: \
`$ git pr show -t 6750`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6750.diff">https://git.openjdk.java.net/jdk/pull/6750.diff</a>

</details>
