### PR TITLE
Add public siftUp/Down methods to PriorityQueue

### DIFF
--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -589,6 +589,50 @@ public class PriorityQueue<E> extends AbstractQueue<E>
     }
 
     /**
+     * Relocates item x to its proper place in the queue, IF its priority
+     * has been raised since it was added to this queue.
+     *
+     * The call has no effect if the item's priority has not changed or
+     * has been lowered since it was added to this queue.
+     *
+     * The call has no effect if the item cannot be found in the queue
+     * by referential equality.
+     *
+     * @param x the item to sift up
+     */
+    public void siftUp(E x) {
+        final Object[] es = queue;
+        for (int i = 0, n = size; i < n; i++) {
+            if (x == es[i]) {
+                siftUp(i, x);
+                break;
+            }
+        }
+    }
+
+    /**
+     * Relocates item x to its proper place in the queue, IF its priority
+     * has been lowered since it was added to this queue.
+     *
+     * The call has no effect if the item's priority has not changed or
+     * has been raised since it was added to this queue.
+     *
+     * The call has no effect if the item cannot be found in the queue
+     * by referential equality.
+     *
+     * @param x the item to sift up
+     */
+    public void siftDown(E x) {
+        final Object[] es = queue;
+        for (int i = 0, n = size; i < n; i++) {
+            if (x == es[i]) {
+                siftDown(i, x);
+                break;
+            }
+        }
+    }
+
+    /**
      * Removes the ith element from queue.
      *
      * Normally this method leaves the elements at up to i-1,

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -620,7 +620,7 @@ public class PriorityQueue<E> extends AbstractQueue<E>
      * The call has no effect if the item cannot be found in the queue
      * by referential equality.
      *
-     * @param x the item to sift up
+     * @param x the item to sift down
      */
     public void siftDown(E x) {
         final Object[] es = queue;


### PR DESCRIPTION
This was just a learning exercise. I actually tried to measure the impact and in fact observed the two-fold performance increase. Full disclosure: The issue came up and I worked on the performance improvement when solving the advent of code 2021 day 15 exercise, just for fun: https://github.com/Pfiver/advent-of-code-2021/blob/main/day15/Solve0.java

I think it would nevertheless be nice to have those methods generally available in the public API.

The semantics, especially the decision to use referential identity instead of equals() equality for finding the updated element in the queue has been guided by performance considerations. They are not very important to me and open for change.

In reference to https://openjdk.java.net/contribute/, the best possible outcome for this PR would IMHO be that a trusted JDK engineer would just pick this code or, more likely, just the idea, up, and push it through the process on their own.

OCA is signed: https://oca.opensource.oracle.com/api/v1/oca-requests/6243/documents/6263/download

To the extent possible under law, I hereby waive all copyright and related or neighboring rights to these [Open JDK Priority Queue siftUp/Down implementations](https://github.com/Pfiver/jdk/commit/a92f9c4), effectively donating it to the [public domain](http://creativecommons.org/publicdomain/zero/1.0/) This work is published from Switzerland.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6938/head:pull/6938` \
`$ git checkout pull/6938`

Update a local copy of the PR: \
`$ git checkout pull/6938` \
`$ git pull https://git.openjdk.java.net/jdk pull/6938/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6938`

View PR using the GUI difftool: \
`$ git pr show -t 6938`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6938.diff">https://git.openjdk.java.net/jdk/pull/6938.diff</a>

</details>
