### PR TITLE
8278871: [JVMCI] assert((uint)reason < 2* _trap_hist_limit) failed: oob

### DIFF
--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -558,8 +558,8 @@
   declare_constant(Deoptimization::Reason_not_compiled_exception_handler) \
   declare_constant(Deoptimization::Reason_unresolved)                     \
   declare_constant(Deoptimization::Reason_jsr_mismatch)                   \
-  declare_constant(Deoptimization::Reason_LIMIT)                          \
-  declare_constant(Deoptimization::_support_large_access_byte_array_virtualization)               \
+  declare_constant(Deoptimization::Reason_TRAP_HISTORY_LENGTH)            \
+  declare_constant(Deoptimization::_support_large_access_byte_array_virtualization) \
                                                                           \
   declare_constant(FieldInfo::access_flags_offset)                        \
   declare_constant(FieldInfo::name_index_offset)                          \

--- a/src/hotspot/share/oops/methodData.hpp
+++ b/src/hotspot/share/oops/methodData.hpp
@@ -30,6 +30,7 @@
 #include "oops/method.hpp"
 #include "oops/oop.hpp"
 #include "runtime/atomic.hpp"
+#include "runtime/deoptimization.hpp"
 #include "runtime/mutex.hpp"
 #include "utilities/align.hpp"
 #include "utilities/copy.hpp"
@@ -1965,7 +1966,7 @@ public:
 
   // Whole-method sticky bits and flags
   enum {
-    _trap_hist_limit    = 25 JVMCI_ONLY(+5),   // decoupled from Deoptimization::Reason_LIMIT
+    _trap_hist_limit    = Deoptimization::Reason_TRAP_HISTORY_LENGTH,
     _trap_hist_mask     = max_jubyte,
     _extra_data_count   = 4     // extra DataLayout headers, for trap history
   }; // Public flag values

--- a/src/hotspot/share/oops/methodData.hpp
+++ b/src/hotspot/share/oops/methodData.hpp
@@ -1981,6 +1981,7 @@ public:
     uint _nof_overflow_traps;         // trap count, excluding _trap_hist
     union {
       intptr_t _align;
+      // JVMCI separates trap history for OSE compilations from normal compilations
       u1 _array[JVMCI_ONLY(2 *) MethodData::_trap_hist_limit];
     } _trap_hist;
 
