### PR TITLE
8278463: [test] Serialization WritePrimitive test revised for readFully test fails

### DIFF
--- a/test/jdk/java/io/Serializable/oldTests/WritePrimitive.java
+++ b/test/jdk/java/io/Serializable/oldTests/WritePrimitive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 
 /* @test
+ * @bug 8276806 8278463
  * @summary it is a new version of an old test which was
  *          /src/share/test/serialization/piotest.java
  *          Test of serialization/deserialization of
@@ -90,7 +91,7 @@ public class WritePrimitive {
             byte[] ba_readFullyBuf = new byte[ba.length];
             int ba_readFullyLen = q.read(ba_readFullyBuf);
             byte[] ba_readFullySizedBuf = new byte[ba.length];
-            int ba_readFullySizedLen = q.read(ba_readFullySizedBuf, 0, ba.length - 1);
+            int ba_readFullySizedLen = q.read(ba_readFullySizedBuf, 0, ba.length - 2);
             String string_utf = q.readUTF();
             String string_u = (String)q.readObject();
             if (i != i_u) {


### PR DESCRIPTION
The test for ObjectInputStream.readFully reads the wrong length causing the test to fail.
Added bugids and update copyrights.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278463](https://bugs.openjdk.java.net/browse/JDK-8278463): [test] Serialization WritePrimitive test revised for readFully test fails


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6775/head:pull/6775` \
`$ git checkout pull/6775`

Update a local copy of the PR: \
`$ git checkout pull/6775` \
`$ git pull https://git.openjdk.java.net/jdk pull/6775/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6775`

View PR using the GUI difftool: \
`$ git pr show -t 6775`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6775.diff">https://git.openjdk.java.net/jdk/pull/6775.diff</a>

</details>
