### PR TITLE
8278131: runtime/cds/appcds/dynamicArchive/* tests failing in loom repo

### DIFF
--- a/test/hotspot/jtreg/runtime/HiddenClasses/InstantiateHiddenClass.java
+++ b/test/hotspot/jtreg/runtime/HiddenClasses/InstantiateHiddenClass.java
@@ -45,6 +45,9 @@ public class InstantiateHiddenClass {
         " } } ");
 
     public static void main(String[] args) throws Throwable {
+        // This class is also used by the appcds/dynamicArchive/RegularHiddenClass.java
+        // test which will pass the "keep-alive" argument during dynamic CDS dump
+        // for preventing from being GC'ed prior to the dumping operation.
         boolean keepAlive = false;
         if (args.length == 1 && args[0].equals("keep-alive")) {
             keepAlive = true;

--- a/test/hotspot/jtreg/runtime/HiddenClasses/InstantiateHiddenClass.java
+++ b/test/hotspot/jtreg/runtime/HiddenClasses/InstantiateHiddenClass.java
@@ -70,8 +70,8 @@ public class InstantiateHiddenClass {
         Class<?> c1 = lookup.defineHiddenClass(klassbuf, false, NESTMATE).lookupClass();
         Class<?> c2 = lookup.defineHiddenClass(klassbuf, false, NESTMATE).lookupClass();
         if (keepAlive) {
-            keptC1 = c1; 
-            keptC2 = c2; 
+            keptC1 = c1;
+            keptC2 = c2;
         }
         Object o1 = c1.newInstance();
         Object o2 = c2.newInstance();

--- a/test/hotspot/jtreg/runtime/HiddenClasses/InstantiateHiddenClass.java
+++ b/test/hotspot/jtreg/runtime/HiddenClasses/InstantiateHiddenClass.java
@@ -32,13 +32,11 @@
 import java.lang.invoke.MethodType;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.invoke.MethodHandles.Lookup.ClassOption;
 import static java.lang.invoke.MethodHandles.Lookup.ClassOption.*;
 import jdk.test.lib.compiler.InMemoryJavaCompiler;
 
 public class InstantiateHiddenClass {
-    // Prevent the following classes from being GC'ed too soon.
-    static Class<?> keptC1 = null;
-    static Class<?> keptC2 = null;
 
     static byte klassbuf[] = InMemoryJavaCompiler.compile("TestClass",
         "public class TestClass { " +
@@ -67,12 +65,9 @@ public class InstantiateHiddenClass {
         // Verify that the references to these objects are different and references
         // to their classes are not equal either.
         Lookup lookup = MethodHandles.lookup();
-        Class<?> c1 = lookup.defineHiddenClass(klassbuf, false, NESTMATE).lookupClass();
-        Class<?> c2 = lookup.defineHiddenClass(klassbuf, false, NESTMATE).lookupClass();
-        if (keepAlive) {
-            keptC1 = c1;
-            keptC2 = c2;
-        }
+        ClassOption classOption = keepAlive ? STRONG : NESTMATE;
+        Class<?> c1 = lookup.defineHiddenClass(klassbuf, false, classOption).lookupClass();
+        Class<?> c2 = lookup.defineHiddenClass(klassbuf, false, classOption).lookupClass();
         Object o1 = c1.newInstance();
         Object o2 = c2.newInstance();
         if (o1 == o2) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
@@ -64,6 +64,9 @@ public class HelloUnload {
             throw new RuntimeException("args[2] can only be either \"true\" or \"false\", actual " + args[1]);
         }
 
+        // The HelloDynamicCustom.java and PrintSharedArchiveAndExit.java tests
+        // under appcds/dynamicArchive pass the keep-alive argument for preventing
+        // the class from being GC'ed prior to dumping of the dynamic CDS archive.
         boolean keepAlive = false;
         if (args[args.length - 1].equals("keep-alive")) {
             keepAlive = true;

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
@@ -30,10 +30,12 @@ import jdk.test.lib.classloader.ClassUnloadCommon;
 
 public class HelloUnload {
     private static String className = "CustomLoadee";
+    // Prevent the following class from being GC'ed too soon.
+    private static Class keptC = null;
 
     public static void main(String args[]) throws Exception {
-        if (args.length != 3) {
-            throw new RuntimeException("Unexpected number of arguments: expected 3, actual " + args.length);
+        if (args.length < 3) {
+            throw new RuntimeException("Unexpected number of arguments: expected at least 3, actual " + args.length);
         }
 
         String path = args[0];
@@ -62,9 +64,17 @@ public class HelloUnload {
             throw new RuntimeException("args[2] can only be either \"true\" or \"false\", actual " + args[1]);
         }
 
+        boolean keepAlive = false;
+        if (args[args.length - 1].equals("keep-alive")) {
+            keepAlive = true;
+        }
+
         URLClassLoader urlClassLoader =
             new URLClassLoader("HelloClassLoader", urls, null);
         Class c = Class.forName(className, true, urlClassLoader);
+        if (keepAlive) {
+            keptC = c; 
+        }
         System.out.println(c);
         System.out.println(c.getClassLoader());
         Object o = c.newInstance();

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
@@ -73,7 +73,7 @@ public class HelloUnload {
             new URLClassLoader("HelloClassLoader", urls, null);
         Class c = Class.forName(className, true, urlClassLoader);
         if (keepAlive) {
-            keptC = c; 
+            keptC = c;
         }
         System.out.println(c);
         System.out.println(c.getClassLoader());

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/OldClassApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/OldClassApp.java
@@ -25,9 +25,12 @@
 import java.io.File;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.HashMap;
 import sun.hotspot.WhiteBox;
 
 public class OldClassApp {
+    // Prevent the classes from being GC'ed too soon.
+    static HashMap<String, Class> clsMap = new HashMap<>();
     public static void main(String args[]) throws Exception {
         String path = args[0];
         URL url = new File(path).toURI().toURL();
@@ -44,13 +47,23 @@ public class OldClassApp {
             throw new RuntimeException("args[1] can only be either \"true\" or \"false\", actual " + args[1]);
         }
 
+        int startIdx = 2;
+        boolean keepAlive = false;
+        if (args[2].equals("keep-alive")) {
+            keepAlive = true;
+            startIdx = 3;
+        }
+
         URLClassLoader urlClassLoader =
             new URLClassLoader("OldClassAppClassLoader", urls, null);
 
-        for (int i = 2; i < args.length; i++) {
+        for (int i = startIdx; i < args.length; i++) {
             Class c = urlClassLoader.loadClass(args[i]);
             System.out.println(c);
             System.out.println(c.getClassLoader());
+            if (keepAlive) {
+                clsMap.put(args[i], c);
+            }
 
             // [1] Check that class is defined by the correct loader
             if (c.getClassLoader() != urlClassLoader) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/OldClassApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/OldClassApp.java
@@ -47,6 +47,9 @@ public class OldClassApp {
             throw new RuntimeException("args[1] can only be either \"true\" or \"false\", actual " + args[1]);
         }
 
+        // The OldClassAndInf.java test under appcds/dynamicArchive passes the keep-alive
+        // argument for preventing the classes from being GC'ed prior to dumping of
+        // the dynamic CDS archive.
         int startIdx = 2;
         boolean keepAlive = false;
         if (args[2].equals("keep-alive")) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/HelloDynamicCustom.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/HelloDynamicCustom.java
@@ -64,7 +64,7 @@ public class HelloDynamicCustom extends DynamicArchiveTestBase {
             "-Xlog:cds",
             "-Xlog:cds+dynamic=debug",
             "-cp", appJar,
-            mainAppClass, customJarPath, "false", "false")
+            mainAppClass, customJarPath, "false", "false", "keep-alive")
             .assertNormalExit(output -> {
                 output.shouldContain("Written dynamic archive 0x")
                       .shouldNotContain("klasses.*=.*CustomLoadee")

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LambdaCustomLoader.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LambdaCustomLoader.java
@@ -49,7 +49,7 @@ public class LambdaCustomLoader extends DynamicArchiveTestBase {
         // 1. Host class loaded by a custom loader is initialized during dump time.
         dump(topArchiveName,
             "-Xlog:class+load,cds=debug,cds+dynamic",
-            "-cp", appJar, mainClass, appJar, "init")
+            "-cp", appJar, mainClass, appJar, "init", "keep-alive")
             .assertNormalExit(output -> {
                 output.shouldMatch("Skipping.LambHello[$][$]Lambda[$].*0x.*:.Hidden.class")
                       .shouldHaveExitValue(0);
@@ -67,7 +67,7 @@ public class LambdaCustomLoader extends DynamicArchiveTestBase {
         // 2. Host class loaded by a custom loader is NOT initialized during dump time.
         dump(topArchiveName,
             "-Xlog:class+load,cds=debug,cds+dynamic",
-            "-cp", appJar, mainClass, appJar)
+            "-cp", appJar, mainClass, appJar, "keep-alive")
             .assertNormalExit(output -> {
                 output.shouldHaveExitValue(0);
             });

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/OldClassAndInf.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/OldClassAndInf.java
@@ -80,7 +80,7 @@ public class OldClassAndInf extends DynamicArchiveTestBase {
                      "-Xlog:cds",
                      "-Xlog:cds+dynamic=debug",
                      "-cp", appJar,
-                     mainAppClass, loadeesJar, inArchive),
+                     mainAppClass, loadeesJar, inArchive, "keep-alive"),
              loadees))
              .assertNormalExit(output -> {
                  output.shouldContain("Written dynamic archive 0x")

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/PrintSharedArchiveAndExit.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/PrintSharedArchiveAndExit.java
@@ -64,7 +64,7 @@ public class PrintSharedArchiveAndExit extends DynamicArchiveTestBase {
             "-Xlog:cds",
             "-Xlog:cds+dynamic=debug",
             "-cp", appJar,
-            mainAppClass, customJarPath, "false", "false")
+            mainAppClass, customJarPath, "false", "false", "keep-alive")
             .assertNormalExit(output -> {
                 output.shouldContain("Written dynamic archive 0x")
                       .shouldNotContain("klasses.*=.*CustomLoadee")

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/RegularHiddenClass.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/RegularHiddenClass.java
@@ -54,7 +54,7 @@ public class RegularHiddenClass extends DynamicArchiveTestBase {
 
         dump(topArchiveName,
             "-Xlog:class+load=debug,cds+dynamic,cds=debug",
-            "-cp", appJar, mainClass)
+            "-cp", appJar, mainClass, "keep-alive")
             .assertNormalExit(output -> {
                 output.shouldMatch("cds.*Skipping.TestClass.0x.*Hidden.class")
                       .shouldNotMatch("cds.dynamic.*Archiving.hidden.TestClass.*")

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/CustomLoaderApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/CustomLoaderApp.java
@@ -52,7 +52,7 @@ public class CustomLoaderApp {
             new URLClassLoader("HelloClassLoader", urls, null);
         Class c = Class.forName(className, init, urlClassLoader);
         if (keepAlive) {
-            keptC = c; 
+            keptC = c;
         }
 
         System.out.println(c);

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/CustomLoaderApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/CustomLoaderApp.java
@@ -43,6 +43,9 @@ public class CustomLoaderApp {
             init = true;
         }
 
+        // The dynamicArchive/LambdaCustomLoader.java test passes the keep-alive
+        // argument for preventing the class from being GC'ed prior to dumping of
+        // the dynamic CDS archive.
         boolean keepAlive = false;
         if (args[args.length - 1].equals("keep-alive")) {
             keepAlive = true;

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/CustomLoaderApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/CustomLoaderApp.java
@@ -28,6 +28,8 @@ import java.net.URLClassLoader;
 
 public class CustomLoaderApp {
     private static String className = "LambHello";
+    // Prevent the class from being GC'ed too soon.
+    private static Class keptC = null;
 
     public static void main(String args[]) throws Exception {
         String path = args[0];
@@ -37,13 +39,22 @@ public class CustomLoaderApp {
         System.out.println(url);
 
         boolean init = false;
-        if (args.length ==2 && args[1].equals("init")) {
+        if (args.length >= 2 && args[1].equals("init")) {
             init = true;
+        }
+
+        boolean keepAlive = false;
+        if (args[args.length - 1].equals("keep-alive")) {
+            keepAlive = true;
         }
 
         URLClassLoader urlClassLoader =
             new URLClassLoader("HelloClassLoader", urls, null);
         Class c = Class.forName(className, init, urlClassLoader);
+        if (keepAlive) {
+            keptC = c; 
+        }
+
         System.out.println(c);
         System.out.println(c.getClassLoader());
         if (c.getClassLoader() != urlClassLoader) {


### PR DESCRIPTION
A few dynamic archive CDS tests are failing in the loom repo due to more aggressive GC of code cache
which leads to unloading of some classes before being written into a dynamic CDS archive.

This change is to make the affected tests more reliable by ensuring the test classes are not unloaded
during dynamic CDS dump time.

Testing: Oracle CI tiers 1,2,4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278131](https://bugs.openjdk.java.net/browse/JDK-8278131): runtime/cds/appcds/dynamicArchive/* tests failing in loom repo


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to 998817f4449d9da12345ac3fedbdd75e93a83016
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**) ⚠️ Review applies to e947fe065c150967829d6f9d9265cbb236c47da1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6843/head:pull/6843` \
`$ git checkout pull/6843`

Update a local copy of the PR: \
`$ git checkout pull/6843` \
`$ git pull https://git.openjdk.java.net/jdk pull/6843/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6843`

View PR using the GUI difftool: \
`$ git pr show -t 6843`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6843.diff">https://git.openjdk.java.net/jdk/pull/6843.diff</a>

</details>
