### PR TITLE
8276694: Pattern trailing unescaped backslash causes internal error

### DIFF
--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -1795,6 +1795,8 @@ loop:   for(int x=0, offset=0; x<nCodePoints; x++, offset+=len) {
             if (patternLength != cursor) {
                 if (peek() == ')') {
                     throw error("Unmatched closing ')'");
+                } else if (cursor == patternLength + 1 && temp[patternLength - 1] == '\\') {
+                    throw error("Unescaped trailing backslash");
                 } else {
                     throw error("Unexpected internal error");
                 }

--- a/test/jdk/java/util/regex/RegExTest.java
+++ b/test/jdk/java/util/regex/RegExTest.java
@@ -35,7 +35,7 @@
  * 8151481 4867170 7080302 6728861 6995635 6736245 4916384 6328855 6192895
  * 6345469 6988218 6693451 7006761 8140212 8143282 8158482 8176029 8184706
  * 8194667 8197462 8184692 8221431 8224789 8228352 8230829 8236034 8235812
- * 8216332 8214245 8237599 8241055 8247546 8258259 8037397 8269753
+ * 8216332 8214245 8237599 8241055 8247546 8258259 8037397 8269753 8276694
  *
  * @library /test/lib
  * @library /lib/testlibrary/java/lang
@@ -4537,5 +4537,14 @@ public class RegExTest {
                 Pattern.compile(pattern));
         var sep = System.lineSeparator();
         assertTrue(e.getMessage().contains(sep + "\t ^"));
+    }
+
+    //This test is for 8276694
+    @Test
+    public static void unescapedBackslash() {
+        String pattern = "\\";
+        var e = expectThrows(PatternSyntaxException.class, () ->
+                Pattern.compile(pattern));
+        assertTrue(e.getMessage().contains("Unescaped trailing backslash"));
     }
 }


### PR DESCRIPTION
Could you please review the 8276694 bug fixes?

A message specific for this exception should be printed instead of an internal error. This fix adds a new check to output an appropriate exception message when the regular expression ends with an unescaped backslash. This fix also checks the position of the cursor to rule out other syntax errors at the middle position of the regular expression.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276694](https://bugs.openjdk.java.net/browse/JDK-8276694): Pattern trailing unescaped backslash causes internal error


### Reviewers
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6891/head:pull/6891` \
`$ git checkout pull/6891`

Update a local copy of the PR: \
`$ git checkout pull/6891` \
`$ git pull https://git.openjdk.java.net/jdk pull/6891/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6891`

View PR using the GUI difftool: \
`$ git pr show -t 6891`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6891.diff">https://git.openjdk.java.net/jdk/pull/6891.diff</a>

</details>
