### PR TITLE
8279223: Define version in .jcheck/conf

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -1,6 +1,7 @@
 [general]
 project=jdk
 jbs=JDK
+version=19
 
 [checks]
 error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace,problemlists


### PR DESCRIPTION
This patch adds the version field to .jcheck/conf. By doing this we can remove the corresponding configuration from the Skara bots, which in turn reduces the need for timing and general complexity of starting a new JDK release.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279223](https://bugs.openjdk.java.net/browse/JDK-8279223): Define version in .jcheck/conf


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6929/head:pull/6929` \
`$ git checkout pull/6929`

Update a local copy of the PR: \
`$ git checkout pull/6929` \
`$ git pull https://git.openjdk.java.net/jdk pull/6929/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6929`

View PR using the GUI difftool: \
`$ git pr show -t 6929`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6929.diff">https://git.openjdk.java.net/jdk/pull/6929.diff</a>

</details>
