### PR TITLE
8279339: (ch) Input/Output streams returned by Channels factory methods don't support concurrent read/write ops

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/Channels.java
+++ b/src/java.base/share/classes/java/nio/channels/Channels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,8 +40,6 @@ import java.nio.charset.UnsupportedCharsetException;
 import java.nio.channels.spi.AbstractInterruptibleChannel;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
-import sun.nio.ch.ChannelInputStream;
-import sun.nio.ch.ChannelOutputStream;
 import sun.nio.cs.StreamDecoder;
 import sun.nio.cs.StreamEncoder;
 
@@ -87,7 +85,7 @@ public final class Channels {
      */
     public static InputStream newInputStream(ReadableByteChannel ch) {
         Objects.requireNonNull(ch, "ch");
-        return new ChannelInputStream(ch);
+        return sun.nio.ch.Streams.of(ch);
     }
 
     /**
@@ -106,7 +104,7 @@ public final class Channels {
      */
     public static OutputStream newOutputStream(WritableByteChannel ch) {
         Objects.requireNonNull(ch, "ch");
-        return new ChannelOutputStream(ch);
+        return sun.nio.ch.Streams.of(ch);
     }
 
     /**

--- a/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
@@ -239,10 +239,6 @@ class ChannelInputStream extends InputStream {
             if (out instanceof ChannelOutputStream cos) {
                 WritableByteChannel wbc = cos.channel();
 
-                if (wbc instanceof FileChannel target) {
-                    return transfer(fc, target);
-                }
-
                 if (wbc instanceof SelectableChannel sc) {
                     synchronized (sc.blockingLock()) {
                         if (!sc.isBlocking())

--- a/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,58 +40,49 @@ import java.util.Objects;
 import jdk.internal.util.ArraysSupport;
 
 /**
- * This class is defined here rather than in java.nio.channels.Channels
- * so that code can be shared with SocketAdaptor.
+ * An InputStream that reads bytes from a channel.
  *
  * @author Mike McCloskey
  * @author Mark Reinhold
- * @since 1.4
  */
-
-public class ChannelInputStream
-    extends InputStream
-{
+class ChannelInputStream extends InputStream {
     private static final int DEFAULT_BUFFER_SIZE = 8192;
 
-    public static int read(ReadableByteChannel ch, ByteBuffer bb,
-                           boolean block)
-        throws IOException
-    {
+    private final ReadableByteChannel ch;
+    private ByteBuffer bb;
+    private byte[] bs;    // cached byte array
+    private byte[] b1;
+
+    ChannelInputStream(ReadableByteChannel ch) {
+        this.ch = ch;
+    }
+
+    /**
+     * Reads a sequence of bytes from the channel into the given buffer.
+     */
+    private int read(ByteBuffer bb) throws IOException {
         if (ch instanceof SelectableChannel sc) {
             synchronized (sc.blockingLock()) {
-                boolean bm = sc.isBlocking();
-                if (!bm)
+                if (!sc.isBlocking())
                     throw new IllegalBlockingModeException();
-                if (bm != block)
-                    sc.configureBlocking(block);
-                int n = ch.read(bb);
-                if (bm != block)
-                    sc.configureBlocking(bm);
-                return n;
+                return ch.read(bb);
             }
         } else {
             return ch.read(bb);
         }
     }
 
-    protected final ReadableByteChannel ch;
-    private ByteBuffer bb = null;
-    private byte[] bs = null;           // Invoker's previous array
-    private byte[] b1 = null;
-
-    public ChannelInputStream(ReadableByteChannel ch) {
-        this.ch = ch;
-    }
-
+    @Override
     public synchronized int read() throws IOException {
         if (b1 == null)
             b1 = new byte[1];
-        int n = this.read(b1);
+        int n = read(b1);
         if (n == 1)
             return b1[0] & 0xff;
         return -1;
     }
 
+    @Override
     public synchronized int read(byte[] bs, int off, int len)
         throws IOException
     {
@@ -107,12 +98,6 @@ public class ChannelInputStream
         this.bb = bb;
         this.bs = bs;
         return read(bb);
-    }
-
-    protected int read(ByteBuffer bb)
-        throws IOException
-    {
-        return ChannelInputStream.read(ch, bb, true);
     }
 
     @Override
@@ -201,6 +186,7 @@ public class ChannelInputStream
         return (capacity == nread) ? buf : Arrays.copyOf(buf, nread);
     }
 
+    @Override
     public int available() throws IOException {
         // special case where the channel is to a file
         if (ch instanceof SeekableByteChannel sbc) {
@@ -210,6 +196,7 @@ public class ChannelInputStream
         return 0;
     }
 
+    @Override
     public synchronized long skip(long n) throws IOException {
         // special case where the channel is to a file
         if (ch instanceof SeekableByteChannel sbc) {
@@ -230,46 +217,66 @@ public class ChannelInputStream
         return super.skip(n);
     }
 
-    public void close() throws IOException {
-        ch.close();
-    }
-
     @Override
     public long transferTo(OutputStream out) throws IOException {
         Objects.requireNonNull(out, "out");
 
-        if (out instanceof ChannelOutputStream cos
-                && ch instanceof FileChannel fc) {
-            WritableByteChannel wbc = cos.channel();
-
-            if (wbc instanceof FileChannel dst) {
-                return transfer(fc, dst);
-            }
-
-            if (wbc instanceof SelectableChannel sc) {
+        if (ch instanceof FileChannel fc) {
+            // FileChannel -> SocketChannel
+            if (out instanceof SocketOutputStream sos) {
+                SocketChannelImpl sc = sos.channel();
                 synchronized (sc.blockingLock()) {
                     if (!sc.isBlocking())
                         throw new IllegalBlockingModeException();
-                    return transfer(fc, wbc);
+                    return transfer(fc, sc);
                 }
             }
 
-            return transfer(fc, wbc);
+            // FileChannel -> WritableByteChannel
+            if (out instanceof ChannelOutputStream cos) {
+                WritableByteChannel wbc = cos.channel();
+
+                if (wbc instanceof FileChannel target) {
+                    return transfer(fc, target);
+                }
+
+                if (wbc instanceof SelectableChannel sc) {
+                    synchronized (sc.blockingLock()) {
+                        if (!sc.isBlocking())
+                            throw new IllegalBlockingModeException();
+                        return transfer(fc, wbc);
+                    }
+                }
+
+                return transfer(fc, wbc);
+            }
         }
 
         return super.transferTo(out);
     }
 
-    private static long transfer(FileChannel src, WritableByteChannel dst) throws IOException {
+    /**
+     * Transfers all bytes a channel's file to a target writeable byte channel.
+     * If the writeable byte channel is a selectable channel then it must be in
+     * blocking mode.
+     */
+    private static long transfer(FileChannel src, WritableByteChannel target)
+        throws IOException
+    {
         long initialPos = src.position();
         long pos = initialPos;
         try {
             while (pos < src.size()) {
-                pos += src.transferTo(pos, Long.MAX_VALUE, dst);
+                pos += src.transferTo(pos, Long.MAX_VALUE, target);
             }
         } finally {
             src.position(pos);
         }
         return pos - initialPos;
+    }
+
+    @Override
+    public void close() throws IOException {
+        ch.close();
     }
 }

--- a/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
@@ -50,9 +50,12 @@ class ChannelInputStream extends InputStream {
 
     private final ReadableByteChannel ch;
     private ByteBuffer bb;
-    private byte[] bs;    // cached byte array
+    private byte[] bs;       // Invoker's previous array
     private byte[] b1;
 
+    /**
+     * Initialize a ChannelInputStream that reads from the given channel.
+     */
     ChannelInputStream(ReadableByteChannel ch) {
         this.ch = ch;
     }
@@ -260,17 +263,17 @@ class ChannelInputStream extends InputStream {
      * If the writeable byte channel is a selectable channel then it must be in
      * blocking mode.
      */
-    private static long transfer(FileChannel src, WritableByteChannel target)
+    private static long transfer(FileChannel fc, WritableByteChannel target)
         throws IOException
     {
-        long initialPos = src.position();
+        long initialPos = fc.position();
         long pos = initialPos;
         try {
-            while (pos < src.size()) {
-                pos += src.transferTo(pos, Long.MAX_VALUE, target);
+            while (pos < fc.size()) {
+                pos += fc.transferTo(pos, Long.MAX_VALUE, target);
             }
         } finally {
-            src.position(pos);
+            fc.position(pos);
         }
         return pos - initialPos;
     }

--- a/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
@@ -255,7 +255,7 @@ class ChannelInputStream extends InputStream {
     }
 
     /**
-     * Transfers all bytes a channel's file to a target writeable byte channel.
+     * Transfers all bytes from a channel's file to a target writeable byte channel.
      * If the writeable byte channel is a selectable channel then it must be in
      * blocking mode.
      */

--- a/src/java.base/share/classes/sun/nio/ch/ChannelOutputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelOutputStream.java
@@ -42,11 +42,11 @@ import java.util.Objects;
 class ChannelOutputStream extends OutputStream {
     private final WritableByteChannel ch;
     private ByteBuffer bb;
-    private byte[] bs;       // cached byte array
+    private byte[] bs;       // Invoker's previous array
     private byte[] b1;
 
     /**
-     * @param ch The channel wrapped by this stream.
+     * Initialize a ChannelOutputStream that writes to the given channel.
      */
     ChannelOutputStream(WritableByteChannel ch) {
         this.ch = ch;

--- a/src/java.base/share/classes/sun/nio/ch/ChannelOutputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,68 +25,30 @@
 
 package sun.nio.ch;
 
-import java.io.*;
-import java.nio.*;
-import java.nio.channels.*;
-import java.nio.channels.spi.*;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.IllegalBlockingModeException;
+import java.nio.channels.SelectableChannel;
+import java.nio.channels.WritableByteChannel;
 import java.util.Objects;
 
 /**
- * This class is defined here rather than in java.nio.channels.Channels
- * so that it will be accessible from java.nio.channels.Channels and
- * sun.nio.ch.ChannelInputStream.
- *
+ * An OutputStream that writes bytes to a channel.
  *
  * @author Mark Reinhold
  * @author Mike McCloskey
- * @author JSR-51 Expert Group
- * @since 18
  */
-public class ChannelOutputStream extends OutputStream {
-
+class ChannelOutputStream extends OutputStream {
     private final WritableByteChannel ch;
     private ByteBuffer bb;
-    private byte[] bs;       // Invoker's previous array
+    private byte[] bs;       // cached byte array
     private byte[] b1;
-
-    /**
-     * Write all remaining bytes in buffer to the given channel.
-     * If the channel is selectable then it must be configured blocking.
-     */
-    private static void writeFullyImpl(WritableByteChannel ch, ByteBuffer bb)
-        throws IOException
-    {
-        while (bb.remaining() > 0) {
-            int n = ch.write(bb);
-            if (n <= 0)
-                throw new RuntimeException("no bytes written");
-        }
-    }
-
-    /**
-     * Write all remaining bytes in buffer to the given channel.
-     *
-     * @throws  IllegalBlockingModeException
-     *          If the channel is selectable and configured non-blocking.
-     */
-    private static void writeFully(WritableByteChannel ch, ByteBuffer bb)
-        throws IOException
-    {
-        if (ch instanceof SelectableChannel sc) {
-            synchronized (sc.blockingLock()) {
-                if (!sc.isBlocking())
-                    throw new IllegalBlockingModeException();
-                writeFullyImpl(ch, bb);
-            }
-        } else {
-            writeFullyImpl(ch, bb);
-        }
-    }
 
     /**
      * @param ch The channel wrapped by this stream.
      */
-    public ChannelOutputStream(WritableByteChannel ch) {
+    ChannelOutputStream(WritableByteChannel ch) {
         this.ch = ch;
     }
 
@@ -97,17 +59,30 @@ public class ChannelOutputStream extends OutputStream {
         return ch;
     }
 
+    /**
+     * Write all remaining bytes in buffer to the channel.
+     * If the channel is selectable then it must be configured blocking.
+     */
+    private void writeFully(ByteBuffer bb) throws IOException {
+        while (bb.remaining() > 0) {
+            int n = ch.write(bb);
+            if (n <= 0)
+                throw new RuntimeException("no bytes written");
+        }
+    }
+
     @Override
     public synchronized void write(int b) throws IOException {
         if (b1 == null)
             b1 = new byte[1];
         b1[0] = (byte) b;
-        this.write(b1);
+        write(b1);
     }
 
     @Override
     public synchronized void write(byte[] bs, int off, int len)
-        throws IOException {
+        throws IOException
+    {
         Objects.checkFromIndexSize(off, len, bs.length);
         if (len == 0) {
             return;
@@ -119,12 +94,20 @@ public class ChannelOutputStream extends OutputStream {
         bb.position(off);
         this.bb = bb;
         this.bs = bs;
-        writeFully(ch, bb);
+
+        if (ch instanceof SelectableChannel sc) {
+            synchronized (sc.blockingLock()) {
+                if (!sc.isBlocking())
+                    throw new IllegalBlockingModeException();
+                writeFully(bb);
+            }
+        } else {
+            writeFully(bb);
+        }
     }
 
     @Override
     public void close() throws IOException {
         ch.close();
     }
-
 }

--- a/src/java.base/share/classes/sun/nio/ch/SocketInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketInputStream.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package sun.nio.ch;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.function.IntSupplier;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * An InputStream that reads bytes from a socket channel.
+ */
+class SocketInputStream extends InputStream {
+    private final SocketChannelImpl sc;
+    private final IntSupplier timeoutSupplier;
+
+    SocketInputStream(SocketChannelImpl sc, IntSupplier timeoutSupplier) {
+        this.sc = sc;
+        this.timeoutSupplier = timeoutSupplier;
+    }
+
+    SocketInputStream(SocketChannelImpl sc) {
+        this(sc, () -> 0);
+    }
+
+    @Override
+    public int read() throws IOException {
+        byte[] a = new byte[1];
+        int n = read(a, 0, 1);
+        return (n > 0) ? (a[0] & 0xff) : -1;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        int timeout = timeoutSupplier.getAsInt();
+        if (timeout > 0) {
+            long nanos = MILLISECONDS.toNanos(timeout);
+            return sc.blockingRead(b, off, len, nanos);
+        } else {
+            return sc.blockingRead(b, off, len, 0);
+        }
+    }
+
+    @Override
+    public int available() throws IOException {
+        return sc.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+        sc.close();
+    }
+}

--- a/src/java.base/share/classes/sun/nio/ch/SocketInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketInputStream.java
@@ -36,11 +36,19 @@ class SocketInputStream extends InputStream {
     private final SocketChannelImpl sc;
     private final IntSupplier timeoutSupplier;
 
+    /**
+     * Initialize a SocketInputStream that reads from the given socket channel.
+     * @param sc the socket channel
+     * @param timeoutSupplier supplies the read timeout, in milliseconds
+     */
     SocketInputStream(SocketChannelImpl sc, IntSupplier timeoutSupplier) {
         this.sc = sc;
         this.timeoutSupplier = timeoutSupplier;
     }
 
+    /**
+     * Initialize a SocketInputStream that reads from the given socket channel.
+     */
     SocketInputStream(SocketChannelImpl sc) {
         this(sc, () -> 0);
     }

--- a/src/java.base/share/classes/sun/nio/ch/SocketOutputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketOutputStream.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package sun.nio.ch;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * An OutputStream that writes bytes to a socket channel.
+ */
+class SocketOutputStream extends OutputStream {
+    private final SocketChannelImpl sc;
+
+    SocketOutputStream(SocketChannelImpl sc) {
+        this.sc = sc;
+    }
+
+    SocketChannelImpl channel() {
+        return sc;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        byte[] a = new byte[]{(byte) b};
+        write(a, 0, 1);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        sc.blockingWriteFully(b, off, len);
+    }
+
+    @Override
+    public void close() throws IOException {
+        sc.close();
+    }
+}

--- a/src/java.base/share/classes/sun/nio/ch/SocketOutputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketOutputStream.java
@@ -33,10 +33,16 @@ import java.io.OutputStream;
 class SocketOutputStream extends OutputStream {
     private final SocketChannelImpl sc;
 
+    /**
+     * Initialize a SocketOutputStream that writes to the given socket channel.
+     */
     SocketOutputStream(SocketChannelImpl sc) {
         this.sc = sc;
     }
 
+    /**
+     * Returns the socket channel.
+     */
     SocketChannelImpl channel() {
         return sc;
     }

--- a/src/java.base/share/classes/sun/nio/ch/Streams.java
+++ b/src/java.base/share/classes/sun/nio/ch/Streams.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package sun.nio.ch;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+
+/**
+ * Factory methods for input/output streams based on channels.
+ */
+public class Streams {
+    private Streams() { }
+
+    /**
+     * Return an input stream that reads bytes from the given channel.
+     */
+    public static InputStream of(ReadableByteChannel ch) {
+        if (ch instanceof SocketChannelImpl sc) {
+            return new SocketInputStream(sc);
+        } else {
+            return new ChannelInputStream(ch);
+        }
+    }
+
+    /**
+     * Return an output stream that writes bytes to the given channel.
+     */
+    public static OutputStream of(WritableByteChannel ch) {
+        if (ch instanceof SocketChannelImpl sc) {
+            return new SocketOutputStream(sc);
+        } else {
+            return new ChannelOutputStream(ch);
+        }
+    }
+}

--- a/test/jdk/java/nio/channels/Channels/SocketChannelStreams.java
+++ b/test/jdk/java/nio/channels/Channels/SocketChannelStreams.java
@@ -434,7 +434,7 @@ public class SocketChannelStreams {
     private void write(SocketChannel sc, int b) throws IOException {
         sc.socket().getOutputStream().write(b);
     }
-    
+
     /**
      * Writes the given data to the socket channel after a delay.
      */

--- a/test/jdk/java/nio/channels/Channels/SocketChannelStreams.java
+++ b/test/jdk/java/nio/channels/Channels/SocketChannelStreams.java
@@ -1,0 +1,480 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8279339
+ * @run testng SocketChannelStreams
+ * @summary Exercise InputStream/OutputStream returned by Channels.newXXXStream
+ *    when channel is a SocketChannel
+ */
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.channels.Channels;
+import java.nio.channels.IllegalBlockingModeException;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.testng.annotations.*;
+import static org.testng.Assert.*;
+
+@Test
+public class SocketChannelStreams {
+    private ScheduledExecutorService executor;
+
+    @BeforeClass()
+    public void init() {
+        executor = Executors.newSingleThreadScheduledExecutor();
+    }
+
+    @AfterClass
+    public void finish() {
+        executor.shutdown();
+    }
+
+    /**
+     * Test read when bytes are available.
+     */
+    public void testRead1() throws Exception {
+        withConnection((sc, peer) -> {
+            write(peer, 99);
+            int n = Channels.newInputStream(sc).read();
+            assertEquals(n, 99);
+        });
+    }
+
+    /**
+     * Test read blocking before bytes are available.
+     */
+    public void testRead2() throws Exception {
+        withConnection((sc, peer) -> {
+            scheduleWrite(peer, 99, 1000);
+            int n = Channels.newInputStream(sc).read();
+            assertEquals(n, 99);
+        });
+    }
+
+    /**
+     * Test read after peer has closed connection.
+     */
+    public void testRead3() throws Exception {
+        withConnection((sc, peer) -> {
+            peer.close();
+            int n = Channels.newInputStream(sc).read();
+            assertEquals(n, -1);
+        });
+    }
+
+    /**
+     * Test read blocking before peer closes connection.
+     */
+    public void testRead4() throws Exception {
+        withConnection((sc, peer) -> {
+            scheduleClose(peer, 1000);
+            int n = Channels.newInputStream(sc).read();
+            assertEquals(n, -1);
+        });
+    }
+
+    /**
+     * Test async close of channel when thread blocked in read.
+     */
+    public void testRead5() throws Exception {
+        withConnection((sc, peer) -> {
+            scheduleClose(sc, 2000);
+            InputStream in = Channels.newInputStream(sc);
+            expectThrows(IOException.class, () -> in.read());
+        });
+    }
+
+    /**
+     * Test async close of input stream, when thread blocked in read.
+     */
+    public void testRead6() throws Exception {
+        withConnection((sc, peer) -> {
+            InputStream in = Channels.newInputStream(sc);
+            scheduleClose(in, 2000);
+            expectThrows(IOException.class, () -> in.read());
+        });
+    }
+
+    /**
+     * Test interrupt status set before read.
+     */
+    public void testRead7() throws Exception {
+        withConnection((sc, peer) -> {
+            Thread.currentThread().interrupt();
+            try {
+                InputStream in = Channels.newInputStream(sc);
+                expectThrows(IOException.class, () -> in.read());
+            } finally {
+                Thread.interrupted();  // clear interrupt
+            }
+            assertFalse(sc.isOpen());
+        });
+    }
+
+    /**
+     * Test interrupt of thread blocked in read.
+     */
+    public void testRead8() throws Exception {
+        withConnection((sc, peer) -> {
+            Future<?> interrupter = scheduleInterrupt(Thread.currentThread(), 2000);
+            try {
+                InputStream in = Channels.newInputStream(sc);
+                expectThrows(IOException.class, () -> in.read());
+            } finally {
+                interrupter.cancel(true);
+                Thread.interrupted();  // clear interrupt
+            }
+            assertFalse(sc.isOpen());
+        });
+    }
+
+    /**
+     * Test that read is untimed when SO_TIMEOUT is set on the Socket adaptor.
+     */
+    public void testRead9() throws Exception {
+        withConnection((sc, peer) -> {
+            sc.socket().setSoTimeout(100);
+            scheduleWrite(peer, 99, 2000);
+            // read should block until bytes are available
+            int b = Channels.newInputStream(sc).read();
+            assertTrue(b == 99);
+        });
+    }
+
+    /**
+     * Test write.
+     */
+    public void testWrite1() throws Exception {
+        withConnection((sc, peer) -> {
+            OutputStream out = Channels.newOutputStream(sc);
+            out.write(99);
+            int n = read(peer);
+            assertEquals(n, 99);
+        });
+    }
+
+    /**
+     * Test async close of channel when thread blocked in write.
+     */
+    public void testWrite2() throws Exception {
+        withConnection((sc, peer) -> {
+            scheduleClose(sc, 2000);
+            expectThrows(IOException.class, () -> {
+                OutputStream out = Channels.newOutputStream(sc);
+                byte[] data = new byte[64*1000];
+                while (true) {
+                    out.write(data);
+                }
+            });
+        });
+    }
+
+    /**
+     * Test async close of output stream when thread blocked in write.
+     */
+    public void testWrite3() throws Exception {
+        withConnection((sc, peer) -> {
+            OutputStream out = Channels.newOutputStream(sc);
+            scheduleClose(out, 2000);
+            expectThrows(IOException.class, () -> {
+                byte[] data = new byte[64*1000];
+                while (true) {
+                    out.write(data);
+                }
+            });
+        });
+    }
+
+    /**
+     * Test interrupt status set before write.
+     */
+    public void testWrite4() throws Exception {
+        withConnection((sc, peer) -> {
+            Thread.currentThread().interrupt();
+            try {
+                OutputStream out = Channels.newOutputStream(sc);
+                expectThrows(IOException.class, () -> out.write(99));
+            } finally {
+                Thread.interrupted();  // clear interrupt
+            }
+            assertFalse(sc.isOpen());
+        });
+    }
+
+    /**
+     * Test interrupt of thread blocked in write.
+     */
+    public void testWrite5() throws Exception {
+        withConnection((sc, peer) -> {
+            Future<?> interrupter = scheduleInterrupt(Thread.currentThread(), 2000);
+            try {
+                expectThrows(IOException.class, () -> {
+                    OutputStream out = Channels.newOutputStream(sc);
+                    byte[] data = new byte[64*1000];
+                    while (true) {
+                        out.write(data);
+                    }
+                });
+            } finally {
+                interrupter.cancel(true);
+                Thread.interrupted();  // clear interrupt
+            }
+            assertFalse(sc.isOpen());
+        });
+    }
+
+    /**
+     * Test read when another thread is blocked in write. The read should
+     * complete immediately.
+     */
+    public void testConcurrentReadWrite1() throws Exception {
+        withConnection((sc, peer) -> {
+            InputStream in = Channels.newInputStream(sc);
+            OutputStream out = Channels.newOutputStream(sc);
+
+            // block thread in write
+            fork(() -> {
+                var data = new byte[64*1024];
+                for (;;) {
+                    out.write(data);
+                }
+            });
+            Thread.sleep(1000); // give writer time to block
+
+            // test read, should not be blocked by writer thread
+            write(peer, 99);
+            int n = in.read();
+            assertEquals(n, 99);
+        });
+    }
+
+    /**
+     * Test read when another thread is blocked in write. The read should
+     * block until bytes are available.
+     */
+    public void testConcurrentReadWrite2() throws Exception {
+        withConnection((sc, peer) -> {
+            InputStream in = Channels.newInputStream(sc);
+            OutputStream out = Channels.newOutputStream(sc);
+
+            // block thread in write
+            fork(() -> {
+                var data = new byte[64*1024];
+                for (;;) {
+                    out.write(data);
+                }
+            });
+            Thread.sleep(1000); // give writer time to block
+
+            // test read, should not be blocked by writer thread
+            scheduleWrite(peer, 99, 500);
+            int n = in.read();
+            assertEquals(n, 99);
+        });
+    }
+
+    /**
+     * Test writing when another thread is blocked in read.
+     */
+    public void testConcurrentReadWrite3() throws Exception {
+        withConnection((sc, peer) -> {
+            InputStream in = Channels.newInputStream(sc);
+            OutputStream out = Channels.newOutputStream(sc);
+
+            // block thread in read
+            fork(() -> {
+                in.read();
+            });
+            Thread.sleep(100); // give reader time to block
+
+            // test write, should not be blocked by reader thread
+            out.write(99);
+            int n = read(peer);
+            assertEquals(n, 99);
+        });
+    }
+
+    /**
+     * Test read/write when channel configured non-blocking.
+     */
+    public void testIllegalBlockingMode() throws Exception {
+        withConnection((sc, peer) -> {
+            InputStream in = Channels.newInputStream(sc);
+            OutputStream out = Channels.newOutputStream(sc);
+
+            sc.configureBlocking(false);
+            expectThrows(IllegalBlockingModeException.class, () -> in.read());
+            expectThrows(IllegalBlockingModeException.class, () -> out.write(99));
+        });
+    }
+
+    /**
+     * Test NullPointerException.
+     */
+    public void testNullPointerException() throws Exception {
+        withConnection((sc, peer) -> {
+            InputStream in = Channels.newInputStream(sc);
+            OutputStream out = Channels.newOutputStream(sc);
+
+            expectThrows(NullPointerException.class, () -> in.read(null));
+            expectThrows(NullPointerException.class, () -> in.read(null, 0, 0));
+
+            expectThrows(NullPointerException.class, () -> out.write(null));
+            expectThrows(NullPointerException.class, () -> out.write(null, 0, 0));
+        });
+    }
+
+    /**
+     * Test IndexOutOfBoundsException.
+     */
+    public void testIndexOutOfBoundsException() throws Exception {
+        withConnection((sc, peer) -> {
+            InputStream in = Channels.newInputStream(sc);
+            OutputStream out = Channels.newOutputStream(sc);
+            byte[] ba = new byte[100];
+
+            expectThrows(IndexOutOfBoundsException.class, () -> in.read(ba, -1, 1));
+            expectThrows(IndexOutOfBoundsException.class, () -> in.read(ba, 0, -1));
+            expectThrows(IndexOutOfBoundsException.class, () -> in.read(ba, 0, 1000));
+            expectThrows(IndexOutOfBoundsException.class, () -> in.read(ba, 1, 100));
+
+            expectThrows(IndexOutOfBoundsException.class, () -> out.write(ba, -1, 1));
+            expectThrows(IndexOutOfBoundsException.class, () -> out.write(ba, 0, -1));
+            expectThrows(IndexOutOfBoundsException.class, () -> out.write(ba, 0, 1000));
+            expectThrows(IndexOutOfBoundsException.class, () -> out.write(ba, 1, 100));
+        });
+    }
+
+    // -- test infrastructure --
+
+    private interface ThrowingTask {
+        void run() throws Exception;
+    }
+
+    private interface ThrowingBiConsumer<T, U> {
+        void accept(T t, U u) throws Exception;
+    }
+
+    /**
+     * Invokes the consumer with a connected pair of socket channels.
+     */
+    private static void withConnection(ThrowingBiConsumer<SocketChannel, SocketChannel> consumer)
+        throws Exception
+    {
+        var loopback = InetAddress.getLoopbackAddress();
+        try (ServerSocketChannel listener = ServerSocketChannel.open()) {
+            listener.bind(new InetSocketAddress(loopback, 0));
+            try (SocketChannel sc = SocketChannel.open(listener.getLocalAddress())) {
+                try (SocketChannel peer = listener.accept()) {
+                    consumer.accept(sc, peer);
+                }
+            }
+        }
+    }
+
+    /**
+     * Forks a thread to execute the given task.
+     */
+    private Future<?> fork(ThrowingTask task) {
+        ExecutorService pool = Executors.newFixedThreadPool(1);
+        try {
+            return pool.submit(() -> {
+                task.run();
+                return null;
+            });
+        } finally {
+            pool.shutdown();
+        }
+    }
+
+    /**
+     * Read a byte from the given socket channel.
+     */
+    private int read(SocketChannel sc) throws IOException {
+        return sc.socket().getInputStream().read();
+    }
+
+    /**
+     * Write a byte to the given socket channel.
+     */
+    private void write(SocketChannel sc, int b) throws IOException {
+        sc.socket().getOutputStream().write(b);
+    }
+    
+    /**
+     * Writes the given data to the socket channel after a delay.
+     */
+    private Future<?> scheduleWrite(SocketChannel sc, byte[] data, long delay) {
+        return schedule(() -> {
+            try {
+                sc.socket().getOutputStream().write(data);
+            } catch (IOException ioe) { }
+        }, delay);
+    }
+
+    /**
+     * Writes a byte to the socket channel after a delay.
+     */
+    private Future<?> scheduleWrite(SocketChannel sc, int b, long delay) {
+        return scheduleWrite(sc, new byte[] { (byte)b }, delay);
+    }
+
+    /**
+     * Closes the given object after a delay.
+     */
+    private Future<?> scheduleClose(Closeable c, long delay) {
+        return schedule(() -> {
+            try {
+                c.close();
+            } catch (IOException ioe) { }
+        }, delay);
+    }
+
+    /**
+     * Interrupts the given Thread after a delay.
+     */
+    private Future<?> scheduleInterrupt(Thread t, long delay) {
+        return schedule(() -> t.interrupt(), delay);
+    }
+
+    /**
+     * Schedules the given task to run after a delay.
+     */
+    private Future<?> schedule(Runnable task, long delay) {
+        return executor.schedule(task, delay, TimeUnit.MILLISECONDS);
+    }
+}


### PR DESCRIPTION
If someone has a SocketChannel sc then one way to obtain input/output streams is via the Socket adaptor, i.e. sc.socket().getXXXStream. Another way is with Channels.newXXXStream(sc) factory methods. A long standing limitation is that the input/output streams returned by the Channels.newXXXStream methods must synchronize on the channel's blockingLock() to prevent the channel from being configured non-blocking. There is one "blocking lock" per SelectableChannel so problematic when the SelectableChannel is also a ByteChannel as it prevents a thread from writing while another is blocked in read (and vice versa).

The change proposed here is to have Channels.newXXXStream special case the SocketChannel implementation so that it returns the same input/output stream as the socket adaptors. These socket streams make use of non-exposed blocking read/write methods that coordinate with configureBlocking so don't need to synchronize on the blockingLock. The core part of the change is that the inner classes that were in SocketAdaptor are moved to be top-level SocketInputStream and SocketOutputStream classes.

There is some minor cleanup to ChannelInputStream and ChannelOutputStream in this patch. Once pattern matching for switch is permanent, and Markus Karg is done with transferTo, then we can see if we want to refactor that method and/or introduce a sub-class for FileChannel.

I've added a new test to exercise the the read/write methods, with focus on async close and interrupt. It includes tests that do concurrent read + write operations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279339](https://bugs.openjdk.java.net/browse/JDK-8279339): (ch) Input/Output streams returned by Channels factory methods don't support concurrent read/write ops


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6953/head:pull/6953` \
`$ git checkout pull/6953`

Update a local copy of the PR: \
`$ git checkout pull/6953` \
`$ git pull https://git.openjdk.java.net/jdk pull/6953/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6953`

View PR using the GUI difftool: \
`$ git pr show -t 6953`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6953.diff">https://git.openjdk.java.net/jdk/pull/6953.diff</a>

</details>
