### PR TITLE
8205187: javac/javadoc should not crash if no java.lang; crash message obsolete

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
@@ -356,8 +356,10 @@ public class TypeEnter implements Completer {
 
                 // Import-on-demand java.lang.
                 PackageSymbol javaLang = syms.enterPackage(syms.java_base, names.java_lang);
-                if (javaLang.members().isEmpty() && !javaLang.exists())
-                    throw new FatalError(diags.fragment(Fragments.FatalErrNoJavaLang));
+                if (javaLang.members().isEmpty() && !javaLang.exists()) {
+                    log.error(Errors.NoJavaLang);
+                    throw new Abort();
+                }
                 importAll(make.at(tree.pos()).Import(make.QualIdent(javaLang), false), javaLang, env);
 
                 JCModuleDecl decl = tree.getModuleDecl();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -1528,12 +1528,12 @@ compiler.err.locn.invalid.arg.for.xpatch=\
 compiler.err.file.sb.on.source.or.patch.path.for.module=\
     file should be on source path, or on patch path for module
 
+compiler.err.no.java.lang=\
+    Unable to find package java.lang in platform classes
+
 #####
 
 # Fatal Errors
-
-compiler.misc.fatal.err.no.java.lang=\
-    Fatal Error: Unable to find package java.lang in classpath or bootclasspath
 
 # 0: name
 compiler.misc.fatal.err.cant.locate.meth=\

--- a/test/langtools/tools/javac/diags/examples/NoJavaLang.java
+++ b/test/langtools/tools/javac/diags/examples/NoJavaLang.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,9 @@
  * questions.
  */
 
-// key: compiler.misc.fatal.err.no.java.lang
+// key: compiler.err.error
+// key: compiler.err.no.java.lang
+// key: compiler.misc.count.error
 // options: -source 8 -target 8 -Xbootclasspath: -classpath .
 // run: backdoor
 

--- a/test/langtools/tools/javac/fatalErrors/NoJavaLangTest.java
+++ b/test/langtools/tools/javac/fatalErrors/NoJavaLangTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4263768 4785453
+ * @bug 4263768 4785453 8205187
  * @summary Verify that the compiler does not crash when java.lang is not available
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -38,7 +38,7 @@ import toolbox.JavacTask;
 import toolbox.Task;
 import toolbox.ToolBox;
 
-public class NoJavaLangTest {
+public class NoJavaLangTest  {
 
     private static final String noJavaLangSrc =
         "public class NoJavaLang {\n" +
@@ -50,7 +50,8 @@ public class NoJavaLangTest {
         "}";
 
     private static final String compilerErrorMessage =
-        "Fatal Error: Unable to find package java.lang in classpath or bootclasspath";
+        "error: Unable to find package java.lang in platform classes\n" +
+        "1 error";
 
     public static void main(String[] args) throws Exception {
         new NoJavaLangTest().run();
@@ -90,7 +91,6 @@ public class NoJavaLangTest {
 
         Files.delete(Paths.get("modules", "java.base", "java", "lang", "Object.class"));
 
-        // ideally we'd have a better message for this case
         String[] mpOpts = { "--system", "none", "--module-path", "modules" };
         test(mpOpts, compilerErrorMessage);
     }
@@ -101,15 +101,13 @@ public class NoJavaLangTest {
         String out = new JavacTask(tb)
                 .options(options)
                 .sources(noJavaLangSrc)
-                .run(Task.Expect.FAIL, 3)
+                .run(Task.Expect.FAIL, 1)
                 .writeAll()
                 .getOutput(Task.OutputKind.DIRECT);
 
         if (!out.trim().equals(expect)) {
             throw new AssertionError("javac generated error output is not correct");
         }
-
-        System.err.println("OK");
     }
 
 }


### PR DESCRIPTION
Please review this PR which is basically changing the error message the compiler shows if the package java.lang can't be found, the current message is obsolete,

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8205187](https://bugs.openjdk.java.net/browse/JDK-8205187): javac/javadoc should not crash if no java.lang; crash message obsolete


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6898/head:pull/6898` \
`$ git checkout pull/6898`

Update a local copy of the PR: \
`$ git checkout pull/6898` \
`$ git pull https://git.openjdk.java.net/jdk pull/6898/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6898`

View PR using the GUI difftool: \
`$ git pr show -t 6898`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6898.diff">https://git.openjdk.java.net/jdk/pull/6898.diff</a>

</details>
