### PR TITLE
8278909: Unproblemlist AdaptiveBlocking001

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -27,8 +27,6 @@
 #
 #############################################################################
 
-vmTestbase/jit/escape/AdaptiveBlocking/AdaptiveBlocking001/AdaptiveBlocking001.java 8260303 windows-x64
-
 resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java 8276539   generic-all
 serviceability/sa/CDSJMapClstats.java                         8276539   generic-all
 serviceability/sa/ClhsdbJhisto.java                           8276539   generic-all


### PR DESCRIPTION
Hi,

vmTestbase/jit/escape/AdaptiveBlocking/AdaptiveBlocking001/AdaptiveBlocking001.java was problemlisted in 17. This problem might have been fixed. I suggest unproblemlisting it now in early 19 time frame so that we might get enough data if this problem still occurs.

Regards,
Nils

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278909](https://bugs.openjdk.java.net/browse/JDK-8278909): Unproblemlist AdaptiveBlocking001


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6865/head:pull/6865` \
`$ git checkout pull/6865`

Update a local copy of the PR: \
`$ git checkout pull/6865` \
`$ git pull https://git.openjdk.java.net/jdk pull/6865/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6865`

View PR using the GUI difftool: \
`$ git pr show -t 6865`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6865.diff">https://git.openjdk.java.net/jdk/pull/6865.diff</a>

</details>
