### PR TITLE
8279134: Fix Amazon copyright in various files

### DIFF
--- a/src/hotspot/cpu/aarch64/spin_wait_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/spin_wait_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Amazon.com Inc. or its affiliates. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1OldGenAllocationTracker.cpp
+++ b/src/hotspot/share/gc/g1/g1OldGenAllocationTracker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1OldGenAllocationTracker.hpp
+++ b/src/hotspot/share/gc/g1/g1OldGenAllocationTracker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitAArch64.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitAArch64.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Amazon.com Inc. or its affiliates. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitAArch64DefaultFlags.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitAArch64DefaultFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Amazon.com Inc. or its affiliates. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitNoneAArch64.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWaitNoneAArch64.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Amazon.com Inc. or its affiliates. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/Thread/TestSpinPause.java
+++ b/test/hotspot/jtreg/runtime/Thread/TestSpinPause.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Amazon.com Inc. or its affiliates. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,4 +84,3 @@ public class TestSpinPause {
         System.out.println("Done: " + test.valueHolder[0]);
     }
 }
-

--- a/test/hotspot/jtreg/serviceability/dcmd/compiler/CodeHeapAnalyticsMethodNames.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/compiler/CodeHeapAnalyticsMethodNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Amazon.com Inc. or its affiliates. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/io/File/LastModifiedTest.java
+++ b/test/jdk/java/io/File/LastModifiedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Amazon and/or its affiliates. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/security/KeyFactory/KeyFactoryGetKeySpecForInvalidSpec.java
+++ b/test/jdk/java/security/KeyFactory/KeyFactoryGetKeySpecForInvalidSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/security/pkcs11/rsa/TestP11KeyFactoryGetRSAKeySpec.java
+++ b/test/jdk/sun/security/pkcs11/rsa/TestP11KeyFactoryGetRSAKeySpec.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketShouldThrowSocketException.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketShouldThrowSocketException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Amazon and/or its affiliates. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/lang/ThreadOnSpinWait.java
+++ b/test/micro/org/openjdk/bench/java/lang/ThreadOnSpinWait.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Amazon.com Inc. or its affiliates. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/lang/ThreadOnSpinWaitProducerConsumer.java
+++ b/test/micro/org/openjdk/bench/java/lang/ThreadOnSpinWaitProducerConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Amazon.com Inc. or its affiliates. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This bug is similar to https://bugs.openjdk.java.net/browse/JDK-8244094

Currently, some of the files in the OpenJDK repo have Amazon copyright notices which are all slightly different and do not conform to Amazons preferred copyright notice which is simply (intentionally without copyright year):

"Copyright Amazon.com Inc. or its affiliates. All Rights Reserved." 

@simonis @phohensee

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279134](https://bugs.openjdk.java.net/browse/JDK-8279134): Fix Amazon copyright in various files


### Reviewers
 * [Xin Liu](https://openjdk.java.net/census#xliu) (@navyxliu - Committer) ⚠️ Review applies to cb05f5bb62e6073eb7a3fac0ad04ceb2f67df5ac
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**) ⚠️ Review applies to cb05f5bb62e6073eb7a3fac0ad04ceb2f67df5ac


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6915/head:pull/6915` \
`$ git checkout pull/6915`

Update a local copy of the PR: \
`$ git checkout pull/6915` \
`$ git pull https://git.openjdk.java.net/jdk pull/6915/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6915`

View PR using the GUI difftool: \
`$ git pr show -t 6915`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6915.diff">https://git.openjdk.java.net/jdk/pull/6915.diff</a>

</details>
