### PR TITLE
8278421: G1: Remove unused HeapRegion::verify

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -736,11 +736,6 @@ void HeapRegion::verify(VerifyOption vo,
   verify_strong_code_roots(vo, failures);
 }
 
-void HeapRegion::verify() const {
-  bool dummy = false;
-  verify(VerifyOption_G1UsePrevMarking, /* failures */ &dummy);
-}
-
 void HeapRegion::verify_rem_set(VerifyOption vo, bool* failures) const {
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
   *failures = false;

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -618,9 +618,6 @@ public:
   // full GC.
   void verify(VerifyOption vo, bool *failures) const;
 
-  // Verify using the "prev" marking information
-  void verify() const;
-
   void verify_rem_set(VerifyOption vo, bool *failures) const;
   void verify_rem_set() const;
 };


### PR DESCRIPTION
Trivial change of removing dead code.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278421](https://bugs.openjdk.java.net/browse/JDK-8278421): G1: Remove unused HeapRegion::verify


### Reviewers
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6766/head:pull/6766` \
`$ git checkout pull/6766`

Update a local copy of the PR: \
`$ git checkout pull/6766` \
`$ git pull https://git.openjdk.java.net/jdk pull/6766/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6766`

View PR using the GUI difftool: \
`$ git pr show -t 6766`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6766.diff">https://git.openjdk.java.net/jdk/pull/6766.diff</a>

</details>