@@ -1997,14 +1998,14 @@ public:
 
     // Return (uint)-1 for overflow.
     uint trap_count(int reason) const {
-      assert((uint)reason < JVMCI_ONLY(2*) _trap_hist_limit, "oob");
+      assert((uint)reason < ARRAY_SIZE(_trap_hist._array), "oob");
       return (int)((_trap_hist._array[reason]+1) & _trap_hist_mask) - 1;
     }
 
     uint inc_trap_count(int reason) {
       // Count another trap, anywhere in this method.
       assert(reason >= 0, "must be single trap");
-      assert((uint)reason < JVMCI_ONLY(2*) _trap_hist_limit, "oob");
+      assert((uint)reason < ARRAY_SIZE(_trap_hist._array), "oob");
       uint cnt1 = 1 + _trap_hist._array[reason];
       if ((cnt1 & _trap_hist_mask) != 0) {  // if no counter overflow...
         _trap_hist._array[reason] = cnt1;

--- a/src/hotspot/share/oops/methodData.hpp
+++ b/src/hotspot/share/oops/methodData.hpp
@@ -1981,7 +1981,7 @@ public:
     uint _nof_overflow_traps;         // trap count, excluding _trap_hist
     union {
       intptr_t _align;
-      // JVMCI separates trap history for OSE compilations from normal compilations
+      // JVMCI separates trap history for OSR compilations from normal compilations
       u1 _array[JVMCI_ONLY(2 *) MethodData::_trap_hist_limit];
     } _trap_hist;
 

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -2274,6 +2274,7 @@ Deoptimization::query_update_method_data(MethodData* trap_mdo,
     uint idx = reason;
 #if INCLUDE_JVMCI
     if (is_osr) {
+      // Upper half of history array used for traps in OSR compilations
       idx += Reason_TRAP_HISTORY_LENGTH;
     }
 #endif

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -2274,7 +2274,7 @@ Deoptimization::query_update_method_data(MethodData* trap_mdo,
     uint idx = reason;
 #if INCLUDE_JVMCI
     if (is_osr) {
-      idx += Reason_LIMIT;
+      idx += Reason_TRAP_HISTORY_LENGTH;
     }
 #endif
     uint prior_trap_count = trap_mdo->trap_count(idx);

--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -46,6 +46,7 @@ class Deoptimization : AllStatic {
 
  public:
   // What condition caused the deoptimization?
+  // Note: Keep this enum in sync. with Deoptimization::_trap_reason_name.
   enum DeoptReason {
     Reason_many = -1,             // indicates presence of several reasons
     Reason_none = 0,              // indicates absence of a relevant deopt.
@@ -98,20 +99,22 @@ class Deoptimization : AllStatic {
     Reason_jsr_mismatch,
 #endif
 
+    // Used to define MethodData::_trap_hist_limit where Reason_tenured isn't included
+    Reason_TRAP_HISTORY_LENGTH,
+
     // Reason_tenured is counted separately, add normal counted Reasons above.
-    // Related to MethodData::_trap_hist_limit where Reason_tenured isn't included
-    Reason_tenured,               // age of the code has reached the limit
+    Reason_tenured = Reason_TRAP_HISTORY_LENGTH, // age of the code has reached the limit
     Reason_LIMIT,
 
-    // Note:  Keep this enum in sync. with _trap_reason_name.
-    Reason_RECORDED_LIMIT = Reason_profile_predicate  // some are not recorded per bc
     // Note:  Reason_RECORDED_LIMIT should fit into 31 bits of
     // DataLayout::trap_bits.  This dependency is enforced indirectly
     // via asserts, to avoid excessive direct header-to-header dependencies.
     // See Deoptimization::trap_state_reason and class DataLayout.
+    Reason_RECORDED_LIMIT = Reason_profile_predicate,  // some are not recorded per bc
   };
 
   // What action must be taken by the runtime?
+  // Note: Keep this enum in sync. with Deoptimization::_trap_action_name.
   enum DeoptAction {
     Action_none,                  // just interpret, do not invalidate nmethod
     Action_maybe_recompile,       // recompile the nmethod; need not invalidate
@@ -119,7 +122,6 @@ class Deoptimization : AllStatic {
     Action_make_not_entrant,      // invalidate the nmethod, recompile (probably)
     Action_make_not_compilable,   // invalidate the nmethod and do not compile
     Action_LIMIT
-    // Note:  Keep this enum in sync. with _trap_action_name.
   };
 
   enum {

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotVMConfig.java
@@ -336,7 +336,7 @@ class HotSpotVMConfig extends HotSpotVMConfigAccess {
     final int deoptReasonLoopLimitCheck = getConstant("Deoptimization::Reason_loop_limit_check", Integer.class);
     final int deoptReasonAliasing = getConstant("Deoptimization::Reason_aliasing", Integer.class);
     final int deoptReasonTransferToInterpreter = getConstant("Deoptimization::Reason_transfer_to_interpreter", Integer.class);
-    final int deoptReasonOSROffset = getConstant("Deoptimization::Reason_LIMIT", Integer.class);
+    final int deoptReasonOSROffset = getConstant("Deoptimization::Reason_TRAP_HISTORY_LENGTH", Integer.class);
 
     final int deoptActionNone = getConstant("Deoptimization::Action_none", Integer.class);
     final int deoptActionMaybeRecompile = getConstant("Deoptimization::Action_maybe_recompile", Integer.class);


### PR DESCRIPTION
This PR fixes a discrepancy between `MethodData::_trap_hist_list` and `Deoptimization::Reason_LIMIT` in terms of JVMCI specific usage.

JVMCI doubles the size of the deopt history for a method so that it can distinguish deopts in a normal method compilation from deopts in an OSR compilation:
```
    union {
      intptr_t _align;
      u1 _array[JVMCI_ONLY(2 *) MethodData::_trap_hist_limit];
    } _trap_hist;
```

To access the history for OSR deopts, the index for a deopt reason needs to be adjusted to the upper half of the history array. The amount used for the adjustment was incorrect and this PR fixes it:

```
  if (update_total_trap_count) {
    uint idx = reason;
#if INCLUDE_JVMCI
    if (is_osr) {
      idx += Reason_TRAP_HISTORY_LENGTH;
    }
#endif
```

I introduced `Reason_TRAP_HISTORY_LENGTH` as a replacement for `25 JVMCI_ONLY(+5),  // decoupled from Deoptimization::Reason_LIMIT` as this decoupling is unnecessary (as dangerous) as far as I can see.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278871](https://bugs.openjdk.java.net/browse/JDK-8278871): [JVMCI] assert((uint)reason < 2* _trap_hist_limit) failed: oob


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to c07e1778a9652daaa300a3f567e6dcf376f21936
 * [Tom Rodriguez](https://openjdk.java.net/census#never) (@tkrodriguez - **Reviewer**) ⚠️ Review applies to d74959032dc183a9a4a59cb82938d10cd47e58a1
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to c07e1778a9652daaa300a3f567e6dcf376f21936


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6855/head:pull/6855` \
`$ git checkout pull/6855`

Update a local copy of the PR: \
`$ git checkout pull/6855` \
`$ git pull https://git.openjdk.java.net/jdk pull/6855/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6855`

View PR using the GUI difftool: \
`$ git pr show -t 6855`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6855.diff">https://git.openjdk.java.net/jdk/pull/6855.diff</a>

</details>
