### PR TITLE
8279060: Parallel: Remove unused PSVirtualSpace constructors

### DIFF
--- a/src/hotspot/share/gc/parallel/psVirtualspace.cpp
+++ b/src/hotspot/share/gc/parallel/psVirtualspace.cpp
@@ -37,14 +37,6 @@ PSVirtualSpace::PSVirtualSpace(ReservedSpace rs, size_t alignment) :
   DEBUG_ONLY(verify());
 }
 
-PSVirtualSpace::PSVirtualSpace(ReservedSpace rs) :
-  _alignment(os::vm_page_size())
-{
-  set_reserved(rs);
-  set_committed(reserved_low_addr(), reserved_low_addr());
-  DEBUG_ONLY(verify());
-}
-
 // Deprecated.
 PSVirtualSpace::PSVirtualSpace():
   _alignment(os::vm_page_size()),

--- a/src/hotspot/share/gc/parallel/psVirtualspace.hpp
+++ b/src/hotspot/share/gc/parallel/psVirtualspace.hpp
@@ -57,21 +57,9 @@ class PSVirtualSpace : public CHeapObj<mtGC> {
 
  public:
   PSVirtualSpace(ReservedSpace rs, size_t alignment);
-  PSVirtualSpace(ReservedSpace rs);
 
   ~PSVirtualSpace();
 
-  // Eventually all instances should be created with the above 1- or 2-arg
-  // constructors.  Then the 1st constructor below should become protected and
-  // the 2nd ctor and initialize() removed.
-  PSVirtualSpace(size_t alignment):
-    _alignment(alignment),
-    _reserved_low_addr(NULL),
-    _reserved_high_addr(NULL),
-    _committed_low_addr(NULL),
-    _committed_high_addr(NULL),
-    _special(false) {
-  }
   PSVirtualSpace();
   void initialize(ReservedSpace rs);
 


### PR DESCRIPTION
Trivial change of removing dead code.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279060](https://bugs.openjdk.java.net/browse/JDK-8279060): Parallel: Remove unused PSVirtualSpace constructors


### Reviewers
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6907/head:pull/6907` \
`$ git checkout pull/6907`

Update a local copy of the PR: \
`$ git checkout pull/6907` \
`$ git pull https://git.openjdk.java.net/jdk pull/6907/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6907`

View PR using the GUI difftool: \
`$ git pr show -t 6907`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6907.diff">https://git.openjdk.java.net/jdk/pull/6907.diff</a>

</details>
