### PR TITLE
8279022: JCmdTestFileSafety.java should check file time stamp for test result

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestFileSafety.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestFileSafety.java
@@ -95,7 +95,7 @@ public class JCmdTestFileSafety extends JCmdTestDumpBase {
         test(localFileName, pid, noBoot,  EXPECT_FAIL);
         FileTime ft2 = Files.getLastModifiedTime(Paths.get(localFileName));
         if (!ft2.equals(ft1)) {
-            throw new RuntimeException("Archive file " + localFileName + " should be created");
+            throw new RuntimeException("Archive file " + localFileName + " should not be updated");
         }
 
         if (fileLocal.exists()) {
@@ -124,7 +124,7 @@ public class JCmdTestFileSafety extends JCmdTestDumpBase {
         test(localFileName, pid, noBoot,  EXPECT_FAIL);
         ft2 = Files.getLastModifiedTime(Paths.get(localFileName));
         if (!ft2.equals(ft1)) {
-            throw new RuntimeException("Archive file " + localFileName + " should be created");
+            throw new RuntimeException("Archive file " + localFileName + " should not be updated");
         }
         app.stopApp();
         if (fileLocal.exists()) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestFileSafety.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestFileSafety.java
@@ -38,6 +38,9 @@
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.attribute.FileTime;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.apps.LingeredApp;
 import jdk.test.lib.Platform;
@@ -76,17 +79,29 @@ public class JCmdTestFileSafety extends JCmdTestDumpBase {
         outputDirFile.setWritable(true);
         String localFileName = subDir + File.separator + "MyStaticDump.jsa";
         setIsStatic(true/*static*/);
+        File fileLocal = new File(localFileName);
+        if (fileLocal.exists()) {
+            fileLocal.delete();
+        }
         // Set target dir not writable, do static dump
         print2ln(test_count++ + " Set target dir not writable, do static dump");
         setKeepArchive(true);
         app = createLingeredApp("-cp", allJars);
         pid = app.getPid();
         test(localFileName, pid, noBoot,  EXPECT_PASS);
+        checkFileExistence(localFileName, true/*exist*/);
+        FileTime ft1 = Files.getLastModifiedTime(Paths.get(localFileName));
         outputDirFile.setWritable(false);
         test(localFileName, pid, noBoot,  EXPECT_FAIL);
-        outputDirFile.setWritable(true);
-        checkFileExistence(localFileName, true/*exist*/);
+        FileTime ft2 = Files.getLastModifiedTime(Paths.get(localFileName));
+        if (!ft2.equals(ft1)) {
+            throw new RuntimeException("Archive file " + localFileName + " should be created");
+        }
 
+        if (fileLocal.exists()) {
+            fileLocal.delete();
+        }
+        outputDirFile.setWritable(true);
         // Illegal character in file name
         localFileName = "mystatic:.jsa";
         OutputAnalyzer output = test(localFileName, pid, noBoot,  EXPECT_FAIL);
@@ -103,18 +118,19 @@ public class JCmdTestFileSafety extends JCmdTestDumpBase {
         pid = app.getPid();
         localFileName = subDir + File.separator + "MyDynamicDump.jsa";
         test(localFileName, pid, noBoot,  EXPECT_PASS);
-        app.stopApp();
-        // cannot dynamically dump twice, restart
-        app = createLingeredApp("-cp", allJars, "-XX:+RecordDynamicDumpInfo");
-        pid = app.getPid();
+        checkFileExistence(localFileName, true/*exist*/);
+        ft1 = Files.getLastModifiedTime(Paths.get(localFileName));
         outputDirFile.setWritable(false);
         test(localFileName, pid, noBoot,  EXPECT_FAIL);
-        outputDirFile.setWritable(true);
+        ft2 = Files.getLastModifiedTime(Paths.get(localFileName));
+        if (!ft2.equals(ft1)) {
+            throw new RuntimeException("Archive file " + localFileName + " should be created");
+        }
         app.stopApp();
-        // MyDynamicDump.jsa should exist
-        checkFileExistence(localFileName, true);
-        File rmFile = new File(localFileName);
-        rmFile.delete();
+        if (fileLocal.exists()) {
+            fileLocal.delete();
+        }
+        outputDirFile.setWritable(true);
         outputDirFile.delete();
     }
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestFileSafety.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestFileSafety.java
@@ -64,6 +64,13 @@ public class JCmdTestFileSafety extends JCmdTestDumpBase {
         }
     }
 
+    private static void removeFile(String fileName) throws Exception {
+        File file = new File(fileName);
+        if (file.exists()) {
+            file.delete();
+        }
+    }
+
     static void test() throws Exception {
         buildJars();
 
@@ -78,11 +85,9 @@ public class JCmdTestFileSafety extends JCmdTestDumpBase {
         }
         outputDirFile.setWritable(true);
         String localFileName = subDir + File.separator + "MyStaticDump.jsa";
+        removeFile(localFileName);
+
         setIsStatic(true/*static*/);
-        File fileLocal = new File(localFileName);
-        if (fileLocal.exists()) {
-            fileLocal.delete();
-        }
         // Set target dir not writable, do static dump
         print2ln(test_count++ + " Set target dir not writable, do static dump");
         setKeepArchive(true);
@@ -97,11 +102,9 @@ public class JCmdTestFileSafety extends JCmdTestDumpBase {
         if (!ft2.equals(ft1)) {
             throw new RuntimeException("Archive file " + localFileName + " should not be updated");
         }
-
-        if (fileLocal.exists()) {
-            fileLocal.delete();
-        }
+        removeFile(localFileName);
         outputDirFile.setWritable(true);
+
         // Illegal character in file name
         localFileName = "mystatic:.jsa";
         OutputAnalyzer output = test(localFileName, pid, noBoot,  EXPECT_FAIL);
@@ -127,9 +130,7 @@ public class JCmdTestFileSafety extends JCmdTestDumpBase {
             throw new RuntimeException("Archive file " + localFileName + " should not be updated");
         }
         app.stopApp();
-        if (fileLocal.exists()) {
-            fileLocal.delete();
-        }
+        removeFile(localFileName);
         outputDirFile.setWritable(true);
         outputDirFile.delete();
     }


### PR DESCRIPTION
When test finished, the created archive file should be checked after  the first run for existence, and checked for time stamp after second run.  Since the file name is same, this method is more accurate than the existing checking, only checking the existence of the file. Since jcmd can do repeat dynamic dump to same java process now, removed unnecessary restart process code.

Tests: tier1, jtreg on local linux-x64.

Thanks
Yumin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279022](https://bugs.openjdk.java.net/browse/JDK-8279022): JCmdTestFileSafety.java should check file time stamp for test result


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6904/head:pull/6904` \
`$ git checkout pull/6904`

Update a local copy of the PR: \
`$ git checkout pull/6904` \
`$ git pull https://git.openjdk.java.net/jdk pull/6904/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6904`

View PR using the GUI difftool: \
`$ git pr show -t 6904`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6904.diff">https://git.openjdk.java.net/jdk/pull/6904.diff</a>

</details>
