### PR TITLE
8278534: Remove some unnecessary code in MethodLiveness::init_basic_blocks

### DIFF
--- a/src/hotspot/share/compiler/methodLiveness.cpp
+++ b/src/hotspot/share/compiler/methodLiveness.cpp
@@ -97,8 +97,6 @@ void MethodLiveness::compute_liveness() {
 
 
 void MethodLiveness::init_basic_blocks() {
-  bool bailout = false;
-
   int method_len = method()->code_size();
   ciMethodBlocks *mblocks = method()->get_method_blocks();
 
@@ -254,10 +252,6 @@ void MethodLiveness::init_basic_blocks() {
       case Bytecodes::_ret:
         // We will patch up jsr/rets in a subsequent pass.
         ret_list->append(current_block);
-        break;
-      case Bytecodes::_breakpoint:
-        // Bail out of there are breakpoints in here.
-        bailout = true;
         break;
       default:
         // Do nothing.


### PR DESCRIPTION
This is a minor patch to remove some unnecessary code in MethodLiveness::init_basic_blocks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278534](https://bugs.openjdk.java.net/browse/JDK-8278534): Remove some unnecessary code in MethodLiveness::init_basic_blocks


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6799/head:pull/6799` \
`$ git checkout pull/6799`

Update a local copy of the PR: \
`$ git checkout pull/6799` \
`$ git pull https://git.openjdk.java.net/jdk pull/6799/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6799`

View PR using the GUI difftool: \
`$ git pr show -t 6799`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6799.diff">https://git.openjdk.java.net/jdk/pull/6799.diff</a>

</details>
