### PR TITLE
8276982: VM.class_hierarchy jcmd help output and man page text needs clarifications/improvements

### DIFF
--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -906,8 +906,9 @@ void CompilerDirectivesClearDCmd::execute(DCmdSource source, TRAPS) {
 ClassHierarchyDCmd::ClassHierarchyDCmd(outputStream* output, bool heap) :
                                        DCmdWithParser(output, heap),
   _print_interfaces("-i", "Inherited interfaces should be printed.", "BOOLEAN", false, "false"),
-  _print_subclasses("-s", "If a classname is specified, print its subclasses. "
-                    "Otherwise only its superclasses are printed.", "BOOLEAN", false, "false"),
+  _print_subclasses("-s", "If a classname is specified, print its subclasses "
+                    "in addition to its superclasses. Without this option only the "
+                    "superclasses will be printed.", "BOOLEAN", false, "false"),
   _classname("classname", "Name of class whose hierarchy should be printed. "
              "If not specified, all class hierarchies are printed.",
              "STRING", false) {

--- a/src/jdk.jcmd/share/man/jcmd.1
+++ b/src/jdk.jcmd/share/man/jcmd.1
@@ -873,9 +873,9 @@ The following \f[I]options\f[R] must be specified using either
 \f[CB]\-i\f[R]: (Optional) Inherited interfaces should be printed.
 (BOOLEAN, false)
 .IP \[bu] 2
-\f[CB]\-s\f[R]: (Optional) If a class name is specified, it prints the
-subclasses.
-If the class name is not specified, only the superclasses are printed.
+\f[CB]\-s\f[R]: (Optional) If a classname is specified, print its
+subclasses in addition to its superclasses.
+Without this option only the superclasses will be printed.
 (BOOLEAN, false)
 .PP
 \f[I]arguments\f[R]:


### PR DESCRIPTION
Clarify the help output for VM.class_hierarchy. The old jcmd help output was misleading, and because of this got translated incorrectly for the man page.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276982](https://bugs.openjdk.java.net/browse/JDK-8276982): VM.class_hierarchy jcmd help output and man page text needs clarifications/improvements


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6845/head:pull/6845` \
`$ git checkout pull/6845`

Update a local copy of the PR: \
`$ git checkout pull/6845` \
`$ git pull https://git.openjdk.java.net/jdk pull/6845/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6845`

View PR using the GUI difftool: \
`$ git pr show -t 6845`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6845.diff">https://git.openjdk.java.net/jdk/pull/6845.diff</a>

</details>
