### PR TITLE
8278842: Parallel: Remove unused VerifyObjectStartArrayClosure::_old_gen

### DIFF
--- a/src/hotspot/share/gc/parallel/psOldGen.cpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.cpp
@@ -400,12 +400,11 @@ void PSOldGen::verify() {
 }
 
 class VerifyObjectStartArrayClosure : public ObjectClosure {
-  PSOldGen* _old_gen;
   ObjectStartArray* _start_array;
 
  public:
-  VerifyObjectStartArrayClosure(PSOldGen* old_gen, ObjectStartArray* start_array) :
-    _old_gen(old_gen), _start_array(start_array) { }
+  VerifyObjectStartArrayClosure(ObjectStartArray* start_array) :
+    _start_array(start_array) { }
 
   virtual void do_object(oop obj) {
     HeapWord* test_addr = cast_from_oop<HeapWord*>(obj) + 1;
@@ -415,7 +414,7 @@ class VerifyObjectStartArrayClosure : public ObjectClosure {
 };
 
 void PSOldGen::verify_object_start_array() {
-  VerifyObjectStartArrayClosure check( this, &_start_array );
+  VerifyObjectStartArrayClosure check(&_start_array);
   object_iterate(&check);
 }
 


### PR DESCRIPTION
Trivial change of removing an unused field.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278842](https://bugs.openjdk.java.net/browse/JDK-8278842): Parallel: Remove unused VerifyObjectStartArrayClosure::_old_gen


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6846/head:pull/6846` \
`$ git checkout pull/6846`

Update a local copy of the PR: \
`$ git checkout pull/6846` \
`$ git pull https://git.openjdk.java.net/jdk pull/6846/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6846`

View PR using the GUI difftool: \
`$ git pr show -t 6846`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6846.diff">https://git.openjdk.java.net/jdk/pull/6846.diff</a>

</details>
