### PR TITLE
8278533: Remove some unused methods in c1_Instruction and c1_ValueMap

### DIFF
--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -926,11 +926,6 @@ void BlockList::iterate_backward(BlockClosure* closure) {
 }
 
 
-void BlockList::blocks_do(void f(BlockBegin*)) {
-  for (int i = length() - 1; i >= 0; i--) f(at(i));
-}
-
-
 void BlockList::values_do(ValueVisitor* f) {
   for (int i = length() - 1; i >= 0; i--) at(i)->block_values_do(f);
 }

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -137,7 +137,6 @@ class BlockList: public GrowableArray<BlockBegin*> {
 
   void iterate_forward(BlockClosure* closure);
   void iterate_backward(BlockClosure* closure);
-  void blocks_do(void f(BlockBegin*));
   void values_do(ValueVisitor* f);
   void print(bool cfg_only = false, bool live_only = false) PRODUCT_RETURN;
 };

--- a/src/hotspot/share/c1/c1_ValueMap.hpp
+++ b/src/hotspot/share/c1/c1_ValueMap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,7 +116,6 @@ class ValueMap: public CompilationResourceObj {
   void kill_memory();
   void kill_field(ciField* field, bool all_offsets);
   void kill_array(ValueType* type);
-  void kill_exception();
   void kill_map(ValueMap* map);
   void kill_all();
 


### PR DESCRIPTION
This is a trivial patch to remove some unused methods in c1_Instruction and c1_ValueMap.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278533](https://bugs.openjdk.java.net/browse/JDK-8278533): Remove some unused methods in c1_Instruction and c1_ValueMap


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6798/head:pull/6798` \
`$ git checkout pull/6798`

Update a local copy of the PR: \
`$ git checkout pull/6798` \
`$ git pull https://git.openjdk.java.net/jdk pull/6798/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6798`

View PR using the GUI difftool: \
`$ git pr show -t 6798`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6798.diff">https://git.openjdk.java.net/jdk/pull/6798.diff</a>

</details>
