### PR TITLE
8278826: Print error if Shenandoah flags are empty (instead of crashing)

### DIFF
--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahIUMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahIUMode.cpp
@@ -65,19 +65,18 @@ void ShenandoahIUMode::initialize_flags() const {
 }
 
 ShenandoahHeuristics* ShenandoahIUMode::initialize_heuristics() const {
-  if (ShenandoahGCHeuristics != NULL) {
-    if (strcmp(ShenandoahGCHeuristics, "aggressive") == 0) {
-      return new ShenandoahAggressiveHeuristics();
-    } else if (strcmp(ShenandoahGCHeuristics, "static") == 0) {
-      return new ShenandoahStaticHeuristics();
-    } else if (strcmp(ShenandoahGCHeuristics, "adaptive") == 0) {
-      return new ShenandoahAdaptiveHeuristics();
-    } else if (strcmp(ShenandoahGCHeuristics, "compact") == 0) {
-      return new ShenandoahCompactHeuristics();
-    } else {
-      vm_exit_during_initialization("Unknown -XX:ShenandoahGCHeuristics option");
-    }
+  if (ShenandoahGCHeuristics == NULL) {
+    vm_exit_during_initialization("Unknown -XX:ShenandoahGCHeuristics option (null)");
   }
-  vm_exit_during_initialization("Unknown -XX:ShenandoahGCHeuristics option (null)");
+  if (strcmp(ShenandoahGCHeuristics, "aggressive") == 0) {
+    return new ShenandoahAggressiveHeuristics();
+  } else if (strcmp(ShenandoahGCHeuristics, "static") == 0) {
+    return new ShenandoahStaticHeuristics();
+  } else if (strcmp(ShenandoahGCHeuristics, "adaptive") == 0) {
+    return new ShenandoahAdaptiveHeuristics();
+  } else if (strcmp(ShenandoahGCHeuristics, "compact") == 0) {
+    return new ShenandoahCompactHeuristics();
+  }
+  vm_exit_during_initialization("Unknown -XX:ShenandoahGCHeuristics option");
   return NULL;
 }

--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahIUMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahIUMode.cpp
@@ -78,6 +78,6 @@ ShenandoahHeuristics* ShenandoahIUMode::initialize_heuristics() const {
       vm_exit_during_initialization("Unknown -XX:ShenandoahGCHeuristics option");
     }
   }
-  ShouldNotReachHere();
+  vm_exit_during_initialization("Unknown -XX:ShenandoahGCHeuristics option (null)");
   return NULL;
 }

--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahPassiveMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahPassiveMode.cpp
@@ -28,6 +28,7 @@
 #include "logging/log.hpp"
 #include "logging/logTag.hpp"
 #include "runtime/globals_extension.hpp"
