### PR TITLE
8278587: StringTokenizer(String, String, boolean) documentation bug

### DIFF
--- a/src/java.base/share/classes/java/util/StringTokenizer.java
+++ b/src/java.base/share/classes/java/util/StringTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -174,9 +174,10 @@ public class StringTokenizer implements Enumeration<Object> {
      * <p>
      * If the {@code returnDelims} flag is {@code true}, then
      * the delimiter characters are also returned as tokens. Each
-     * delimiter is returned as a string of length one. If the flag is
-     * {@code false}, the delimiter characters are skipped and only
-     * serve as separators between tokens.
+     * delimiter is returned as a string consisting of a single
+     * <a href="../lang/Character.html#unicode">Unicode code point</a>
+     * of the delimiter. If the flag is {@code false}, the delimiter
+     * characters are skipped and only serve as separators between tokens.
      * <p>
      * Note that if {@code delim} is {@code null}, this constructor does
      * not throw an exception. However, trying to invoke other methods on the

--- a/src/java.base/share/classes/java/util/StringTokenizer.java
+++ b/src/java.base/share/classes/java/util/StringTokenizer.java
@@ -176,8 +176,9 @@ public class StringTokenizer implements Enumeration<Object> {
      * the delimiter characters are also returned as tokens. Each
      * delimiter is returned as a string consisting of a single
      * <a href="../lang/Character.html#unicode">Unicode code point</a>
-     * of the delimiter. If the flag is {@code false}, the delimiter
-     * characters are skipped and only serve as separators between tokens.
+     * of the delimiter (which may be one or two {@code char}s). If the
+     * flag is {@code false}, the delimiter characters are skipped
+     * and only serve as separators between tokens.
      * <p>
      * Note that if {@code delim} is {@code null}, this constructor does
      * not throw an exception. However, trying to invoke other methods on the


### PR DESCRIPTION
This is a doc fix to `StringTokenizer`, where the original spec does not account for the delimiter's length in the case of a supplementary character. Corresponding CSR has been drafted: https://bugs.openjdk.java.net/browse/JDK-8278814

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8278587](https://bugs.openjdk.java.net/browse/JDK-8278587): StringTokenizer(String, String, boolean) documentation bug
 * [JDK-8278814](https://bugs.openjdk.java.net/browse/JDK-8278814): StringTokenizer(String, String, boolean) documentation bug (**CSR**)


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to 1fcb399d90a0e454cb615432bbcc7af60166f243
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to 1fcb399d90a0e454cb615432bbcc7af60166f243
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6836/head:pull/6836` \
`$ git checkout pull/6836`

Update a local copy of the PR: \
`$ git checkout pull/6836` \
`$ git pull https://git.openjdk.java.net/jdk pull/6836/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6836`

View PR using the GUI difftool: \
`$ git pr show -t 6836`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6836.diff">https://git.openjdk.java.net/jdk/pull/6836.diff</a>

</details>
