### PR TITLE
8278581: Improve reference processing statistics log output

### DIFF
--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -483,7 +483,7 @@ void RefProcTask::process_discovered_list(uint worker_id,
                                                                        keep_alive,
                                                                        enqueue,
                                                                        do_enqueue_and_clear);
-    _phase_times->add_ref_cleared(ref_type, removed);
+    _phase_times->add_ref_dropped(ref_type, removed);
   }
 }
 

--- a/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
@@ -280,9 +280,6 @@ void ReferenceProcessorPhaseTimes::print_reference(ReferenceType ref_type, uint 
     LogStream ls(lt);
     ResourceMark rm;
 
-    ls.print_cr("%s%s:", Indents[base_indent], ref_type_2_string(ref_type));
-
-    uint const next_indent = base_indent + 1;
     int const ref_type_index = ref_type_2_index(ref_type);
 
     size_t discovered = _ref_discovered[ref_type_index];
@@ -290,9 +287,9 @@ void ReferenceProcessorPhaseTimes::print_reference(ReferenceType ref_type, uint 
     assert(discovered >= dropped, "invariant");
     size_t processed = discovered - dropped;
 
-    ls.print_cr("%sDiscovered: " SIZE_FORMAT, Indents[next_indent], discovered);
-    ls.print_cr("%sDropped: " SIZE_FORMAT, Indents[next_indent], dropped);
-    ls.print_cr("%sProcessed: " SIZE_FORMAT, Indents[next_indent], processed);
+    ls.print_cr("%s%s Discovered: %zu, Dropped: %zu, Processed: %zu",
+                Indents[base_indent], ref_type_2_string(ref_type),
+                discovered, dropped, processed);
   }
 }
 

