### PR TITLE
8278761: Parallel: Remove unused PSOldPromotionLAB constructor

### DIFF
--- a/src/hotspot/share/gc/parallel/psPromotionLAB.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionLAB.hpp
@@ -106,7 +106,6 @@ class PSOldPromotionLAB : public PSPromotionLAB {
 
  public:
   PSOldPromotionLAB() : _start_array(NULL) { }
-  PSOldPromotionLAB(ObjectStartArray* start_array) : _start_array(start_array) { }
 
   void set_start_array(ObjectStartArray* start_array) { _start_array = start_array; }
 


### PR DESCRIPTION
Trivial change of removing dead code.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278761](https://bugs.openjdk.java.net/browse/JDK-8278761): Parallel: Remove unused PSOldPromotionLAB constructor


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6830/head:pull/6830` \
`$ git checkout pull/6830`

Update a local copy of the PR: \
`$ git checkout pull/6830` \
`$ git pull https://git.openjdk.java.net/jdk pull/6830/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6830`

View PR using the GUI difftool: \
`$ git pr show -t 6830`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6830.diff">https://git.openjdk.java.net/jdk/pull/6830.diff</a>

</details>
