### PR TITLE
8279356: Method linking fails with guarantee(mh->adapter() != NULL) failed: Adapter blob must already exist!

### DIFF
--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -1198,7 +1198,7 @@ void Method::unlink_method() {
 void Method::link_method(const methodHandle& h_method, TRAPS) {
   // If the code cache is full, we may reenter this function for the
   // leftover methods that weren't linked.
-  if (_i2i_entry != NULL) {
+  if (adapter() != NULL) {
     return;
   }
   assert( _code == NULL, "nothing compiled yet" );

--- a/test/hotspot/jtreg/compiler/codecache/OverflowCodeCacheTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/OverflowCodeCacheTest.java
@@ -33,11 +33,11 @@
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:CompileCommand=compileonly,null::*
- *                   -XX:-SegmentedCodeCache
+ *                   -XX:-SegmentedCodeCache -Xmixed
  *                   compiler.codecache.OverflowCodeCacheTest CompilationDisabled
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:CompileCommand=compileonly,null::*
- *                   -XX:+SegmentedCodeCache
+ *                   -XX:+SegmentedCodeCache -Xmixed
  *                   compiler.codecache.OverflowCodeCacheTest CompilationDisabled
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:-SegmentedCodeCache -Xmixed


### PR DESCRIPTION
Adapter creation during method linking may fail due to a lack of code cache space which leads to a `VirtualMachineError` being thrown and thus a bail out from linking the holder klass:
https://github.com/openjdk/jdk/blob/4243f4c998344e77dccd4d5605e56e869bc8af89/src/hotspot/share/oops/method.cpp#L1239-L1247

If the `VirtualMachineError` is handled/ignored by the application, we may later attempt to link the same klass and therefore also the same method again. We then incorrectly bail out from adapter creation because the `_i2i_entry` is set, assuming that this can only happen if adapters have already been created. However, that is not guaranteed because the interpreter entry is set right **before** adapters are created:
https://github.com/openjdk/jdk/blob/4243f4c998344e77dccd4d5605e56e869bc8af89/src/hotspot/share/oops/method.cpp#L1213-L1230

I propose to instead check if adapters have been created.

This is an old bug that was just recently triggered by an unrelated change.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279356](https://bugs.openjdk.java.net/browse/JDK-8279356): Method linking fails with guarantee(mh->adapter() != NULL) failed: Adapter blob must already exist!


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6990/head:pull/6990` \
`$ git checkout pull/6990`

Update a local copy of the PR: \
`$ git checkout pull/6990` \
`$ git pull https://git.openjdk.java.net/jdk pull/6990/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6990`

View PR using the GUI difftool: \
`$ git pr show -t 6990`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6990.diff">https://git.openjdk.java.net/jdk/pull/6990.diff</a>

</details>