--- a/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
@@ -207,7 +207,7 @@ void ReferenceProcessorPhaseTimes::reset() {
   _soft_weak_final_refs_phase_worker_time_sec->reset();
 
   for (int i = 0; i < number_of_subclasses_of_ref; i++) {
-    _ref_cleared[i] = 0;
+    _ref_dropped[i] = 0;
     _ref_discovered[i] = 0;
   }
 
@@ -223,9 +223,9 @@ ReferenceProcessorPhaseTimes::~ReferenceProcessorPhaseTimes() {
   delete _soft_weak_final_refs_phase_worker_time_sec;
 }
 
-void ReferenceProcessorPhaseTimes::add_ref_cleared(ReferenceType ref_type, size_t count) {
+void ReferenceProcessorPhaseTimes::add_ref_dropped(ReferenceType ref_type, size_t count) {
   ASSERT_REF_TYPE(ref_type);
-  Atomic::add(&_ref_cleared[ref_type_2_index(ref_type)], count, memory_order_relaxed);
+  Atomic::add(&_ref_dropped[ref_type_2_index(ref_type)], count, memory_order_relaxed);
 }
 
 void ReferenceProcessorPhaseTimes::set_ref_discovered(ReferenceType ref_type, size_t count) {
@@ -285,8 +285,14 @@ void ReferenceProcessorPhaseTimes::print_reference(ReferenceType ref_type, uint 
     uint const next_indent = base_indent + 1;
     int const ref_type_index = ref_type_2_index(ref_type);
 
-    ls.print_cr("%sDiscovered: " SIZE_FORMAT, Indents[next_indent], _ref_discovered[ref_type_index]);
-    ls.print_cr("%sCleared: " SIZE_FORMAT, Indents[next_indent], _ref_cleared[ref_type_index]);
+    size_t discovered = _ref_discovered[ref_type_index];
+    size_t dropped = _ref_dropped[ref_type_index];
+    assert(discovered >= dropped, "invariant");
+    size_t processed = discovered - dropped;
+
+    ls.print_cr("%sDiscovered: " SIZE_FORMAT, Indents[next_indent], discovered);
+    ls.print_cr("%sDropped: " SIZE_FORMAT, Indents[next_indent], dropped);
+    ls.print_cr("%sProcessed: " SIZE_FORMAT, Indents[next_indent], processed);
   }
 }
 

--- a/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.hpp
@@ -52,7 +52,7 @@ class ReferenceProcessorPhaseTimes : public CHeapObj<mtGC> {
   // Total spent time for reference processing.
   double                   _total_time_ms;
 
-  size_t                   _ref_cleared[number_of_subclasses_of_ref];
+  size_t                   _ref_dropped[number_of_subclasses_of_ref];
   size_t                   _ref_discovered[number_of_subclasses_of_ref];
 
   bool                     _processing_is_mt;
@@ -83,7 +83,7 @@ public:
 
   void set_total_time_ms(double total_time_ms) { _total_time_ms = total_time_ms; }
 
-  void add_ref_cleared(ReferenceType ref_type, size_t count);
+  void add_ref_dropped(ReferenceType ref_type, size_t count);
   void set_ref_discovered(ReferenceType ref_type, size_t count);
   size_t ref_discovered(ReferenceType ref_type);
 

--- a/test/hotspot/jtreg/gc/logging/TestPrintReferences.java
+++ b/test/hotspot/jtreg/gc/logging/TestPrintReferences.java
@@ -80,10 +80,10 @@ public class TestPrintReferences {
 
     private static String refRegex(String reftype) {
         String countRegex = "[0-9]+";
-        return gcLogTimeRegex + indent(6) + reftype + ":\n" +
-               gcLogTimeRegex + indent(8) + "Discovered: " + countRegex + "\n" +
-               gcLogTimeRegex + indent(8) + "Dropped: "    + countRegex + "\n" +
-               gcLogTimeRegex + indent(8) + "Processed: "  + countRegex + "\n"
+        return gcLogTimeRegex + indent(6) + reftype + " " +
+               "Discovered: " + countRegex + ", " +
+               "Dropped: "    + countRegex + ", " +
+               "Processed: "  + countRegex + "\n"
                ;
     }
 

--- a/test/hotspot/jtreg/gc/logging/TestPrintReferences.java
+++ b/test/hotspot/jtreg/gc/logging/TestPrintReferences.java
@@ -82,7 +82,9 @@ public class TestPrintReferences {
         String countRegex = "[0-9]+";
         return gcLogTimeRegex + indent(6) + reftype + ":\n" +
                gcLogTimeRegex + indent(8) + "Discovered: " + countRegex + "\n" +
-               gcLogTimeRegex + indent(8) + "Cleared: " + countRegex + "\n";
+               gcLogTimeRegex + indent(8) + "Dropped: "    + countRegex + "\n" +
+               gcLogTimeRegex + indent(8) + "Processed: "  + countRegex + "\n"
+               ;
     }
 
     private static void checkRefsLogFormat(OutputAnalyzer output) {


### PR DESCRIPTION
The first commit renames `Cleared` to `Dropped` and added `Processed` in the log output.

The second commit compressed the log output into one line per ref-type. The final log format looks like:

```
[11.803s][debug][gc,phases,ref  ] GC(0)   SoftReference Discovered: 0, Dropped: 0, Processed: 0
[11.803s][debug][gc,phases,ref  ] GC(0)   WeakReference Discovered: 1147, Dropped: 752, Processed: 395
[11.803s][debug][gc,phases,ref  ] GC(0)   FinalReference Discovered: 0, Dropped: 0, Processed: 0
[11.803s][debug][gc,phases,ref  ] GC(0)   PhantomReference Discovered: 242, Dropped: 2, Processed: 240
```

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278581](https://bugs.openjdk.java.net/browse/JDK-8278581): Improve reference processing statistics log output


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6806/head:pull/6806` \
`$ git checkout pull/6806`

Update a local copy of the PR: \
`$ git checkout pull/6806` \
`$ git pull https://git.openjdk.java.net/jdk pull/6806/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6806`

View PR using the GUI difftool: \
`$ git pr show -t 6806`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6806.diff">https://git.openjdk.java.net/jdk/pull/6806.diff</a>

</details>
