### PR TITLE
8279523: Parallel: Remove unnecessary PSScavenge::_to_space_top_before_gc

### DIFF
--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -70,7 +70,6 @@
 #include "services/memoryService.hpp"
 #include "utilities/stack.inline.hpp"
 
-HeapWord*                     PSScavenge::_to_space_top_before_gc = NULL;
 SpanSubjectToDiscoveryClosure PSScavenge::_span_based_discoverer;
 ReferenceProcessor*           PSScavenge::_ref_processor = NULL;
 PSCardTable*                  PSScavenge::_card_table = NULL;
@@ -442,8 +441,6 @@ bool PSScavenge::invoke_no_policy() {
     assert(young_gen->to_space()->is_empty(),
            "Attempt to scavenge with live objects in to_space");
     young_gen->to_space()->clear(SpaceDecorator::Mangle);
-
-    save_to_space_top_before_gc();
 
 #if COMPILER2_OR_JVMCI
     DerivedPointerTable::clear();

--- a/src/hotspot/share/gc/parallel/psScavenge.hpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.hpp
@@ -53,10 +53,6 @@ class PSScavenge: AllStatic {
    full_follows_scavenge
  };
 
-  // Saved value of to_space->top(), used to prevent objects in to_space from
-  // being rescanned.
-  static HeapWord* _to_space_top_before_gc;
-
  protected:
   // Flags/counters
   static SpanSubjectToDiscoveryClosure _span_based_discoverer;
@@ -79,9 +75,6 @@ class PSScavenge: AllStatic {
   static void clean_up_failed_promotion();
 
   static bool should_attempt_scavenge();
-
-  static HeapWord* to_space_top_before_gc() { return _to_space_top_before_gc; }
-  static inline void save_to_space_top_before_gc();
 
   // Private accessors
   static PSCardTable* const card_table()           { assert(_card_table != NULL, "Sanity"); return _card_table; }

--- a/src/hotspot/share/gc/parallel/psScavenge.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.inline.hpp
@@ -35,11 +35,6 @@
 #include "oops/oop.inline.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-inline void PSScavenge::save_to_space_top_before_gc() {
-  ParallelScavengeHeap* heap = ParallelScavengeHeap::heap();
-  _to_space_top_before_gc = heap->young_gen()->to_space()->top();
-}
-
 template <class T> inline bool PSScavenge::should_scavenge(T* p) {
   T heap_oop = RawAccess<>::oop_load(p);
   return PSScavenge::is_obj_in_young(heap_oop);
@@ -51,7 +46,7 @@ inline bool PSScavenge::should_scavenge(T* p, MutableSpace* to_space) {
     oop obj = RawAccess<IS_NOT_NULL>::oop_load(p);
     // Skip objects copied to to_space since the scavenge started.
     HeapWord* const addr = cast_from_oop<HeapWord*>(obj);
-    return addr < to_space_top_before_gc() || addr >= to_space->end();
+    return addr < to_space->bottom() || addr >= to_space->end();
   }
   return false;
 }


### PR DESCRIPTION
Simple change of removing an unnecessary field.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279523](https://bugs.openjdk.java.net/browse/JDK-8279523): Parallel: Remove unnecessary PSScavenge::_to_space_top_before_gc


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6968/head:pull/6968` \
`$ git checkout pull/6968`

Update a local copy of the PR: \
`$ git checkout pull/6968` \
`$ git pull https://git.openjdk.java.net/jdk pull/6968/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6968`

View PR using the GUI difftool: \
`$ git pr show -t 6968`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6968.diff">https://git.openjdk.java.net/jdk/pull/6968.diff</a>

</details>
