### PR TITLE
8279547: [vectorapi] Enable vector cast tests after JDK-8278948

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/utils/TestCastMethods.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/utils/TestCastMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@ import static compiler.vectorapi.reshape.utils.VectorReshapeHelper.*;
 import static compiler.vectorapi.reshape.utils.VectorSpeciesPair.makePair;
 
 /**
- * The cast intrinsics implemented on each platform, commented out tests are the ones that are
- * supposed to work but currently don't.
+ * The cast intrinsics implemented on each platform.
  */
 public class TestCastMethods {
     public static final List<VectorSpeciesPair> AVX1_CAST_TESTS = List.of(
@@ -39,7 +38,7 @@ public class TestCastMethods {
             makePair(BSPEC64, SSPEC128),
             makePair(BSPEC64, ISPEC128),
             makePair(BSPEC64, FSPEC128),
-//            makePair(BSPEC64, DSPEC256),
+            makePair(BSPEC64, DSPEC256),
             makePair(SSPEC64, BSPEC64),
             makePair(SSPEC128, BSPEC64),
             makePair(SSPEC64, ISPEC64),
@@ -48,7 +47,7 @@ public class TestCastMethods {
             makePair(SSPEC64, FSPEC64),
             makePair(SSPEC64, FSPEC128),
             makePair(SSPEC64, DSPEC128),
-//            makePair(SSPEC64, DSPEC256),
+            makePair(SSPEC64, DSPEC256),
             makePair(ISPEC128, BSPEC64),
             makePair(ISPEC64, SSPEC64),
             makePair(ISPEC128, SSPEC64),


### PR DESCRIPTION
Hi,

This patch enables 2 vector cast operations that fail before.

Thank you very much.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279547](https://bugs.openjdk.java.net/browse/JDK-8279547): [vectorapi] Enable vector cast tests after JDK-8278948


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6976/head:pull/6976` \
`$ git checkout pull/6976`

Update a local copy of the PR: \
`$ git checkout pull/6976` \
`$ git pull https://git.openjdk.java.net/jdk pull/6976/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6976`

View PR using the GUI difftool: \
`$ git pr show -t 6976`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6976.diff">https://git.openjdk.java.net/jdk/pull/6976.diff</a>

</details>
