### PR TITLE
JDK-8278466: "spurious markup" warnings in snippets when building `docs-reference`

### DIFF
--- a/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
@@ -82,7 +82,7 @@ import static javax.tools.JavaFileObject.Kind;
  * section&nbsp;3.3.  Informally, this should be true:
  *
  * {@snippet id="valid-relative-name" lang=java :
- *     // @link substring="create" target="URI#create" : @link substring=normalize target="URI#normalize" : @link substring=getPath target="URI#getPath" :
+ *     // @link substring="create" target="URI#create" @link substring=normalize target="URI#normalize" @link substring=getPath target="URI#getPath" :
  *     URI.create(relativeName).normalize().getPath().equals(relativeName)
  *     }
  *

--- a/src/java.compiler/share/classes/javax/tools/StandardJavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/StandardJavaFileManager.java
@@ -76,7 +76,7 @@ import java.util.List;
  *         must succeed if the following would succeed (ignoring
  *         encoding issues):
  *         {@snippet id="equiv-input" lang=java :
- *             // @link substring=FileInputStream target="java.io.FileInputStream#FileInputStream(File)" : @link regex="File\W" target="File#File(java.net.URI)" : @link substring=fileObject target=FileObject :  @link substring=toURI target="FileObject#toUri()" :
+ *             // @link substring=FileInputStream target="java.io.FileInputStream#FileInputStream(File)" @link regex="File\b" target="File#File(java.net.URI)" @link substring=fileObject target=FileObject @link substring=toURI target="FileObject#toUri()" :
  *             new FileInputStream(new File(fileObject.toURI()))
  *             }
  *       </li>
@@ -87,7 +87,7 @@ import java.util.List;
  *         succeed if the following would succeed (ignoring encoding
  *         issues):
  *         {@snippet id="equiv-output" lang=java :
- *             // @link substring=FileOutputStream target="java.io.FileOutputStream#FileOutputStream(File)" : @link regex="File\W" target="File#File(java.net.URI)" : @link substring=fileObject target=FileObject :  @link substring=toURI target="FileObject#toUri()" :
+ *             // @link substring=FileOutputStream target="java.io.FileOutputStream#FileOutputStream(File)" @link regex="File\b" target="File#File(java.net.URI)" @link substring=fileObject target=FileObject @link substring=toURI target="FileObject#toUri()" :
  *             new FileOutputStream(new File(fileObject.toURI()))
  *             }
  *       </li>


### PR DESCRIPTION
Please review a minor cleanup to some new snippet markup, to remove some `:` characters, which are no longer required, and which now cause warnings.

In addition, a couple of regular expressions have been adjusted to use `\b` (word boundary) instead of `\W` (non-word character), which includes the non-word character in the match.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278466](https://bugs.openjdk.java.net/browse/JDK-8278466): "spurious markup" warnings in snippets when building `docs-reference`


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6777/head:pull/6777` \
`$ git checkout pull/6777`

Update a local copy of the PR: \
`$ git checkout pull/6777` \
`$ git pull https://git.openjdk.java.net/jdk pull/6777/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6777`

View PR using the GUI difftool: \
`$ git pr show -t 6777`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6777.diff">https://git.openjdk.java.net/jdk/pull/6777.diff</a>

</details>
