### PR TITLE
8278580: ProblemList javax/swing/JTree/4908142/bug4908142.java on macosx-x64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -749,7 +749,7 @@ javax/swing/JMenu/4515762/bug4515762.java 8276074 macosx-all
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8225012 windows-all,macosx-all
 sanity/client/SwingSet/src/ScrollPaneDemoTest.java 8225013 linux-all
 sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java 8265770 macosx-all
-javax/swing/JTree/4908142/bug4908142.java 8278348 macosx-aarch64
+javax/swing/JTree/4908142/bug4908142.java 8278348 macosx-all
 
 ############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList javax/swing/JTree/4908142/bug4908142.java on macosx-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278580](https://bugs.openjdk.java.net/browse/JDK-8278580): ProblemList javax/swing/JTree/4908142/bug4908142.java on macosx-x64


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6805/head:pull/6805` \
`$ git checkout pull/6805`

Update a local copy of the PR: \
`$ git checkout pull/6805` \
`$ git pull https://git.openjdk.java.net/jdk pull/6805/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6805`

View PR using the GUI difftool: \
`$ git pr show -t 6805`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6805.diff">https://git.openjdk.java.net/jdk/pull/6805.diff</a>

</details>
