### PR TITLE
8278763: Parallel: Remove grows_up/grows_down in PSVirtualSpace

### DIFF
--- a/src/hotspot/share/gc/parallel/psVirtualspace.cpp
+++ b/src/hotspot/share/gc/parallel/psVirtualspace.cpp
@@ -143,13 +143,9 @@ void PSVirtualSpace::verify() const {
          "bad reserved addrs");
   assert(committed_low_addr() <= committed_high_addr(), "bad committed addrs");
 
-  if (grows_up()) {
-    assert(reserved_low_addr() == committed_low_addr(), "bad low addrs");
-    assert(reserved_high_addr() >= committed_high_addr(), "bad high addrs");
-  } else {
-    assert(reserved_high_addr() == committed_high_addr(), "bad high addrs");
-    assert(reserved_low_addr() <= committed_low_addr(), "bad low addrs");
-  }
+  // committed addr grows up
+  assert(reserved_low_addr() == committed_low_addr(), "bad low addrs");
+  assert(reserved_high_addr() >= committed_high_addr(), "bad high addrs");
 }
 
 #endif // #ifndef PRODUCT

--- a/src/hotspot/share/gc/parallel/psVirtualspace.hpp
+++ b/src/hotspot/share/gc/parallel/psVirtualspace.hpp
@@ -103,8 +103,6 @@ class PSVirtualSpace : public CHeapObj<mtGC> {
           bool is_aligned(size_t val) const;
           bool is_aligned(char* val) const;
           void verify() const;
-  virtual bool grows_up() const   { return true; }
-          bool grows_down() const { return !grows_up(); }
 
   // Helper class to verify a space when entering/leaving a block.
   class PSVirtualSpaceVerifier: public StackObj {


### PR DESCRIPTION
Simple change of inlining statically-known value.

Test: hotspot-gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278763](https://bugs.openjdk.java.net/browse/JDK-8278763): Parallel: Remove grows_up/grows_down in PSVirtualSpace


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6831/head:pull/6831` \
`$ git checkout pull/6831`

Update a local copy of the PR: \
`$ git checkout pull/6831` \
`$ git pull https://git.openjdk.java.net/jdk pull/6831/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6831`

View PR using the GUI difftool: \
`$ git pr show -t 6831`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6831.diff">https://git.openjdk.java.net/jdk/pull/6831.diff</a>

</details>
