### PR TITLE
6496103: isFileHidingEnabled return false by default

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JFileChooser.java
+++ b/src/java.desktop/share/classes/javax/swing/JFileChooser.java
@@ -1412,8 +1412,8 @@ public class JFileChooser extends JComponent implements Accessible {
 
     /**
      * Returns true if hidden files are not shown in the file chooser;
-     * otherwise, returns false. The default value of this property is derived
-     * from native Operating System, unless set explicitly by the programmer.
+     * otherwise, returns false. The default value of this property may be
+     * derived from the underlying Operating System.
      *
      * @return the status of the file hiding property
      * @see #setFileHidingEnabled

--- a/src/java.desktop/share/classes/javax/swing/JFileChooser.java
+++ b/src/java.desktop/share/classes/javax/swing/JFileChooser.java
@@ -1412,8 +1412,8 @@ public class JFileChooser extends JComponent implements Accessible {
 
     /**
      * Returns true if hidden files are not shown in the file chooser;
-     * otherwise, returns false. The default value of this property is derived from native platform,
-     * unless set explicitly by the developer.
+     * otherwise, returns false. The default value of this property is derived
+     * from native Operating System, unless set explicitly by the programmer.
      *
      * @return the status of the file hiding property
      * @see #setFileHidingEnabled

--- a/src/java.desktop/share/classes/javax/swing/JFileChooser.java
+++ b/src/java.desktop/share/classes/javax/swing/JFileChooser.java
@@ -1412,7 +1412,8 @@ public class JFileChooser extends JComponent implements Accessible {
 
     /**
      * Returns true if hidden files are not shown in the file chooser;
-     * otherwise, returns false.
+     * otherwise, returns false. The default value of this property is derived from native platform,
+     * unless set explicitly by the developer.
      *
      * @return the status of the file hiding property
      * @see #setFileHidingEnabled


### PR DESCRIPTION
The default value of this property is derived from native platform. The same is updated in the documentation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-6496103](https://bugs.openjdk.java.net/browse/JDK-6496103): isFileHidingEnabled return false by default
 * [JDK-8279420](https://bugs.openjdk.java.net/browse/JDK-8279420): isFileHidingEnabled return false by default (**CSR**)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6780/head:pull/6780` \
`$ git checkout pull/6780`

Update a local copy of the PR: \
`$ git checkout pull/6780` \
`$ git pull https://git.openjdk.java.net/jdk pull/6780/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6780`

View PR using the GUI difftool: \
`$ git pr show -t 6780`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6780.diff">https://git.openjdk.java.net/jdk/pull/6780.diff</a>

</details>