+#include "runtime/java.hpp"
 
 void ShenandoahPassiveMode::initialize_flags() const {
   // Do not allow concurrent cycles.
@@ -58,6 +59,6 @@ ShenandoahHeuristics* ShenandoahPassiveMode::initialize_heuristics() const {
   if (ShenandoahGCHeuristics != NULL) {
     return new ShenandoahPassiveHeuristics();
   }
-  ShouldNotReachHere();
+  vm_exit_during_initialization("Unknown -XX:ShenandoahGCHeuristics option (null)");
   return NULL;
 }

--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahPassiveMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahPassiveMode.cpp
@@ -56,9 +56,8 @@ void ShenandoahPassiveMode::initialize_flags() const {
   // No barriers are required to run.
 }
 ShenandoahHeuristics* ShenandoahPassiveMode::initialize_heuristics() const {
-  if (ShenandoahGCHeuristics != NULL) {
-    return new ShenandoahPassiveHeuristics();
+  if (ShenandoahGCHeuristics == NULL) {
+    vm_exit_during_initialization("Unknown -XX:ShenandoahGCHeuristics option (null)");
   }
-  vm_exit_during_initialization("Unknown -XX:ShenandoahGCHeuristics option (null)");
-  return NULL;
+  return new ShenandoahPassiveHeuristics();
 }

--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahSATBMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahSATBMode.cpp
@@ -53,19 +53,18 @@ void ShenandoahSATBMode::initialize_flags() const {
 }
 
 ShenandoahHeuristics* ShenandoahSATBMode::initialize_heuristics() const {
-  if (ShenandoahGCHeuristics != NULL) {
-    if (strcmp(ShenandoahGCHeuristics, "aggressive") == 0) {
-      return new ShenandoahAggressiveHeuristics();
-    } else if (strcmp(ShenandoahGCHeuristics, "static") == 0) {
-      return new ShenandoahStaticHeuristics();
-    } else if (strcmp(ShenandoahGCHeuristics, "adaptive") == 0) {
-      return new ShenandoahAdaptiveHeuristics();
-    } else if (strcmp(ShenandoahGCHeuristics, "compact") == 0) {
-      return new ShenandoahCompactHeuristics();
-    } else {
-      vm_exit_during_initialization("Unknown -XX:ShenandoahGCHeuristics option");
-    }
+  if (ShenandoahGCHeuristics == NULL) {
+    vm_exit_during_initialization("Unknown -XX:ShenandoahGCHeuristics option (null)");
   }
-  vm_exit_during_initialization("Unknown -XX:ShenandoahGCHeuristics option (null)");
+  if (strcmp(ShenandoahGCHeuristics, "aggressive") == 0) {
+    return new ShenandoahAggressiveHeuristics();
+  } else if (strcmp(ShenandoahGCHeuristics, "static") == 0) {
+    return new ShenandoahStaticHeuristics();
+  } else if (strcmp(ShenandoahGCHeuristics, "adaptive") == 0) {
+    return new ShenandoahAdaptiveHeuristics();
+  } else if (strcmp(ShenandoahGCHeuristics, "compact") == 0) {
+    return new ShenandoahCompactHeuristics();
+  }
+  vm_exit_during_initialization("Unknown -XX:ShenandoahGCHeuristics option");
   return NULL;
 }

--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahSATBMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahSATBMode.cpp
@@ -66,6 +66,6 @@ ShenandoahHeuristics* ShenandoahSATBMode::initialize_heuristics() const {
       vm_exit_during_initialization("Unknown -XX:ShenandoahGCHeuristics option");
     }
   }
-  ShouldNotReachHere();
+  vm_exit_during_initialization("Unknown -XX:ShenandoahGCHeuristics option (null)");
   return NULL;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -416,7 +416,7 @@ void ShenandoahHeap::initialize_mode() {
       vm_exit_during_initialization("Unknown -XX:ShenandoahGCMode option");
     }
   } else {
-    ShouldNotReachHere();
+    vm_exit_during_initialization("Unknown -XX:ShenandoahGCMode option (null)");
   }
   _gc_mode->initialize_flags();
   if (_gc_mode->is_diagnostic() && !UnlockDiagnosticVMOptions) {


### PR DESCRIPTION
ShouldNotReachHere() is replaced by vm_exit_during_initialization() in few places where ShenandoahGCMode and ShenandoahGCHeuristics are examined.

Generic testing: gc/shenandoah jtreg tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278826](https://bugs.openjdk.java.net/browse/JDK-8278826): Print error if Shenandoah flags are empty (instead of crashing)


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**) ⚠️ Review applies to 5823d5dc0a4c6084555321bcefea53d33c5c1871
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**) ⚠️ Review applies to 5823d5dc0a4c6084555321bcefea53d33c5c1871


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6842/head:pull/6842` \
`$ git checkout pull/6842`

Update a local copy of the PR: \
`$ git checkout pull/6842` \
`$ git pull https://git.openjdk.java.net/jdk pull/6842/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6842`

View PR using the GUI difftool: \
`$ git pr show -t 6842`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6842.diff">https://git.openjdk.java.net/jdk/pull/6842.diff</a>

</details>
