### PR TITLE
8279642: JFR: Remove unnecessary creation of Duration and Instant objects

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,6 +107,9 @@ public final class RecordedEvent extends RecordedObject {
      * @return the duration in nanoseconds, not {@code null}
      */
     public Duration getDuration() {
+        if(startTimeTicks == endTimeTicks) {
+            return Duration.ZERO;
+        }
         return Duration.ofNanos(getEndTimeNanos() - getStartTimeNanos());
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -827,8 +827,11 @@ public class RecordedObject {
         throw newIllegalArgumentException(name, "java.time.Duration");
     }
 
-    private Duration getDuration(long timespan, String name) throws InternalError {
+    private Duration getDuration(long timespan, String name) {
         ValueDescriptor v = getValueDescriptor(objectContext.fields, name, null);
+        if (timespan == 0) {
+            return Duration.ZERO;
+        }
         if (timespan == Long.MIN_VALUE) {
             return Duration.ofSeconds(Long.MIN_VALUE, 0);
         }
@@ -997,7 +1000,7 @@ public class RecordedObject {
         if (instant.equals(Instant.MIN)) {
             return OffsetDateTime.MIN;
         }
-        return OffsetDateTime.ofInstant(getInstant(name), objectContext.getZoneOffset());
+        return OffsetDateTime.ofInstant(instant, objectContext.getZoneOffset());
     }
 
     private static IllegalArgumentException newIllegalArgumentException(String name, String typeName) {


### PR DESCRIPTION
Hi,

Could I have review of an enhancement that removes a few unnecessary allocations when consuming JFR events. It's quite common that events have no duration and there is no need to recalculate an instant twice. I also removed an unnecessary throws clause.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279642](https://bugs.openjdk.java.net/browse/JDK-8279642): JFR: Remove unnecessary creation of Duration and Instant objects


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6994/head:pull/6994` \
`$ git checkout pull/6994`

Update a local copy of the PR: \
`$ git checkout pull/6994` \
`$ git pull https://git.openjdk.java.net/jdk pull/6994/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6994`

View PR using the GUI difftool: \
`$ git pr show -t 6994`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6994.diff">https://git.openjdk.java.net/jdk/pull/6994.diff</a>

</details>
