### PR TITLE
8278445: ProblemList tools/jpackage/share/IconTest.java on macosx-x64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -833,6 +833,7 @@ jdk/jfr/api/consumer/streaming/TestLatestEvent.java             8268297 windows-
 
 # jdk_jpackage
 
+tools/jpackage/share/IconTest.java 8278233 macosx-x64
 tools/jpackage/share/MultiNameTwoPhaseTest.java 8278233 macosx-x64
 
 ############################################################################


### PR DESCRIPTION
A trivial fix to ProblemList tools/jpackage/share/IconTest.java on macosx-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278445](https://bugs.openjdk.java.net/browse/JDK-8278445): ProblemList tools/jpackage/share/IconTest.java on macosx-x64


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6773/head:pull/6773` \
`$ git checkout pull/6773`

Update a local copy of the PR: \
`$ git checkout pull/6773` \
`$ git pull https://git.openjdk.java.net/jdk pull/6773/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6773`

View PR using the GUI difftool: \
`$ git pr show -t 6773`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6773.diff">https://git.openjdk.java.net/jdk/pull/6773.diff</a>

</details>
