### PR TITLE
8279115: Fix internal doc comment errors.

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/ConstructorWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/ConstructorWriter.java
@@ -74,7 +74,7 @@ public interface ConstructorWriter extends MemberWriter {
      * Add the preview output for the given member.
      *
      * @param member the member being documented
-     * @param annotationDocTree content tree to which the preview information will be added
+     * @param contentTree content tree to which the preview information will be added
      */
     void addPreview(ExecutableElement member, Content contentTree);
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/EnumConstantWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/EnumConstantWriter.java
@@ -79,7 +79,7 @@ public interface EnumConstantWriter extends MemberWriter {
      * Add the preview output for the given member.
      *
      * @param member the member being documented
-     * @param annotationDocTree content tree to which the preview information will be added
+     * @param contentTree content tree to which the preview information will be added
      */
     void addPreview(VariableElement member, Content contentTree);
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/MethodWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/MethodWriter.java
@@ -75,7 +75,7 @@ public interface MethodWriter extends MemberWriter {
      * Adds the preview output for the given member.
      *
      * @param member the member being documented
-     * @param annotationDocTree content tree to which the preview information will be added
+     * @param contentTree content tree to which the preview information will be added
      */
     void addPreview(ExecutableElement member, Content contentTree);
 


### PR DESCRIPTION
Please review a trivial fix to some internal comments, to remove some irritating errors when running javadoc on its own internal classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279115](https://bugs.openjdk.java.net/browse/JDK-8279115): Fix internal doc comment errors.


### Reviewers
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6913/head:pull/6913` \
`$ git checkout pull/6913`

Update a local copy of the PR: \
`$ git checkout pull/6913` \
`$ git pull https://git.openjdk.java.net/jdk pull/6913/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6913`

View PR using the GUI difftool: \
`$ git pr show -t 6913`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6913.diff">https://git.openjdk.java.net/jdk/pull/6913.diff</a>

</details>
