### PR TITLE
8278961: Enable debug logging in java/net/DatagramSocket/SendDatagramToBadAddress.java

### DIFF
--- a/test/jdk/java/net/DatagramSocket/SendDatagramToBadAddress.java
+++ b/test/jdk/java/net/DatagramSocket/SendDatagramToBadAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /*
  * @test
  *
- * @bug 4204320 8278961
+ * @bug 4204320
  *
  * @summary DatagramSocket.send should throw exception when connected
  *  to an invalid destination (on platforms that support it).

--- a/test/jdk/java/net/DatagramSocket/SendDatagramToBadAddress.java
+++ b/test/jdk/java/net/DatagramSocket/SendDatagramToBadAddress.java
@@ -24,11 +24,11 @@
 /*
  * @test
  *
- * @bug 4204320
+ * @bug 4204320 8278961
  *
  * @summary DatagramSocket.send should throw exception when connected
  *  to an invalid destination (on platforms that support it).
- * @run main/othervm SendDatagramToBadAddress
+ * @run main/othervm SendDatagramToBadAddress -d
  */
 
 import java.net.*;
@@ -70,6 +70,8 @@ public class SendDatagramToBadAddress {
             for (int i=0; i<loop; i++) {
                 try {
                     server.receive (pack);
+                    print("received data from address " + pack.getAddress()
+                            + " port " + pack.getPort());
                 } catch (Exception e) {
                     if (expectError) {
                         print ("Got expected error: " + e);
@@ -116,12 +118,15 @@ public class SendDatagramToBadAddress {
         DatagramPacket p;
         byte[] buf;
         int port = serversock.getLocalPort ();
+        print("tests will be run against destination address " + addr + " port " + port);
         final int loop = 5;
         Server s = new Server (serversock);
         int i;
 
         print ("Checking send to connected address ...");
         sock.connect(addr, port);
+        print("socket is locally bound to address " + sock.getLocalAddress()
+                + " port " + sock.getLocalPort());
 
         for (i = 0; i < loop; i++) {
             try {
@@ -170,6 +175,8 @@ public class SendDatagramToBadAddress {
                 sock.send(p);
                 p = new DatagramPacket(buf, buf.length, addr, port);
                 sock.receive (p);
+                print("(unexpectedly) received data from address " + p.getAddress()
+                        + " port " + p.getPort() + " on attempt " + i);
             } catch (InterruptedIOException ex) {
                 print ("socket timeout");
             } catch (Exception ex) {


### PR DESCRIPTION
Can I please get a review for this test only change which proposes to enable debug logs from the test that failed intermittently? This change addresses https://bugs.openjdk.java.net/browse/JDK-8278961.

The change passes the (test specific) `-d` option to enable logs from that test by default. While I was at it, I even added a few more debug logs hoping it might provide some hints if/when it fails next.

For reference, a (successful) run of this test will now print something like:

```
----------System.out:(18/930)----------
running on OS that supports ICMP port unreachable
Testing with class java.net.DatagramSocket
tests will be run against destination address localhost/127.0.0.1 port 52682
Checking send to connected address ...
socket is locally bound to address /127.0.0.1 port 52681
received data from address /127.0.0.1 port 52681
received data from address /127.0.0.1 port 52681
received data from address /127.0.0.1 port 52681
received data from address /127.0.0.1 port 52681
received data from address /127.0.0.1 port 52681
Checking send to non-connected address ...
received data from address /127.0.0.1 port 52681
Checking send to invalid address ...
Got expected exception: java.net.PortUnreachableException
Got expected exception: java.net.PortUnreachableException
Got expected exception: java.net.PortUnreachableException
Got expected exception: java.net.PortUnreachableException
Got expected exception: java.net.PortUnreachableException
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278961](https://bugs.openjdk.java.net/browse/JDK-8278961): Enable debug logging in java/net/DatagramSocket/SendDatagramToBadAddress.java


### Reviewers
 * @djelinski (no known github.com user name / role) ⚠️ Review applies to 721cd07d96d0c015bad926cd0fc7523e700b91e8
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Mark Sheppard](https://openjdk.java.net/census#msheppar) (@msheppar - **Reviewer**) ⚠️ Review applies to 721cd07d96d0c015bad926cd0fc7523e700b91e8


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6883/head:pull/6883` \
`$ git checkout pull/6883`

Update a local copy of the PR: \
`$ git checkout pull/6883` \
`$ git pull https://git.openjdk.java.net/jdk pull/6883/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6883`

View PR using the GUI difftool: \
`$ git pr show -t 6883`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6883.diff">https://git.openjdk.java.net/jdk/pull/6883.diff</a>

</details>
