### PR TITLE
8277998: runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java#custom-cl-zgc failed "assert(ZAddress::is_marked(addr)) failed: Should be marked"

### DIFF
--- a/src/hotspot/share/cds/dynamicArchive.cpp
+++ b/src/hotspot/share/cds/dynamicArchive.cpp
@@ -354,6 +354,9 @@ public:
 
     _builder.doit();
   }
+  ~VM_PopulateDynamicDumpSharedSpace() {
+    LambdaFormInvokers::cleanup_regenerated_classes();
+  }
 };
 
 void DynamicArchive::check_for_dynamic_dump() {

--- a/src/hotspot/share/cds/lambdaFormInvokers.hpp
+++ b/src/hotspot/share/cds/lambdaFormInvokers.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_CDS_LAMBDAFORMINVOKERS_HPP
 #define SHARE_CDS_LAMBDAFORMINVOKERS_HPP
 #include "memory/allStatic.hpp"
+#include "oops/oopHandle.hpp"
 #include "runtime/handles.hpp"
 #include "utilities/growableArray.hpp"
 
@@ -37,7 +38,9 @@ class LambdaFormInvokers : public AllStatic {
   static GrowableArrayCHeap<char*, mtClassShared>* _lambdaform_lines;
   // For storing LF form lines (LF_RESOLVE only) in read only table.
   static Array<Array<char>*>* _static_archive_invokers;
-  static void reload_class(char* name, ClassFileStream& st, TRAPS);
+  static GrowableArrayCHeap<OopHandle, mtClassShared>* _regenerated_mirrors;
+  static void regenerate_class(char* name, ClassFileStream& st, TRAPS);
+  static void add_regenerated_class(oop regenerated_class);
  public:
   static void append(char* line);
   static void append_filtered(char* line);
@@ -45,5 +48,6 @@ class LambdaFormInvokers : public AllStatic {
   static void read_static_archive_invokers();
   static void regenerate_holder_classes(TRAPS);
   static void serialize(SerializeClosure* soc);
+  static void cleanup_regenerated_classes();
 };
 #endif // SHARE_CDS_LAMBDAFORMINVOKERS_HPP

--- a/test/hotspot/jtreg/runtime/cds/appcds/DumpClassListWithLF.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/DumpClassListWithLF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@
  */
 
 public class DumpClassListWithLF extends ClassListFormatBase {
-    static final String REPLACE_OK = "Replaced class java/lang/invoke/DirectMethodHandle$Holder";
+    static final String REPLACE_OK = "Regenerated class java/lang/invoke/DirectMethodHandle$Holder";
 
     public static void main(String[] args) throws Throwable {
         String appJar = JarBuilder.getOrCreateHelloJar();


### PR DESCRIPTION
This fix is to ensure the classes created from `LambdaFormInvokers::reload_class` (being renamed to `LambdaFormInvokers::regenerate_class`) are being kept alive by adding them into an array of OopHandle.
Cleanup of the array is done for dynamic CDS dump only because for static dump, the VM will exit right after dumping a CDS archive.

Testing in progress: CI mach5 tiers 1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277998](https://bugs.openjdk.java.net/browse/JDK-8277998): runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java#custom-cl-zgc failed "assert(ZAddress::is_marked(addr)) failed: Should be marked"


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6751/head:pull/6751` \
`$ git checkout pull/6751`

Update a local copy of the PR: \
`$ git checkout pull/6751` \
`$ git pull https://git.openjdk.java.net/jdk pull/6751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6751`

View PR using the GUI difftool: \
`$ git pr show -t 6751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6751.diff">https://git.openjdk.java.net/jdk/pull/6751.diff</a>

</details>
