### PR TITLE
8279412: [JVMCI] failed speculations list must outlive any nmethod that refers to it

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotNmethod.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotNmethod.java
@@ -68,8 +68,8 @@ public class HotSpotNmethod extends HotSpotInstalledCode {
 
     /**
      * If this field is 0, this object is in the oops table of the nmethod. Otherwise, the value of
-     * the field records the nmethod's compile identifier. This value is used to confirm an entry in
-     * the code cache retrieved by {@link #address} is indeed the nmethod represented by this
+     * the field records the nmethod's compile identifier. This value is used to confirm if an entry
+     * in the code cache retrieved by {@link #address} is indeed the nmethod represented by this
      * object.
      *
      * @see #inOopsTable
@@ -84,6 +84,23 @@ public class HotSpotNmethod extends HotSpotInstalledCode {
         this.compileIdSnapshot = inOopsTable ? 0L : compileId;
         assert inOopsTable || compileId != 0L : this;
     }
+
+    /**
+     * Attaches {@code log} to this object. If {@code log.managesFailedSpeculations() == true}, this
+     * ensures the failed speculation list lives at least as long as this object.
+     */
+    public void setSpeculationLog(HotSpotSpeculationLog log) {
+        this.speculationLog = log;
+    }
+
+    /**
+     * The speculation log containing speculations embedded in the nmethod.
+     *
+     * If {@code speculationLog.managesFailedSpeculations() == true}, this field ensures the failed
+     * speculation list lives at least as long as this object. This prevents deoptimization from
+     * appending to an already freed list.
+     */
+    @SuppressWarnings("unused") private HotSpotSpeculationLog speculationLog;
 
     /**
      * Determines if the nmethod associated with this object is the compiled entry point for


### PR DESCRIPTION
This PR adds a strong reference from a `HotSpotNmethod` object to the non-empty `HotSpotSpeculationLog` used when compiling the nmethod. This ensures that a `HotSpotSpeculationLog` that [manages](https://github.com/openjdk/jdk/blob/739769c8fc4b496f08a92225a12d07414537b6c0/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotSpeculationLog.java#L116) a failed speculation list (i.e., the native memory of the failed speculations list is freed after the `HotSpotSpeculationLog` is collected) lives at least as long as the nmethod. Without this guarantee, when the nmethod deopts, it may try add a failed speculation to an already freed list.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279412](https://bugs.openjdk.java.net/browse/JDK-8279412): [JVMCI] failed speculations list must outlive any nmethod that refers to it


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tom Rodriguez](https://openjdk.java.net/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6949/head:pull/6949` \
`$ git checkout pull/6949`

Update a local copy of the PR: \
`$ git checkout pull/6949` \
`$ git pull https://git.openjdk.java.net/jdk pull/6949/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6949`

View PR using the GUI difftool: \
`$ git pr show -t 6949`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6949.diff">https://git.openjdk.java.net/jdk/pull/6949.diff</a>

</details>
