### PR TITLE
8278612: test/jdk/java/awt/dnd/RemoveDropTargetCrashTest crashes with VoiceOver on macOS

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -95,7 +95,11 @@ static jobject sAccessibilityClass = NULL;
         return NO;
     }
 
-    return isChildSelected(env, ((CommonComponentAccessibility *)[self parent])->fAccessible, fIndex, fComponent);
+    id parent = [self parent];
+    if ([parent isKindOfClass:[CommonComponentAccessibility class]]) {
+        return isChildSelected(env, ((CommonComponentAccessibility *)parent)->fAccessible, fIndex, fComponent);
+    }
+    return NO;
 }
 
 - (BOOL)isSelectable:(JNIEnv *)env

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TabButtonAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TabButtonAccessibility.m
@@ -59,11 +59,14 @@
 - (jobject)tabGroup
 {
     if (fTabGroupAxContext == NULL) {
-        JNIEnv* env = [ThreadUtilities getJNIEnv];
-        jobject tabGroupAxContext = [(CommonComponentAccessibility *)[self parent] axContextWithEnv:env];
-        fTabGroupAxContext = (*env)->NewWeakGlobalRef(env, tabGroupAxContext);
-        CHECK_EXCEPTION();
-        (*env)->DeleteLocalRef(env, tabGroupAxContext);
+        id parent = [self parent];
+        if ([parent isKindOfClass:[CommonComponentAccessibility class]]) {
+            JNIEnv *env = [ThreadUtilities getJNIEnv];
+            jobject tabGroupAxContext = [(CommonComponentAccessibility *)parent axContextWithEnv:env];
+            fTabGroupAxContext = (*env)->NewWeakGlobalRef(env, tabGroupAxContext);
+            CHECK_EXCEPTION();
+            (*env)->DeleteLocalRef(env, tabGroupAxContext);
+        }
     }
     return fTabGroupAxContext;
 }


### PR DESCRIPTION
… VoiceOver on macOS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8278612](https://bugs.openjdk.java.net/browse/JDK-8278612)

### Issue
 * [JDK-8278612](https://bugs.openjdk.java.net/browse/JDK-8278612): [macos] test/jdk/java/awt/dnd/RemoveDropTargetCrashTest crashes with VoiceOver on macOS ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6816/head:pull/6816` \
`$ git checkout pull/6816`

Update a local copy of the PR: \
`$ git checkout pull/6816` \
`$ git pull https://git.openjdk.java.net/jdk pull/6816/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6816`

View PR using the GUI difftool: \
`$ git pr show -t 6816`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6816.diff">https://git.openjdk.java.net/jdk/pull/6816.diff</a>

</details>
