### PR TITLE
8278310: Improve logging in CDS DynamicLoaderConstraintsTest.java

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.hpp
+++ b/src/hotspot/share/cds/archiveBuilder.hpp
@@ -312,14 +312,14 @@ public:
   template <typename T>
   u4 buffer_to_offset_u4(T p) const {
     uintx offset = buffer_to_offset((address)p);
-    guarantee(offset <= MAX_SHARED_DELTA, "must be 32-bit offset");
+    guarantee(offset <= MAX_SHARED_DELTA, "must be 32-bit offset " INTPTR_FORMAT, offset);
     return (u4)offset;
   }
 
   template <typename T>
   u4 any_to_offset_u4(T p) const {
     uintx offset = any_to_offset((address)p);
-    guarantee(offset <= MAX_SHARED_DELTA, "must be 32-bit offset");
+    guarantee(offset <= MAX_SHARED_DELTA, "must be 32-bit offset " INTPTR_FORMAT, offset);
     return (u4)offset;
   }
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java
@@ -139,7 +139,7 @@ public class DynamicLoaderConstraintsTest extends DynamicArchiveTestBase {
                 "java.base,jdk.httpserver",
                 "--add-exports",
                 "java.base/jdk.internal.misc=ALL-UNNAMED",
-                "-Xlog:class+load,class+loader+constraints",
+                "-Xlog:cds=debug,class+load,class+loader+constraints",
             };
 
             if (useCustomLoader) {


### PR DESCRIPTION
A simple change to add more logging in the DynamicLoaderConstraintsTest.java test.

Ran the test on linux-x64 to make sure CDS debug logging is in the output files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278310](https://bugs.openjdk.java.net/browse/JDK-8278310): Improve logging in CDS DynamicLoaderConstraintsTest.java


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6756/head:pull/6756` \
`$ git checkout pull/6756`

Update a local copy of the PR: \
`$ git checkout pull/6756` \
`$ git pull https://git.openjdk.java.net/jdk pull/6756/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6756`

View PR using the GUI difftool: \
`$ git pr show -t 6756`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6756.diff">https://git.openjdk.java.net/jdk/pull/6756.diff</a>

</details>
