### PR TITLE
8268573: Remove expired flags in JDK 19

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -543,19 +543,7 @@ static SpecialFlag const special_jvm_flags[] = {
   { "TLABStats",                    JDK_Version::jdk(12), JDK_Version::undefined(), JDK_Version::undefined() },
 
   // -------------- Obsolete Flags - sorted by expired_in --------------
-  { "CriticalJNINatives",           JDK_Version::jdk(16), JDK_Version::jdk(18), JDK_Version::jdk(19) },
-  { "InlineFrequencyCount",         JDK_Version::undefined(), JDK_Version::jdk(18), JDK_Version::jdk(19) },
-  { "G1RSetRegionEntries",          JDK_Version::undefined(), JDK_Version::jdk(18), JDK_Version::jdk(19) },
-  { "G1RSetSparseRegionEntries",    JDK_Version::undefined(), JDK_Version::jdk(18), JDK_Version::jdk(19) },
-  { "AlwaysLockClassLoader",        JDK_Version::jdk(17), JDK_Version::jdk(18), JDK_Version::jdk(19) },
-  { "UseBiasedLocking",             JDK_Version::jdk(15), JDK_Version::jdk(18), JDK_Version::jdk(19) },
-  { "BiasedLockingStartupDelay",    JDK_Version::jdk(15), JDK_Version::jdk(18), JDK_Version::jdk(19) },
-  { "PrintBiasedLockingStatistics", JDK_Version::jdk(15), JDK_Version::jdk(18), JDK_Version::jdk(19) },
-  { "BiasedLockingBulkRebiasThreshold",    JDK_Version::jdk(15), JDK_Version::jdk(18), JDK_Version::jdk(19) },
-  { "BiasedLockingBulkRevokeThreshold",    JDK_Version::jdk(15), JDK_Version::jdk(18), JDK_Version::jdk(19) },
-  { "BiasedLockingDecayTime",              JDK_Version::jdk(15), JDK_Version::jdk(18), JDK_Version::jdk(19) },
-  { "UseOptoBiasInlining",                 JDK_Version::jdk(15), JDK_Version::jdk(18), JDK_Version::jdk(19) },
-  { "PrintPreciseBiasedLockingStatistics", JDK_Version::jdk(15), JDK_Version::jdk(18), JDK_Version::jdk(19) },
+
 #ifdef ASSERT
   { "DummyObsoleteTestFlag",        JDK_Version::undefined(), JDK_Version::jdk(18), JDK_Version::undefined() },
 #endif

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -4039,6 +4039,14 @@ This option was deprecated in JDK 16 by \f[B]JEP 396\f[R]
 \f[B]JEP 403\f[R] [https://openjdk.java.net/jeps/403].
 .RS
 .RE
+.SH REMOVED JAVA OPTIONS
+.PP
+These \f[CB]java\f[R] options have been removed in JDK 19 and using them
+results in an error of:
+.RS
+.PP
+\f[CB]Unrecognized\ VM\ option\f[R] \f[I]option\-name\f[R]
+.RE
 .TP
 .B \f[CB]\-XX:+UseBiasedLocking\f[R]
 Enables the use of biased locking.
@@ -4046,15 +4054,13 @@ Some applications with significant amounts of uncontended
 synchronization may attain significant speedups with this flag enabled,
 but applications with certain patterns of locking may see slowdowns.
 .RS
-.PP
-By default, this option is disabled.
 .RE
-.SH REMOVED JAVA OPTIONS
-.PP
-No documented \f[CB]java\f[R] options have been removed in JDK 18.
 .PP
 For the lists and descriptions of options removed in previous releases
 see the \f[I]Removed Java Options\f[R] section in:
+.IP \[bu] 2
+\f[B]The \f[BC]java\f[B] Command, Release 18\f[R]
+[https://docs.oracle.com/en/java/javase/18/docs/specs/man/java.html]
 .IP \[bu] 2
 \f[B]The \f[BC]java\f[B] Command, Release 17\f[R]
 [https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html]


### PR DESCRIPTION
Please review this simple change to remove all the flags that expired in JDK 19 from the flag table in arguments.cpp.

The java manpage is also updated as the UseBiasedLocking flag is moved from the "obsoleted" section, to the "removed" section. Plus we update the list of previous release docs.

Testing: local - all the runtime/CommandLine tests

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268573](https://bugs.openjdk.java.net/browse/JDK-8268573): Remove expired flags in JDK 19


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Patricio Chilano Mateo](https://openjdk.java.net/census#pchilanomate) (@pchilano - Committer)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6819/head:pull/6819` \
`$ git checkout pull/6819`

Update a local copy of the PR: \
`$ git checkout pull/6819` \
`$ git pull https://git.openjdk.java.net/jdk pull/6819/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6819`

View PR using the GUI difftool: \
`$ git pr show -t 6819`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6819.diff">https://git.openjdk.java.net/jdk/pull/6819.diff</a>

</details>
