### PR TITLE
8279354 JFR: Jlink plugin to reduce startup time

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -50,7 +50,7 @@ import jdk.jfr.internal.Type;
 import jdk.jfr.internal.jfc.JFC;
 import jdk.jfr.internal.jfc.model.JFCModel;
 import jdk.jfr.internal.jfc.model.XmlInput;
-
+import jdk.jfr.internal.startup.Archive;
 /**
  * JFR.start
  *
@@ -96,12 +96,15 @@ final class DCmdStart extends AbstractDCmd {
         if (settings.length == 1 && settings[0].length() == 0) {
             throw new DCmdException("No settings specified. Use settings=none to start without any settings");
         }
-
-        LinkedHashMap<String, String> s;
-        if (parser.hasExtendedOptions()) {
-           s = configureExtended(settings, parser);
+        Map<String, String> s;
+        if (list == null) {
+            s = Archive.DEFAULT_SETTINGS;
         } else {
-           s = configureStandard(settings);
+            if (parser.hasExtendedOptions()) {
+                s = configureExtended(settings, parser);
+            } else {
+                s = configureStandard(settings);
+            }
         }
 
         OldObjectSample.updateSettingPathToGcRoots(s, pathToGcRoots);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/startup/Archive.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/startup/Archive.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.jfr.internal.startup;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Purpose of this class is to provide access to artifacts generated at build
+ * time.
+ */
+public class Archive {
+    private final static String FILENAME = "/jdk/jfr/internal/startup/archive.bin";
+
+    private Archive() {
+        // Don't instantiate
+    }
+
+    static {
+        try {
+            try (var is = Archive.class.getResourceAsStream(FILENAME)) {
+                if (is == null) {
+                    throw new InternalError("Could not find generated JFR startup archive at: " + FILENAME);
+                }
+                try (var dais = new DataInputStream(is)) {
+                    DEFAULT_SETTINGS = readSettings(dais);
+                }
+            }
+        } catch (IOException e) {
+            throw new InternalError("Could not read data from generated JFR startup archive: " + e.getMessage(), e);
+        }
+    }
+
+    public final static Map<String, String> DEFAULT_SETTINGS;
+
+    public static Map<String, String> readSettings(DataInputStream dais) throws IOException {
+        int count = dais.readInt();
+        Map<String, String> settings = new LinkedHashMap<>(count);
+        for (int i = 0; i < count; i++) {
+            String key = dais.readUTF();
+            String value = dais.readUTF();
+            settings.put(key, value);
+        }
+        return settings;
+    }
+}

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/startup/ArchivePlugin.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/startup/ArchivePlugin.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.jfr.internal.startup;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import jdk.jfr.Configuration;
+import jdk.tools.jlink.plugin.Plugin;
+import jdk.tools.jlink.plugin.PluginException;
+import jdk.tools.jlink.plugin.ResourcePool;
+import jdk.tools.jlink.plugin.ResourcePoolBuilder;
+import jdk.tools.jlink.plugin.ResourcePoolEntry;
+
+/**
+ * Purpose of this Jlink plug-in is to generate an archive of pregenerated
+ * information that can be read quickly during JFR startup
+ */
+public final class ArchivePlugin implements Plugin {
+    public final static String FILENAME = "/jdk/jfr/internal/startup/archive.bin";
+
+    public ArchivePlugin() {
+    }
+
+    public Set<State> getState() {
+        return EnumSet.of(State.AUTO_ENABLED, State.FUNCTIONAL);
+    }
+
+    public Category getType() {
+        return Category.ADDER;
+    }
+
+    @Override
+    public ResourcePool transform(ResourcePool in, ResourcePoolBuilder out) {
+        System.out.println("koko och jag");
+        var module = in.moduleView().findModule("jdk.jfr");
+        if (module.isPresent()) {
+            try {
+                byte[] bytes = getArchiveBytes();
+                if (bytes != null) { // JFR classes are not available, ignore
+                    in.transformAndCopy(Function.identity(), out);
+                    out.add(ResourcePoolEntry.create(FILENAME, bytes));
+                    return out.build();
+                }
+
+            } catch (IOException | ParseException e) {
+                throw new PluginException("Could not generate jfr archive. " + e.getMessage(), e);
+            }
+        }
+        return in;
+    }
+
+    public static byte[] getArchiveBytes() throws IOException, ParseException {
+        try (var baos = new ByteArrayOutputStream(); var daos = new DataOutputStream(baos)) {
+            writeSettings(daos, "default");
+            daos.flush();
+            return baos.toByteArray();
+        }
+    }
+
+    private static void writeSettings(DataOutputStream daos, String name) throws IOException, ParseException {
+        Configuration c = Configuration.getConfiguration(name);
+        Map<String, String> settings = c.getSettings();
+        daos.writeInt(settings.size());
+        for (var entry : settings.entrySet()) {
+            daos.writeUTF(entry.getKey());
+            daos.writeUTF(entry.getValue());
+        }
+    }
+
+    public String getDescription() {
+        return "JFR plugin: generate jfr archive if the runtime image supports the JFR feature";
+    }
+
+    public String getUsage() {
+        return "--generate-jfr-archive    Generate JFR archive if the runtime image supports\n" + "                          the JFR feature";
+    }
+}

