### PR TITLE
JDK-8280498: jdk/java/net/Inet4Address/PingThis.java fails on AIX

### DIFF
--- a/test/jdk/java/net/Inet4Address/PingThis.java
+++ b/test/jdk/java/net/Inet4Address/PingThis.java
@@ -27,9 +27,14 @@
 
 /* @test
  * @bug 7163874 8133015
+ * @requires os.family != "windows" && os.family != "aix"
  * @library /test/lib
  * @summary InetAddress.isReachable is returning false
  *          for InetAdress 0.0.0.0 and ::0
+ *          On AIX InetAddress ::0 is not valid, InetAddress 0.0.0.0 is valid,
+ *          but does not respond as 127.0.0.1 (i.e., only responds
+ *          when an external device reacts to 0.0.0.0)
+ */
  * @run main PingThis
  * @run main/othervm -Djava.net.preferIPv4Stack=true PingThis
  */
@@ -45,14 +50,6 @@ import jdk.test.lib.net.IPSupport;
 
 public class PingThis {
     public static void main(String args[]) throws Exception {
-        osname = System.getProperty("os.name");
-        /*
-         * On AIX InetAddress ::0 is not valid, InetAddress 0.0.0.0 only responds
-         *          when an external device reacts to 0.0.0.0
-         */
-        if (osname.startsWith("Windows") || osname.startsWith("AIX")) {
-            return;
-        }
         IPSupport.throwSkippedExceptionIfNonOperational();
 
         List<String> addrs = new ArrayList<String>();

--- a/test/jdk/java/net/Inet4Address/PingThis.java
+++ b/test/jdk/java/net/Inet4Address/PingThis.java
@@ -45,7 +45,7 @@ import jdk.test.lib.net.IPSupport;
 
 public class PingThis {
     public static void main(String args[]) throws Exception {
-        osname = System.getProperty("os.name")
+        osname = System.getProperty("os.name");
         /*
          * On AIX InetAddress ::0 is not valid, InetAddress 0.0.0.0 only responds
          *          when an external device reacts to 0.0.0.0

--- a/test/jdk/java/net/Inet4Address/PingThis.java
+++ b/test/jdk/java/net/Inet4Address/PingThis.java
@@ -32,9 +32,6 @@
  *          for InetAdress 0.0.0.0 and ::0
  * @run main PingThis
  * @run main/othervm -Djava.net.preferIPv4Stack=true PingThis
- * @bug 8280498
- * @summary InetAddress ::0 is not valid, InetAddress 0.0.0.0 only responds
- *          when an external device reacts to 0.0.0.0
  */
 
 import java.net.Inet6Address;
@@ -49,6 +46,10 @@ import jdk.test.lib.net.IPSupport;
 public class PingThis {
     public static void main(String args[]) throws Exception {
         osname = System.getProperty("os.name")
+        /*
+         * On AIX InetAddress ::0 is not valid, InetAddress 0.0.0.0 only responds
+         *          when an external device reacts to 0.0.0.0
+         */
         if (osname.startsWith("Windows") || osname.startsWith("AIX")) {
             return;
         }

--- a/test/jdk/java/net/Inet4Address/PingThis.java
+++ b/test/jdk/java/net/Inet4Address/PingThis.java
@@ -27,14 +27,13 @@
 
 /* @test
  * @bug 7163874 8133015
- * @requires os.family != "windows" && os.family != "aix"
+ * @requires os.family != "windows" & os.family != "aix"
  * @library /test/lib
  * @summary InetAddress.isReachable is returning false
- *          for InetAdress 0.0.0.0 and ::0
+ *          for InetAddress 0.0.0.0 and ::0
  *          On AIX InetAddress ::0 is not valid, InetAddress 0.0.0.0 is valid,
  *          but does not respond as 127.0.0.1 (i.e., only responds
  *          when an external device reacts to 0.0.0.0)
- */
  * @run main PingThis
  * @run main/othervm -Djava.net.preferIPv4Stack=true PingThis
  */

--- a/test/jdk/java/net/Inet4Address/PingThis.java
+++ b/test/jdk/java/net/Inet4Address/PingThis.java
@@ -32,6 +32,9 @@
  *          for InetAdress 0.0.0.0 and ::0
  * @run main PingThis
  * @run main/othervm -Djava.net.preferIPv4Stack=true PingThis
+ * @bug 8280498
+ * @summary InetAddress ::0 is not valid, InetAddress 0.0.0.0 only responds
+ *          when an external device reacts to 0.0.0.0
  */
 
 import java.net.Inet6Address;
@@ -45,7 +48,8 @@ import jdk.test.lib.net.IPSupport;
 
 public class PingThis {
     public static void main(String args[]) throws Exception {
-        if (System.getProperty("os.name").startsWith("Windows")) {
+        osname = System.getProperty("os.name")
+        if (osname.startsWith("Windows") || osname.startsWith("AIX")) {
             return;
         }
         IPSupport.throwSkippedExceptionIfNonOperational();


### PR DESCRIPTION
with IP "0.0.0.0"

- it either does nothing and ping fails, or, in some virtual environments
is treated as the default route address.
- IPv6 support for ::1 is available since 1977; however, ::0 is not accepted
as a vaild psuedo IPv6 address. '::1' must be used instead.
```
ping: bind: The socket name is not available on this system.
ping: bind: The socket name is not available on this system.
PING ::1: (::1): 56 data bytes
64 bytes from ::1: icmp_seq=0 ttl=255 time=0.037 ms
64 bytes from ::1: icmp_seq=1 ttl=255 time=0.045 ms

--- ::1 ping statistics ---
2 packets transmitted, 2 packets received, 0% packet loss
round-trip min/avg/max = 0/0/0 ms
PING ::1: (::1): 56 data bytes
64 bytes from ::1: icmp_seq=0 ttl=255 time=0.052 ms
64 bytes from ::1: icmp_seq=1 ttl=255 time=0.047 ms

--- ::1 ping statistics ---
2 packets transmitted, 2 packets received, 0% packet loss
```

A long commit message. 

This came to light because some systems failed with IPv4 (those that passed
replaced 0.0.0.0 with the default router. but most just fail - not substituting
0.0.0.0 with 127.0.0.1. However, InetAddress.getByName("") returns 127.0.0.1
which compares well with other platform's behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8280498](https://bugs.openjdk.java.net/browse/JDK-8280498): jdk/java/net/Inet4Address/PingThis.java fails on AIX


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Michael McMahon](https://openjdk.java.net/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)
 * [Aleksei Efimov](https://openjdk.java.net/census#aefimov) (@AlekseiEfimov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7013/head:pull/7013` \
`$ git checkout pull/7013`

Update a local copy of the PR: \
`$ git checkout pull/7013` \
`$ git pull https://git.openjdk.java.net/jdk pull/7013/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7013`

View PR using the GUI difftool: \
`$ git pr show -t 7013`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7013.diff">https://git.openjdk.java.net/jdk/pull/7013.diff</a>

</details>
