### PR TITLE
8279485: Incorrect copyright year in compiler/lib/ir_framework/IRNode.java  after JDK-8278114

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
```
/*
 - * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
 + * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.

 ```
=>
```
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279485](https://bugs.openjdk.java.net/browse/JDK-8279485): Incorrect copyright year in compiler/lib/ir_framework/IRNode.java  after JDK-8278114


### Reviewers
 * [Hao Sun](https://openjdk.java.net/census#haosun) (@shqking - Author)
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6962/head:pull/6962` \
`$ git checkout pull/6962`

Update a local copy of the PR: \
`$ git checkout pull/6962` \
`$ git pull https://git.openjdk.java.net/jdk pull/6962/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6962`

View PR using the GUI difftool: \
`$ git pr show -t 6962`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6962.diff">https://git.openjdk.java.net/jdk/pull/6962.diff</a>

</details>
