### PR TITLE
8279244: test accompaning fix for JDK-8205187 is failing in Windows

### DIFF
--- a/test/langtools/tools/javac/fatalErrors/NoJavaLangTest.java
+++ b/test/langtools/tools/javac/fatalErrors/NoJavaLangTest.java
@@ -50,8 +50,7 @@ public class NoJavaLangTest  {
         "}";
 
     private static final String compilerErrorMessage =
-        "error: Unable to find package java.lang in platform classes\n" +
-        "1 error";
+        "error: Unable to find package java.lang in platform classes";
 
     public static void main(String[] args) throws Exception {
         new NoJavaLangTest().run();
@@ -105,7 +104,7 @@ public class NoJavaLangTest  {
                 .writeAll()
                 .getOutput(Task.OutputKind.DIRECT);
 
-        if (!out.trim().equals(expect)) {
+        if (!out.trim().startsWith(expect)) {
             throw new AssertionError("javac generated error output is not correct");
         }
     }


### PR DESCRIPTION
Fix for JDK-8205187 broke a Windows test. This patch is fixing that issue by avoiding to use a expected output containing a new line character,

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279244](https://bugs.openjdk.java.net/browse/JDK-8279244): test accompaning fix for JDK-8205187 is failing in Windows


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6932/head:pull/6932` \
`$ git checkout pull/6932`

Update a local copy of the PR: \
`$ git checkout pull/6932` \
`$ git pull https://git.openjdk.java.net/jdk pull/6932/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6932`

View PR using the GUI difftool: \
`$ git pr show -t 6932`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6932.diff">https://git.openjdk.java.net/jdk/pull/6932.diff</a>

</details>
