### PR TITLE
8279374: Remove unused JNIHandles::weak_oops_do

### DIFF
--- a/src/hotspot/share/runtime/jniHandles.cpp
+++ b/src/hotspot/share/runtime/jniHandles.cpp
@@ -168,11 +168,6 @@ void JNIHandles::oops_do(OopClosure* f) {
 }
 
 
-void JNIHandles::weak_oops_do(BoolObjectClosure* is_alive, OopClosure* f) {
-  weak_global_handles()->weak_oops_do(is_alive, f);
-}
-
-
 void JNIHandles::weak_oops_do(OopClosure* f) {
   weak_global_handles()->weak_oops_do(f);
 }

--- a/src/hotspot/share/runtime/jniHandles.hpp
+++ b/src/hotspot/share/runtime/jniHandles.hpp
@@ -117,8 +117,6 @@ class JNIHandles : AllStatic {
   // Garbage collection support(global handles only, local handles are traversed from thread)
   // Traversal of regular global handles
   static void oops_do(OopClosure* f);
-  // Traversal of weak global handles. Unreachable oops are cleared.
-  static void weak_oops_do(BoolObjectClosure* is_alive, OopClosure* f);
   // Traversal of weak global handles.
   static void weak_oops_do(OopClosure* f);
 


### PR DESCRIPTION
Trivial change of removing unused code.

Test: tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279374](https://bugs.openjdk.java.net/browse/JDK-8279374): Remove unused JNIHandles::weak_oops_do


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6944/head:pull/6944` \
`$ git checkout pull/6944`

Update a local copy of the PR: \
`$ git checkout pull/6944` \
`$ git pull https://git.openjdk.java.net/jdk pull/6944/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6944`

View PR using the GUI difftool: \
`$ git pr show -t 6944`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6944.diff">https://git.openjdk.java.net/jdk/pull/6944.diff</a>

</details>
