### PR TITLE
8279057: Consolidate InstructionPrinter::do_BlockBegin and remove extra lines in logs of blocks with phi functions

### DIFF
--- a/src/hotspot/share/c1/c1_InstructionPrinter.cpp
+++ b/src/hotspot/share/c1/c1_InstructionPrinter.cpp
@@ -628,7 +628,7 @@ void InstructionPrinter::do_BlockBegin(BlockBegin* x) {
     return;
   }
 
-  // print values in locals
+  // print values in locals related to phi functions
   ValueStack* state = x->state();
   bool printed_phis_in_locals_header = false;
   do {
@@ -636,7 +636,7 @@ void InstructionPrinter::do_BlockBegin(BlockBegin* x) {
       Value v = state->local_at(i);
       if (v && is_phi_of_block(v, x)) {
         if (!printed_phis_in_locals_header) {
-          output()->cr(); output()->print("Locals:");
+          output()->cr(); output()->print("Values in locals related to phi functions:");
           printed_phis_in_locals_header = true;
         }
         output()->cr(); print_phi(i, v, x);
@@ -649,7 +649,7 @@ void InstructionPrinter::do_BlockBegin(BlockBegin* x) {
     state = state->caller_state();
   } while (state != NULL);
 
-  // print values on stack
+  // print values on stack related to phi functions
   state = x->state();
   bool printed_phis_in_stack_header = false;
   int i = 0;
@@ -658,7 +658,7 @@ void InstructionPrinter::do_BlockBegin(BlockBegin* x) {
     Value v = state->stack_at_inc(i);
     if (v && is_phi_of_block(v, x)) {
       if (!printed_phis_in_stack_header) {
-        output()->cr(); output()->print("Stack:");
+        output()->cr(); output()->print("Values on stack related to phi functions:");
         printed_phis_in_stack_header = true;
       }
       output()->cr(); print_phi(o, v, x);


### PR DESCRIPTION
This pr does following things:
 - First, the code related to printing phi in InstructionPrinter::do_BlockBegin is bit redudant, it could be consolidated;
 - Second, only locals and stack values related to phi functions are printed out now.
 - Third, there are extra blank lines in printed log of blocks with phi functions, these blank lines are better to be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8279057](https://bugs.openjdk.java.net/browse/JDK-8279057): Consolidate InstructionPrinter::do_BlockBegin and remove extra lines in logs of blocks with phi functions


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6921/head:pull/6921` \
`$ git checkout pull/6921`

Update a local copy of the PR: \
`$ git checkout pull/6921` \
`$ git pull https://git.openjdk.java.net/jdk pull/6921/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6921`

View PR using the GUI difftool: \
`$ git pr show -t 6921`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6921.diff">https://git.openjdk.java.net/jdk/pull/6921.diff</a>

</details>
