### PR TITLE
8279453: Disable tools/jar/ReproducibleJar.java on 32-bit platforms

### DIFF
--- a/test/jdk/tools/jar/ReproducibleJar.java
+++ b/test/jdk/tools/jar/ReproducibleJar.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @requires vm.bits == 64
  * @bug 8276766
  * @summary Test jar --date source date of entries and that jars are
  *          reproducible


### PR DESCRIPTION
The real problem is Y2038 ([JDK-8279444](https://bugs.openjdk.java.net/browse/JDK-8279444)), which does not look solvable at this time. So for test cleanliness, we might just disable this test on 32-bit platforms.

Additional testing:
 - [x] Linux x86_64 fastdebug, affected test still passes
 - [x]  Linux x86_32 fastdebug, affected test is now skipped

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279453](https://bugs.openjdk.java.net/browse/JDK-8279453): Disable tools/jar/ReproducibleJar.java on 32-bit platforms


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6957/head:pull/6957` \
`$ git checkout pull/6957`

Update a local copy of the PR: \
`$ git checkout pull/6957` \
`$ git pull https://git.openjdk.java.net/jdk pull/6957/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6957`

View PR using the GUI difftool: \
`$ git pr show -t 6957`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6957.diff">https://git.openjdk.java.net/jdk/pull/6957.diff</a>

</details>
