### PR TITLE
8279700: Parallel: Simplify ScavengeRootsTask constructor API

### DIFF
--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -283,37 +283,30 @@ class ScavengeRootsTask : public WorkerTask {
   PSOldGen* _old_gen;
   HeapWord* _gen_top;
   uint _active_workers;
-  bool _is_empty;
+  bool _is_old_gen_empty;
   TaskTerminator _terminator;
 
 public:
   ScavengeRootsTask(PSOldGen* old_gen,
-                    HeapWord* gen_top,
-                    uint active_workers,
-                    bool is_empty) :
+                    uint active_workers) :
       WorkerTask("ScavengeRootsTask"),
       _strong_roots_scope(active_workers),
       _subtasks(ParallelRootType::sentinel),
       _old_gen(old_gen),
-      _gen_top(gen_top),
+      _gen_top(old_gen->object_space()->top()),
       _active_workers(active_workers),
-      _is_empty(is_empty),
+      _is_old_gen_empty(old_gen->object_space()->is_empty()),
       _terminator(active_workers, PSPromotionManager::vm_thread_promotion_manager()->stack_array_depth()) {
+    assert(_old_gen != NULL, "Sanity");
   }
 
   virtual void work(uint worker_id) {
+    assert(worker_id < _active_workers, "Sanity");
     ResourceMark rm;
 
-    if (!_is_empty) {
+    if (!_is_old_gen_empty) {
       // There are only old-to-young pointers if there are objects
       // in the old gen.
-
-      assert(_old_gen != NULL, "Sanity");
-      // There are no old-to-young pointers if the old gen is empty.
-      assert(!_old_gen->object_space()->is_empty(), "Should not be called is there is no work");
-      assert(_old_gen->object_space()->contains(_gen_top) || _gen_top == _old_gen->object_space()->top(), "Sanity");
-      assert(worker_id < ParallelGCThreads, "Sanity");
-
       {
         PSPromotionManager* pm = PSPromotionManager::gc_thread_promotion_manager(worker_id);
         PSCardTable* card_table = ParallelScavengeHeap::heap()->card_table();
@@ -453,12 +446,6 @@ bool PSScavenge::invoke_no_policy() {
     // Reset our survivor overflow.
     set_survivor_overflow(false);
 
-    // We need to save the old top values before
-    // creating the promotion_manager. We pass the top
-    // values to the card_table, to prevent it from
-    // straying into the promotion labs.
-    HeapWord* old_top = old_gen->object_space()->top();
-
     const uint active_workers =
       WorkerPolicy::calc_active_workers(ParallelScavengeHeap::heap()->workers().max_workers(),
                                         ParallelScavengeHeap::heap()->workers().active_workers(),
@@ -472,7 +459,7 @@ bool PSScavenge::invoke_no_policy() {
     {
       GCTraceTime(Debug, gc, phases) tm("Scavenge", &_gc_timer);
 
-      ScavengeRootsTask task(old_gen, old_top, active_workers, old_gen->object_space()->is_empty());
+      ScavengeRootsTask task(old_gen, active_workers);
       ParallelScavengeHeap::heap()->workers().run_task(&task);
     }
 


### PR DESCRIPTION
Simple cleanup around `ScavengeRootsTask`.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279700](https://bugs.openjdk.java.net/browse/JDK-8279700): Parallel: Simplify ScavengeRootsTask constructor API


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7011/head:pull/7011` \
`$ git checkout pull/7011`

Update a local copy of the PR: \
`$ git checkout pull/7011` \
`$ git pull https://git.openjdk.java.net/jdk pull/7011/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7011`

View PR using the GUI difftool: \
`$ git pr show -t 7011`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7011.diff">https://git.openjdk.java.net/jdk/pull/7011.diff</a>

</details>
