### PR TITLE
8279646: JFR: Remove recursive call in jdk.jfr.internal.Control

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Control.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Control.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,7 @@ public final class Control {
     public String getValue() {
         if (context == null) {
             // VM events requires no access control context
-            return getValue();
+            return delegate.getValue();
         } else {
             return AccessController.doPrivileged(new PrivilegedAction<String>() {
                 @Override


### PR DESCRIPTION
Hi,

Could I have a review of a fix that removes an endless recursive call.

The reason this has gone unnoticed is because the Control::getValue() method is never invoked for VM events. 

The getValue() method is invoked when a new SettingControl is instantiated for a user-defined event, see line 177 in EventControl.java, which never happens for native events. The method is also invoked when fetching the default value, see line 69 in Control.java, but native events provides them directly, when instantiated, for example in EventControl::defineThreshold, so the bug has never been exposed.

That said, getValue() should delegate like the other methods, i.e combine(Set) and setValue(String), in the Control class.


Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279646](https://bugs.openjdk.java.net/browse/JDK-8279646): JFR: Remove recursive call in jdk.jfr.internal.Control


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/6998/head:pull/6998` \
`$ git checkout pull/6998`

Update a local copy of the PR: \
`$ git checkout pull/6998` \
`$ git pull https://git.openjdk.java.net/jdk pull/6998/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6998`

View PR using the GUI difftool: \
`$ git pr show -t 6998`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/6998.diff">https://git.openjdk.java.net/jdk/pull/6998.diff</a>

</details>
