### PR TITLE
8279024: Remove javascript references from clhsdb.html

### DIFF
--- a/src/jdk.hotspot.agent/doc/clhsdb.html
+++ b/src/jdk.hotspot.agent/doc/clhsdb.html
@@ -10,25 +10,16 @@ Command line HSDB
 <p>
 When debugging remote core dumps it is easier to work with command line tools instead of
 GUI tools. Command line HSDB (CLHSDB) tool is alternative to SA GUI tool HSDB.
+CLHSDB is launched from the command line using the "jhsdb clhsdb" command.
 </p>
 
 <p>
-There is also JavaScript based SA command line interface called <a href="jsdb.html">jsdb</a>.
-But, CLHSDB supports Unix shell-like (or dbx/gdb-like) command line interface with
+CLHSDB supports Unix shell-like (or dbx/gdb-like) command line interface with
 support for output redirection/appending (familiar &gt;, &gt;&gt;), command history and so on.
 Each CLHSDB command can have zero or more arguments and optionally end with output redirection
 (or append) to a file. Commands may be stored in a file and run using <b>source</b> command.
 <b>help</b> command prints usage message for all supported commands (or a specific command)
 </p>
-
-<h3>Shell/batch scripts to run command line HSDB</h3>
-
-<ul>
-<li>clhsdbproc.sh
-<li>clhsdbproc64.sh
-<li>clhsdbwindbg.bat
-<li>clhsdbwindbg64.bat
-</ul>
 
 <h3>Annotated output of CLHSDB help command</h3>
 
@@ -62,8 +53,6 @@ Available commands:
   intConstant [ name [ value ] ] <font color="red">print out hotspot integer constant(s)</font>
   jdis address <font color="red">show bytecode disassembly of a given Method*</font>
   jhisto <font color="red">show Java heap histogram</font>
-  jseval script <font color="red">evaluate a given string as JavaScript code</font>
-  jsload file <font color="red">load and evaluate a JavaScript file</font>
   jstack [-v] <font color="red">show Java stack trace of all Java threads. -v is verbose mode</font>
   livenmethods <font color="red">show all live nmethods</font>
   longConstant [ name [ value ] ] <font color="red">print out hotspot long constant(s)s</font>
@@ -92,39 +81,6 @@ Available commands:
   versioncheck [ true | false ] <font color="red">turn on/off debuggee VM version check</font>
   whatis address <font color="red">print info about any arbitrary address</font>
   where { -a | id } <font color="red">print Java stack trace of given Java thread or all Java threads (-a)</font>
-</code>
-</pre>
-
-<h3>JavaScript integration</h3>
-
-<p>Few CLHSDB commands are already implemented in JavaScript. It is possible to extend CLHSDB command set
-by implementing more commands in a JavaScript file and by loading it by <b>jsload</b> command. <b>jseval</b>
-command may be used to evaluate arbitrary JavaScript expression from a string. Any JavaScript function
-may be exposed as a CLHSDB command by registering it using JavaScript <b><code>registerCommand</code></b>
-function. This function accepts command name, usage and name of the JavaScript implementation function
-as arguments.
-</p>
-
-<h3>Simple CLHSDB command implemented in JavaScript</h3>
-
-<b>File: test.js</b>
-<pre>
-<code>
-function helloImpl(name) {
-    println("hello, " + name);
-}
-
-// register the above JavaScript function as CLHSDB command
-registerCommand("hello", "hello name", "helloImpl");
-</code>
-</pre>
----------<br>
-
-"test.js" can be loaded in CLHSDB prompt using <b>jsload</b> command using
-
-<pre>
-<code>
-hsdb&gt; jsload test.js
 </code>
 </pre>
 

--- a/src/jdk.hotspot.agent/doc/index.html
+++ b/src/jdk.hotspot.agent/doc/index.html
@@ -35,8 +35,7 @@ of.
 
 <h3>Command line HSDB</h3>
 <p>
-There is also a command line HSDB variants ("clhsdbproc.sh" or "clhsdbwindbg.bat"
-or 64-bit variants).  More details on the command line interface can be found in
+There is also a command line HSDB variant.  More details on the command line interface can be found in:
 <ul>
 <li><a href="clhsdb.html">clhsdb.html</a>
 </ul> 

--- a/src/jdk.hotspot.agent/doc/index.html
+++ b/src/jdk.hotspot.agent/doc/index.html
@@ -35,13 +35,10 @@ of.
 
 <h3>Command line HSDB</h3>
 <p>
-There are also command line HSDB variants ("clhsdbproc.sh" or "clhsdbwindbg.bat"
-or 64-bit variants). There is also a JavaScript based command line interface
-called "jsdbproc.sh" [or "jsdbwindbg.bat" or 64-bit variants]. More details on 
-command line interfaces can be found in 
+There is also a command line HSDB variants ("clhsdbproc.sh" or "clhsdbwindbg.bat"
+or 64-bit variants).  More details on the command line interface can be found in
 <ul>
 <li><a href="clhsdb.html">clhsdb.html</a>
-<li><a href="jsdb.html">jsdb.html</a>
 </ul> 
 </p>
 


### PR DESCRIPTION
clhsdb no longer supports javascript. Remove some remaining references in the docs. I also removed some script references.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279024](https://bugs.openjdk.java.net/browse/JDK-8279024): Remove javascript references from clhsdb.html


### Reviewers
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6903/head:pull/6903` \
`$ git checkout pull/6903`

Update a local copy of the PR: \
`$ git checkout pull/6903` \
`$ git pull https://git.openjdk.java.net/jdk pull/6903/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6903`

View PR using the GUI difftool: \
`$ git pr show -t 6903`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6903.diff">https://git.openjdk.java.net/jdk/pull/6903.diff</a>

</details>
