### PR TITLE
8244765: Undo exclusiveAccess.dirs changes for JDK-8220295 and see if there are still any testing issues

### DIFF
--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -25,9 +25,7 @@ javax/management sun/awt sun/java2d javax/xml/jaxp/testng/validation java/lang/P
 # Tests that cannot run concurrently
 exclusiveAccess.dirs=java/math/BigInteger/largeMemory \
 java/rmi/Naming java/util/prefs sun/management/jmxremote \
-sun/tools/jstatd sun/tools/jcmd \
-sun/tools/jinfo sun/tools/jmap sun/tools/jps sun/tools/jstack sun/tools/jstat \
-com/sun/tools/attach sun/security/mscapi java/util/Arrays/largeMemory \
+sun/tools/jstatd sun/security/mscapi java/util/Arrays/largeMemory \
 java/util/BitSet/stream javax/rmi java/net/httpclient/websocket \
 com/sun/net/httpserver/simpleserver
 


### PR DESCRIPTION
This changes removes (most) Attach API tests from exclusiveAccess.dirs so the tests can be run in parallel. I haven't seen any issues with this change, except the jstatd tests can fail due to an RMI issue. I filed https://bugs.openjdk.java.net/browse/JDK-8278625 to cover that issue, and left jstatd tests in exclusiveAccess.dirs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244765](https://bugs.openjdk.java.net/browse/JDK-8244765): Undo exclusiveAccess.dirs changes for JDK-8220295 and see if there are still any testing issues


### Reviewers
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6818/head:pull/6818` \
`$ git checkout pull/6818`

Update a local copy of the PR: \
`$ git checkout pull/6818` \
`$ git pull https://git.openjdk.java.net/jdk pull/6818/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6818`

View PR using the GUI difftool: \
`$ git pr show -t 6818`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6818.diff">https://git.openjdk.java.net/jdk/pull/6818.diff</a>

</details>
