### PR TITLE
8278371: Scalability bottleneck in NativePRNG

### DIFF
--- a/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
+++ b/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
@@ -553,7 +553,7 @@ public final class NativePRNG extends SecureRandomSpi {
                                 len = data_len;
                                 buffered -= len;
                             }
-                            System.arraycopy(nextBuffer, buf_pos, 
+                            System.arraycopy(nextBuffer, buf_pos,
                                     localBuffer, 0,
                                     len);
                         }

--- a/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
+++ b/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
@@ -540,7 +540,7 @@ public final class NativePRNG extends SecureRandomSpi {
                     int len;
                     int buf_pos;
                     int localofs;
-                    byte[] localBuffer;
+                    byte[] localBuffer = new byte[data_len];
 
                     while (data_len > 0) {
                         synchronized (LOCK_GET_BYTES) {
@@ -553,8 +553,9 @@ public final class NativePRNG extends SecureRandomSpi {
                                 len = data_len;
                                 buffered -= len;
                             }
-                            localBuffer = Arrays.copyOfRange(nextBuffer, buf_pos,
-                                    buf_pos + len);
+                            System.arraycopy(nextBuffer, buf_pos, 
+                                    localBuffer, 0,
+                                    len);
                         }
                         localofs = 0;
                         while (len > localofs) {
@@ -562,11 +563,11 @@ public final class NativePRNG extends SecureRandomSpi {
                             ofs++;
                             localofs++;
                         }
-                    data_len -= len;
+                        data_len -= len;
                     }
                 } catch (IOException e){
                     throw new ProviderException("nextBytes() failed", e);
                 }
-        }
+            }
         }
 }


### PR DESCRIPTION
RandomIO.implNextBytes() in NativePRNG class can become a bottleneck at high contention. This shows up as the hotest lock in SPECjvm crypto.rsa benchmark.

This can be reduced by doing less work in the "synchronized (LOCK_GET_BYTES)" block.

Initial fix is to remove the array allocation out of the synchronized block.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8278371](https://bugs.openjdk.java.net/browse/JDK-8278371): Scalability bottleneck in NativePRNG


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6757/head:pull/6757` \
`$ git checkout pull/6757`

Update a local copy of the PR: \
`$ git checkout pull/6757` \
`$ git pull https://git.openjdk.java.net/jdk pull/6757/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6757`

View PR using the GUI difftool: \
`$ git pr show -t 6757`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6757.diff">https://git.openjdk.java.net/jdk/pull/6757.diff</a>

</details>
