### PR TITLE
8278638: Remove FLAG_IS_CMDLINE(UseSharedSpaces)

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -119,6 +119,9 @@ bool Arguments::_has_jimage = false;
 
 char* Arguments::_ext_dirs = NULL;
 
+// True if -Xshare:auto option was specified.
+static bool xshare_auto_cmd_line = false;
+
 bool PathString::set_value(const char *value) {
   if (_value != NULL) {
     FreeHeap(_value);
@@ -2712,6 +2715,7 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
     } else if (match_option(option, "-Xshare:auto")) {
       UseSharedSpaces = true;
       RequireSharedSpaces = false;
+      xshare_auto_cmd_line = true;
     // -Xshare:off
     } else if (match_option(option, "-Xshare:off")) {
       UseSharedSpaces = false;
@@ -3992,7 +3996,7 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
       "DumpLoadedClassList is not supported in this VM\n");
     return JNI_ERR;
   }
-  if ((UseSharedSpaces && FLAG_IS_CMDLINE(UseSharedSpaces)) ||
+  if ((UseSharedSpaces && xshare_auto_cmd_line) ||
       log_is_enabled(Info, cds)) {
     warning("Shared spaces are not supported in this VM");
     UseSharedSpaces = false;


### PR DESCRIPTION
Please review this small fix for bug JDK-827638.  The fix was tested by running Mach5 tiers 1 and 2 on Linux, Mac OS, and Windows, Mach5 tier 4 on Linux x64, and by building on linux-aarch64-zero and linux-x64-zero.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278638](https://bugs.openjdk.java.net/browse/JDK-8278638): Remove FLAG_IS_CMDLINE(UseSharedSpaces)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6835/head:pull/6835` \
`$ git checkout pull/6835`

Update a local copy of the PR: \
`$ git checkout pull/6835` \
`$ git pull https://git.openjdk.java.net/jdk pull/6835/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6835`

View PR using the GUI difftool: \
`$ git pr show -t 6835`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6835.diff">https://git.openjdk.java.net/jdk/pull/6835.diff</a>

</details>
