### PR TITLE
JDK-8258603 c1 IR::verify is expensive

### DIFF
--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -180,6 +180,9 @@ void Compilation::build_hir() {
     _hir->optimize_blocks();
   }
 
+  // JANIUK _hir->optimize_blocks(); already runs verify lol
+  // Could argue for removing all in blockmerger
+  // Or this one probably
   _hir->verify();
 
   _hir->split_critical_edges();

--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -180,9 +180,6 @@ void Compilation::build_hir() {
     _hir->optimize_blocks();
   }
 
-  // JANIUK _hir->optimize_blocks(); already runs verify lol
-  // Could argue for removing all in blockmerger
-  // Or this one probably
   _hir->verify();
 
   _hir->split_critical_edges();

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1373,7 +1373,9 @@ public:
 void IR::verify() {
 #ifdef ASSERT
   PredecessorValidator pv(this);
+
   EndNotNullValidator(this);
+
   VerifyBlockBeginField verifier;
   this->iterate_postorder(&verifier);
 #endif // ASSERT

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1418,6 +1418,9 @@ void IR::verify() {
   EndNotNullValidator ennv;
   this->iterate_postorder(&ennv);
 
+  ValidateEdgeMutuality vem;
+  this->iterate_postorder(&vem);
+
   VerifyBlockBeginField verifier;
   this->iterate_postorder(&verifier);
 #endif // ASSERT

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1408,6 +1408,19 @@ class ValidateEdgeMutuality : public BlockClosure {
   }
 };
 
+void IR::verify_local(BlockList& blocks) {
+#ifdef ASSERT
+  EndNotNullValidator ennv;
+  blocks.iterate_forward(&ennv);
+
+  ValidateEdgeMutuality vem;
+  blocks.iterate_forward(&vem);
+
+  VerifyBlockBeginField verifier;
+  blocks.iterate_forward(&verifier);
+#endif // ASSERT
+}
+
 void IR::verify() {
 #ifdef ASSERT
   XentryFlagValidator xe;

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1283,6 +1283,12 @@ void verify_successor_xentry_flag(const BlockBegin* block) {
   }
 }
 
+// Validation goals:
+// * Verify successor xentry flags
+// * code() length == blocks length
+// * code() contents == blocks content
+// * Each block's computed predecessors match sux lists (length)
+// * Each block's computed predecessors match sux lists (set content)
 class PredecessorValidator : public BlockClosure {
  private:
   BlockListList* _predecessors; // Each index i will hold predecessors of block with id i

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1359,14 +1359,16 @@ class PredecessorValidator : public BlockClosure {
   }
 };
 
+inline void verify_block_begin_field(BlockBegin* block) {
+  for ( Instruction *cur = block; cur != NULL; cur = cur->next()) {
+    assert(cur->block() == block, "Block begin is not correct");
+  }
+}
+
 class VerifyBlockBeginField : public BlockClosure {
-
 public:
-
-  virtual void block_do(BlockBegin *block) {
-    for ( Instruction *cur = block; cur != NULL; cur = cur->next()) {
-      assert(cur->block() == block, "Block begin is not correct");
-    }
+  virtual void block_do(BlockBegin* block) {
+    verify_block_begin_field(block);
   }
 };
 

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1376,7 +1376,7 @@ void IR::verify() {
   EndNotNullValidator(this);
   VerifyBlockBeginField verifier;
   this->iterate_postorder(&verifier);
-#endif
+#endif // ASSERT
 }
 
 #endif // PRODUCT

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1283,8 +1283,14 @@ void verify_successor_xentry_flag(const BlockBegin* block) {
   }
 }
 
+class XentryFlagValidator : public BlockClosure {
+ public:
+  virtual void block_do(BlockBegin* block) {
+    verify_successor_xentry_flag(block);
+  }
+};
+
 // Validation goals:
-// * Verify successor xentry flags
 // * code() length == blocks length
 // * code() contents == blocks content
 // * Each block's computed predecessors match sux lists (length)
@@ -1320,7 +1326,6 @@ class PredecessorValidator : public BlockClosure {
 
   virtual void block_do(BlockBegin* block) {
     _blocks->append(block);
-    verify_successor_xentry_flag(block);
     collect_predecessors(block);
   }
 
@@ -1405,6 +1410,9 @@ class ValidateEdgeMutuality : public BlockClosure {
 
 void IR::verify() {
 #ifdef ASSERT
+  XentryFlagValidator xe;
+  this->iterate_postorder(&xe);
+
   PredecessorValidator pv(this);
 
   EndNotNullValidator ennv;

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1260,7 +1260,10 @@ void IR::print(bool cfg_only, bool live_only) {
     tty->print_cr("invalid IR");
   }
 }
+#endif // PRODUCT
 
+
+#ifdef ASSERT
 class EndNotNullValidator : public BlockClosure {
  public:
   virtual void block_do(BlockBegin* block) {
@@ -1443,8 +1446,7 @@ void IR::verify() {
   VerifyBlockBeginField verifier;
   iterate_postorder(&verifier);
 }
-
-#endif // PRODUCT
+#endif // ASSERT
 
 void SubstitutionResolver::visit(Value* v) {
   Value v0 = *v;

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1295,7 +1295,7 @@ class XentryFlagValidator : public BlockClosure {
 // * code() contents == blocks content
 // * Each block's computed predecessors match sux lists (length)
 // * Each block's computed predecessors match sux lists (set content)
-class PredecessorValidator : public BlockClosure {
+class PredecessorAndCodeValidator : public BlockClosure {
  private:
   BlockListList* _predecessors; // Each index i will hold predecessors of block with id i
   BlockList*     _blocks;
@@ -1305,7 +1305,7 @@ class PredecessorValidator : public BlockClosure {
   }
 
  public:
-  PredecessorValidator(IR* hir) {
+  PredecessorAndCodeValidator(IR* hir) {
     ResourceMark rm;
     _predecessors = new BlockListList(BlockBegin::number_of_blocks(), BlockBegin::number_of_blocks(), NULL);
     _blocks = new BlockList(BlockBegin::number_of_blocks());
@@ -1413,7 +1413,7 @@ void IR::verify() {
   XentryFlagValidator xe;
   this->iterate_postorder(&xe);
 
-  PredecessorValidator pv(this);
+  PredecessorAndCodeValidator pv(this);
 
   EndNotNullValidator ennv;
   this->iterate_postorder(&ennv);

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1398,18 +1398,21 @@ void IR::expand_with_neighborhood(BlockList& blocks) {
     BlockBegin* block = blocks.at(h);
 
     for (int i = 0; i < block->end()->number_of_sux(); i++) {
-      if (blocks.contains(block->end()->sux_at(i))) { continue; }
-      blocks.append(block->end()->sux_at(i));
+      if (!blocks.contains(block->end()->sux_at(i))) {
+        blocks.append(block->end()->sux_at(i));
+      }
     }
 
     for (int i = 0; i < block->number_of_preds(); i++) {
-      if (blocks.contains(block->pred_at(i))) { continue; }
-      blocks.append(block->pred_at(i));
+      if (!blocks.contains(block->pred_at(i))) {
+        blocks.append(block->pred_at(i));
+      }
     }
 
     for (int i = 0; i < block->number_of_exception_handlers(); i++) {
-      if (blocks.contains(block->exception_handler_at(i))) { continue; }
-      blocks.append(block->exception_handler_at(i));
+      if (!blocks.contains(block->exception_handler_at(i))) {
+        blocks.append(block->exception_handler_at(i));
+      }
     }
   }
 }

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1274,6 +1274,15 @@ class EndNotNullValidator : public BlockClosure {
 
 typedef GrowableArray<BlockList*> BlockListList;
 
+void verify_successor_xentry_flag(const BlockBegin* block) {
+  for (int i = 0; i < block->end()->number_of_sux(); i++) {
+    assert(!block->end()->sux_at(i)->is_set(BlockBegin::exception_entry_flag), "must not be xhandler");
+  }
+  for (int i = 0; i < block->number_of_exception_handlers(); i++) {
+    assert(block->exception_handler_at(i)->is_set(BlockBegin::exception_entry_flag), "must be xhandler");
+  }
+}
+
 class PredecessorValidator : public BlockClosure {
  private:
   BlockListList* _predecessors; // Each index i will hold predecessors of block with id i
@@ -1310,15 +1319,6 @@ class PredecessorValidator : public BlockClosure {
   }
 
  private:
-  void verify_successor_xentry_flag(const BlockBegin* block) const {
-    for (int i = 0; i < block->end()->number_of_sux(); i++) {
-      assert(!block->end()->sux_at(i)->is_set(BlockBegin::exception_entry_flag), "must not be xhandler");
-    }
-    for (int i = 0; i < block->number_of_exception_handlers(); i++) {
-      assert(block->exception_handler_at(i)->is_set(BlockBegin::exception_entry_flag), "must be xhandler");
-    }
-  }
-
   void collect_predecessors(BlockBegin* block) {
     for (int i = 0; i < block->end()->number_of_sux(); i++) {
       collect_predecessor(block, block->end()->sux_at(i));

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1261,14 +1261,14 @@ void IR::print(bool cfg_only, bool live_only) {
   }
 }
 
+inline void validate_end_not_null(BlockBegin* block) {
+  assert(block->end() != NULL, "Expect block end to exist.");
+}
+
 class EndNotNullValidator : public BlockClosure {
  public:
-  EndNotNullValidator(IR* hir) {
-    hir->start()->iterate_postorder(this);
-  }
-
-  void block_do(BlockBegin* block) {
-    assert(block->end() != NULL, "Expect block end to exist.");
+  virtual void block_do(BlockBegin* block) {
+    validate_end_not_null(block);
   }
 };
 
@@ -1374,7 +1374,8 @@ void IR::verify() {
 #ifdef ASSERT
   PredecessorValidator pv(this);
 
-  EndNotNullValidator(this);
+  EndNotNullValidator ennv;
+  this->iterate_postorder(&ennv);
 
   VerifyBlockBeginField verifier;
   this->iterate_postorder(&verifier);

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1372,6 +1372,31 @@ public:
   }
 };
 
+void validate_edge_mutuality(BlockBegin* block) {
+  for (int i = 0; i < block->end()->number_of_sux(); i++) {
+    assert(block->end()->sux_at(i)->is_predecessor(block), "Block's successor should have it as predecessor");
+  }
+
+  for (int i = 0; i < block->number_of_exception_handlers(); i++) {
+    assert(block->exception_handler_at(i)->is_predecessor(block), "Block's exception handler should have it as predecessor");
+  }
+
+  for (int i = 0; i < block->number_of_preds(); i++) {
+    assert(block->pred_at(i) != NULL, "Predecessor must exist");
+    assert(block->pred_at(i)->end() != NULL, "Predecessor end must exist");
+    bool is_sux      = block->pred_at(i)->end()->is_sux(block);
+    bool is_xhandler = block->pred_at(i)->is_exception_handler(block);
+    assert(is_sux || is_xhandler, "Block's predecessor should have it as successor or xhandler");
+  }
+}
+
+class ValidateEdgeMutuality : public BlockClosure {
+ public:
+  virtual void block_do(BlockBegin* block) {
+    validate_edge_mutuality(block);
+  }
+};
+
 void IR::verify() {
 #ifdef ASSERT
   PredecessorValidator pv(this);

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1262,7 +1262,6 @@ void IR::print(bool cfg_only, bool live_only) {
 }
 #endif // PRODUCT
 
-
 #ifdef ASSERT
 class EndNotNullValidator : public BlockClosure {
  public:
@@ -1270,8 +1269,6 @@ class EndNotNullValidator : public BlockClosure {
     assert(block->end() != NULL, "Expect block end to exist.");
   }
 };
-
-typedef GrowableArray<BlockList*> BlockListList;
 
 class XentryFlagValidator : public BlockClosure {
  public:
@@ -1284,6 +1281,8 @@ class XentryFlagValidator : public BlockClosure {
     }
   }
 };
+
+typedef GrowableArray<BlockList*> BlockListList;
 
 // Validation goals:
 // - code() length == blocks length

--- a/src/hotspot/share/c1/c1_IR.cpp
+++ b/src/hotspot/share/c1/c1_IR.cpp
@@ -1408,6 +1408,28 @@ class ValidateEdgeMutuality : public BlockClosure {
   }
 };
 
+void IR::expand_with_neighborhood(BlockList& blocks) {
+  int original_size = blocks.length();
+  for (int h = 0; h < original_size; h++) {
+    BlockBegin* block = blocks.at(h);
+
+    for (int i = 0; i < block->end()->number_of_sux(); i++) {
+      if (blocks.contains(block->end()->sux_at(i))) continue;
+      blocks.append(block->end()->sux_at(i));
+    }
+
+    for (int i = 0; i < block->number_of_preds(); i++) {
+      if (blocks.contains(block->pred_at(i))) continue;
+      blocks.append(block->pred_at(i));
+    }
+
+    for (int i = 0; i < block->number_of_exception_handlers(); i++) {
+      if (blocks.contains(block->exception_handler_at(i))) continue;
+      blocks.append(block->exception_handler_at(i));
+    }
+  }
+}
+
 void IR::verify_local(BlockList& blocks) {
 #ifdef ASSERT
   EndNotNullValidator ennv;

--- a/src/hotspot/share/c1/c1_IR.hpp
+++ b/src/hotspot/share/c1/c1_IR.hpp
@@ -338,6 +338,7 @@ class IR: public CompilationResourceObj {
   // debugging
   static void print(BlockBegin* start, bool cfg_only, bool live_only = false) PRODUCT_RETURN;
   void print(bool cfg_only, bool live_only = false)                           PRODUCT_RETURN;
+  void verify_local(BlockList&)                                               PRODUCT_RETURN;
   void verify()                                                               PRODUCT_RETURN;
 };
 

--- a/src/hotspot/share/c1/c1_IR.hpp
+++ b/src/hotspot/share/c1/c1_IR.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -338,9 +338,12 @@ class IR: public CompilationResourceObj {
   // debugging
   static void print(BlockBegin* start, bool cfg_only, bool live_only = false) PRODUCT_RETURN;
   void print(bool cfg_only, bool live_only = false)                           PRODUCT_RETURN;
-  void expand_with_neighborhood(BlockList& blocks)                            PRODUCT_RETURN;
-  void verify_local(BlockList&)                                               PRODUCT_RETURN;
-  void verify()                                                               PRODUCT_RETURN;
+
+#ifdef ASSERT
+  void expand_with_neighborhood(BlockList& blocks);
+  void verify_local(BlockList&);
+  void verify();
+#endif // ASSERT
 };
 
 

--- a/src/hotspot/share/c1/c1_IR.hpp
+++ b/src/hotspot/share/c1/c1_IR.hpp
@@ -338,7 +338,7 @@ class IR: public CompilationResourceObj {
   // debugging
   static void print(BlockBegin* start, bool cfg_only, bool live_only = false) PRODUCT_RETURN;
   void print(bool cfg_only, bool live_only = false)                           PRODUCT_RETURN;
-  void expand_with_neighborhood(BlockList& blocks);
+  void expand_with_neighborhood(BlockList& blocks)                            PRODUCT_RETURN;
   void verify_local(BlockList&)                                               PRODUCT_RETURN;
   void verify()                                                               PRODUCT_RETURN;
 };

--- a/src/hotspot/share/c1/c1_IR.hpp
+++ b/src/hotspot/share/c1/c1_IR.hpp
@@ -338,6 +338,7 @@ class IR: public CompilationResourceObj {
   // debugging
   static void print(BlockBegin* start, bool cfg_only, bool live_only = false) PRODUCT_RETURN;
   void print(bool cfg_only, bool live_only = false)                           PRODUCT_RETURN;
+  void expand_with_neighborhood(BlockList& blocks);
   void verify_local(BlockList&)                                               PRODUCT_RETURN;
   void verify()                                                               PRODUCT_RETURN;
 };

--- a/src/hotspot/share/c1/c1_IR.hpp
+++ b/src/hotspot/share/c1/c1_IR.hpp
@@ -339,11 +339,9 @@ class IR: public CompilationResourceObj {
   static void print(BlockBegin* start, bool cfg_only, bool live_only = false) PRODUCT_RETURN;
   void print(bool cfg_only, bool live_only = false)                           PRODUCT_RETURN;
 
-#ifdef ASSERT
-  void expand_with_neighborhood(BlockList& blocks);
-  void verify_local(BlockList&);
-  void verify();
-#endif // ASSERT
+  void expand_with_neighborhood(BlockList& blocks)                          NOT_DEBUG_RETURN;
+  void verify_local(BlockList&)                                             NOT_DEBUG_RETURN;
+  void verify()                                                             NOT_DEBUG_RETURN;
 };
 
 

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1822,6 +1822,7 @@ BASE(BlockEnd, StateSplit)
   // successors
   int number_of_sux() const                      { return _sux != NULL ? _sux->length() : 0; }
   BlockBegin* sux_at(int i) const                { return _sux->at(i); }
+  bool is_sux(BlockBegin* sux) const             { return _sux == NULL ? false : _sux->contains(sux); }
   BlockBegin* default_sux() const                { return sux_at(number_of_sux() - 1); }
   void substitute_sux(BlockBegin* old_sux, BlockBegin* new_sux);
 };

--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -265,9 +265,6 @@ void CE_Eliminator::block_do(BlockBegin* block) {
   _hir->verify_local(blocks_to_verify_later);
 #endif // __DO_DELAYED_VERIFICATION
 
-#ifdef ASSERT
-#undef __DO_DELAYED_VERIFICATION
-#endif // ASSERT
 }
 
 Value CE_Eliminator::make_ifop(Value x, Instruction::Condition cond, Value y, Value tval, Value fval) {
@@ -518,6 +515,10 @@ class BlockMerger: public BlockClosure {
     while (try_merge(block)) ;
   }
 };
+
+#ifdef ASSERT
+#undef __DO_DELAYED_VERIFICATION
+#endif // ASSERT
 
 
 void Optimizer::eliminate_blocks() {

--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -400,15 +400,6 @@ class BlockMerger: public BlockClosure {
 #endif
 
 #ifdef ASSERT
-    {
-      BlockList b;
-      b.append(block);
-      b.append(sux);
-      _hir->verify_local(b);
-    }
-#endif // ASSERT
-
-#ifdef ASSERT
     BlockList blocks_to_verify_later;
     blocks_to_verify_later.append(block);
     _hir->expand_with_neighborhood(blocks_to_verify_later);

--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -180,14 +180,14 @@ void CE_Eliminator::block_do(BlockBegin* block) {
     return;
   }
 
-#ifndef PRODUCT
+#ifdef ASSERT
   BlockList blocks_to_verify_later;
   blocks_to_verify_later.append(block);
   blocks_to_verify_later.append(t_block);
   blocks_to_verify_later.append(f_block);
   blocks_to_verify_later.append(sux);
   _hir->expand_with_neighborhood(blocks_to_verify_later);
-#endif // PRODUCT
+#endif // ASSERT
 
   // 2) substitute conditional expression
   //    with an IfOp followed by a Goto
@@ -257,7 +257,7 @@ void CE_Eliminator::block_do(BlockBegin* block) {
     tty->print_cr("%d. IfOp in B%d", ifop_count(), block->block_id());
   }
 
-  NOT_PRODUCT(_hir->verify_local(blocks_to_verify_later));
+  DEBUG_ONLY(_hir->verify_local(blocks_to_verify_later));
 }
 
 Value CE_Eliminator::make_ifop(Value x, Instruction::Condition cond, Value y, Value tval, Value fval) {
@@ -397,11 +397,11 @@ class BlockMerger: public BlockClosure {
     assert(sux_state->caller_state() == end_state->caller_state(), "caller not equal");
 #endif
 
-#ifndef PRODUCT
+#ifdef ASSERT
     BlockList blocks_to_verify_later;
     blocks_to_verify_later.append(block);
     _hir->expand_with_neighborhood(blocks_to_verify_later);
-#endif // PRODUCT
+#endif // ASSERT
 
     // find instruction before end & append first instruction of sux block
     Instruction* prev = end->prev();
@@ -412,7 +412,7 @@ class BlockMerger: public BlockClosure {
 
     // disconnect this block from all other blocks
     disconnect_from_graph(sux);
-    NOT_PRODUCT(blocks_to_verify_later.remove(sux)); // Sux is not part of graph anymore
+    DEBUG_ONLY(blocks_to_verify_later.remove(sux)); // Sux is not part of graph anymore
     block->set_end(sux->end());
 
     // TODO Should this be done in set_end universally?
@@ -437,9 +437,7 @@ class BlockMerger: public BlockClosure {
                     _merge_count, block->block_id(), sux->block_id(), sux->state()->stack_size());
     }
 
-#ifndef PRODUCT
-    _hir->verify_local(blocks_to_verify_later);
-#endif // PRODUCT
+    DEBUG_ONLY(_hir->verify_local(blocks_to_verify_later));
 
     If* if_ = block->end()->as_If();
     if (if_) {
@@ -489,7 +487,7 @@ class BlockMerger: public BlockClosure {
                 tty->print_cr("%d. replaced If and IfOp at end of B%d with single If", _merge_count, block->block_id());
               }
 
-              NOT_PRODUCT(_hir->verify_local(blocks_to_verify_later));
+              DEBUG_ONLY(_hir->verify_local(blocks_to_verify_later));
             }
           }
         }

--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -407,11 +407,11 @@ class BlockMerger: public BlockClosure {
     assert(sux_state->caller_state() == end_state->caller_state(), "caller not equal");
 #endif
 
-#ifdef ASSERT
+#ifdef __DO_DELAYED_VERIFICATION
     BlockList blocks_to_verify_later;
     blocks_to_verify_later.append(block);
     _hir->expand_with_neighborhood(blocks_to_verify_later);
-#endif // ASSERT
+#endif // __DO_DELAYED_VERIFICATION
 
     // find instruction before end & append first instruction of sux block
     Instruction* prev = end->prev();
@@ -422,7 +422,9 @@ class BlockMerger: public BlockClosure {
 
     // disconnect this block from all other blocks
     disconnect_from_graph(sux);
-    DEBUG_ONLY(blocks_to_verify_later.remove(sux)); // Sux is not part of graph anymore
+#ifdef __DO_DELAYED_VERIFICATION
+    blocks_to_verify_later.remove(sux); // Sux is not part of graph anymore
+#endif // __DO_DELAYED_VERIFICATION
     block->set_end(sux->end());
 
     // TODO Should this be done in set_end universally?
@@ -447,7 +449,9 @@ class BlockMerger: public BlockClosure {
                     _merge_count, block->block_id(), sux->block_id(), sux->state()->stack_size());
     }
 
-    DEBUG_ONLY(_hir->verify_local(blocks_to_verify_later));
+#ifdef __DO_DELAYED_VERIFICATION
+    _hir->verify_local(blocks_to_verify_later);
+#endif // __DO_DELAYED_VERIFICATION
 
     If* if_ = block->end()->as_If();
     if (if_) {
@@ -497,7 +501,9 @@ class BlockMerger: public BlockClosure {
                 tty->print_cr("%d. replaced If and IfOp at end of B%d with single If", _merge_count, block->block_id());
               }
 
-              DEBUG_ONLY(_hir->verify_local(blocks_to_verify_later));
+#ifdef __DO_DELAYED_VERIFICATION
+              _hir->verify_local(blocks_to_verify_later);
+#endif // __DO_DELAYED_VERIFICATION
             }
           }
         }

--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -181,13 +181,17 @@ void CE_Eliminator::block_do(BlockBegin* block) {
   }
 
 #ifdef ASSERT
+#define __DO_DELAYED_VERIFICATION
+#endif // ASSERT
+
+#ifdef __DO_DELAYED_VERIFICATION
   BlockList blocks_to_verify_later;
   blocks_to_verify_later.append(block);
   blocks_to_verify_later.append(t_block);
   blocks_to_verify_later.append(f_block);
   blocks_to_verify_later.append(sux);
   _hir->expand_with_neighborhood(blocks_to_verify_later);
-#endif // ASSERT
+#endif // __DO_DELAYED_VERIFICATION
 
   // 2) substitute conditional expression
   //    with an IfOp followed by a Goto
@@ -257,7 +261,13 @@ void CE_Eliminator::block_do(BlockBegin* block) {
     tty->print_cr("%d. IfOp in B%d", ifop_count(), block->block_id());
   }
 
-  DEBUG_ONLY(_hir->verify_local(blocks_to_verify_later));
+#ifdef __DO_DELAYED_VERIFICATION
+  _hir->verify_local(blocks_to_verify_later);
+#endif // __DO_DELAYED_VERIFICATION
+
+#ifdef ASSERT
+#undef __DO_DELAYED_VERIFICATION
+#endif // ASSERT
 }
 
 Value CE_Eliminator::make_ifop(Value x, Instruction::Condition cond, Value y, Value tval, Value fval) {

--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -181,17 +181,17 @@ void CE_Eliminator::block_do(BlockBegin* block) {
   }
 
 #ifdef ASSERT
-#define __DO_DELAYED_VERIFICATION
+#define DO_DELAYED_VERIFICATION
 #endif // ASSERT
 
-#ifdef __DO_DELAYED_VERIFICATION
+#ifdef DO_DELAYED_VERIFICATION
   BlockList blocks_to_verify_later;
   blocks_to_verify_later.append(block);
   blocks_to_verify_later.append(t_block);
   blocks_to_verify_later.append(f_block);
   blocks_to_verify_later.append(sux);
   _hir->expand_with_neighborhood(blocks_to_verify_later);
-#endif // __DO_DELAYED_VERIFICATION
+#endif // DO_DELAYED_VERIFICATION
 
   // 2) substitute conditional expression
   //    with an IfOp followed by a Goto
@@ -261,9 +261,9 @@ void CE_Eliminator::block_do(BlockBegin* block) {
     tty->print_cr("%d. IfOp in B%d", ifop_count(), block->block_id());
   }
 
-#ifdef __DO_DELAYED_VERIFICATION
+#ifdef DO_DELAYED_VERIFICATION
   _hir->verify_local(blocks_to_verify_later);
-#endif // __DO_DELAYED_VERIFICATION
+#endif // DO_DELAYED_VERIFICATION
 
 }
 
@@ -404,11 +404,11 @@ class BlockMerger: public BlockClosure {
     assert(sux_state->caller_state() == end_state->caller_state(), "caller not equal");
 #endif
 
-#ifdef __DO_DELAYED_VERIFICATION
+#ifdef DO_DELAYED_VERIFICATION
     BlockList blocks_to_verify_later;
     blocks_to_verify_later.append(block);
     _hir->expand_with_neighborhood(blocks_to_verify_later);
-#endif // __DO_DELAYED_VERIFICATION
+#endif // DO_DELAYED_VERIFICATION
 
     // find instruction before end & append first instruction of sux block
     Instruction* prev = end->prev();
@@ -419,9 +419,9 @@ class BlockMerger: public BlockClosure {
 
     // disconnect this block from all other blocks
     disconnect_from_graph(sux);
-#ifdef __DO_DELAYED_VERIFICATION
+#ifdef DO_DELAYED_VERIFICATION
     blocks_to_verify_later.remove(sux); // Sux is not part of graph anymore
-#endif // __DO_DELAYED_VERIFICATION
+#endif // DO_DELAYED_VERIFICATION
     block->set_end(sux->end());
 
     // TODO Should this be done in set_end universally?
@@ -446,9 +446,9 @@ class BlockMerger: public BlockClosure {
                     _merge_count, block->block_id(), sux->block_id(), sux->state()->stack_size());
     }
 
-#ifdef __DO_DELAYED_VERIFICATION
+#ifdef DO_DELAYED_VERIFICATION
     _hir->verify_local(blocks_to_verify_later);
-#endif // __DO_DELAYED_VERIFICATION
+#endif // DO_DELAYED_VERIFICATION
 
     If* if_ = block->end()->as_If();
     if (if_) {
@@ -498,9 +498,9 @@ class BlockMerger: public BlockClosure {
                 tty->print_cr("%d. replaced If and IfOp at end of B%d with single If", _merge_count, block->block_id());
               }
 
-#ifdef __DO_DELAYED_VERIFICATION
+#ifdef DO_DELAYED_VERIFICATION
               _hir->verify_local(blocks_to_verify_later);
-#endif // __DO_DELAYED_VERIFICATION
+#endif // DO_DELAYED_VERIFICATION
             }
           }
         }
@@ -517,7 +517,7 @@ class BlockMerger: public BlockClosure {
 };
 
 #ifdef ASSERT
-#undef __DO_DELAYED_VERIFICATION
+#undef DO_DELAYED_VERIFICATION
 #endif // ASSERT
 
 void Optimizer::eliminate_blocks() {

--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -182,6 +182,12 @@ void CE_Eliminator::block_do(BlockBegin* block) {
 
 #ifdef ASSERT
 #define DO_DELAYED_VERIFICATION
+  /*
+   * We need to verify the internal representation after modifying it.
+   * Verifying only the blocks that have been tampered with is cheaper than verifying the whole graph, but we must
+   * capture blocks_to_verify_later before making the changes, since they might not be reachable afterwards.
+   * DO_DELAYED_VERIFICATION ensures that the code for this is either enabled in full, or not at all.
+   */
 #endif // ASSERT
 
 #ifdef DO_DELAYED_VERIFICATION

--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -180,14 +180,14 @@ void CE_Eliminator::block_do(BlockBegin* block) {
     return;
   }
 
-#ifdef ASSERT
+#ifndef PRODUCT
   BlockList blocks_to_verify_later;
   blocks_to_verify_later.append(block);
   blocks_to_verify_later.append(t_block);
   blocks_to_verify_later.append(f_block);
   blocks_to_verify_later.append(sux);
   _hir->expand_with_neighborhood(blocks_to_verify_later);
-#endif //ASSERT
+#endif // PRODUCT
 
   // 2) substitute conditional expression
   //    with an IfOp followed by a Goto
@@ -257,9 +257,9 @@ void CE_Eliminator::block_do(BlockBegin* block) {
     tty->print_cr("%d. IfOp in B%d", ifop_count(), block->block_id());
   }
 
-#ifdef ASSERT
+#ifndef PRODUCT
   _hir->verify_local(blocks_to_verify_later);
-#endif // ASSERT
+#endif // PRODUCT
 }
 
 Value CE_Eliminator::make_ifop(Value x, Instruction::Condition cond, Value y, Value tval, Value fval) {
@@ -399,11 +399,11 @@ class BlockMerger: public BlockClosure {
     assert(sux_state->caller_state() == end_state->caller_state(), "caller not equal");
 #endif
 
-#ifdef ASSERT
+#ifndef PRODUCT
     BlockList blocks_to_verify_later;
     blocks_to_verify_later.append(block);
     _hir->expand_with_neighborhood(blocks_to_verify_later);
-#endif //ASSERT
+#endif // PRODUCT
 
     // find instruction before end & append first instruction of sux block
     Instruction* prev = end->prev();
@@ -414,9 +414,7 @@ class BlockMerger: public BlockClosure {
 
     // disconnect this block from all other blocks
     disconnect_from_graph(sux);
-#ifdef ASSERT
-    blocks_to_verify_later.remove(sux); // Sux is not part of graph anymore
-#endif //ASSERT
+    NOT_PRODUCT(blocks_to_verify_later.remove(sux)); // Sux is not part of graph anymore
     block->set_end(sux->end());
 
     // TODO Should this be done in set_end universally?
@@ -441,9 +439,9 @@ class BlockMerger: public BlockClosure {
                     _merge_count, block->block_id(), sux->block_id(), sux->state()->stack_size());
     }
 
-#ifdef ASSERT
+#ifndef PRODUCT
     _hir->verify_local(blocks_to_verify_later);
-#endif // ASSERT
+#endif // PRODUCT
 
     If* if_ = block->end()->as_If();
     if (if_) {
@@ -493,9 +491,7 @@ class BlockMerger: public BlockClosure {
                 tty->print_cr("%d. replaced If and IfOp at end of B%d with single If", _merge_count, block->block_id());
               }
 
-#ifdef ASSERT
-              _hir->verify_local(blocks_to_verify_later);
-#endif // ASSERT
+              NOT_PRODUCT(_hir->verify_local(blocks_to_verify_later));
             }
           }
         }

--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -257,9 +257,7 @@ void CE_Eliminator::block_do(BlockBegin* block) {
     tty->print_cr("%d. IfOp in B%d", ifop_count(), block->block_id());
   }
 
-#ifndef PRODUCT
-  _hir->verify_local(blocks_to_verify_later);
-#endif // PRODUCT
+  NOT_PRODUCT(_hir->verify_local(blocks_to_verify_later));
 }
 
 Value CE_Eliminator::make_ifop(Value x, Instruction::Condition cond, Value y, Value tval, Value fval) {

--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -520,7 +520,6 @@ class BlockMerger: public BlockClosure {
 #undef __DO_DELAYED_VERIFICATION
 #endif // ASSERT
 
-
 void Optimizer::eliminate_blocks() {
   // merge blocks if possible
   BlockMerger bm(ir());


### PR DESCRIPTION
IR::verify iterates the whole object graph. This proves costly when used in e.g. BlockMerger inside of iterations over BlockLists, leading to quadratic or worse complexities as a function of bytecode length. In several cases, only a few Blocks were changed, and there was no need to go over the whole graph, but until now there was no less blunt tool for verification than IR::verify.

This PR introduces IR::verify_local, intended to be used when only a defined set of blocks have been modified. As a complement, expand_with_neighbors provides a way to also capture the neighbors of the "modified set" ahead of modification, so that afterwards the appropriate asserts can be made on all blocks which might possibly have been changed. All this should let us remove the expensive IR::verify calls, while still performing equivalent (or stricter) assertions.

Some changes have been made in the verifiers along the way. Some amount of refactoring, and even added invariants (see validate_edge_mutiality).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258603](https://bugs.openjdk.java.net/browse/JDK-8258603): c1 IR::verify is expensive


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6850/head:pull/6850` \
`$ git checkout pull/6850`

Update a local copy of the PR: \
`$ git checkout pull/6850` \
`$ git pull https://git.openjdk.java.net/jdk pull/6850/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6850`

View PR using the GUI difftool: \
`$ git pr show -t 6850`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6850.diff">https://git.openjdk.java.net/jdk/pull/6850.diff</a>

</details>
