### PR TITLE
8278643: CoreUtils.getCoreFileLocation() should print out the size of the core file found

### DIFF
--- a/test/lib/jdk/test/lib/util/CoreUtils.java
+++ b/test/lib/jdk/test/lib/util/CoreUtils.java
@@ -107,8 +107,10 @@ public class CoreUtils {
         // Find the core file
         String coreFileLocation = parseCoreFileLocationFromOutput(crashOutputString);
         if (coreFileLocation != null) {
-            System.out.println("Found core file: " + coreFileLocation);
-            Asserts.assertGT(new File(coreFileLocation).length(), 0L, "Unexpected core size");
+            long coreFileSize = new File(coreFileLocation).length();
+            System.out.println("Found core file " + coreFileLocation +
+                               ", size = " + coreFileSize / 1024 / 1024 + "mb");
+            Asserts.assertGT(coreFileSize, 0L, "Unexpected core size");
 
             // Make sure the core file is moved into the cwd if not already there.
             Path corePath = Paths.get(coreFileLocation);


### PR DESCRIPTION
Include the size of the core file when printing a message that it was found.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278643](https://bugs.openjdk.java.net/browse/JDK-8278643): CoreUtils.getCoreFileLocation() should print out the size of the core file found


### Reviewers
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6822/head:pull/6822` \
`$ git checkout pull/6822`

Update a local copy of the PR: \
`$ git checkout pull/6822` \
`$ git pull https://git.openjdk.java.net/jdk pull/6822/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6822`

View PR using the GUI difftool: \
`$ git pr show -t 6822`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6822.diff">https://git.openjdk.java.net/jdk/pull/6822.diff</a>

</details>
