### PR TITLE
8278519: serviceability/jvmti/FieldAccessWatch/FieldAccessWatch.java failed "assert(handle != __null) failed: JNI handle should not be null"

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/FieldAccessWatch/FieldAccessWatch.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/FieldAccessWatch/FieldAccessWatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ public class FieldAccessWatch {
             throw ex;
         }
 
-        if (!initWatchers(MyList.class, MyList.class.getDeclaredField("items"))) {
+        if (!initWatchers(MyList.class, MyList.class.getDeclaredField("items"), Thread.currentThread())) {
             throw new RuntimeException("Watchers initializations error");
         }
 
@@ -131,7 +131,7 @@ public class FieldAccessWatch {
         log(descr + ": OK");
     }
 
-    private static native boolean initWatchers(Class cls, Field field);
+    private static native boolean initWatchers(Class cls, Field field, Thread testThread);
     private static native boolean startTest(TestResult results);
     private static native void stopTest();
 

--- a/test/hotspot/jtreg/serviceability/jvmti/FieldAccessWatch/libFieldAccessWatch.c
+++ b/test/hotspot/jtreg/serviceability/jvmti/FieldAccessWatch/libFieldAccessWatch.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/jvmti/FieldAccessWatch/libFieldAccessWatch.c
+++ b/test/hotspot/jtreg/serviceability/jvmti/FieldAccessWatch/libFieldAccessWatch.c
@@ -37,6 +37,7 @@ static jvmtiEnv *jvmti = NULL;
 // valid while a test is executed
 static jobject testResultObject = NULL;
 static jclass testResultClass = NULL;
+static jthread testThread = NULL;
 
 
 static void reportError(const char *msg, int err) {
@@ -46,6 +47,7 @@ static void reportError(const char *msg, int err) {
 
 // logs the notification and updates currentTestResult
 static void handleNotification(JNIEnv *jni_env,
+    jthread thread,
     jmethodID method,
     jfieldID field,
     jclass field_klass,
@@ -62,6 +64,10 @@ static void handleNotification(JNIEnv *jni_env,
     if (testResultObject == NULL) {
         // we are out of test
         return;
+    }
+
+    if (!(*jni_env)->IsSameObject(jni_env, thread, testThread)) {
+        return; // skip events from unexpected threads
     }
 
     err = (*jvmti)->GetFieldName(jvmti, field_klass, field, &name, NULL, NULL);
@@ -179,7 +185,7 @@ onFieldAccess(jvmtiEnv *jvmti_env,
             jobject object,
             jfieldID field)
 {
-    handleNotification(jni_env, method, field, field_klass, 0, location);
+    handleNotification(jni_env, thread, method, field, field_klass, 0, location);
 }
 
 
@@ -195,7 +201,7 @@ onFieldModification(jvmtiEnv *jvmti_env,
             char signature_type,
             jvalue new_value)
 {
-    handleNotification(jni_env, method, field, field_klass, 1, location);
+    handleNotification(jni_env, thread, method, field, field_klass, 1, location);
 
     if (signature_type == 'L') {
         jobject newObject = new_value.l;
@@ -251,7 +257,7 @@ Agent_OnLoad(JavaVM *jvm, char *options, void *reserved)
 
 
 JNIEXPORT jboolean JNICALL
-Java_FieldAccessWatch_initWatchers(JNIEnv *env, jclass thisClass, jclass cls, jobject field)
+Java_FieldAccessWatch_initWatchers(JNIEnv *env, jclass thisClass, jclass cls, jobject field, jthread thread)
 {
     jfieldID fieldId;
     jvmtiError err;
@@ -274,6 +280,8 @@ Java_FieldAccessWatch_initWatchers(JNIEnv *env, jclass thisClass, jclass cls, jo
         reportError("SetFieldAccessWatch failed", err);
         return JNI_FALSE;
     }
+
+    testThread = (jthread)(*env)->NewGlobalRef(env, thread);
 
     return JNI_TRUE;
 }


### PR DESCRIPTION
The fix adds a check in the event handler which filters out event from non-test threads

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278519](https://bugs.openjdk.java.net/browse/JDK-8278519): serviceability/jvmti/FieldAccessWatch/FieldAccessWatch.java failed "assert(handle != __null) failed: JNI handle should not be null"


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to 022a689f6d934e030c388e662de8d5b4a9285b54
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to 022a689f6d934e030c388e662de8d5b4a9285b54


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6874/head:pull/6874` \
`$ git checkout pull/6874`

Update a local copy of the PR: \
`$ git checkout pull/6874` \
`$ git pull https://git.openjdk.java.net/jdk pull/6874/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6874`

View PR using the GUI difftool: \
`$ git pr show -t 6874`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6874.diff">https://git.openjdk.java.net/jdk/pull/6874.diff</a>

</details>
