### PR TITLE
8279386: Remove duplicate RefProcPhaseTimeTracker

### DIFF
--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -748,8 +748,6 @@ void ReferenceProcessor::process_soft_weak_final_refs(RefProcProxyTask& proxy_ta
     maybe_balance_queues(_discoveredFinalRefs);
   }
 
-  RefProcPhaseTimeTracker tt(SoftWeakFinalRefsPhase, &phase_times);
-
   log_reflist("SoftWeakFinalRefsPhase Soft before", _discoveredSoftRefs, _max_num_queues);
   log_reflist("SoftWeakFinalRefsPhase Weak before", _discoveredWeakRefs, _max_num_queues);
   log_reflist("SoftWeakFinalRefsPhase Final before", _discoveredFinalRefs, _max_num_queues);
@@ -780,7 +778,6 @@ void ReferenceProcessor::process_final_keep_alive(RefProcProxyTask& proxy_task,
   }
 
   // Traverse referents of final references and keep them and followers alive.
-  RefProcPhaseTimeTracker tt(KeepAliveFinalRefsPhase, &phase_times);
   RefProcKeepAliveFinalPhaseTask phase_task(*this, &phase_times);
   run_task(phase_task, proxy_task, true);
 
@@ -803,9 +800,6 @@ void ReferenceProcessor::process_phantom_refs(RefProcProxyTask& proxy_task,
     RefProcBalanceQueuesTimeTracker tt(PhantomRefsPhase, &phase_times);
     maybe_balance_queues(_discoveredPhantomRefs);
   }
-
-  // Walk phantom references appropriately.
-  RefProcPhaseTimeTracker tt(PhantomRefsPhase, &phase_times);
 
   log_reflist("PhantomRefsPhase Phantom before", _discoveredPhantomRefs, _max_num_queues);
 

--- a/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.cpp
@@ -143,16 +143,6 @@ RefProcBalanceQueuesTimeTracker::~RefProcBalanceQueuesTimeTracker() {
   phase_times()->set_balance_queues_time_ms(_phase_number, elapsed);
 }
 
-RefProcPhaseTimeTracker::RefProcPhaseTimeTracker(ReferenceProcessor::RefProcPhases phase_number,
-                                                       ReferenceProcessorPhaseTimes* phase_times) :
-  RefProcPhaseTimeBaseTracker(phase_enum_2_phase_string(phase_number), phase_number, phase_times) {
-}
-
-RefProcPhaseTimeTracker::~RefProcPhaseTimeTracker() {
-  double elapsed = elapsed_time();
-  phase_times()->set_phase_time_ms(_phase_number, elapsed);
-}
-
 RefProcTotalPhaseTimesTracker::RefProcTotalPhaseTimesTracker(ReferenceProcessor::RefProcPhases phase_number,
                                                              ReferenceProcessorPhaseTimes* phase_times) :
   RefProcPhaseTimeBaseTracker(phase_enum_2_phase_string(phase_number), phase_number, phase_times) {

--- a/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.hpp
+++ b/src/hotspot/share/gc/shared/referenceProcessorPhaseTimes.hpp
@@ -146,14 +146,6 @@ public:
   ~RefProcBalanceQueuesTimeTracker();
 };
 
-// Updates phase time at ReferenceProcessorPhaseTimes and save it into GCTimer.
-class RefProcPhaseTimeTracker : public RefProcPhaseTimeBaseTracker {
-public:
-  RefProcPhaseTimeTracker(ReferenceProcessor::RefProcPhases phase_number,
-                          ReferenceProcessorPhaseTimes* phase_times);
-  ~RefProcPhaseTimeTracker();
-};
-
 // Highest level time tracker.
 class RefProcTotalPhaseTimesTracker : public RefProcPhaseTimeBaseTracker {
 public:


### PR DESCRIPTION
Simple change of removing duplicate code.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279386](https://bugs.openjdk.java.net/browse/JDK-8279386): Remove duplicate RefProcPhaseTimeTracker


### Reviewers
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6947/head:pull/6947` \
`$ git checkout pull/6947`

Update a local copy of the PR: \
`$ git checkout pull/6947` \
`$ git pull https://git.openjdk.java.net/jdk pull/6947/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6947`

View PR using the GUI difftool: \
`$ git pr show -t 6947`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6947.diff">https://git.openjdk.java.net/jdk/pull/6947.diff</a>

</details>
