### PR TITLE
8261404: Class.getReflectionFactory() is not thread-safe

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -3820,9 +3820,9 @@ public final class Class<T> implements java.io.Serializable,
     // Fetches the factory for reflective objects
     @SuppressWarnings("removal")
     private static ReflectionFactory getReflectionFactory() {
-        ReflectionFactory reflectionFactory = Class.reflectionFactory;
-        if (reflectionFactory == null) {
-            return Class.reflectionFactory =
+        var factory = reflectionFactory;
+        if (factory == null) {
+            return reflectionFactory =
                 java.security.AccessController.doPrivileged
                     (new ReflectionFactory.GetReflectionFactoryAction());
         }

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -3820,8 +3820,9 @@ public final class Class<T> implements java.io.Serializable,
     // Fetches the factory for reflective objects
     @SuppressWarnings("removal")
     private static ReflectionFactory getReflectionFactory() {
+        ReflectionFactory reflectionFactory = Class.reflectionFactory;
         if (reflectionFactory == null) {
-            reflectionFactory =
+            return Class.reflectionFactory =
                 java.security.AccessController.doPrivileged
                     (new ReflectionFactory.GetReflectionFactoryAction());
         }

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -3821,12 +3821,12 @@ public final class Class<T> implements java.io.Serializable,
     @SuppressWarnings("removal")
     private static ReflectionFactory getReflectionFactory() {
         var factory = reflectionFactory;
-        if (factory == null) {
-            return reflectionFactory =
-                java.security.AccessController.doPrivileged
-                    (new ReflectionFactory.GetReflectionFactoryAction());
+        if (factory != null) {
+            return factory;
         }
-        return reflectionFactory;
+        return reflectionFactory =
+                java.security.AccessController.doPrivileged
+                        (new ReflectionFactory.GetReflectionFactoryAction());
     }
     private static ReflectionFactory reflectionFactory;
 


### PR DESCRIPTION
Simply changes this to only read the static field once to prevent `null` on second read.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261404](https://bugs.openjdk.java.net/browse/JDK-8261404): Class.getReflectionFactory() is not thread-safe


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6870/head:pull/6870` \
`$ git checkout pull/6870`

Update a local copy of the PR: \
`$ git checkout pull/6870` \
`$ git pull https://git.openjdk.java.net/jdk pull/6870/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6870`

View PR using the GUI difftool: \
`$ git pr show -t 6870`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6870.diff">https://git.openjdk.java.net/jdk/pull/6870.diff</a>

</details>
