### PR TITLE
8278568: Consolidate filler objects

### DIFF
--- a/src/hotspot/share/gc/parallel/psPromotionLAB.cpp
+++ b/src/hotspot/share/gc/parallel/psPromotionLAB.cpp
@@ -76,7 +76,7 @@ void PSPromotionLAB::flush() {
   // PLAB's never allocate the last aligned_header_size
   // so they can always fill with an array.
   HeapWord* tlab_end = end() + CollectedHeap::min_dummy_object_size();
-  CollectedHeap::fill_with_object(top(), tlab_end, DEBUG_ONLY(true) NOT_DEBUG(false));
+  CollectedHeap::fill_with_object(top(), tlab_end, trueInDebug);
 
   set_bottom(NULL);
   set_end(NULL);

--- a/src/hotspot/share/gc/parallel/psPromotionLAB.cpp
+++ b/src/hotspot/share/gc/parallel/psPromotionLAB.cpp
@@ -29,8 +29,6 @@
 #include "memory/universe.hpp"
 #include "oops/oop.inline.hpp"
 
-size_t PSPromotionLAB::filler_header_size;
-
 // This is the shared initialization code. It sets up the basic pointers,
 // and allows enough extra space for a filler object. We call a virtual
 // method, "lab_is_valid()" to handle the different asserts the old/young
@@ -45,10 +43,6 @@ void PSPromotionLAB::initialize(MemRegion lab) {
   set_end(end);
   set_top(bottom);
 
-  // Initialize after VM starts up because header_size depends on compressed
-  // oops.
-  filler_header_size = align_object_size(typeArrayOopDesc::header_size(T_INT));
-
   // We can be initialized to a zero size!
   if (free() > 0) {
     if (ZapUnusedHeapArea) {
@@ -56,8 +50,8 @@ void PSPromotionLAB::initialize(MemRegion lab) {
     }
 
     // NOTE! We need to allow space for a filler object.
-    assert(lab.word_size() >= filler_header_size, "lab is too small");
-    end = end - filler_header_size;
+    assert(lab.word_size() >= CollectedHeap::min_dummy_object_size(), "lab is too small");
+    end = end - CollectedHeap::min_dummy_object_size();
     set_end(end);
 
     _state = needs_flush;
@@ -81,20 +75,8 @@ void PSPromotionLAB::flush() {
 
   // PLAB's never allocate the last aligned_header_size
   // so they can always fill with an array.
-  HeapWord* tlab_end = end() + filler_header_size;
-  typeArrayOop filler_oop = (typeArrayOop) cast_to_oop(top());
-  filler_oop->set_mark(markWord::prototype());
-  filler_oop->set_klass(Universe::intArrayKlassObj());
-  const size_t array_length =
-    pointer_delta(tlab_end, top()) - typeArrayOopDesc::header_size(T_INT);
-  assert( (array_length * (HeapWordSize/sizeof(jint))) < (size_t)max_jint, "array too big in PSPromotionLAB");
-  filler_oop->set_length((int)(array_length * (HeapWordSize/sizeof(jint))));
-
-#ifdef ASSERT
-  // Note that we actually DO NOT want to use the aligned header size!
-  HeapWord* elt_words = cast_from_oop<HeapWord*>(filler_oop) + typeArrayOopDesc::header_size(T_INT);
-  Copy::fill_to_words(elt_words, array_length, 0xDEAABABE);
-#endif
+  HeapWord* tlab_end = end() + CollectedHeap::min_dummy_object_size();
+  CollectedHeap::fill_with_object(top(), tlab_end, DEBUG_ONLY(true) NOT_DEBUG(false));
 
   set_bottom(NULL);
   set_end(NULL);

--- a/src/hotspot/share/gc/parallel/psPromotionLAB.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionLAB.hpp
@@ -39,8 +39,6 @@ class ObjectStartArray;
 
 class PSPromotionLAB : public CHeapObj<mtGC> {
  protected:
-  static size_t filler_header_size;
-
   enum LabState {
     needs_flush,
     flushed,

--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -493,10 +493,6 @@ void CollectedHeap::fill_with_dummy_object(HeapWord* start, HeapWord* end, bool 
   CollectedHeap::fill_with_object(start, end, zap);
 }
 
-size_t CollectedHeap::min_dummy_object_size() {
-  return oopDesc::header_size();
-}
-
 size_t CollectedHeap::tlab_alloc_reserve() const {
   size_t min_size = min_dummy_object_size();
   return min_size > (size_t)MinObjAlignment ? align_object_size(min_size) : 0;

--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -493,7 +493,7 @@ void CollectedHeap::fill_with_dummy_object(HeapWord* start, HeapWord* end, bool 
   CollectedHeap::fill_with_object(start, end, zap);
 }
 
-size_t CollectedHeap::min_dummy_object_size() const {
+size_t CollectedHeap::min_dummy_object_size() {
   return oopDesc::header_size();
 }
 

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -289,7 +289,9 @@ class CollectedHeap : public CHeapObj<mtInternal> {
   }
 
   virtual void fill_with_dummy_object(HeapWord* start, HeapWord* end, bool zap);
-  static size_t min_dummy_object_size();
+  static constexpr size_t min_dummy_object_size() {
+    return oopDesc::header_size();
+  }
 
   size_t tlab_alloc_reserve() const;
 

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -289,7 +289,8 @@ class CollectedHeap : public CHeapObj<mtInternal> {
   }
 
   virtual void fill_with_dummy_object(HeapWord* start, HeapWord* end, bool zap);
-  virtual size_t min_dummy_object_size() const;
+  static size_t min_dummy_object_size();
+
   size_t tlab_alloc_reserve() const;
 
   // Some heaps may offer a contiguous region for shared non-blocking

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -730,38 +730,6 @@ HeapWord* ContiguousSpace::par_allocate(size_t size) {
   return par_allocate_impl(size);
 }
 
-void ContiguousSpace::allocate_temporary_filler(int factor) {
-  // allocate temporary type array decreasing free size with factor 'factor'
-  assert(factor >= 0, "just checking");
-  size_t size = pointer_delta(end(), top());
-
-  // if space is full, return
-  if (size == 0) return;
-
-  if (factor > 0) {
-    size -= size/factor;
-  }
-  size = align_object_size(size);
-
-  const size_t array_header_size = typeArrayOopDesc::header_size(T_INT);
-  if (size >= align_object_size(array_header_size)) {
-    size_t length = (size - array_header_size) * (HeapWordSize / sizeof(jint));
-    // allocate uninitialized int array
-    typeArrayOop t = (typeArrayOop) cast_to_oop(allocate(size));
-    assert(t != NULL, "allocation should succeed");
-    t->set_mark(markWord::prototype());
-    t->set_klass(Universe::intArrayKlassObj());
-    t->set_length((int)length);
-  } else {
-    assert(size == CollectedHeap::min_fill_size(),
-           "size for smallest fake object doesn't match");
-    instanceOop obj = (instanceOop) cast_to_oop(allocate(size));
-    obj->set_mark(markWord::prototype());
-    obj->set_klass_gap(0);
-    obj->set_klass(vmClasses::Object_klass());
-  }
-}
-
 void OffsetTableContigSpace::initialize_threshold() {
   _offsets.initialize_threshold();
 }

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -532,10 +532,6 @@ class ContiguousSpace: public CompactibleSpace {
 
   // Debugging
   virtual void verify() const;
-
-  // Used to increase collection frequency.  "factor" of 0 means entire
-  // space.
-  void allocate_temporary_filler(int factor);
 };
 
 

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -96,7 +96,7 @@ class oopDesc {
   static inline void set_klass_gap(HeapWord* mem, int z);
 
   // size of object header, aligned to platform wordSize
-  static int header_size() { return sizeof(oopDesc)/HeapWordSize; }
+  static constexpr int header_size() { return sizeof(oopDesc)/HeapWordSize; }
 
   // Returns whether this is an instance of k or an instance of a subclass of k
   inline bool is_a(Klass* k) const;


### PR DESCRIPTION
In PSPromotionLAB exists some code that fills unused tails of promotion LABs, which is semantically the same as the CollectedHeap::fill* family of methods. They can be consolidated.

We also have ContiguousSpace::allocate_temporary_filler() which does the same, but is unused and can be removed. 

Testing:
 - [x] hotspot_gc
 - [x] tier1
 - [ ] tier2
 - [ ] tier3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278568](https://bugs.openjdk.java.net/browse/JDK-8278568): Consolidate filler objects


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**) ⚠️ Review applies to f763bbaf5dccaf64cb10a3869609f23b816615a3
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6814/head:pull/6814` \
`$ git checkout pull/6814`

Update a local copy of the PR: \
`$ git checkout pull/6814` \
`$ git pull https://git.openjdk.java.net/jdk pull/6814/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6814`

View PR using the GUI difftool: \
`$ git pr show -t 6814`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6814.diff">https://git.openjdk.java.net/jdk/pull/6814.diff</a>

</details>
