### PR TITLE
8278296: Generalize long range check transformation

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -1109,8 +1109,6 @@ bool IdealLoopTree::policy_range_check(PhaseIdealLoop* phase, bool provisional, 
         continue; // not RC
       }
       Node *cmp = bol->in(1);
-      Node *rc_exp = cmp->in(1);
-      Node *limit = cmp->in(2);
 
       if (provisional) {
         // Try to pattern match with either cmp inputs, do not check
@@ -1121,6 +1119,8 @@ bool IdealLoopTree::policy_range_check(PhaseIdealLoop* phase, bool provisional, 
           continue;
         }
       } else {
+        Node *rc_exp = cmp->in(1);
+        Node *limit = cmp->in(2);
         Node *limit_c = phase->get_ctrl(limit);
         if (limit_c == phase->C->top()) {
           return false;           // Found dead test on live IF?  No RCE!
@@ -2523,7 +2523,7 @@ bool PhaseIdealLoop::is_iv(Node* exp, Node* iv, BasicType bt) {
 
 //------------------------------is_scaled_iv---------------------------------
 // Return true if exp is a constant times an induction var
-bool PhaseIdealLoop::is_scaled_iv(Node* exp, Node* iv, jlong* p_scale, BasicType bt, bool* converted) {
+bool PhaseIdealLoop::is_scaled_iv(Node* exp, Node* iv, jlong* p_scale, BasicType bt) {
   exp = exp->uncast();
   assert(bt == T_INT || bt == T_LONG, "unexpected int type");
   if (is_iv(exp, iv, bt)) {
@@ -2531,13 +2531,6 @@ bool PhaseIdealLoop::is_scaled_iv(Node* exp, Node* iv, jlong* p_scale, BasicType
       *p_scale = 1;
     }
     return true;
-  }
-  if (bt == T_LONG && iv->bottom_type()->isa_int() && exp->Opcode() == Op_ConvI2L) {
-    exp = exp->in(1);
-    bt = T_INT;
-    if (converted != NULL) {
-      *converted = true;
-    }
   }
   int opc = exp->Opcode();
   // Can't use is_Mul() here as it's true for AndI and AndL
@@ -2572,47 +2565,60 @@ bool PhaseIdealLoop::is_scaled_iv(Node* exp, Node* iv, jlong* p_scale, BasicType
 
 //-----------------------------is_scaled_iv_plus_offset------------------------------
 // Return true if exp is a simple induction variable expression: k1*iv + (invar + k2)
-bool PhaseIdealLoop::is_scaled_iv_plus_offset(Node* exp, Node* iv, jlong* p_scale, Node** p_offset, BasicType bt, bool* converted, int depth) {
+bool PhaseIdealLoop::is_scaled_iv_plus_offset(Node* exp, Node* iv, jlong* p_scale, Node** p_offset, BasicType bt, bool* p_converted, int depth) {
+  bool converted = false;
   assert(bt == T_INT || bt == T_LONG, "unexpected int type");
-  if (is_scaled_iv(exp, iv, p_scale, bt, converted)) {
+  if (bt == T_LONG && iv->bottom_type()->isa_int() && exp->Opcode() == Op_ConvI2L) {
+    exp = exp->in(1);
+    bt = T_INT;
+    converted = true;
+  }
+  if (is_scaled_iv(exp, iv, p_scale, bt)) {
     if (p_offset != NULL) {
       Node *zero = _igvn.integercon(0, bt);
       set_ctrl(zero, C->root());
       *p_offset = zero;
+    }
+    if (p_converted != NULL) {
+      *p_converted = converted;
     }
     return true;
   }
   exp = exp->uncast();
   int opc = exp->Opcode();
   if (opc == Op_Add(bt)) {
-    if (is_scaled_iv(exp->in(1), iv, p_scale, bt, converted)) {
+    if (is_scaled_iv(exp->in(1), iv, p_scale, bt)) {
       if (p_offset != NULL) {
         *p_offset = exp->in(2);
       }
+      if (p_converted != NULL) {
+        *p_converted = converted;
+      }
       return true;
     }
-    if (is_scaled_iv(exp->in(2), iv, p_scale, bt, converted)) {
+    if (is_scaled_iv(exp->in(2), iv, p_scale, bt)) {
       if (p_offset != NULL) {
         *p_offset = exp->in(1);
       }
+      if (p_converted != NULL) {
+        *p_converted = converted;
+      }
       return true;
     }
-    if (exp->in(2)->is_Con()) {
-      Node* offset2 = NULL;
-      if (depth < 2 &&
-          is_scaled_iv_plus_offset(exp->in(1), iv, p_scale,
-                                   p_offset != NULL ? &offset2 : NULL, bt, converted, depth+1)) {
-        if (p_offset != NULL) {
-          Node *ctrl_off2 = get_ctrl(offset2);
-          Node* offset = AddNode::make(offset2, exp->in(2), bt);
-          register_new_node(offset, ctrl_off2);
-          *p_offset = offset;
-        }
-        return true;
+    if (is_scaled_iv_plus_extra_offset(exp->in(1), exp->in(2), iv, p_scale, p_offset, bt, converted, depth)) {
+      if (p_converted != NULL) {
+        *p_converted = converted;
       }
+      return true;
+    }
+    if (is_scaled_iv_plus_extra_offset(exp->in(2), exp->in(1), iv, p_scale, p_offset, bt, converted, depth)) {
+      if (p_converted != NULL) {
+        *p_converted = converted;
+      }
+      return true;
     }
   } else if (opc == Op_Sub(bt)) {
-    if (is_scaled_iv(exp->in(1), iv, p_scale, bt, converted)) {
+    if (is_scaled_iv(exp->in(1), iv, p_scale, bt)) {
       if (p_offset != NULL) {
         Node *zero = _igvn.integercon(0, bt);
         set_ctrl(zero, C->root());
@@ -2621,19 +2627,55 @@ bool PhaseIdealLoop::is_scaled_iv_plus_offset(Node* exp, Node* iv, jlong* p_scal
         register_new_node(offset, ctrl_off);
         *p_offset = offset;
       }
-      return true;
-    }
-    if (is_scaled_iv(exp->in(2), iv, p_scale, bt, converted)) {
-      if (p_offset != NULL) {
-        // We can't handle a scale of min_jint (or min_jlong) here as -1 * min_jint = min_jint
-        if (*p_scale == min_signed_integer(bt)) {
-          return false;
-        }
-        *p_scale *= -1;
-        *p_offset = exp->in(1);
+      if (p_converted != NULL) {
+        *p_converted = converted;
       }
       return true;
     }
+    jlong scale;
+    if (is_scaled_iv(exp->in(2), iv, &scale, bt)) {
+      if (scale == min_signed_integer(bt)) {
+        return false;
+      }
+      if (p_offset != NULL) {
+        // We can't handle a scale of min_jint (or min_jlong) here as -1 * min_jint = min_jint
+        scale *= -1;
+        *p_offset = exp->in(1);
+      }
+      if (p_scale != NULL) {
+        *p_scale = scale;
+      }
+      if (p_converted != NULL) {
+        *p_converted = converted;
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
+bool PhaseIdealLoop::is_scaled_iv_plus_extra_offset(Node* exp1, Node* exp2, Node* iv, jlong* p_scale, Node** p_offset,
+                                                    BasicType bt, bool& converted, int depth) {
+  Node* offset2 = NULL;
+  if (depth < 2 &&
+          is_scaled_iv_plus_offset(exp1, iv, p_scale,
+                               &offset2, bt, &converted, depth+1)) {
+    if (bt == T_LONG && _igvn.type(offset2)->isa_int() &&
+        (!_igvn.type(offset2)->is_int()->is_con() || _igvn.type(offset2)->is_int()->get_con() != 0)) {
+      return false;
+    }
+    if (p_offset != NULL) {
+      Node* ctrl_off2 = get_ctrl(offset2);
+      if (bt == T_LONG && _igvn.type(offset2)->isa_int()) {
+        offset2 = new ConvI2LNode(offset2);
+        register_new_node(offset2, ctrl_off2);
+      }
+      Node* ctrl_exp2 = get_ctrl(exp2);
+      Node* offset = AddNode::make(offset2, exp2, bt);
+      register_new_node(offset, get_early_ctrl(offset));
+      *p_offset = offset;
+    }
+    return true;
   }
   return false;
 }

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -1126,9 +1126,6 @@ void PhaseIdealLoop::strip_mined_nest_back_to_counted_loop(IdealLoopTree* loop, 
 
 int PhaseIdealLoop::extract_long_range_checks(const IdealLoopTree* loop, jlong stride_con, int iters_limit, PhiNode* phi,
                                               Node_List& range_checks) {
-  if (stride_con < 0) { // only for stride_con > 0 && scale > 0 for now
-    return iters_limit;
-  }
   const jlong min_iters = 2;
   jlong reduced_iters_limit = iters_limit;
   jlong original_iters_limit = iters_limit;
@@ -1143,7 +1140,6 @@ int PhaseIdealLoop::extract_long_range_checks(const IdealLoopTree* loop, jlong s
         RangeCheckNode* rc = c->in(0)->as_RangeCheck();
         if (loop->is_range_check_if(rc, this, T_LONG, phi, range, offset, scale) &&
             loop->is_invariant(range) && loop->is_invariant(offset) &&
-            scale > 0 && // only for stride_con > 0 && scale > 0 for now
             original_iters_limit / ABS(scale * stride_con) >= min_iters) {
           reduced_iters_limit = MIN2(reduced_iters_limit, original_iters_limit/ABS(scale));
           range_checks.push(c);
@@ -1161,24 +1157,21 @@ int PhaseIdealLoop::extract_long_range_checks(const IdealLoopTree* loop, jlong s
 // i is never Z.  It will be B=Z-1 if S=1, or B=Z+1 if S=-1.  If |S|>1 the formula for the last value requires a floor
 // operation, specifically B=floor((Z-sgn(S)-A)/S)*S+A.  Thus i ranges as i:[A,B] or i:[A,Z) or i:[A,Z-U) for some U<S.
 
-// N.B. We handle only the case of positive S currently, so comments about S<0 are not operative at present.  Also,
-// we only support positive index scale value (K > 0) to simplify the logic for clamping 32-bit bounds (L_2, R_2).
-// For restrictions on S and K, see the guards in extract_long_range_checks.
-
 // Within the loop there may be many range checks.  Each such range check (R.C.) is of the form 0 <= i*K+L < R, where K
 // is a scale factor applied to the loop iteration variable i, and L is some offset; K, L, and R are loop-invariant.
 // Because R is never negative, this check can always be simplified to an unsigned check i*K+L <u R.
 
 // When a long loop over a 64-bit variable i (outer_iv) is decomposed into a series of shorter sub-loops over a 32-bit
-// variable j (inner_iv), j ranges over a shorter interval j:[0,Z_2), where the limit is chosen to prevent various cases
-// of 32-bit overflow (including multiplications j*K below).  In the sub-loop the logical value i is offset from j by a
-// 64-bit constant C, so i ranges in i:C+[0,Z_2).
+// variable j (inner_iv), j ranges over a shorter interval j:[0, B_2] or [0,Z_2) (assuming S > 0), where the limit is
+// chosen to prevent various cases of 32-bit overflow (including multiplications j*K below).  In the sub-loop the
+// logical value i is offset from j by a 64-bit constant C, so i ranges in i:C+[0,Z_2).
 
 // The union of all the C+[0,Z_2) ranges from the sub-loops must be identical to the whole range [A,B].  Assuming S>0,
 // the first C must be A itself, and the next C value is the previous C+Z_2.  In each sub-loop, j counts up from zero
 // and exits just before i=C+Z_2.
 
-// (N.B. If S<0 the formulas are different, because all the loops count downward.)
+// If S<0, j iterates over [A_2, 0]. The union of the sub-loops must be identical to the whole range [A, B] in this case
+// as well.
 
 // Returning to range checks, we see that each i*K+L <u R expands to (C+j)*K+L <u R, or j*K+Q <u R, where Q=(C*K+L).
 // (Recall that K and L and R are loop-invariant scale, offset and range values for a particular R.C.)  This is still a
@@ -1198,13 +1191,12 @@ int PhaseIdealLoop::extract_long_range_checks(const IdealLoopTree* loop, jlong s
 
 // If 32-bit multiplication j*K might overflow, we adjust the sub-loop limit Z_2 closer to zero to reduce j's range.
 
-// For each R.C. j*K+Q <u32 R, the range of mathematical values of j*K+Q in the sub-loop is [Q_min, Q_max), where
-// Q_min=Q and Q_max=Z_2*K+Q.  Making the upper limit Q_max be exclusive helps it integrate correctly with the strict
-// comparisons against R and R_2.  Sometimes a very high R will be replaced by an R_2 derived from the more moderate
-// Q_max, and replacing one exclusive limit by another exclusive limit avoids off-by-one complexities.
+// For each R.C. j*K+Q <u32 R, the range of mathematical values of j*K+Q in the sub-loop is [Q_min, Q_max], where
+// Q_min=Q and Q_max=B_2*K+Q (if S>0 and K>0), Q_min=A_2*K+Q and Q_max=Q (if S<0 and K>0),
+// Q_min=B_2*K+Q and Q_max=Q if (S>0 and K<0), Q_min=Q and Q_max=A_2*K+Q (if S<0 and K<0)
 
-// N.B. If (S*K)<0 then the formulas for Q_min and Q_max may differ; the values may need to be swapped and adjusted to
-// the correct type of bound (inclusive or exclusive).
+// If S*K>0 then, as the loop iterations progress, j*K+Q goes from Q_min towards Q_max.
+// If S*K<0 then j*K+Q starts at Q_max and goes towards Q_min.
 
 // Case A: Some Negatives (but no overflow).
 // Number line:
@@ -1213,7 +1205,8 @@ int PhaseIdealLoop::extract_long_range_checks(const IdealLoopTree* loop, jlong s
 // |    .     .    .  Q_min..0..Q_max  .    .     .    |  small mixed
 //
 // if Q_min <s64 0, then use this test:
-// j*K + s32_trunc(Q_min) <u32 clamp(R, 0, Q_max)
+// j*K + s32_trunc(Q_min) <u32 clamp'(R, 0, Q_max) if S*K>0
+// j*K + s32_trunc(Q_max) <u32 clamp'(R, 0, Q_max) if S*K<0
 
 // If the 32-bit truncation loses information, no harm is done, since certainly the clamp also returns R_2=zero.
 
@@ -1224,31 +1217,38 @@ int PhaseIdealLoop::extract_long_range_checks(const IdealLoopTree* loop, jlong s
 // |    .     .    .    .    0    . Q_min..Q_max  .    |  s64 positive
 //
 // if both Q_min, Q_max >=s64 0, then use this test:
-// j*K + 0 <u32 clamp(R, Q_min, Q_max) - Q_min
+// j*K + 0 <u32 clamp'(R, Q_min, Q_max) - Q_min if S*K>0
 // or equivalently:
-// j*K + 0 <u32 clamp(R - Q_min, 0, Q_max - Q_min)
+// j*K + 0 <u32 clamp'(R - Q_min, 0, Q_max - Q_min)
+//
+// j*K + Q_max - Q_min <u32 clamp'(R, Q_min, Q_max) - Q_min if S*K<0
 
 // Case C: Overflow in the 64-bit domain
 // Number line:
 // |..Q_max-2^64   .    .    0    .    .    .   Q_min..|  s64 overflow
 //
 // if Q_min >=s64 0 but Q_max <s64 0, then use this test:
-// j*K + 0 <u32 clamp(R, Q_min, R) - Q_min
+// j*K + 0 <u32 clamp(R, Q_min, R) - Q_min if S*K>0
 // or equivalently:
 // j*K + 0 <u32 clamp(R - Q_min, 0, R - Q_min)
 // or also equivalently:
 // j*K + 0 <u32 max(0, R - Q_min)
 //
+// j*K + Q_max - Q_min <u32 clamp(R, Q_min, R) - Q_min if S*K<0
+//
 // Here the clamp function is a simple 64-bit min/max:
 // clamp(X, L, H) := max(L, min(X, H))
+// clamp'(X, L, H) := max(L, min(X-1, H)+1) (in case H is inclusive but X is not)
 // When degenerately L > H, it returns L not H.
 //
 // Tests above can be merged into a single one:
 // L_clamp = Q_min < 0 ? 0 : Q_min
-// H_clamp = Q_max < Q_min ? R : Q_max
-// j*K + Q_min - L_clamp <u32 clamp(R, L_clamp, H_clamp) - L_clamp
+// H_clamp = Q_max+1 < Q_min ? R : Q_max+1
+// j*K + Q_min - L_clamp <u32 clamp(R, L_clamp, H_clamp) - L_clamp if S*K>0
 // or equivalently:
 // j*K + Q_min - L_clamp <u32 clamp(R - L_clamp, 0, H_clamp - L_clamp)
+//
+// j*K + Q_max - L_clamp <u32 clamp(R, L_clamp, H_clamp) - L_clamp if S*K>0
 //
 // Readers may find the equivalent forms easier to reason about, but the forms given first generate better code.
 
@@ -1257,6 +1257,12 @@ void PhaseIdealLoop::transform_long_range_checks(int stride_con, const Node_List
                                                  Node* iv_add, LoopNode* inner_head) {
   Node* long_zero = _igvn.longcon(0);
   set_ctrl(long_zero, C->root());
+  Node* int_zero = _igvn.intcon(0);
+  set_ctrl(int_zero, this->C->root());
+  Node* long_one = _igvn.longcon(1);
+  set_ctrl(long_one, this->C->root());
+  Node* int_stride = _igvn.intcon(checked_cast<int>(stride_con));
+  set_ctrl(int_stride, this->C->root());
 
   for (uint i = 0; i < range_checks.size(); i++) {
     ProjNode* proj = range_checks.at(i)->as_Proj();
@@ -1319,8 +1325,6 @@ void PhaseIdealLoop::transform_long_range_checks(int stride_con, const Node_List
     }
 
     Node* C = outer_phi;
-    Node* Z_2 = new ConvI2LNode(inner_iters_actual_int, TypeLong::LONG);
-    register_new_node(Z_2, entry_control);
 
     // Start with 64-bit values:
     //   i*K + L <u64 R
@@ -1334,10 +1338,23 @@ void PhaseIdealLoop::transform_long_range_checks(int stride_con, const Node_List
     // Compute endpoints of the range of values j*K.
     //  Q_min = (j=0)*K + L_2;  Q_max = (j=Z_2)*K + L_2
     Node* Q_min = L_2;
-    Node* Q_max = new MulLNode(Z_2, K);
+
+    // A_2 if S < 0
+    Node* B_2 = new LoopLimitNode(this->C, int_zero, inner_iters_actual_int, int_stride);
+    register_new_node(B_2, entry_control);
+    B_2 = new SubINode(B_2, int_stride);
+    register_new_node(B_2, entry_control);
+    B_2 = new ConvI2LNode(B_2);
+    register_new_node(B_2, entry_control);
+
+    Node* Q_max = new MulLNode(B_2, K);
     register_new_node(Q_max, entry_control);
     Q_max = new AddLNode(Q_max, L_2);
     register_new_node(Q_max, entry_control);
+
+    if (scale * stride_con < 0) {
+      swap(Q_min, Q_max);
+    }
 
     // L_clamp = Q_min < 0 ? 0 : Q_min
     Node* Q_min_cmp = new CmpLNode(Q_min, long_zero);
@@ -1347,12 +1364,15 @@ void PhaseIdealLoop::transform_long_range_checks(int stride_con, const Node_List
     Node* L_clamp = new CMoveLNode(Q_min_bool, Q_min, long_zero, TypeLong::LONG);
     register_new_node(L_clamp, entry_control);
 
-    // H_clamp = Q_max < Q_min ? R : Q_max
-    Node* Q_max_cmp = new CmpLNode(Q_max, Q_min);
+    Node* Q_max_plus_one = new AddLNode(Q_max, long_one);
+    register_new_node(Q_max_plus_one, entry_control);
+
+    // H_clamp = Q_max+1 < Q_min ? R : Q_max+1
+    Node* Q_max_cmp = new CmpLNode(Q_max_plus_one, Q_min);
     register_new_node(Q_max_cmp, entry_control);
     Node* Q_max_bool = new BoolNode(Q_max_cmp, BoolTest::lt);
     register_new_node(Q_max_bool, entry_control);
-    Node* H_clamp = new CMoveLNode(Q_max_bool, Q_max, R, TypeLong::LONG);
+    Node* H_clamp = new CMoveLNode(Q_max_bool, Q_max_plus_one, R, TypeLong::LONG);
     register_new_node(H_clamp, entry_control);
 
     // R_2 = clamp(R, L_clamp, H_clamp) - L_clamp
@@ -1364,11 +1384,18 @@ void PhaseIdealLoop::transform_long_range_checks(int stride_con, const Node_List
     R_2 = new ConvL2INode(R_2, TypeInt::POS);
     register_new_node(R_2, entry_control);
 
-    // Q = Q_min - L_clamp
-    // that is: Q = Q_min - 0 if Q_min < 0
-    // or:      Q = Q_min - Q_min = 0 if Q_min > 0
-    Node* Q = new SubLNode(Q_min, L_clamp);
-    register_new_node(Q, entry_control);
+    Node* Q = NULL;
+    if (scale * stride_con > 0) {
+      // Q = Q_min - L_clamp
+      // that is: Q = Q_min - 0 if Q_min < 0
+      // or:      Q = Q_min - Q_min = 0 if Q_min > 0
+      Q = new SubLNode(Q_min, L_clamp);
+      register_new_node(Q, entry_control);
+    } else {
+      Q = new SubLNode(Q_max, L_clamp);
+      register_new_node(Q, entry_control);
+    }
+
     Q = new ConvL2INode(Q, TypeInt::INT);
     register_new_node(Q, entry_control);
 

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1255,7 +1255,7 @@ public:
   void mark_reductions( IdealLoopTree *loop );
 
   // Return true if exp is a constant times an induction var
-  bool is_scaled_iv(Node* exp, Node* iv, jlong* p_scale, BasicType bt, bool* converted);
+  bool is_scaled_iv(Node* exp, Node* iv, jlong* p_scale, BasicType bt);
 
   bool is_iv(Node* exp, Node* iv, BasicType bt);
 
@@ -1647,6 +1647,9 @@ public:
 
   void strip_mined_nest_back_to_counted_loop(IdealLoopTree* loop, const BaseCountedLoopNode* head, Node* back_control,
                                              IfNode*&exit_test, SafePointNode*&safepoint);
+
+  bool is_scaled_iv_plus_extra_offset(Node* exp1, Node* exp2, Node* iv, jlong* p_scale, Node** p_offset, BasicType bt,
+                                      bool& converted, int depth);
 };
 
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestLongRangeChecks.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestLongRangeChecks.java
@@ -96,4 +96,150 @@ public class TestLongRangeChecks {
     private void testStridePosScalePosInIntLoop2_runner() {
         testStridePosScalePosInIntLoop2(0, 100, 200, 0);
     }
+
+    @Test
+    @IR(counts = { IRNode.LOOP, "1"})
+    @IR(failOn = { IRNode.COUNTEDLOOP})
+    public static void testStrideNegScaleNeg(long start, long stop, long length, long offset) {
+        final long scale = -1;
+        final long stride = 1;
+        for (long i = stop; i > start; i -= stride) {
+            Objects.checkIndex(scale * i + offset, length);
+        }
+    }
+
+    @Run(test = "testStrideNegScaleNeg")
+    private void testStrideNegScaleNeg_runner() {
+        testStrideNegScaleNeg(0, 100, 100, 100);
+    }
+
+    @Test
+    @IR(counts = { IRNode.LOOP, "1" })
+    @IR(failOn = { IRNode.COUNTEDLOOP })
+    public static void testStrideNegScaleNegInIntLoop1(int start, int stop, long length, long offset) {
+        final long scale = -2;
+        final int stride = 1;
+
+        for (int i = stop; i > start; i -= stride) {
+            Objects.checkIndex(scale * i + offset, length);
+        }
+    }
+
+    @Run(test = "testStrideNegScaleNegInIntLoop1")
+    private void testStrideNegScaleNegInIntLoop1_runner() {
+        testStrideNegScaleNegInIntLoop1(0, 100, 200, 200);
+    }
+
+    @Test
+    @IR(counts = { IRNode.LOOP, "1" })
+    @IR(failOn = { IRNode.COUNTEDLOOP })
+    public static void testStrideNegScaleNegInIntLoop2(int start, int stop, long length, long offset) {
+        final int scale = -2;
+        final int stride = 1;
+
+        for (int i = stop; i > start; i -= stride) {
+            Objects.checkIndex(scale * i + offset, length);
+        }
+    }
+
+    @Run(test = "testStrideNegScaleNegInIntLoop2")
+    private void testStrideNegScaleNegInIntLoop2_runner() {
+        testStrideNegScaleNegInIntLoop2(0, 100, 200, 200);
+    }
+
+    @Test
+    @IR(counts = { IRNode.LOOP, "1"})
+    @IR(failOn = { IRNode.COUNTEDLOOP})
+    public static void testStrideNegScalePos(long start, long stop, long length, long offset) {
+        final long scale = 1;
+        final long stride = 1;
+        for (long i = stop-1; i >= start; i -= stride) {
+            Objects.checkIndex(scale * i + offset, length);
+        }
+    }
+
+    @Run(test = "testStrideNegScalePos")
+    private void testStrideNegScalePos_runner() {
+        testStrideNegScalePos(0, 100, 100, 0);
+    }
+
+    @Test
+    @IR(counts = { IRNode.LOOP, "1" })
+    @IR(failOn = { IRNode.COUNTEDLOOP })
+    public static void testStrideNegScalePosInIntLoop1(int start, int stop, long length, long offset) {
+        final long scale = 2;
+        final int stride = 1;
+        for (int i = stop-1; i >= start; i -= stride) {
+            Objects.checkIndex(scale * i + offset, length);
+        }
+    }
+
+    @Run(test = "testStrideNegScalePosInIntLoop1")
+    private void testStrideNegScalePosInIntLoop1_runner() {
+        testStrideNegScalePosInIntLoop1(0, 100, 200, 0);
+    }
+
+    @Test
+    @IR(counts = { IRNode.LOOP, "1" })
+    @IR(failOn = { IRNode.COUNTEDLOOP })
+    public static void testStrideNegScalePosInIntLoop2(int start, int stop, long length, long offset) {
+        final int scale = 2;
+        final int stride = 1;
+        for (int i = stop-1; i >= start; i -= stride) {
+            Objects.checkIndex(scale * i + offset, length);
+        }
+    }
+
+    @Run(test = "testStrideNegScalePosInIntLoop2")
+    private void testStrideNegScalePosInIntLoop2_runner() {
+        testStrideNegScalePosInIntLoop1(0, 100, 200, 0);
+    }
+
+    @Test
+    @IR(counts = { IRNode.LOOP, "1"})
+    @IR(failOn = { IRNode.COUNTEDLOOP})
+    public static void testStridePosScaleNeg(long start, long stop, long length, long offset) {
+        final long scale = -1;
+        final long stride = 1;
+        for (long i = start; i < stop; i += stride) {
+            Objects.checkIndex(scale * i + offset, length);
+        }
+    }
+
+    @Run(test = "testStridePosScaleNeg")
+    private void testStridePosScaleNeg_runner() {
+        testStridePosScaleNeg(0, 100, 100, 99);
+    }
+
+    @Test
+    @IR(counts = { IRNode.LOOP, "1"})
+    @IR(failOn = { IRNode.COUNTEDLOOP})
+    public static void testStridePosScaleNegInIntLoop1(int start, int stop, long length, long offset) {
+        final long scale = -2;
+        final int stride = 1;
+        for (int i = start; i < stop; i += stride) {
+            Objects.checkIndex(scale * i + offset, length);
+        }
+    }
+
+    @Run(test = "testStridePosScaleNegInIntLoop1")
+    private void testStridePosScaleNegInIntLoop1_runner() {
+        testStridePosScaleNegInIntLoop1(0, 100, 200, 198);
+    }
+
+    @Test
+    @IR(counts = { IRNode.LOOP, "1"})
+    @IR(failOn = { IRNode.COUNTEDLOOP})
+    public static void testStridePosScaleNegInIntLoop2(int start, int stop, long length, long offset) {
+        final int scale = -2;
+        final int stride = 1;
+        for (int i = start; i < stop; i += stride) {
+            Objects.checkIndex(scale * i + offset, length);
+        }
+    }
+
+    @Run(test = "testStridePosScaleNegInIntLoop2")
+    private void testStridePosScaleNegInIntLoop2_runner() {
+        testStridePosScaleNegInIntLoop1(0, 100, 200, 198);
+    }
 }

--- a/test/hotspot/jtreg/compiler/rangechecks/TestLongRangeCheck.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestLongRangeCheck.java
@@ -127,6 +127,73 @@ public class TestLongRangeCheck {
         assertIsNotCompiled(m);
     }
 
+    private static void testOverflow(String method, long start, long stop, long length, long offset0, long offset1) throws Exception {
+        Method m = newClassLoader().loadClass("TestLongRangeCheck").getDeclaredMethod(method, long.class, long.class, long.class, long.class);
+        m.invoke(null, start, stop, length, offset0);
+        compile(m);
+        
+        m.invoke(null, start, stop, length, offset0);
+        assertIsCompiled(m);
+        try {
+            m.invoke(null, start, stop, length, offset1);
+            throw new RuntimeException("should have thrown");
+        } catch(InvocationTargetException e) {
+            if (!(e.getCause() instanceof IndexOutOfBoundsException)) {
+                throw new RuntimeException("unexpected exception");
+            }
+        }
+        assertIsNotCompiled(m);
+    }
+
+    private static void testConditional(String method, long start, long stop, long length, long offset0, long offset1, long start1, long stop1) throws Exception {
+        Method m;
+
+        if (start1 != start) {
+            m = newClassLoader().loadClass("TestLongRangeCheck").getDeclaredMethod(method, long.class, long.class, long.class, long.class, long.class, long.class);
+            m.invoke(null, start, stop, length, offset0, start, stop);
+            compile(m);
+
+            m.invoke(null, start, stop, length, offset0, start, stop);
+            assertIsCompiled(m);
+            try {
+                m.invoke(null, start, stop, length, offset1, start1-1, stop1);
+                throw new RuntimeException("should have thrown");
+            } catch(InvocationTargetException e) {
+                if (!(e.getCause() instanceof IndexOutOfBoundsException)) {
+                    throw new RuntimeException("unexpected exception");
+                }
+            }
+            assertIsNotCompiled(m);
+        }
+
+        if (stop1 != stop) {
+            m = newClassLoader().loadClass("TestLongRangeCheck").getDeclaredMethod(method, long.class, long.class, long.class, long.class, long.class, long.class);
+            m.invoke(null, start, stop, length, offset0, start, stop);
+            compile(m);
+
+            m.invoke(null, start, stop, length, offset0, start, stop);
+            assertIsCompiled(m);
+            try {
+                m.invoke(null, start, stop, length, offset1, start1, stop1+1);
+                throw new RuntimeException("should have thrown");
+            } catch(InvocationTargetException e) {
+                if (!(e.getCause() instanceof IndexOutOfBoundsException)) {
+                    throw new RuntimeException("unexpected exception");
+                }
+            }
+            assertIsNotCompiled(m);
+        }
+
+        m = newClassLoader().loadClass("TestLongRangeCheck").getDeclaredMethod(method, long.class, long.class, long.class, long.class, long.class, long.class);
+        m.invoke(null, start, stop, length, offset0, start, stop);
+        compile(m);
+
+        m.invoke(null, start, stop, length, offset0, start, stop);
+        assertIsCompiled(m);
+
+        m.invoke(null, start, stop, length, offset1, start1, stop1);
+        assertIsCompiled(m);
+    }
 
     public static void main(String[] args) throws Exception {
 
@@ -157,42 +224,20 @@ public class TestLongRangeCheck {
         test("testStridePosNotOneScaleNeg", -v, v, v * 2, v-1);
 
         // offset causes overflow
-
-        {
-            Method m = newClassLoader().loadClass("TestLongRangeCheck").getDeclaredMethod("testStridePosScalePos", long.class, long.class, long.class, long.class);
-            m.invoke(null, 0, 100, 100, 0);
-            compile(m);
-
-            m.invoke(null, 0, 100, 100, 0);
-            assertIsCompiled(m);
-            try {
-                m.invoke(null, 0, 100, 100, Long.MAX_VALUE - 50);
-                throw new RuntimeException("should have thrown");
-            } catch(InvocationTargetException e) {
-                if (!(e.getCause() instanceof IndexOutOfBoundsException)) {
-                    throw new RuntimeException("unexpected exception");
-                }
-            }
-            assertIsNotCompiled(m);
-        }
+        testOverflow("testStridePosScalePos", 0, 100, 100, 0, Long.MAX_VALUE - 50);
+        testOverflow("testStrideNegScaleNeg", 0, 100, 100, 100, Long.MIN_VALUE + 50);
+        testOverflow("testStrideNegScalePos", 0, 100, 100, 0, Long.MAX_VALUE - 50);
+        testOverflow("testStridePosScaleNeg", 0, 100, 100, 99, Long.MIN_VALUE + 50);
 
         // no spurious deopt if the range check doesn't fail because not executed
-        {
-            Method m = newClassLoader().loadClass("TestLongRangeCheck").getDeclaredMethod("testStridePosScalePosConditional", long.class, long.class, long.class, long.class, long.class, long.class);
-            m.invoke(null, 0, 100, 100, 0, 0, 100);
-            compile(m);
-
-            m.invoke(null, 0, 100, 100, -50, 50, 100);
-            assertIsCompiled(m);
-        }
-        {
-            Method m = newClassLoader().loadClass("TestLongRangeCheck").getDeclaredMethod("testStridePosScalePosConditional", long.class, long.class, long.class, long.class, long.class, long.class);
-            m.invoke(null, 0, 100, 100, 0, 0, 100);
-            compile(m);
-
-            m.invoke(null, 0, 100, Long.MAX_VALUE, Long.MAX_VALUE - 50, 0, 50);
-            assertIsCompiled(m);
-        }
+        testConditional("testStridePosScalePosConditional", 0, 100, 100, 0, -50, 50, 100);
+        testConditional("testStridePosScalePosConditional", 0, 100, Long.MAX_VALUE, 0, Long.MAX_VALUE - 50, 0, 50);
+        testConditional("testStrideNegScaleNegConditional", 0, 100, 100, 100, 50, 0, 51);
+        testConditional("testStrideNegScaleNegConditional", 0, 100, Long.MAX_VALUE, 100, Long.MIN_VALUE + 50, 52, 100);
+        testConditional("testStrideNegScalePosConditional", 0, 100, 100, 0, -50, 50, 100);
+        testConditional("testStrideNegScalePosConditional", 0, 100, Long.MAX_VALUE, 100, Long.MAX_VALUE - 50, 0, 50);
+        testConditional("testStridePosScaleNegConditional", 0, 100, 100, 99, 50, 0, 51);
+        testConditional("testStridePosScaleNegConditional", 0, 100, Long.MAX_VALUE, 99, Long.MIN_VALUE + 50, 52, 100);
 
         test("testStridePosScalePosInIntLoop", 0, 100, 100, 0);
 
@@ -221,40 +266,19 @@ public class TestLongRangeCheck {
         test("testStridePosNotOneScaleNegInIntLoop", -v, v, v * 4, 2 * v - 1);
 
         // offset causes overflow
-        {
-            Method m = newClassLoader().loadClass("TestLongRangeCheck").getDeclaredMethod("testStridePosScalePosInIntLoop", long.class, long.class, long.class, long.class);
-            m.invoke(null, 0, 100, 100, 0);
-            compile(m);
-
-            m.invoke(null, 0, 100, 100, 0);
-            assertIsCompiled(m);
-            try {
-                m.invoke(null, 0, 100, 100, Long.MAX_VALUE - 50);
-                throw new RuntimeException("should have thrown");
-            } catch(InvocationTargetException e) {
-                if (!(e.getCause() instanceof IndexOutOfBoundsException)) {
-                    throw new RuntimeException("unexpected exception");
-                }
-            }
-            assertIsNotCompiled(m);
-        }
+        testOverflow("testStridePosScalePosInIntLoop", 0, 100, 100, 0, Long.MAX_VALUE - 50);
+        testOverflow("testStrideNegScaleNegInIntLoop", 0, 100, 100, 100, Long.MIN_VALUE + 50);
+        testOverflow("testStrideNegScalePosInIntLoop", 0, 100, 100, 0, Long.MAX_VALUE - 50);
+        testOverflow("testStridePosScaleNegInIntLoop", 0, 100, 100, 99, Long.MIN_VALUE + 50);
         // no spurious deopt if the range check doesn't fail because not executed
-        {
-            Method m = newClassLoader().loadClass("TestLongRangeCheck").getDeclaredMethod("testStridePosScalePosConditional", long.class, long.class, long.class, long.class, long.class, long.class);
-            m.invoke(null, 0, 100, 100, 0, 0, 100);
-            compile(m);
-
-            m.invoke(null, 0, 100, 100, -50, 50, 100);
-            assertIsCompiled(m);
-        }
-        {
-            Method m = newClassLoader().loadClass("TestLongRangeCheck").getDeclaredMethod("testStridePosScalePosConditional", long.class, long.class, long.class, long.class, long.class, long.class);
-            m.invoke(null, 0, 100, 100, 0, 0, 100);
-            compile(m);
-
-            m.invoke(null, 0, 100, Long.MAX_VALUE, Long.MAX_VALUE - 50, 0, 50);
-            assertIsCompiled(m);
-        }
+        testConditional("testStridePosScalePosConditionalInIntLoop", 0, 100, 100, 0, -50, 50, 100);
+        testConditional("testStridePosScalePosConditionalInIntLoop", 0, 100, Long.MAX_VALUE, 0, Long.MAX_VALUE - 50, 0, 50);
+        testConditional("testStrideNegScaleNegConditionalInIntLoop", 0, 100, 100, 100, 50, 0, 51);
+        testConditional("testStrideNegScaleNegConditionalInIntLoop", 0, 100, Long.MAX_VALUE, 100, Long.MIN_VALUE + 50, 52, 100);
+        testConditional("testStrideNegScalePosConditionalInIntLoop", 0, 100, 100, 0, -50, 50, 100);
+        testConditional("testStrideNegScalePosConditionalInIntLoop", 0, 100, Long.MAX_VALUE, 100, Long.MAX_VALUE - 50, 0, 50);
+        testConditional("testStridePosScaleNegConditionalInIntLoop", 0, 100, 100, 99, 50, 0, 51);
+        testConditional("testStridePosScaleNegConditionalInIntLoop", 0, 100, Long.MAX_VALUE, 99, Long.MIN_VALUE + 50, 52, 100);
 
         test("testStridePosScalePosNotOneInIntLoop2", 0, 100, 1090, 0);
 
@@ -411,6 +435,36 @@ public class TestLongRangeCheck {
         }
     }
 
+    public static void testStrideNegScaleNegConditional(long start, long stop, long length, long offset, long start2, long stop2) {
+        final long scale = -1;
+        final long stride = 1;
+        for (long i = stop; i > start; i -= stride) {
+            if (i >= start2 && i < stop2) {
+                Preconditions.checkIndex(scale * i + offset, length, null);
+            }
+        }
+    }
+
+    public static void testStrideNegScalePosConditional(long start, long stop, long length, long offset, long start2, long stop2) {
+        final long scale = 1;
+        final long stride = 1;
+        for (long i = stop-1; i >= start; i -= stride) {
+            if (i >= start2 && i < stop2) {
+                Preconditions.checkIndex(scale * i + offset, length, null);
+            }
+        }
+    }
+
+    public static void testStridePosScaleNegConditional(long start, long stop, long length, long offset, long start2, long stop2) {
+        final long scale = -1;
+        final long stride = 1;
+        for (long i = start; i < stop; i += stride) {
+            if (i >= start2 && i < stop2) {
+                Preconditions.checkIndex(scale * i + offset, length, null);
+            }
+        }
+    }
+
     private static void checkInputs(long... inputs) {
         for (int i = 0; i < inputs.length; i++) {
             if ((long)((int)inputs[i]) != inputs[i]) {
@@ -529,8 +583,40 @@ public class TestLongRangeCheck {
 
     public static void testStridePosScalePosConditionalInIntLoop(long start, long stop, long length, long offset, long start2, long stop2) {
         checkInputs(start, stop, start2, stop2);
-        Preconditions.checkIndex(0, length, null);
         final long scale = 1;
+        final int stride = 1;
+        for (int i = (int)start; i < (int)stop; i += stride) {
+            if (i >= (int)start2 && i < (int)stop2) {
+                Preconditions.checkIndex(scale * i + offset, length, null);
+            }
+        }
+    }
+
+    public static void testStrideNegScaleNegConditionalInIntLoop(long start, long stop, long length, long offset, long start2, long stop2) {
+        checkInputs(start, stop, start2, stop2);
+        final long scale = -1;
+        final int stride = 1;
+        for (int i = (int)stop; i > (int)start; i -= stride) {
+            if (i >= (int)start2 && i < (int)stop2) {
+                Preconditions.checkIndex(scale * i + offset, length, null);
+            }
+        }
+    }
+
+    public static void testStrideNegScalePosConditionalInIntLoop(long start, long stop, long length, long offset, long start2, long stop2) {
+        checkInputs(start, stop, start2, stop2);
+        final long scale = 1;
+        final int stride = 1;
+        for (int i = (int)(stop-1); i >= (int)start; i -= stride) {
+            if (i >= (int)start2 && i < (int)stop2) {
+                Preconditions.checkIndex(scale * i + offset, length, null);
+            }
+        }
+    }
+
+    public static void testStridePosScaleNegConditionalInIntLoop(long start, long stop, long length, long offset, long start2, long stop2) {
+        checkInputs(start, stop, start2, stop2);
+        final long scale = -1;
         final int stride = 1;
         for (int i = (int)start; i < (int)stop; i += stride) {
             if (i >= (int)start2 && i < (int)stop2) {


### PR DESCRIPTION
8259609 (C2: optimize long range checks in long counted loops) only
covered the case of a counted loop with a positive stride and a range
check with a positive scale. This change generalizes the long range
check transformation to all 4 combinations of stride and scale signs.

The stride > 0, scale > 0 case (covered 8259609) was tweaked so it now
uses Qmax computed as the inclusive limit of j*K+Q. That helps in
generalizing the formulas to other cases.

The addition of PhaseIdealLoop::is_scaled_iv_plus_extra_offset() was
required for the case of negative scale in an int loop. The range
check then has the shape:

(CmpUL (AddL (ConvI2L (SubI ConI (LshiftI (Phi

with ConI, the zero constant.

This change also addresses this comment from John:

https://github.com/openjdk/jdk/pull/6576#discussion_r765343664

as part of 8276116 (C2: optimize long range checks in int counted loops)
