### PR TITLE
8278891: G1: Call reset in G1RegionMarkStatsCache constructor

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
@@ -45,7 +45,6 @@ G1FullGCMarker::G1FullGCMarker(G1FullCollector* collector,
     _stack_closure(this),
     _cld_closure(mark_closure(), ClassLoaderData::_claim_strong),
     _mark_stats_cache(mark_stats, G1RegionMarkStatsCache::RegionMarkStatsCacheSize) {
-  _mark_stats_cache.reset();
 }
 
 G1FullGCMarker::~G1FullGCMarker() {

--- a/src/hotspot/share/gc/g1/g1RegionMarkStatsCache.cpp
+++ b/src/hotspot/share/gc/g1/g1RegionMarkStatsCache.cpp
@@ -39,6 +39,7 @@ G1RegionMarkStatsCache::G1RegionMarkStatsCache(G1RegionMarkStats* target, uint n
   guarantee(is_power_of_2(num_cache_entries),
             "Number of cache entries must be power of two, but is %u", num_cache_entries);
   _cache = NEW_C_HEAP_ARRAY(G1RegionMarkStatsCacheEntry, _num_cache_entries, mtGC);
+  reset();
 }
 
 G1RegionMarkStatsCache::~G1RegionMarkStatsCache() {

--- a/src/hotspot/share/gc/g1/g1RegionMarkStatsCache.cpp
+++ b/src/hotspot/share/gc/g1/g1RegionMarkStatsCache.cpp
@@ -30,10 +30,7 @@
 
 G1RegionMarkStatsCache::G1RegionMarkStatsCache(G1RegionMarkStats* target, uint num_cache_entries) :
   _target(target),
-  _cache(NULL),
   _num_cache_entries(num_cache_entries),
-  _cache_hits(0),
-  _cache_misses(0),
   _num_cache_entries_mask(_num_cache_entries - 1) {
 
   guarantee(is_power_of_2(num_cache_entries),


### PR DESCRIPTION
Currently, G1RegionMarkStatsCache constructor does not call G1RegionMarkStatsCache::reset(), it depends on user to call it explicitly to make sure it works well and without crash in G1RegionMarkStatsCache::evict(uint idx).

In fact G1RegionMarkStatsCache constructor should call G1RegionMarkStatsCache::reset() to ensure its valid initial state.

( I met this issue when I tried to reuse this class to implement some parallel cache when improve the parallelism of evacuation failure. )

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278891](https://bugs.openjdk.java.net/browse/JDK-8278891): G1: Call reset in G1RegionMarkStatsCache constructor


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 4855018cf14ac08141146a6505be6ff27349dee0
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to 4855018cf14ac08141146a6505be6ff27349dee0


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6861/head:pull/6861` \
`$ git checkout pull/6861`

Update a local copy of the PR: \
`$ git checkout pull/6861` \
`$ git pull https://git.openjdk.java.net/jdk pull/6861/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6861`

View PR using the GUI difftool: \
`$ git pr show -t 6861`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6861.diff">https://git.openjdk.java.net/jdk/pull/6861.diff</a>

</details>
