### PR TITLE
JDK-8278585: Drop unused code from OSThread

### DIFF
--- a/src/hotspot/os/aix/osThread_aix.hpp
+++ b/src/hotspot/os/aix/osThread_aix.hpp
@@ -63,13 +63,6 @@
   // Used for debugging, return a unique integer for each thread.
   int thread_identifier() const   { return _thread_id; }
 #endif
-#ifdef ASSERT
-  // We expect no reposition failures so kill vm if we get one.
-  //
-  bool valid_reposition_failure() {
-    return false;
-  }
-#endif // ASSERT
   tid_t kernel_thread_id() const {
     return _kernel_thread_id;
   }

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -741,7 +741,7 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
   assert(thread->osthread() == NULL, "caller responsible");
 
   // Allocate the OSThread object.
-  OSThread* osthread = new OSThread(NULL, NULL);
+  OSThread* osthread = new OSThread();
   if (osthread == NULL) {
     return false;
   }
@@ -855,7 +855,7 @@ bool os::create_attached_thread(JavaThread* thread) {
 #endif
 
   // Allocate the OSThread object
-  OSThread* osthread = new OSThread(NULL, NULL);
+  OSThread* osthread = new OSThread();
 
   if (osthread == NULL) {
     return false;

--- a/src/hotspot/os/bsd/osThread_bsd.hpp
+++ b/src/hotspot/os/bsd/osThread_bsd.hpp
@@ -67,14 +67,6 @@
   intptr_t thread_identifier() const   { return (intptr_t)_pthread_id; }
 #endif
 
-#ifdef ASSERT
-  // We expect no reposition failures so kill vm if we get one.
-  //
-  bool valid_reposition_failure() {
-    return false;
-  }
-#endif // ASSERT
-
   pthread_t pthread_id() const {
     return _pthread_id;
   }

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -589,7 +589,7 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
   assert(thread->osthread() == NULL, "caller responsible");
 
   // Allocate the OSThread object
-  OSThread* osthread = new OSThread(NULL, NULL);
+  OSThread* osthread = new OSThread();
   if (osthread == NULL) {
     return false;
   }
@@ -682,7 +682,7 @@ bool os::create_attached_thread(JavaThread* thread) {
 #endif
 
   // Allocate the OSThread object
-  OSThread* osthread = new OSThread(NULL, NULL);
+  OSThread* osthread = new OSThread();
 
   if (osthread == NULL) {
     return false;

--- a/src/hotspot/os/linux/osThread_linux.hpp
+++ b/src/hotspot/os/linux/osThread_linux.hpp
@@ -55,13 +55,7 @@
   // Used for debugging, return a unique integer for each thread.
   int thread_identifier() const   { return _thread_id; }
 #endif
-#ifdef ASSERT
-  // We expect no reposition failures so kill vm if we get one.
-  //
-  bool valid_reposition_failure() {
-    return false;
-  }
-#endif // ASSERT
+
   pthread_t pthread_id() const {
     return _pthread_id;
   }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -786,7 +786,7 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
   assert(thread->osthread() == NULL, "caller responsible");
 
   // Allocate the OSThread object
-  OSThread* osthread = new OSThread(NULL, NULL);
+  OSThread* osthread = new OSThread();
   if (osthread == NULL) {
     return false;
   }
@@ -915,7 +915,7 @@ bool os::create_attached_thread(JavaThread* thread) {
 #endif
 
   // Allocate the OSThread object
-  OSThread* osthread = new OSThread(NULL, NULL);
+  OSThread* osthread = new OSThread();
 
   if (osthread == NULL) {
     return false;

--- a/src/hotspot/os/windows/osThread_windows.hpp
+++ b/src/hotspot/os/windows/osThread_windows.hpp
@@ -49,13 +49,6 @@
   // Used for debugging, return a unique integer for each thread.
   int thread_identifier() const                    { return _thread_id; }
 #endif
-#ifdef ASSERT
-  // We expect no reposition failures so kill vm if we get one
-  //
-  bool valid_reposition_failure() {
-    return false;
-  }
-#endif // ASSERT
 
  private:
   void pd_initialize();

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -568,7 +568,7 @@ static unsigned __stdcall thread_native_entry(Thread* thread) {
 static OSThread* create_os_thread(Thread* thread, HANDLE thread_handle,
                                   int thread_id) {
   // Allocate the OSThread object
-  OSThread* osthread = new OSThread(NULL, NULL);
+  OSThread* osthread = new OSThread();
   if (osthread == NULL) return NULL;
 
   // Initialize the JDK library's interrupt event.
@@ -671,7 +671,7 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
   unsigned thread_id;
 
   // Allocate the OSThread object
-  OSThread* osthread = new OSThread(NULL, NULL);
+  OSThread* osthread = new OSThread();
   if (osthread == NULL) {
     return false;
   }

--- a/src/hotspot/share/jfr/writers/jfrJavaEventWriter.cpp
+++ b/src/hotspot/share/jfr/writers/jfrJavaEventWriter.cpp
@@ -45,7 +45,6 @@ static int start_pos_address_offset = invalid_offset;
 static int current_pos_offset = invalid_offset;
 static int max_pos_offset = invalid_offset;
 static int notified_offset = invalid_offset;
-static int thread_id_offset = invalid_offset;
 static int valid_offset = invalid_offset;
 
 static bool find_field(InstanceKlass* ik,

--- a/src/hotspot/share/runtime/osThread.cpp
+++ b/src/hotspot/share/runtime/osThread.cpp
@@ -26,10 +26,8 @@
 #include "oops/oop.inline.hpp"
 #include "runtime/osThread.hpp"
 
-OSThread::OSThread(OSThreadStartFunc start_proc, void* start_parm) {
+OSThread::OSThread() {
   pd_initialize();
-  set_start_proc(start_proc);
-  set_start_parm(start_parm);
 }
 
 OSThread::~OSThread() {

--- a/src/hotspot/share/runtime/osThread.hpp
+++ b/src/hotspot/share/runtime/osThread.hpp
@@ -61,8 +61,6 @@ class OSThread: public CHeapObj<mtThread> {
   friend class VMStructs;
   friend class JVMCIVMStructs;
  private:
-  OSThreadStartFunc _start_proc;  // Thread start routine
-  void* _start_parm;              // Thread start routine parameter
   volatile ThreadState _state;    // Thread state *hint*
 
   // Methods
@@ -70,18 +68,9 @@ class OSThread: public CHeapObj<mtThread> {
   void set_state(ThreadState state)                { _state = state; }
   ThreadState get_state()                          { return _state; }
 
-  OSThread(OSThreadStartFunc start_proc, void* start_parm);
+  OSThread();
   ~OSThread();
 
-  // Accessors
-  OSThreadStartFunc start_proc() const              { return _start_proc; }
-  void set_start_proc(OSThreadStartFunc start_proc) { _start_proc = start_proc; }
-  void* start_parm() const                          { return _start_parm; }
-  void set_start_parm(void* start_parm)             { _start_parm = start_parm; }
-  // This is specialized on Windows.
-#ifndef _WINDOWS
-  void set_interrupted(bool z)                      { /* nothing to do */ }
-#endif
   // Printing
   void print_on(outputStream* st) const;
   void print() const;
@@ -90,8 +79,6 @@ class OSThread: public CHeapObj<mtThread> {
 #include OS_HEADER(osThread)
 
  public:
-  static ByteSize thread_id_offset()              { return byte_offset_of(OSThread, _thread_id); }
-  static size_t thread_id_size()                  { return sizeof(thread_id_t); }
 
   thread_id_t thread_id() const                   { return _thread_id; }
 

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1111,7 +1111,7 @@ void JavaThread::interrupt() {
   debug_only(check_for_dangling_thread_pointer(this);)
 
   // For Windows _interrupt_event
-  osthread()->set_interrupted(true);
+  WINDOWS_ONLY(osthread()->set_interrupted(true);)
 
   // For Thread.sleep
   _SleepEvent->unpark();
@@ -1156,7 +1156,7 @@ bool JavaThread::is_interrupted(bool clear_interrupted) {
   if (interrupted && clear_interrupted) {
     assert(this == Thread::current(), "only the current thread can clear");
     java_lang_Thread::set_interrupted(threadObj(), false);
-    osthread()->set_interrupted(false);
+    WINDOWS_ONLY(osthread()->set_interrupted(false);)
   }
 
   return interrupted;


### PR DESCRIPTION
Gentle cleanup of OSThread, removes some unused functionality. No functional changes.

- both start proc and start param parameters are unused (when we create threads we always start with `thread_native_entry` as thread procedure). Removed members and constructor arguments (had always been called with NULL)
- `valid_reposition_failure()` is unused, returns always false on all platforms. Used to return true on Solaris, but I could not find a caller even going back to jdk-8.
- removed `thread_id_offset`, `thread_id_size`, both had been used at one time by C1 but not anymore.
- Finally, removed the platform-independent stub for the windows-only `set_interrupted()`; replaced it with WINDOWS_ONLY at the only two places where it is invoked. Matter of taste, but I find this actually clearer than having a single-platform function looking like a generic one.

Thanks, Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278585](https://bugs.openjdk.java.net/browse/JDK-8278585): Drop unused code from OSThread


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6809/head:pull/6809` \
`$ git checkout pull/6809`

Update a local copy of the PR: \
`$ git checkout pull/6809` \
`$ git pull https://git.openjdk.java.net/jdk pull/6809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6809`

View PR using the GUI difftool: \
`$ git pr show -t 6809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6809.diff">https://git.openjdk.java.net/jdk/pull/6809.diff</a>

</details>
