### PR TITLE
8278831: Use table lookup for the last two bytes in Integer.getChars

### DIFF
--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -517,13 +517,9 @@ public final class Integer extends Number
         }
 
         // We know there are at most two digits left at this point.
-        q = i / 10;
-        r = (q * 10) - i;
-        buf[--charPos] = (byte)('0' + r);
-
-        // Whatever left is the remaining digit.
-        if (q < 0) {
-            buf[--charPos] = (byte)('0' - q);
+        buf[--charPos] = DigitOnes[-i];
+        if (i < -9) {
+            buf[--charPos] = DigitTens[-i];
         }
 
         if (negative) {

--- a/src/java.base/share/classes/java/lang/Long.java
+++ b/src/java.base/share/classes/java/lang/Long.java
@@ -565,13 +565,9 @@ public final class Long extends Number
         }
 
         // We know there are at most two digits left at this point.
-        q2 = i2 / 10;
-        r  = (q2 * 10) - i2;
-        buf[--charPos] = (byte)('0' + r);
-
-        // Whatever left is the remaining digit.
-        if (q2 < 0) {
-            buf[--charPos] = (byte)('0' - q2);
+        buf[--charPos] = Integer.DigitOnes[-i2];
+        if (i2 < -9) {
+            buf[--charPos] = Integer.DigitTens[-i2];
         }
 
         if (negative) {

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -1549,13 +1549,9 @@ final class StringUTF16 {
         }
 
         // We know there are at most two digits left at this point.
-        q = i / 10;
-        r = (q * 10) - i;
-        putChar(buf, --charPos, '0' + r);
-
-        // Whatever left is the remaining digit.
-        if (q < 0) {
-            putChar(buf, --charPos, '0' - q);
+        putChar(buf, --charPos, Integer.DigitOnes[-i]);
+        if (i < -9) {
+            putChar(buf, --charPos, Integer.DigitTens[-i]);
         }
 
         if (negative) {
@@ -1604,13 +1600,9 @@ final class StringUTF16 {
         }
 
         // We know there are at most two digits left at this point.
-        q2 = i2 / 10;
-        r  = (q2 * 10) - i2;
-        putChar(buf, --charPos, '0' + r);
-
-        // Whatever left is the remaining digit.
-        if (q2 < 0) {
-            putChar(buf, --charPos, '0' - q2);
+        putChar(buf, --charPos, Integer.DigitOnes[-i2]);
+        if (i2 < -9) {
+            putChar(buf, --charPos, Integer.DigitTens[-i2]);
         }
 
         if (negative) {

--- a/test/micro/org/openjdk/bench/java/lang/Integers.java
+++ b/test/micro/org/openjdk/bench/java/lang/Integers.java
@@ -53,17 +53,20 @@ public class Integers {
     private int size;
 
     private String[] strings;
+    private int[] intsTiny;
     private int[] intsSmall;
     private int[] intsBig;
 
     @Setup
     public void setup() {
-        Random r = new Random(0);
-        strings = new String[size];
+        Random r  = new Random(0);
+        strings   = new String[size];
+        intsTiny  = new int[size];
         intsSmall = new int[size];
-        intsBig = new int[size];
+        intsBig   = new int[size];
         for (int i = 0; i < size; i++) {
             strings[i] = "" + (r.nextInt(10000) - (5000));
+            intsTiny[i] = r.nextInt(99);
             intsSmall[i] = 100 * i + i + 103;
             intsBig[i] = ((100 * i + i) << 24) + 4543 + i * 4;
         }
@@ -87,6 +90,14 @@ public class Integers {
     @Benchmark
     public void toStringSmall(Blackhole bh) {
         for (int i : intsSmall) {
+            bh.consume(Integer.toString(i));
+        }
+    }
+
+    /** Performs toString on very small values, just one or two digits. */
+    @Benchmark
+    public void toStringTiny(Blackhole bh) {
+        for (int i : intsTiny) {
             bh.consume(Integer.toString(i));
         }
     }


### PR DESCRIPTION
During TemplatedStrings work Jim has noticed that we could probably profit from reusing the lookup tables also for the 1 or 2 leftmost bytes:

        // We know there are at most two digits left at this point.
        buf[--charPos] = DigitOnes[-i];
        if (i < -9) {
            buf[--charPos] = DigitTens[-i];
        }

This avoids some arithmetic, and on average achieves a small speed-up since the lookup tables are likely cached are likely to be in cache. Small improvements on a few affected microbenchmarks, including the new Integers.toStringTiny, can be observed. 

Baseline:
```
Benchmark              (size)  Mode  Cnt   Score   Error  Units
Integers.toStringTiny     500  avgt   50  21.862 ± 0.211  us/op
```

Patch:
```
Benchmark              (size)  Mode  Cnt   Score   Error  Units
Integers.toStringTiny     500  avgt   50  20.619 ± 0.330  us/op
```