### PR TITLE
8278623: compiler/vectorapi/reshape/TestVectorCastAVX512.java after JDK-8259610

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -74,8 +74,6 @@ compiler/whitebox/MakeMethodNotCompilableTest.java 8265360 macosx-aarch64
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-x64
 compiler/codecache/TestStressCodeBuffers.java 8272094 generic-aarch64
 
-compiler/vectorapi/reshape/TestVectorCastAVX512.java 8278623 generic-x64
-
 
 #############################################################################
 

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX512BW.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX512BW.java
@@ -29,7 +29,7 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
 
 /*
  * @test
- * @bug 8259610
+ * @bug 8278623
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.misc
  * @summary Test that vector cast intrinsics work as intended on avx512bw.

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX512BW.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX512BW.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi.reshape;
+
+import compiler.vectorapi.reshape.tests.TestVectorCast;
+import compiler.vectorapi.reshape.utils.TestCastMethods;
+import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
+
+/*
+ * @test
+ * @bug 8259610
+ * @modules jdk.incubator.vector
+ * @modules java.base/jdk.internal.misc
+ * @summary Test that vector cast intrinsics work as intended on avx512bw.
+ * @requires vm.cpu.features ~= ".*avx512bw.*"
+ * @library /test/lib /
+ * @run driver compiler.vectorapi.reshape.TestVectorCastAVX512BW
+ */
+public class TestVectorCastAVX512BW {
+    public static void main(String[] args) {
+        VectorReshapeHelper.runMainHelper(
+                TestVectorCast.class,
+                TestCastMethods.AVX512BW_CAST_TESTS.stream(),
+                "-XX:UseAVX=3");
+    }
+}
+

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorReinterpret.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorReinterpret.java
@@ -74,8 +74,7 @@ public class TestVectorReinterpret {
                                         .filter(ftype -> ftype != etype)
                                         .map(ftype -> VectorSpeciesPair.makePair(VectorSpecies.of(etype, shape),
                                                 VectorSpecies.of(ftype, shape)))))
-                        .filter(p -> p.isp().length() > 1 && p.osp().length() > 1),
-                "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED"
+                        .filter(p -> p.isp().length() > 1 && p.osp().length() > 1)
         );
     }
 }

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/tests/TestVectorCast.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/tests/TestVectorCast.java
@@ -34,12 +34,18 @@ import static jdk.incubator.vector.VectorOperators.*;
  * This class contains all possible cast operations between different vector species.
  * The methods only take into consideration the actual cast in C2, as the vectors are
  * ofter shrunk or expanded before/after casting if the element numbers mismatch.
