### PR TITLE
8279283 - BufferedInputStream should override transferTo

### DIFF
--- a/src/java.base/share/classes/java/io/BufferedInputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedInputStream.java
@@ -587,7 +587,7 @@ public class BufferedInputStream extends FilterInputStream {
     }
 
     @Override
-    public long transferTo(OutputStream out) throws IOException {
+    public synchronized long transferTo(OutputStream out) throws IOException {
         Objects.requireNonNull(out, "out");
         int avail = count - pos;
         if (avail > 0) {

--- a/src/java.base/share/classes/java/io/BufferedInputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedInputStream.java
@@ -591,7 +591,7 @@ public class BufferedInputStream extends FilterInputStream {
         Objects.requireNonNull(out, "out");
         int avail = count - pos;
         if (avail > 0) {
-            out.write(buf, pos, avail);
+            out.write(getBufIfOpen(), pos, avail);
             count = 0;
             pos = 0;
         }

--- a/src/java.base/share/classes/java/io/BufferedInputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedInputStream.java
@@ -604,13 +604,12 @@ public class BufferedInputStream extends FilterInputStream {
     }
 
     private long implTransferTo(OutputStream out) throws IOException {
-        int avail = count - pos;
-        if (avail > 0) {
-            out.write(getBufIfOpen(), pos, avail);
-            count = 0;
-            pos = 0;
+        if (getClass() == BufferedInputStream.class
+                && ((count - pos) <= 0) && (markpos == -1)) {
+            return getInIfOpen().transferTo(out);
+        } else {
+            return super.transferTo(out);
         }
-        return avail + getInIfOpen().transferTo(out);
     }
 
 }

--- a/src/java.base/share/classes/java/io/BufferedInputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedInputStream.java
@@ -25,6 +25,8 @@
 
 package java.io;
 
+import java.util.Objects;
+
 import jdk.internal.misc.InternalLock;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.util.ArraysSupport;
@@ -583,4 +585,17 @@ public class BufferedInputStream extends FilterInputStream {
             // Else retry in case a new buf was CASed in fill()
         }
     }
+
+    @Override
+    public long transferTo(OutputStream out) throws IOException {
+        Objects.requireNonNull(out, "out");
+        int avail = count - pos;
+        if (avail > 0) {
+            out.write(buf, pos, avail);
+            count = 0;
+            pos = 0;
+        }
+        return avail + getInIfOpen().transferTo(out);
+    }
+
 }

--- a/src/java.base/share/classes/java/io/BufferedInputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedInputStream.java
@@ -587,8 +587,23 @@ public class BufferedInputStream extends FilterInputStream {
     }
 
     @Override
-    public synchronized long transferTo(OutputStream out) throws IOException {
+    public long transferTo(OutputStream out) throws IOException {
         Objects.requireNonNull(out, "out");
+        if (lock != null) {
+            lock.lock();
+            try {
+                return implTransferTo(out);
+            } finally {
+                lock.unlock();
+            }
+        } else {
+            synchronized (this) {
+                return implTransferTo(out);
+            }
+        }
+    }
+
+    private long implTransferTo(OutputStream out) throws IOException {
         int avail = count - pos;
         if (avail > 0) {
             out.write(getBufIfOpen(), pos, avail);

--- a/test/jdk/java/io/BufferedInputStream/TransferTo.java
+++ b/test/jdk/java/io/BufferedInputStream/TransferTo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/io/BufferedInputStream/TransferTo.java
+++ b/test/jdk/java/io/BufferedInputStream/TransferTo.java
@@ -74,13 +74,7 @@ public class TransferTo {
 
     private static final int ITERATIONS = 10;
 
-    private static final int NUM_WRITES = 3*1024;
-    private static final int BYTES_PER_WRITE = 1024*1024;
-    private static final long BYTES_WRITTEN = (long) NUM_WRITES*BYTES_PER_WRITE;
-
     private static final Random RND = RandomFactory.getRandom();
-
-    private static final Path CWD = Path.of(".");
 
     /*
      * Testing API compliance: input stream must throw NullPointerException

--- a/test/jdk/java/io/BufferedInputStream/TransferTo.java
+++ b/test/jdk/java/io/BufferedInputStream/TransferTo.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.IllegalBlockingModeException;
+import java.nio.channels.Pipe;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.SelectableChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.testng.annotations.Test;
+
+import jdk.test.lib.RandomFactory;
+
+import static java.lang.String.format;
+import static java.nio.file.StandardOpenOption.*;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+/*
+ * @test
+ * @library /test/lib
+ * @build jdk.test.lib.RandomFactory
+ * @run testng/othervm/timeout=180 TransferTo
+ * @bug 8279283
+ * @summary Tests whether java.io.BufferedInputStream.transferTo conforms to the
+ *          InputStream.transferTo specification
+ * @key randomness
+ */
+public class TransferTo {
+    private static final int MIN_SIZE      = 10_000;
+    private static final int MAX_SIZE_INCR = 100_000_000 - MIN_SIZE;
+
+    private static final int ITERATIONS = 10;
+
+    private static final int NUM_WRITES = 3*1024;
+    private static final int BYTES_PER_WRITE = 1024*1024;
+    private static final long BYTES_WRITTEN = (long) NUM_WRITES*BYTES_PER_WRITE;
+
+    private static final Random RND = RandomFactory.getRandom();
+
+    private static final Path CWD = Path.of(".");
+
+    /*
+     * Testing API compliance: input stream must throw NullPointerException
+     * when parameter "out" is null.
+     */
+    @Test
+    public void testNullPointerException() throws Exception {
+        // factory for incoming data provider
+        InputStreamProvider inputStreamProvider = byteArrayInput();
+
+        // tests empty input stream
+        assertThrows(NullPointerException.class, () -> inputStreamProvider.input().transferTo(null));
+
+        // tests single-byte input stream
+        assertThrows(NullPointerException.class, () -> inputStreamProvider.input((byte) 1).transferTo(null));
+
+        // tests dual-byte input stream
+        assertThrows(NullPointerException.class, () -> inputStreamProvider.input((byte) 1, (byte) 2).transferTo(null));
+    }
+
+    /*
+     * Testing API compliance: complete content of input stream must be
+     * transferred to output stream.
+     */
+    @Test
+    public void testStreamContents() throws Exception {
+        // factory for incoming data provider
+        InputStreamProvider inputStreamProvider = byteArrayInput();
+
+        // factory for outgoing data recorder
+        OutputStreamProvider outputStreamProvider = byteArrayOutput();
+
+        // tests empty input stream
+        checkTransferredContents(inputStreamProvider, outputStreamProvider, new byte[0]);
+
+        // tests input stream with a length between 1k and 4k
+        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(1024, 4096));
+
+        // tests input stream with several data chunks, as 16k is more than a
+        // single chunk can hold
+        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(16384, 16384));
+
+        // tests randomly chosen starting positions within source and
+        // target stream
+        for (int i = 0; i < ITERATIONS; i++) {
+            byte[] inBytes = createRandomBytes(MIN_SIZE, MAX_SIZE_INCR);
+            int posIn = RND.nextInt(inBytes.length);
+            int posOut = RND.nextInt(MIN_SIZE);
+            checkTransferredContents(inputStreamProvider, outputStreamProvider, inBytes, posIn, posOut);
+        }
+
+        // tests reading beyond source EOF (must not transfer any bytes)
+        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(4096, 0), 4096, 0);
+
+        // tests writing beyond target EOF (must extend output stream)
+        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(4096, 0), 0, 4096);
+    }
+
+    /*
+     * Asserts that the transferred content is correct, i.e., compares the bytes
+     * actually transferred to those expected. The position of the input and
+     * output streams before the transfer are zero (BOF).
+     */
+    private static void checkTransferredContents(InputStreamProvider inputStreamProvider,
+            OutputStreamProvider outputStreamProvider, byte[] inBytes) throws Exception {
+        checkTransferredContents(inputStreamProvider, outputStreamProvider, inBytes, 0, 0);
+    }
+
+    /*
+     * Asserts that the transferred content is correct, i. e. compares the bytes
+     * actually transferred to those expected. The positions of the input and
+     * output streams before the transfer are provided by the caller.
+     */
+    private static void checkTransferredContents(InputStreamProvider inputStreamProvider,
+            OutputStreamProvider outputStreamProvider, byte[] inBytes, int posIn, int posOut) throws Exception {
+        AtomicReference<Supplier<byte[]>> recorder = new AtomicReference<>();
+        try (InputStream in = inputStreamProvider.input(inBytes);
+            OutputStream out = outputStreamProvider.output(recorder::set)) {
+            // skip bytes until starting position
+            in.skipNBytes(posIn);
+            out.write(new byte[posOut]);
+
+            long reported = in.transferTo(out);
+            int count = inBytes.length - posIn;
+
+            assertEquals(reported, count, format("reported %d bytes but should report %d", reported, count));
+
+            byte[] outBytes = recorder.get().get();
+            assertTrue(Arrays.equals(inBytes, posIn, posIn + count, outBytes, posOut, posOut + count),
+                format("inBytes.length=%d, outBytes.length=%d", count, outBytes.length));
+        }
+    }
+
+    /*
+     * Creates an array of random size (between min and min + maxRandomAdditive)
+     * filled with random bytes
+     */
+    private static byte[] createRandomBytes(int min, int maxRandomAdditive) {
+        byte[] bytes = new byte[min + (maxRandomAdditive == 0 ? 0 : RND.nextInt(maxRandomAdditive))];
+        RND.nextBytes(bytes);
+        return bytes;
+    }
+
+    private interface InputStreamProvider {
+        InputStream input(byte... bytes) throws Exception;
+    }
+
+    private interface OutputStreamProvider {
+        OutputStream output(Consumer<Supplier<byte[]>> spy) throws Exception;
+    }
+
+    private static InputStreamProvider byteArrayInput() {
+        return bytes -> new ByteArrayInputStream(bytes);
+    }
+
+    private static OutputStreamProvider byteArrayOutput() {
+        return new OutputStreamProvider() {
+            @Override
+            public OutputStream output(Consumer<Supplier<byte[]>> spy) {
+                ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+                spy.accept(outputStream::toByteArray);
+                return outputStream;
+            }
+        };
+    }
+
+}

--- a/test/jdk/java/io/BufferedInputStream/TransferTo.java
+++ b/test/jdk/java/io/BufferedInputStream/TransferTo.java
@@ -85,13 +85,16 @@ public class TransferTo {
         InputStreamProvider inputStreamProvider = byteArrayInput();
 
         // tests empty input stream
-        assertThrows(NullPointerException.class, () -> inputStreamProvider.input().transferTo(null));
+        assertThrows(NullPointerException.class,
+                () -> inputStreamProvider.input().transferTo(null));
 
         // tests single-byte input stream
-        assertThrows(NullPointerException.class, () -> inputStreamProvider.input((byte) 1).transferTo(null));
+        assertThrows(NullPointerException.class,
+                () -> inputStreamProvider.input((byte) 1).transferTo(null));
 
         // tests dual-byte input stream
-        assertThrows(NullPointerException.class, () -> inputStreamProvider.input((byte) 1, (byte) 2).transferTo(null));
+        assertThrows(NullPointerException.class,
+                () -> inputStreamProvider.input((byte) 1, (byte) 2).transferTo(null));
     }
 
     /*
@@ -107,14 +110,17 @@ public class TransferTo {
         OutputStreamProvider outputStreamProvider = byteArrayOutput();
 
         // tests empty input stream
-        checkTransferredContents(inputStreamProvider, outputStreamProvider, new byte[0]);
+        checkTransferredContents(inputStreamProvider,
+                outputStreamProvider, new byte[0]);
 
         // tests input stream with a length between 1k and 4k
-        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(1024, 4096));
+        checkTransferredContents(inputStreamProvider,
+                outputStreamProvider, createRandomBytes(1024, 4096));
 
         // tests input stream with several data chunks, as 16k is more than a
         // single chunk can hold
-        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(16384, 16384));
+        checkTransferredContents(inputStreamProvider,
+                outputStreamProvider, createRandomBytes(16384, 16384));
 
         // tests randomly chosen starting positions within source and
         // target stream and random buffer level
@@ -124,14 +130,17 @@ public class TransferTo {
             int posOut = RND.nextInt(MIN_SIZE);
             int bufferBytes = RND.nextInt(inBytes.length - posIn);
             boolean markAndReset = RND.nextBoolean();
-            checkTransferredContents(inputStreamProvider, outputStreamProvider, inBytes, posIn, posOut, bufferBytes, markAndReset);
+            checkTransferredContents(inputStreamProvider,
+                    outputStreamProvider, inBytes, posIn, posOut, bufferBytes, markAndReset);
         }
 
         // tests reading beyond source EOF (must not transfer any bytes)
-        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(4096, 0), 4096, 0, 0, false);
+        checkTransferredContents(inputStreamProvider,
+                outputStreamProvider, createRandomBytes(4096, 0), 4096, 0, 0, false);
 
         // tests writing beyond target EOF (must extend output stream)
-        checkTransferredContents(inputStreamProvider, outputStreamProvider, createRandomBytes(4096, 0), 0, 4096, 0, false);
+        checkTransferredContents(inputStreamProvider,
+                outputStreamProvider, createRandomBytes(4096, 0), 0, 4096, 0, false);
     }
 
     /*
@@ -141,7 +150,8 @@ public class TransferTo {
      */
     private static void checkTransferredContents(InputStreamProvider inputStreamProvider,
             OutputStreamProvider outputStreamProvider, byte[] inBytes) throws Exception {
-        checkTransferredContents(inputStreamProvider, outputStreamProvider, inBytes, 0, 0, 0, false);
+        checkTransferredContents(inputStreamProvider,
+                outputStreamProvider, inBytes, 0, 0, 0, false);
     }
 
     /*
@@ -150,7 +160,8 @@ public class TransferTo {
      * output streams before the transfer are provided by the caller.
      */
     private static void checkTransferredContents(InputStreamProvider inputStreamProvider,
-            OutputStreamProvider outputStreamProvider, byte[] inBytes, int posIn, int posOut, int bufferBytes, boolean markAndReset) throws Exception {
+            OutputStreamProvider outputStreamProvider, byte[] inBytes, int posIn,
+            int posOut, int bufferBytes, boolean markAndReset) throws Exception {
         AtomicReference<Supplier<byte[]>> recorder = new AtomicReference<>();
         try (InputStream in = inputStreamProvider.input(inBytes);
             OutputStream out = outputStreamProvider.output(recorder::set)) {
@@ -172,11 +183,13 @@ public class TransferTo {
             int count = inBytes.length - posIn;
             int expected = count - bufferBytes;
 
-            assertEquals(reported, expected, format("transferred %d bytes but should report %d", reported, expected));
+            assertEquals(reported, expected,
+                    format("transferred %d bytes but should report %d", reported, expected));
 
             byte[] outBytes = recorder.get().get();
-            assertTrue(Arrays.equals(inBytes, posIn, posIn + count, outBytes, posOut, posOut + count),
-                format("inBytes.length=%d, outBytes.length=%d", count, outBytes.length));
+            assertTrue(Arrays.equals(inBytes, posIn, posIn + count,
+                    outBytes, posOut, posOut + count),
+                    format("inBytes.length=%d, outBytes.length=%d", count, outBytes.length));
 
             // replay from marked position
             if (markAndReset) {
@@ -185,11 +198,15 @@ public class TransferTo {
                 reported = in.transferTo(out);
                 expected = count - bufferBytes;
 
-                assertEquals(reported, expected, format("replayed %d bytes but should report %d", reported, expected));
+                assertEquals(reported, expected,
+                        format("replayed %d bytes but should report %d", reported, expected));
 
                 outBytes = recorder.get().get();
-                assertTrue(Arrays.equals(inBytes, posIn + bufferBytes, inBytes.length, outBytes, posOut + count, outBytes.length),
-                    format("inBytes.length=%d, outBytes.length=%d", inBytes.length - posIn - bufferBytes, outBytes.length - posOut - count));
+                assertTrue(Arrays.equals(inBytes, posIn + bufferBytes, inBytes.length,
+                        outBytes, posOut + count, outBytes.length),
+                        format("inBytes.length=%d, outBytes.length=%d",
+                                inBytes.length - posIn - bufferBytes,
+                                outBytes.length - posOut - count));
             }
         }
     }
@@ -199,7 +216,8 @@ public class TransferTo {
      * filled with random bytes
      */
     private static byte[] createRandomBytes(int min, int maxRandomAdditive) {
-        byte[] bytes = new byte[min + (maxRandomAdditive == 0 ? 0 : RND.nextInt(maxRandomAdditive))];
+        byte[] bytes = new byte[min +
+                                (maxRandomAdditive == 0 ? 0 : RND.nextInt(maxRandomAdditive))];
         RND.nextBytes(bytes);
         return bytes;
     }

--- a/test/jdk/java/io/BufferedInputStream/TransferTo.java
+++ b/test/jdk/java/io/BufferedInputStream/TransferTo.java
@@ -187,7 +187,7 @@ public class TransferTo {
     }
 
     private static InputStreamProvider byteArrayInput() {
-        return bytes -> new ByteArrayInputStream(bytes);
+        return bytes -> new BufferedInputStream(new ByteArrayInputStream(bytes));
     }
 
     private static OutputStreamProvider byteArrayOutput() {

--- a/test/jdk/java/io/BufferedInputStream/TransferTo.java
+++ b/test/jdk/java/io/BufferedInputStream/TransferTo.java
@@ -37,7 +37,6 @@ import java.nio.channels.SelectableChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;

--- a/test/jdk/java/io/BufferedInputStream/TransferTo.java
+++ b/test/jdk/java/io/BufferedInputStream/TransferTo.java
@@ -169,7 +169,7 @@ public class TransferTo {
             in.skipNBytes(posIn);
             out.write(new byte[posOut]);
 
-            // fill buffer by reading some bytes before transformTo
+            // fill buffer by reading some bytes before transferTo
             byte[] bytes = new byte[bufferBytes];
             in.read(bytes);
             out.write(bytes);

--- a/test/lib/jdk/test/lib/hexdump/HexPrinter.java
+++ b/test/lib/jdk/test/lib/hexdump/HexPrinter.java
@@ -1185,12 +1185,5 @@ public final class HexPrinter {
             byteOffset += Math.max(size, 0);
             return size;
         }
-
-        @Override
-        public long transferTo(OutputStream out) throws IOException {
-            long size = super.transferTo(out);
-            byteOffset += size;
-            return size;
-        }
     }
 }

--- a/test/lib/jdk/test/lib/hexdump/HexPrinter.java
+++ b/test/lib/jdk/test/lib/hexdump/HexPrinter.java
@@ -1185,5 +1185,12 @@ public final class HexPrinter {
             byteOffset += Math.max(size, 0);
             return size;
         }
+
+        @Override
+        public long transferTo(OutputStream out) throws IOException {
+            long size = super.transferTo(out);
+            byteOffset += size;
+            return size;
+        }
     }
 }


### PR DESCRIPTION
Implementation of JDK-8279283

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279283](https://bugs.openjdk.org/browse/JDK-8279283): BufferedInputStream should override transferTo


### Reviewers
 * @stsypanov (no known github.com user name / role) ⚠️ Review applies to [b4d5004d](https://git.openjdk.org/jdk/pull/6935/files/b4d5004dd3299d084769309b505b19ed7dd3182e)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/6935/head:pull/6935` \
`$ git checkout pull/6935`

Update a local copy of the PR: \
`$ git checkout pull/6935` \
`$ git pull https://git.openjdk.org/jdk pull/6935/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6935`

View PR using the GUI difftool: \
`$ git pr show -t 6935`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/6935.diff">https://git.openjdk.org/jdk/pull/6935.diff</a>

</details>
