### PR TITLE
8279522: Serial: Remove unused Generation::clear_remembered_set

### DIFF
--- a/src/hotspot/share/gc/shared/cardGeneration.cpp
+++ b/src/hotspot/share/gc/shared/cardGeneration.cpp
@@ -174,11 +174,6 @@ void CardGeneration::shrink(size_t bytes) {
                       name(), old_mem_size/K, new_mem_size/K);
 }
 
-// No young generation references, clear this generation's cards.
-void CardGeneration::clear_remembered_set() {
-  _rs->clear(reserved());
-}
-
 // Objects in this generation may have moved, invalidate this
 // generation's cards.
 void CardGeneration::invalidate_remembered_set() {

--- a/src/hotspot/share/gc/shared/cardGeneration.hpp
+++ b/src/hotspot/share/gc/shared/cardGeneration.hpp
@@ -71,8 +71,6 @@ class CardGeneration: public Generation {
 
   virtual void compute_new_size();
 
-  virtual void clear_remembered_set();
-
   virtual void invalidate_remembered_set();
 
   virtual void prepare_for_verify();

--- a/src/hotspot/share/gc/shared/generation.hpp
+++ b/src/hotspot/share/gc/shared/generation.hpp
@@ -422,11 +422,6 @@ class Generation: public CHeapObj<mtGC> {
   // each.
   virtual void object_iterate(ObjectClosure* cl);
 
-  // Inform a generation that it longer contains references to objects
-  // in any younger generation.    [e.g. Because younger gens are empty,
-  // clear the card table.]
-  virtual void clear_remembered_set() { }
-
   // Inform a generation that some of its objects have moved.  [e.g. The
   // generation's spaces were compacted, invalidating the card table.]
   virtual void invalidate_remembered_set() { }


### PR DESCRIPTION
Trivial change of removing unused code.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279522](https://bugs.openjdk.java.net/browse/JDK-8279522): Serial: Remove unused Generation::clear_remembered_set


### Reviewers
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6967/head:pull/6967` \
`$ git checkout pull/6967`

Update a local copy of the PR: \
`$ git checkout pull/6967` \
`$ git pull https://git.openjdk.java.net/jdk pull/6967/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6967`

View PR using the GUI difftool: \
`$ git pr show -t 6967`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6967.diff">https://git.openjdk.java.net/jdk/pull/6967.diff</a>

</details>
