### PR TITLE
8279534: Consolidate and remove oopDesc::klass_gap methods

### DIFF
--- a/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
@@ -1942,16 +1942,13 @@ run:
                 Copy::fill_to_words(result + hdr_size, obj_size - hdr_size, 0);
               }
 
+              // Initialize header, mirrors MemAllocator.
+              oopDesc::set_mark(result, markWord::prototype());
+              oopDesc::set_klass_gap(result, 0);
+              oopDesc::release_set_klass(result, ik);
+
               oop obj = cast_to_oop(result);
 
-              // Initialize header
-              obj->set_mark(markWord::prototype());
-              obj->set_klass_gap(0);
-              obj->set_klass(ik);
-
-              // Must prevent reordering of stores for object initialization
-              // with stores that publish the new object.
-              OrderAccess::storestore();
               SET_STACK_OBJECT(obj, 0);
               UPDATE_PC_AND_TOS_AND_CONTINUE(3, 1);
             }

--- a/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
@@ -1949,6 +1949,9 @@ run:
 
               oop obj = cast_to_oop(result);
 
+              // Must prevent reordering of stores for object initialization
+              // with stores that publish the new object.
+              OrderAccess::storestore();
               SET_STACK_OBJECT(obj, 0);
               UPDATE_PC_AND_TOS_AND_CONTINUE(3, 1);
             }

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -91,8 +91,6 @@ class oopDesc {
   static inline void release_set_klass(HeapWord* mem, Klass* k);
 
   // For klass field compression
-  inline int klass_gap() const;
-  inline void set_klass_gap(int z);
   static inline void set_klass_gap(HeapWord* mem, int z);
 
   // size of object header, aligned to platform wordSize

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -125,18 +125,10 @@ void oopDesc::release_set_klass(HeapWord* mem, Klass* k) {
   }
 }
 
-int oopDesc::klass_gap() const {
-  return *(int*)(((intptr_t)this) + klass_gap_offset_in_bytes());
-}
-
 void oopDesc::set_klass_gap(HeapWord* mem, int v) {
   if (UseCompressedClassPointers) {
     *(int*)(((char*)mem) + klass_gap_offset_in_bytes()) = v;
   }
-}
-
-void oopDesc::set_klass_gap(int v) {
-  set_klass_gap((HeapWord*)this, v);
 }
 
 bool oopDesc::is_a(Klass* k) const {


### PR DESCRIPTION
After JDK-8278568, these methods are unused:
  inline int klass_gap() const;
  inline void set_klass_gap(int z);

Except Zero which uses set_klass_gap(int), but we agreed elsewhere (#5585) that we don't want to access partly initialized oops as such. We should use the HeapWord* initialization variants in Zero, too.

Note: we could take that even further and replace the initialization in Zero with ObjAllocator::initialize() call, but that would also have to remove the storestore fence, and possibly adopt ObjAllocator to avoid clearing in already-zeroed TLABs, all of which would have wider consequences and would be a matter for separate PR.

Testing:
 - [x] Build (for klass_gap methods removal)
 - [ ] GHA for Zero stuff

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279534](https://bugs.openjdk.java.net/browse/JDK-8279534): Consolidate and remove oopDesc::klass_gap methods


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7008/head:pull/7008` \
`$ git checkout pull/7008`

Update a local copy of the PR: \
`$ git checkout pull/7008` \
`$ git pull https://git.openjdk.java.net/jdk pull/7008/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7008`

View PR using the GUI difftool: \
`$ git pr show -t 7008`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7008.diff">https://git.openjdk.java.net/jdk/pull/7008.diff</a>

</details>
