### PR TITLE
8273904: debug agent ArrayTypeImp::newInstance() fails to send reply packet if there is an error

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/ArrayTypeImpl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/ArrayTypeImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -227,7 +227,7 @@ newInstance(PacketInputStream *in, PacketOutputStream *out)
     error = classSignature(arrayClass, &signature, NULL);
     if ( error != JVMTI_ERROR_NONE ) {
         outStream_setError(out, map2jdwpError(error));
-        return JNI_FALSE;
+        return JNI_TRUE;
     }
     componentSignature = componentTypeSignature(signature);
 


### PR DESCRIPTION
ArrayTypeImp::newInstance() was returning false instead of true for one error condition, resulting in a failure to send a reply packet containing the error. See the bug description for details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273904](https://bugs.openjdk.java.net/browse/JDK-8273904): debug agent ArrayTypeImp::newInstance() fails to send reply packet if there is an error


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6825/head:pull/6825` \
`$ git checkout pull/6825`

Update a local copy of the PR: \
`$ git checkout pull/6825` \
`$ git pull https://git.openjdk.java.net/jdk pull/6825/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6825`

View PR using the GUI difftool: \
`$ git pr show -t 6825`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6825.diff">https://git.openjdk.java.net/jdk/pull/6825.diff</a>

</details>
