### PR TITLE
8278415: [TESTBUG] vmTestbase/nsk/stress/stack/stack018.java fails with "java.lang.Error: TEST_RFE"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack018.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack018.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@
  *     invocations until stack overflow, and then tries to reproduce similar
  *     stack overflows 10 times in each of 10 threads -- each time by trying
  *     to invoke the same recursive method for the given fixed depth
- *     of invocations (which is 10 times that crucial depth just measured).
+ *     of invocations (which is 100 times that crucial depth just measured).
  *     The test is deemed passed, if VM have not crashed, and
  *     if exception other than due to stack overflow was not
  *     thrown.
@@ -103,7 +103,7 @@ public class stack018 extends Thread {
         // Measure maximal recursion depth until stack overflow:
         //
         int maxDepth = 0;
-        for (depthToTry = 0; ; depthToTry += STEP)
+        for (depthToTry = 0; ; depthToTry += STEP) {
             try {
                 invokeRecurse(depthToTry);
                 maxDepth = depthToTry;
@@ -117,6 +117,12 @@ public class stack018 extends Thread {
                     throw (ThreadDeath) target;
                 return 2;
             }
+        }
+
+        if (maxDepth == 0) {
+            // The depth STEP was enough to cause StackOverflowError or OutOfMemoryError.
+            maxDepth = STEP;
+        }
         out.println("Maximal recursion depth: " + maxDepth);
 
         //


### PR DESCRIPTION
Fix `vmTestbase/nsk/stress/stack/stack018.java` to have `maxDepth` equal to `STEP(100)` if the depth `STEP` causes stack overflow.

Testing: `vmTestbase/nsk/stress/stack/stack018.java`
- `fastdebug` build: Passed.
- `release` build: Passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278415](https://bugs.openjdk.java.net/browse/JDK-8278415): [TESTBUG] vmTestbase/nsk/stress/stack/stack018.java fails with "java.lang.Error: TEST_RFE"


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6767/head:pull/6767` \
`$ git checkout pull/6767`

Update a local copy of the PR: \
`$ git checkout pull/6767` \
`$ git pull https://git.openjdk.java.net/jdk pull/6767/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6767`

View PR using the GUI difftool: \
`$ git pr show -t 6767`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6767.diff">https://git.openjdk.java.net/jdk/pull/6767.diff</a>

</details>
