### PR TITLE
JDK-8278344: sun/security/pkcs12/KeytoolOpensslInteropTest.java test fails because of different openssl output

### DIFF
--- a/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
+++ b/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
@@ -462,7 +462,7 @@ public class KeytoolOpensslInteropTest {
                 "pkcs12", "-in", "ksnormal", "-passin", "pass:changeit",
                 "-info", "-nokeys", "-nocerts");
         output1.shouldHaveExitValue(0)
-            .shouldContain("MAC: sha256, Iteration 10000")
+            .shouldContain("MAC:").shouldContain("sha256").shouldContain("Iteration 10000")
             .shouldContain("Shrouded Keybag: PBES2, PBKDF2, AES-256-CBC,"
                     + " Iteration 10000, PRF hmacWithSHA256")
             .shouldContain("PKCS7 Encrypted data: PBES2, PBKDF2, AES-256-CBC,"
@@ -505,7 +505,7 @@ public class KeytoolOpensslInteropTest {
                 "ksnewic", "-passin", "pass:changeit", "-info", "-nokeys",
                 "-nocerts");
         output1.shouldHaveExitValue(0)
-            .shouldContain("MAC: sha256, Iteration 5555")
+            .shouldContain("MAC:").shouldContain("sha256").shouldContain("Iteration 5555")
             .shouldContain("Shrouded Keybag: PBES2, PBKDF2, AES-256-CBC,"
                     + " Iteration 7777, PRF hmacWithSHA256")
             .shouldContain("Shrouded Keybag: pbeWithSHA1And128BitRC4,"


### PR DESCRIPTION
Please review this small test fix.
KeytoolOpensslInteropTest.java fails with the output below.
Seems on our SUSE Linux 15 (openssl is
~> openssl version
OpenSSL 1.1.0i-fips 14 Aug 2018
) we get a slightly different output with a blank missing after "MAC:" :

:stdErr:
Mon Dec 06 21:54:48 CET 2021
stdout: [];
stderr: [MAC:sha256 Iteration 10000
 . . .
java.lang.RuntimeException: 'MAC: sha256, Iteration 10000' missing from stdout/stderr

So it is necessary to adjust the test to the other openssl version.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278344](https://bugs.openjdk.java.net/browse/JDK-8278344): sun/security/pkcs12/KeytoolOpensslInteropTest.java test fails because of different openssl output


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6779/head:pull/6779` \
`$ git checkout pull/6779`

Update a local copy of the PR: \
`$ git checkout pull/6779` \
`$ git pull https://git.openjdk.java.net/jdk pull/6779/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6779`

View PR using the GUI difftool: \
`$ git pr show -t 6779`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6779.diff">https://git.openjdk.java.net/jdk/pull/6779.diff</a>

</details>
