### PR TITLE
8278548: G1: Remove unnecessary check in forward_to_block_containing_addr

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
@@ -149,6 +149,7 @@ inline HeapWord* G1BlockOffsetTablePart::forward_to_block_containing_addr(HeapWo
            "BOT not precise. Index for n: " SIZE_FORMAT " must be equal to the index for addr: " SIZE_FORMAT,
            _bot->index_for(n), _bot->index_for(addr));
     q = n;
+    assert(cast_to_oop(q)->klass_or_null() != nullptr, "must have non-null klass");
     n += block_size(q);
   }
   assert(q <= n, "wrong order for q and addr");

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
@@ -149,7 +149,8 @@ inline HeapWord* G1BlockOffsetTablePart::forward_to_block_containing_addr(HeapWo
            "BOT not precise. Index for n: " SIZE_FORMAT " must be equal to the index for addr: " SIZE_FORMAT,
            _bot->index_for(n), _bot->index_for(addr));
     q = n;
-    assert(cast_to_oop(q)->klass_or_null() != nullptr, "must have non-null klass");
+    assert(cast_to_oop(q)->klass_or_null() != nullptr,
+        "start of block must be an initialized object");
     n += block_size(q);
   }
   assert(q <= n, "wrong order for q and addr");

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
@@ -149,10 +149,6 @@ inline HeapWord* G1BlockOffsetTablePart::forward_to_block_containing_addr(HeapWo
            "BOT not precise. Index for n: " SIZE_FORMAT " must be equal to the index for addr: " SIZE_FORMAT,
            _bot->index_for(n), _bot->index_for(addr));
     q = n;
-    oop obj = cast_to_oop(q);
-    if (obj->klass_or_null_acquire() == NULL) {
-      return q;
-    }
     n += block_size(q);
   }
   assert(q <= n, "wrong order for q and addr");


### PR DESCRIPTION
Simple change of removing an always-false `if`.

Test: I added `assert(false)` inside the `if`, and no failure in tier1-6.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278548](https://bugs.openjdk.java.net/browse/JDK-8278548): G1: Remove unnecessary check in forward_to_block_containing_addr


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**) ⚠️ Review applies to 52e49e1739cc9f199afe5b05348bc52a6f5bbc7d
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6797/head:pull/6797` \
`$ git checkout pull/6797`

Update a local copy of the PR: \
`$ git checkout pull/6797` \
`$ git pull https://git.openjdk.java.net/jdk pull/6797/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6797`

View PR using the GUI difftool: \
`$ git pr show -t 6797`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6797.diff">https://git.openjdk.java.net/jdk/pull/6797.diff</a>

</details>
