### PR TITLE
8279526: Exceptions::count_out_of_memory_exceptions miscounts class metaspace OOMEs

### DIFF
--- a/src/hotspot/share/utilities/exceptions.cpp
+++ b/src/hotspot/share/utilities/exceptions.cpp
@@ -463,7 +463,7 @@ volatile int Exceptions::_out_of_memory_error_class_metaspace_errors = 0;
 void Exceptions::count_out_of_memory_exceptions(Handle exception) {
   if (Universe::is_out_of_memory_error_metaspace(exception())) {
      Atomic::inc(&_out_of_memory_error_metaspace_errors, memory_order_relaxed);
-  } else if (Universe::is_out_of_memory_error_metaspace(exception())) {
+  } else if (Universe::is_out_of_memory_error_class_metaspace(exception())) {
      Atomic::inc(&_out_of_memory_error_class_metaspace_errors, memory_order_relaxed);
   } else {
      // everything else reported as java heap OOM


### PR DESCRIPTION
SonarCloud reports that `Universe::is_out_of_memory_error_class_metaspace` is not used after JDK-8278125. Indeed, that patch [seems to introduce](https://github.com/openjdk/jdk/commit/ad1dc9c2ae5463363aff20072a3f2ca4ea23acd2?diff=unified#diff-997cf62de09eb9ba3ba9a8fc1d48666b913b4ece76a4f37559a985282788d913L466-R466) a typo in `Exceptions::count_out_of_memory_exceptions`.

Additional testing:
 - [x] Linux x86_64 fastdebug `hotspot:tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279526](https://bugs.openjdk.java.net/browse/JDK-8279526): Exceptions::count_out_of_memory_exceptions miscounts class metaspace OOMEs


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6970/head:pull/6970` \
`$ git checkout pull/6970`

Update a local copy of the PR: \
`$ git checkout pull/6970` \
`$ git pull https://git.openjdk.java.net/jdk pull/6970/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6970`

View PR using the GUI difftool: \
`$ git pr show -t 6970`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6970.diff">https://git.openjdk.java.net/jdk/pull/6970.diff</a>

</details>
