### PR TITLE
8267341: macos attempt_reserve_memory_at(arg1, arg2, true) failure

### DIFF
--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -364,7 +364,7 @@ static address reserve_multiple(int num_stripes, size_t stripe_len) {
 #ifdef __APPLE__
   // Workaround: try reserving memory with executable=true
   // to figure out if that's supported on this macOS version
-  const bool executable = true;
+  bool executable = true;
   size_t test_len = 128;
   address p_test = (address)os::reserve_memory(test_len, executable);
   bool exec_supported = (p_test != NULL);
@@ -385,7 +385,7 @@ static address reserve_multiple(int num_stripes, size_t stripe_len) {
     // Commit, alternatingly with or without exec permission,
     //  to prevent kernel from folding these mappings.
 #ifdef __APPLE__
-    const bool executable = exec_supported? (stripe % 2 == 0) : false;
+    const bool executable = exec_supported ? (stripe % 2 == 0) : false;
 #else
     const bool executable = stripe % 2 == 0;
 #endif

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -352,7 +352,7 @@ TEST_VM(os, jio_snprintf) {
 }
 
 #ifdef __APPLE__
-static inline bool can_alloc_executable_memory(void) {
+static inline bool can_reserve_executable_memory(void) {
   bool executable = true;
   size_t len = 128;
   char* p = os::reserve_memory(len, executable);
@@ -377,7 +377,7 @@ static address reserve_multiple(int num_stripes, size_t stripe_len) {
 #ifdef __APPLE__
   // Workaround: try reserving memory with executable flag set to True
   // to figure out if such operation is supported on this macOS version
-  const bool exec_supported = can_alloc_executable_memory();
+  const bool exec_supported = can_reserve_executable_memory();
 #endif
 
   size_t total_range_len = num_stripes * stripe_len;

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -352,6 +352,10 @@ TEST_VM(os, jio_snprintf) {
 }
 
 #ifdef __APPLE__
+// Not all macOS versions can use os::reserve_memory (i.e. anon_mmap) API
+// to reserve executable memory, so before attempting to use it,
+// we need to verify that we can do so by asking for a tiny exectuable
+// memory chunk
 static inline bool can_reserve_executable_memory(void) {
   bool executable = true;
   size_t len = 128;

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -354,8 +354,8 @@ TEST_VM(os, jio_snprintf) {
 #ifdef __APPLE__
 // Not all macOS versions can use os::reserve_memory (i.e. anon_mmap) API
 // to reserve executable memory, so before attempting to use it,
-// we need to verify that we can do so by asking for a tiny exectuable
-// memory chunk
+// we need to verify that we can do so by asking for a tiny executable
+// memory chunk.
 static inline bool can_reserve_executable_memory(void) {
   bool executable = true;
   size_t len = 128;

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -375,8 +375,8 @@ static address reserve_multiple(int num_stripes, size_t stripe_len) {
   assert(is_aligned(stripe_len, os::vm_allocation_granularity()), "Sanity");
 
 #ifdef __APPLE__
-  // Workaround: try reserving memory with executable flag set to True
-  // to figure out if such operation is supported on this macOS version
+  // Workaround: try reserving executable memory to figure out
+  // if such operation is supported on this macOS version
   const bool exec_supported = can_reserve_executable_memory();
 #endif
 


### PR DESCRIPTION
Re-enable **release_multi_mappings** gtest on macOS

This test would occasionally fail on macOS, but thanks to Dan's catch, it turned out that it actually only fails on those test machines that run macOS 10.13.6 or earlier.

The proposed fix simply makes a single call to `os::reserve_memory()` with the `executable` flag `True`, and if that failed forces `executable`  to `False` later in the actual test code (alternatively we could have just also skipped that test portion completely, but this way we actually do something rather than nothing at all).

Tested manually on macOS 10.13.6 and via Mach5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267341](https://bugs.openjdk.java.net/browse/JDK-8267341): macos attempt_reserve_memory_at(arg1, arg2, true) failure


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6960/head:pull/6960` \
`$ git checkout pull/6960`

Update a local copy of the PR: \
`$ git checkout pull/6960` \
`$ git pull https://git.openjdk.java.net/jdk pull/6960/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6960`

View PR using the GUI difftool: \
`$ git pr show -t 6960`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6960.diff">https://git.openjdk.java.net/jdk/pull/6960.diff</a>

</details>
