### PR TITLE
8279225: [arm32] C1 longs comparison operation destroys argument registers

### DIFF
--- a/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
@@ -1820,8 +1820,8 @@ void LIR_Assembler::comp_op(LIR_Condition condition, LIR_Opr opr1, LIR_Opr opr2,
         __ teq(xhi, yhi);
         __ teq(xlo, ylo, eq);
       } else {
-        __ subs(xlo, xlo, ylo);
-        __ sbcs(xhi, xhi, yhi);
+        __ cmp(xlo, ylo);
+        __ sbcs(Rtemp, xhi, yhi);
       }
     } else {
       ShouldNotReachHere();

--- a/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
@@ -1820,7 +1820,7 @@ void LIR_Assembler::comp_op(LIR_Condition condition, LIR_Opr opr1, LIR_Opr opr2,
         __ teq(xhi, yhi);
         __ teq(xlo, ylo, eq);
       } else {
-        __ cmp(xlo, ylo);
+        __ subs(Rtemp, xlo, ylo);
         __ sbcs(Rtemp, xhi, yhi);
       }
     } else {


### PR DESCRIPTION
Several regression tests are failed on arm32 CPU if tiered compilation is enabled.

The list includes
java/math/BigDecimal/DivideMcTests
java/util/Arrays/Sorting.java
java/util/Arrays/SortingNearlySortedPrimitive.java
java/util/concurrent/tck/JSR166TestCase
java/util/stream/SliceOpTest.java
etc

It appears C1 comp_op for long operands destroys arguments registers:
void LIR_Assembler::comp_op(LIR_Condition condition, LIR_Opr opr1, LIR_Opr opr2, LIR_Op2* op) {
....
      Register ylo = opr2->as_register_lo();
      Register yhi = opr2->as_register_hi();
      if (condition == lir_cond_equal || condition == lir_cond_notEqual) {
        __ teq(xhi, yhi);
        __ teq(xlo, ylo, eq);
      } else {
        __ subs(xlo, xlo, ylo); // <<< incorrect
        __ sbcs(xhi, xhi, yhi); // <<< incorrect
      }
...
} 

Tested with hotspot_tier2, jdk_tier3 on linux_arm

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279225](https://bugs.openjdk.java.net/browse/JDK-8279225): [arm32] C1 longs comparison operation destroys argument registers


### Reviewers
 * [Hao Sun](https://openjdk.java.net/census#haosun) (@shqking - Author)
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6934/head:pull/6934` \
`$ git checkout pull/6934`

Update a local copy of the PR: \
`$ git checkout pull/6934` \
`$ git pull https://git.openjdk.java.net/jdk pull/6934/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6934`

View PR using the GUI difftool: \
`$ git pr show -t 6934`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6934.diff">https://git.openjdk.java.net/jdk/pull/6934.diff</a>

</details>
