### PR TITLE
8209398: sun/security/pkcs11/KeyStore/SecretKeysBasic.sh failed with "PKCS11Exception: CKR_ATTRIBUTE_SENSITIVE"

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -90,6 +90,9 @@ abstract class P11Key implements Key, Length {
     // flags indicating whether the key is a token object, sensitive, extractable
     final boolean tokenObject, sensitive, extractable;
 
+    // flag indicating whether the current token is NSS
+    final transient boolean isNSS;
+
     @SuppressWarnings("serial") // Type of field is not Serializable
     private final NativeKeyHolder keyIDHolder;
 
@@ -138,7 +141,7 @@ abstract class P11Key implements Key, Length {
         this.sensitive = sensitive;
         this.extractable = extractable;
         char[] tokenLabel = this.token.tokenInfo.label;
-        boolean isNSS = (tokenLabel[0] == 'N' && tokenLabel[1] == 'S'
+        isNSS = (tokenLabel[0] == 'N' && tokenLabel[1] == 'S'
                 && tokenLabel[2] == 'S');
         boolean extractKeyInfo = (!DISABLE_NATIVE_KEYS_EXTRACTION && isNSS &&
                 extractable && !tokenObject);
@@ -239,7 +242,8 @@ abstract class P11Key implements Key, Length {
         } else {
             // XXX short term serialization for unextractable keys
             throw new NotSerializableException
-                ("Cannot serialize sensitive and unextractable keys");
+                    ("Cannot serialize sensitive, unextractable " + (isNSS ?
+                    ", and NSS token keys" : "keys"));
         }
         return new KeyRep(type, getAlgorithm(), format, getEncodedInternal());
     }
@@ -448,7 +452,7 @@ abstract class P11Key implements Key, Length {
 
         public String getFormat() {
             token.ensureValid();
-            if (sensitive || (extractable == false)) {
+            if (sensitive || !extractable || (isNSS && tokenObject)) {
                 return null;
             } else {
                 return "RAW";

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -647,8 +647,6 @@ javax/net/ssl/DTLS/CipherSuite.java                             8202059 macosx-x
 
 sun/security/provider/KeyStore/DKSTest.sh                       8180266 windows-all
 
-sun/security/pkcs11/KeyStore/SecretKeysBasic.java                 8209398 generic-all
-
 security/infra/java/security/cert/CertPathValidator/certification/ActalisCA.java  8224768 generic-all
 
 sun/security/smartcardio/TestChannel.java                       8039280 generic-all


### PR DESCRIPTION
Can someone help review this small fix? NSS returns PKCS11 CKR_ATTRIBUTE_SENSITIVE error when trying to retrieve CKA_VALUE out of its token keys. So this fix is to add special handling for NSS token secret keys. There is already an existing regression test which detects this and disabled in ProblemList.txt. Removing that test from ProblemList.txt to verify this fix.

Thanks,
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8209398](https://bugs.openjdk.java.net/browse/JDK-8209398): sun/security/pkcs11/KeyStore/SecretKeysBasic.sh failed with "PKCS11Exception: CKR_ATTRIBUTE_SENSITIVE"


### Reviewers
 * [Hai-May Chao](https://openjdk.java.net/census#hchao) (@haimaychao - Committer)
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6837/head:pull/6837` \
`$ git checkout pull/6837`

Update a local copy of the PR: \
`$ git checkout pull/6837` \
`$ git pull https://git.openjdk.java.net/jdk pull/6837/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6837`

View PR using the GUI difftool: \
`$ git pr show -t 6837`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6837.diff">https://git.openjdk.java.net/jdk/pull/6837.diff</a>

</details>
