### PR TITLE
8278943: Use big M letter for month in javadocs's dateformat

### DIFF
--- a/src/java.sql/share/classes/java/sql/Date.java
+++ b/src/java.sql/share/classes/java/sql/Date.java
@@ -102,12 +102,12 @@ public class Date extends java.util.Date {
      * a {@code Date} value.
      *
      * @param s a {@code String} object representing a date in
-     *        in the format "yyyy-[m]m-[d]d". The leading zero for {@code mm}
+     *        in the format "yyyy-[M]M-[d]d". The leading zero for {@code MM}
      * and {@code dd} may also be omitted.
      * @return a {@code java.sql.Date} object representing the
      *         given date
      * @throws IllegalArgumentException if the date given is not in the
-     *         JDBC date escape format (yyyy-[m]m-[d]d)
+     *         JDBC date escape format (yyyy-[M]M-[d]d)
      */
     public static Date valueOf(String s) {
         if (s == null) {
@@ -147,9 +147,9 @@ public class Date extends java.util.Date {
 
 
     /**
-     * Formats a date in the date escape format yyyy-mm-dd.
+     * Formats a date in the date escape format yyyy-MM-dd.
      *
-     * @return a String in yyyy-mm-dd format
+     * @return a String in yyyy-MM-dd format
      */
     @SuppressWarnings("deprecation")
     public String toString () {

--- a/src/java.sql/share/classes/java/sql/Timestamp.java
+++ b/src/java.sql/share/classes/java/sql/Timestamp.java
@@ -39,9 +39,9 @@ import java.time.LocalDateTime;
  *
  * <p>The precision of a Timestamp object is calculated to be either:
  * <ul>
- * <li>{@code 19 }, which is the number of characters in yyyy-mm-dd hh:mm:ss
+ * <li>{@code 19 }, which is the number of characters in yyyy-MM-dd hh:mm:ss
  * <li> {@code  20 + s }, which is the number
- * of characters in the yyyy-mm-dd hh:mm:ss.[fff...] and {@code s} represents  the scale of the given Timestamp,
+ * of characters in the yyyy-MM-dd hh:mm:ss.[fff...] and {@code s} represents  the scale of the given Timestamp,
  * its fractional seconds precision.
  *</ul>
  *
@@ -158,13 +158,13 @@ public class Timestamp extends java.util.Date {
      * Converts a {@code String} object in JDBC timestamp escape format to a
      * {@code Timestamp} value.
      *
-     * @param s timestamp in format {@code yyyy-[m]m-[d]d hh:mm:ss[.f...]}.  The
-     * fractional seconds may be omitted. The leading zero for {@code mm}
+     * @param s timestamp in format {@code yyyy-[M]M-[d]d hh:mm:ss[.f...]}.  The
+     * fractional seconds may be omitted. The leading zero for {@code MM}
      * and {@code dd} may also be omitted.
      *
      * @return corresponding {@code Timestamp} value
      * @throws java.lang.IllegalArgumentException if the given argument
-     * does not have the format {@code yyyy-[m]m-[d]d hh:mm:ss[.f...]}
+     * does not have the format {@code yyyy-[M]M-[d]d hh:mm:ss[.f...]}
      */
     public static Timestamp valueOf(String s) {
         final int YEAR_LENGTH = 4;
@@ -185,7 +185,7 @@ public class Timestamp extends java.util.Date {
         int firstColon;
         int secondColon;
         int period;
-        String formatError = "Timestamp format must be yyyy-mm-dd hh:mm:ss[.fffffffff]";
+        String formatError = "Timestamp format must be yyyy-MM-dd hh:mm:ss[.fffffffff]";
 
         if (s == null) throw new java.lang.IllegalArgumentException("null string");
 
@@ -256,11 +256,11 @@ public class Timestamp extends java.util.Date {
 
     /**
      * Formats a timestamp in JDBC timestamp escape format.
-     *         {@code yyyy-mm-dd hh:mm:ss.fffffffff},
+     *         {@code yyyy-MM-dd hh:mm:ss.fffffffff},
      * where {@code fffffffff} indicates nanoseconds.
      *
      * @return a {@code String} object in
-     *           {@code yyyy-mm-dd hh:mm:ss.fffffffff} format
+     *           {@code yyyy-MM-dd hh:mm:ss.fffffffff} format
      */
     @SuppressWarnings("deprecation")
     public String toString() {


### PR DESCRIPTION
The PR fixes date format in javadocs by making use of big `M` letters for months

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8278943](https://bugs.openjdk.java.net/browse/JDK-8278943)

### Issue
 * [JDK-8278943](https://bugs.openjdk.java.net/browse/JDK-8278943): Improve dateformat in javadocs about the meaning of 'm' and 'M' ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6888/head:pull/6888` \
`$ git checkout pull/6888`

Update a local copy of the PR: \
`$ git checkout pull/6888` \
`$ git pull https://git.openjdk.java.net/jdk pull/6888/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6888`

View PR using the GUI difftool: \
`$ git pr show -t 6888`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6888.diff">https://git.openjdk.java.net/jdk/pull/6888.diff</a>

</details>
