### PR TITLE
8279333: Some JFR tests do not accept 'GCLocker Initiated GC' as a valid GC cause

### DIFF
--- a/test/jdk/jdk/jfr/event/gc/collection/TestGCCauseWithG1ConcurrentMark.java
+++ b/test/jdk/jdk/jfr/event/gc/collection/TestGCCauseWithG1ConcurrentMark.java
@@ -40,7 +40,8 @@ public class TestGCCauseWithG1ConcurrentMark {
         String testID = "G1ConcurrentMark";
         String[] vmFlags = {"-XX:+UseG1GC", "-XX:+ExplicitGCInvokesConcurrent"};
         String[] gcNames = {GCHelper.gcG1New, GCHelper.gcG1Old, GCHelper.gcG1Full};
-        String[] gcCauses = {"G1 Evacuation Pause", "G1 Preventive Collection", "G1 Compaction Pause", "System.gc()"};
+        String[] gcCauses = {"GCLocker Initiated GC", "G1 Evacuation Pause", "G1 Preventive Collection",
+                             "G1 Compaction Pause", "System.gc()"};
         GCGarbageCollectionUtil.test(testID, vmFlags, gcNames, gcCauses);
     }
 }

--- a/test/jdk/jdk/jfr/event/gc/collection/TestGCCauseWithG1FullCollection.java
+++ b/test/jdk/jdk/jfr/event/gc/collection/TestGCCauseWithG1FullCollection.java
@@ -40,7 +40,8 @@ public class TestGCCauseWithG1FullCollection {
         String testID = "G1FullCollection";
         String[] vmFlags = {"-XX:+UseG1GC"};
         String[] gcNames = {GCHelper.gcG1New, GCHelper.gcG1Old, GCHelper.gcG1Full};
-        String[] gcCauses = {"G1 Evacuation Pause", "G1 Preventive Collection", "G1 Compaction Pause", "System.gc()"};
+        String[] gcCauses = {"GCLocker Initiated GC", "G1 Evacuation Pause", "G1 Preventive Collection",
+                             "G1 Compaction Pause", "System.gc()"};
         GCGarbageCollectionUtil.test(testID, vmFlags, gcNames, gcCauses);
     }
 }


### PR DESCRIPTION
Some JFR tests do not accept 'GCLocker Initiated GC' as a valid GC cause

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8279333](https://bugs.openjdk.java.net/browse/JDK-8279333): Some JFR tests do not accept 'GCLocker Initiated GC' as a valid GC cause


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6978/head:pull/6978` \
`$ git checkout pull/6978`

Update a local copy of the PR: \
`$ git checkout pull/6978` \
`$ git pull https://git.openjdk.java.net/jdk pull/6978/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6978`

View PR using the GUI difftool: \
`$ git pr show -t 6978`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6978.diff">https://git.openjdk.java.net/jdk/pull/6978.diff</a>

</details>
