### PR TITLE
8278324: Update the --generate-cds-archive jlink plugin usage message

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/plugins.properties
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/plugins.properties
@@ -142,7 +142,8 @@ generate-cds-archive.description=\
 CDS plugin: generate cds archives if the runtime image supports CDS feature.\n\
 
 generate-cds-archive.usage=\
-\  --generate-cds-archive    Generate CDS archives if the runtime image supports CDS feature.
+\  --generate-cds-archive    Generate CDS archive if the runtime image supports\n\
+\                            the CDS feature.
 
 generate-jli-classes.argument=@filename
 


### PR DESCRIPTION
Simple change to update the --generate-cds-archive plugin usage message.

Before:

```
  --exclude-resources <pattern-list>
                            Specify resources to exclude.
                            e.g.: **.jcov,glob:**/META-INF/**
  --generate-cds-archive    Generate CDS archives if the runtime image supports CDS feature.
```

After:

```
  --exclude-resources <pattern-list>
                            Specify resources to exclude.
                            e.g.: **.jcov,glob:**/META-INF/**
  --generate-cds-archive    Generate CDS archive if the runtime image supports
                            the CDS feature.
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278324](https://bugs.openjdk.java.net/browse/JDK-8278324): Update the --generate-cds-archive jlink plugin usage message


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6758/head:pull/6758` \
`$ git checkout pull/6758`

Update a local copy of the PR: \
`$ git checkout pull/6758` \
`$ git pull https://git.openjdk.java.net/jdk pull/6758/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6758`

View PR using the GUI difftool: \
`$ git pr show -t 6758`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6758.diff">https://git.openjdk.java.net/jdk/pull/6758.diff</a>

</details>
