### PR TITLE
8273108: RunThese24H crashes with SEGV in markWord::displaced_mark_helper() after JDK-8268276

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -6261,6 +6261,9 @@ address generate_avx_ghash_processBlocks() {
       __ cmpl(length, 63);
       __ jcc(Assembler::lessEqual, L_finalBit);
 
+      __ mov64(rax, 0x0000ffffffffffff);
+      __ kmovql(k2, rax);
+
       __ align32();
       __ BIND(L_process64Loop);
 
@@ -6282,7 +6285,7 @@ address generate_avx_ghash_processBlocks() {
       __ vpmaddwd(merged0, merge_ab_bc0, pack32_op, Assembler::AVX_512bit);
       __ vpermb(merged0, pack24bits, merged0, Assembler::AVX_512bit);
 
-      __ evmovdquq(Address(dest, dp), merged0, Assembler::AVX_512bit);
+      __ evmovdqub(Address(dest, dp), k2, merged0, true, Assembler::AVX_512bit);
 
       __ subl(length, 64);
       __ addptr(source, 64);


### PR DESCRIPTION
The base64 decoder overwrites memory past the end of its output buffer in certain cases.  It will not overwrite if the encoded string length is < 64 bytes.  It also will not overwrite if the encoded string length mod 64 is >= 16.  So the case where it *will* overwrite is when the input string length (the encoded byte length) mod 64 is less than 16.

I also added a test case to detect this overrun.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issues
 * [JDK-8273108](https://bugs.openjdk.java.net/browse/JDK-8273108): RunThese24H crashes with SEGV in markWord::displaced_mark_helper() after JDK-8268276
 * [JDK-8275427](https://bugs.openjdk.java.net/browse/JDK-8275427): RunThese24H.java failed with EXCEPTION_ACCESS_VIOLATION in java.util.ArrayList.add
 * [JDK-8272809](https://bugs.openjdk.java.net/browse/JDK-8272809): JFR thread sampler SI_KERNEL SEGV in metaspace::VirtualSpaceList::contains


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6786/head:pull/6786` \
`$ git checkout pull/6786`

Update a local copy of the PR: \
`$ git checkout pull/6786` \
`$ git pull https://git.openjdk.java.net/jdk pull/6786/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6786`

View PR using the GUI difftool: \
`$ git pr show -t 6786`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6786.diff">https://git.openjdk.java.net/jdk/pull/6786.diff</a>

</details>
