### PR TITLE
8278825: Unused variable for diagnostic in Resolve

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -2942,9 +2942,6 @@ public class Resolve {
                                 sym.kind != WRONG_MTHS) {
                                 sym = super.access(env, pos, location, sym);
                             } else {
-                                final JCDiagnostic details = sym.kind == WRONG_MTH ?
-                                                ((InapplicableSymbolError)sym.baseSymbol()).errCandidate().snd :
-                                                null;
                                 sym = new DiamondError(sym, currentResolutionContext);
                                 sym = accessMethod(sym, pos, site, names.init, true, argtypes, typeargtypes);
                                 env.info.pendingResolutionPhase = currentResolutionContext.step;


### PR DESCRIPTION
The change removes an unused variable that was left over after [JDK-8067883](https://bugs.openjdk.java.net/browse/JDK-8067883).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278825](https://bugs.openjdk.java.net/browse/JDK-8278825): Unused variable for diagnostic in Resolve


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6841/head:pull/6841` \
`$ git checkout pull/6841`

Update a local copy of the PR: \
`$ git checkout pull/6841` \
`$ git pull https://git.openjdk.java.net/jdk pull/6841/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6841`

View PR using the GUI difftool: \
`$ git pr show -t 6841`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6841.diff">https://git.openjdk.java.net/jdk/pull/6841.diff</a>

</details>
