### PR TITLE
JDK-8278549: UNIX sun/font coding misses SUSE distro detection on recent distro SUSE 15

### DIFF
--- a/src/java.desktop/unix/classes/sun/font/FcFontConfiguration.java
+++ b/src/java.desktop/unix/classes/sun/font/FcFontConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -295,6 +295,12 @@ public class FcFontConfiguration extends FontConfiguration {
         return null;
     }
 
+    private String getOsinfo(String s) {
+        if (s.startsWith("\"")) s = s.substring(1);
+        if (s.endsWith("\"")) s = s.substring(0, s.length()-1);
+        return s;
+    }
+
     /**
      * Sets the OS name and version from environment information.
      */
@@ -331,6 +337,16 @@ public class FcFontConfiguration extends FontConfiguration {
             } else if ((f = new File("/etc/fedora-release")).canRead()) {
                 osName = "Fedora";
                 osVersion = getVersionString(f);
+            } else if ((f = new File("/etc/os-release")).canRead()) {
+                Properties props = new Properties();
+                try (FileInputStream fis = new FileInputStream(f)) {
+                    props.load(fis);
+                }
+                osName = props.getProperty("NAME");
+                osVersion =  props.getProperty("VERSION_ID");
+                osName = getOsinfo(osName);
+                if (osName.equals("SLES")) osName = "SuSE";
+                osVersion = getOsinfo(osVersion);
             }
         } catch (Exception e) {
             if (FontUtilities.debugFonts()) {

--- a/src/java.desktop/unix/classes/sun/font/MFontConfiguration.java
+++ b/src/java.desktop/unix/classes/sun/font/MFontConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,6 +114,16 @@ public class MFontConfiguration extends FontConfiguration {
                     }
                     osName = props.getProperty("DISTRIB_ID");
                     osVersion =  props.getProperty("DISTRIB_RELEASE");
+                } else if ((f = new File("/etc/os-release")).canRead()) {
+                    Properties props = new Properties();
+                    try (FileInputStream fis = new FileInputStream(f)) {
+                        props.load(fis);
+                    }
+                    osName = props.getProperty("NAME");
+                    osVersion =  props.getProperty("VERSION_ID");
+                    osName = getOsinfo(osName);
+                    if (osName.equals("SLES")) osName = "SuSE";
+                    osVersion = getOsinfo(osVersion);
                 }
             } catch (Exception e) {
             }
@@ -132,6 +142,12 @@ public class MFontConfiguration extends FontConfiguration {
         catch (Exception e){
         }
         return null;
+    }
+
+    private String getOsinfo(String s) {
+        if (s.startsWith("\"")) s = s.substring(1);
+        if (s.endsWith("\"")) s = s.substring(0, s.length()-1);
+        return s;
     }
 
     private static final String fontsDirPrefix = "$JRE_LIB_FONTS";


### PR DESCRIPTION
Hello, please review this adjustment for recent SUSE Linux 15.
The font coding on UNIX, see setOsNameAndVersion in files 

src/java.desktop/unix/classes/sun/font/FcFontConfiguration.java
src/java.desktop/unix/classes/sun/font/MFontConfiguration.java

uses the file /etc/SuSE-release to detect SUSE Linux. However on SUSE Linux 15 this file does not exist any more.
Instead /etc/os-release can be used as a replacement on SLES12 and SLES15 :

Example content of /etc/os-release
NAME="SLES"
VERSION="12-SP2"
VERSION_ID="12.2"
PRETTY_NAME="SUSE Linux Enterprise Server 12 SP2"

There the name and version information is stored (NAME=... , VERSION_ID=...).

Additionally I noticed that there is some code duplication in FcFontConfiguration.java and MFontConfiguration.java , what do you think about moving this to some common place ?

Thanks, Matthias