### PR TITLE
8277980: ObjectMethods::bootstrap throws NPE when lookup is null

### DIFF
--- a/src/java.base/share/classes/java/lang/runtime/ObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ObjectMethods.java
@@ -396,9 +396,8 @@ public class ObjectMethods {
      *                     if invoked by a condy
      * @throws IllegalArgumentException if the bootstrap arguments are invalid
      *                                  or inconsistent
-     * @throws NullPointerException if any argument is {@code null}, in the case
-     *                              of the {@code getters} argument, its
-     *                              contents cannot be {@code null} either
+     * @throws NullPointerException if any argument is {@code null} or if any element
+     *                              in the {@code getters} array is {@code null}
      * @throws Throwable if any exception is thrown during call site construction
      */
     public static Object bootstrap(MethodHandles.Lookup lookup, String methodName, TypeDescriptor type,

--- a/src/java.base/share/classes/java/lang/runtime/ObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ObjectMethods.java
@@ -396,8 +396,8 @@ public class ObjectMethods {
      *                     if invoked by a condy
      * @throws IllegalArgumentException if the bootstrap arguments are invalid
      *                                  or inconsistent
-     * @throws NullPointerException if any argument but {@code lookup} is {@code null},
-     *                              in the case of the {@code getters} argument, its
+     * @throws NullPointerException if any argument is {@code null}, in the case
+     *                              of the {@code getters} argument, its
      *                              contents cannot be {@code null} either
      * @throws Throwable if any exception is thrown during call site construction
      */
@@ -405,6 +405,7 @@ public class ObjectMethods {
                                    Class<?> recordClass,
                                    String names,
                                    MethodHandle... getters) throws Throwable {
+        requireNonNull(lookup);
         requireNonNull(methodName);
         requireNonNull(type);
         requireNonNull(recordClass);

--- a/test/jdk/java/lang/runtime/ObjectMethodsTest.java
+++ b/test/jdk/java/lang/runtime/ObjectMethodsTest.java
@@ -166,6 +166,7 @@ public class ObjectMethodsTest {
             assertThrows(NPE, () -> ObjectMethods.bootstrap(LOOKUP, npt.mn(), npt.mt(), null,    "x;y", C.ACCESSORS));
             assertThrows(NPE, () -> ObjectMethods.bootstrap(LOOKUP, npt.mn(), null,     C.class, "x;y", C.ACCESSORS));
             assertThrows(NPE, () -> ObjectMethods.bootstrap(LOOKUP, null,     npt.mt(), C.class, "x;y", C.ACCESSORS));
+            assertThrows(NPE, () -> ObjectMethods.bootstrap(null, npt.mn(),     npt.mt(), C.class, "x;y", C.ACCESSORS));
         }
     }
 


### PR DESCRIPTION
Please review this simple patch along with the related CSR. The `lookup` argument at method java.lang.runtime.ObjectMethods::bootstrap was ignored until the fix for [JDK-8261847](https://bugs.openjdk.java.net/browse/JDK-8261847) which improved the performance of the default implementation of Record::toString, given that now we are delegating part of the concatenation to StringConcatFactory::makeConcatWithConstants we do need now the lookup argument which can't be null anymore,

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8277980](https://bugs.openjdk.java.net/browse/JDK-8277980): ObjectMethods::bootstrap throws NPE when lookup is null
 * [JDK-8278316](https://bugs.openjdk.java.net/browse/JDK-8278316): ObjectMethods::bootstrap throws NPE when lookup is null (**CSR**)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to 6dbd35ca8ea6ce277c7aa037bcb6481b156a9a71


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6754/head:pull/6754` \
`$ git checkout pull/6754`

Update a local copy of the PR: \
`$ git checkout pull/6754` \
`$ git pull https://git.openjdk.java.net/jdk pull/6754/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6754`

View PR using the GUI difftool: \
`$ git pr show -t 6754`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6754.diff">https://git.openjdk.java.net/jdk/pull/6754.diff</a>

</details>
