### PR TITLE
JDK-8278346: java/nio/file/Files/probeContentType/Basic.java fails on Linux SLES15 machine

### DIFF
--- a/test/jdk/java/nio/file/Files/probeContentType/Basic.java
+++ b/test/jdk/java/nio/file/Files/probeContentType/Basic.java
@@ -110,9 +110,8 @@ public class Basic {
                             + " cannot be determined");
                     failures++;
                 } else if (!expectedTypes.contains(type)) {
-                    System.err.printf("For extension " + extension
-                            + " we got content type: %s; expected: %s%n",
-                            type, expectedTypes);
+                    System.err.printf("For extension %s we got content type: %s; expected: %s%n",
+                            extension, type, expectedTypes);
                     failures++;
                 }
             } finally {

--- a/test/jdk/java/nio/file/Files/probeContentType/Basic.java
+++ b/test/jdk/java/nio/file/Files/probeContentType/Basic.java
@@ -110,8 +110,9 @@ public class Basic {
                             + " cannot be determined");
                     failures++;
                 } else if (!expectedTypes.contains(type)) {
-                    System.err.printf("Content type: %s; expected: %s%n",
-                        type, expectedTypes);
+                    System.err.printf("For extension " + extension
+                            + " we got content type: %s; expected: %s%n",
+                            type, expectedTypes);
                     failures++;
                 }
             } finally {
@@ -155,7 +156,7 @@ public class Basic {
         // Verify that certain extensions are mapped to the correct type.
         var exTypes = new ExType[] {
                 new ExType("adoc", List.of("text/plain")),
-                new ExType("bz2", List.of("application/bz2", "application/x-bzip2")),
+                new ExType("bz2", List.of("application/bz2", "application/x-bzip2", "application/x-bzip")),
                 new ExType("css", List.of("text/css")),
                 new ExType("csv", List.of("text/csv")),
                 new ExType("doc", List.of("application/msword")),
@@ -166,19 +167,19 @@ public class Basic {
                 new ExType("js", List.of("text/javascript", "application/javascript")),
                 new ExType("json", List.of("application/json")),
                 new ExType("markdown", List.of("text/markdown")),
-                new ExType("md", List.of("text/markdown")),
+                new ExType("md", List.of("text/markdown", "application/x-genesis-rom")),
                 new ExType("mp3", List.of("audio/mpeg")),
                 new ExType("mp4", List.of("video/mp4")),
                 new ExType("odp", List.of("application/vnd.oasis.opendocument.presentation")),
                 new ExType("ods", List.of("application/vnd.oasis.opendocument.spreadsheet")),
                 new ExType("odt", List.of("application/vnd.oasis.opendocument.text")),
                 new ExType("pdf", List.of("application/pdf")),
-                new ExType("php", List.of("text/plain", "text/php")),
+                new ExType("php", List.of("text/plain", "text/php", "application/x-php")),
                 new ExType("png", List.of("image/png")),
                 new ExType("ppt", List.of("application/vnd.ms-powerpoint")),
                 new ExType("pptx",List.of("application/vnd.openxmlformats-officedocument.presentationml.presentation")),
                 new ExType("py", List.of("text/plain", "text/x-python", "text/x-python-script")),
-                new ExType("rar", List.of("application/rar", "application/vnd.rar")),
+                new ExType("rar", List.of("application/rar", "application/vnd.rar", "application/x-rar")),
                 new ExType("rtf", List.of("application/rtf", "text/rtf")),
                 new ExType("webm", List.of("video/webm")),
                 new ExType("webp", List.of("image/webp")),


### PR DESCRIPTION
Hello, please review this small test adjustment.

The test java/nio/file/Files/probeContentType/Basic.java fails on a SLES15 Linux machine with this output :
Content type: application/x-bzip; expected: [application/bz2, application/x-bzip2]
Content type: application/x-genesis-rom; expected: [text/markdown]
Content type: application/x-php; expected: [text/plain, text/php]
Content type: application/x-rar; expected: [application/rar, application/vnd.rar]
java.lang.RuntimeException: Test failed!
        at Basic.main(Basic.java:192)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
        at java.base/java.lang.reflect.Method.invoke(Method.java:577)
        at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
        at java.base/java.lang.Thread.run(Thread.java:833)

For see the strange 'application/x-genesis-rom' mapping see also
markdown files ending in .md get marked as 'application/x-genesis-rom'
https://bugs.launchpad.net/ubuntu/+source/shared-mime-info/+bug/611763

The other mappings look okay to me but sems we need to add them to the test.

Best regards, Matthias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278346](https://bugs.openjdk.java.net/browse/JDK-8278346): java/nio/file/Files/probeContentType/Basic.java fails on Linux SLES15 machine


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6761/head:pull/6761` \
`$ git checkout pull/6761`

Update a local copy of the PR: \
`$ git checkout pull/6761` \
`$ git pull https://git.openjdk.java.net/jdk pull/6761/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6761`

View PR using the GUI difftool: \
`$ git pr show -t 6761`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6761.diff">https://git.openjdk.java.net/jdk/pull/6761.diff</a>

</details>
