### PR TITLE
8278381: [GCC 11] Address::make_raw() does not initialize rspec

### DIFF
--- a/src/hotspot/cpu/arm/assembler_arm_32.cpp
+++ b/src/hotspot/cpu/arm/assembler_arm_32.cpp
@@ -46,7 +46,7 @@
 // Convert the raw encoding form into the form expected by the
 // constructor for Address.
 Address Address::make_raw(int base, int index, int scale, int disp, relocInfo::relocType disp_reloc) {
-  RelocationHolder rspec;
+  RelocationHolder rspec = RelocationHolder::none;
   if (disp_reloc != relocInfo::none) {
     rspec = Relocation::spec_simple(disp_reloc);
   }

--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -186,7 +186,7 @@ Address::Address(address loc, RelocationHolder spec) {
 // Address.  An index of 4 (rsp) corresponds to having no index, so convert
 // that to noreg for the Address constructor.
 Address Address::make_raw(int base, int index, int scale, int disp, relocInfo::relocType disp_reloc) {
-  RelocationHolder rspec;
+  RelocationHolder rspec = RelocationHolder::none;
   if (disp_reloc != relocInfo::none) {
     rspec = Relocation::spec_simple(disp_reloc);
   }


### PR DESCRIPTION
The issue was encountered on OpenJDK11 with the error below, there is no error in tip because of the changes in [8240669](https://bugs.openjdk.java.net/browse/JDK-8240669). Fixing here for correctness and to backport.

.../src/hotspot/cpu/x86/assembler_x86.cpp: In static member function 'static Address Address::make_raw(int, int, int, int, relocInfo::relocType)':
.../src/hotspot/cpu/x86/assembler_x86.cpp:189:20: error: 'rspec.RelocationHolder::_relocbuf[3]' is used uninitialized [-Werror=uninitialized]
 189 |  RelocationHolder rspec;
   |          ^~~~~
...src/hotspot/cpu/x86/assembler_x86.cpp:189:20: error: 'rspec.RelocationHolder::_relocbuf[2]' is used uninitialized [-Werror=uninitialized]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278381](https://bugs.openjdk.java.net/browse/JDK-8278381): [GCC 11] Address::make_raw() does not initialize rspec


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)
 * [Xin Liu](https://openjdk.java.net/census#xliu) (@navyxliu - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6785/head:pull/6785` \
`$ git checkout pull/6785`

Update a local copy of the PR: \
`$ git checkout pull/6785` \
`$ git pull https://git.openjdk.java.net/jdk pull/6785/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6785`

View PR using the GUI difftool: \
`$ git pr show -t 6785`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6785.diff">https://git.openjdk.java.net/jdk/pull/6785.diff</a>

</details>
