### PR TITLE
JDK-8279533 Bad indentation and missing curly braces in BlockBegin::set_end

### DIFF
--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -529,9 +529,10 @@ void BlockBegin::set_end(BlockEnd* new_end) { // Assumes that no predecessor of 
   if (new_end == _end) return;
 
   // Remove this block as predecessor of its current successors
-  if (_end != NULL)
-  for (int i = 0; i < number_of_sux(); i++) {
-    sux_at(i)->remove_predecessor(this);
+  if (_end != NULL) {
+    for (int i = 0; i < number_of_sux(); i++) {
+      sux_at(i)->remove_predecessor(this);
+    }
   }
 
   _end = new_end;


### PR DESCRIPTION
Fixed this to please SonarCloud, but it was already working as intended. This change is equivalent with the original code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279533](https://bugs.openjdk.java.net/browse/JDK-8279533): Bad indentation and missing curly braces in BlockBegin::set_end


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6972/head:pull/6972` \
`$ git checkout pull/6972`

Update a local copy of the PR: \
`$ git checkout pull/6972` \
`$ git pull https://git.openjdk.java.net/jdk pull/6972/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6972`

View PR using the GUI difftool: \
`$ git pr show -t 6972`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6972.diff">https://git.openjdk.java.net/jdk/pull/6972.diff</a>

</details>
