### PR TITLE
8278601: Parallel: Remove redundant code in ObjectStartArray::initialize

### DIFF
--- a/src/hotspot/share/gc/parallel/objectStartArray.cpp
+++ b/src/hotspot/share/gc/parallel/objectStartArray.cpp
@@ -68,13 +68,7 @@ void ObjectStartArray::initialize(MemRegion reserved_region) {
   _virtual_space.initialize(backing_store);
 
   _raw_base = (jbyte*)_virtual_space.low_boundary();
-
-  if (_raw_base == NULL) {
-    vm_exit_during_initialization("Could not get raw_base address");
-  }
-
-  MemTracker::record_virtual_memory_type((address)_raw_base, mtGC);
-
+  assert(_raw_base != nullptr, "set from the backing_store");
 
   _offset_base = _raw_base - (size_t(reserved_region.start()) >> _card_shift);
 


### PR DESCRIPTION
Simple change of removing some redundant code and converting an unnecessary check to an assertion.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278601](https://bugs.openjdk.java.net/browse/JDK-8278601): Parallel: Remove redundant code in ObjectStartArray::initialize


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6813/head:pull/6813` \
`$ git checkout pull/6813`

Update a local copy of the PR: \
`$ git checkout pull/6813` \
`$ git pull https://git.openjdk.java.net/jdk pull/6813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6813`

View PR using the GUI difftool: \
`$ git pr show -t 6813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6813.diff">https://git.openjdk.java.net/jdk/pull/6813.diff</a>

</details>
