### PR TITLE
8278410: Improve argument processing around UseHeavyMonitors

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2024,16 +2024,23 @@ bool Arguments::check_vm_args_consistency() {
 
 #if !defined(X86) && !defined(AARCH64) && !defined(PPC64)
   if (UseHeavyMonitors) {
-    warning("UseHeavyMonitors is not fully implemented on this architecture");
+    jio_fprintf(defaultStream::error_stream(),
+                "UseHeavyMonitors is not fully implemented on this architecture");
+    return false;
   }
 #endif
 #if (defined(X86) || defined(PPC64)) && !defined(ZERO)
   if (UseHeavyMonitors && UseRTMForStackLocks) {
-    fatal("-XX:+UseHeavyMonitors and -XX:+UseRTMForStackLocks are mutually exclusive");
+    jio_fprintf(defaultStream::error_stream(),
+                "-XX:+UseHeavyMonitors and -XX:+UseRTMForStackLocks are mutually exclusive");
+
+    return false;
   }
 #endif
   if (VerifyHeavyMonitors && !UseHeavyMonitors) {
-    fatal("-XX:+VerifyHeavyMonitors requires -XX:+UseHeavyMonitors");
+    jio_fprintf(defaultStream::error_stream(),
+                "-XX:+VerifyHeavyMonitors requires -XX:+UseHeavyMonitors");
+    return false;
   }
 
   return status;


### PR DESCRIPTION
JDK-8276901 improved the implementation of the UseHeavyMonitors flag, however, the argument checking for it should not use fatal() but instead report a warning or error message, and return false accordingly.
Also for platforms where UseHeavyMonitors is not fully implemented it should not just be a warning but also cause initialization to not continue. If we are going to return false then the error message should go to the error stream not be issued as a warning().

Testing:
 - [x] java/util/concurrent/ConcurrentHashMap/MapLoops.java
 - [x] tier1
 - [ ] tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278410](https://bugs.openjdk.java.net/browse/JDK-8278410): Improve argument processing around UseHeavyMonitors


### Reviewers
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6765/head:pull/6765` \
`$ git checkout pull/6765`

Update a local copy of the PR: \
`$ git checkout pull/6765` \
`$ git pull https://git.openjdk.java.net/jdk pull/6765/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6765`

View PR using the GUI difftool: \
`$ git pr show -t 6765`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6765.diff">https://git.openjdk.java.net/jdk/pull/6765.diff</a>

</details>
