### PR TITLE
8279645: JFR: The cacheEventType in Dispatcher is never assigned

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/Dispatcher.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/Dispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -160,6 +160,7 @@ final class Dispatcher {
                 dispatcherLookup.put(type.getId(), dispatchers);
             }
             cacheDispatchers = dispatchers;
+            cacheEventType = type;
         }
         // Expected behavior if exception occurs in onEvent:
         //


### PR DESCRIPTION
Hi,

Could I have review of a bug fix that assign the last event type to the cache when dispatching events for event streaming.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279645](https://bugs.openjdk.java.net/browse/JDK-8279645): JFR: The cacheEventType in Dispatcher is never assigned


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6996/head:pull/6996` \
`$ git checkout pull/6996`

Update a local copy of the PR: \
`$ git checkout pull/6996` \
`$ git pull https://git.openjdk.java.net/jdk pull/6996/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6996`

View PR using the GUI difftool: \
`$ git pr show -t 6996`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6996.diff">https://git.openjdk.java.net/jdk/pull/6996.diff</a>

</details>
