### PR TITLE
8278254: Cleanup doclint warnings in java.desktop module

### DIFF
--- a/src/java.desktop/share/classes/java/awt/BufferCapabilities.java
+++ b/src/java.desktop/share/classes/java/awt/BufferCapabilities.java
@@ -33,7 +33,6 @@ package java.awt;
  * @author Michael Martak
  * @since 1.4
  */
-@SuppressWarnings("doclint:missing")
 public class BufferCapabilities implements Cloneable {
 
     private ImageCapabilities frontCaps;
@@ -63,13 +62,18 @@ public class BufferCapabilities implements Cloneable {
     }
 
     /**
-     * @return the image capabilities of the front (displayed) buffer
+     * Returns the imaga capabilities of the front buffer
+     *
+     * @return the imaga capabilities of the front buffer
      */
     public ImageCapabilities getFrontBufferCapabilities() {
         return frontCaps;
     }
 
     /**
+     * Returns the image capabilities of all back buffers (intermediate buffers
+     * are considered back buffers)
+     *
      * @return the image capabilities of all back buffers (intermediate buffers
      * are considered back buffers)
      */
@@ -78,7 +82,7 @@ public class BufferCapabilities implements Cloneable {
     }
 
     /**
-     * @return whether or not the buffer strategy uses page flipping; a set of
+     * Returns whether or not the buffer strategy uses page flipping; a set of
      * buffers that uses page flipping
      * can swap the contents internally between the front buffer and one or
      * more back buffers by switching the video pointer (or by copying memory
@@ -86,19 +90,23 @@ public class BufferCapabilities implements Cloneable {
      * buffers uses blitting to copy the contents from one buffer to
      * another; when this is the case, {@code getFlipContents} returns
      * {@code null}
+     *
+     * @return whether or not the buffer strategy uses page flipping
      */
     public boolean isPageFlipping() {
         return (getFlipContents() != null);
     }
 
     /**
-     * @return the resulting contents of the back buffer after page-flipping.
+     * Returns the resulting contents of the back buffer after page-flipping.
      * This value is {@code null} when the {@code isPageFlipping}
      * returns {@code false}, implying blitting.  It can be one of
      * {@code FlipContents.UNDEFINED}
      * (the assumed default), {@code FlipContents.BACKGROUND},
      * {@code FlipContents.PRIOR}, or
      * {@code FlipContents.COPIED}.
+     *
+     * @return the resulting contents of the back buffer after page-flipping
      * @see #isPageFlipping
      * @see FlipContents#UNDEFINED
      * @see FlipContents#BACKGROUND
@@ -110,9 +118,11 @@ public class BufferCapabilities implements Cloneable {
     }
 
     /**
-     * @return whether page flipping is only available in full-screen mode.  If this
+     * Returns whether page flipping is only available in full-screen mode.  If this
      * is {@code true}, full-screen exclusive mode is required for
      * page-flipping.
+     *
+     * @return whether page flipping is only available in full-screen mode
      * @see #isPageFlipping
      * @see GraphicsDevice#setFullScreenWindow
      */
@@ -121,6 +131,10 @@ public class BufferCapabilities implements Cloneable {
     }
 
     /**
+     * Returns whether or not
+     * page flipping can be performed using more than two buffers (one or more
+     * intermediate buffers as well as the front and back buffer).
+     *
      * @return whether or not
      * page flipping can be performed using more than two buffers (one or more
      * intermediate buffers as well as the front and back buffer).

--- a/src/java.desktop/share/classes/java/awt/BufferCapabilities.java
+++ b/src/java.desktop/share/classes/java/awt/BufferCapabilities.java
@@ -62,9 +62,9 @@ public class BufferCapabilities implements Cloneable {
     }
 
     /**
-     * Returns the imaga capabilities of the front buffer
+     * Returns the imaga capabilities of the front (displayed) buffer.
      *
-     * @return the imaga capabilities of the front buffer
+     * @return the imaga capabilities of the front (displayed) buffer
      */
     public ImageCapabilities getFrontBufferCapabilities() {
         return frontCaps;

--- a/src/java.desktop/share/classes/java/awt/BufferCapabilities.java
+++ b/src/java.desktop/share/classes/java/awt/BufferCapabilities.java
@@ -62,9 +62,9 @@ public class BufferCapabilities implements Cloneable {
     }
 
     /**
-     * Returns the imaga capabilities of the front (displayed) buffer.
+     * Returns the image capabilities of the front (displayed) buffer.
      *
-     * @return the imaga capabilities of the front (displayed) buffer
+     * @return the image capabilities of the front (displayed) buffer
      */
     public ImageCapabilities getFrontBufferCapabilities() {
         return frontCaps;
@@ -72,7 +72,7 @@ public class BufferCapabilities implements Cloneable {
 
     /**
      * Returns the image capabilities of all back buffers (intermediate buffers
-     * are considered back buffers)
+     * are considered back buffers).
      *
      * @return the image capabilities of all back buffers (intermediate buffers
      * are considered back buffers)
@@ -82,14 +82,14 @@ public class BufferCapabilities implements Cloneable {
     }
 
     /**
-     * Returns whether or not the buffer strategy uses page flipping; a set of
-     * buffers that uses page flipping
+     * Returns whether or not the buffer strategy uses page flipping.
+     * A set of buffers that uses page flipping
      * can swap the contents internally between the front buffer and one or
      * more back buffers by switching the video pointer (or by copying memory
      * internally).  A non-flipping set of
      * buffers uses blitting to copy the contents from one buffer to
      * another; when this is the case, {@code getFlipContents} returns
-     * {@code null}
+     * {@code null}.
      *
      * @return whether or not the buffer strategy uses page flipping
      */
@@ -136,8 +136,7 @@ public class BufferCapabilities implements Cloneable {
      * intermediate buffers as well as the front and back buffer).
      *
      * @return whether or not
-     * page flipping can be performed using more than two buffers (one or more
-     * intermediate buffers as well as the front and back buffer).
+     * page flipping can be performed using more than two buffers
      * @see #isPageFlipping
      */
     public boolean isMultiBufferAvailable() {

--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -214,7 +214,6 @@ import static sun.java2d.pipe.hw.ExtendedBufferCapabilities.VSyncType.VSYNC_ON;
  * @author      Arthur van Hoff
  * @author      Sami Shaio
  */
-@SuppressWarnings("doclint:missing")
 public abstract class Component implements ImageObserver, MenuContainer,
                                            Serializable
 {
@@ -4133,6 +4132,8 @@ public abstract class Component implements ImageObserver, MenuContainer,
         }
 
         /**
+         * Gets direct access to the back buffer, as an image.
+	 *
          * @return direct access to the back buffer, as an image.
          * @exception IllegalStateException if the buffers have not yet
          * been created
@@ -4693,6 +4694,9 @@ public abstract class Component implements ImageObserver, MenuContainer,
     }
 
     /**
+     * Checks whether or not paint messages received from the operating system
+     * should be ignored.
+     *
      * @return whether or not paint messages received from the operating system
      * should be ignored.
      *

--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -4134,7 +4134,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
         /**
          * Provides direct access to the back buffer as an image.
          *
-         * @return direct access to the back buffer as an image.
+         * @return the back buffer as an image.
          * @exception IllegalStateException if the buffers have not yet
          * been created
          */

--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -4694,7 +4694,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
     }
 
     /**
-     * Checks whether or not paint messages received from the operating system
+     * Returns whether or not paint messages received from the operating system
      * should be ignored.
      *
      * @return whether or not paint messages received from the operating system

--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -4133,7 +4133,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
 
         /**
          * Gets direct access to the back buffer, as an image.
-	 *
+         *
          * @return direct access to the back buffer, as an image.
          * @exception IllegalStateException if the buffers have not yet
          * been created

--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -4134,7 +4134,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
         /**
          * Provides direct access to the back buffer as an image.
          *
-         * @return the back buffer as an image.
+         * @return the back buffer as an image
          * @exception IllegalStateException if the buffers have not yet
          * been created
          */
@@ -4698,7 +4698,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
      * should be ignored.
      *
      * @return whether or not paint messages received from the operating system
-     * should be ignored.
+     * should be ignored
      *
      * @since 1.4
      * @see #setIgnoreRepaint

--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -4132,9 +4132,9 @@ public abstract class Component implements ImageObserver, MenuContainer,
         }
 
         /**
-         * Gets direct access to the back buffer, as an image.
+         * Provides direct access to the back buffer as an image.
          *
-         * @return direct access to the back buffer, as an image.
+         * @return direct access to the back buffer as an image.
          * @exception IllegalStateException if the buffers have not yet
          * been created
          */

--- a/src/java.desktop/share/classes/java/awt/event/KeyEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/KeyEvent.java
@@ -650,97 +650,97 @@ public class KeyEvent extends InputEvent {
 
     /* For European keyboards */
     /**
-     * Constant for the DEAD_GRAVE key.
+     * Constant for the Dead Grave key.
      * @since 1.2
      */
     public static final int VK_DEAD_GRAVE               = 0x80;
 
     /**
-     * Constant for the DEAD_ACUTE key.
+     * Constant for the Dead Acute key.
      * @since 1.2
      */
     public static final int VK_DEAD_ACUTE               = 0x81;
 
     /**
-     * Constant for the DEAD_CIRCUMFLEX key.
+     * Constant for the Dead Circumflex key.
      * @since 1.2
      */
     public static final int VK_DEAD_CIRCUMFLEX          = 0x82;
 
     /**
-     * Constant for the DEAD_TILDE key.
+     * Constant for the Dead Tilde key.
      * @since 1.2
      */
     public static final int VK_DEAD_TILDE               = 0x83;
 
     /**
-     * Constant for the DEAD_MACRON key.
+     * Constant for the Dead Macron key.
      * @since 1.2
      */
     public static final int VK_DEAD_MACRON              = 0x84;
 
     /**
-     * Constant for the DEAD_BREVE key.
+     * Constant for the Dead Breve key.
      * @since 1.2
      */
     public static final int VK_DEAD_BREVE               = 0x85;
 
     /**
-     * Constant for the DEAD_ABOVEDOT key.
+     * Constant for the Dead Above Dot key.
      * @since 1.2
      */
     public static final int VK_DEAD_ABOVEDOT            = 0x86;
 
     /**
-     * Constant for the DEAD_DIAERESIS key.
+     * Constant for the Dead Diaeresis key.
      * @since 1.2
      */
     public static final int VK_DEAD_DIAERESIS           = 0x87;
 
     /**
-     * Constant for the DEAD_ABOVERING key.
+     * Constant for the Dead Above Ring key.
      * @since 1.2
      */
     public static final int VK_DEAD_ABOVERING           = 0x88;
 
     /**
-     * Constant for the DEAD_DOUBLEACUTE key.
+     * Constant for the Dead Double Acute key.
      * @since 1.2
      */
     public static final int VK_DEAD_DOUBLEACUTE         = 0x89;
 
     /**
-     * Constant for the DEAD_CARON key.
+     * Constant for the Dead Caron key.
      * @since 1.2
      */
     public static final int VK_DEAD_CARON               = 0x8a;
 
     /**
-     * Constant for the DEAD_CEDILLA key.
+     * Constant for the Dead Cedilla key.
      * @since 1.2
      */
     public static final int VK_DEAD_CEDILLA             = 0x8b;
 
     /**
-     * Constant for the DEAD_OGONEK key.
+     * Constant for the Dead Ogonek key.
      * @since 1.2
      */
     public static final int VK_DEAD_OGONEK              = 0x8c;
 
     /**
-     * Constant for the DEAD_IOTA key.
+     * Constant for the Dead Iota key.
      * @since 1.2
      */
     public static final int VK_DEAD_IOTA                = 0x8d;
 
     /**
-     * Constant for the DEAD_VOICED_SOUND key.
+     * Constant for the Dead Voiced Sound key.
      * @since 1.2
      */
     public static final int VK_DEAD_VOICED_SOUND        = 0x8e;
 
     /**
-     * Constant for the DEAD_SEMIVOICED_SOUND key.
+     * Constant for the Dead Semivoiced Sound key.
      * @since 1.2
      */
     public static final int VK_DEAD_SEMIVOICED_SOUND    = 0x8f;
@@ -776,13 +776,13 @@ public class KeyEvent extends InputEvent {
     public static final int VK_GREATER                  = 0xa0;
 
     /**
-     * Constant for the BRACELEFT key.
+     * Constant for the "{" key.
      * @since 1.2
      */
     public static final int VK_BRACELEFT                = 0xa1;
 
     /**
-     * Constant for the BRACERIGHT key.
+     * Constant for the "}" key.
      * @since 1.2
      */
     public static final int VK_BRACERIGHT               = 0xa2;
@@ -1015,49 +1015,49 @@ public class KeyEvent extends InputEvent {
 
     /* for Sun keyboards */
     /**
-     * Constant for the "CUT" key.
+     * Constant for the Cut key.
      * @since 1.2
      */
     public static final int VK_CUT                      = 0xFFD1;
 
     /**
-     * Constant for the "COPY" key.
+     * Constant for the Copy key.
      * @since 1.2
      */
     public static final int VK_COPY                     = 0xFFCD;
 
     /**
-     * Constant for the "PASTE" key.
+     * Constant for the Paste key.
      * @since 1.2
      */
     public static final int VK_PASTE                    = 0xFFCF;
 
     /**
-     * Constant for the "UNDO" key.
+     * Constant for the Undo key.
      * @since 1.2
      */
     public static final int VK_UNDO                     = 0xFFCB;
 
     /**
-     * Constant for the "AGAIN" key.
+     * Constant for the Again key.
      * @since 1.2
      */
     public static final int VK_AGAIN                    = 0xFFC9;
 
     /**
-     * Constant for the "FIND" key.
+     * Constant for the Find key.
      * @since 1.2
      */
     public static final int VK_FIND                     = 0xFFD0;
 
     /**
-     * Constant for the "PROPS" key.
+     * Constant for the Props key.
      * @since 1.2
      */
     public static final int VK_PROPS                    = 0xFFCA;
 
     /**
-     * Constant for the "STOP" key.
+     * Constant for the Stop key.
      * @since 1.2
      */
     public static final int VK_STOP                     = 0xFFC8;

--- a/src/java.desktop/share/classes/java/awt/event/KeyEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/KeyEvent.java
@@ -151,7 +151,6 @@ import sun.awt.AWTAccessor;
  *
  * @since 1.1
  */
-@SuppressWarnings("doclint:missing")
 public class KeyEvent extends InputEvent {
 
     /**
@@ -650,53 +649,142 @@ public class KeyEvent extends InputEvent {
     public static final int VK_KP_RIGHT       = 0xE3;
 
     /* For European keyboards */
-    /** @since 1.2 */
+    /**
+     * Constant for the DEAD_GRAVE function key.
+     * @since 1.2
+     */
     public static final int VK_DEAD_GRAVE               = 0x80;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the DEAD_ACUTE function key.
+     * @since 1.2
+     */
     public static final int VK_DEAD_ACUTE               = 0x81;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the DEAD_CIRCUMFLEX function key.
+     * @since 1.2
+     */
     public static final int VK_DEAD_CIRCUMFLEX          = 0x82;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the DEAD_TILDE function key.
+     * @since 1.2
+     */
     public static final int VK_DEAD_TILDE               = 0x83;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the DEAD_MACRON function key.
+     * @since 1.2
+     */
     public static final int VK_DEAD_MACRON              = 0x84;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the DEAD_BREVE function key.
+     * @since 1.2
+     */
     public static final int VK_DEAD_BREVE               = 0x85;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the DEAD_ABOVEDOT function key.
+     * @since 1.2
+     */
     public static final int VK_DEAD_ABOVEDOT            = 0x86;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the DEAD_DIAERESIS function key.
+     * @since 1.2
+     */
     public static final int VK_DEAD_DIAERESIS           = 0x87;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the DEAD_ABOVERING function key.
+     * @since 1.2
+     */
     public static final int VK_DEAD_ABOVERING           = 0x88;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the DEAD_DOUBLEACUTE function key.
+     * @since 1.2
+     */
     public static final int VK_DEAD_DOUBLEACUTE         = 0x89;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the DEAD_CARON function key.
+     * @since 1.2
+     */
     public static final int VK_DEAD_CARON               = 0x8a;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the DEAD_CEDILLA function key.
+     * @since 1.2
+     */
     public static final int VK_DEAD_CEDILLA             = 0x8b;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the DEAD_OGONEK function key.
+     * @since 1.2
+     */
     public static final int VK_DEAD_OGONEK              = 0x8c;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the DEAD_IOTA function key.
+     * @since 1.2
+     */
     public static final int VK_DEAD_IOTA                = 0x8d;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the DEAD_VOICED_SOUND function key.
+     * @since 1.2
+     */
     public static final int VK_DEAD_VOICED_SOUND        = 0x8e;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the DEAD_SEMIVOICED_SOUND function key.
+     * @since 1.2
+     */
     public static final int VK_DEAD_SEMIVOICED_SOUND    = 0x8f;
 
-    /** @since 1.2 */
+    /**
+     * Constant for the "&amp;" function key.
+     * @since 1.2
+     */
     public static final int VK_AMPERSAND                = 0x96;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the "*" function key.
+     * @since 1.2
+     */
     public static final int VK_ASTERISK                 = 0x97;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the """" function key.
+     * @since 1.2
+     */
     public static final int VK_QUOTEDBL                 = 0x98;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the "&lt;" function key.
+     * @since 1.2
+     */
     public static final int VK_LESS                     = 0x99;
 
-    /** @since 1.2 */
+    /**
+     * Constant for the "&gt;" function key.
+     * @since 1.2
+     */
     public static final int VK_GREATER                  = 0xa0;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the BRACELEFT function key.
+     * @since 1.2
+     */
     public static final int VK_BRACELEFT                = 0xa1;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the BRACERIGHT function key.
+     * @since 1.2
+     */
     public static final int VK_BRACERIGHT               = 0xa2;
 
     /**
@@ -926,21 +1014,52 @@ public class KeyEvent extends InputEvent {
     public static final int VK_INPUT_METHOD_ON_OFF      = 0x0107;
 
     /* for Sun keyboards */
-    /** @since 1.2 */
+    /**
+     * Constant for the "CUT" key.
+     * @since 1.2
+     */
     public static final int VK_CUT                      = 0xFFD1;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the "COPY" key.
+     * @since 1.2
+     */
     public static final int VK_COPY                     = 0xFFCD;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the "PASTE" key.
+     * @since 1.2
+     */
     public static final int VK_PASTE                    = 0xFFCF;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the "UNDO" key.
+     * @since 1.2
+     */
     public static final int VK_UNDO                     = 0xFFCB;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the "AGAIN" key.
+     * @since 1.2
+     */
     public static final int VK_AGAIN                    = 0xFFC9;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the "FIND" key.
+     * @since 1.2
+     */
     public static final int VK_FIND                     = 0xFFD0;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the "PROPS" key.
+     * @since 1.2
+     */
     public static final int VK_PROPS                    = 0xFFCA;
-    /** @since 1.2 */
+
+    /**
+     * Constant for the "STOP" key.
+     * @since 1.2
+     */
     public static final int VK_STOP                     = 0xFFC8;
 
     /**

--- a/src/java.desktop/share/classes/java/awt/event/KeyEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/KeyEvent.java
@@ -650,139 +650,139 @@ public class KeyEvent extends InputEvent {
 
     /* For European keyboards */
     /**
-     * Constant for the DEAD_GRAVE function key.
+     * Constant for the DEAD_GRAVE key.
      * @since 1.2
      */
     public static final int VK_DEAD_GRAVE               = 0x80;
 
     /**
-     * Constant for the DEAD_ACUTE function key.
+     * Constant for the DEAD_ACUTE key.
      * @since 1.2
      */
     public static final int VK_DEAD_ACUTE               = 0x81;
 
     /**
-     * Constant for the DEAD_CIRCUMFLEX function key.
+     * Constant for the DEAD_CIRCUMFLEX key.
      * @since 1.2
      */
     public static final int VK_DEAD_CIRCUMFLEX          = 0x82;
 
     /**
-     * Constant for the DEAD_TILDE function key.
+     * Constant for the DEAD_TILDE key.
      * @since 1.2
      */
     public static final int VK_DEAD_TILDE               = 0x83;
 
     /**
-     * Constant for the DEAD_MACRON function key.
+     * Constant for the DEAD_MACRON key.
      * @since 1.2
      */
     public static final int VK_DEAD_MACRON              = 0x84;
 
     /**
-     * Constant for the DEAD_BREVE function key.
+     * Constant for the DEAD_BREVE key.
      * @since 1.2
      */
     public static final int VK_DEAD_BREVE               = 0x85;
 
     /**
-     * Constant for the DEAD_ABOVEDOT function key.
+     * Constant for the DEAD_ABOVEDOT key.
      * @since 1.2
      */
     public static final int VK_DEAD_ABOVEDOT            = 0x86;
 
     /**
-     * Constant for the DEAD_DIAERESIS function key.
+     * Constant for the DEAD_DIAERESIS key.
      * @since 1.2
      */
     public static final int VK_DEAD_DIAERESIS           = 0x87;
 
     /**
-     * Constant for the DEAD_ABOVERING function key.
+     * Constant for the DEAD_ABOVERING key.
      * @since 1.2
      */
     public static final int VK_DEAD_ABOVERING           = 0x88;
 
     /**
-     * Constant for the DEAD_DOUBLEACUTE function key.
+     * Constant for the DEAD_DOUBLEACUTE key.
      * @since 1.2
      */
     public static final int VK_DEAD_DOUBLEACUTE         = 0x89;
 
     /**
-     * Constant for the DEAD_CARON function key.
+     * Constant for the DEAD_CARON key.
      * @since 1.2
      */
     public static final int VK_DEAD_CARON               = 0x8a;
 
     /**
-     * Constant for the DEAD_CEDILLA function key.
+     * Constant for the DEAD_CEDILLA key.
      * @since 1.2
      */
     public static final int VK_DEAD_CEDILLA             = 0x8b;
 
     /**
-     * Constant for the DEAD_OGONEK function key.
+     * Constant for the DEAD_OGONEK key.
      * @since 1.2
      */
     public static final int VK_DEAD_OGONEK              = 0x8c;
 
     /**
-     * Constant for the DEAD_IOTA function key.
+     * Constant for the DEAD_IOTA key.
      * @since 1.2
      */
     public static final int VK_DEAD_IOTA                = 0x8d;
 
     /**
-     * Constant for the DEAD_VOICED_SOUND function key.
+     * Constant for the DEAD_VOICED_SOUND key.
      * @since 1.2
      */
     public static final int VK_DEAD_VOICED_SOUND        = 0x8e;
 
     /**
-     * Constant for the DEAD_SEMIVOICED_SOUND function key.
+     * Constant for the DEAD_SEMIVOICED_SOUND key.
      * @since 1.2
      */
     public static final int VK_DEAD_SEMIVOICED_SOUND    = 0x8f;
 
     /**
-     * Constant for the "&amp;" function key.
+     * Constant for the "&amp;" key.
      * @since 1.2
      */
     public static final int VK_AMPERSAND                = 0x96;
 
     /**
-     * Constant for the "*" function key.
+     * Constant for the "*" key.
      * @since 1.2
      */
     public static final int VK_ASTERISK                 = 0x97;
 
     /**
-     * Constant for the """" function key.
+     * Constant for the """" key.
      * @since 1.2
      */
     public static final int VK_QUOTEDBL                 = 0x98;
 
     /**
-     * Constant for the "&lt;" function key.
+     * Constant for the "&lt;" key.
      * @since 1.2
      */
     public static final int VK_LESS                     = 0x99;
 
     /**
-     * Constant for the "&gt;" function key.
+     * Constant for the "&gt;" key.
      * @since 1.2
      */
     public static final int VK_GREATER                  = 0xa0;
 
     /**
-     * Constant for the BRACELEFT function key.
+     * Constant for the BRACELEFT key.
      * @since 1.2
      */
     public static final int VK_BRACELEFT                = 0xa1;
 
     /**
-     * Constant for the BRACERIGHT function key.
+     * Constant for the BRACERIGHT key.
      * @since 1.2
      */
     public static final int VK_BRACERIGHT               = 0xa2;

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesSupport.java
@@ -157,8 +157,8 @@ public class      BeanContextServicesSupport extends BeanContextSupport
      */
 
     /**
-     * protected nested class containing per child information
-     * in the "children" hashtable.
+     * A protected nested class containing per-child information
+     * in the {@code children} hashtable.
      */
     protected class BCSSChild extends BeanContextSupport.BCSChild  {
 
@@ -791,7 +791,7 @@ public class      BeanContextServicesSupport extends BeanContextSupport
      */
 
     /**
-     * subclasses may subclass this nested class to represent proxy for
+     * Subclasses may subclass this nested class to represent a proxy for
      * each BeanContextServiceProvider.
      */
     protected class BCSSProxyServiceProvider implements BeanContextServiceProvider, BeanContextServiceRevokedListener {

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesSupport.java
@@ -147,7 +147,7 @@ public class      BeanContextServicesSupport extends BeanContextSupport
 
     /************************************************************************/
 
-    /**
+    /*
      * protected nested class containing per child information, an instance
      * of which is associated with each child in the "children" hashtable.
      * subclasses can extend this class to include their own per-child state.
@@ -156,6 +156,10 @@ public class      BeanContextServicesSupport extends BeanContextSupport
      * when the BeanContextSupport is serialized.
      */
 
+    /**
+     * protected nested class containing per child information
+     * in the "children" hashtable.
+     */
     protected class BCSSChild extends BeanContextSupport.BCSChild  {
 
         /**
@@ -781,11 +785,15 @@ public class      BeanContextServicesSupport extends BeanContextSupport
 
     /************************************************************************/
 
-    /**
+    /*
      * a nested subclass used to represent a proxy for serviceClasses delegated
      * to an enclosing BeanContext.
      */
 
+    /**
+     * subclasses may subclass this nested class to represent proxy for
+     * each BeanContextServiceProvider.
+     */
     protected class BCSSProxyServiceProvider implements BeanContextServiceProvider, BeanContextServiceRevokedListener {
 
         BCSSProxyServiceProvider(BeanContextServices bcs) {

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesSupport.java
@@ -54,7 +54,6 @@ import java.util.TooManyListenersException;
  * @author Laurence P. G. Cable
  * @since 1.2
  */
-@SuppressWarnings("doclint:missing")
 public class      BeanContextServicesSupport extends BeanContextSupport
        implements BeanContextServices {
 
@@ -148,7 +147,7 @@ public class      BeanContextServicesSupport extends BeanContextSupport
 
     /************************************************************************/
 
-    /*
+    /**
      * protected nested class containing per child information, an instance
      * of which is associated with each child in the "children" hashtable.
      * subclasses can extend this class to include their own per-child state.
@@ -782,7 +781,7 @@ public class      BeanContextServicesSupport extends BeanContextSupport
 
     /************************************************************************/
 
-    /*
+    /**
      * a nested subclass used to represent a proxy for serviceClasses delegated
      * to an enclosing BeanContext.
      */

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
@@ -305,8 +305,8 @@ public class      BeanContextSupport extends BeanContextChildSupport
      */
 
     /**
-     * protected nested class containing per child information
-     * in the "children" hashtable.
+     * A protected nested class containing per-child information
+     * in the {@code children} hashtable.
      */
     protected class BCSChild implements Serializable {
 

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
@@ -59,7 +59,6 @@ import java.util.Map;
  * @author Laurence P. G. Cable
  * @since 1.2
  */
-@SuppressWarnings("doclint:missing")
 public class      BeanContextSupport extends BeanContextChildSupport
        implements BeanContext,
                   Serializable,
@@ -296,7 +295,7 @@ public class      BeanContextSupport extends BeanContextChildSupport
 
     /************************************************************************/
 
-    /*
+    /**
      * protected nested class containing per child information, an instance
      * of which is associated with each child in the "children" hashtable.
      * subclasses can extend this class to include their own per-child state.

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
@@ -310,11 +310,11 @@ public class      BeanContextSupport extends BeanContextChildSupport
      */
     protected class BCSChild implements Serializable {
 
-    /**
-     * Use serialVersionUID from JDK 1.7 for interoperability.
-     */
-    @Serial
-    private static final long serialVersionUID = -5815286101609939109L;
+        /**
+         * Use serialVersionUID from JDK 1.7 for interoperability.
+         */
+        @Serial
+        private static final long serialVersionUID = -5815286101609939109L;
 
         BCSChild(Object bcc, Object peer) {
             super();

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
@@ -295,7 +295,7 @@ public class      BeanContextSupport extends BeanContextChildSupport
 
     /************************************************************************/
 
-    /**
+    /*
      * protected nested class containing per child information, an instance
      * of which is associated with each child in the "children" hashtable.
      * subclasses can extend this class to include their own per-child state.
@@ -304,6 +304,10 @@ public class      BeanContextSupport extends BeanContextChildSupport
      * when the BeanContextSupport is serialized.
      */
 
+    /**
+     * protected nested class containing per child information
+     * in the "children" hashtable.
+     */
     protected class BCSChild implements Serializable {
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/DefaultListSelectionModel.java
+++ b/src/java.desktop/share/classes/javax/swing/DefaultListSelectionModel.java
@@ -50,8 +50,7 @@ import javax.swing.event.*;
  * @see ListSelectionModel
  * @since 1.2
  */
-@SuppressWarnings({"serial", // Same-version serialization only
-                   "doclint:missing"})
+@SuppressWarnings({"serial"}) // Same-version serialization only
 public class DefaultListSelectionModel implements ListSelectionModel, Cloneable, Serializable
 {
     private static final int MIN = -1;
@@ -206,6 +205,11 @@ public class DefaultListSelectionModel implements ListSelectionModel, Cloneable,
     }
 
     /**
+     * Notifies <code>ListSelectionListeners</code> that the value
+     * of the selection, in the closed interval <code>firstIndex</code>,
+     * <code>lastIndex</code>, has changed and if this is the final change
+     * in the series of adjustments.
+     *
      * @param firstIndex the first index in the interval
      * @param lastIndex the last index in the interval
      * @param isAdjusting true if this is the final change in a series of

--- a/src/java.desktop/share/classes/javax/swing/JApplet.java
+++ b/src/java.desktop/share/classes/javax/swing/JApplet.java
@@ -106,7 +106,7 @@ public class JApplet extends Applet implements Accessible,
 {
     /**
      * The <code>JRootPane</code> instance that manages the
-     * <code>contentPane</code>
+     * <code>contentPane</code>.
      *
      * @see #getRootPane
      * @see #setRootPane

--- a/src/java.desktop/share/classes/javax/swing/JApplet.java
+++ b/src/java.desktop/share/classes/javax/swing/JApplet.java
@@ -99,13 +99,15 @@ import javax.accessibility.AccessibleContext;
 @Deprecated(since = "9", forRemoval = true)
 @JavaBean(defaultProperty = "JMenuBar", description = "Swing's Applet subclass.")
 @SwingContainer(delegate = "getContentPane")
-@SuppressWarnings({"serial", "removal", // Same-version serialization only
-                   "doclint:missing"})
+@SuppressWarnings({"serial", "removal"}) // Same-version serialization only
 public class JApplet extends Applet implements Accessible,
                                                RootPaneContainer,
                                TransferHandler.HasGetTransferHandler
 {
     /**
+     * The <code>JRootPane</code> instance that manages the
+     * <code>contentPane</code>
+     *
      * @see #getRootPane
      * @see #setRootPane
      */

--- a/src/java.desktop/share/classes/javax/swing/JDialog.java
+++ b/src/java.desktop/share/classes/javax/swing/JDialog.java
@@ -112,7 +112,7 @@ public class JDialog extends Dialog implements WindowConstants,
 
     /**
      * The <code>JRootPane</code> instance that manages the
-     * <code>contentPane</code>
+     * <code>contentPane</code>.
      *
      * @see #getRootPane
      * @see #setRootPane

--- a/src/java.desktop/share/classes/javax/swing/JDialog.java
+++ b/src/java.desktop/share/classes/javax/swing/JDialog.java
@@ -95,8 +95,7 @@ import javax.accessibility.*;
  */
 @JavaBean(defaultProperty = "JMenuBar", description = "A toplevel window for creating dialog boxes.")
 @SwingContainer(delegate = "getContentPane")
-@SuppressWarnings({"serial", // Same-version serialization only
-                   "doclint:missing"})
+@SuppressWarnings({"serial"}) // Same-version serialization only
 public class JDialog extends Dialog implements WindowConstants,
                                                Accessible,
                                                RootPaneContainer,
@@ -112,6 +111,9 @@ public class JDialog extends Dialog implements WindowConstants,
     private int defaultCloseOperation = HIDE_ON_CLOSE;
 
     /**
+     * The <code>JRootPane</code> instance that manages the
+     * <code>contentPane</code>
+     *
      * @see #getRootPane
      * @see #setRootPane
      */

--- a/src/java.desktop/share/classes/javax/swing/JScrollBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JScrollBar.java
@@ -108,7 +108,7 @@ public class JScrollBar extends JComponent implements Adjustable, Accessible
 
 
     /**
-     * Orientation for this scrollBar
+     * Orientation of this scrollBar.
      *
      * @see #setOrientation
      */
@@ -116,8 +116,8 @@ public class JScrollBar extends JComponent implements Adjustable, Accessible
 
 
     /**
-     * Amount to change the scrollbar's value by,
-     * given a unit up/down request.
+     * Stores the amount by which the value of the scrollbar is changed
+     * upon a unit up/down request.
      *
      * @see #setUnitIncrement
      */
@@ -125,8 +125,8 @@ public class JScrollBar extends JComponent implements Adjustable, Accessible
 
 
     /**
-     * Amount to change the scrollbar's value by,
-     * given a block (usually "page") up/down request.
+     * Stores the amount by which the value of the scrollbar is changed
+     * upon a block (usually "page") up/down request.
      *
      * @see #setBlockIncrement
      */

--- a/src/java.desktop/share/classes/javax/swing/JScrollBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JScrollBar.java
@@ -83,8 +83,7 @@ import javax.swing.plaf.ScrollBarUI;
  */
 @JavaBean(defaultProperty = "UI", description = "A component that helps determine the visible content range of an area.")
 @SwingContainer(false)
-@SuppressWarnings({"serial",  // Same-version serialization only
-                   "doclint:missing"})
+@SuppressWarnings({"serial"})  // Same-version serialization only
 public class JScrollBar extends JComponent implements Adjustable, Accessible
 {
     /**
@@ -109,18 +108,26 @@ public class JScrollBar extends JComponent implements Adjustable, Accessible
 
 
     /**
+     * Orientation for this scrollBar
+     *
      * @see #setOrientation
      */
     protected int orientation;
 
 
     /**
+     * Amount to change the scrollbar's value by,
+     * given a unit up/down request.
+     *
      * @see #setUnitIncrement
      */
     protected int unitIncrement;
 
 
     /**
+     * Amount to change the scrollbar's value by,
+     * given a block (usually "page") up/down request.
+     *
      * @see #setBlockIncrement
      */
     protected int blockIncrement;

--- a/src/java.desktop/share/classes/javax/swing/filechooser/FileSystemView.java
+++ b/src/java.desktop/share/classes/javax/swing/filechooser/FileSystemView.java
@@ -350,7 +350,7 @@ public abstract class FileSystemView {
      * Returns a <code>File</code> object which is normally constructed with <code>new
      * File(parent, fileName)</code> except when the parent and child are both
      * special folders, in which case the <code>File</code> is a wrapper containing
-     * a <code>ShellFolder</code> object.
+     * a ShellFolder object.
      *
      * @param parent a <code>File</code> object representing a directory or special folder
      * @param fileName a name of a file or folder which exists in <code>parent</code>

--- a/src/java.desktop/share/classes/javax/swing/filechooser/FileSystemView.java
+++ b/src/java.desktop/share/classes/javax/swing/filechooser/FileSystemView.java
@@ -347,17 +347,14 @@ public abstract class FileSystemView {
     }
 
     /**
-     * Returns a File object which is normally constructed with <code>new
-     * File(parent, fileName)</code> except when parent and child are both
+     * Returns a <code>File</code> object which is normally constructed with <code>new
+     * File(parent, fileName)</code> except when the parent and child are both
      * special folders, in which case the <code>File</code> is a wrapper containing
      * a <code>ShellFolder</code> object.
      *
      * @param parent a <code>File</code> object representing a directory or special folder
      * @param fileName a name of a file or folder which exists in <code>parent</code>
-     * @return a File object. This is normally constructed with <code>new
-     * File(parent, fileName)</code> except when parent and child are both
-     * special folders, in which case the <code>File</code> is a wrapper containing
-     * a <code>ShellFolder</code> object.
+     * @return a File object. 
      * @since 1.4
      */
     public File getChild(File parent, String fileName) {

--- a/src/java.desktop/share/classes/javax/swing/filechooser/FileSystemView.java
+++ b/src/java.desktop/share/classes/javax/swing/filechooser/FileSystemView.java
@@ -354,7 +354,7 @@ public abstract class FileSystemView {
      *
      * @param parent a <code>File</code> object representing a directory or special folder
      * @param fileName a name of a file or folder which exists in <code>parent</code>
-     * @return a File object. 
+     * @return a File object.
      * @since 1.4
      */
     public File getChild(File parent, String fileName) {

--- a/src/java.desktop/share/classes/javax/swing/filechooser/FileSystemView.java
+++ b/src/java.desktop/share/classes/javax/swing/filechooser/FileSystemView.java
@@ -65,7 +65,6 @@ import sun.awt.shell.ShellFolder;
 // PENDING(jeff) - need to provide a specification for
 // how Mac/OS2/BeOS/etc file systems can modify FileSystemView
 // to handle their particular type of file system.
-@SuppressWarnings("doclint:missing")
 public abstract class FileSystemView {
 
     static FileSystemView windowsFileSystemView = null;
@@ -348,6 +347,10 @@ public abstract class FileSystemView {
     }
 
     /**
+     * Returns a File object which is normally constructed with <code>new
+     * File(parent, fileName)</code> except when parent and child are both
+     * special folders, in which case the <code>File</code> is a wrapper containing
+     * a <code>ShellFolder</code> object.
      *
      * @param parent a <code>File</code> object representing a directory or special folder
      * @param fileName a name of a file or folder which exists in <code>parent</code>

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuItemUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuItemUI.java
@@ -45,7 +45,6 @@ import sun.swing.*;
  * @author Arnaud Weber
  * @author Fredrik Lagerblad
  */
-@SuppressWarnings("doclint:missing")
 public class BasicMenuItemUI extends MenuItemUI
 {
     /**
@@ -257,6 +256,7 @@ public class BasicMenuItemUI extends MenuItemUI
     }
 
     /**
+     * Registers the subcomponents of the men.
      *
      * @param menuItem a menu item
      * @since 1.3

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuItemUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuItemUI.java
@@ -256,7 +256,7 @@ public class BasicMenuItemUI extends MenuItemUI
     }
 
     /**
-     * Registers the subcomponents of the men.
+     * Registers the subcomponents of the menu.
      *
      * @param menuItem a menu item
      * @since 1.3

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicMenuUI.java
@@ -46,7 +46,6 @@ import java.util.ArrayList;
  * @author David Karlton
  * @author Arnaud Weber
  */
-@SuppressWarnings("doclint:missing")
 public class BasicMenuUI extends BasicMenuItemUI
 {
     /**

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalBorders.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalBorders.java
@@ -47,7 +47,6 @@ import sun.swing.SwingUtilities2;
  * Factory object that can vend Borders appropriate for the metal L &amp; F.
  * @author Steve Wilson
  */
-@SuppressWarnings("doclint:missing")
 public class MetalBorders {
 
     /**
@@ -926,7 +925,7 @@ public class MetalBorders {
     }
 
     /**
-     * The class represents the border of a {@code JTestField}.
+     * The class represents the border of a {@code JTextField}.
      */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     public static class TextFieldBorder extends Flush3DBorder {
@@ -1027,6 +1026,8 @@ public class MetalBorders {
     }
 
     /**
+     * The class represents the border of a {@code JToggleButton}.
+     *
      * @since 1.3
      */
     @SuppressWarnings("serial") // Superclass is not serializable across versions

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalBorders.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalBorders.java
@@ -925,7 +925,7 @@ public class MetalBorders {
     }
 
     /**
-     * The class represents the border of a {@code JTextField}.
+     * Border for a {@code JTextField}.
      */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     public static class TextFieldBorder extends Flush3DBorder {
@@ -1026,7 +1026,7 @@ public class MetalBorders {
     }
 
     /**
-     * The class represents the border of a {@code JToggleButton}.
+     * Border for a {@code JToggleButton}.
      *
      * @since 1.3
      */

--- a/src/java.desktop/share/classes/javax/swing/text/LayeredHighlighter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/LayeredHighlighter.java
@@ -69,8 +69,8 @@ public abstract class LayeredHighlighter implements Highlighter {
         protected LayerPainter() {}
 
         /**
-	 * Paints a portion of a highlight.
-	 *
+         * Paints a portion of a highlight.
+         *
          * @return a shape
          * @param g Graphics used to draw
          * @param p0 starting offset of view

--- a/src/java.desktop/share/classes/javax/swing/text/LayeredHighlighter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/LayeredHighlighter.java
@@ -28,12 +28,13 @@ import java.awt.Graphics;
 import java.awt.Shape;
 
 /**
+ * Highlighter interface to mark up the background of leaf views
+ * with colored areas.
  *
  * @author  Scott Violet
  * @author  Timothy Prinzing
  * @see     Highlighter
  */
-@SuppressWarnings("doclint:missing")
 public abstract class LayeredHighlighter implements Highlighter {
     /**
      * Constructor for subclasses to call.
@@ -68,6 +69,8 @@ public abstract class LayeredHighlighter implements Highlighter {
         protected LayerPainter() {}
 
         /**
+	 * Paints a portion of a highlight.
+	 *
          * @return a shape
          * @param g Graphics used to draw
          * @param p0 starting offset of view

--- a/src/java.desktop/share/classes/javax/swing/text/LayeredHighlighter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/LayeredHighlighter.java
@@ -28,8 +28,8 @@ import java.awt.Graphics;
 import java.awt.Shape;
 
 /**
- * Highlighter interface to mark up the background of leaf views
- * with colored areas.
+ * Implementation of {@code Highlighter} interface to mark up the
+ * background of leaf views with colored areas.
  *
  * @author  Scott Violet
  * @author  Timothy Prinzing

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTML.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTML.java
@@ -61,9 +61,9 @@ public class HTML {
 
         /**
          * Constructs a {@code Tag}.
-	 *
-	 * @since 1.3
-	 */
+         *
+         * @since 1.3
+         */
         public Tag() {}
 
         /**

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTML.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTML.java
@@ -43,7 +43,6 @@ import javax.swing.text.StyleContext;
  * @author  Sunita Mani
  *
  */
-@SuppressWarnings("doclint:missing")
 public class HTML {
 
     /**
@@ -60,7 +59,11 @@ public class HTML {
      */
     public static class Tag {
 
-        /** @since 1.3 */
+        /**
+         * Constructs a {@code Tag}.
+	 *
+	 * @since 1.3
+	 */
         public Tag() {}
 
         /**

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
@@ -1683,8 +1683,8 @@ public class HTMLEditorKit extends StyledEditorKit implements Accessible {
         }
 
         /**
-	 * Returns HTMLDocument of given <code>JEditorPane</code>.
-	 *
+         * Returns HTMLDocument of given <code>JEditorPane</code>.
+         *
          * @param e the JEditorPane
          * @return HTMLDocument of <code>e</code>.
          */
@@ -1697,8 +1697,8 @@ public class HTMLEditorKit extends StyledEditorKit implements Accessible {
         }
 
         /**
-	 * Returns HTMLEditorKit of given <code>JEditorPane</code>.
-	 *
+         * Returns HTMLEditorKit of given <code>JEditorPane</code>.
+         *
          * @param e the JEditorPane
          * @return HTMLEditorKit for <code>e</code>.
          */

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
@@ -1683,7 +1683,7 @@ public class HTMLEditorKit extends StyledEditorKit implements Accessible {
         }
 
         /**
-         * Returns HTMLDocument of given <code>JEditorPane</code>.
+         * Returns <code>HTMLDocument</code> of given <code>JEditorPane</code>.
          *
          * @param e the JEditorPane
          * @return HTMLDocument of <code>e</code>.

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
@@ -1683,7 +1683,7 @@ public class HTMLEditorKit extends StyledEditorKit implements Accessible {
         }
 
         /**
-         * Returns <code>HTMLDocument</code> of given <code>JEditorPane</code>.
+         * Returns <code>HTMLDocument</code> of the given <code>JEditorPane</code>.
          *
          * @param e the JEditorPane
          * @return HTMLDocument of <code>e</code>.
@@ -1697,7 +1697,7 @@ public class HTMLEditorKit extends StyledEditorKit implements Accessible {
         }
 
         /**
-         * Returns HTMLEditorKit of given <code>JEditorPane</code>.
+         * Returns <code>HTMLEditorKit</code> of the given <code>JEditorPane</code>.
          *
          * @param e the JEditorPane
          * @return HTMLEditorKit for <code>e</code>.

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
@@ -216,8 +216,7 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
  *
  * @author  Timothy Prinzing
  */
-@SuppressWarnings({"serial", // Same-version serialization only
-                   "doclint:missing"})
+@SuppressWarnings({"serial"}) // Same-version serialization only
 public class HTMLEditorKit extends StyledEditorKit implements Accessible {
 
     private JEditorPane theEditor;
@@ -1684,6 +1683,8 @@ public class HTMLEditorKit extends StyledEditorKit implements Accessible {
         }
 
         /**
+	 * Returns HTMLDocument of given <code>JEditorPane</code>.
+	 *
          * @param e the JEditorPane
          * @return HTMLDocument of <code>e</code>.
          */
@@ -1696,6 +1697,8 @@ public class HTMLEditorKit extends StyledEditorKit implements Accessible {
         }
 
         /**
+	 * Returns HTMLEditorKit of given <code>JEditorPane</code>.
+	 *
          * @param e the JEditorPane
          * @return HTMLEditorKit for <code>e</code>.
          */

--- a/src/java.desktop/share/classes/javax/swing/text/html/parser/AttributeList.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/parser/AttributeList.java
@@ -110,18 +110,14 @@ class AttributeList implements DTDConstants, Serializable {
     }
 
     /**
-     * Returns the attribute name.
-     *
-     * @return attribute name
+     * {@return the attribute name}
      */
     public String getName() {
         return name;
     }
 
     /**
-     * Returns the attribute type.
-     *
-     * @return attribute type
+     * {@return the attribute type}
      * @see DTDConstants
      */
     public int getType() {
@@ -129,9 +125,7 @@ class AttributeList implements DTDConstants, Serializable {
     }
 
     /**
-     * Returns attribute modifier.
-     *
-     * @return attribute modifier
+     * {@return the attribute modifier}
      * @see DTDConstants
      */
     public int getModifier() {
@@ -139,27 +133,21 @@ class AttributeList implements DTDConstants, Serializable {
     }
 
     /**
-     * Returns possible attribute values.
-     *
-     * @return possible attribute values
+     * {@return possible attribute values}
      */
     public Enumeration<?> getValues() {
         return (values != null) ? values.elements() : null;
     }
 
     /**
-     * Returns default attribute value.
-     *
-     * @return default attribute value
+     * {@return default attribute value}
      */
     public String getValue() {
         return value;
     }
 
     /**
-     * Returns the next attribute in the list.
-     *
-     * @return the next attribute in the list
+     * {@return the next attribute in the list}
      */
     public AttributeList getNext() {
         return next;

--- a/src/java.desktop/share/classes/javax/swing/text/html/parser/AttributeList.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/parser/AttributeList.java
@@ -44,8 +44,7 @@ import java.io.*;
  * @author      Arthur Van Hoff
  *
  */
-@SuppressWarnings({"serial", // Same-version serialization only
-                   "doclint:missing"})
+@SuppressWarnings({"serial"}) // Same-version serialization only
 public final
 class AttributeList implements DTDConstants, Serializable {
 
@@ -111,6 +110,8 @@ class AttributeList implements DTDConstants, Serializable {
     }
 
     /**
+     * Return the attribute name.
+     *
      * @return attribute name
      */
     public String getName() {
@@ -118,6 +119,8 @@ class AttributeList implements DTDConstants, Serializable {
     }
 
     /**
+     * Return the attribute type.
+     *
      * @return attribute type
      * @see DTDConstants
      */
@@ -126,6 +129,8 @@ class AttributeList implements DTDConstants, Serializable {
     }
 
     /**
+     * Return attribute modifier.
+     *
      * @return attribute modifier
      * @see DTDConstants
      */
@@ -134,6 +139,8 @@ class AttributeList implements DTDConstants, Serializable {
     }
 
     /**
+     * Return possible attribute values.
+     *
      * @return possible attribute values
      */
     public Enumeration<?> getValues() {
@@ -141,6 +148,8 @@ class AttributeList implements DTDConstants, Serializable {
     }
 
     /**
+     * Return default attribute value.
+     *
      * @return default attribute value
      */
     public String getValue() {
@@ -148,6 +157,8 @@ class AttributeList implements DTDConstants, Serializable {
     }
 
     /**
+     * Return the next attribute in the list.
+     *
      * @return the next attribute in the list
      */
     public AttributeList getNext() {

--- a/src/java.desktop/share/classes/javax/swing/text/html/parser/AttributeList.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/parser/AttributeList.java
@@ -110,7 +110,7 @@ class AttributeList implements DTDConstants, Serializable {
     }
 
     /**
-     * Return the attribute name.
+     * Returns the attribute name.
      *
      * @return attribute name
      */
@@ -119,7 +119,7 @@ class AttributeList implements DTDConstants, Serializable {
     }
 
     /**
-     * Return the attribute type.
+     * Returns the attribute type.
      *
      * @return attribute type
      * @see DTDConstants
@@ -129,7 +129,7 @@ class AttributeList implements DTDConstants, Serializable {
     }
 
     /**
-     * Return attribute modifier.
+     * Returns attribute modifier.
      *
      * @return attribute modifier
      * @see DTDConstants
@@ -139,7 +139,7 @@ class AttributeList implements DTDConstants, Serializable {
     }
 
     /**
-     * Return possible attribute values.
+     * Returns possible attribute values.
      *
      * @return possible attribute values
      */
@@ -148,7 +148,7 @@ class AttributeList implements DTDConstants, Serializable {
     }
 
     /**
-     * Return default attribute value.
+     * Returns default attribute value.
      *
      * @return default attribute value
      */
@@ -157,7 +157,7 @@ class AttributeList implements DTDConstants, Serializable {
     }
 
     /**
-     * Return the next attribute in the list.
+     * Returns the next attribute in the list.
      *
      * @return the next attribute in the list
      */

--- a/src/java.desktop/share/classes/javax/swing/text/html/parser/Parser.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/parser/Parser.java
@@ -210,7 +210,7 @@ class Parser implements DTDConstants {
 
 
     /**
-     * Return the line number of the line currently being parsed.
+     * Returns the line number of the line currently being parsed.
      *
      * @return the line number of the line currently being parsed
      */

--- a/src/java.desktop/share/classes/javax/swing/text/html/parser/Parser.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/parser/Parser.java
@@ -75,7 +75,6 @@ import java.net.URL;
  * @author Arthur van Hoff
  * @author Sunita Mani
  */
-@SuppressWarnings("doclint:missing")
 public
 class Parser implements DTDConstants {
 
@@ -211,6 +210,8 @@ class Parser implements DTDConstants {
 
 
     /**
+     * Return the line number of the line currently being parsed.
+     *
      * @return the line number of the line currently being parsed
      */
     protected int getCurrentLine() {

--- a/src/java.desktop/share/classes/javax/swing/undo/UndoableEditSupport.java
+++ b/src/java.desktop/share/classes/javax/swing/undo/UndoableEditSupport.java
@@ -147,7 +147,7 @@ public class UndoableEditSupport {
     }
 
     /**
-     * Start UndoableEdit.
+     * Starts a compound edit update.
      */
     public synchronized void beginUpdate() {
         if (updateLevel == 0) {

--- a/src/java.desktop/share/classes/javax/swing/undo/UndoableEditSupport.java
+++ b/src/java.desktop/share/classes/javax/swing/undo/UndoableEditSupport.java
@@ -33,7 +33,6 @@ import java.util.*;
  *
  * @author Ray Ryan
  */
-@SuppressWarnings("doclint:missing")
 public class UndoableEditSupport {
     /**
      * The update level.
@@ -148,7 +147,7 @@ public class UndoableEditSupport {
     }
 
     /**
-     *
+     * Start UndoableEdit.
      */
     public synchronized void beginUpdate() {
         if (updateLevel == 0) {


### PR DESCRIPTION
The changes done under JDK-8278175 suppress on a per-file basis various missing comments that would otherwise trigger doclint warnings. Fixed them so as to remove the doclint:missing warnings.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8278254](https://bugs.openjdk.java.net/browse/JDK-8278254): Cleanup doclint warnings in java.desktop module
 * [JDK-8280765](https://bugs.openjdk.java.net/browse/JDK-8280765): Cleanup doclint warnings in java.desktop module (**CSR**)


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to 752b7a0960bbb61bf594d8b2eca55eb68125c616


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7004/head:pull/7004` \
`$ git checkout pull/7004`

Update a local copy of the PR: \
`$ git checkout pull/7004` \
`$ git pull https://git.openjdk.java.net/jdk pull/7004/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7004`

View PR using the GUI difftool: \
`$ git pr show -t 7004`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7004.diff">https://git.openjdk.java.net/jdk/pull/7004.diff</a>

</details>
