### PR TITLE
8278379: Zero VM is broken due to UseRTMForStackLocks was not declared after JDK-8276901

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2026,7 +2026,7 @@ bool Arguments::check_vm_args_consistency() {
     warning("UseHeavyMonitors is not fully implemented on this architecture");
   }
 #endif
-#if defined(X86) || defined(PPC64)
+#if (defined(X86) || defined(PPC64)) && !defined(ZERO)
   if (UseHeavyMonitors && UseRTMForStackLocks) {
     fatal("-XX:+UseHeavyMonitors and -XX:+UseRTMForStackLocks are mutually exclusive");
   }


### PR DESCRIPTION
Hi all,

Zero VM is broken due to `UseRTMForStackLocks` was not declared after JDK-8276901.
Please review this fix.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278379](https://bugs.openjdk.java.net/browse/JDK-8278379): Zero VM is broken due to UseRTMForStackLocks was not declared after JDK-8276901


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6753/head:pull/6753` \
`$ git checkout pull/6753`

Update a local copy of the PR: \
`$ git checkout pull/6753` \
`$ git pull https://git.openjdk.java.net/jdk pull/6753/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6753`

View PR using the GUI difftool: \
`$ git pr show -t 6753`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6753.diff">https://git.openjdk.java.net/jdk/pull/6753.diff</a>

</details>
