### PR TITLE
8278396: G1: Initialize the BOT threshold to be region bottom

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -55,7 +55,7 @@ private:
   volatile u_char* _offset_array;  // byte array keeping backwards offsets
 
   void check_offset(size_t offset, const char* msg) const {
-    assert(offset <= BOTConstants::card_size_in_words(),
+    assert(offset < BOTConstants::card_size_in_words(),
            "%s - offset: " SIZE_FORMAT ", N_words: %u",
            msg, offset, BOTConstants::card_size_in_words());
   }
@@ -129,10 +129,6 @@ private:
   // that is closed: [start_index, end_index]
   void set_remainder_to_point_to_start_incl(size_t start, size_t end);
 
-  // Zero out the entry for _bottom (offset will be zero). Does not check for availability of the
-  // memory first.
-  void zero_bottom_entry_raw();
-
   inline size_t block_size(const HeapWord* p) const;
 
   // Returns the address of a block whose start is at most "addr".
@@ -177,14 +173,10 @@ public:
   // discussed above.
   inline HeapWord* block_start_const(const void* addr) const;
 
-  // Initialize the threshold to reflect the first boundary after the
-  // bottom of the covered region.
-  void initialize_threshold();
+  // Reset bot to be empty.
+  void reset_bot();
 
-  void reset_bot() {
-    zero_bottom_entry_raw();
-    initialize_threshold();
-  }
+  bool is_empty() const;
 
   // Return the next threshold, the point at which the table should be
   // updated.

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -798,7 +798,7 @@ void HeapRegion::mangle_unused_area() {
 #endif
 
 void HeapRegion::initialize_bot_threshold() {
-  _bot_part.initialize_threshold();
+  _bot_part.reset_bot();
 }
 
 void HeapRegion::alloc_block_in_bot(HeapWord* start, HeapWord* end) {


### PR DESCRIPTION
This simple patch tightens the assert for offset card value and drops the special treatment of the first card for a region.

Test: tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278396](https://bugs.openjdk.java.net/browse/JDK-8278396): G1: Initialize the BOT threshold to be region bottom


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6762/head:pull/6762` \
`$ git checkout pull/6762`

Update a local copy of the PR: \
`$ git checkout pull/6762` \
`$ git pull https://git.openjdk.java.net/jdk pull/6762/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6762`

View PR using the GUI difftool: \
`$ git pr show -t 6762`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6762.diff">https://git.openjdk.java.net/jdk/pull/6762.diff</a>

</details>
