### PR TITLE
8269556: sun/tools/jhsdb/JShellHeapDumpTest.java fails with RuntimeException 'JShellToolProvider' missing from stdout/stderr

### DIFF
--- a/test/jdk/sun/tools/jhsdb/JShellHeapDumpTest.java
+++ b/test/jdk/sun/tools/jhsdb/JShellHeapDumpTest.java
@@ -98,7 +98,7 @@ public class JShellHeapDumpTest {
     }
 
     /* Returns false if the attempt should be retried. */
-    public static boolean printStackTraces(String file, boolean isRetry) throws IOException {
+    public static boolean printStackTraces(String file, boolean allowRetry) throws IOException {
         try {
             String output = HprofReader.getStack(file, 0);
             // We only require JShellToolProvider to be in the output if we did the
@@ -109,7 +109,7 @@ public class JShellHeapDumpTest {
                 // of the main thread do to it actively executing. See JDK-8269556. We retry once
                 // if that happens. This failure is so rare that this should be enough to make it
                 // extremely unlikely that we ever see this test fail again for this reason.
-                if (isRetry) {
+                if (allowRetry) {
                     throw new RuntimeException("'JShellToolProvider' missing from stdout/stderr");
                 } else {
                     System.out.println("'JShellToolProvider' missing. Allow one retry.");
@@ -123,7 +123,7 @@ public class JShellHeapDumpTest {
     }
 
     /* Returns false if the attempt should be retried. */
-    public static boolean testHeapDump(boolean isRetry) throws IOException {
+    public static boolean testHeapDump(boolean allowRetry) throws IOException {
         File hprofFile = new File("jhsdb.jmap.heap." +
                              System.currentTimeMillis() + ".hprof");
         if (hprofFile.exists()) {
@@ -136,7 +136,7 @@ public class JShellHeapDumpTest {
         assertTrue(hprofFile.exists() && hprofFile.isFile(),
                    "Could not create dump file " + hprofFile.getAbsolutePath());
 
-        boolean retry = printStackTraces(hprofFile.getAbsolutePath(), isRetry);
+        boolean retry = printStackTraces(hprofFile.getAbsolutePath(), allowRetry);
 
         System.out.println("hprof file size: " + hprofFile.length());
         hprofFile.delete();
@@ -181,10 +181,10 @@ public class JShellHeapDumpTest {
             throw new RuntimeException("Too many args: " + args.length);
         }
 
-        boolean retry = testHeapDump(false);
+        boolean retry = testHeapDump(true);
         // In case of rare failure to find 'JShellToolProvider' in the output, allow one retry.
         if (retry) {
-            testHeapDump(true);
+            testHeapDump(false);
         }
 
         // The test throws RuntimeException on error.

--- a/test/jdk/sun/tools/jhsdb/JShellHeapDumpTest.java
+++ b/test/jdk/sun/tools/jhsdb/JShellHeapDumpTest.java
@@ -109,7 +109,7 @@ public class JShellHeapDumpTest {
                 // of the main thread do to it actively executing. See JDK-8269556. We retry once
                 // if that happens. This failure is so rare that this should be enough to make it
                 // extremely unlikely that we ever see this test fail again for this reason.
-                if (allowRetry) {
+                if (!allowRetry) {
                     throw new RuntimeException("'JShellToolProvider' missing from stdout/stderr");
                 } else {
                     System.out.println("'JShellToolProvider' missing. Allow one retry.");

--- a/test/jdk/sun/tools/jhsdb/JShellHeapDumpTest.java
+++ b/test/jdk/sun/tools/jhsdb/JShellHeapDumpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,21 +97,33 @@ public class JShellHeapDumpTest {
         launch(expectedMessage, Arrays.asList(toolArgs));
     }
 
-    public static void printStackTraces(String file) throws IOException {
+    /* Returns false if the attempt should be retried. */
+    public static boolean printStackTraces(String file, boolean isRetry) throws IOException {
         try {
             String output = HprofReader.getStack(file, 0);
             // We only require JShellToolProvider to be in the output if we did the
             // short sleep. If we did not, the java process may not have executed far
             // enough along to even start the main thread.
             if (doSleep && !output.contains("JShellToolProvider")) {
-                throw new RuntimeException("'JShellToolProvider' missing from stdout/stderr");
+                // This check will very rarely fail due to not be able to get the stack trace
+                // of the main thread do to it actively executing. See JDK-8269556. We retry once
+                // if that happens. This failure is so rare that this should be enough to make it
+                // extremely unlikely that we ever see this test fail again for this reason.
+                if (isRetry) {
+                    throw new RuntimeException("'JShellToolProvider' missing from stdout/stderr");
+                } else {
+                    System.out.println("'JShellToolProvider' missing. Allow one retry.");
+                    return true; // Allow one retry
+                }
             }
         } catch (Exception ex) {
             throw new RuntimeException("Test ERROR " + ex, ex);
         }
+        return false;
     }
 
-    public static void testHeapDump() throws IOException {
+    /* Returns false if the attempt should be retried. */
+    public static boolean testHeapDump(boolean isRetry) throws IOException {
         File hprofFile = new File("jhsdb.jmap.heap." +
                              System.currentTimeMillis() + ".hprof");
         if (hprofFile.exists()) {
@@ -124,10 +136,12 @@ public class JShellHeapDumpTest {
         assertTrue(hprofFile.exists() && hprofFile.isFile(),
                    "Could not create dump file " + hprofFile.getAbsolutePath());
 
-        printStackTraces(hprofFile.getAbsolutePath());
+        boolean retry = printStackTraces(hprofFile.getAbsolutePath(), isRetry);
 
         System.out.println("hprof file size: " + hprofFile.length());
         hprofFile.delete();
+
+        return retry;
     }
 
     public static void launchJshell() throws IOException {
@@ -149,7 +163,7 @@ public class JShellHeapDumpTest {
         // Give jshell a chance to fully start up. This makes SA more stable for the jmap dump.
         try {
             if (doSleep) {
-                Thread.sleep(2000);
+                Thread.sleep(4000);
             }
         } catch (Exception e) {
         }
@@ -166,7 +180,12 @@ public class JShellHeapDumpTest {
         } else if (args.length != 0) {
             throw new RuntimeException("Too many args: " + args.length);
         }
-        testHeapDump();
+
+        boolean retry = testHeapDump(false);
+        // In case of rare failure to find 'JShellToolProvider' in the output, allow one retry.
+        if (retry) {
+            testHeapDump(true);
+        }
 
         // The test throws RuntimeException on error.
         // IOException is thrown if Jshell can't start because of some bad


### PR DESCRIPTION
The test searches for "JShellToolProvider" in the main thread's stack trace, which is pulled from an SA heap dump. Typically the main thread is blocked in Object.wait(), so SA can determine its stack trace. However, the wait has a 100ms timeout, so the thread does periodically wake up and does a few things before waiting again. If SA tries to get the stack trace while the thread is active, it may not be able to, and this causes the test to fail. I determined this only happens about 1 in 5000-10000 runs. So as a fix I'm allowing the test to do one retry. That should make it extremely unlikely that we ever see this failure again. I also bumped up the amount of time the test waits before doing the heap dump from 2 seconds to 4 just to make absolutely sure the main thread is fully started before doing the heap dump.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269556](https://bugs.openjdk.java.net/browse/JDK-8269556): sun/tools/jhsdb/JShellHeapDumpTest.java fails with RuntimeException 'JShellToolProvider' missing from stdout/stderr


### Reviewers
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to 65e14883060878e3cb092d8e2fa51fa2f34e47af
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6795/head:pull/6795` \
`$ git checkout pull/6795`

Update a local copy of the PR: \
`$ git checkout pull/6795` \
`$ git pull https://git.openjdk.java.net/jdk pull/6795/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6795`

View PR using the GUI difftool: \
`$ git pr show -t 6795`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6795.diff">https://git.openjdk.java.net/jdk/pull/6795.diff</a>

</details>
