### PR TITLE
8279510: Parallel: Remove unused PSScavenge::_consecutive_skipped_scavenges

### DIFF
--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -71,7 +71,6 @@
 #include "utilities/stack.inline.hpp"
 
 HeapWord*                     PSScavenge::_to_space_top_before_gc = NULL;
-int                           PSScavenge::_consecutive_skipped_scavenges = 0;
 SpanSubjectToDiscoveryClosure PSScavenge::_span_based_discoverer;
 ReferenceProcessor*           PSScavenge::_ref_processor = NULL;
 PSCardTable*                  PSScavenge::_card_table = NULL;
@@ -729,7 +728,6 @@ bool PSScavenge::should_attempt_scavenge() {
 
   // Do not attempt to promote unless to_space is empty
   if (!young_gen->to_space()->is_empty()) {
-    _consecutive_skipped_scavenges++;
     if (UsePerfData) {
       counters->update_scavenge_skipped(to_space_not_empty);
     }
@@ -753,10 +751,7 @@ bool PSScavenge::should_attempt_scavenge() {
     log_trace(ergo)(" padded_promoted_average is greater than maximum promotion = " SIZE_FORMAT, young_gen->used_in_bytes());
   }
 
-  if (result) {
-    _consecutive_skipped_scavenges = 0;
-  } else {
-    _consecutive_skipped_scavenges++;
+  if (!result) {
     if (UsePerfData) {
       counters->update_scavenge_skipped(promoted_too_large);
     }

--- a/src/hotspot/share/gc/parallel/psScavenge.hpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.hpp
@@ -57,10 +57,6 @@ class PSScavenge: AllStatic {
   // being rescanned.
   static HeapWord* _to_space_top_before_gc;
 
-  // Number of consecutive attempts to scavenge that were skipped
-  static int                _consecutive_skipped_scavenges;
-
-
  protected:
   // Flags/counters
   static SpanSubjectToDiscoveryClosure _span_based_discoverer;
@@ -95,8 +91,6 @@ class PSScavenge: AllStatic {
   // Accessors
   static uint             tenuring_threshold()  { return _tenuring_threshold; }
   static elapsedTimer*    accumulated_time()    { return &_accumulated_time; }
-  static int              consecutive_skipped_scavenges()
-    { return _consecutive_skipped_scavenges; }
 
   // Performance Counters
   static CollectorCounters* counters()           { return _counters; }


### PR DESCRIPTION
Simple change of removing effectively unused code.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279510](https://bugs.openjdk.java.net/browse/JDK-8279510): Parallel: Remove unused PSScavenge::_consecutive_skipped_scavenges


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6965/head:pull/6965` \
`$ git checkout pull/6965`

Update a local copy of the PR: \
`$ git checkout pull/6965` \
`$ git pull https://git.openjdk.java.net/jdk pull/6965/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6965`

View PR using the GUI difftool: \
`$ git pr show -t 6965`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6965.diff">https://git.openjdk.java.net/jdk/pull/6965.diff</a>

</details>
