### PR TITLE
8279445: Update JMH devkit to 1.34

### DIFF
--- a/make/devkit/createJMHBundle.sh
+++ b/make/devkit/createJMHBundle.sh
@@ -26,7 +26,7 @@
 # Create a bundle in the build directory, containing what's needed to
 # build and run JMH microbenchmarks from the OpenJDK build.
 
-JMH_VERSION=1.33
+JMH_VERSION=1.34
 COMMONS_MATH3_VERSION=3.2
 JOPT_SIMPLE_VERSION=4.6
 


### PR DESCRIPTION
Brings lots of goodies, including automatic enablement of Compiler Blackholes: https://mail.openjdk.java.net/pipermail/jmh-dev/2021-December/003406.html 

Additional testing:
 - [x] Devkit creation works
 - [x] Sample benchmarks runs with new devkit

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279445](https://bugs.openjdk.java.net/browse/JDK-8279445): Update JMH devkit to 1.34


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6955/head:pull/6955` \
`$ git checkout pull/6955`

Update a local copy of the PR: \
`$ git checkout pull/6955` \
`$ git pull https://git.openjdk.java.net/jdk pull/6955/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6955`

View PR using the GUI difftool: \
`$ git pr show -t 6955`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6955.diff">https://git.openjdk.java.net/jdk/pull/6955.diff</a>

</details>
