### PR TITLE
8278630: ProblemList compiler/vectorapi/reshape/TestVectorCastAVX512.java on X64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -74,6 +74,8 @@ compiler/whitebox/MakeMethodNotCompilableTest.java 8265360 macosx-aarch64
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-x64
 compiler/codecache/TestStressCodeBuffers.java 8272094 generic-aarch64
 
+compiler/vectorapi/reshape/TestVectorCastAVX512.java 8278623 generic-x64
+
 
 #############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList compiler/vectorapi/reshape/TestVectorCastAVX512.java on X64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278630](https://bugs.openjdk.java.net/browse/JDK-8278630): ProblemList compiler/vectorapi/reshape/TestVectorCastAVX512.java on X64


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6817/head:pull/6817` \
`$ git checkout pull/6817`

Update a local copy of the PR: \
`$ git checkout pull/6817` \
`$ git pull https://git.openjdk.java.net/jdk pull/6817/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6817`

View PR using the GUI difftool: \
`$ git pr show -t 6817`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6817.diff">https://git.openjdk.java.net/jdk/pull/6817.diff</a>

</details>
