### PR TITLE
8279643: JFR: Explain why path is sometimes missing from FileRead and FileWrite events

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/events/FileReadEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/FileReadEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ public final class FileReadEvent extends AbstractJDKEvent {
     // EventHandler::write(..., String, long, boolean)
 
     @Label("Path")
-    @Description("Full path of the file")
+    @Description("Full path of the file, or N/A if a file descriptor was used to create the stream, for example System.in")
     public String path;
 
     @Label("Bytes Read")

--- a/src/jdk.jfr/share/classes/jdk/jfr/events/FileWriteEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/FileWriteEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ public final class FileWriteEvent extends AbstractJDKEvent {
     // EventHandler::write(..., String, long)
 
     @Label("Path")
-    @Description("Full path of the file")
+    @Description("Full path of the file, or N/A if a file descriptor was used to create the stream, for example System.out and System.err")
     public String path;
 
     @Label("Bytes Written")


### PR DESCRIPTION
Hi,

Could I have a review of an enhancement that explains why the path fields for the FileRead and FileWrite events sometimes miss a value.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279643](https://bugs.openjdk.java.net/browse/JDK-8279643): JFR: Explain why path is sometimes missing from FileRead and FileWrite events


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6995/head:pull/6995` \
`$ git checkout pull/6995`

Update a local copy of the PR: \
`$ git checkout pull/6995` \
`$ git pull https://git.openjdk.java.net/jdk pull/6995/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6995`

View PR using the GUI difftool: \
`$ git pr show -t 6995`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6995.diff">https://git.openjdk.java.net/jdk/pull/6995.diff</a>

</details>
