### PR TITLE
8278767: Shenandoah: Remove unused ShenandoahRootScanner

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.cpp
@@ -97,29 +97,6 @@ ShenandoahRootProcessor::ShenandoahRootProcessor(ShenandoahPhaseTimings::Phase p
   _worker_phase(phase) {
 }
 
-ShenandoahRootScanner::ShenandoahRootScanner(uint n_workers, ShenandoahPhaseTimings::Phase phase) :
-  ShenandoahRootProcessor(phase),
-  _thread_roots(phase, n_workers > 1) {
-  nmethod::oops_do_marking_prologue();
-}
-
-ShenandoahRootScanner::~ShenandoahRootScanner() {
-  nmethod::oops_do_marking_epilogue();
-}
-
-void ShenandoahRootScanner::roots_do(uint worker_id, OopClosure* oops) {
-  MarkingCodeBlobClosure blobs_cl(oops, !CodeBlobToOopClosure::FixRelocations);
-  roots_do(worker_id, oops, &blobs_cl);
-}
-
-void ShenandoahRootScanner::roots_do(uint worker_id, OopClosure* oops, CodeBlobClosure* code, ThreadClosure *tc) {
-  assert(ShenandoahSafepoint::is_at_shenandoah_safepoint(), "Must be at a safepoint");
-
-  ShenandoahParallelOopsDoThreadClosure tc_cl(oops, code, tc);
-  ResourceMark rm;
-  _thread_roots.threads_do(&tc_cl, worker_id);
-}
-
 ShenandoahSTWRootScanner::ShenandoahSTWRootScanner(ShenandoahPhaseTimings::Phase phase) :
    ShenandoahRootProcessor(phase),
    _thread_roots(phase, ShenandoahHeap::heap()->workers()->active_workers() > 1),

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.hpp
@@ -143,20 +143,6 @@ public:
   ShenandoahHeap* heap() const { return _heap; }
 };
 
-class ShenandoahRootScanner : public ShenandoahRootProcessor {
-private:
-  ShenandoahThreadRoots                                     _thread_roots;
-
-public:
-  ShenandoahRootScanner(uint n_workers, ShenandoahPhaseTimings::Phase phase);
-  ~ShenandoahRootScanner();
-
-  void roots_do(uint worker_id, OopClosure* cl);
-
-private:
-  void roots_do(uint worker_id, OopClosure* oops, CodeBlobClosure* code, ThreadClosure* tc = NULL);
-};
-
 // STW root scanner
 class ShenandoahSTWRootScanner : public ShenandoahRootProcessor {
 private:


### PR DESCRIPTION
Please review this trivial patch that removes unused ShenandoahRootScanner class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278767](https://bugs.openjdk.java.net/browse/JDK-8278767): Shenandoah: Remove unused ShenandoahRootScanner


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6832/head:pull/6832` \
`$ git checkout pull/6832`

Update a local copy of the PR: \
`$ git checkout pull/6832` \
`$ git pull https://git.openjdk.java.net/jdk pull/6832/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6832`

View PR using the GUI difftool: \
`$ git pr show -t 6832`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6832.diff">https://git.openjdk.java.net/jdk/pull/6832.diff</a>

</details>
