### PR TITLE
8279043: Some Security Exception Messages Miss Spaces

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
@@ -1304,7 +1304,7 @@ abstract class GaloisCounterMode extends CipherSpi {
             // 'len' includes ibuffer data
             checkDataLength(len, tagLenBytes);
             if (dst.remaining() < len + tagLenBytes) {
-                throw new ShortBufferException("Output buffer too small, must" +
+                throw new ShortBufferException("Output buffer too small, must " +
                     "be at least " + (len + tagLenBytes) + " bytes long");
             }
 
@@ -1472,7 +1472,7 @@ abstract class GaloisCounterMode extends CipherSpi {
             }
 
             if (len - tagLenBytes > out.length - outOfs) {
-                throw new ShortBufferException("Output buffer too small, must" +
+                throw new ShortBufferException("Output buffer too small, must " +
                     "be at least " + (len - tagLenBytes) + " bytes long");
             }
 

--- a/src/java.base/share/classes/com/sun/crypto/provider/TlsKeyMaterialGenerator.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/TlsKeyMaterialGenerator.java
@@ -213,7 +213,7 @@ public final class TlsKeyMaterialGenerator extends KeyGeneratorSpi {
                 if (protocolVersion >= 0x0302) {
                     // TLS 1.1+
                     throw new RuntimeException(
-                            "Internal Error:  TLS 1.1+ should not be negotiating" +
+                            "Internal Error:  TLS 1.1+ should not be negotiating " +
                                     "exportable ciphersuites");
                 } else if (protocolVersion == 0x0301) {
                     // TLS 1.0

--- a/src/java.base/share/classes/javax/crypto/Cipher.java
+++ b/src/java.base/share/classes/javax/crypto/Cipher.java
@@ -340,7 +340,7 @@ public class Cipher {
                                            "format:" + transformation);
         }
         if ((parts[0] == null) || (parts[0].isEmpty())) {
-            throw new NoSuchAlgorithmException("Invalid transformation:" +
+            throw new NoSuchAlgorithmException("Invalid transformation: " +
                                    "algorithm not specified-"
                                    + transformation);
         }

--- a/src/java.base/share/classes/sun/security/pkcs/PKCS9Attribute.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS9Attribute.java
@@ -481,12 +481,12 @@ public class PKCS9Attribute implements DerEncoder {
                                   "attribute not supported.");
             // break unnecessary
         case 10:    // issuerAndserialNumber attribute -- not supported
-            throw new IOException("PKCS9 IssuerAndSerialNumber" +
+            throw new IOException("PKCS9 IssuerAndSerialNumber " +
                                   "attribute not supported.");
             // break unnecessary
         case 11:    // RSA DSI proprietary
         case 12:    // RSA DSI proprietary
-            throw new IOException("PKCS9 RSA DSI attributes" +
+            throw new IOException("PKCS9 RSA DSI attributes " +
                                   "11 and 12, not supported.");
             // break unnecessary
         case 13:    // S/MIME unused attribute
@@ -604,12 +604,12 @@ public class PKCS9Attribute implements DerEncoder {
                                   "attribute not supported.");
             // break unnecessary
         case 10:    // issuerAndserialNumber attribute -- not supported
-            throw new IOException("PKCS9 IssuerAndSerialNumber" +
+            throw new IOException("PKCS9 IssuerAndSerialNumber " +
                                   "attribute not supported.");
             // break unnecessary
         case 11:    // RSA DSI proprietary
         case 12:    // RSA DSI proprietary
-            throw new IOException("PKCS9 RSA DSI attributes" +
+            throw new IOException("PKCS9 RSA DSI attributes " +
                                   "11 and 12, not supported.");
             // break unnecessary
         case 13:    // S/MIME unused attribute

--- a/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
+++ b/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
@@ -635,7 +635,7 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
                         }
                     }
                 } else {
-                    throw new KeyStoreException("Private key is not encoded" +
+                    throw new KeyStoreException("Private key is not encoded " +
                                 "as PKCS#8");
                 }
 

--- a/src/java.base/share/classes/sun/security/rsa/RSAPadding.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAPadding.java
@@ -270,7 +270,7 @@ public final class RSAPadding {
      */
     public byte[] unpad(byte[] padded) throws BadPaddingException {
         if (padded.length != paddedSize) {
-            throw new BadPaddingException("Decryption error." +
+            throw new BadPaddingException("Decryption error. " +
                 "The padded array length (" + padded.length +
                 ") is not the specified padded size (" + paddedSize + ")");
         }

--- a/src/java.base/share/classes/sun/security/ssl/CertificateAuthoritiesExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/CertificateAuthoritiesExtension.java
@@ -211,7 +211,7 @@ final class CertificateAuthoritiesExtension {
             if (encodedCAs.isEmpty()) {
                 if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
                     SSLLogger.warning(
-                            "The number of CAs exceeds the maximum size" +
+                            "The number of CAs exceeds the maximum size " +
                             "of the certificate_authorities extension");
                 }
 

--- a/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
@@ -451,7 +451,7 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
             for (Constraint constraint : list) {
                 if (!constraint.permits(key)) {
                     if (debug != null) {
-                        debug.println("Constraints: failed key size" +
+                        debug.println("Constraints: failed key size " +
                                 "constraint check " + KeyUtil.getKeySize(key));
                     }
                     return false;

--- a/src/java.base/share/classes/sun/security/x509/PolicyConstraintsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/PolicyConstraintsExtension.java
@@ -154,7 +154,7 @@ implements CertAttrSet<String> {
 
             if (next.isContextSpecific(TAG_REQUIRE) && !next.isConstructed()) {
                 if (this.require != -1)
-                    throw new IOException("Duplicate requireExplicitPolicy" +
+                    throw new IOException("Duplicate requireExplicitPolicy " +
                           "found in the PolicyConstraintsExtension");
                 next.resetTag(DerValue.tag_Integer);
                 this.require = next.getInteger();
@@ -162,7 +162,7 @@ implements CertAttrSet<String> {
             } else if (next.isContextSpecific(TAG_INHIBIT) &&
                        !next.isConstructed()) {
                 if (this.inhibit != -1)
-                    throw new IOException("Duplicate inhibitPolicyMapping" +
+                    throw new IOException("Duplicate inhibitPolicyMapping " +
                           "found in the PolicyConstraintsExtension");
                 next.resetTag(DerValue.tag_Integer);
                 this.inhibit = next.getInteger();

--- a/src/java.base/share/classes/sun/security/x509/PolicyInformation.java
+++ b/src/java.base/share/classes/sun/security/x509/PolicyInformation.java
@@ -202,7 +202,7 @@ public class PolicyInformation {
             if (obj instanceof Set) {
                 for (Object obj1 : (Set<?>) obj) {
                     if (!(obj1 instanceof PolicyQualifierInfo)) {
-                        throw new IOException("Attribute value must be a" +
+                        throw new IOException("Attribute value must be a " +
                                     "Set of PolicyQualifierInfo objects.");
                     }
                 }

--- a/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5MechFactory.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5MechFactory.java
@@ -154,7 +154,7 @@ public final class Krb5MechFactory implements MechanismFactory {
                 sm.checkPermission(perm);
             } catch (SecurityException e) {
                 if (DEBUG) {
-                    System.out.println("Permission to initiate" +
+                    System.out.println("Permission to initiate " +
                         "kerberos init credential" + e.getMessage());
                 }
                 throw e;

--- a/test/jdk/com/sun/crypto/provider/Cipher/AEAD/GCMBufferTest.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AEAD/GCMBufferTest.java
@@ -258,7 +258,7 @@ public class GCMBufferTest implements Cloneable {
             // If incrementalSegments is enabled, run through that test only
             if (incremental) {
                 if (ops.size() < 2) {
-                    throw new Exception("To do incrementalSegments you must" +
+                    throw new Exception("To do incrementalSegments you must " +
                         "have more that 1 dtype in the list");
                 }
                 sizes = new int[ops.size()];

--- a/test/jdk/com/sun/crypto/provider/Cipher/AEAD/GCMShortBuffer.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AEAD/GCMShortBuffer.java
@@ -57,7 +57,7 @@ public class GCMShortBuffer {
         int r = c.doFinal(cipherText, 1, len, pt, 0);
         if (r != pt.length) {
             System.out.println(
-                "doFinal() return ( " + r + ") is not the same" +
+                "doFinal() return ( " + r + ") is not the same " +
                     "as getOutputSize returned" + pt.length);
             error = true;
         }

--- a/test/jdk/sun/security/provider/PolicyParser/PrincipalExpansionError.java
+++ b/test/jdk/sun/security/provider/PolicyParser/PrincipalExpansionError.java
@@ -110,7 +110,7 @@ public class PrincipalExpansionError {
                     ("PrincipalExpansionError test failed (file not found)");
                 java.io.FileNotFoundException fnfe =
                         (java.io.FileNotFoundException)e;
-                throw new SecurityException("PrincipalExpansionError" +
+                throw new SecurityException("PrincipalExpansionError " +
                         "test failed (file not found)");
             } else {
                 // i don't know???

--- a/test/jdk/sun/security/ssl/X509TrustManagerImpl/CacertsLimit.java
+++ b/test/jdk/sun/security/ssl/X509TrustManagerImpl/CacertsLimit.java
@@ -69,7 +69,7 @@ public class CacertsLimit {
                 throw new Exception(
                         "There are too many trusted CAs in cacerts. The " +
                         "certificate_authorities extension cannot be used " +
-                        "for TLS connections.  Please rethink about the size" +
+                        "for TLS connections.  Please rethink about the size " +
                         "of the cacerts, or have a release note for the " +
                         "impacted behaviors");
             } else if (sizeAccount > 0x4000) {

--- a/test/jdk/sun/security/tools/keytool/fakegen/jdk.crypto.ec/sun/security/ec/ECKeyPairGenerator.java
+++ b/test/jdk/sun/security/tools/keytool/fakegen/jdk.crypto.ec/sun/security/ec/ECKeyPairGenerator.java
@@ -71,7 +71,7 @@ public final class ECKeyPairGenerator extends KeyPairGeneratorSpi {
                 break;
             default:
                 throw new AssertionError("SunEC ECKeyPairGenerator" +
-                    "has been patched. Key size " + keySize +
+                    " has been patched. Key size " + keySize +
                     " is not supported");
         }
         ECParameterSpec ecParams = ECUtil.getECParameterSpec(null, keySize);


### PR DESCRIPTION
Trivial change. Issue reported by [lgtm.com](https://lgtm.com/projects/g/openjdk/jdk/alerts/?mode=tree&lang=java&ruleFocus=1952840153).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279043](https://bugs.openjdk.java.net/browse/JDK-8279043): Some Security Exception Messages Miss Spaces


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6894/head:pull/6894` \
`$ git checkout pull/6894`

Update a local copy of the PR: \
`$ git checkout pull/6894` \
`$ git pull https://git.openjdk.java.net/jdk pull/6894/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6894`

View PR using the GUI difftool: \
`$ git pr show -t 6894`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6894.diff">https://git.openjdk.java.net/jdk/pull/6894.diff</a>

</details>
