### PR TITLE
8279528: Unused TypeEnter.diag after JDK-8205187

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
@@ -109,7 +109,6 @@ public class TypeEnter implements Completer {
     private final Annotate annotate;
     private final TypeAnnotations typeAnnotations;
     private final Types types;
-    private final JCDiagnostic.Factory diags;
     private final DeferredLintHandler deferredLintHandler;
     private final Lint lint;
     private final TypeEnvs typeEnvs;
@@ -137,7 +136,6 @@ public class TypeEnter implements Completer {
         annotate = Annotate.instance(context);
         typeAnnotations = TypeAnnotations.instance(context);
         types = Types.instance(context);
-        diags = JCDiagnostic.Factory.instance(context);
         deferredLintHandler = DeferredLintHandler.instance(context);
         lint = Lint.instance(context);
         typeEnvs = TypeEnvs.instance(context);


### PR DESCRIPTION
SonarCloud reports that `TypeEnter.diag` is not used. The last use was removed by [JDK-8205187](https://bugs.openjdk.java.net/browse/JDK-8205187). We can probably save a few bytes/cycles by not retaining it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279528](https://bugs.openjdk.java.net/browse/JDK-8279528): Unused TypeEnter.diag after JDK-8205187


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6971/head:pull/6971` \
`$ git checkout pull/6971`

Update a local copy of the PR: \
`$ git checkout pull/6971` \
`$ git pull https://git.openjdk.java.net/jdk pull/6971/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6971`

View PR using the GUI difftool: \
`$ git pr show -t 6971`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6971.diff">https://git.openjdk.java.net/jdk/pull/6971.diff</a>

</details>
