### PR TITLE
8276819: javax/print/PrintServiceLookup/FlushCustomClassLoader.java fails to free

### DIFF
--- a/test/jdk/javax/print/PrintServiceLookup/FlushCustomClassLoader.java
+++ b/test/jdk/javax/print/PrintServiceLookup/FlushCustomClassLoader.java
@@ -34,6 +34,9 @@ import javax.print.PrintServiceLookup;
  * @test
  * @bug 8273831
  * @summary Tests custom class loader cleanup
+ * @library /javax/swing/regtesthelpers
+ * @build Util
+ * @run main/timeout=60/othervm -mx32m FlushCustomClassLoader
  */
 public final class FlushCustomClassLoader {
 
@@ -42,12 +45,8 @@ public final class FlushCustomClassLoader {
 
         int attempt = 0;
         while (loader.get() != null) {
-            if (++attempt > 10) {
-                throw new RuntimeException("Too many attempts: " + attempt);
-            }
-            System.gc();
-            Thread.sleep(1000);
-            System.out.println("Not freed, attempt: " + attempt);
+            Util.generateOOME();
+            System.out.println("Not freed, attempt: " + attempt++);
         }
     }
 


### PR DESCRIPTION
This is an attempt to make the FlushCustomClassLoader more stable. I cannot reproduce this bug so added some improvement blindly, based on assumption that the test may fail on the slow/overloaded system.

 * The attempt limitation was removed, but the test execution time decreased to 1 minute
 * For each attempt the generation of OOM was added to make sure that the GC was triggered

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276819](https://bugs.openjdk.java.net/browse/JDK-8276819): javax/print/PrintServiceLookup/FlushCustomClassLoader.java fails to free


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6778/head:pull/6778` \
`$ git checkout pull/6778`

Update a local copy of the PR: \
`$ git checkout pull/6778` \
`$ git pull https://git.openjdk.java.net/jdk pull/6778/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6778`

View PR using the GUI difftool: \
`$ git pr show -t 6778`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6778.diff">https://git.openjdk.java.net/jdk/pull/6778.diff</a>

</details>