+ *
+ * We must load from/store to the exact type array since vector support for byte may be
+ * smaller than that for other types. Failing to intrinsify LoadVectorNode causes C2
+ * compilation to stop, which results in non-compilable failure since we only have one
+ * chance of compilation before IR verification.
+ *
  * In each cast, the VectorCastNode is expected to appear exactly once.
  */
 public class TestVectorCast {
     @Test
     @IR(counts = {B2X_NODE, "1"})
-    public static void testB64toS64(byte[] input, byte[] output) {
+    public static void testB64toS64(byte[] input, short[] output) {
         vectorCast(B2S, BSPEC64, SSPEC64, input, output);
     }
 
@@ -50,7 +56,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {B2X_NODE, "1"})
-    public static void testB64toS128(byte[] input, byte[] output) {
+    public static void testB64toS128(byte[] input, short[] output) {
         vectorCast(B2S, BSPEC64, SSPEC128, input, output);
     }
 
@@ -61,7 +67,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {B2X_NODE, "1"})
-    public static void testB128toS256(byte[] input, byte[] output) {
+    public static void testB128toS256(byte[] input, short[] output) {
         vectorCast(B2S, BSPEC128, SSPEC256, input, output);
     }
 
@@ -72,7 +78,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {B2X_NODE, "1"})
-    public static void testB256toS512(byte[] input, byte[] output) {
+    public static void testB256toS512(byte[] input, short[] output) {
         vectorCast(B2S, BSPEC256, SSPEC512, input, output);
     }
 
@@ -83,7 +89,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {B2X_NODE, "1"})
-    public static void testB64toI64(byte[] input, byte[] output) {
+    public static void testB64toI64(byte[] input, int[] output) {
         vectorCast(B2I, BSPEC64, ISPEC64, input, output);
     }
 
@@ -94,7 +100,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {B2X_NODE, "1"})
-    public static void testB64toI128(byte[] input, byte[] output) {
+    public static void testB64toI128(byte[] input, int[] output) {
         vectorCast(B2I, BSPEC64, ISPEC128, input, output);
     }
 
@@ -105,7 +111,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {B2X_NODE, "1"})
-    public static void testB64toI256(byte[] input, byte[] output) {
+    public static void testB64toI256(byte[] input, int[] output) {
         vectorCast(B2I, BSPEC64, ISPEC256, input, output);
     }
 
@@ -116,7 +122,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {B2X_NODE, "1"})
-    public static void testB128toI512(byte[] input, byte[] output) {
+    public static void testB128toI512(byte[] input, int[] output) {
         vectorCast(B2I, BSPEC128, ISPEC512, input, output);
     }
 
@@ -127,7 +133,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {B2X_NODE, "1"})
-    public static void testB64toL64(byte[] input, byte[] output) {
+    public static void testB64toL64(byte[] input, long[] output) {
         vectorCast(B2L, BSPEC64, LSPEC64, input, output);
     }
 
@@ -138,7 +144,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {B2X_NODE, "1"})
-    public static void testB64toL128(byte[] input, byte[] output) {
+    public static void testB64toL128(byte[] input, long[] output) {
         vectorCast(B2L, BSPEC64, LSPEC128, input, output);
     }
 
@@ -149,7 +155,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {B2X_NODE, "1"})
-    public static void testB64toL256(byte[] input, byte[] output) {
+    public static void testB64toL256(byte[] input, long[] output) {
         vectorCast(B2L, BSPEC64, LSPEC256, input, output);
     }
 
@@ -160,7 +166,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {B2X_NODE, "1"})
-    public static void testB64toL512(byte[] input, byte[] output) {
+    public static void testB64toL512(byte[] input, long[] output) {
         vectorCast(B2L, BSPEC64, LSPEC512, input, output);
     }
 
@@ -171,7 +177,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {B2X_NODE, "1"})
-    public static void testB64toF64(byte[] input, byte[] output) {
+    public static void testB64toF64(byte[] input, float[] output) {
         vectorCast(B2F, BSPEC64, FSPEC64, input, output);
     }
 
@@ -182,7 +188,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {B2X_NODE, "1"})
-    public static void testB64toF128(byte[] input, byte[] output) {
+    public static void testB64toF128(byte[] input, float[] output) {
         vectorCast(B2F, BSPEC64, FSPEC128, input, output);
     }
 
@@ -193,7 +199,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {B2X_NODE, "1"})
-    public static void testB64toF256(byte[] input, byte[] output) {
+    public static void testB64toF256(byte[] input, float[] output) {
         vectorCast(B2F, BSPEC64, FSPEC256, input, output);
     }
 
@@ -204,7 +210,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {B2X_NODE, "1"})
-    public static void testB128toF512(byte[] input, byte[] output) {
+    public static void testB128toF512(byte[] input, float[] output) {
         vectorCast(B2F, BSPEC128, FSPEC512, input, output);
     }
 
@@ -215,7 +221,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {B2X_NODE, "1"})
-    public static void testB64toD64(byte[] input, byte[] output) {
+    public static void testB64toD64(byte[] input, double[] output) {
         vectorCast(B2D, BSPEC64, DSPEC64, input, output);
     }
 
@@ -226,7 +232,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {B2X_NODE, "1"})
-    public static void testB64toD128(byte[] input, byte[] output) {
+    public static void testB64toD128(byte[] input, double[] output) {
         vectorCast(B2D, BSPEC64, DSPEC128, input, output);
     }
 
@@ -237,7 +243,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {B2X_NODE, "1"})
-    public static void testB64toD256(byte[] input, byte[] output) {
+    public static void testB64toD256(byte[] input, double[] output) {
         vectorCast(B2D, BSPEC64, DSPEC256, input, output);
     }
 
@@ -248,7 +254,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {B2X_NODE, "1"})
-    public static void testB64toD512(byte[] input, byte[] output) {
+    public static void testB64toD512(byte[] input, double[] output) {
         vectorCast(B2D, BSPEC64, DSPEC512, input, output);
     }
 
@@ -259,7 +265,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {S2X_NODE, "1"})
-    public static void testS64toB64(byte[] input, byte[] output) {
+    public static void testS64toB64(short[] input, byte[] output) {
         vectorCast(S2B, SSPEC64, BSPEC64, input, output);
     }
 
@@ -270,7 +276,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {S2X_NODE, "1"})
-    public static void testS128toB64(byte[] input, byte[] output) {
+    public static void testS128toB64(short[] input, byte[] output) {
         vectorCast(S2B, SSPEC128, BSPEC64, input, output);
     }
 
@@ -281,7 +287,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {S2X_NODE, "1"})
-    public static void testS256toB128(byte[] input, byte[] output) {
+    public static void testS256toB128(short[] input, byte[] output) {
         vectorCast(S2B, SSPEC256, BSPEC128, input, output);
     }
 
@@ -292,7 +298,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {S2X_NODE, "1"})
-    public static void testS512toB256(byte[] input, byte[] output) {
+    public static void testS512toB256(short[] input, byte[] output) {
         vectorCast(S2B, SSPEC512, BSPEC256, input, output);
     }
 
@@ -303,7 +309,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {S2X_NODE, "1"})
-    public static void testS64toI64(byte[] input, byte[] output) {
+    public static void testS64toI64(short[] input, int[] output) {
         vectorCast(S2I, SSPEC64, ISPEC64, input, output);
     }
 
@@ -314,7 +320,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {S2X_NODE, "1"})
-    public static void testS64toI128(byte[] input, byte[] output) {
+    public static void testS64toI128(short[] input, int[] output) {
         vectorCast(S2I, SSPEC64, ISPEC128, input, output);
     }
 
@@ -325,7 +331,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {S2X_NODE, "1"})
-    public static void testS128toI256(byte[] input, byte[] output) {
+    public static void testS128toI256(short[] input, int[] output) {
         vectorCast(S2I, SSPEC128, ISPEC256, input, output);
     }
 
@@ -336,7 +342,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {S2X_NODE, "1"})
-    public static void testS256toI512(byte[] input, byte[] output) {
+    public static void testS256toI512(short[] input, int[] output) {
         vectorCast(S2I, SSPEC256, ISPEC512, input, output);
     }
 
@@ -347,7 +353,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {S2X_NODE, "1"})
-    public static void testS64toL64(byte[] input, byte[] output) {
+    public static void testS64toL64(short[] input, long[] output) {
         vectorCast(S2L, SSPEC64, LSPEC64, input, output);
     }
 
@@ -358,7 +364,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {S2X_NODE, "1"})
-    public static void testS64toL128(byte[] input, byte[] output) {
+    public static void testS64toL128(short[] input, long[] output) {
         vectorCast(S2L, SSPEC64, LSPEC128, input, output);
     }
 
@@ -369,7 +375,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {S2X_NODE, "1"})
-    public static void testS64toL256(byte[] input, byte[] output) {
+    public static void testS64toL256(short[] input, long[] output) {
         vectorCast(S2L, SSPEC64, LSPEC256, input, output);
     }
 
@@ -380,7 +386,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {S2X_NODE, "1"})
-    public static void testS128toL512(byte[] input, byte[] output) {
+    public static void testS128toL512(short[] input, long[] output) {
         vectorCast(S2L, SSPEC128, LSPEC512, input, output);
     }
 
@@ -391,7 +397,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {S2X_NODE, "1"})
-    public static void testS64toF64(byte[] input, byte[] output) {
+    public static void testS64toF64(short[] input, float[] output) {
         vectorCast(S2F, SSPEC64, FSPEC64, input, output);
     }
 
@@ -402,7 +408,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {S2X_NODE, "1"})
-    public static void testS64toF128(byte[] input, byte[] output) {
+    public static void testS64toF128(short[] input, float[] output) {
         vectorCast(S2F, SSPEC64, FSPEC128, input, output);
     }
 
@@ -413,7 +419,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {S2X_NODE, "1"})
-    public static void testS128toF256(byte[] input, byte[] output) {
+    public static void testS128toF256(short[] input, float[] output) {
         vectorCast(S2F, SSPEC128, FSPEC256, input, output);
     }
 
@@ -424,7 +430,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {S2X_NODE, "1"})
-    public static void testS256toF512(byte[] input, byte[] output) {
+    public static void testS256toF512(short[] input, float[] output) {
         vectorCast(S2F, SSPEC256, FSPEC512, input, output);
     }
 
@@ -435,7 +441,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {S2X_NODE, "1"})
-    public static void testS64toD64(byte[] input, byte[] output) {
+    public static void testS64toD64(short[] input, double[] output) {
         vectorCast(S2D, SSPEC64, DSPEC64, input, output);
     }
 
@@ -446,7 +452,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {S2X_NODE, "1"})
-    public static void testS64toD128(byte[] input, byte[] output) {
+    public static void testS64toD128(short[] input, double[] output) {
         vectorCast(S2D, SSPEC64, DSPEC128, input, output);
     }
 
@@ -457,7 +463,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {S2X_NODE, "1"})
-    public static void testS64toD256(byte[] input, byte[] output) {
+    public static void testS64toD256(short[] input, double[] output) {
         vectorCast(S2D, SSPEC64, DSPEC256, input, output);
     }
 
@@ -468,7 +474,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {S2X_NODE, "1"})
-    public static void testS128toD512(byte[] input, byte[] output) {
+    public static void testS128toD512(short[] input, double[] output) {
         vectorCast(S2D, SSPEC128, DSPEC512, input, output);
     }
 
@@ -479,7 +485,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {I2X_NODE, "1"})
-    public static void testI64toB64(byte[] input, byte[] output) {
+    public static void testI64toB64(int[] input, byte[] output) {
         vectorCast(I2B, ISPEC64, BSPEC64, input, output);
     }
 
@@ -490,7 +496,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {I2X_NODE, "1"})
-    public static void testI128toB64(byte[] input, byte[] output) {
+    public static void testI128toB64(int[] input, byte[] output) {
         vectorCast(I2B, ISPEC128, BSPEC64, input, output);
     }
 
@@ -501,7 +507,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {I2X_NODE, "1"})
-    public static void testI256toB64(byte[] input, byte[] output) {
+    public static void testI256toB64(int[] input, byte[] output) {
         vectorCast(I2B, ISPEC256, BSPEC64, input, output);
     }
 
@@ -512,7 +518,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {I2X_NODE, "1"})
-    public static void testI512toB128(byte[] input, byte[] output) {
+    public static void testI512toB128(int[] input, byte[] output) {
         vectorCast(I2B, ISPEC512, BSPEC128, input, output);
     }
 
@@ -523,7 +529,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {I2X_NODE, "1"})
-    public static void testI64toS64(byte[] input, byte[] output) {
+    public static void testI64toS64(int[] input, short[] output) {
         vectorCast(I2S, ISPEC64, SSPEC64, input, output);
     }
 
@@ -534,7 +540,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {I2X_NODE, "1"})
-    public static void testI128toS64(byte[] input, byte[] output) {
+    public static void testI128toS64(int[] input, short[] output) {
         vectorCast(I2S, ISPEC128, SSPEC64, input, output);
     }
 
@@ -545,7 +551,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {I2X_NODE, "1"})
-    public static void testI256toS128(byte[] input, byte[] output) {
+    public static void testI256toS128(int[] input, short[] output) {
         vectorCast(I2S, ISPEC256, SSPEC128, input, output);
     }
 
@@ -556,7 +562,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {I2X_NODE, "1"})
-    public static void testI512toS256(byte[] input, byte[] output) {
+    public static void testI512toS256(int[] input, short[] output) {
         vectorCast(I2S, ISPEC512, SSPEC256, input, output);
     }
 
@@ -567,7 +573,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {I2X_NODE, "1"})
-    public static void testI64toL64(byte[] input, byte[] output) {
+    public static void testI64toL64(int[] input, long[] output) {
         vectorCast(I2L, ISPEC64, LSPEC64, input, output);
     }
 
@@ -578,7 +584,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {I2X_NODE, "1"})
-    public static void testI64toL128(byte[] input, byte[] output) {
+    public static void testI64toL128(int[] input, long[] output) {
         vectorCast(I2L, ISPEC64, LSPEC128, input, output);
     }
 
@@ -589,7 +595,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {I2X_NODE, "1"})
-    public static void testI128toL256(byte[] input, byte[] output) {
+    public static void testI128toL256(int[] input, long[] output) {
         vectorCast(I2L, ISPEC128, LSPEC256, input, output);
     }
 
@@ -600,7 +606,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {I2X_NODE, "1"})
-    public static void testI256toL512(byte[] input, byte[] output) {
+    public static void testI256toL512(int[] input, long[] output) {
         vectorCast(I2L, ISPEC256, LSPEC512, input, output);
     }
 
@@ -611,7 +617,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {I2X_NODE, "1"})
-    public static void testI64toF64(byte[] input, byte[] output) {
+    public static void testI64toF64(int[] input, float[] output) {
         vectorCast(I2F, ISPEC64, FSPEC64, input, output);
     }
 
@@ -622,7 +628,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {I2X_NODE, "1"})
-    public static void testI128toF128(byte[] input, byte[] output) {
+    public static void testI128toF128(int[] input, float[] output) {
         vectorCast(I2F, ISPEC128, FSPEC128, input, output);
     }
 
@@ -633,7 +639,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {I2X_NODE, "1"})
-    public static void testI256toF256(byte[] input, byte[] output) {
+    public static void testI256toF256(int[] input, float[] output) {
         vectorCast(I2F, ISPEC256, FSPEC256, input, output);
     }
 
@@ -644,7 +650,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {I2X_NODE, "1"})
-    public static void testI512toF512(byte[] input, byte[] output) {
+    public static void testI512toF512(int[] input, float[] output) {
         vectorCast(I2F, ISPEC512, FSPEC512, input, output);
     }
 
@@ -655,7 +661,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {I2X_NODE, "1"})
-    public static void testI64toD64(byte[] input, byte[] output) {
+    public static void testI64toD64(int[] input, double[] output) {
         vectorCast(I2D, ISPEC64, DSPEC64, input, output);
     }
 
@@ -666,7 +672,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {I2X_NODE, "1"})
-    public static void testI64toD128(byte[] input, byte[] output) {
+    public static void testI64toD128(int[] input, double[] output) {
         vectorCast(I2D, ISPEC64, DSPEC128, input, output);
     }
 
@@ -677,7 +683,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {I2X_NODE, "1"})
-    public static void testI128toD256(byte[] input, byte[] output) {
+    public static void testI128toD256(int[] input, double[] output) {
         vectorCast(I2D, ISPEC128, DSPEC256, input, output);
     }
 
@@ -688,7 +694,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {I2X_NODE, "1"})
-    public static void testI256toD512(byte[] input, byte[] output) {
+    public static void testI256toD512(int[] input, double[] output) {
         vectorCast(I2D, ISPEC256, DSPEC512, input, output);
     }
 
@@ -699,7 +705,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {L2X_NODE, "1"})
-    public static void testL64toB64(byte[] input, byte[] output) {
+    public static void testL64toB64(long[] input, byte[] output) {
         vectorCast(L2B, LSPEC64, BSPEC64, input, output);
     }
 
@@ -710,7 +716,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {L2X_NODE, "1"})
-    public static void testL128toB64(byte[] input, byte[] output) {
+    public static void testL128toB64(long[] input, byte[] output) {
         vectorCast(L2B, LSPEC128, BSPEC64, input, output);
     }
 
@@ -721,7 +727,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {L2X_NODE, "1"})
-    public static void testL256toB64(byte[] input, byte[] output) {
+    public static void testL256toB64(long[] input, byte[] output) {
         vectorCast(L2B, LSPEC256, BSPEC64, input, output);
     }
 
@@ -732,7 +738,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {L2X_NODE, "1"})
-    public static void testL512toB64(byte[] input, byte[] output) {
+    public static void testL512toB64(long[] input, byte[] output) {
         vectorCast(L2B, LSPEC512, BSPEC64, input, output);
     }
 
@@ -743,7 +749,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {L2X_NODE, "1"})
-    public static void testL64toS64(byte[] input, byte[] output) {
+    public static void testL64toS64(long[] input, short[] output) {
         vectorCast(L2S, LSPEC64, SSPEC64, input, output);
     }
 
@@ -754,7 +760,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {L2X_NODE, "1"})
-    public static void testL128toS64(byte[] input, byte[] output) {
+    public static void testL128toS64(long[] input, short[] output) {
         vectorCast(L2S, LSPEC128, SSPEC64, input, output);
     }
 
@@ -765,7 +771,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {L2X_NODE, "1"})
-    public static void testL256toS64(byte[] input, byte[] output) {
+    public static void testL256toS64(long[] input, short[] output) {
         vectorCast(L2S, LSPEC256, SSPEC64, input, output);
     }
 
@@ -776,7 +782,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {L2X_NODE, "1"})
-    public static void testL512toS128(byte[] input, byte[] output) {
+    public static void testL512toS128(long[] input, short[] output) {
         vectorCast(L2S, LSPEC512, SSPEC128, input, output);
     }
 
@@ -787,7 +793,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {L2X_NODE, "1"})
-    public static void testL64toI64(byte[] input, byte[] output) {
+    public static void testL64toI64(long[] input, int[] output) {
         vectorCast(L2I, LSPEC64, ISPEC64, input, output);
     }
 
@@ -798,7 +804,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {L2X_NODE, "1"})
-    public static void testL128toI64(byte[] input, byte[] output) {
+    public static void testL128toI64(long[] input, int[] output) {
         vectorCast(L2I, LSPEC128, ISPEC64, input, output);
     }
 
@@ -809,7 +815,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {L2X_NODE, "1"})
-    public static void testL256toI128(byte[] input, byte[] output) {
+    public static void testL256toI128(long[] input, int[] output) {
         vectorCast(L2I, LSPEC256, ISPEC128, input, output);
     }
 
@@ -820,7 +826,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {L2X_NODE, "1"})
-    public static void testL512toI256(byte[] input, byte[] output) {
+    public static void testL512toI256(long[] input, int[] output) {
         vectorCast(L2I, LSPEC512, ISPEC256, input, output);
     }
 
@@ -831,7 +837,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {L2X_NODE, "1"})
-    public static void testL64toF64(byte[] input, byte[] output) {
+    public static void testL64toF64(long[] input, float[] output) {
         vectorCast(L2F, LSPEC64, FSPEC64, input, output);
     }
 
@@ -842,7 +848,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {L2X_NODE, "1"})
-    public static void testL128toF64(byte[] input, byte[] output) {
+    public static void testL128toF64(long[] input, float[] output) {
         vectorCast(L2F, LSPEC128, FSPEC64, input, output);
     }
 
@@ -853,7 +859,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {L2X_NODE, "1"})
-    public static void testL256toF128(byte[] input, byte[] output) {
+    public static void testL256toF128(long[] input, float[] output) {
         vectorCast(L2F, LSPEC256, FSPEC128, input, output);
     }
 
@@ -864,7 +870,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {L2X_NODE, "1"})
-    public static void testL512toF256(byte[] input, byte[] output) {
+    public static void testL512toF256(long[] input, float[] output) {
         vectorCast(L2F, LSPEC512, FSPEC256, input, output);
     }
 
@@ -875,7 +881,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {L2X_NODE, "1"})
-    public static void testL64toD64(byte[] input, byte[] output) {
+    public static void testL64toD64(long[] input, double[] output) {
         vectorCast(L2D, LSPEC64, DSPEC64, input, output);
     }
 
@@ -886,7 +892,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {L2X_NODE, "1"})
-    public static void testL128toD128(byte[] input, byte[] output) {
+    public static void testL128toD128(long[] input, double[] output) {
         vectorCast(L2D, LSPEC128, DSPEC128, input, output);
     }
 
@@ -897,7 +903,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {L2X_NODE, "1"})
-    public static void testL256toD256(byte[] input, byte[] output) {
+    public static void testL256toD256(long[] input, double[] output) {
         vectorCast(L2D, LSPEC256, DSPEC256, input, output);
     }
 
@@ -908,7 +914,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {L2X_NODE, "1"})
-    public static void testL512toD512(byte[] input, byte[] output) {
+    public static void testL512toD512(long[] input, double[] output) {
         vectorCast(L2D, LSPEC512, DSPEC512, input, output);
     }
 
@@ -919,7 +925,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {F2X_NODE, "1"})
-    public static void testF64toB64(byte[] input, byte[] output) {
+    public static void testF64toB64(float[] input, byte[] output) {
         vectorCast(F2B, FSPEC64, BSPEC64, input, output);
     }
 
@@ -930,7 +936,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {F2X_NODE, "1"})
-    public static void testF128toB64(byte[] input, byte[] output) {
+    public static void testF128toB64(float[] input, byte[] output) {
         vectorCast(F2B, FSPEC128, BSPEC64, input, output);
     }
 
@@ -941,7 +947,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {F2X_NODE, "1"})
-    public static void testF256toB64(byte[] input, byte[] output) {
+    public static void testF256toB64(float[] input, byte[] output) {
         vectorCast(F2B, FSPEC256, BSPEC64, input, output);
     }
 
@@ -952,7 +958,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {F2X_NODE, "1"})
-    public static void testF512toB128(byte[] input, byte[] output) {
+    public static void testF512toB128(float[] input, byte[] output) {
         vectorCast(F2B, FSPEC512, BSPEC128, input, output);
     }
 
@@ -963,7 +969,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {F2X_NODE, "1"})
-    public static void testF64toS64(byte[] input, byte[] output) {
+    public static void testF64toS64(float[] input, short[] output) {
         vectorCast(F2S, FSPEC64, SSPEC64, input, output);
     }
 
@@ -974,7 +980,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {F2X_NODE, "1"})
-    public static void testF128toS64(byte[] input, byte[] output) {
+    public static void testF128toS64(float[] input, short[] output) {
         vectorCast(F2S, FSPEC128, SSPEC64, input, output);
     }
 
@@ -985,7 +991,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {F2X_NODE, "1"})
-    public static void testF256toS128(byte[] input, byte[] output) {
+    public static void testF256toS128(float[] input, short[] output) {
         vectorCast(F2S, FSPEC256, SSPEC128, input, output);
     }
 
@@ -996,7 +1002,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {F2X_NODE, "1"})
-    public static void testF512toS256(byte[] input, byte[] output) {
+    public static void testF512toS256(float[] input, short[] output) {
         vectorCast(F2S, FSPEC512, SSPEC256, input, output);
     }
 
@@ -1007,51 +1013,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {F2X_NODE, "1"})
-    public static void testF64toL64(byte[] input, byte[] output) {
-        vectorCast(F2L, FSPEC64, LSPEC64, input, output);
-    }
-
-    @Run(test = "testF64toL64")
-    public static void runF64toL64() throws Throwable {
-        runCastHelper(F2L, FSPEC64, LSPEC64);
-    }
-
-    @Test
-    @IR(counts = {F2X_NODE, "1"})
-    public static void testF64toL128(byte[] input, byte[] output) {
-        vectorCast(F2L, FSPEC64, LSPEC128, input, output);
-    }
-
-    @Run(test = "testF64toL128")
-    public static void runF64toL128() throws Throwable {
-        runCastHelper(F2L, FSPEC64, LSPEC128);
-    }
-
-    @Test
-    @IR(counts = {F2X_NODE, "1"})
-    public static void testF128toL256(byte[] input, byte[] output) {
-        vectorCast(F2L, FSPEC128, LSPEC256, input, output);
-    }
-
-    @Run(test = "testF128toL256")
-    public static void runF128toL256() throws Throwable {
-        runCastHelper(F2L, FSPEC128, LSPEC256);
-    }
-
-    @Test
-    @IR(counts = {F2X_NODE, "1"})
-    public static void testF256toL512(byte[] input, byte[] output) {
-        vectorCast(F2L, FSPEC256, LSPEC512, input, output);
-    }
-
-    @Run(test = "testF256toL512")
-    public static void runF256toL512() throws Throwable {
-        runCastHelper(F2L, FSPEC256, LSPEC512);
-    }
-
-    @Test
-    @IR(counts = {F2X_NODE, "1"})
-    public static void testF64toI64(byte[] input, byte[] output) {
+    public static void testF64toI64(float[] input, int[] output) {
         vectorCast(F2I, FSPEC64, ISPEC64, input, output);
     }
 
@@ -1062,7 +1024,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {F2X_NODE, "1"})
-    public static void testF128toI128(byte[] input, byte[] output) {
+    public static void testF128toI128(float[] input, int[] output) {
         vectorCast(F2I, FSPEC128, ISPEC128, input, output);
     }
 
@@ -1073,7 +1035,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {F2X_NODE, "1"})
-    public static void testF256toI256(byte[] input, byte[] output) {
+    public static void testF256toI256(float[] input, int[] output) {
         vectorCast(F2I, FSPEC256, ISPEC256, input, output);
     }
 
@@ -1084,7 +1046,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {F2X_NODE, "1"})
-    public static void testF512toI512(byte[] input, byte[] output) {
+    public static void testF512toI512(float[] input, int[] output) {
         vectorCast(F2I, FSPEC512, ISPEC512, input, output);
     }
 
@@ -1095,7 +1057,51 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {F2X_NODE, "1"})
-    public static void testF64toD64(byte[] input, byte[] output) {
+    public static void testF64toL64(float[] input, long[] output) {
+        vectorCast(F2L, FSPEC64, LSPEC64, input, output);
+    }
+
+    @Run(test = "testF64toL64")
+    public static void runF64toL64() throws Throwable {
+        runCastHelper(F2L, FSPEC64, LSPEC64);
+    }
+
+    @Test
+    @IR(counts = {F2X_NODE, "1"})
+    public static void testF64toL128(float[] input, long[] output) {
+        vectorCast(F2L, FSPEC64, LSPEC128, input, output);
+    }
+
+    @Run(test = "testF64toL128")
+    public static void runF64toL128() throws Throwable {
+        runCastHelper(F2L, FSPEC64, LSPEC128);
+    }
+
+    @Test
+    @IR(counts = {F2X_NODE, "1"})
+    public static void testF128toL256(float[] input, long[] output) {
+        vectorCast(F2L, FSPEC128, LSPEC256, input, output);
+    }
+
+    @Run(test = "testF128toL256")
+    public static void runF128toL256() throws Throwable {
+        runCastHelper(F2L, FSPEC128, LSPEC256);
+    }
+
+    @Test
+    @IR(counts = {F2X_NODE, "1"})
+    public static void testF256toL512(float[] input, long[] output) {
+        vectorCast(F2L, FSPEC256, LSPEC512, input, output);
+    }
+
+    @Run(test = "testF256toL512")
+    public static void runF256toL512() throws Throwable {
+        runCastHelper(F2L, FSPEC256, LSPEC512);
+    }
+
+    @Test
+    @IR(counts = {F2X_NODE, "1"})
+    public static void testF64toD64(float[] input, double[] output) {
         vectorCast(F2D, FSPEC64, DSPEC64, input, output);
     }
 
@@ -1106,7 +1112,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {F2X_NODE, "1"})
-    public static void testF64toD128(byte[] input, byte[] output) {
+    public static void testF64toD128(float[] input, double[] output) {
         vectorCast(F2D, FSPEC64, DSPEC128, input, output);
     }
 
@@ -1117,7 +1123,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {F2X_NODE, "1"})
-    public static void testF128toD256(byte[] input, byte[] output) {
+    public static void testF128toD256(float[] input, double[] output) {
         vectorCast(F2D, FSPEC128, DSPEC256, input, output);
     }
 
@@ -1128,7 +1134,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {F2X_NODE, "1"})
-    public static void testF256toD512(byte[] input, byte[] output) {
+    public static void testF256toD512(float[] input, double[] output) {
         vectorCast(F2D, FSPEC256, DSPEC512, input, output);
     }
 
@@ -1139,7 +1145,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {D2X_NODE, "1"})
-    public static void testD64toB64(byte[] input, byte[] output) {
+    public static void testD64toB64(double[] input, byte[] output) {
         vectorCast(D2B, DSPEC64, BSPEC64, input, output);
     }
 
@@ -1150,7 +1156,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {D2X_NODE, "1"})
-    public static void testD128toB64(byte[] input, byte[] output) {
+    public static void testD128toB64(double[] input, byte[] output) {
         vectorCast(D2B, DSPEC128, BSPEC64, input, output);
     }
 
@@ -1161,7 +1167,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {D2X_NODE, "1"})
-    public static void testD256toB64(byte[] input, byte[] output) {
+    public static void testD256toB64(double[] input, byte[] output) {
         vectorCast(D2B, DSPEC256, BSPEC64, input, output);
     }
 
@@ -1172,7 +1178,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {D2X_NODE, "1"})
-    public static void testD512toB64(byte[] input, byte[] output) {
+    public static void testD512toB64(double[] input, byte[] output) {
         vectorCast(D2B, DSPEC512, BSPEC64, input, output);
     }
 
@@ -1183,7 +1189,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {D2X_NODE, "1"})
-    public static void testD64toS64(byte[] input, byte[] output) {
+    public static void testD64toS64(double[] input, short[] output) {
         vectorCast(D2S, DSPEC64, SSPEC64, input, output);
     }
 
@@ -1194,7 +1200,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {D2X_NODE, "1"})
-    public static void testD128toS64(byte[] input, byte[] output) {
+    public static void testD128toS64(double[] input, short[] output) {
         vectorCast(D2S, DSPEC128, SSPEC64, input, output);
     }
 
@@ -1205,7 +1211,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {D2X_NODE, "1"})
-    public static void testD256toS64(byte[] input, byte[] output) {
+    public static void testD256toS64(double[] input, short[] output) {
         vectorCast(D2S, DSPEC256, SSPEC64, input, output);
     }
 
@@ -1216,7 +1222,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {D2X_NODE, "1"})
-    public static void testD512toS128(byte[] input, byte[] output) {
+    public static void testD512toS128(double[] input, short[] output) {
         vectorCast(D2S, DSPEC512, SSPEC128, input, output);
     }
 
@@ -1227,7 +1233,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {D2X_NODE, "1"})
-    public static void testD64toI64(byte[] input, byte[] output) {
+    public static void testD64toI64(double[] input, int[] output) {
         vectorCast(D2I, DSPEC64, ISPEC64, input, output);
     }
 
@@ -1238,7 +1244,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {D2X_NODE, "1"})
-    public static void testD128toI64(byte[] input, byte[] output) {
+    public static void testD128toI64(double[] input, int[] output) {
         vectorCast(D2I, DSPEC128, ISPEC64, input, output);
     }
 
@@ -1249,7 +1255,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {D2X_NODE, "1"})
-    public static void testD256toI128(byte[] input, byte[] output) {
+    public static void testD256toI128(double[] input, int[] output) {
         vectorCast(D2I, DSPEC256, ISPEC128, input, output);
     }
 
@@ -1260,7 +1266,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {D2X_NODE, "1"})
-    public static void testD512toI256(byte[] input, byte[] output) {
+    public static void testD512toI256(double[] input, int[] output) {
         vectorCast(D2I, DSPEC512, ISPEC256, input, output);
     }
 
@@ -1271,51 +1277,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {D2X_NODE, "1"})
-    public static void testD64toF64(byte[] input, byte[] output) {
-        vectorCast(D2F, DSPEC64, FSPEC64, input, output);
-    }
-
-    @Run(test = "testD64toF64")
-    public static void runD64toF64() throws Throwable {
-        runCastHelper(D2F, DSPEC64, FSPEC64);
-    }
-
-    @Test
-    @IR(counts = {D2X_NODE, "1"})
-    public static void testD128toF64(byte[] input, byte[] output) {
-        vectorCast(D2F, DSPEC128, FSPEC64, input, output);
-    }
-
-    @Run(test = "testD128toF64")
-    public static void runD128toF64() throws Throwable {
-        runCastHelper(D2F, DSPEC128, FSPEC64);
-    }
-
-    @Test
-    @IR(counts = {D2X_NODE, "1"})
-    public static void testD256toF128(byte[] input, byte[] output) {
-        vectorCast(D2F, DSPEC256, FSPEC128, input, output);
-    }
-
-    @Run(test = "testD256toF128")
-    public static void runD256toF128() throws Throwable {
-        runCastHelper(D2F, DSPEC256, FSPEC128);
-    }
-
-    @Test
-    @IR(counts = {D2X_NODE, "1"})
-    public static void testD512toF256(byte[] input, byte[] output) {
-        vectorCast(D2F, DSPEC512, FSPEC256, input, output);
-    }
-
-    @Run(test = "testD512toF256")
-    public static void runD512toF256() throws Throwable {
-        runCastHelper(D2F, DSPEC512, FSPEC256);
-    }
-
-    @Test
-    @IR(counts = {D2X_NODE, "1"})
-    public static void testD64toL64(byte[] input, byte[] output) {
+    public static void testD64toL64(double[] input, long[] output) {
         vectorCast(D2L, DSPEC64, LSPEC64, input, output);
     }
 
@@ -1326,7 +1288,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {D2X_NODE, "1"})
-    public static void testD128toL128(byte[] input, byte[] output) {
+    public static void testD128toL128(double[] input, long[] output) {
         vectorCast(D2L, DSPEC128, LSPEC128, input, output);
     }
 
@@ -1337,7 +1299,7 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {D2X_NODE, "1"})
-    public static void testD256toL256(byte[] input, byte[] output) {
+    public static void testD256toL256(double[] input, long[] output) {
         vectorCast(D2L, DSPEC256, LSPEC256, input, output);
     }
 
@@ -1348,12 +1310,56 @@ public class TestVectorCast {
 
     @Test
     @IR(counts = {D2X_NODE, "1"})
-    public static void testD512toL512(byte[] input, byte[] output) {
+    public static void testD512toL512(double[] input, long[] output) {
         vectorCast(D2L, DSPEC512, LSPEC512, input, output);
     }
 
     @Run(test = "testD512toL512")
     public static void runD512toL512() throws Throwable {
         runCastHelper(D2L, DSPEC512, LSPEC512);
+    }
+
+    @Test
+    @IR(counts = {D2X_NODE, "1"})
+    public static void testD64toF64(double[] input, float[] output) {
+        vectorCast(D2F, DSPEC64, FSPEC64, input, output);
+    }
+
+    @Run(test = "testD64toF64")
+    public static void runD64toF64() throws Throwable {
+        runCastHelper(D2F, DSPEC64, FSPEC64);
+    }
+
+    @Test
+    @IR(counts = {D2X_NODE, "1"})
+    public static void testD128toF64(double[] input, float[] output) {
+        vectorCast(D2F, DSPEC128, FSPEC64, input, output);
+    }
+
+    @Run(test = "testD128toF64")
+    public static void runD128toF64() throws Throwable {
+        runCastHelper(D2F, DSPEC128, FSPEC64);
+    }
+
+    @Test
+    @IR(counts = {D2X_NODE, "1"})
+    public static void testD256toF128(double[] input, float[] output) {
+        vectorCast(D2F, DSPEC256, FSPEC128, input, output);
+    }
+
+    @Run(test = "testD256toF128")
+    public static void runD256toF128() throws Throwable {
+        runCastHelper(D2F, DSPEC256, FSPEC128);
+    }
+
+    @Test
+    @IR(counts = {D2X_NODE, "1"})
+    public static void testD512toF256(double[] input, float[] output) {
+        vectorCast(D2F, DSPEC512, FSPEC256, input, output);
+    }
+
+    @Run(test = "testD512toF256")
+    public static void runD512toF256() throws Throwable {
+        runCastHelper(D2F, DSPEC512, FSPEC256);
     }
 }

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/tests/TestVectorDoubleExpandShrink.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/tests/TestVectorDoubleExpandShrink.java
@@ -32,6 +32,7 @@ import static compiler.vectorapi.reshape.utils.VectorReshapeHelper.*;
 /**
  * As spot in 8259353. We need to do a shrink and an expand together to not accidentally
  * zero out elements in the physical registers that may not be zero in general cases.
+ *
  * In some methods, 2 consecutive ReinterpretNodes may be optimized out.
  */
 public class TestVectorDoubleExpandShrink {

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/tests/TestVectorExpandShrink.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/tests/TestVectorExpandShrink.java
@@ -32,6 +32,7 @@ import static compiler.vectorapi.reshape.utils.VectorReshapeHelper.*;
 /**
  *  This class contains method to ensure a resizing reinterpretation operations work as
  *  intended.
+ *
  *  In each test, the ReinterpretNode is expected to appear exactly once.
  */
 public class TestVectorExpandShrink {

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/tests/TestVectorRebracket.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/tests/TestVectorRebracket.java
@@ -31,10 +31,12 @@ import static compiler.vectorapi.reshape.utils.VectorReshapeHelper.*;
 
 /**
  * This class contains methods to test for reinterpretation operations that reinterpret
- * a vector as a similar vector with another element type. It is complicated to verify
- * the IR in this case since a load/store with respect to byte array will result in
- * additional ReinterpretNodes if the vector element type is not byte. As a result,
- * arguments need to be arrays of the correct type.
+ * a vector as a similar vector with another element type.
+ *
+ * It is complicated to verify the IR in this case since a load/store with respect to
+ * byte array will result in additional ReinterpretNodes if the vector element type is
+ * not byte. As a result, arguments need to be arrays of the correct type.
+ *
  * In each test, the ReinterpretNode is expected to appear exactly once.
  */
 public class TestVectorRebracket {

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/utils/TestCastMethods.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/utils/TestCastMethods.java
@@ -30,8 +30,7 @@ import static compiler.vectorapi.reshape.utils.VectorReshapeHelper.*;
 import static compiler.vectorapi.reshape.utils.VectorSpeciesPair.makePair;
 
 /**
- * The cast intrinsics implemented on each platform, commented out tests are the ones that are
- * supposed to work but currently don't.
+ * The cast intrinsics implemented on each platform.
  */
 public class TestCastMethods {
     public static final List<VectorSpeciesPair> AVX1_CAST_TESTS = List.of(
@@ -39,7 +38,7 @@ public class TestCastMethods {
             makePair(BSPEC64, SSPEC128),
             makePair(BSPEC64, ISPEC128),
             makePair(BSPEC64, FSPEC128),
-            // makePair(BSPEC64, DSPEC256),
+//            makePair(BSPEC64, DSPEC256),
             makePair(SSPEC64, BSPEC64),
             makePair(SSPEC128, BSPEC64),
             makePair(SSPEC64, ISPEC64),
@@ -48,7 +47,7 @@ public class TestCastMethods {
             makePair(SSPEC64, FSPEC64),
             makePair(SSPEC64, FSPEC128),
             makePair(SSPEC64, DSPEC128),
-            // makePair(SSPEC64, DSPEC256),
+//            makePair(SSPEC64, DSPEC256),
             makePair(ISPEC128, BSPEC64),
             makePair(ISPEC64, SSPEC64),
             makePair(ISPEC128, SSPEC64),
@@ -63,11 +62,11 @@ public class TestCastMethods {
             makePair(FSPEC128, ISPEC128),
             makePair(FSPEC64, DSPEC128),
             makePair(FSPEC128, DSPEC256),
-            makePair(DSPEC128, FSPEC64)
-            // makePair(DSPEC256, FSPEC128)
+            makePair(DSPEC128, FSPEC64),
+            makePair(DSPEC256, FSPEC128)
     );
 
-    public static final List<VectorSpeciesPair> AVX2_CAST_TESTS = Stream.concat(AVX1_CAST_TESTS.stream(), List.of(
+    public static final List<VectorSpeciesPair> AVX2_CAST_TESTS = Stream.concat(AVX1_CAST_TESTS.stream(), Stream.of(
             makePair(BSPEC128, SSPEC256),
             makePair(BSPEC64, ISPEC256),
             makePair(BSPEC64, LSPEC256),
@@ -84,15 +83,13 @@ public class TestCastMethods {
             makePair(LSPEC256, SSPEC64),
             makePair(LSPEC256, ISPEC128),
             makePair(FSPEC256, ISPEC256)
-    ).stream()).toList();
+    )).toList();
 
-    public static final List<VectorSpeciesPair> AVX512_CAST_TESTS = Stream.concat(AVX2_CAST_TESTS.stream(), List.of(
-            makePair(BSPEC256, SSPEC512),
+    public static final List<VectorSpeciesPair> AVX512_CAST_TESTS = Stream.concat(AVX2_CAST_TESTS.stream(), Stream.of(
             makePair(BSPEC128, ISPEC512),
             makePair(BSPEC64, LSPEC512),
             makePair(BSPEC128, FSPEC512),
             makePair(BSPEC64, DSPEC512),
-            makePair(SSPEC512, BSPEC256),
             makePair(SSPEC256, ISPEC512),
             makePair(SSPEC128, LSPEC512),
             makePair(SSPEC256, FSPEC512),
@@ -108,16 +105,21 @@ public class TestCastMethods {
             makePair(FSPEC512, ISPEC512),
             makePair(FSPEC256, DSPEC512),
             makePair(DSPEC512, FSPEC256)
-    ).stream()).toList();
+    )).toList();
 
-    public static final List<VectorSpeciesPair> AVX512DQ_CAST_TESTS = Stream.concat(AVX512_CAST_TESTS.stream(), List.of(
+    public static final List<VectorSpeciesPair> AVX512BW_CAST_TESTS = Stream.concat(AVX512_CAST_TESTS.stream(), Stream.of(
+            makePair(BSPEC256, SSPEC512),
+            makePair(SSPEC512, BSPEC256)
+    )).toList();
+
+    public static final List<VectorSpeciesPair> AVX512DQ_CAST_TESTS = Stream.concat(AVX512_CAST_TESTS.stream(), Stream.of(
             makePair(LSPEC128, DSPEC128),
             makePair(LSPEC256, DSPEC256),
             makePair(LSPEC512, DSPEC512),
             makePair(DSPEC128, LSPEC128),
             makePair(DSPEC256, LSPEC256),
             makePair(DSPEC512, LSPEC512)
-    ).stream()).toList();
+    )).toList();
 
     public static final List<VectorSpeciesPair> SVE_CAST_TESTS = List.of(
             makePair(BSPEC64, SSPEC128),

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/utils/TestCastMethods.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/utils/TestCastMethods.java
@@ -30,7 +30,8 @@ import static compiler.vectorapi.reshape.utils.VectorReshapeHelper.*;
 import static compiler.vectorapi.reshape.utils.VectorSpeciesPair.makePair;
 
 /**
- * The cast intrinsics implemented on each platform.
+ * The cast intrinsics implemented on each platform, commented out tests are the ones that are
+ * supposed to work but currently don't.
  */
 public class TestCastMethods {
     public static final List<VectorSpeciesPair> AVX1_CAST_TESTS = List.of(

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/utils/UnsafeUtils.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/utils/UnsafeUtils.java
@@ -35,12 +35,53 @@ public class UnsafeUtils {
         return UNSAFE.arrayBaseOffset(etype.arrayType());
     }
 
-    public static int getByte(Object o, long base, int i) {
-        // This is technically an UB, what we need is UNSAFE.getByteUnaligned but they seem to be equivalent
-        return UNSAFE.getByte(o, base + i);
+    public static byte getByte(Object o, long base, int i) {
+        // This technically leads to UB, what we need is UNSAFE.getByteUnaligned but they seem to be equivalent
+        return UNSAFE.getByte(o, base + (long)i * Unsafe.ARRAY_BYTE_INDEX_SCALE);
     }
 
-    public static void putByte(Object o, long base, int i, int value) {
-        UNSAFE.putByte(o, base + i, (byte)value);
+    public static void putByte(Object o, long base, int i, byte value) {
+        // This technically leads to UB, what we need is UNSAFE.putByteUnaligned but they seem to be equivalent
+        UNSAFE.putByte(o, base + (long)i * Unsafe.ARRAY_BYTE_INDEX_SCALE, value);
+    }
+
+    public static short getShort(Object o, long base, int i) {
+        return UNSAFE.getShort(o, base + (long)i * Unsafe.ARRAY_SHORT_INDEX_SCALE);
+    }
+
+    public static void putShort(Object o, long base, int i, short value) {
+        UNSAFE.putShort(o, base + (long)i * Unsafe.ARRAY_SHORT_INDEX_SCALE, value);
+    }
+
+    public static int getInt(Object o, long base, int i) {
+        return UNSAFE.getInt(o, base + (long)i * Unsafe.ARRAY_INT_INDEX_SCALE);
+    }
+
+    public static void putInt(Object o, long base, int i, int value) {
+        UNSAFE.putInt(o, base + (long)i * Unsafe.ARRAY_INT_INDEX_SCALE, value);
+    }
+
+    public static long getLong(Object o, long base, int i) {
+        return UNSAFE.getLong(o, base + (long)i * Unsafe.ARRAY_LONG_INDEX_SCALE);
+    }
+
+    public static void putLong(Object o, long base, int i, long value) {
+        UNSAFE.putLong(o, base + (long)i * Unsafe.ARRAY_LONG_INDEX_SCALE, value);
+    }
+
+    public static float getFloat(Object o, long base, int i) {
+        return UNSAFE.getFloat(o, base + (long)i * Unsafe.ARRAY_FLOAT_INDEX_SCALE);
+    }
+
+    public static void putFloat(Object o, long base, int i, float value) {
+        UNSAFE.putFloat(o, base + (long)i * Unsafe.ARRAY_FLOAT_INDEX_SCALE, value);
+    }
+
+    public static double getDouble(Object o, long base, int i) {
+        return UNSAFE.getDouble(o, base + (long)i * Unsafe.ARRAY_DOUBLE_INDEX_SCALE);
+    }
+
+    public static void putDouble(Object o, long base, int i, double value) {
+        UNSAFE.putDouble(o, base + (long)i * Unsafe.ARRAY_DOUBLE_INDEX_SCALE, value);
     }
 }


### PR DESCRIPTION
The problem is that loading vector from byte array requires the vector shape to support byte vector before the reinterpretation to the correct type. The failure to intrinsify seems to stop the compilation of the method, leads to IR verification failure. The patch simply changes the argument of vector cast methods to correct types.

Thanh you very much.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278623](https://bugs.openjdk.java.net/browse/JDK-8278623): compiler/vectorapi/reshape/TestVectorCastAVX512.java after JDK-8259610


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6852/head:pull/6852` \
`$ git checkout pull/6852`

Update a local copy of the PR: \
`$ git checkout pull/6852` \
`$ git pull https://git.openjdk.java.net/jdk pull/6852/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6852`

View PR using the GUI difftool: \
`$ git pr show -t 6852`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6852.diff">https://git.openjdk.java.net/jdk/pull/6852.diff</a>

</details>
