### PR TITLE
8272746: ZipFile can't open big file (NegativeArraySizeException)

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -1497,6 +1497,9 @@ public class ZipFile implements ZipConstants, Closeable {
                     zerror("invalid END header (bad central directory offset)");
                 }
                 // read in the CEN and END
+                if (end.cenlen + ENDHDR >= Integer.MAX_VALUE) {
+                    zerror("invalid END header (too large central directory size)");
+                }
                 cen = this.cen = new byte[(int)(end.cenlen + ENDHDR)];
                 if (readFullyAt(cen, 0, cen.length, cenpos) != end.cenlen + ENDHDR) {
                     zerror("read CEN tables failed");

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -1498,7 +1498,7 @@ public class ZipFile implements ZipConstants, Closeable {
                 }
                 // read in the CEN and END
                 if (end.cenlen + ENDHDR >= Integer.MAX_VALUE) {
-                    zerror("invalid END header (too large central directory size)");
+                    zerror("invalid END header (central directory size too large)");
                 }
                 cen = this.cen = new byte[(int)(end.cenlen + ENDHDR)];
                 if (readFullyAt(cen, 0, cen.length, cenpos) != end.cenlen + ENDHDR) {

--- a/test/jdk/java/util/zip/ZipFile/TestTooManyEntries.java
+++ b/test/jdk/java/util/zip/ZipFile/TestTooManyEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,11 @@
  * @bug 8272746
  * @summary ZipFile can't open big file (NegativeArraySizeException)
  * @requires (sun.arch.data.model == "64" & os.maxMemory > 8g)
- * @run main/othervm/timeout=3600 -Xmx8g TestTooManyEntries
+ * @run testng/manual/othervm -Xmx8g TestTooManyEntries
  */
+
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.BufferedOutputStream;
@@ -37,41 +40,39 @@ import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 import java.util.UUID;
 
+import static org.testng.Assert.assertThrows;
+
 public class TestTooManyEntries {
-    public static void main(String[] args) throws Exception {
-        boolean passed = false;
-        File hugeZipFile = File.createTempFile("hugeZip", ".zip", new File("."));
+    private static final int DIR_COUNT = 25000;
+    private static final int ENTRIES_IN_DIR = 1000;
+
+    private File hugeZipFile;
+
+    @BeforeTest
+    public void setup() throws Exception {
+        hugeZipFile = File.createTempFile("hugeZip", ".zip", new File("."));
         hugeZipFile.deleteOnExit();
         long startTime = System.currentTimeMillis();
         try (ZipOutputStream zip = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(hugeZipFile)))) {
-            int dirCount = 25_000;
             long nextLog = System.currentTimeMillis();
-            for (int dirN = 0; dirN < dirCount; dirN++) {
+            for (int dirN = 0; dirN < DIR_COUNT; dirN++) {
                 String dirName = UUID.randomUUID() + "/";
-                for (int fileN = 0; fileN < 1_000; fileN++) {
+                for (int fileN = 0; fileN < ENTRIES_IN_DIR; fileN++) {
                     ZipEntry entry = new ZipEntry(dirName + UUID.randomUUID());
                     zip.putNextEntry(entry);
                     zip.closeEntry(); // all files are empty
                 }
-                if (System.currentTimeMillis() >= nextLog) {
-                    nextLog = 30_000 + System.currentTimeMillis();
-                    System.out.printf("Processed %s%% directories (%s), file size is %sMb (%ss)%n",
-                            dirN * 100 / dirCount, dirN, hugeZipFile.length() / 1024 / 1024,
+                if ((dirN + 1) % 1000 == 0) {
+                    System.out.printf("%s / %s of entries written, file size is %sMb (%ss)%n",
+                            (dirN + 1) * ENTRIES_IN_DIR, DIR_COUNT * ENTRIES_IN_DIR, hugeZipFile.length() / 1024 / 1024,
                             (System.currentTimeMillis() - startTime) / 1000);
                 }
             }
         }
-        System.out.printf("File generated in %ss, file size is %sMb%n",
-                (System.currentTimeMillis() - startTime) / 1000, hugeZipFile.length() / 1024 / 1024);
+    }
 
-        try {
-            ZipFile zip = new ZipFile(hugeZipFile);
-        } catch (ZipException ze) {
-            passed = true;
-        }
-
-        if (!passed) {
-            throw new RuntimeException("Failed.");
-        }
+    @Test
+    public void test() {
+        assertThrows(ZipException.class, () -> new ZipFile(hugeZipFile));
     }
 }

--- a/test/jdk/java/util/zip/ZipFile/TestTooManyEntries.java
+++ b/test/jdk/java/util/zip/ZipFile/TestTooManyEntries.java
@@ -79,7 +79,7 @@ public class TestTooManyEntries {
     }
 
     /**
-     * Validates that an appropriate exception is thrown when the ZipFile class
+     * Validates that the ZipException is thrown when the ZipFile class
      * is initialized with a zip file whose entries exceed the CEN limit.
      */
     @Test

--- a/test/jdk/java/util/zip/ZipFile/TestTooManyEntries.java
+++ b/test/jdk/java/util/zip/ZipFile/TestTooManyEntries.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8272746
+ * @summary ZipFile can't open big file (NegativeArraySizeException)
+ * @requires (sun.arch.data.model == "64" & os.maxMemory > 8g)
+ * @run main/othervm/timeout=3600 -Xmx8g TestTooManyEntries
+ */
+
+import java.io.File;
+import java.io.BufferedOutputStream;
+import java.io.FileOutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+import java.util.UUID;
+
+public class TestTooManyEntries {
+    public static void main(String[] args) throws Exception {
+        boolean passed = false;
+        File hugeZipFile = File.createTempFile("hugeZip", ".zip", new File("."));
+        hugeZipFile.deleteOnExit();
+        long startTime = System.currentTimeMillis();
+        try (ZipOutputStream zip = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(hugeZipFile)))) {
+            int dirCount = 25_000;
+            long nextLog = System.currentTimeMillis();
+            for (int dirN = 0; dirN < dirCount; dirN++) {
+                String dirName = UUID.randomUUID() + "/";
+                for (int fileN = 0; fileN < 1_000; fileN++) {
+                    ZipEntry entry = new ZipEntry(dirName + UUID.randomUUID());
+                    zip.putNextEntry(entry);
+                    zip.closeEntry(); // all files are empty
+                }
+                if (System.currentTimeMillis() >= nextLog) {
+                    nextLog = 30_000 + System.currentTimeMillis();
+                    System.out.printf("Processed %s%% directories (%s), file size is %sMb (%ss)%n",
+                            dirN * 100 / dirCount, dirN, hugeZipFile.length() / 1024 / 1024,
+                            (System.currentTimeMillis() - startTime) / 1000);
+                }
+            }
+        }
+        System.out.printf("File generated in %ss, file size is %sMb%n",
+                (System.currentTimeMillis() - startTime) / 1000, hugeZipFile.length() / 1024 / 1024);
+
+        try {
+            ZipFile zip = new ZipFile(hugeZipFile);
+        } catch (ZipException ze) {
+            passed = true;
+        }
+
+        if (!passed) {
+            throw new RuntimeException("Failed.");
+        }
+    }
+}

--- a/test/jdk/java/util/zip/ZipFile/TestTooManyEntries.java
+++ b/test/jdk/java/util/zip/ZipFile/TestTooManyEntries.java
@@ -34,6 +34,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.BufferedOutputStream;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
@@ -43,18 +44,24 @@ import java.util.UUID;
 import static org.testng.Assert.assertThrows;
 
 public class TestTooManyEntries {
+    // Number of directories in the zip file
     private static final int DIR_COUNT = 25000;
+    // Number of entries per directory
     private static final int ENTRIES_IN_DIR = 1000;
 
+    // Zip file to create for testing
     private File hugeZipFile;
 
+    /**
+     * Create a zip file and add entries that exceed the CEN limit.
+     * @throws IOException if an error occurs creating the ZIP File
+     */
     @BeforeTest
-    public void setup() throws Exception {
+    public void setup() throws IOException {
         hugeZipFile = File.createTempFile("hugeZip", ".zip", new File("."));
         hugeZipFile.deleteOnExit();
         long startTime = System.currentTimeMillis();
         try (ZipOutputStream zip = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(hugeZipFile)))) {
-            long nextLog = System.currentTimeMillis();
             for (int dirN = 0; dirN < DIR_COUNT; dirN++) {
                 String dirName = UUID.randomUUID() + "/";
                 for (int fileN = 0; fileN < ENTRIES_IN_DIR; fileN++) {
@@ -71,6 +78,10 @@ public class TestTooManyEntries {
         }
     }
 
+    /**
+     * Validates that an appropriate exception is thrown when the ZipFile class
+     * is initialized with a zip file whose entries exceed the CEN limit.
+     */
     @Test
     public void test() {
         assertThrows(ZipException.class, () -> new ZipFile(hugeZipFile));


### PR DESCRIPTION
Could you please review the JDK-8272746 bug fixes?
Since the array index is of type int, the overflow occurs when the value of end.cenlen is too large because of too many entries.
It is necessary to read a part of the CEN from the file to fix the problem fundamentally, but the way will require an extensive fix and degrade performance.
In practical terms, the size of the central directory rarely grows that large. So, I fixed it to check the size of the central directory and throw an exception if it is too large.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272746](https://bugs.openjdk.java.net/browse/JDK-8272746): ZipFile can't open big file (NegativeArraySizeException)


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to 9ebb2a7ad63acc726d68b710423f4529dbbde44c


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6927/head:pull/6927` \
`$ git checkout pull/6927`

Update a local copy of the PR: \
`$ git checkout pull/6927` \
`$ git pull https://git.openjdk.java.net/jdk pull/6927/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6927`

View PR using the GUI difftool: \
`$ git pr show -t 6927`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6927.diff">https://git.openjdk.java.net/jdk/pull/6927.diff</a>

</details>
