### PR TITLE
8279644: hsdis may not work when it was built with --with-binutils=system

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -847,6 +847,7 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_HSDIS],
       AC_CHECK_LIB(opcodes, disassembler, [ HSDIS_LIBS="$HSDIS_LIBS -lopcodes" ], [ binutils_system_error="libopcodes not found" ])
       AC_CHECK_LIB(iberty, xmalloc, [ HSDIS_LIBS="$HSDIS_LIBS -liberty" ], [ binutils_system_error="libiberty not found" ])
       AC_CHECK_LIB(z, deflate, [ HSDIS_LIBS="$HSDIS_LIBS -lz" ], [ binutils_system_error="libz not found" ])
+      HSDIS_CFLAGS="-DLIBARCH_$OPENJDK_TARGET_CPU_LEGACY_LIB"
     elif test "x$BINUTILS_DIR" != x; then
       if test -e $BINUTILS_DIR/bfd/libbfd.a && \
           test -e $BINUTILS_DIR/opcodes/libopcodes.a && \
@@ -864,7 +865,7 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_HSDIS],
           AC_MSG_ERROR([binutils on system is supported for Linux only])
         elif test "x$binutils_system_error" = x; then
           AC_MSG_RESULT([system])
-          HSDIS_CFLAGS="-DSYSTEM_BINUTILS"
+          HSDIS_CFLAGS="$HSDIS_CFLAGS -DSYSTEM_BINUTILS"
         else
           AC_MSG_RESULT([invalid])
           AC_MSG_ERROR([$binutils_system_error])


### PR DESCRIPTION
[JDK-8277089](https://bugs.openjdk.java.net/browse/JDK-8277089) (PR #6378 ) introduced the feature to build hsdis with binutils which is provided by the system, however it may not work when it was build with --with-binutils=system.

We can see the following message when the problem happens. I saw it on Ubuntu 20.04.

```
hsdis: bad native mach=architecture not set in Makefile!; please port hsdis to this platform
```

The cause is `-DLIBARCH_$OPENJDK_TARGET_CPU_LEGACY_LIB` is not set in `HSDIS_CFLAGS`. For example, it will be set `LIBARCH_amd64` on AMD64. We should set `LIBARCH_$OPENJDK_TARGET_CPU_LEGACY_LIB` to `HSDIS_CFLAGS` even if the builder uses system binutils.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279644](https://bugs.openjdk.java.net/browse/JDK-8279644): hsdis may not work when it was built with --with-binutils=system


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6997/head:pull/6997` \
`$ git checkout pull/6997`

Update a local copy of the PR: \
`$ git checkout pull/6997` \
`$ git pull https://git.openjdk.java.net/jdk pull/6997/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6997`

View PR using the GUI difftool: \
`$ git pr show -t 6997`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6997.diff">https://git.openjdk.java.net/jdk/pull/6997.diff</a>

</details>
