### PR TITLE
8279540: Shenandoah: Should only clear CLD::_claim_strong mark for strong CLD iterations

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.inline.hpp
@@ -82,7 +82,7 @@ ShenandoahClassLoaderDataRoots<CONCURRENT>::ShenandoahClassLoaderDataRoots(Shena
   if (heap_iteration) {
     ClassLoaderDataGraph::clear_claimed_marks(ClassLoaderData::_claim_other);
   } else {
-    ClassLoaderDataGraph::clear_claimed_marks();
+    ClassLoaderDataGraph::clear_claimed_marks(ClassLoaderData::_claim_strong);
   }
 
   if (CONCURRENT) {


### PR DESCRIPTION
JDK-8273559 started to use CLD::_claim_other for heap iteration in supporting multi-threaded heap walk. For regular CLD, it still uses CLD::_claim_strong, but for those walks, it clears all claim bits, instead of just _claim_strong bit.

I don't think it is a fatal bug, it just means heap iteration may walk a CLD by multiple workers, which impacts performance.

Test:
- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279540](https://bugs.openjdk.java.net/browse/JDK-8279540): Shenandoah: Should only clear CLD::_claim_strong mark for strong CLD iterations


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6980/head:pull/6980` \
`$ git checkout pull/6980`

Update a local copy of the PR: \
`$ git checkout pull/6980` \
`$ git pull https://git.openjdk.java.net/jdk pull/6980/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6980`

View PR using the GUI difftool: \
`$ git pr show -t 6980`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6980.diff">https://git.openjdk.java.net/jdk/pull/6980.diff</a>

</details>
