### PR TITLE
8278482: G1: Improve HeapRegion::block_is_obj

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -655,10 +655,8 @@ void HeapRegion::verify(VerifyOption vo,
   VerifyLiveClosure vl_cl(g1h, vo);
   VerifyRemSetClosure vr_cl(g1h, vo);
   bool is_region_humongous = is_humongous();
-  if (is_region_humongous) {
-    // We cast p to an oop, so region-bottom must be an obj-start.
-    assert(is_starts_humongous(), "invariant");
-  }
+  // We cast p to an oop, so region-bottom must be an obj-start.
+  assert(!is_region_humongous || is_starts_humongous(), "invariant");
   size_t object_num = 0;
   while (p < top()) {
     oop obj = cast_to_oop(p);

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -655,6 +655,10 @@ void HeapRegion::verify(VerifyOption vo,
   VerifyLiveClosure vl_cl(g1h, vo);
   VerifyRemSetClosure vr_cl(g1h, vo);
   bool is_region_humongous = is_humongous();
+  if (is_region_humongous) {
+    // We cast p to an oop, so region-bottom must be an obj-start.
+    assert(is_starts_humongous(), "invariant");
+  }
   size_t object_num = 0;
   while (p < top()) {
     oop obj = cast_to_oop(p);


### PR DESCRIPTION
Adding assertions to `HeapRegion::block_is_obj` and its callers, and removing some dead code based on the assertions.

Test: tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278482](https://bugs.openjdk.java.net/browse/JDK-8278482): G1: Improve HeapRegion::block_is_obj


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to d430c6373875a0ee05f6c4c82941ef9f58a8a218
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6781/head:pull/6781` \
`$ git checkout pull/6781`

Update a local copy of the PR: \
`$ git checkout pull/6781` \
`$ git pull https://git.openjdk.java.net/jdk pull/6781/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6781`

View PR using the GUI difftool: \
`$ git pr show -t 6781`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6781.diff">https://git.openjdk.java.net/jdk/pull/6781.diff</a>

</details>
