### PR TITLE
8278551: Shenandoah: Adopt WorkerThread::worker_id() to replace Shenandoah specific implementation

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
@@ -338,7 +338,6 @@ bool ShenandoahReferenceProcessor::discover(oop reference, ReferenceType type, u
   }
 
   // Add reference to discovered list
-  assert(worker_id != ShenandoahThreadLocalData::INVALID_WORKER_ID, "need valid worker ID");
   ShenandoahRefProcThreadLocal& refproc_data = _ref_proc_thread_locals[worker_id];
   oop discovered_head = refproc_data.discovered_list_head<T>();
   if (discovered_head == NULL) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
@@ -25,6 +25,7 @@
 
 #include "precompiled.hpp"
 #include "classfile/javaClasses.hpp"
+#include "gc/shared/workerThread.hpp"
 #include "gc/shenandoah/shenandoahOopClosures.inline.hpp"
 #include "gc/shenandoah/shenandoahReferenceProcessor.hpp"
 #include "gc/shenandoah/shenandoahThreadLocalData.hpp"
@@ -361,7 +362,7 @@ bool ShenandoahReferenceProcessor::discover_reference(oop reference, ReferenceTy
   }
 
   log_trace(gc, ref)("Encountered Reference: " PTR_FORMAT " (%s)", p2i(reference), reference_type_name(type));
-  uint worker_id = ShenandoahThreadLocalData::worker_id(Thread::current());
+  uint worker_id = WorkerThread::worker_id();
   _ref_proc_thread_locals->inc_encountered(type);
 
   if (UseCompressedOops) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
@@ -36,9 +36,6 @@
 #include "utilities/sizes.hpp"
 
 class ShenandoahThreadLocalData {
-public:
-  static const uint INVALID_WORKER_ID = uint(-1);
-
 private:
   char _gc_state;
   // Evacuation OOM state

--- a/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
@@ -47,7 +47,6 @@ private:
   SATBMarkQueue           _satb_mark_queue;
   PLAB* _gclab;
   size_t _gclab_size;
-  uint  _worker_id;
   int  _disarmed_value;
   double _paced_time;
 
@@ -58,7 +57,6 @@ private:
     _satb_mark_queue(&ShenandoahBarrierSet::satb_mark_queue_set()),
     _gclab(NULL),
     _gclab_size(0),
-    _worker_id(INVALID_WORKER_ID),
     _disarmed_value(0),
     _paced_time(0) {
 
@@ -101,16 +99,6 @@ public:
 
   static char gc_state(Thread* thread) {
     return data(thread)->_gc_state;
-  }
-
-  static void set_worker_id(Thread* thread, uint id) {
-    assert(thread->is_Worker_thread(), "Must be a worker thread");
-    data(thread)->_worker_id = id;
-  }
-
-  static uint worker_id(Thread* thread) {
-    assert(thread->is_Worker_thread(), "Must be a worker thread");
-    return data(thread)->_worker_id;
   }
 
   static void initialize_gclab(Thread* thread) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
@@ -146,10 +146,8 @@ ShenandoahGCWorkerPhase::~ShenandoahGCWorkerPhase() {
   _timings->record_workers_end(_phase);
 }
 
-ShenandoahWorkerSession::ShenandoahWorkerSession(uint worker_id) : _worker_id(worker_id) {
-  Thread* thr = Thread::current();
-  assert(ShenandoahThreadLocalData::worker_id(thr) == ShenandoahThreadLocalData::INVALID_WORKER_ID, "Already set");
-  ShenandoahThreadLocalData::set_worker_id(thr, worker_id);
+ShenandoahWorkerSession::ShenandoahWorkerSession(uint worker_id) {
+  assert(worker_id == WorkerThread::worker_id(), "Wrong worker id");
 }
 
 ShenandoahConcurrentWorkerSession::~ShenandoahConcurrentWorkerSession() {
@@ -157,12 +155,5 @@ ShenandoahConcurrentWorkerSession::~ShenandoahConcurrentWorkerSession() {
 }
 
 ShenandoahParallelWorkerSession::~ShenandoahParallelWorkerSession() {
-  _event.commit(GCId::current(), _worker_id, ShenandoahPhaseTimings::phase_name(ShenandoahGCPhase::current_phase()));
-}
-ShenandoahWorkerSession::~ShenandoahWorkerSession() {
-#ifdef ASSERT
-  Thread* thr = Thread::current();
-  assert(ShenandoahThreadLocalData::worker_id(thr) != ShenandoahThreadLocalData::INVALID_WORKER_ID, "Must be set");
-  ShenandoahThreadLocalData::set_worker_id(thr, ShenandoahThreadLocalData::INVALID_WORKER_ID);
-#endif
+  _event.commit(GCId::current(), WorkerThread::worker_id(), ShenandoahPhaseTimings::phase_name(ShenandoahGCPhase::current_phase()));
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2017, 2021, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
 #include "gc/shared/gcVMOperations.hpp"
 #include "gc/shared/isGCActiveMark.hpp"
 #include "gc/shared/suspendibleThreadSet.hpp"
+#include "gc/shared/workerThread.hpp"
 #include "gc/shenandoah/shenandoahPhaseTimings.hpp"
 #include "gc/shenandoah/shenandoahThreadLocalData.hpp"
 #include "jfr/jfrEvents.hpp"
@@ -173,16 +174,10 @@ public:
 
 class ShenandoahWorkerSession : public StackObj {
 protected:
-  uint _worker_id;
-
   ShenandoahWorkerSession(uint worker_id);
-  ~ShenandoahWorkerSession();
 public:
   static inline uint worker_id() {
-    Thread* thr = Thread::current();
-    uint id = ShenandoahThreadLocalData::worker_id(thr);
-    assert(id != ShenandoahThreadLocalData::INVALID_WORKER_ID, "Worker session has not been created");
-    return id;
+    return WorkerThread::worker_id();
   }
 };
 


### PR DESCRIPTION
Shenandoah stores worker_id in ThreadLocalData for the same purpose as JDK-8278351.

After JDK-8278351, Shenandoah should adopt WorkerThread::worker_id() from JDK-8278351 to replace its own implementation.

Test:
- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278551](https://bugs.openjdk.java.net/browse/JDK-8278551): Shenandoah: Adopt WorkerThread::worker_id() to replace Shenandoah specific implementation


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6853/head:pull/6853` \
`$ git checkout pull/6853`

Update a local copy of the PR: \
`$ git checkout pull/6853` \
`$ git pull https://git.openjdk.java.net/jdk pull/6853/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6853`

View PR using the GUI difftool: \
`$ git pr show -t 6853`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6853.diff">https://git.openjdk.java.net/jdk/pull/6853.diff</a>

</details>
