### PR TITLE
8279063: Consolidate push and push_if_necessary in PreservedMarks

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
@@ -54,12 +54,10 @@ inline bool G1FullGCMarker::mark_object(oop obj) {
   }
 
   // Marked by us, preserve if needed.
-  markWord mark = obj->mark();
-  if (obj->mark_must_be_preserved(mark) &&
-      // It is not necessary to preserve marks for objects in regions we do not
-      // compact because we do not change their headers (i.e. forward them).
-      _collector->is_compacting(obj)) {
-    preserved_stack()->push(obj, mark);
+  if (_collector->is_compacting(obj)) {
+    // It is not necessary to preserve marks for objects in regions we do not
+    // compact because we do not change their headers (i.e. forward them).
+    preserved_stack()->push_if_necessary(obj, obj->mark());
   }
 
   // Check if deduplicatable string.

--- a/src/hotspot/share/gc/shared/preservedMarks.hpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.hpp
@@ -56,7 +56,6 @@ private:
 
 public:
   size_t size() const { return _stack.size(); }
-  inline void push(oop obj, markWord m);
   inline void push_if_necessary(oop obj, markWord m);
   // Iterate over the stack, restore all preserved marks, and
   // reclaim the memory taken up by the stack segments.

--- a/src/hotspot/share/gc/shared/preservedMarks.inline.hpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.inline.hpp
@@ -35,15 +35,10 @@ inline bool PreservedMarks::should_preserve_mark(oop obj, markWord m) const {
   return obj->mark_must_be_preserved(m);
 }
 
-inline void PreservedMarks::push(oop obj, markWord m) {
-  assert(should_preserve_mark(obj, m), "pre-condition");
-  OopAndMarkWord elem(obj, m);
-  _stack.push(elem);
-}
-
 inline void PreservedMarks::push_if_necessary(oop obj, markWord m) {
   if (should_preserve_mark(obj, m)) {
-    push(obj, m);
+    OopAndMarkWord elem(obj, m);
+    _stack.push(elem);
   }
 }
 

--- a/test/hotspot/gtest/gc/shared/test_preservedMarks.cpp
+++ b/test/hotspot/gtest/gc/shared/test_preservedMarks.cpp
@@ -68,8 +68,8 @@ TEST_VM(PreservedMarks, iterate_and_restore) {
   ASSERT_MARK_WORD_EQ(o2.mark(), FakeOop::changedMark());
 
   // Push o1 and o2 to have their marks preserved.
-  pm.push(o1.get_oop(), o1.mark());
-  pm.push(o2.get_oop(), o2.mark());
+  pm.push_if_necessary(o1.get_oop(), o1.mark());
+  pm.push_if_necessary(o2.get_oop(), o2.mark());
 
   // Fake a move from o1->o3 and o2->o4.
   o1.forward_to(o3.get_oop());


### PR DESCRIPTION
Simple change of cleaning up `PreservedMarks` API.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279063](https://bugs.openjdk.java.net/browse/JDK-8279063): Consolidate push and push_if_necessary in PreservedMarks


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6909/head:pull/6909` \
`$ git checkout pull/6909`

Update a local copy of the PR: \
`$ git checkout pull/6909` \
`$ git pull https://git.openjdk.java.net/jdk pull/6909/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6909`

View PR using the GUI difftool: \
`$ git pr show -t 6909`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6909.diff">https://git.openjdk.java.net/jdk/pull/6909.diff</a>

</details>
