### PR TITLE
8279702: [macosx] ignore xcodebuild warnings on M1

### DIFF
--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -234,7 +234,7 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETERMINE_TOOLCHAIN_TYPE],
   if test "x$OPENJDK_TARGET_OS" = xmacosx; then
     if test -n "$XCODEBUILD"; then
       # On Mac OS X, default toolchain to clang after Xcode 5
-      XCODE_VERSION_OUTPUT=`"$XCODEBUILD" -version 2>&1 | $HEAD -n 1`
+      XCODE_VERSION_OUTPUT=`"$XCODEBUILD" -version | $HEAD -n 1`
       $ECHO "$XCODE_VERSION_OUTPUT" | $GREP "Xcode " > /dev/null
       if test $? -ne 0; then
         AC_MSG_NOTICE([xcodebuild output: $XCODE_VERSION_OUTPUT])


### PR DESCRIPTION
Simple change to `make/autoconf/toolchain.m4` to fix the bug as described in its title and description.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8279702](https://bugs.openjdk.java.net/browse/JDK-8279702): [macosx] ignore xcodebuild warnings on M1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7015/head:pull/7015` \
`$ git checkout pull/7015`

Update a local copy of the PR: \
`$ git checkout pull/7015` \
`$ git pull https://git.openjdk.java.net/jdk pull/7015/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7015`

View PR using the GUI difftool: \
`$ git pr show -t 7015`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7015.diff">https://git.openjdk.java.net/jdk/pull/7015.diff</a>

</details>
