### PR TITLE
8278954: Using clang together with devkit on linux doesn't work for building

### DIFF
--- a/make/autoconf/flags.m4
+++ b/make/autoconf/flags.m4
@@ -215,8 +215,21 @@ AC_DEFUN([FLAGS_SETUP_SYSROOT_FLAGS],
       $1SYSROOT_CFLAGS="--sysroot=[$]$1SYSROOT"
       $1SYSROOT_LDFLAGS="--sysroot=[$]$1SYSROOT"
     elif test "x$TOOLCHAIN_TYPE" = xclang; then
-      $1SYSROOT_CFLAGS="-isysroot [$]$1SYSROOT"
-      $1SYSROOT_LDFLAGS="-isysroot [$]$1SYSROOT"
+      if test "x$OPENJDK_TARGET_OS" = "xlinux"; then
+        # -isysroot has no effect on linux
+        # https://bugs.llvm.org/show_bug.cgi?id=11503
+        $1SYSROOT_CFLAGS="--sysroot=[$]$1SYSROOT"
+        $1SYSROOT_LDFLAGS="--sysroot=[$]$1SYSROOT"
+        if test -d "$DEVKIT_TOOLCHAIN_PATH"; then
+          # In devkits, gcc is not located in the sysroot.
+          # use --gcc-toolchain to let clang find the gcc installation.
+          $1SYSROOT_CFLAGS="[$]$1SYSROOT_CFLAGS --gcc-toolchain=$DEVKIT_TOOLCHAIN_PATH/.."
+          $1SYSROOT_LDFLAGS="[$]$1SYSROOT_LDFLAGS --gcc-toolchain=$DEVKIT_TOOLCHAIN_PATH/.."
+        fi
+      else
+        $1SYSROOT_CFLAGS="-isysroot [$]$1SYSROOT"
+        $1SYSROOT_LDFLAGS="-isysroot [$]$1SYSROOT"
+      fi
     fi
   fi
 


### PR DESCRIPTION
When running `configure`, using `--with-devkit=` to point to a typical linux devkit along with `--with-toolchain-path=` and `--with-toolchain-type=clang` to point to a clang-based toolchain results in:
```
configure:75064: checking whether the C compiler works
configure:75086: /dl/tools/clang -m64 -isysroot /dl/x86_64-linux-gnu-to-x86_64-linux-gnu/x86_64-linux-gnu/sysroot -isysroot /dl/x86_64-linux-gnu-to-x86_64-linux-gnu/x86_64-linux-gnu/sysroot -m64 -isysroot /dl/x86_64-linux-gnu-to-x86_64-linux-gnu/x86_64-linux-gnu/sysroot conftest.c >&5
d.lld: error: cannot open crt1.o: No such file or directory
ld.lld: error: cannot open crti.o: No such file or directory
ld.lld: error: cannot open crtbegin.o: No such file or directory
ld.lld: error: unable to find library -lgcc
ld.lld: error: unable to find library -lgcc_s
ld.lld: error: unable to find library -lc
ld.lld: error: unable to find library -lgcc
ld.lld: error: unable to find library -lgcc_s
ld.lld: error: cannot open crtend.o: No such file or directory
ld.lld: error: cannot open crtn.o: No such file or directory
clang-12: error: linker command failed with exit code 1 (use -v to see invocation)
``` 
This is because clang is unable to locate the gcc installation from the devkit.
The gcc toolchain is not in the location clang expects in the sysroot (that's not how our devkits are structured).
Note that it might go unnoticed on machines that have gcc installed because clang will fallback to system-global locations.

We can help clang by letting it now about the gcc location in the devkit with `--gcc-toolchain=`.
However that's not enough and we then get:
```
ld.lld: error: cannot open crt1.o: No such file or directory
ld.lld: error: cannot open crti.o: No such file or directory
ld.lld: error: unable to find library -lc
ld.lld: error: cannot open crtn.o: No such file or directory
```
clang was able to locate the gcc support libraries but is not able to locate required system libraries.
That's because `-isysroot` is not intended for libraries (only headers) but also because `-isysroot` has no effect for clang on linux (see [llvm#11503](https://bugs.llvm.org/show_bug.cgi?id=11503)).
Using `--sysroot=` in this case (clang on linux) resolves this issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278954](https://bugs.openjdk.java.net/browse/JDK-8278954): Using clang together with devkit on linux doesn't work for building


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6880/head:pull/6880` \
`$ git checkout pull/6880`

Update a local copy of the PR: \
`$ git checkout pull/6880` \
`$ git pull https://git.openjdk.java.net/jdk pull/6880/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6880`

View PR using the GUI difftool: \
`$ git pr show -t 6880`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6880.diff">https://git.openjdk.java.net/jdk/pull/6880.diff</a>

</details>
