### PR TITLE
8279568: IGV: Add bci and line number property for OSR compilations

### DIFF
--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -316,7 +316,9 @@ void IdealGraphPrinter::begin_method() {
   }
 
   if (C->is_osr_compilation()) {
-      print_prop(COMPILATION_OSR_PROPERTY, TRUE_VALUE);
+      stringStream ss;
+      ss.print("bci: %d, line: %d", C->entry_bci(), method->line_number_from_bci(C->entry_bci()));
+      print_prop(COMPILATION_OSR_PROPERTY, ss.as_string());
   }
 
   print_prop(COMPILATION_ID_PROPERTY, C->compile_id());


### PR DESCRIPTION
IGV currently only shows "osr = true" in the "Properties" view:

![Screenshot from 2022-01-06 14-27-43](https://user-images.githubusercontent.com/17833009/148391331-9e6ab764-6ba0-4f46-83e5-f283b03382ea.png)

This small patch changes "true" to show the actual bci and line number info instead:

![Screenshot from 2022-01-06 14-38-10](https://user-images.githubusercontent.com/17833009/148391352-a128249e-eae1-4e5e-be70-f37202e994d2.png)

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279568](https://bugs.openjdk.java.net/browse/JDK-8279568): IGV: Add bci and line number property for OSR compilations


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6981/head:pull/6981` \
`$ git checkout pull/6981`

Update a local copy of the PR: \
`$ git checkout pull/6981` \
`$ git pull https://git.openjdk.java.net/jdk pull/6981/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6981`

View PR using the GUI difftool: \
`$ git pr show -t 6981`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6981.diff">https://git.openjdk.java.net/jdk/pull/6981.diff</a>

</details>
