### PR TITLE
Fix jdwpTransport relative address in comment

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
+++ b/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
@@ -46,7 +46,7 @@
  * The Socket Transport Library.
  *
  * This module is an implementation of the Java Debug Wire Protocol Transport
- * Service Provider Interface - see src/share/javavm/export/jdwpTransport.h.
+ * Service Provider Interface - see src/jdk.jdwp.agent/share/native/include/jdwpTransport.h.
  */
 
 static int serverSocketFD = -1;


### PR DESCRIPTION
Due to the modularization of java9, the relative address of jdwpTransport.h in comment is wrong.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6810/head:pull/6810` \
`$ git checkout pull/6810`

Update a local copy of the PR: \
`$ git checkout pull/6810` \
`$ git pull https://git.openjdk.java.net/jdk pull/6810/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6810`

View PR using the GUI difftool: \
`$ git pr show -t 6810`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6810.diff">https://git.openjdk.java.net/jdk/pull/6810.diff</a>

</details>
