### PR TITLE
8278937: JCK test for java_awt/geom/Line2D.Float fails after 8277868

### DIFF
--- a/src/java.desktop/share/classes/java/awt/geom/Line2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Line2D.java
@@ -532,7 +532,7 @@ public abstract class Line2D implements Shape, Cloneable {
                 }
             }
         }
-        return java.lang.Double.compare(ccw, 0.0);
+        return (ccw < 0.0) ? -1 : ((ccw > 0.0) ? 1 : 0);
     }
 
     /**

--- a/src/java.desktop/share/classes/sun/awt/geom/Curve.java
+++ b/src/java.desktop/share/classes/sun/awt/geom/Curve.java
@@ -730,7 +730,13 @@ public abstract class Curve {
     }
 
     public static int orderof(double x1, double x2) {
-      return Double.compare(x1, x2);
+        if (x1 < x2) {
+             return -1;
+         }
+         if (x1 > x2) {
+             return 1;
+         }
+         return 0;
     }
 
     public static long signeddiffbits(double y1, double y2) {

--- a/src/java.desktop/share/classes/sun/java2d/Spans.java
+++ b/src/java.desktop/share/classes/sun/java2d/Spans.java
@@ -317,7 +317,18 @@ public class Spans {
          */
         @Override
         public int compareTo(Span otherSpan) {
-            return Float.compare(mStart, otherSpan.getStart());
+            float otherStart = otherSpan.getStart();
+            int result;
+
+            if (mStart < otherStart) {
+                result = -1;
+            } else if (mStart > otherStart) {
+                result = 1;
+            } else {
+                result = 0;
+            }
+
+            return result; 
         }
 
         public String toString() {

--- a/src/java.desktop/share/classes/sun/java2d/Spans.java
+++ b/src/java.desktop/share/classes/sun/java2d/Spans.java
@@ -328,7 +328,7 @@ public class Spans {
                 result = 0;
             }
 
-            return result; 
+            return result;
         }
 
         public String toString() {


### PR DESCRIPTION
This reverts the uses of Float.compare() and Double.compare() made by the fix for 8277868
since it appears clear that for better or worse they are not 100% compatible with the previous code.
These uses are all in the desktop module

For comparison the original changes are here : https://github.com/openjdk/jdk/pull/6575/files

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278937](https://bugs.openjdk.java.net/browse/JDK-8278937): JCK test for java_awt/geom/Line2D.Float fails after 8277868


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Author)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6875/head:pull/6875` \
`$ git checkout pull/6875`

Update a local copy of the PR: \
`$ git checkout pull/6875` \
`$ git pull https://git.openjdk.java.net/jdk pull/6875/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6875`

View PR using the GUI difftool: \
`$ git pr show -t 6875`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6875.diff">https://git.openjdk.java.net/jdk/pull/6875.diff</a>

</details>
