### PR TITLE
8278384: Bytecodes::result_type() for arraylength returns T_VOID instead of T_INT

### DIFF
--- a/src/hotspot/share/interpreter/bytecodeUtils.cpp
+++ b/src/hotspot/share/interpreter/bytecodeUtils.cpp
@@ -1029,7 +1029,6 @@ int ExceptionMessageBuilder::do_instruction(int bci) {
       break;
 
     case Bytecodes::_arraylength:
-      // The return type of arraylength is wrong in the bytecodes table (T_VOID).
       stack->pop(1);
       stack->push(bci, T_INT);
       break;

--- a/src/hotspot/share/interpreter/bytecodes.cpp
+++ b/src/hotspot/share/interpreter/bytecodes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -471,7 +471,7 @@ void Bytecodes::initialize() {
   def(_new                 , "new"                 , "bkk"  , NULL    , T_OBJECT ,  1, true );
   def(_newarray            , "newarray"            , "bc"   , NULL    , T_OBJECT ,  0, true );
   def(_anewarray           , "anewarray"           , "bkk"  , NULL    , T_OBJECT ,  0, true );
-  def(_arraylength         , "arraylength"         , "b"    , NULL    , T_VOID   ,  0, true );
+  def(_arraylength         , "arraylength"         , "b"    , NULL    , T_INT    ,  0, true );
   def(_athrow              , "athrow"              , "b"    , NULL    , T_VOID   , -1, true );
   def(_checkcast           , "checkcast"           , "bkk"  , NULL    , T_OBJECT ,  0, true );
   def(_instanceof          , "instanceof"          , "bkk"  , NULL    , T_INT    ,  0, true );


### PR DESCRIPTION
Please review this small change to specify T_INT instead of T_VOID as the return type for the arraylength bytecode.  The fix was tested with Mach5 tiers 1-2 on Linux, Mac OS, and Windows, and Mach5 tiers 3-5 on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278384](https://bugs.openjdk.java.net/browse/JDK-8278384): Bytecodes::result_type() for arraylength returns T_VOID instead of T_INT


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6863/head:pull/6863` \
`$ git checkout pull/6863`

Update a local copy of the PR: \
`$ git checkout pull/6863` \
`$ git pull https://git.openjdk.java.net/jdk pull/6863/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6863`

View PR using the GUI difftool: \
`$ git pr show -t 6863`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6863.diff">https://git.openjdk.java.net/jdk/pull/6863.diff</a>

</details>
