### PR TITLE
8214976: Warn about uses of functions replaced for portability

### DIFF
--- a/src/hotspot/cpu/ppc/vm_version_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -435,7 +435,7 @@ void VM_Version::check_virtualizations() {
   // system_type=...qemu indicates PowerKVM
   // e.g. system_type=IBM pSeries (emulated by qemu)
   char line[500];
-  FILE* fp = fopen(info_file, "r");
+  FILE* fp = os::fopen(info_file, "r");
   if (fp == NULL) {
     return;
   }

--- a/src/hotspot/os/aix/loadlib_aix.cpp
+++ b/src/hotspot/os/aix/loadlib_aix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2019 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -71,7 +71,7 @@ class StringList {
       }
     }
     assert0(_cap > _num);
-    char* s2 = ::strdup(s);
+    char* s2 = os::strdup(s);
     if (!s2) {
       return NULL;
     }

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -107,6 +107,8 @@
 #include <sys/types.h>
 #include <sys/utsname.h>
 #include <sys/vminfo.h>
+
+PRAGMA_PERMIT_FORBIDDEN_C_FUNCTION(close); // prevents compiler warnings for all functions
 
 // Missing prototypes for various system APIs.
 extern "C"

--- a/src/hotspot/os/aix/os_perf_aix.cpp
+++ b/src/hotspot/os/aix/os_perf_aix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -239,7 +239,7 @@ static int SCANF_ARGS(2, 0) vread_statdata(const char* procfile, _SCANFMT_ const
   int n;
   char buf[2048];
 
-  if ((f = fopen(procfile, "r")) == NULL) {
+  if ((f = os::fopen(procfile, "r")) == NULL) {
     return -1;
   }
 
@@ -615,7 +615,7 @@ bool SystemProcessInterface::SystemProcesses::ProcessIterator::is_dir(const char
   struct stat mystat;
   int ret_val = 0;
 
-  ret_val = stat(name, &mystat);
+  ret_val = os::stat(name, &mystat);
   if (ret_val < 0) {
     return false;
   }
@@ -662,7 +662,7 @@ void SystemProcessInterface::SystemProcesses::ProcessIterator::get_exe_name() {
 
   jio_snprintf(buffer, PATH_MAX, "/proc/%s/stat", _entry->d_name);
   buffer[PATH_MAX - 1] = '\0';
-  if ((fp = fopen(buffer, "r")) != NULL) {
+  if ((fp = os::fopen(buffer, "r")) != NULL) {
     if (fgets(buffer, PATH_MAX, fp) != NULL) {
       char* start, *end;
       // exe-name is between the first pair of ( and )
@@ -690,7 +690,7 @@ char* SystemProcessInterface::SystemProcesses::ProcessIterator::get_cmdline() {
 
   jio_snprintf(buffer, PATH_MAX, "/proc/%s/cmdline", _entry->d_name);
   buffer[PATH_MAX - 1] = '\0';
-  if ((fp = fopen(buffer, "r")) != NULL) {
+  if ((fp = os::fopen(buffer, "r")) != NULL) {
     size_t size = 0;
     char   dummy;
 

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -107,6 +107,8 @@
   #define MAP_ANONYMOUS MAP_ANON
 #endif
 
+PRAGMA_PERMIT_FORBIDDEN_C_FUNCTION(close); // prevents compiler warnings for all functions
+
 #define MAX_PATH    (2 * K)
 
 // for timer info max values which include all bits

--- a/src/hotspot/os/linux/attachListener_linux.cpp
+++ b/src/hotspot/os/linux/attachListener_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -167,7 +167,7 @@ extern "C" {
     if (s != -1) {
       LinuxAttachListener::set_listener(-1);
       ::shutdown(s, SHUT_RDWR);
-      ::close(s);
+      os::close(s);
     }
     if (LinuxAttachListener::has_path()) {
       ::unlink(LinuxAttachListener::path());
@@ -199,7 +199,7 @@ int LinuxAttachListener::init() {
   }
 
   // create the listener socket
-  listener = ::socket(PF_UNIX, SOCK_STREAM, 0);
+  listener = os::socket(PF_UNIX, SOCK_STREAM, 0);
   if (listener == -1) {
     return -1;
   }
@@ -212,7 +212,7 @@ int LinuxAttachListener::init() {
   ::unlink(initial_path);
   int res = ::bind(listener, (struct sockaddr*)&addr, sizeof(addr));
   if (res == -1) {
-    ::close(listener);
+    os::close(listener);
     return -1;
   }
 
@@ -230,7 +230,7 @@ int LinuxAttachListener::init() {
     }
   }
   if (res == -1) {
-    ::close(listener);
+    os::close(listener);
     ::unlink(initial_path);
     return -1;
   }
@@ -271,7 +271,7 @@ LinuxAttachOperation* LinuxAttachListener::read_request(int s) {
 
   do {
     int n;
-    RESTARTABLE(read(s, buf+off, left), n);
+    RESTARTABLE(os::read(s, buf+off, left), n);
     assert(n <= left, "buffer was too small, impossible!");
     buf[max_len - 1] = '\0';
     if (n == -1) {
@@ -360,21 +360,21 @@ LinuxAttachOperation* LinuxAttachListener::dequeue() {
     socklen_t optlen = sizeof(cred_info);
     if (::getsockopt(s, SOL_SOCKET, SO_PEERCRED, (void*)&cred_info, &optlen) == -1) {
       log_debug(attach)("Failed to get socket option SO_PEERCRED");
-      ::close(s);
+      os::close(s);
       continue;
     }
 
     if (!os::Posix::matches_effective_uid_and_gid_or_root(cred_info.uid, cred_info.gid)) {
       log_debug(attach)("euid/egid check failed (%d/%d vs %d/%d)",
               cred_info.uid, cred_info.gid, geteuid(), getegid());
-      ::close(s);
+      os::close(s);
       continue;
     }
 
     // peer credential look okay so we read the request
     LinuxAttachOperation* op = read_request(s);
     if (op == NULL) {
-      ::close(s);
+      os::close(s);
       continue;
     } else {
       return op;
@@ -385,7 +385,7 @@ LinuxAttachOperation* LinuxAttachListener::dequeue() {
 // write the given buffer to the socket
 int LinuxAttachListener::write_fully(int s, char* buf, int len) {
   do {
-    int n = ::write(s, buf, len);
+    int n = os::write(s, buf, len);
     if (n == -1) {
       if (errno != EINTR) return -1;
     } else {
@@ -421,7 +421,7 @@ void LinuxAttachOperation::complete(jint result, bufferedStream* st) {
   }
 
   // done
-  ::close(this->socket());
+  os::close(this->socket());
 
   delete this;
 }

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -146,7 +146,7 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
    * Conversely, for cgroups v2 (unified hierarchy), cpu, cpuacct, cpuset, memory
    * controllers must have hierarchy ID 0 and the unified controller mounted.
    */
-  cgroups = fopen(proc_cgroups, "r");
+  cgroups = os::fopen(proc_cgroups, "r");
   if (cgroups == NULL) {
     log_debug(os, container)("Can't open %s, %s", proc_cgroups, os::strerror(errno));
     *flags = INVALID_CGROUPS_GENERIC;
@@ -214,7 +214,7 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
    *  - on a cgroups v1 system, collect info for mapping
    *    the host mount point to the local one via /proc/self/mountinfo below.
    */
-  cgroup = fopen(proc_self_cgroup, "r");
+  cgroup = os::fopen(proc_self_cgroup, "r");
   if (cgroup == NULL) {
     log_debug(os, container)("Can't open %s, %s",
                              proc_self_cgroup, os::strerror(errno));
@@ -269,7 +269,7 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
 
   // Find various mount points by reading /proc/self/mountinfo
   // mountinfo format is documented at https://www.kernel.org/doc/Documentation/filesystems/proc.txt
-  mntinfo = fopen(proc_self_mountinfo, "r");
+  mntinfo = os::fopen(proc_self_mountinfo, "r");
   if (mntinfo == NULL) {
       log_debug(os, container)("Can't open %s, %s",
                                proc_self_mountinfo, os::strerror(errno));

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,7 +108,7 @@ template <typename T> int subsystem_file_line_contents(CgroupController* c,
   }
   strncat(file, filename, MAXPATHLEN-filelen);
   log_trace(os, container)("Path to %s is %s", filename, file);
-  fp = fopen(file, "r");
+  fp = os::fopen(file, "r");
   if (fp != NULL) {
     int err = 0;
     while ((p = fgets(buf, MAXPATHLEN, fp)) != NULL) {

--- a/src/hotspot/os/linux/decoder_linux.cpp
+++ b/src/hotspot/os/linux/decoder_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@ bool ElfDecoder::demangle(const char* symbol, char *buf, int buflen) {
 bool ElfFile::specifies_noexecstack(const char* filepath) {
   if (filepath == NULL) return true;
 
-  FILE* file = fopen(filepath, "r");
+  FILE* file = os::fopen(filepath, "r");
   if (file == NULL)  return true;
 
   // AARCH64 defaults to noexecstack. All others default to execstack.

--- a/src/hotspot/os/linux/gc/z/zMountPoint_linux.cpp
+++ b/src/hotspot/os/linux/gc/z/zMountPoint_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,8 @@
 
 // Mount information, see proc(5) for more details.
 #define PROC_SELF_MOUNTINFO        "/proc/self/mountinfo"
+
+PRAGMA_PERMIT_FORBIDDEN_C_FUNCTION(fopen);
 
 ZMountPoint::ZMountPoint(const char* filesystem, const char** preferred_mountpoints) {
   if (AllocateHeapAt != NULL) {

--- a/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
+++ b/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
@@ -130,7 +130,7 @@ ZPhysicalMemoryBacking::ZPhysicalMemoryBacking(size_t max_capacity) :
   }
 
   // Truncate backing file
-  while (ftruncate(_fd, max_capacity) == -1) {
+  while (os::ftruncate(_fd, max_capacity) == -1) {
     if (errno != EINTR) {
       ZErrno err;
       log_error_p(gc)("Failed to truncate backing file (%s)", err.to_string());
@@ -329,7 +329,7 @@ void ZPhysicalMemoryBacking::warn_available_space(size_t max_capacity) const {
 
 void ZPhysicalMemoryBacking::warn_max_map_count(size_t max_capacity) const {
   const char* const filename = ZFILENAME_PROC_MAX_MAP_COUNT;
-  FILE* const file = fopen(filename, "r");
+  FILE* const file = os::fopen(filename, "r");
   if (file == NULL) {
     // Failed to open file, skip check
     log_debug_p(gc, init)("Failed to open %s", filename);

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -149,6 +149,8 @@ enum CoredumpFilterBit {
   LARGEPAGES_BIT = 1 << 6,
   DAX_SHARED_BIT = 1 << 8
 };
+
+PRAGMA_PERMIT_FORBIDDEN_C_FUNCTION(closedir);  // prevents compiler warning for all functions
 
 ////////////////////////////////////////////////////////////////////////////////
 // global variables

--- a/src/hotspot/os/linux/os_perf_linux.cpp
+++ b/src/hotspot/os/linux/os_perf_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -234,7 +234,7 @@ static int SCANF_ARGS(2, 0) vread_statdata(const char* procfile, _SCANFMT_ const
   int n;
   char buf[2048];
 
-  if ((f = fopen(procfile, "r")) == NULL) {
+  if ((f = os::fopen(procfile, "r")) == NULL) {
     return -1;
   }
 
@@ -271,7 +271,7 @@ static int SCANF_ARGS(2, 3) read_statdata(const char* procfile, _SCANFMT_ const 
 static FILE* open_statfile(void) {
   FILE *f;
 
-  if ((f = fopen("/proc/stat", "r")) == NULL) {
+  if ((f = os::fopen("/proc/stat", "r")) == NULL) {
     static int haveWarned = 0;
     if (!haveWarned) {
       haveWarned = 1;
@@ -289,11 +289,11 @@ static int get_systemtype(void) {
   }
 
   // Check whether we have a task subdirectory
-  if ((taskDir = opendir("/proc/self/task")) == NULL) {
+  if ((taskDir = os::opendir("/proc/self/task")) == NULL) {
     procEntriesType = UNDETECTABLE;
   } else {
     // The task subdirectory exists; we're on a Linux >= 2.6 system
-    closedir(taskDir);
+    os::closedir(taskDir);
     procEntriesType = LINUX26_NPTL;
   }
 
@@ -675,7 +675,7 @@ bool SystemProcessInterface::SystemProcesses::ProcessIterator::is_dir(const char
   struct stat mystat;
   int ret_val = 0;
 
-  ret_val = stat(name, &mystat);
+  ret_val = os::stat(name, &mystat);
   if (ret_val < 0) {
     return false;
   }
@@ -688,7 +688,7 @@ int SystemProcessInterface::SystemProcesses::ProcessIterator::fsize(const char* 
   size = 0;
   struct stat fbuf;
 
-  if (stat(name, &fbuf) < 0) {
+  if (os::stat(name, &fbuf) < 0) {
     return OS_ERR;
   }
   size = fbuf.st_size;
@@ -722,7 +722,7 @@ void SystemProcessInterface::SystemProcesses::ProcessIterator::get_exe_name() {
 
   jio_snprintf(buffer, PATH_MAX, "/proc/%s/stat", _entry->d_name);
   buffer[PATH_MAX - 1] = '\0';
-  if ((fp = fopen(buffer, "r")) != NULL) {
+  if ((fp = os::fopen(buffer, "r")) != NULL) {
     if (fgets(buffer, PATH_MAX, fp) != NULL) {
       char* start, *end;
       // exe-name is between the first pair of ( and )
@@ -750,7 +750,7 @@ char* SystemProcessInterface::SystemProcesses::ProcessIterator::get_cmdline() {
 
   jio_snprintf(buffer, PATH_MAX, "/proc/%s/cmdline", _entry->d_name);
   buffer[PATH_MAX - 1] = '\0';
-  if ((fp = fopen(buffer, "r")) != NULL) {
+  if ((fp = os::fopen(buffer, "r")) != NULL) {
     size_t size = 0;
     char   dummy;
 
@@ -992,8 +992,8 @@ int64_t NetworkPerformanceInterface::NetworkPerformance::read_counter(const char
     return -1;
   }
 
-  ssize_t num_bytes = read(fd, buf, sizeof(buf));
-  close(fd);
+  ssize_t num_bytes = os::read(fd, buf, sizeof(buf));
+  os::close(fd);
   if ((num_bytes == -1) || (num_bytes >= static_cast<ssize_t>(sizeof(buf))) || (num_bytes < 1)) {
     return -1;
   }

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,6 +89,8 @@
 
 #define assert_with_errno(cond, msg)    check_with_errno(assert, cond, msg)
 #define guarantee_with_errno(cond, msg) check_with_errno(guarantee, cond, msg)
+
+PRAGMA_PERMIT_FORBIDDEN_C_FUNCTION(closedir); // prevents compiler warnings for all functions
 
 static jlong initial_time_count = 0;
 

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,6 +101,8 @@
 #include <psapi.h>
 #include <mmsystem.h>
 #include <winsock2.h>
+
+PRAGMA_PERMIT_FORBIDDEN_C_FUNCTION(close); // prevents compiler warnings for all functions
 
 // for timer info max values which include all bits
 #define ALL_64_BITS CONST64(-1)

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -143,7 +143,7 @@ void VM_Version::get_os_cpu_info() {
     _zva_length = 4 << (dczid_el0 & 0xf);
   }
 
-  if (FILE *f = fopen("/proc/cpuinfo", "r")) {
+  if (FILE *f = os::fopen("/proc/cpuinfo", "r")) {
     // need a large buffer as the flags line may include lots of text
     char buf[1024], *p;
     while (fgets(buf, sizeof (buf), f) != NULL) {

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -462,7 +462,7 @@ juint os::cpu_microcode_revision() {
   juint result = 0;
   char data[2048] = {0}; // lines should fit in 2K buf
   size_t len = sizeof(data);
-  FILE *fp = fopen("/proc/cpuinfo", "r");
+  FILE *fp = os::fopen("/proc/cpuinfo", "r");
   if (fp) {
     while (!feof(fp)) {
       if (fgets(data, len, fp)) {

--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -703,7 +703,7 @@ void Compilation::print_timers() {
 #ifndef PRODUCT
 void Compilation::compile_only_this_method() {
   ResourceMark rm;
-  fileStream stream(fopen("c1_compile_only", "wt"));
+  fileStream stream(os::fopen("c1_compile_only", "wt"));
   stream.print_cr("# c1 compile only directives");
   compile_only_this_scope(&stream, hir()->top_scope());
 }
@@ -717,7 +717,7 @@ void Compilation::compile_only_this_scope(outputStream* st, IRScope* scope) {
 }
 
 void Compilation::exclude_this_method() {
-  fileStream stream(fopen(".hotspot_compiler", "at"));
+  fileStream stream(os::fopen(".hotspot_compiler", "at"));
   stream.print("exclude ");
   method()->holder()->name()->print_symbol_on(&stream);
   stream.print(" ");

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1080,7 +1080,7 @@ public:
     // First read the generic header so we know the exact size of the actual header.
     GenericCDSFileMapHeader gen_header;
     size_t size = sizeof(GenericCDSFileMapHeader);
-    lseek(fd, 0, SEEK_SET);
+    os::lseek(fd, 0, SEEK_SET);
     size_t n = os::read(fd, (void*)&gen_header, (unsigned int)size);
     if (n != size) {
       FileMapInfo::fail_continue("Unable to read generic CDS file map header from shared archive");
@@ -1108,7 +1108,7 @@ public:
     // Read the actual header and perform more checks
     size = gen_header._header_size;
     _header = (GenericCDSFileMapHeader*)NEW_C_HEAP_ARRAY(char, size, mtInternal);
-    lseek(fd, 0, SEEK_SET);
+    os::lseek(fd, 0, SEEK_SET);
     n = os::read(fd, (void*)_header, (unsigned int)size);
     if (n != size) {
       FileMapInfo::fail_continue("Unable to read actual CDS file map header from shared archive");
@@ -1276,7 +1276,7 @@ bool FileMapInfo::init_from_file(int fd) {
   }
 
   _header = (FileMapHeader*)os::malloc(gen_header->_header_size, mtInternal);
-  lseek(fd, 0, SEEK_SET); // reset to begin of the archive
+  os::lseek(fd, 0, SEEK_SET); // reset to begin of the archive
   size_t size = gen_header->_header_size;
   size_t n = os::read(fd, (void*)_header, (unsigned int)size);
   if (n != size) {
@@ -1326,7 +1326,7 @@ bool FileMapInfo::init_from_file(int fd) {
   if (is_static()) {
     // just checking the last region is sufficient since the archive is written
     // in sequential order
-    size_t len = lseek(fd, 0, SEEK_END);
+    size_t len = os::lseek(fd, 0, SEEK_END);
     FileMapRegion* si = space_at(MetaspaceShared::last_valid_region);
     // The last space might be empty
     if (si->file_offset() > len || len - si->file_offset() < si->used()) {
@@ -1339,7 +1339,7 @@ bool FileMapInfo::init_from_file(int fd) {
 }
 
 void FileMapInfo::seek_to_position(size_t pos) {
-  if (lseek(_fd, (long)pos, SEEK_SET) < 0) {
+  if (os::lseek(_fd, (long)pos, SEEK_SET) < 0) {
     fail_stop("Unable to seek to position " SIZE_FORMAT, pos);
   }
 }
@@ -1659,7 +1659,7 @@ void FileMapInfo::write_bytes_aligned(const void* buffer, size_t nbytes) {
 
 void FileMapInfo::close() {
   if (_file_open) {
-    if (::close(_fd) < 0) {
+    if (os::close(_fd) < 0) {
       fail_stop("Unable to close the shared archive file.");
     }
     _file_open = false;
@@ -1750,7 +1750,7 @@ bool FileMapInfo::read_region(int i, char* base, size_t size, bool do_commit) {
       return false;
     }
   }
-  if (lseek(_fd, (long)si->file_offset(), SEEK_SET) != (int)si->file_offset() ||
+  if (os::lseek(_fd, (long)si->file_offset(), SEEK_SET) != (int)si->file_offset() ||
       read_bytes(base, size) != size) {
     return false;
   }

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -145,7 +145,7 @@ class CompileReplay : public StackObj {
     _protection_domain = Handle();
     _protection_domain_initialized = false;
 
-    _stream = fopen(filename, "rt");
+    _stream = os::fopen(filename, "rt");
     if (_stream == NULL) {
       fprintf(stderr, "ERROR: Can't open replay file %s\n", filename);
     }

--- a/src/hotspot/share/classfile/compactHashtable.cpp
+++ b/src/hotspot/share/classfile/compactHashtable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -252,7 +252,7 @@ HashtableTextDump::HashtableTextDump(const char* filename) : _fd(-1) {
 HashtableTextDump::~HashtableTextDump() {
   os::unmap_memory((char*)_base, _size);
   if (_fd >= 0) {
-    close(_fd);
+    os::close(_fd);
   }
 }
 

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2003,7 +2003,7 @@ void CompileBroker::init_compiler_thread_log() {
                      os::file_separator(), thread_id, os::current_process_id());
       }
 
-      fp = fopen(file_name, "wt");
+      fp = os::fopen(file_name, "wt");
       if (fp != NULL) {
         if (LogCompilation && Verbose) {
           tty->print_cr("Opening compilation log %s", file_name);

--- a/src/hotspot/share/compiler/compileLog.cpp
+++ b/src/hotspot/share/compiler/compileLog.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -225,7 +225,7 @@ void CompileLog::finish_log_on_error(outputStream* file, char* buf, int buflen) 
         if (to_read < (julong)buflen)
               nr = (size_t)to_read;
         else  nr = buflen;
-        bytes_read = read(partial_fd, buf, (int)nr);
+        bytes_read = os::read(partial_fd, buf, (int)nr);
         if (bytes_read <= 0) break;
         nr = bytes_read;
         to_read -= (julong)nr;
@@ -235,7 +235,7 @@ void CompileLog::finish_log_on_error(outputStream* file, char* buf, int buflen) 
       // Copy any remaining data inside a quote:
       bool saw_slop = false;
       int end_cdata = 0;  // state machine [0..2] watching for too many "]]"
-      while ((bytes_read = read(partial_fd, buf, buflen-1)) > 0) {
+      while ((bytes_read = os::read(partial_fd, buf, buflen-1)) > 0) {
         nr = bytes_read;
         buf[buflen-1] = '\0';
         if (!saw_slop) {
@@ -285,7 +285,7 @@ void CompileLog::finish_log_on_error(outputStream* file, char* buf, int buflen) 
         file->print_raw_cr("</fragment>");
       }
       file->print_raw_cr("</compilation_log>");
-      close(partial_fd);
+      os::close(partial_fd);
     }
     CompileLog* next_log = log->_next;
     delete log; // Removes partial file

--- a/src/hotspot/share/compiler/compilerEvent.cpp
+++ b/src/hotspot/share/compiler/compilerEvent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,7 +99,7 @@ int CompilerEvent::PhaseEvent::get_phase_id(const char* phase_name, bool may_exi
     }
 
     index = phase_names->length();
-    phase_names->append(use_strdup ? strdup(phase_name) : phase_name);
+    phase_names->append(use_strdup ? os::strdup(phase_name) : phase_name);
   }
   if (register_jfr_serializer) {
     JfrSerializer::register_serializer(TYPE_COMPILERPHASETYPE, false, new CompilerPhaseTypeConstant());

--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -932,7 +932,7 @@ bool CompilerOracle::_quiet = false;
 
 void CompilerOracle::parse_from_file() {
   assert(has_command_file(), "command file must be specified");
-  FILE* stream = fopen(cc_file(), "rt");
+  FILE* stream = os::fopen(cc_file(), "rt");
   if (stream == NULL) return;
 
   char token[1024];

--- a/src/hotspot/share/compiler/disassembler.cpp
+++ b/src/hotspot/share/compiler/disassembler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -267,7 +267,7 @@ void decode_env::print_hook_comments(address pc, bool newline) {
           _cached_src_lines = new (ResourceObj::C_HEAP, mtCode)GrowableArray<const char*>(0, mtCode);
         }
 
-        if ((fp = fopen(file, "r")) == NULL) {
+        if ((fp = os::fopen(file, "r")) == NULL) {
           _cached_src = NULL;
           return;
         }

--- a/src/hotspot/share/gc/shared/gcLogPrecious.cpp
+++ b/src/hotspot/share/gc/shared/gcLogPrecious.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,7 @@ void GCLogPrecious::vwrite_and_debug(LogTargetHandle log,
   {
     MutexLocker locker(_lock, Mutex::_no_safepoint_check_flag);
     vwrite_inner(log, format, args);
-    DEBUG_ONLY(debug_message = strdup(_temp->base()));
+    DEBUG_ONLY(debug_message = os::strdup(_temp->base()));
   }
 
   // report error outside lock scope, since report_vm_error will call print_on_error

--- a/src/hotspot/share/jvmci/jvmci.cpp
+++ b/src/hotspot/share/jvmci/jvmci.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,7 +90,7 @@ void* JVMCI::get_shared_library(char*& path, bool load) {
       fatal("Unable to load JVMCI shared library from %s: %s", path, ebuf);
     }
     _shared_library_handle = handle;
-    _shared_library_path = strdup(path);
+    _shared_library_path = os::strdup(path);
 
     JVMCI_event_1("loaded JVMCI shared library from %s", path);
   }

--- a/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
+++ b/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -508,7 +508,7 @@ JVMCI::CodeInstallResult CodeInstaller::install(JVMCICompiler* compiler,
     if (stubName.is_null()) {
       JVMCI_ERROR_OK("stub should have a name");
     }
-    char* name = strdup(jvmci_env()->as_utf8_string(stubName));
+    char* name = os::strdup(jvmci_env()->as_utf8_string(stubName));
     cb = RuntimeStub::new_runtime_stub(name,
                                        &buffer,
                                        _offsets.value(CodeOffsets::Frame_Complete),

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2836,7 +2836,7 @@ void jio_print(const char* s, size_t len) {
     jio_fprintf(defaultStream::output_stream(), "%.*s", (int)len, s);
   } else {
     // Make an unused local variable to avoid warning from gcc compiler.
-    size_t count = ::write(defaultStream::output_fd(), s, (int)len);
+    size_t count = os::write(defaultStream::output_fd(), s, (int)len);
   }
 }
 

--- a/src/hotspot/share/runtime/abstract_vm_version.cpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -318,7 +318,7 @@ void Abstract_VM_Version::insert_features_names(char* buf, size_t buflen, const 
 
 bool Abstract_VM_Version::print_matching_lines_from_file(const char* filename, outputStream* st, const char* keywords_to_match[]) {
   char line[500];
-  FILE* fp = fopen(filename, "r");
+  FILE* fp = os::fopen(filename, "r");
   if (fp == NULL) {
     return false;
   }

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1244,7 +1244,7 @@ bool Arguments::process_argument(const char* arg,
 }
 
 bool Arguments::process_settings_file(const char* file_name, bool should_exist, jboolean ignore_unrecognized) {
-  FILE* stream = fopen(file_name, "rb");
+  FILE* stream = os::fopen(file_name, "rb");
   if (stream == NULL) {
     if (should_exist) {
       jio_fprintf(defaultStream::error_stream(),

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,6 +89,8 @@ julong os::alloc_bytes = 0;         // # of bytes allocated
 julong os::num_frees = 0;           // # of calls to free
 julong os::free_bytes = 0;          // # of bytes freed
 #endif
+
+PRAGMA_PERMIT_FORBIDDEN_C_FUNCTION(fopen); // prevents compiler warnings for all functions
 
 static size_t cur_malloc_words = 0;  // current size for MallocMaxTestWords
 

--- a/src/hotspot/share/utilities/compilerWarnings.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,12 @@
 #define SHARE_UTILITIES_COMPILERWARNINGS_HPP
 
 // Macros related to control of compiler warnings.
+
+#if __GNUC__ >= 9
+#include <dirent.h>
+#include <sys/socket.h>
+#include <stdio.h>
+#endif
 
 #include "utilities/macros.hpp"
 
@@ -69,5 +75,44 @@
 #ifndef PRAGMA_NONNULL_IGNORED
 #define PRAGMA_NONNULL_IGNORED
 #endif
+
+#if __GNUC__ >= 9
+
+#define FORBID_C_FUNCTION(signature, alternative) \
+  extern "C" signature __attribute__((__warning__(alternative)))
+
+#define PRAGMA_PERMIT_FORBIDDEN_C_FUNCTION(name) \
+  PRAGMA_DISABLE_GCC_WARNING("-Wattribute-warning")
+
+FORBID_C_FUNCTION(void abort(void),                            "use os::abort");
+FORBID_C_FUNCTION(int close(int),                              "use os::close");
+FORBID_C_FUNCTION(int closedir(DIR *),                         "use os::closedir");
+FORBID_C_FUNCTION(int connect(int, const struct sockaddr*, socklen_t), "use os::connect");
+FORBID_C_FUNCTION(void flockfile(FILE*),                       "use os::flockfile");
+FORBID_C_FUNCTION(FILE *fopen(const char *, const char *),     "use os::fopen");
+FORBID_C_FUNCTION(int fsync(int),                              "use os::fsync");
+FORBID_C_FUNCTION(int ftruncate(int, off_t),                   "use os::ftruncate");
+FORBID_C_FUNCTION(void funlockfile(FILE *),                    "use os::funlockfile");
+FORBID_C_FUNCTION(off_t lseek(int, off_t, int),                "use os::lseek");
+FORBID_C_FUNCTION(DIR *opendir(const char *),                  "use os::opendir");
+FORBID_C_FUNCTION(long int random(void),                       "use os::random");
+FORBID_C_FUNCTION(ssize_t read(int, void*, size_t),            "use os::read");
+FORBID_C_FUNCTION(struct dirent* readdir(DIR*),                "use os::readdir");
+FORBID_C_FUNCTION(ssize_t recv(int, void*, size_t, int),       "use os::recv");
+FORBID_C_FUNCTION(int stat(const char*, struct stat*),         "use os::stat");
+FORBID_C_FUNCTION(ssize_t send(int, const void*, size_t, int), "use os::send");
+FORBID_C_FUNCTION(int socket(int, int, int),                   "use os::socket");
+FORBID_C_FUNCTION(char *strdup(const char*),                   "use os::strdup");
+FORBID_C_FUNCTION(char* strerror(int),                         "use os::strerror");
+FORBID_C_FUNCTION(ssize_t write(int, const void*, size_t),     "use os::write");
+
+FORBID_C_FUNCTION(char *strtok(char*, const char*),            "use strtok_r");
+
+#else
+
+#define FORBID_C_FUNCTION(signature, alternative)
+#define PRAGMA_PERMIT_FORBIDDEN_C_FUNCTION(name)
+
+#endif // __GNUC__ >= 9
 
 #endif // SHARE_UTILITIES_COMPILERWARNINGS_HPP

--- a/src/hotspot/share/utilities/elfFile.cpp
+++ b/src/hotspot/share/utilities/elfFile.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -168,7 +168,7 @@ void ElfFile::cleanup_tables() {
 NullDecoder::decoder_status ElfFile::parse_elf(const char* filepath) {
   assert(filepath, "null file path");
 
-  _file = fopen(filepath, "r");
+  _file = os::fopen(filepath, "r");
   if (_file != NULL) {
     return load_tables();
   } else {

--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -545,7 +545,7 @@ const char* make_log_name(const char* log_name, const char* force_directory) {
 }
 
 fileStream::fileStream(const char* file_name) {
-  _file = fopen(file_name, "w");
+  _file = os::fopen(file_name, "w");
   if (_file != NULL) {
     _need_close = true;
   } else {
@@ -555,7 +555,7 @@ fileStream::fileStream(const char* file_name) {
 }
 
 fileStream::fileStream(const char* file_name, const char* opentype) {
-  _file = fopen(file_name, opentype);
+  _file = os::fopen(file_name, opentype);
   if (_file != NULL) {
     _need_close = true;
   } else {
@@ -614,7 +614,7 @@ void fileStream::flush() {
 void fdStream::write(const char* s, size_t len) {
   if (_fd != -1) {
     // Make an unused local variable to avoid warning from gcc compiler.
-    size_t count = ::write(_fd, s, (int)len);
+    size_t count = os::write(_fd, s, (int)len);
     update_position(s, len);
   }
 }

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -1654,7 +1654,7 @@ void VMError::report_and_die(int id, const char* message, const char* detail_fmt
     _current_step_info = "";
 
     if (fd_log > 3) {
-      close(fd_log);
+      os::close(fd_log);
       fd_log = -1;
     }
 

--- a/test/hotspot/gtest/gtestMain.cpp
+++ b/test/hotspot/gtest/gtestMain.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -278,7 +278,7 @@ static void runUnitTestsInner(int argc, char** argv) {
     int ret;
     if ((ret = init_jvm(argc, argv, is_vmassert_test, &jvm)) != 0) {
       fprintf(stderr, "ERROR: JNI_CreateJavaVM failed: %d\n", ret);
-      abort();
+      os::abort();
     }
   } else {
     ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();

--- a/test/hotspot/gtest/logging/logTestUtils.inline.hpp
+++ b/test/hotspot/gtest/logging/logTestUtils.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -138,8 +138,8 @@ static inline char* read_line(FILE* fp) {
 
 static bool file_contains_substrings_in_order(const char* filename, const char* substrs[]) {
   AsyncLogWriter::flush();
-  FILE* fp = fopen(filename, "r");
-  assert(fp != NULL, "error opening file %s: %s", filename, strerror(errno));
+  FILE* fp = os::fopen(filename, "r");
+  assert(fp != NULL, "error opening file %s: %s", filename, os::strerror(errno));
 
   size_t idx = 0;
   while (substrs[idx] != NULL) {

--- a/test/hotspot/gtest/logging/test_asynclog.cpp
+++ b/test/hotspot/gtest/logging/test_asynclog.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,7 +86,7 @@ LOG_LEVEL_LIST
 
   // stdout/stderr support
   bool write_to_file(const std::string& output) {
-    FILE* f = fopen(TestLogFileName, "w");
+    FILE* f = os::fopen(TestLogFileName, "w");
 
     if (f != NULL) {
       size_t sz = output.size();

--- a/test/hotspot/gtest/logging/test_log.cpp
+++ b/test/hotspot/gtest/logging/test_log.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ TEST_VM_F(LogTest, large_message) {
 
   AsyncLogWriter::flush();
   ResourceMark rm;
-  FILE* fp = fopen(TestLogFileName, "r");
+  FILE* fp = os::fopen(TestLogFileName, "r");
   ASSERT_NE((void*)NULL, fp);
   char* output = read_line(fp);
   fclose(fp);

--- a/test/hotspot/gtest/logging/test_logDecorators.cpp
+++ b/test/hotspot/gtest/logging/test_logDecorators.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 #include "jvm.h"
 #include "logging/logDecorators.hpp"
 #include "unittest.hpp"
+
+PRAGMA_PERMIT_FORBIDDEN_C_FUNCTION(strdup);
 
 static LogDecorators::Decorator decorator_array[] = {
 #define DECORATOR(name, abbr) LogDecorators::name##_decorator,

--- a/test/hotspot/gtest/logging/test_logTagSetDescriptions.cpp
+++ b/test/hotspot/gtest/logging/test_logTagSetDescriptions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ TEST_VM(LogTagSetDescriptions, describe) {
 TEST_VM(LogTagSetDescriptions, command_line_help) {
   ResourceMark rm;
   const char* filename = prepend_temp_dir("logtagset_descriptions");
-  FILE* fp = fopen(filename, "w+");
+  FILE* fp = os::fopen(filename, "w+");
   ASSERT_NE((void*)NULL, fp);
   fileStream stream(fp);
   LogConfiguration::print_command_line_help(&stream);


### PR DESCRIPTION
Please review this change for JDK-8214976.  This change adds attribute warnings to header file compilerWarnings.hpp so that compilation warnings get issued when certain system functions are called directly, instead of hotspot's os:: versions of the functions.  Many additional files were changed because of compilation warnings resulting from the compilerWarnings.hpp changes.

A sample warning is:
```
.../open/test/hotspot/gtest/logging/test_log.cpp:63:19: error: call to 'fopen' declared with attribute warning: use os::fopen [-Werror=attribute-warning]
   63 |   FILE* fp = fopen(TestLogFileName, "r");
      |              ~~~~~^~~~~~~~~~~~~~~~~~~~~~
```

Note that changing src/hotspot/os/linux/gc/z/zMountPoint_linux.cpp to call os:: functions requires adding "#include "runtime/os.hpp" and caused test gc/z/TestAllocateHeapAt.java to fail.  So, for now, I just added PRAGMA_PERMIT_FORBIDDEN_C_FUNCTION to zMountPoint_linux.cpp.  There's a similar issue with gtest/logging/test_logDecorators.cpp.

Attribute warnings for additional functions, such as malloc(), were not included in this change because they require lots of source code changes, or, in the case of open(), require adding an "open(const char *path, int oflag)" version of open() to os.hpp and os.cpp.

This change was tested by running mach5 tiers 1-2 on Linux, Mac OS, and Windows, Mach5 tiers 3-5 on Linux x64.  Also, builds were done on Linux-zero, Linux-s390, and Linux-ppc.

Thanks, Harold
