### PR TITLE
8278232: [macos] Wrong chars emitted when entering certain char-sequence of Indic language

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -546,12 +546,13 @@ static BOOL shouldUsePressAndHold() {
 -(BOOL) isCodePointInUnicodeBlockNeedingIMEvent: (unichar) codePoint {
     if ((codePoint == 0x0024) || (codePoint == 0x00A3) ||
         (codePoint == 0x00A5) ||
+        ((codePoint >= 0x900) && (codePoint <= 0x97F)) ||
         ((codePoint >= 0x20A3) && (codePoint <= 0x20BF)) ||
         ((codePoint >= 0x3000) && (codePoint <= 0x303F)) ||
         ((codePoint >= 0xFF00) && (codePoint <= 0xFFEF))) {
         // Code point is in 'CJK Symbols and Punctuation' or
         // 'Halfwidth and Fullwidth Forms' Unicode block or
-        // currency symbols unicode
+        // currency symbols unicode or Devanagari script
         return YES;
     }
     return NO;
@@ -957,11 +958,17 @@ static jclass jc_CInputMethod = NULL;
 
 #ifdef IM_DEBUG
     NSLog(@"insertText kbdlayout %@ ",(NSString *)kbdLayout);
+
+    NSLog(@"utf8Length %lu utf16Lenght %lu", (unsigned long)utf8Length, (unsigned long)utf16Length);
+    NSLog(@"codePoint %x", codePoint);
 #endif // IM_DEBUG
 
     if ((utf16Length > 2) ||
         ((utf8Length > 1) && [self isCodePointInUnicodeBlockNeedingIMEvent:codePoint]) ||
         ((codePoint == 0x5c) && ([(NSString *)kbdLayout containsString:@"Kotoeri"]))) {
+#ifdef IM_DEBUG
+        NSLog(@"string complex ");
+#endif
         aStringIsComplex = YES;
     }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -959,7 +959,7 @@ static jclass jc_CInputMethod = NULL;
 #ifdef IM_DEBUG
     NSLog(@"insertText kbdlayout %@ ",(NSString *)kbdLayout);
 
-    NSLog(@"utf8Length %lu utf16Lenght %lu", (unsigned long)utf8Length, (unsigned long)utf16Length);
+    NSLog(@"utf8Length %lu utf16Length %lu", (unsigned long)utf8Length, (unsigned long)utf16Length);
     NSLog(@"codePoint %x", codePoint);
 #endif // IM_DEBUG
 


### PR DESCRIPTION
Devanagiri script was not rendered properly in macos after JDK-8068283 due to incorporated check of utf16 string encoding should be more than 2 bytes is not satisfied. 
Additional check added in JDK-8132503 to ascertain if utf8 string encoding is complex or not was also not satisfied because of which complex Devanagairi unicode text insertion was not working.
Fix is to add Devanagiri codePoint to the complex list so that it is rendered properly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278232](https://bugs.openjdk.java.net/browse/JDK-8278232): [macos] Wrong chars emitted when entering certain char-sequence of Indic language


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to 227b6287f50e0bb81c18ecd034d067d612620023


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6979/head:pull/6979` \
`$ git checkout pull/6979`

Update a local copy of the PR: \
`$ git checkout pull/6979` \
`$ git pull https://git.openjdk.java.net/jdk pull/6979/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6979`

View PR using the GUI difftool: \
`$ git pr show -t 6979`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6979.diff">https://git.openjdk.java.net/jdk/pull/6979.diff</a>

</details>
