### PR TITLE
4884570: StreamPrintService.isAttributeValueSupported does not work properly for SheetCollate

### DIFF
--- a/src/java.desktop/share/classes/sun/print/PSStreamPrintService.java
+++ b/src/java.desktop/share/classes/sun/print/PSStreamPrintService.java
@@ -440,7 +440,7 @@ public class PSStreamPrintService extends StreamPrintService
             if (flavor != null &&
                 !(flavor.equals(DocFlavor.SERVICE_FORMATTED.PAGEABLE) ||
                 flavor.equals(DocFlavor.SERVICE_FORMATTED.PRINTABLE))) {
-                return false;
+                return attr == SheetCollate.UNCOLLATED;
             }
         } else if (attr.getCategory() == Sides.class) {
             if (flavor != null &&

--- a/src/java.desktop/share/classes/sun/print/PSStreamPrintService.java
+++ b/src/java.desktop/share/classes/sun/print/PSStreamPrintService.java
@@ -427,7 +427,17 @@ public class PSStreamPrintService extends StreamPrintService
             if (attr == OrientationRequested.REVERSE_PORTRAIT ||
                 (flavor != null) &&
                 !(flavor.equals(DocFlavor.SERVICE_FORMATTED.PAGEABLE) ||
-                flavor.equals(DocFlavor.SERVICE_FORMATTED.PRINTABLE))) {
+                  flavor.equals(DocFlavor.SERVICE_FORMATTED.PRINTABLE) ||
+                  flavor.equals(DocFlavor.INPUT_STREAM.GIF) ||
+                  flavor.equals(DocFlavor.INPUT_STREAM.JPEG) ||
+                  flavor.equals(DocFlavor.INPUT_STREAM.PNG) ||
+                  flavor.equals(DocFlavor.BYTE_ARRAY.GIF) ||
+                  flavor.equals(DocFlavor.BYTE_ARRAY.JPEG) ||
+                  flavor.equals(DocFlavor.BYTE_ARRAY.PNG) ||
+                  flavor.equals(DocFlavor.URL.GIF) ||
+                  flavor.equals(DocFlavor.URL.JPEG) ||
+                  flavor.equals(DocFlavor.URL.PNG)))
+            {
                 return false;
             }
         } else if (attr.getCategory() == PageRanges.class) {

--- a/test/jdk/javax/print/attribute/StreamServiceAttributeTest.java
+++ b/test/jdk/javax/print/attribute/StreamServiceAttributeTest.java
@@ -70,7 +70,7 @@ public class StreamServiceAttributeTest {
             throw new RuntimeException("Inconsistent support reported");
         }
     }
- 
+
     private static void test(StreamPrintService sps,
                              Class<? extends Attribute> ac) {
         if (!sps.isAttributeCategorySupported(ac)) {

--- a/test/jdk/javax/print/attribute/StreamServiceSheetCollateTest.java
+++ b/test/jdk/javax/print/attribute/StreamServiceSheetCollateTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4884570
+ * @summary SheetCollate support reporting should be consistent
+*/
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+
+import javax.print.DocFlavor;
+import javax.print.StreamPrintService;
+import javax.print.StreamPrintServiceFactory;
+import javax.print.attribute.Attribute;
+import javax.print.attribute.standard.SheetCollate;
+
+public class StreamServiceSheetCollateTest {
+
+    public static void main(String args[]) {
+
+        StreamPrintServiceFactory[] fact =
+          StreamPrintServiceFactory.lookupStreamPrintServiceFactories(
+                null, null);
+
+        if (fact.length == 0) {
+            return;
+        }
+        OutputStream out = new ByteArrayOutputStream();
+        StreamPrintService sps = fact[0].getPrintService(out);
+        if (!sps.isAttributeCategorySupported(SheetCollate.class)) {
+            return;
+        }
+        boolean allSupported = true;
+        DocFlavor[] dfs = sps.getSupportedDocFlavors();
+        for (DocFlavor f : dfs) {
+            Attribute[] attrs = (Attribute[])
+               sps.getSupportedAttributeValues(SheetCollate.class, f, null);
+            for (Attribute a : attrs) {
+                if (!sps.isAttributeValueSupported(a, f, null)) {
+                    allSupported = false;
+                    System.out.println("Unsupported : " + f + " " + a);
+                }
+            }
+        }
+        if (!allSupported) {
+            throw new RuntimeException("Inconsistent support reported");
+        }
+    }
+}


### PR DESCRIPTION
This fixes a longstanding consistency issue where the Postscript StreamPrintService would report SheetCollate.UNCOLLATED in a list of supported values then report it was not supported under the same conditions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-4884570](https://bugs.openjdk.java.net/browse/JDK-4884570): StreamPrintService.isAttributeValueSupported does not work properly for SheetCollate


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6963/head:pull/6963` \
`$ git checkout pull/6963`

Update a local copy of the PR: \
`$ git checkout pull/6963` \
`$ git pull https://git.openjdk.java.net/jdk pull/6963/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6963`

View PR using the GUI difftool: \
`$ git pr show -t 6963`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6963.diff">https://git.openjdk.java.net/jdk/pull/6963.diff</a>

</details>
