### PR TITLE
8278893: Parallel: Remove GCWorkerDelayMillis 

### DIFF
--- a/src/hotspot/share/gc/parallel/parallel_globals.hpp
+++ b/src/hotspot/share/gc/parallel/parallel_globals.hpp
@@ -55,9 +55,6 @@
           "limiter (a number between 0-100)")                               \
           range(0, 100)                                                     \
                                                                             \
-  develop(uintx, GCWorkerDelayMillis, 0,                                    \
-          "Delay in scheduling GC workers (in milliseconds)")               \
-                                                                            \
   product(bool, PSChunkLargeArrays, true,                                   \
           "Process large arrays in chunks")
 

--- a/src/hotspot/share/gc/parallel/psCardTable.cpp
+++ b/src/hotspot/share/gc/parallel/psCardTable.cpp
@@ -165,7 +165,6 @@ void PSCardTable::scavenge_contents_parallel(ObjectStartArray* start_array,
                                              uint stripe_number,
                                              uint stripe_total) {
   int ssize = 128; // Naked constant!  Work unit = 64k.
-  int dirty_card_count = 0;
 
   // It is a waste to get here if empty.
   assert(sp->bottom() < sp->top(), "Should not be called if empty");
@@ -194,16 +193,6 @@ void PSCardTable::scavenge_contents_parallel(ObjectStartArray* start_array,
     // Note! ending cards are exclusive!
     HeapWord* slice_start = addr_for(worker_start_card);
     HeapWord* slice_end = MIN2((HeapWord*) sp_top, addr_for(worker_end_card));
-
-#ifdef ASSERT
-    if (GCWorkerDelayMillis > 0) {
-      // Delay 1 worker so that it proceeds after all the work
-      // has been completed.
-      if (stripe_number < 2) {
-        os::naked_sleep(GCWorkerDelayMillis);
-      }
-    }
-#endif
 
     // If there are not objects starting within the chunk, skip it.
     if (!start_array->object_starts_in_range(slice_start, slice_end)) {

--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -219,13 +219,6 @@ inline oop PSPromotionManager::copy_unmarked_to_survivor_space(oop o,
 
           HeapWord* lab_base = old_gen()->allocate(OldPLABSize);
           if(lab_base != NULL) {
-#ifdef ASSERT
-            // Delay the initialization of the promotion lab (plab).
-            // This exposes uninitialized plabs to card table processing.
-            if (GCWorkerDelayMillis > 0) {
-              os::naked_sleep(GCWorkerDelayMillis);
-            }
-#endif
             _old_lab.initialize(MemRegion(lab_base, OldPLABSize));
             // Try the old lab allocation again.
             new_obj = cast_to_oop(_old_lab.allocate(new_obj_size));


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that removes the unnecessary and unused flag develop `GCWorkerDelayMillis`?

Testing: local compilation, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278893](https://bugs.openjdk.java.net/browse/JDK-8278893): Parallel: Remove GCWorkerDelayMillis


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6862/head:pull/6862` \
`$ git checkout pull/6862`

Update a local copy of the PR: \
`$ git checkout pull/6862` \
`$ git pull https://git.openjdk.java.net/jdk pull/6862/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6862`

View PR using the GUI difftool: \
`$ git pr show -t 6862`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6862.diff">https://git.openjdk.java.net/jdk/pull/6862.diff</a>

</details>
