### PR TITLE
8278456: Define jtreg jdk_desktop test group time-based sub-tasks for use by headful testing.

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -385,16 +385,33 @@ jdk_editpad = \
      jdk/editpad
 
 jdk_desktop = \
-    :jdk_awt \
-    :jdk_2d \
-    :jdk_beans \
+    :jdk_desktop_part1 \
+    :jdk_desktop_part2 \
+    :jdk_desktop_part3
+
+jdk_desktop_part1 = \
+    :jdk_client_sanity \
     :jdk_swing \
+    :jdk_2d \
     :jdk_sound \
     :jdk_imageio \
-    :jdk_accessibility \
+    :jdk_editpad \
     :jfc_demo \
-    :jdk_client_sanity \
-    :jdk_editpad
+    :jdk_accessibility \
+    :jdk_beans
+
+jdk_desktop_part2 = \
+    :jdk_awt \
+    -java/awt/Component \
+    -java/awt/Modal \
+    -java/awt/datatransfer \
+    -java/awt/Window
+
+jdk_desktop_part3 = \
+    java/awt/Component \
+    java/awt/Modal \
+    java/awt/datatransfer \
+    java/awt/Window
 
 # SwingSet3 tests.
 jdk_client_sanity = \


### PR DESCRIPTION
Define part1/part2/part3 for client jtreg tests as done for some other areas
See the bug report for some numbers on the potential benefits of this for faster testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278456](https://bugs.openjdk.java.net/browse/JDK-8278456): Define jtreg jdk_desktop test group time-based sub-tasks for use by headful testing.


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6784/head:pull/6784` \
`$ git checkout pull/6784`

Update a local copy of the PR: \
`$ git checkout pull/6784` \
`$ git pull https://git.openjdk.java.net/jdk pull/6784/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6784`

View PR using the GUI difftool: \
`$ git pr show -t 6784`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6784.diff">https://git.openjdk.java.net/jdk/pull/6784.diff</a>

</details>
