### PR TITLE
8277100: Dynamic dump can inadvertently overwrite default CDS archive

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3514,6 +3514,11 @@ void Arguments::init_shared_archive_paths() {
       vm_exit_during_initialization("-XX:ArchiveClassesAtExit cannot be used with -Xshare:dump");
     }
     check_unsupported_dumping_properties();
+
+    if (os::same_files((const char*)get_default_shared_archive_path(), ArchiveClassesAtExit)) {
+      vm_exit_during_initialization(
+        "Cannot specify the default CDS archive for -XX:ArchiveClassesAtExit", get_default_shared_archive_path());
+    }
   }
 
   if (SharedArchiveFile == nullptr) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DumpToDefaultArchive.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DumpToDefaultArchive.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8277100
+ * @summary VM should exit with an error message if the specified dynamic archive
+ *          is the same as the default CDS archive.
+ * @requires vm.cds
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. DumpToDefaultArchive
+ */
+
+import jdk.test.lib.helpers.ClassFileInstaller;
+import sun.hotspot.WhiteBox;
+
+public class DumpToDefaultArchive extends DynamicArchiveTestBase {
+
+    public static void main(String[] args) throws Exception {
+        runTest(DumpToDefaultArchive::doTest);
+    }
+
+    private static void doTest() throws Exception {
+        WhiteBox wb = WhiteBox.getWhiteBox();
+        String topArchiveName = wb.getDefaultArchivePath();
+
+        dump(topArchiveName,
+             "-Xlog:cds",
+             "-version")
+            .assertAbnormalExit(output -> {
+                    output.shouldContain("Cannot specify the default CDS archive for -XX:ArchiveClassesAtExit: "
+                        + topArchiveName);
+                });
+    }
+}


### PR DESCRIPTION
Please review this small fix for preventing the default CDS archive from being overwritten via the
-XX:ArchiveClassesAtExit VM option.

If the user sets the -XX:ArchiveClassesAtExit option pointing to the default CDS archive, VM will
exit with the following message:

`Cannot specify the default CDS archive for -XX:ArchiveClassesAtExit: <path to classes.jsa>`

Passed CI tiers 1 and 2 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277100](https://bugs.openjdk.java.net/browse/JDK-8277100): Dynamic dump can inadvertently overwrite default CDS archive


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6896/head:pull/6896` \
`$ git checkout pull/6896`

Update a local copy of the PR: \
`$ git checkout pull/6896` \
`$ git pull https://git.openjdk.java.net/jdk pull/6896/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6896`

View PR using the GUI difftool: \
`$ git pr show -t 6896`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6896.diff">https://git.openjdk.java.net/jdk/pull/6896.diff</a>

</details>
