### PR TITLE
8225093: Special property jdk.boot.class.path.append should not default to empty string

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -412,7 +412,7 @@ void Arguments::init_system_properties() {
   // It can only be set by either:
   //    - -Xbootclasspath/a:
   //    - AddToBootstrapClassLoaderSearch during JVMTI OnLoad phase
-  _jdk_boot_class_path_append = new SystemProperty("jdk.boot.class.path.append", "", false, true);
+  _jdk_boot_class_path_append = new SystemProperty("jdk.boot.class.path.append", NULL, false, true);
 
   // Add to System Property list.
   PropertyList_add(&_system_properties, _sun_boot_library_path);

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -109,7 +109,8 @@ class SystemProperty : public PathString {
   void set_next(SystemProperty* next) { _next = next; }
 
   bool is_readable() const {
-    return !_internal || strcmp(_key, "jdk.boot.class.path.append") == 0;
+    return !_internal || (strcmp(_key, "jdk.boot.class.path.append") == 0 &&
+                          value() != NULL);
   }
 
   // A system property should only have its value set

--- a/test/hotspot/jtreg/runtime/BootClassAppendProp/GetBootClassPathAppendProp.java
+++ b/test/hotspot/jtreg/runtime/BootClassAppendProp/GetBootClassPathAppendProp.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8224791
+ * @summary Check that JVMTI GetSystemProperty API returns the right values for
+ *          property jdk.boot.class.path.append.
+ * @requires vm.jvmti
+ * @library /test/lib
+ * @run main/othervm/native -agentlib:GetBootClassPathAppendProp GetBootClassPathAppendProp
+ * @run main/othervm/native -Xbootclasspath/a:blah -agentlib:GetBootClassPathAppendProp GetBootClassPathAppendProp one_arg
+ *
+ */
+
+public class GetBootClassPathAppendProp {
+    private static native String getSystemProperty();
+
+    public static void main(String[] args) throws Exception {
+        String vm_info_jvmti = getSystemProperty();
+        if (args.length > 0) {
+            if (!vm_info_jvmti.equals("blah")) {
+                throw new RuntimeException("Wrong value returned for jdk.boot.class.path.append: " +
+                                           vm_info_jvmti);
+           }
+        } else {
+            if (vm_info_jvmti != null) {
+                throw new RuntimeException("Null value expected for jdk.boot.class.path.append: " +
+                                           vm_info_jvmti);
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/BootClassAppendProp/GetBootClassPathAppendProp.java
+++ b/test/hotspot/jtreg/runtime/BootClassAppendProp/GetBootClassPathAppendProp.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8224791
+ * @bug 8225093
  * @summary Check that JVMTI GetSystemProperty API returns the right values for
  *          property jdk.boot.class.path.append.
  * @requires vm.jvmti
@@ -37,16 +37,16 @@ public class GetBootClassPathAppendProp {
     private static native String getSystemProperty();
 
     public static void main(String[] args) throws Exception {
-        String vm_info_jvmti = getSystemProperty();
+        String path = getSystemProperty();
         if (args.length > 0) {
-            if (!vm_info_jvmti.equals("blah")) {
+            if (!path.equals("blah")) {
                 throw new RuntimeException("Wrong value returned for jdk.boot.class.path.append: " +
-                                           vm_info_jvmti);
+                                           path);
            }
         } else {
-            if (vm_info_jvmti != null) {
+            if (path != null) {
                 throw new RuntimeException("Null value expected for jdk.boot.class.path.append: " +
-                                           vm_info_jvmti);
+                                           path);
             }
         }
     }

--- a/test/hotspot/jtreg/runtime/BootClassAppendProp/libGetBootClassPathAppendProp.c
+++ b/test/hotspot/jtreg/runtime/BootClassAppendProp/libGetBootClassPathAppendProp.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <jvmti.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static jvmtiEnv *jvmti = NULL;
+
+JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+  int err = (*jvm)->GetEnv(jvm, (void**) &jvmti, JVMTI_VERSION_9);
+  if (err != JNI_OK) {
+    return JNI_ERR;
+  }
+  return JNI_OK;
+}
+
+JNIEXPORT jstring JNICALL
+Java_GetBootClassPathAppendProp_getSystemProperty(JNIEnv *env, jclass cls) {
+  jvmtiError err;
+  char* prop_value;
+
+  err = (*jvmti)->GetSystemProperty(jvmti, "jdk.boot.class.path.append", &prop_value);
+  if (err == JVMTI_ERROR_NOT_AVAILABLE) {
+    return NULL;
+  }
+  if (err != JVMTI_ERROR_NONE) {
+    return (*env)->NewStringUTF(env, "wrong error code");
+  }
+
+  return (*env)->NewStringUTF(env, prop_value);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/test/hotspot/jtreg/runtime/BootClassAppendProp/libGetBootClassPathAppendProp.c
+++ b/test/hotspot/jtreg/runtime/BootClassAppendProp/libGetBootClassPathAppendProp.c
@@ -49,7 +49,9 @@ Java_GetBootClassPathAppendProp_getSystemProperty(JNIEnv *env, jclass cls) {
     return NULL;
   }
   if (err != JVMTI_ERROR_NONE) {
-    return (*env)->NewStringUTF(env, "wrong error code");
+    char err_msg[50];
+    snprintf(err_msg, 50, "Wrong JVM TI error code: %d", err);
+    return (*env)->NewStringUTF(env, err_msg);
   }
 
   return (*env)->NewStringUTF(env, prop_value);


### PR DESCRIPTION
Please review this fix for JDK-8225093 to set the default value of property jdk.boot.class.path.append to NULL instead of "".  This fix was tested by running Mach5 tiers 1-2 on Linux, Mac OS, and Windows, and Mach5 tiers 3-5 on Linux x64.  The fix was also tested by running the agent.c example in JDK-8224791.

Thanks! Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8225093](https://bugs.openjdk.java.net/browse/JDK-8225093): Special property jdk.boot.class.path.append should not default to empty string
 * [JDK-8278918](https://bugs.openjdk.java.net/browse/JDK-8278918): Special property jdk.boot.class.path.append should not default to empty string (**CSR**)


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to a1c9218bbd7e169e1d3596f0741c54dec4846775
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6868/head:pull/6868` \
`$ git checkout pull/6868`

Update a local copy of the PR: \
`$ git checkout pull/6868` \
`$ git pull https://git.openjdk.java.net/jdk pull/6868/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6868`

View PR using the GUI difftool: \
`$ git pr show -t 6868`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6868.diff">https://git.openjdk.java.net/jdk/pull/6868.diff</a>

</details>
