### PR TITLE
8278461: Use Executable.getSharedParameterTypes() instead of Executable.getParameterTypes() in trusted code

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/Constructor.java
+++ b/src/java.base/share/classes/java/lang/reflect/Constructor.java
@@ -371,7 +371,7 @@ public final class Constructor<T> extends Executable {
         sb.append(getDeclaringClass().getTypeName());
         sb.append('(');
         StringJoiner sj = new StringJoiner(",");
-        for (Class<?> parameterType : getParameterTypes()) {
+        for (Class<?> parameterType : getSharedParameterTypes()) {
             sj.add(parameterType.getTypeName());
         }
         sb.append(sj);

--- a/src/java.base/share/classes/java/lang/reflect/Executable.java
+++ b/src/java.base/share/classes/java/lang/reflect/Executable.java
@@ -30,7 +30,6 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
-import java.util.stream.Stream;
 import java.util.stream.Collectors;
 
 import jdk.internal.access.SharedSecrets;
@@ -311,11 +310,11 @@ public abstract sealed class Executable extends AccessibleObject
         // this case, we just return the result of
         // getParameterTypes().
         if (!genericInfo) {
-            return getParameterTypes();
+            return getSharedParameterTypes();
         } else {
             final boolean realParamData = hasRealParameterData();
             final Type[] genericParamTypes = getGenericParameterTypes();
-            final Type[] nonGenericParamTypes = getParameterTypes();
+            final Type[] nonGenericParamTypes = getSharedParameterTypes();
             // If we have real parameter data, then we use the
             // synthetic and mandate flags to our advantage.
             if (realParamData) {
@@ -326,7 +325,7 @@ public abstract sealed class Executable extends AccessibleObject
                     final Parameter param = params[i];
                     if (param.isSynthetic() || param.isImplicit()) {
                         // If we hit a synthetic or mandated parameter,
-                        // use the non generic parameter info.
+                        // use the non-generic parameter info.
                         out[i] = nonGenericParamTypes[i];
                     } else {
                         // Otherwise, use the generic parameter info.

--- a/src/java.base/share/classes/java/lang/reflect/Executable.java
+++ b/src/java.base/share/classes/java/lang/reflect/Executable.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
+import java.util.stream.Stream;
 import java.util.stream.Collectors;
 
 import jdk.internal.access.SharedSecrets;
@@ -310,11 +311,11 @@ public abstract sealed class Executable extends AccessibleObject
         // this case, we just return the result of
         // getParameterTypes().
         if (!genericInfo) {
-            return getSharedParameterTypes();
+            return getParameterTypes();
         } else {
             final boolean realParamData = hasRealParameterData();
             final Type[] genericParamTypes = getGenericParameterTypes();
-            final Type[] nonGenericParamTypes = getSharedParameterTypes();
+            final Type[] nonGenericParamTypes = getParameterTypes();
             // If we have real parameter data, then we use the
             // synthetic and mandate flags to our advantage.
             if (realParamData) {
@@ -325,7 +326,7 @@ public abstract sealed class Executable extends AccessibleObject
                     final Parameter param = params[i];
                     if (param.isSynthetic() || param.isImplicit()) {
                         // If we hit a synthetic or mandated parameter,
-                        // use the non-generic parameter info.
+                        // use the non generic parameter info.
                         out[i] = nonGenericParamTypes[i];
                     } else {
                         // Otherwise, use the generic parameter info.

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -431,7 +431,7 @@ public final class Method extends Executable {
 
     String toShortSignature() {
         StringJoiner sj = new StringJoiner(",", getName() + "(", ")");
-        for (Class<?> parameterType : getParameterTypes()) {
+        for (Class<?> parameterType : getSharedParameterTypes()) {
             sj.add(parameterType.getTypeName());
         }
         return sj.toString();


### PR DESCRIPTION
`Executable.getParameterTypes()` creates a copy of underlying array which is redundant in trusted code when we are sure the action is read-only.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278461](https://bugs.openjdk.java.net/browse/JDK-8278461): Use Executable.getSharedParameterTypes() instead of Executable.getParameterTypes() in trusted code


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to ee5fdb043a7807fdc6fefc91fec608fc543978df


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6782/head:pull/6782` \
`$ git checkout pull/6782`

Update a local copy of the PR: \
`$ git checkout pull/6782` \
`$ git pull https://git.openjdk.java.net/jdk pull/6782/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6782`

View PR using the GUI difftool: \
`$ git pr show -t 6782`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6782.diff">https://git.openjdk.java.net/jdk/pull/6782.diff</a>

</details>
