### PR TITLE
8278908: [macOS] Unexpected text normalization on pasting from clipboard

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CDataTransferer.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CDataTransferer.java
@@ -33,8 +33,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.Charset;
-import java.text.Normalizer;
-import java.text.Normalizer.Form;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -165,9 +163,6 @@ public class CDataTransferer extends DataTransferer {
             // regular string that allows to translate data to target represantation
             // class by base method
             format = CF_STRING;
-        } else if (format == CF_STRING) {
-            String src = new String(bytes, UTF_8);
-            bytes = Normalizer.normalize(src, Form.NFC).getBytes(UTF_8);
         }
 
         return super.translateBytes(bytes, flavor, format, transferable);

--- a/test/jdk/java/awt/datatransfer/UnicodeTransferTest/UnicodeTransferTest.java
+++ b/test/jdk/java/awt/datatransfer/UnicodeTransferTest/UnicodeTransferTest.java
@@ -25,7 +25,7 @@
 /*
   @test
   @key headful
-  @bug 4718897
+  @bug 4718897 8278908
   @summary tests that a Unicode string can be transferred between JVMs.
   @author das@sparc.spb.su area=datatransfer
   @library ../../regtesthelpers/process
@@ -35,7 +35,6 @@
 
 import java.awt.datatransfer.*;
 import java.awt.*;
-import java.text.Normalizer;
 
 import test.java.awt.regtesthelpers.process.ProcessResults;
 import test.java.awt.regtesthelpers.process.ProcessCommunicator;
@@ -77,10 +76,7 @@ class Util {
                 buf.append(0x20);
             }
         }
-        // On OS X the unicode string is normalized but the clipboard,
-        // so we need to use normalized strings as well to be able to
-        // check the result
-        testString = Normalizer.normalize(buf.toString(), Normalizer.Form.NFC);
+        testString = buf.toString();
     }
 
     public static String getTestString() {


### PR DESCRIPTION
The fix just removes the explicit normalization of text obtained from system clipboard in JDK code, as I've found no
good justification for such a normalization, at least for the latest macOS version.
The same fix was performed in JetBrains Runtime by a user's request more than 4 years ago, and we didn't receive any
related complaints from our users ever since.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278908](https://bugs.openjdk.java.net/browse/JDK-8278908): [macOS] Unexpected text normalization on pasting from clipboard


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6866/head:pull/6866` \
`$ git checkout pull/6866`

Update a local copy of the PR: \
`$ git checkout pull/6866` \
`$ git pull https://git.openjdk.java.net/jdk pull/6866/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6866`

View PR using the GUI difftool: \
`$ git pr show -t 6866`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6866.diff">https://git.openjdk.java.net/jdk/pull/6866.diff</a>

</details>
