### PR TITLE
8279676: Dubious YMM register clearing in x86_64 arraycopy stubs

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
@@ -817,11 +817,10 @@ class StubGenerator: public StubCodeGenerator {
     __ subl(qword_count, 8);
     __ jcc(Assembler::greaterEqual, L_copy_64_bytes_loop);
 
-    if (UseUnalignedLoadStores && (UseAVX >= 2)) {
-      // clean upper bits of YMM registers: qword/byte copy loops
-      // would use lower bits of these registers.
-      __ vpxor(xmm0, xmm0, xmm0, Assembler::AVX_128bit);
-      __ vpxor(xmm1, xmm1, xmm1, Assembler::AVX_128bit);
+    if (UseUnalignedLoadStores && (UseAVX == 2)) {
+      // clean upper bits of YMM registers
+      __ vpxor(xmm0, xmm0);
+      __ vpxor(xmm1, xmm1);
     }
     __ addl(qword_count, 8);
     __ jccb(Assembler::zero, L_exit);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
@@ -817,7 +817,7 @@ class StubGenerator: public StubCodeGenerator {
     __ subl(qword_count, 8);
     __ jcc(Assembler::greaterEqual, L_copy_64_bytes_loop);
 
-    if (UseUnalignedLoadStores && (UseAVX == 2)) {
+    if (UseUnalignedLoadStores && (UseAVX >= 2)) {
       // clean upper bits of YMM registers: qword/byte copy loops
       // would use lower bits of these registers.
       __ vpxor(xmm0, xmm0, xmm0, Assembler::AVX_128bit);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
@@ -818,9 +818,10 @@ class StubGenerator: public StubCodeGenerator {
     __ jcc(Assembler::greaterEqual, L_copy_64_bytes_loop);
 
     if (UseUnalignedLoadStores && (UseAVX == 2)) {
-      // clean upper bits of YMM registers
-      __ vpxor(xmm0, xmm0);
-      __ vpxor(xmm1, xmm1);
+      // clean upper bits of YMM registers: qword/byte copy loops
+      // would use lower bits of these registers.
+      __ vpxor(xmm0, xmm0, xmm0, Assembler::AVX_128bit);
+      __ vpxor(xmm1, xmm1, xmm1, Assembler::AVX_128bit);
     }
     __ addl(qword_count, 8);
     __ jccb(Assembler::zero, L_exit);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -1221,11 +1221,6 @@ class StubGenerator: public StubCodeGenerator {
       }
       __ addptr(qword_count, 4);
       __ BIND(L_end);
-      if (UseAVX >= 2) {
-        // clean upper bits of YMM registers
-        __ vpxor(xmm0, xmm0);
-        __ vpxor(xmm1, xmm1);
-      }
     } else {
       // Copy 32-bytes per iteration
       __ BIND(L_loop);
@@ -1299,11 +1294,6 @@ class StubGenerator: public StubCodeGenerator {
       }
       __ subptr(qword_count, 4);
       __ BIND(L_end);
-      if (UseAVX >= 2) {
-        // clean upper bits of YMM registers
-        __ vpxor(xmm0, xmm0);
-        __ vpxor(xmm1, xmm1);
-      }
     } else {
       // Copy 32-bytes per iteration
       __ BIND(L_loop);


### PR DESCRIPTION
See discussion in the bug.

Additional testing, TR3970X (Zen 2, AVX2):
 - [x] Linux x86_64 fastdebug `hotspot_compiler_arraycopy`
 - [x] Linux x86_64 fastdebug `tier1`
 - [x] Linux x86_64 fastdebug `tier2`
 - [x] Linux x86_64 fastdebug `tier3`

Additional testing, i5-11500 (Rocket Lake, AVX-512):
 - [x] Linux x86_64 fastdebug `hotspot_compiler_arraycopy`
 - [x] Linux x86_64 fastdebug `tier1`
 - [x] Linux x86_64 fastdebug `tier2`
 - [x] Linux x86_64 fastdebug `tier3`

Targeted arraycopy microbenchmarks find a barely noticeable improvement on TR 3970X and i5-11500 with UseAVX=2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279676](https://bugs.openjdk.java.net/browse/JDK-8279676): Dubious YMM register clearing in x86_64 arraycopy stubs


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7016/head:pull/7016` \
`$ git checkout pull/7016`

Update a local copy of the PR: \
`$ git checkout pull/7016` \
`$ git pull https://git.openjdk.java.net/jdk pull/7016/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7016`

View PR using the GUI difftool: \
`$ git pr show -t 7016`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7016.diff">https://git.openjdk.java.net/jdk/pull/7016.diff</a>

</details>
