### PR TITLE
8255739: x509Certificate returns � for invalid subjectAlternativeNames

### DIFF
--- a/src/java.base/share/classes/sun/security/util/DerValue.java
+++ b/src/java.base/share/classes/sun/security/util/DerValue.java
@@ -33,6 +33,8 @@ import java.io.*;
 import java.math.BigInteger;
 import java.nio.charset.Charset;
 import java.util.*;
+import java.nio.*;
+import java.nio.charset.*;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -768,7 +770,18 @@ public class DerValue {
             throw new IOException("Incorrect string type " + tag + " is not " + expectedTag);
         }
         data.pos = data.end; // Compatibility. Reach end.
-        return new String(buffer, start, end - start, cs);
+
+        try {
+            byte b[] = new byte[end-start];
+            System.arraycopy(buffer, start, b, 0, end-start);
+            CharBuffer cb = cs.newDecoder()
+                .onUnmappableCharacter(CodingErrorAction.REPORT)
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .decode(ByteBuffer.wrap(b));
+            return cb.toString();
+        } catch (IOException e) {
+            throw new IOException("Incorrect string value", e);
+        }
     }
 
     /**

--- a/test/jdk/sun/security/x509/GeneralName/DNSNameErrorTest.java
+++ b/test/jdk/sun/security/x509/GeneralName/DNSNameErrorTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8255739
+ * @library /test/lib
+ * @summary CertificateFactory.generateCertificate should not read invalid
+ *          subjectAlternativeNames values.
+ */
+
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+import java.util.Collection;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+
+public class DNSNameErrorTest {
+
+    /* Invalid SubjectAlternativeName without criticality
+     *   #1: ObjectId: 2.5.29.17 Criticality=false
+     *   SubjectAlternativeName [
+     *     DNSName: ???.com      ??? is incorrect IA5String 'e2 84 a1'
+     *     DNSName: ???.com
+     *   ]
+     */
+    private static String invalidSANCertStr =
+        "-----BEGIN CERTIFICATE-----\n" +
+        "MIIBSDCB86ADAgECAhRLR4TGgXBegg0np90FZ1KPeWpDtjANBgkqhkiG9w0BAQsF\n" +
+        "ADASMRAwDgYDVQQDDAdmb28uY29tMCAXDTIwMTAyOTA2NTkwNVoYDzIxMjAxMDA1\n" +
+        "MDY1OTA1WjASMRAwDgYDVQQDDAdmb28uY29tMFwwDQYJKoZIhvcNAQEBBQADSwAw\n" +
+        "SAJBALQcTVW9aW++ClIV9/9iSzijsPvQGEu/FQOjIycSrSIheZyZmR8bluSNBq0C\n" +
+        "9fpalRKZb0S2tlCTi5WoX8d3K30CAwEAAaMfMB0wGwYDVR0RBBQwEoIH4oShLmNv\n" +
+        "bYIH4oSqLmNvbTANBgkqhkiG9w0BAQsFAANBAA1+/eDvSUGv78iEjNW+1w3OPAwt\n" +
+        "Ij1qLQ/YI8OogZPMk7YY46/ydWWp7UpD47zy/vKmm4pOc8Glc8MoDD6UADs=\n" +
+        "-----END CERTIFICATE-----";
+
+    /* Invalid SubjectAlternativeName with criticality
+     *   #1: ObjectId: 2.5.29.17 Criticality=true
+     *   SubjectAlternativeName [
+     *     DNSName: ???.com      ??? is incorrect IA5String 'e2 84 a1'
+     *     DNSName: ???.com
+     *   ]
+     */
+    private static String invalidCriticalSANCertStr =
+        "-----BEGIN CERTIFICATE-----\n" +
+        "MIIBWTCCAQOgAwIBAgIEN5HYCDANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDEwdm\n" +
+        "b28uY29tMB4XDTIxMTIxNzA5MTEzMVoXDTIyMDMxNzA5MTEzMVowEjEQMA4GA1UE\n" +
+        "AxMHZm9vLmNvbTBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQCQ/I+QhhOmUywaRIv7\n" +
+        "zijFGL0grGZ/iGkob+L0dlO8iZAvV9If8tyCSQY/YDbmxP4X0JByOChJFZLERNrg\n" +
+        "8vk1AgMBAAGjQTA/MB4GA1UdEQEB/wQUMBKCB+KEoS5jb22CB+KEqi5jb20wHQYD\n" +
+        "VR0OBBYEFNSLW2LFszpr+rIc+ubAfGGLn64oMA0GCSqGSIb3DQEBCwUAA0EAgqU7\n" +
+        "lOMtR8l9ZyXYIro+c6PNdTF1m6xWHt4Eofyi70PFX4oGNT5dXc2sqO4tXnDFi804\n" +
+        "w3l4T5it0fa5qw50gQ==\n" +
+        "-----END CERTIFICATE-----";
+
+    public static void main(String[] args) throws Exception {
+
+        if (args.length > 0) {
+            String test = args[0];
+            if (test.equals("nonCritical")) {
+               testNonCriticalName();
+            }
+            else if (test.equals("critical")) {
+               testCriticalName();
+            }
+        }
+
+        runTestNonCriticalName();
+        runTestNonCriticalNameWithDBG();
+        runTestCriticalName();
+    }
+
+    private static void testNonCriticalName() throws Exception {
+        // getSubjectAlternativeNames() doesn't throw an Exception and retrun null
+        // when critical is not specified, even if it has incorrect strings.
+        X509Certificate certificate = certificate(invalidSANCertStr);
+        Collection<?> subjectAltNames = certificate.getSubjectAlternativeNames();
+        if (subjectAltNames != null) {
+            throw new RuntimeException("Read invalid subjectAlternativeNames.");
+        }
+        System.out.println("Passed.");
+    }
+
+    private static void testCriticalName() throws Exception {
+        // getSubjectAlternativeNames() should throw an Exception
+        // when critical is specified and it has incorrect strings.
+        X509Certificate certificate = certificate(invalidCriticalSANCertStr);
+        Collection<?> subjectAltNames = certificate.getSubjectAlternativeNames();
+        System.out.println("Failed.");
+    }
+
+    private static X509Certificate certificate(String certificate) throws CertificateException {
+        return (X509Certificate) CertificateFactory.getInstance("X.509")
+            .generateCertificate(new ByteArrayInputStream(certificate.getBytes()));
+    }
+
+    private static void runTestNonCriticalName() throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "DNSNameErrorTest", "nonCritical");
+        OutputAnalyzer output = ProcessTools.executeProcess(pb);
+        output.shouldContain("Passed.");
+    }
+
+    static void runTestNonCriticalNameWithDBG() throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "-Djava.security.debug=x509", "DNSNameErrorTest", "nonCritical");
+        OutputAnalyzer output = ProcessTools.executeProcess(pb);
+        output.shouldContain("java.io.IOException: Incorrect string value");
+        output.shouldContain("Caused by: java.nio.charset.MalformedInputException");
+        output.shouldContain("Passed.");
+    }
+
+    static void runTestCriticalName() throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "DNSNameErrorTest", "critical");
+        OutputAnalyzer output = ProcessTools.executeProcess(pb);
+        output.shouldContain("java.io.IOException: Incorrect string value");
+        output.shouldContain("Caused by: java.nio.charset.MalformedInputException");
+        output.shouldNotContain("Failed.");
+    }
+}


### PR DESCRIPTION
Could you please review the JDK-8255739 bug fix?

I think sun.security.x509.SubjectAlternativeNameExtension() should throw an exception for incorrect SubjectAlternativeNames instead of returning the substituted characters, which is explained in the description of BugDB.

I modified DerValue.readStringInternal() not to read incorrect SubjectAlternativeNames and throw an IOException. sun.security.x509.X509CertInfo.parse() catch the IOExcepton and ignore it if SAN is a non-ciritical extension like the behavior of the IOException in readStringInternal(). So I added a test with -Djava.security.debug=x509 to confirm that.