### PR TITLE
8279008: G1: Calculate BOT threshold on-the-fly during Object Copy phase 

### DIFF
--- a/src/hotspot/share/gc/g1/g1Allocator.cpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.cpp
@@ -301,10 +301,7 @@ G1PLABAllocator::G1PLABAllocator(G1Allocator* allocator) :
     _alloc_buffers[state] = NEW_C_HEAP_ARRAY(PLAB*, length, mtGC);
     size_t word_sz = _g1h->desired_plab_sz(state);
     for (uint node_index = 0; node_index < length; node_index++) {
-      // Specialized PLABs for old that handle BOT updates for object allocations.
-      _alloc_buffers[state][node_index] = (state == G1HeapRegionAttr::Old)
-                                        ? new G1BotUpdatingPLAB(word_sz)
-                                        : new PLAB(word_sz);
+      _alloc_buffers[state][node_index] = new PLAB(word_sz);
     }
   }
 }
@@ -364,7 +361,6 @@ HeapWord* G1PLABAllocator::allocate_direct_or_new_plab(G1HeapRegionAttr dest,
   // Try direct allocation.
   HeapWord* result = _allocator->par_allocate_during_gc(dest, word_sz, node_index);
   if (result != NULL) {
-    update_bot_for_direct_allocation(dest, result, word_sz);
     _direct_allocated[dest.type()] += word_sz;
   }
   return result;

--- a/src/hotspot/share/gc/g1/g1Allocator.hpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.hpp
@@ -145,22 +145,6 @@ public:
                                    uint node_index);
 };
 
-// Specialized PLAB for old generation promotions. For old regions the
-// BOT needs to be updated and the relevant data to do this efficiently
-// is stored in the PLAB.
-class G1BotUpdatingPLAB : public PLAB {
-  // An object spanning this threshold will cause a BOT update.
-  HeapWord* _next_bot_threshold;
-  // The region in which the PLAB resides.
-  HeapRegion* _region;
-public:
-  G1BotUpdatingPLAB(size_t word_sz) : PLAB(word_sz) { }
-  // Sets the new PLAB buffer as well as updates the threshold and region.
-  void set_buf(HeapWord* buf, size_t word_sz) override;
-  // Updates the BOT if the last allocation crossed the threshold.
-  inline void update_bot(size_t word_sz);
-};
-
 // Manages the PLABs used during garbage collection. Interface for allocation from PLABs.
 // Needs to handle multiple contexts, extra alignment in any "survivor" area and some
 // statistics.
@@ -181,17 +165,10 @@ private:
   inline PLAB* alloc_buffer(G1HeapRegionAttr dest, uint node_index) const;
   inline PLAB* alloc_buffer(region_type_t dest, uint node_index) const;
 
-  // Helpers to do explicit BOT updates for allocations in old generation regions.
-  void update_bot_for_direct_allocation(G1HeapRegionAttr attr, HeapWord* addr, size_t size);
-
   // Returns the number of allocation buffers for the given dest.
   // There is only 1 buffer for Old while Young may have multiple buffers depending on
   // active NUMA nodes.
   inline uint alloc_buffers_length(region_type_t dest) const;
-
-  // Returns if BOT updates are needed for the given destinaion. Currently we only have
-  // two destinations and BOT updates are only needed for the old generation.
-  inline bool needs_bot_update(G1HeapRegionAttr dest) const;
 
   bool may_throw_away_buffer(size_t const allocation_word_sz, size_t const buffer_size) const;
 public:
@@ -220,9 +197,6 @@ public:
                             size_t word_sz,
                             bool* refill_failed,
                             uint node_index);
-
-  // Update the BOT for the last PLAB allocation.
-  inline void update_bot_for_plab_allocation(G1HeapRegionAttr dest, size_t word_sz, uint node_index);
 
   void undo_allocation(G1HeapRegionAttr dest, HeapWord* obj, size_t word_sz, uint node_index);
 };

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -164,8 +164,7 @@ public:
 
   void verify() const;
 
-  // Given an address calculate where the next threshold needing an update is.
-  inline HeapWord* threshold_for_addr(const void* addr);
+  inline HeapWord* align_up_by_card_size(HeapWord* const addr) const;
 
   // Returns the address of the start of the block containing "addr", or
   // else "null" if it is covered by no block.  (May have side effects,

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
@@ -31,7 +31,7 @@
 #include "gc/shared/memset_with_concurrent_readers.hpp"
 #include "runtime/atomic.hpp"
 
