### PR TITLE
8279699: Parallel: More precise boundary in ObjectStartArray::object_starts_in_range

### DIFF
--- a/src/hotspot/share/gc/parallel/objectStartArray.cpp
+++ b/src/hotspot/share/gc/parallel/objectStartArray.cpp
@@ -133,9 +133,9 @@ bool ObjectStartArray::object_starts_in_range(HeapWord* start_addr,
          p2i(start_addr), p2i(end_addr));
 
   jbyte* start_block = block_for_addr(start_addr);
-  jbyte* end_block = block_for_addr(end_addr);
+  jbyte* end_block = block_for_addr(align_up(end_addr, _card_size));
 
-  for (jbyte* block = start_block; block <= end_block; block++) {
+  for (jbyte* block = start_block; block < end_block; block++) {
     if (*block != clean_block) {
       return true;
     }

--- a/src/hotspot/share/gc/parallel/objectStartArray.hpp
+++ b/src/hotspot/share/gc/parallel/objectStartArray.hpp
@@ -165,9 +165,11 @@ class ObjectStartArray : public CHeapObj<mtGC> {
     return *block != clean_block;
   }
 
-  // Return true if an object starts in the range of heap addresses.
-  // If an object starts at an address corresponding to
-  // "start", the method will return true.
+  // Return true iff an object starts in
+  //   [start_addr_aligned_down, end_addr_aligned_up)
+  // where
+  //   start_addr_aligned_down = align_down(start_addr, _card_size)
+  //   end_addr_aligned_up = align_up(end_addr, _card_size)
   bool object_starts_in_range(HeapWord* start_addr, HeapWord* end_addr) const;
 };
 


### PR DESCRIPTION
Simple change in boundary condition checking and updating the API doc.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279699](https://bugs.openjdk.java.net/browse/JDK-8279699): Parallel: More precise boundary in ObjectStartArray::object_starts_in_range


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7012/head:pull/7012` \
`$ git checkout pull/7012`

Update a local copy of the PR: \
`$ git checkout pull/7012` \
`$ git pull https://git.openjdk.java.net/jdk pull/7012/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7012`

View PR using the GUI difftool: \
`$ git pr show -t 7012`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7012.diff">https://git.openjdk.java.net/jdk/pull/7012.diff</a>

</details>
