### PR TITLE
8279351: [TESTBUG] SADebugDTest.java does not handle "Address already in use" error

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/SADebugDTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/SADebugDTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,8 +71,7 @@ public class SADebugDTest {
         }
     }
 
-    private static boolean checkOutput(final String line, final int rmiPort) {
-        boolean useRmiPort = rmiPort != -1;
+    private static boolean checkOutput(final String line, final boolean useRmiPort, final int rmiPort) {
         if (!useRmiPort && line.contains(GOLDEN)) {
             testResult = true;
         } else if (useRmiPort && line.contains(RMI_CONNECTOR_IS_BOUND + rmiPort)) {
@@ -119,7 +118,7 @@ public class SADebugDTest {
 
                 // The startProcess will block until the 'golden' string appears in either process' stdout or stderr
                 // In case of timeout startProcess kills the debugd process
-                Process debugd = startProcess("debugd", pb, null, l -> checkOutput(l, rmiPort), 20, TimeUnit.SECONDS);
+                Process debugd = startProcess("debugd", pb, null, l -> checkOutput(l, useRmiPort, rmiPort), 20, TimeUnit.SECONDS);
 
                 // If we are here, this means we have received the golden line and the test has passed
                 // The debugd remains running, we have to kill it


### PR DESCRIPTION
We expect SADebugDTest.java will retly the test when it encounters "Address already in use" error. However RuntimeException is thrown when the error happens.

So I fixed it with some refactoring in this PR. Key change is the condition in L129.

Please see serviceability-dev post for details.
https://mail.openjdk.java.net/pipermail/serviceability-dev/2021-December/040453.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279351](https://bugs.openjdk.java.net/browse/JDK-8279351): [TESTBUG] SADebugDTest.java does not handle "Address already in use" error


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6941/head:pull/6941` \
`$ git checkout pull/6941`

Update a local copy of the PR: \
`$ git checkout pull/6941` \
`$ git pull https://git.openjdk.java.net/jdk pull/6941/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6941`

View PR using the GUI difftool: \
`$ git pr show -t 6941`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6941.diff">https://git.openjdk.java.net/jdk/pull/6941.diff</a>

</details>