--- a/src/jdk.jfr/share/classes/module-info.java
+++ b/src/jdk.jfr/share/classes/module-info.java
@@ -30,8 +30,15 @@
  * @since 9
  */
 module jdk.jfr {
+
+    requires static jdk.jlink;
+
     exports jdk.jfr;
     exports jdk.jfr.consumer;
+
+    uses jdk.tools.jlink.plugin.Plugin;
+
+    provides jdk.tools.jlink.plugin.Plugin with jdk.jfr.internal.startup.ArchivePlugin;
 
     exports jdk.jfr.internal.management to jdk.management.jfr;
 }

--- a/src/jdk.jlink/share/classes/module-info.java
+++ b/src/jdk.jlink/share/classes/module-info.java
@@ -52,6 +52,8 @@ module jdk.jlink {
     requires jdk.internal.opt;
     requires jdk.jdeps;
 
+    exports jdk.tools.jlink.plugin to jdk.jfr;
+
     uses jdk.tools.jlink.plugin.Plugin;
 
     provides java.util.spi.ToolProvider with
@@ -78,5 +80,4 @@ module jdk.jlink {
         jdk.tools.jlink.internal.plugins.VendorVMBugURLPlugin,
         jdk.tools.jlink.internal.plugins.VendorVersionPlugin,
         jdk.tools.jlink.internal.plugins.CDSPlugin;
-
 }


### PR DESCRIPTION
JFR jlink plugin located in jdk.jfr module.

Fails with:

Error: jdk.tools.jlink.plugin.Plugin: Unable to load jdk.jfr.internal.startup.ArchivePlugin
java.util.ServiceConfigurationError: jdk.tools.jlink.plugin.Plugin: Unable to load jdk.jfr.internal.startup.ArchivePlugin
	at java.base/java.util.ServiceLoader.fail(ServiceLoader.java:586)
	at java.base/java.util.ServiceLoader.loadProvider(ServiceLoader.java:861)
	at java.base/java.util.ServiceLoader$LayerLookupIterator.hasNext(ServiceLoader.java:958)
	at java.base/java.util.ServiceLoader$3.hasNext(ServiceLoader.java:1393)
	at jdk.jlink/jdk.tools.jlink.internal.PluginRepository.getPlugins(PluginRepository.java:143)
	at jdk.jlink/jdk.tools.jlink.internal.PluginRepository.getPlugins(PluginRepository.java:110)
	at jdk.jlink/jdk.tools.jlink.internal.TaskHelper$PluginsHelper.<init>(TaskHelper.java:244)
	at jdk.jlink/jdk.tools.jlink.internal.TaskHelper$OptionsHelper.handleOptions(TaskHelper.java:531)
	at jdk.jlink/jdk.tools.jlink.internal.JlinkTask.run(JlinkTask.java:233)
	at jdk.jlink/jdk.tools.jlink.internal.Main.run(Main.java:55)
	at jdk.jlink/jdk.tools.jlink.internal.Main.main(Main.java:33)
Caused by: java.lang.NoClassDefFoundError: jdk/tools/jlink/plugin/Plugin
	at java.base/java.lang.ClassLoader.findBootstrapClass(Native Method)
	at java.base/java.lang.ClassLoader.findBootstrapClassOrNull(ClassLoader.java:1263)
	at java.base/java.lang.System$2.findBootstrapClassOrNull(System.java:2349)
	at java.base/jdk.internal.loader.BootLoader.loadClassOrNull(BootLoader.java:127)
	at java.base/jdk.internal.loader.BootLoader.loadClass(BootLoader.java:135)
	at java.base/java.lang.Class.forName(Class.java:579)
	at java.base/java.lang.Class.forName(Class.java:552)
	at java.base/java.util.ServiceLoader.loadProvider(ServiceLoader.java:859)

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8279354](https://bugs.openjdk.java.net/browse/JDK-8279354): JFR: Jlink plugin to reduce startup time


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6954/head:pull/6954` \
`$ git checkout pull/6954`

Update a local copy of the PR: \
`$ git checkout pull/6954` \
`$ git pull https://git.openjdk.java.net/jdk pull/6954/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6954`

View PR using the GUI difftool: \
`$ git pr show -t 6954`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6954.diff">https://git.openjdk.java.net/jdk/pull/6954.diff</a>

</details>
