### PR TITLE
8279621: x86: Arraycopy stubs should use 256-bit copies with AVX=1

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -1188,7 +1188,7 @@ class StubGenerator: public StubCodeGenerator {
     if (UseUnalignedLoadStores) {
       Label L_end;
       __ BIND(L_loop);
-      if (UseAVX >= 2) {
+      if (UseAVX >= 1) {
         __ vmovdqu(xmm0, Address(end_from, qword_count, Address::times_8, -56));
         __ vmovdqu(Address(end_to, qword_count, Address::times_8, -56), xmm0);
         __ vmovdqu(xmm1, Address(end_from, qword_count, Address::times_8, -24));
@@ -1210,7 +1210,7 @@ class StubGenerator: public StubCodeGenerator {
       __ subptr(qword_count, 4);  // sub(8) and add(4)
       __ jccb(Assembler::greater, L_end);
       // Copy trailing 32 bytes
-      if (UseAVX >= 2) {
+      if (UseAVX >= 1) {
         __ vmovdqu(xmm0, Address(end_from, qword_count, Address::times_8, -24));
         __ vmovdqu(Address(end_to, qword_count, Address::times_8, -24), xmm0);
       } else {
@@ -1260,7 +1260,7 @@ class StubGenerator: public StubCodeGenerator {
     if (UseUnalignedLoadStores) {
       Label L_end;
       __ BIND(L_loop);
-      if (UseAVX >= 2) {
+      if (UseAVX >= 1) {
         __ vmovdqu(xmm0, Address(from, qword_count, Address::times_8, 32));
         __ vmovdqu(Address(dest, qword_count, Address::times_8, 32), xmm0);
         __ vmovdqu(xmm1, Address(from, qword_count, Address::times_8,  0));
@@ -1283,7 +1283,7 @@ class StubGenerator: public StubCodeGenerator {
       __ addptr(qword_count, 4);  // add(8) and sub(4)
       __ jccb(Assembler::less, L_end);
       // Copy trailing 32 bytes
-      if (UseAVX >= 2) {
+      if (UseAVX >= 1) {
         __ vmovdqu(xmm0, Address(from, qword_count, Address::times_8, 0));
         __ vmovdqu(Address(dest, qword_count, Address::times_8, 0), xmm0);
       } else {


### PR DESCRIPTION
See the discussion in the bug.

Additional testing, TR 3970X (Zen 2, AVX2):
 - [x] Linux x86_64 fastdebug `hotspot_compiler_arraycopy` (explicitly tests all AVX modes)
 - [ ]  Linux x86_64 fastdebug `tier1` with `-XX:UseAVX=1`
 - [ ]  Linux x86_64 fastdebug `tier2` with `-XX:UseAVX=1`
 - [ ]  Linux x86_64 fastdebug `tier3` with `-XX:UseAVX=1`

Additional testing, TR 3970X (Zen 2, AVX2):
 - [x] Linux x86_64 fastdebug `hotspot_compiler_arraycopy` (explicitly tests all AVX modes)
 - [x]  Linux x86_64 fastdebug `tier1` with `-XX:UseAVX=1`
 - [x]  Linux x86_64 fastdebug `tier2` with `-XX:UseAVX=1`
 - [ ]  Linux x86_64 fastdebug `tier3` with `-XX:UseAVX=1`

This change improves the arraycopy performance significantly with `-XX:UseAVX=1` at least on TR 3970X. (Benchmark code pending)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8279621](https://bugs.openjdk.java.net/browse/JDK-8279621)

### Issue
 * [JDK-8279621](https://bugs.openjdk.java.net/browse/JDK-8279621): x86_64 arraycopy stubs should use 256-bit copies with AVX=1 ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6987/head:pull/6987` \
`$ git checkout pull/6987`

Update a local copy of the PR: \
`$ git checkout pull/6987` \
`$ git pull https://git.openjdk.java.net/jdk pull/6987/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6987`

View PR using the GUI difftool: \
`$ git pr show -t 6987`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6987.diff">https://git.openjdk.java.net/jdk/pull/6987.diff</a>

</details>
