### PR TITLE
8278956: Remove unimplemented PLAB::allocate_aligned

### DIFF
--- a/src/hotspot/share/gc/shared/plab.hpp
+++ b/src/hotspot/share/gc/shared/plab.hpp
@@ -94,9 +94,6 @@ public:
     }
   }
 
-  // Allocate the object aligned to "alignment_in_bytes".
-  inline HeapWord* allocate_aligned(size_t word_sz, unsigned short alignment_in_bytes);
-
   // Undo any allocation in the buffer, which is required to be of the
   // "obj" of the given "word_sz".
   void undo_allocation(HeapWord* obj, size_t word_sz);


### PR DESCRIPTION
Trivial change of removing dead code.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278956](https://bugs.openjdk.java.net/browse/JDK-8278956): Remove unimplemented PLAB::allocate_aligned


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6881/head:pull/6881` \
`$ git checkout pull/6881`

Update a local copy of the PR: \
`$ git checkout pull/6881` \
`$ git pull https://git.openjdk.java.net/jdk pull/6881/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6881`

View PR using the GUI difftool: \
`$ git pr show -t 6881`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6881.diff">https://git.openjdk.java.net/jdk/pull/6881.diff</a>

</details>
