### PR TITLE
8278793: Interpreter(x64) intrinsify Thread.currentThread()

### DIFF
--- a/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
@@ -420,9 +420,9 @@ void ShenandoahBarrierSetAssembler::load_reference_barrier(MacroAssembler* masm,
 
   if (is_strong) {
     if (is_narrow) {
-      __ call_VM_leaf(CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong_narrow), arg0, arg1);
+      __ super_call_VM_leaf(CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong_narrow), arg0, arg1);
     } else {
-      __ call_VM_leaf(CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong), arg0, arg1);
+      __ super_call_VM_leaf(CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong), arg0, arg1);
     }
   } else if (is_weak) {
     if (is_narrow) {
@@ -433,7 +433,7 @@ void ShenandoahBarrierSetAssembler::load_reference_barrier(MacroAssembler* masm,
   } else {
     assert(is_phantom, "only remaining strength");
     assert(!is_narrow, "phantom access cannot be narrow");
-    __ call_VM_leaf(CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_phantom), arg0, arg1);
+    __ super_call_VM_leaf(CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_phantom), arg0, arg1);
   }
 
 #ifdef _LP64

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86_64.cpp
@@ -449,11 +449,9 @@ address TemplateInterpreterGenerator::generate_currentThread() {
 
   address entry_point = __ pc();
 
-  __ movptr(rscratch2, Address(r15_thread, JavaThread::threadObj_offset()));
+  __ movptr(rax, Address(r15_thread, JavaThread::threadObj_offset()));
 
-  // Only IN_HEAP loads require a thread_tmp register
-  __ access_load_at(T_OBJECT, IN_NATIVE, rax,
-                    Address(rscratch2, 0), rscratch1, noreg);
+  __ resolve_oop_handle(rax, rscratch1);
 
   __ pop(rcx);
   __ mov(rsp, r13);

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86_64.cpp
@@ -445,3 +445,20 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
   return entry_point;
 }
 
+address TemplateInterpreterGenerator::generate_currentThread() {
+
+  address entry_point = __ pc();
+
+  __ movptr(rscratch2, Address(r15_thread, JavaThread::threadObj_offset()));
+
+  // Only IN_HEAP loads require a thread_tmp register
+  __ access_load_at(T_OBJECT, IN_NATIVE, rax,
+                    Address(rscratch2, 0), rscratch1, noreg);
+
+  __ pop(rcx);
+  __ mov(rsp, r13);
+  __ jmp(rcx);
+
+  return entry_point;
+}
+

--- a/src/hotspot/share/interpreter/abstractInterpreter.cpp
+++ b/src/hotspot/share/interpreter/abstractInterpreter.cpp
@@ -134,6 +134,9 @@ AbstractInterpreter::MethodKind AbstractInterpreter::method_kind(const methodHan
       case vmIntrinsics::_floatToRawIntBits: return java_lang_Float_floatToRawIntBits;
       case vmIntrinsics::_longBitsToDouble:  return java_lang_Double_longBitsToDouble;
       case vmIntrinsics::_doubleToRawLongBits: return java_lang_Double_doubleToRawLongBits;
+#ifdef AMD64
+      case vmIntrinsics::_currentThread:     return java_lang_Thread_currentThread;
+#endif
 #endif // ZERO
       case vmIntrinsics::_dsin:              return java_lang_math_sin;
       case vmIntrinsics::_dcos:              return java_lang_math_cos;

--- a/src/hotspot/share/interpreter/abstractInterpreter.hpp
+++ b/src/hotspot/share/interpreter/abstractInterpreter.hpp
@@ -90,6 +90,7 @@ class AbstractInterpreter: AllStatic {
     java_lang_Float_floatToRawIntBits,                          // implementation of java.lang.Float.floatToRawIntBits()
     java_lang_Double_longBitsToDouble,                          // implementation of java.lang.Double.longBitsToDouble()
     java_lang_Double_doubleToRawLongBits,                       // implementation of java.lang.Double.doubleToRawLongBits()
+    java_lang_Thread_currentThread,                             // implementation of java.lang.Thread.currentThread()
     number_of_method_entries,
     invalid = -1
   };

--- a/src/hotspot/share/interpreter/templateInterpreterGenerator.cpp
+++ b/src/hotspot/share/interpreter/templateInterpreterGenerator.cpp
@@ -201,7 +201,9 @@ void TemplateInterpreterGenerator::generate_all() {
   method_entry(java_lang_math_fmaF )
   method_entry(java_lang_math_fmaD )
   method_entry(java_lang_ref_reference_get)
-
+#ifdef AMD64
+  method_entry(java_lang_Thread_currentThread)
+#endif
   AbstractInterpreter::initialize_method_handle_entries();
 
   // all native method kinds (must be one contiguous block)
@@ -431,6 +433,11 @@ address TemplateInterpreterGenerator::generate_method_entry(
                                            : // fall thru
   case Interpreter::java_util_zip_CRC32C_updateDirectByteBuffer
                                            : entry_point = generate_CRC32C_updateBytes_entry(kind); break;
+#ifdef AMD64
+  case Interpreter::java_lang_Thread_currentThread
+                                           : entry_point = generate_currentThread(); break;
+#endif
+
 #ifdef IA32
   // On x86_32 platforms, a special entry is generated for the following four methods.
   // On other platforms the normal entry is used to enter these methods.

--- a/src/hotspot/share/interpreter/templateInterpreterGenerator.hpp
+++ b/src/hotspot/share/interpreter/templateInterpreterGenerator.hpp
@@ -94,6 +94,9 @@ class TemplateInterpreterGenerator: public AbstractInterpreterGenerator {
   address generate_CRC32_update_entry();
   address generate_CRC32_updateBytes_entry(AbstractInterpreter::MethodKind kind);
   address generate_CRC32C_updateBytes_entry(AbstractInterpreter::MethodKind kind);
+#ifdef AMD64
+  address generate_currentThread();
+#endif
 #ifdef IA32
   address generate_Float_intBitsToFloat_entry();
   address generate_Float_floatToRawIntBits_entry();


### PR DESCRIPTION
Please consider this enhancement.
This makes Thread.currentThread() eight times faster on my box when running in interpreter.

Passes t1-t4

As suggested I added a related fix to Shenandoah.
Shenandoah LB was using InterpreterMacroAssembler version of call_VM_leaf_base (it's virtual).
The interpreter version adds a check on last_sp, since the intrinsic is not setting up a new frame, this check is faulty.
Other GC seems to always use the base version, so let's use the base version in Shenandoah also.
No issues found when locally running gc/shenandoah.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278793](https://bugs.openjdk.java.net/browse/JDK-8278793): Interpreter(x64) intrinsify Thread.currentThread()


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6833/head:pull/6833` \
`$ git checkout pull/6833`

Update a local copy of the PR: \
`$ git checkout pull/6833` \
`$ git pull https://git.openjdk.java.net/jdk pull/6833/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6833`

View PR using the GUI difftool: \
`$ git pr show -t 6833`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6833.diff">https://git.openjdk.java.net/jdk/pull/6833.diff</a>

</details>
