### PR TITLE
8279703: G1: Remove unused force_not_compacted local in G1CalculatePointersClosure::do_heap_region 

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -52,7 +52,6 @@ void G1FullGCPrepareTask::G1CalculatePointersClosure::free_pinned_region(HeapReg
 }
 
 bool G1FullGCPrepareTask::G1CalculatePointersClosure::do_heap_region(HeapRegion* hr) {
-  bool force_not_compacted = false;
   if (should_compact(hr)) {
     assert(!hr->is_humongous(), "moving humongous objects not supported.");
     prepare_for_compaction(hr);


### PR DESCRIPTION
Hi all,

  please review this trivial removal of an unused local I came across when looking through that code for another purpose.

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279703](https://bugs.openjdk.java.net/browse/JDK-8279703): G1: Remove unused force_not_compacted local in G1CalculatePointersClosure::do_heap_region


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7014/head:pull/7014` \
`$ git checkout pull/7014`

Update a local copy of the PR: \
`$ git checkout pull/7014` \
`$ git pull https://git.openjdk.java.net/jdk pull/7014/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7014`

View PR using the GUI difftool: \
`$ git pr show -t 7014`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7014.diff">https://git.openjdk.java.net/jdk/pull/7014.diff</a>

</details>
