### PR TITLE
8279194: Add Annotated Memory Viewer feature to SA's HSDB

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HSDB.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HSDB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HSDB.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HSDB.java
@@ -337,6 +337,15 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
     item.setMnemonic(KeyEvent.VK_M);
     toolsMenu.add(item);
 
+    item = createMenuItem("Annotated Memory Viewer",
+                          new ActionListener() {
+                             public void actionPerformed(ActionEvent e) {
+                                showAnnotatedMemoryViewer();
+                             }
+                          });
+    item.setMnemonic(KeyEvent.VK_W);
+    toolsMenu.add(item);
+
     item = createMenuItem("Monitor Cache Dump",
                           new ActionListener() {
                               public void actionPerformed(ActionEvent e) {
@@ -1611,7 +1620,11 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
   }
 
   public void showMemoryViewer() {
-    showPanel("Memory Viewer", new MemoryViewer(agent.getDebugger(), agent.getTypeDataBase().getAddressSize() == 8));
+    showPanel("Memory Viewer", new MemoryViewer(agent.getDebugger(), false, agent.getTypeDataBase().getAddressSize() == 8));
+  }
+
+  public void showAnnotatedMemoryViewer() {
+    showPanel("Annotated Memory Viewer", new MemoryViewer(agent.getDebugger(), true, agent.getTypeDataBase().getAddressSize() == 8));
   }
 
   public void showCommandLineFlags() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MemoryPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MemoryPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MemoryPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MemoryPanel.java
@@ -104,7 +104,7 @@ public class MemoryPanel extends JPanel {
           return numVisibleRows;
         }
         public int getColumnCount() {
-            return isAnnotated ? 1 : 2;
+          return isAnnotated ? 1 : 2;
         }
         public Object getValueAt(int row, int column) {
           // When not annotated, we just display the address followed by its contents in two

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MemoryPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MemoryPanel.java
@@ -27,7 +27,9 @@ package sun.jvm.hotspot.ui;
 import java.awt.*;
 import java.awt.datatransfer.*;
 import java.awt.event.*;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.math.*;
 import java.util.*;
 import javax.swing.*;
@@ -35,9 +37,12 @@ import javax.swing.event.*;
 import javax.swing.table.*;
 import sun.jvm.hotspot.debugger.*;
 import sun.jvm.hotspot.ui.*;
+import sun.jvm.hotspot.utilities.PointerFinder;
+import sun.jvm.hotspot.utilities.PointerLocation;
 
 public class MemoryPanel extends JPanel {
   private boolean is64Bit;
+  private boolean isAnnotated;
   private Debugger debugger;
   private int addressSize;
   private String unmappedAddrString;
@@ -78,10 +83,11 @@ public class MemoryPanel extends JPanel {
     }
   }
 
-  public MemoryPanel(final Debugger debugger, boolean is64Bit) {
+  public MemoryPanel(final Debugger debugger, boolean isAnnotated, boolean is64Bit) {
     super();
     this.debugger = debugger;
     this.is64Bit = is64Bit;
+    this.isAnnotated = isAnnotated;
     if (is64Bit) {
       addressSize = 8;
       unmappedAddrString = "??????????????????";
@@ -98,23 +104,59 @@ public class MemoryPanel extends JPanel {
           return numVisibleRows;
         }
         public int getColumnCount() {
-          return 2;
+            return isAnnotated ? 1 : 2;
         }
         public Object getValueAt(int row, int column) {
-          switch (column) {
-          case 0:  return bigIntToHexString(startVal.add(new BigInteger(Integer.toString((row * addressSize)))));
-          case 1: {
-            try {
-              Address addr = bigIntToAddress(startVal.add(new BigInteger(Integer.toString((row * addressSize)))));
-              if (addr != null) {
-                return addressToString(addr.getAddressAt(0));
+          // When not annotated, we just display the address followed by its contents in two
+          // separate columns. When annotated the format is just one column which contains:
+          //   <address>: <contents> <PointerFinder output>
+          // For example:
+          //   0x00007f7eb010c330: 0x00007f7eb6c9dfb0 vtable for os::PlatformMonitor + 0x10
+          if (!isAnnotated) {
+            switch (column) {
+            case 0:  return bigIntToHexString(startVal.add(new BigInteger(Integer.toString((row * addressSize)))));
+            case 1: {
+              try {
+                Address addr = bigIntToAddress(startVal.add(new BigInteger(Integer.toString((row * addressSize)))));
+                if (addr != null) {
+                  return addressToString(addr.getAddressAt(0));
+                }
+                return unmappedAddrString;
+              } catch (UnmappedAddressException e) {
+                return unmappedAddrString;
               }
-              return unmappedAddrString;
-            } catch (UnmappedAddressException e) {
-              return unmappedAddrString;
             }
-          }
-          default: throw new RuntimeException("Column " + column + " out of bounds");
+            default: throw new RuntimeException("Column " + column + " out of bounds");
+            }
+          } else {
+            switch (column) {
+            case 0: {
+              String col1;
+              String col2 = unmappedAddrString;
+              String col3 = "";
+              BigInteger bigaddr = startVal.add(new BigInteger(Integer.toString((row * addressSize))));
+              Address addr = bigIntToAddress(bigaddr);
+
+              col1 = bigIntToHexString(bigaddr);
+
+              if (addr != null) {
+                try {
+                  col2 = addressToString(addr.getAddressAt(0));
+                  PointerLocation loc = PointerFinder.find(addr.getAddressAt(0));
+                  if (!loc.isUnknown()) {
+                    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                    PrintStream tty = new PrintStream(bos);
+                    loc.printOn(tty, false, false);
+                    col3 = bos.toString();
+                  }
+                } catch (UnmappedAddressException e) {
+                }
+              }
+
+              return col1 + ": " + col2 + " " + col3;
+            }
+            default: throw new RuntimeException("Column " + column + " out of bounds");
+            }
           }
         }
         public boolean isCellEditable(int row, int col) {
@@ -198,6 +240,15 @@ public class MemoryPanel extends JPanel {
         private void handleImport(JComponent c, String str) {
           // do whatever you want with the string here
           try {
+            // If someone drag-n-dropped a selection from the Annotated Memory Viewer,
+            // window, it will look like this:
+            //   0x00007f7eb010c330: 0x00007f7eb6c9dfb0 vtable for os::PlatformMonitor + 0x10
+            // We need to grab the second address.
+            int secondAddrStartIndex = str.indexOf("0x", 2);
+            if (secondAddrStartIndex != -1) {
+              str = str.substring(secondAddrStartIndex);
+              str = str.split("\\s")[0];
+            }
             makeVisible(debugger.parseAddress(str));
             clearSelection();
             table.clearSelection();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MemoryPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MemoryPanel.java
@@ -131,13 +131,12 @@ public class MemoryPanel extends JPanel {
           } else {
             switch (column) {
             case 0: {
-              String col1;
-              String col2 = unmappedAddrString;
-              String col3 = "";
               BigInteger bigaddr = startVal.add(new BigInteger(Integer.toString((row * addressSize))));
               Address addr = bigIntToAddress(bigaddr);
 
-              col1 = bigIntToHexString(bigaddr);
+              String col1 = bigIntToHexString(bigaddr);
+              String col2 = unmappedAddrString;
+              String col3 = "";
 
               if (addr != null) {
                 try {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MemoryViewer.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MemoryViewer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,9 +33,9 @@ import sun.jvm.hotspot.debugger.*;
     address. */
 
 public class MemoryViewer extends JPanel {
-  public MemoryViewer(final Debugger debugger, boolean is64Bit) {
+  public MemoryViewer(final Debugger debugger, boolean isAnnotated, boolean is64Bit) {
     super();
-    final MemoryPanel memory = new MemoryPanel(debugger, is64Bit);
+    final MemoryPanel memory = new MemoryPanel(debugger, isAnnotated, is64Bit);
     memory.setBorder(GraphicsUtilities.newBorder(5));
     JPanel addressPanel = new JPanel();
     addressPanel.setLayout(new BoxLayout(addressPanel, BoxLayout.X_AXIS));

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MemoryViewer.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MemoryViewer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
HSDB has a Memory Viewer feature that brings up a window that shows the memory contents in a specific address range. It basically looks just like the clhsdb "mem" output. The recently revived "mem" command (see [JDK-824466](https://bugs.openjdk.java.net/browse/JDK-8244669) and PR #6902) adds a -v options which causes PointerFinder (aka findpc) to be called on each value in memory to provide details about what the value points to (if it is an address). This PR adds this same feature to HSDB by adding a new Annotated Memory Viewer window. See the [this image](https://bugs.openjdk.java.net/secure/attachment/97439/memory_viewer.png) which shows the current Memory Viewer window, and just below it the new Annotated Memory Viewer window showing the same address range. 

A couple of implementation notes. Both types of memory viewers share the MemoryPanel class. The traditional viewer uses two columns, one for the  address and one for its contents. The annotated viewer uses just one column which contains the entire line. For example:

  0x00007f7eb010c330: 0x00007f7eb6c9dfb0 vtable for os::PlatformMonitor + 0x10

This approach was chosen rather than using 3 columns because it was a difficult to get the first two columns to be just wide enough for the 64-bit values while having the 3rd column be a long line of text. You end up with a lot of wasted space in the first two columns as you make the window wider while trying to get all the text of the 3rd column into view.

Regarding the changes in MemoryPanel.handleImport(), Memory Viewer supports clicking on a value that's an address and dragging it back onto the window to start displaying memory at that address. This dropped text ends up being processed by MemoryPanel.handleImport(). When you try this with Annotated Memory Viewer, you end up with the entire line being passed to MemoryPanel.handleImport(), not just an address (one downside of going with just 1 column instead of 3). So the changes in MemoryPanel.handleImport() detect this and pull the desired address out of the string.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279194](https://bugs.openjdk.java.net/browse/JDK-8279194): Add Annotated Memory Viewer feature to SA's HSDB


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Yasumasa Suenaga](https://openjdk.java.net/census#ysuenaga) (@YaSuenag - **Reviewer**) ⚠️ Review applies to bc91a67eda58fe4a553afceb1d779e602a28b7ea


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6923/head:pull/6923` \
`$ git checkout pull/6923`

Update a local copy of the PR: \
`$ git checkout pull/6923` \
`$ git pull https://git.openjdk.java.net/jdk pull/6923/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6923`

View PR using the GUI difftool: \
`$ git pr show -t 6923`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6923.diff">https://git.openjdk.java.net/jdk/pull/6923.diff</a>

</details>
