### PR TITLE
8279290: symbol not found error, implicit lambdas and diamond constructor invocations

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -2914,6 +2914,7 @@ public class Attr extends JCTree.Visitor {
                     && ((tree.constructorType != null && inferenceContext.free(tree.constructorType))
                     || (tree.clazz.type != null && inferenceContext.free(tree.clazz.type)))) {
                 final ResultInfo resultInfoForClassDefinition = this.resultInfo;
+                Env<AttrContext> dupLocalEnv = localEnv.dup(localEnv.tree, localEnv.info.dup(localEnv.info.scope.dupUnshared()));
                 inferenceContext.addFreeTypeListener(List.of(tree.constructorType, tree.clazz.type),
                         instantiatedContext -> {
                             tree.constructorType = instantiatedContext.asInstType(tree.constructorType);
@@ -2922,7 +2923,7 @@ public class Attr extends JCTree.Visitor {
                             try {
                                 this.resultInfo = resultInfoForClassDefinition;
                                 visitAnonymousClassDefinition(tree, clazz, clazz.type, cdef,
-                                                            localEnv, argtypes, typeargtypes, pkind);
+                                        dupLocalEnv, argtypes, typeargtypes, pkind);
                             } finally {
                                 this.resultInfo = prevResult;
                             }

--- a/test/langtools/tools/javac/lambda/CantFindSymbolImplicitLambdaAndDiamondTest.java
+++ b/test/langtools/tools/javac/lambda/CantFindSymbolImplicitLambdaAndDiamondTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary symbol not found error, implicit lambdas and diamond constructor invocations
+ * @compile CantFindSymbolImplicitLambdaAndDiamondTest.java
+ */
+
+import java.util.function.Consumer;
+
+class CantFindSymbolImplicitLambdaAndDiamondTest {
+    static class B<T>{}
+
+    static class A1 {
+        <T> A1(Consumer<T> cons) {}
+    }
+
+    static class A2<T> {
+        A2(Consumer<T> cons) {}
+    }
+
+    public void mount() {
+        new A1(inHours ->
+                new B<>() {{
+                    System.out.println(inHours);
+                }});
+
+        new A2<>(inHours ->
+            new B<>() {{
+                System.out.println(inHours);
+            }});
+    }
+}


### PR DESCRIPTION
Please review this PR which is fixing a bug caused by scope sharing. In particular for code like:
```
class Test {
    static class B<T>{}

    static class A1 {
        <T> A1(Consumer<T> cons) {}
    }

    void foo() {
        new A1(findMe ->
                new B<>() {{
                    System.out.println(findMe); // javac is failing here with symbol not found for findMe
                }});
    }
}
```
the reason for the error is that when attributing the diamond constructor invocation, a listener is registered in the current inference context. But the scope inside the environment passed to the listener is shared with the implicit lambda and once the lambda has been attributed, the argument `findMe` is removed from the shared scope. See the `localEnv.info.scope.leave()` at the end of `Attr::visitLambda`. This is why it is necessary to duplicate the scope as proposed in this patch.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279290](https://bugs.openjdk.java.net/browse/JDK-8279290): symbol not found error, implicit lambdas and diamond constructor invocations


### Reviewers
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6977/head:pull/6977` \
`$ git checkout pull/6977`

Update a local copy of the PR: \
`$ git checkout pull/6977` \
`$ git pull https://git.openjdk.java.net/jdk pull/6977/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6977`

View PR using the GUI difftool: \
`$ git pr show -t 6977`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6977.diff">https://git.openjdk.java.net/jdk/pull/6977.diff</a>

</details>