-inline HeapWord* G1BlockOffsetTablePart::align_up_by_card_size(HeapWord* const addr) const{
+inline HeapWord* G1BlockOffsetTablePart::align_up_by_card_size(HeapWord* const addr) const {
   assert(addr >= _hr->bottom() && addr < _hr->top(), "invalid address");
   return align_up(addr, BOTConstants::card_size());
 }

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
@@ -31,18 +31,9 @@
 #include "gc/shared/memset_with_concurrent_readers.hpp"
 #include "runtime/atomic.hpp"
 
-inline HeapWord* G1BlockOffsetTablePart::threshold_for_addr(const void* addr) {
+inline HeapWord* G1BlockOffsetTablePart::align_up_by_card_size(HeapWord* const addr) const{
   assert(addr >= _hr->bottom() && addr < _hr->top(), "invalid address");
-  size_t index = _bot->index_for(addr);
-  HeapWord* card_boundary = _bot->address_for_index(index);
-  // Address at card boundary, use as threshold.
-  if (card_boundary == addr) {
-    return card_boundary;
-  }
-
-  // Calculate next threshold.
-  HeapWord* threshold = card_boundary + BOTConstants::card_size_in_words();
-  return threshold;
+  return align_up(addr, BOTConstants::card_size());
 }
 
 inline HeapWord* G1BlockOffsetTablePart::block_start(const void* addr) {

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -434,6 +434,12 @@ void G1ParScanThreadState::undo_allocation(G1HeapRegionAttr dest_attr,
   _plab_allocator->undo_allocation(dest_attr, obj_ptr, word_sz, node_index);
 }
 
+void G1ParScanThreadState::update_bot_after_copying(oop obj, size_t word_sz) {
+  HeapWord* obj_start = cast_from_oop<HeapWord*>(obj);
+  HeapRegion* region = _g1h->heap_region_containing(obj_start);
+  region->update_bot_if_crossing_boundary(obj_start, word_sz);
+}
+
 // Private inline function, for direct internal use and providing the
 // implementation of the public not-inline function.
 MAYBE_INLINE_EVACUATION
@@ -506,7 +512,7 @@ oop G1ParScanThreadState::do_copy_to_survivor_space(G1HeapRegionAttr const regio
       // Currently we only have two destinations and we only need BOT updates for
       // old. If the current allocation was done outside the PLAB this call will
       // have no effect since the _top of the PLAB has not changed.
-      _plab_allocator->update_bot_for_plab_allocation(dest_attr, word_sz, node_index);
+      update_bot_after_copying(obj, word_sz);
     }
 
     // Most objects are not arrays, so do one array check rather than

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -509,9 +509,6 @@ oop G1ParScanThreadState::do_copy_to_survivor_space(G1HeapRegionAttr const regio
       }
       _age_table.add(age, word_sz);
     } else {
-      // Currently we only have two destinations and we only need BOT updates for
-      // old. If the current allocation was done outside the PLAB this call will
-      // have no effect since the _top of the PLAB has not changed.
       update_bot_after_copying(obj, word_sz);
     }
 

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
@@ -169,6 +169,8 @@ private:
                        size_t word_sz,
                        uint node_index);
 
+  void update_bot_after_copying(oop obj, size_t word_sz);
+
   oop do_copy_to_survivor_space(G1HeapRegionAttr region_attr,
                                 oop obj,
                                 markWord old_mark);

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -815,7 +815,7 @@ void HeapRegion::object_iterate(ObjectClosure* blk) {
 void HeapRegion::fill_with_dummy_object(HeapWord* address, size_t word_size, bool zap) {
   // Keep the BOT in sync for old generation regions.
   if (is_old()) {
-    update_bot_at(address, word_size);
+    update_bot_if_crossing_boundary(address, word_size);
   }
   // Fill in the object.
   CollectedHeap::fill_with_object(address, word_size, zap);

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -163,13 +163,8 @@ public:
   inline HeapWord* allocate(size_t word_size);
   inline HeapWord* allocate(size_t min_word_size, size_t desired_word_size, size_t* actual_size);
 
-  // Update the BOT for the given address if it crosses the next
-  // BOT threshold at or after obj_start.
-  inline void update_bot_at(HeapWord* obj_start, size_t obj_size);
-  // Update BOT at the given threshold for the given object. The
-  // given object must cross the threshold.
-  inline void update_bot_crossing_threshold(HeapWord** threshold, HeapWord* obj_start, HeapWord* obj_end);
-  inline HeapWord* bot_threshold_for_addr(const void* addr);
+  // Update BOT if this obj is the first entering a new card (i.e. crossing the card boundary).
+  inline void update_bot_if_crossing_boundary(HeapWord* obj_start, size_t obj_size);
 
   // Full GC support methods.
 

--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -248,7 +248,11 @@ inline void HeapRegion::update_bot_if_crossing_boundary(HeapWord* obj_start, siz
   bool cross_card_boundary = (obj_end > cur_card_boundary);
 
   if (cross_card_boundary) {
-    _bot_part.alloc_block_work(&cur_card_boundary, obj_start, obj_end);
+    // Creating a dummy variable inside this `if` as the arg of `&`; this
+    // avoids unnecessary loads in the assembly code on the fast path (the
+    // bot-not-updating case).
+    HeapWord* dummy = cur_card_boundary;
+    _bot_part.alloc_block_work(&dummy, obj_start, obj_end);
   }
 }
 

--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -232,32 +232,23 @@ inline HeapWord* HeapRegion::allocate(size_t min_word_size,
   return allocate_impl(min_word_size, desired_word_size, actual_word_size);
 }
 
-inline HeapWord* HeapRegion::bot_threshold_for_addr(const void* addr) {
-  HeapWord* threshold = _bot_part.threshold_for_addr(addr);
-  assert(threshold >= addr,
-         "threshold must be at or after given address. " PTR_FORMAT " >= " PTR_FORMAT,
-         p2i(threshold), p2i(addr));
-  assert(is_old(),
-         "Should only calculate BOT threshold for old regions. addr: " PTR_FORMAT " region:" HR_FORMAT,
-         p2i(addr), HR_FORMAT_PARAMS(this));
-  return threshold;
-}
-
-inline void HeapRegion::update_bot_crossing_threshold(HeapWord** threshold, HeapWord* obj_start, HeapWord* obj_end) {
+inline void HeapRegion::update_bot_if_crossing_boundary(HeapWord* obj_start, size_t obj_size) {
   assert(is_old(), "should only do BOT updates for old regions");
+
+  HeapWord* obj_end   = obj_start + obj_size;
+
   assert(is_in(obj_start), "obj_start must be in this region: " HR_FORMAT
-         " obj_start " PTR_FORMAT " obj_end " PTR_FORMAT " threshold " PTR_FORMAT,
+         " obj_start " PTR_FORMAT " obj_end " PTR_FORMAT,
          HR_FORMAT_PARAMS(this),
-         p2i(obj_start), p2i(obj_end), p2i(*threshold));
-  _bot_part.alloc_block_work(threshold, obj_start, obj_end);
-}
+         p2i(obj_start), p2i(obj_end));
 
-inline void HeapRegion::update_bot_at(HeapWord* obj_start, size_t obj_size) {
-  HeapWord* threshold = bot_threshold_for_addr(obj_start);
-  HeapWord* obj_end = obj_start + obj_size;
+  HeapWord* cur_card_boundary = _bot_part.align_up_by_card_size(obj_start);
 
-  if (obj_end > threshold) {
-    update_bot_crossing_threshold(&threshold, obj_start, obj_end);
+  // strictly greater-than
+  bool cross_card_boundary = (obj_end > cur_card_boundary);
+
+  if (cross_card_boundary) {
+    _bot_part.alloc_block_work(&cur_card_boundary, obj_start, obj_end);
   }
 }
 

--- a/src/hotspot/share/gc/shared/plab.hpp
+++ b/src/hotspot/share/gc/shared/plab.hpp
@@ -116,7 +116,7 @@ public:
   }
 
   // Sets the space of the buffer to be [buf, space+word_sz()).
-  virtual void set_buf(HeapWord* buf, size_t new_word_sz) {
+  void set_buf(HeapWord* buf, size_t new_word_sz) {
     assert(new_word_sz > AlignmentReserve, "Too small");
     _word_sz = new_word_sz;
 


### PR DESCRIPTION
Simple change of unifying BOT logic for PLAB and direct allocation during GC.

Test: tier1-6; no difference observed while running BigRamTester, SPECjbb2015

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279008](https://bugs.openjdk.java.net/browse/JDK-8279008): G1: Calculate BOT threshold on-the-fly during Object Copy phase


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 962d3398e9855f7b1b0066db5b38924339388fb5
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6916/head:pull/6916` \
`$ git checkout pull/6916`

Update a local copy of the PR: \
`$ git checkout pull/6916` \
`$ git pull https://git.openjdk.java.net/jdk pull/6916/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6916`

View PR using the GUI difftool: \
`$ git pr show -t 6916`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6916.diff">https://git.openjdk.java.net/jdk/pull/6916.diff</a>

</details>
