### PR TITLE
8259774: Deprecate -XX:FlightRecorderOptions:samplethreads

### DIFF
--- a/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
+++ b/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
@@ -420,9 +420,6 @@ void JfrConfigureFlightRecorderDCmd::print_help(const char* name) const {
   out->print_cr("                     performance and is not recommended. This value cannot be changed");
   out->print_cr("                     once JFR has been initialized. (STRING, 8k)");
   out->print_cr("");
-  out->print_cr("  samplethreads      (Optional) Flag for activating thread sampling. This value cannot");
-  out->print_cr("                     be changed once JFR has been initialized. (BOOLEAN, true)");
-  out->print_cr("");
   out->print_cr("Options must be specified using the <key> or <key>=<value> syntax.");
   out->print_cr("");
   out->print_cr("Example usage:");
@@ -477,7 +474,6 @@ void JfrConfigureFlightRecorderDCmd::execute(DCmdSource source, TRAPS) {
   jobject thread_buffer_size = NULL;
   jobject max_chunk_size = NULL;
   jobject memory_size = NULL;
-  jobject sample_threads = NULL;
 
   if (!JfrRecorder::is_created()) {
     if (_stack_depth.is_set()) {
@@ -499,7 +495,13 @@ void JfrConfigureFlightRecorderDCmd::execute(DCmdSource source, TRAPS) {
       memory_size = JfrJavaSupport::new_java_lang_Long(_memory_size.value()._size, CHECK);
     }
     if (_sample_threads.is_set()) {
-      sample_threads = JfrJavaSupport::new_java_lang_Boolean(_sample_threads.value(), CHECK);
+      bool startup = DCmd_Source_Internal == source;
+      if (startup) {
+        log_warning(jfr,startup)("%s", "Option samplethreads is deprecated. Use -XX:StartFlightRecording:method-profiling=<off|normal|high|max>");
+      } else {
+        output()->print_cr("%s", "Option samplethreads is deprecated. Use JFR.start method-profiling=<off|normal|high|max>");
+        output()->print_cr("");
+      }
     }
   }
 
@@ -507,7 +509,7 @@ void JfrConfigureFlightRecorderDCmd::execute(DCmdSource source, TRAPS) {
   static const char method[] = "execute";
   static const char signature[] = "(ZLjava/lang/String;Ljava/lang/String;Ljava/lang/Integer;"
     "Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;"
-    "Ljava/lang/Long;Ljava/lang/Boolean;)[Ljava/lang/String;";
+    "Ljava/lang/Long;)[Ljava/lang/String;";
 
   JfrJavaArguments execute_args(&result, klass, method, signature, CHECK);
   execute_args.set_receiver(h_dcmd_instance);
@@ -522,7 +524,6 @@ void JfrConfigureFlightRecorderDCmd::execute(DCmdSource source, TRAPS) {
   execute_args.push_jobject(thread_buffer_size);
   execute_args.push_jobject(memory_size);
   execute_args.push_jobject(max_chunk_size);
-  execute_args.push_jobject(sample_threads);
 
   JfrJavaSupport::call_virtual(&execute_args, THREAD);
   handle_dcmd_result(output(), result.get_oop(), source, THREAD);

--- a/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
@@ -121,10 +121,6 @@ NO_TRANSITION(void, jfr_set_file_notification(JNIEnv* env, jobject jvm, jlong th
   JfrChunkRotation::set_threshold(threshold);
 NO_TRANSITION_END
 
-NO_TRANSITION(void, jfr_set_sample_threads(JNIEnv* env, jobject jvm, jboolean sampleThreads))
-  JfrOptionSet::set_sample_threads(sampleThreads);
-NO_TRANSITION_END
-
 NO_TRANSITION(void, jfr_set_stack_depth(JNIEnv* env, jobject jvm, jint depth))
   JfrOptionSet::set_stackdepth((jlong)depth);
 NO_TRANSITION_END

--- a/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
@@ -87,8 +87,6 @@ void JNICALL jfr_set_method_sampling_interval(JNIEnv* env, jobject jvm, jlong ty
 
 void JNICALL jfr_set_output(JNIEnv* env, jobject jvm, jstring path);
 
-void JNICALL jfr_set_sample_threads(JNIEnv* env, jobject jvm, jboolean sampleThreads);
-
 void JNICALL jfr_set_stack_depth(JNIEnv* env, jobject jvm, jint depth);
 
 void JNICALL jfr_set_stacktrace_enabled(JNIEnv* env, jobject jvm, jlong event_type_id, jboolean enabled);

--- a/src/hotspot/share/jfr/jni/jfrJniMethodRegistration.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethodRegistration.cpp
@@ -59,7 +59,6 @@ JfrJniMethodRegistration::JfrJniMethodRegistration(JNIEnv* env) {
       (char*)"setGlobalBufferSize", (char*)"(J)V", (void*)jfr_set_global_buffer_size,
       (char*)"setMethodSamplingInterval", (char*)"(JJ)V", (void*)jfr_set_method_sampling_interval,
       (char*)"setOutput", (char*)"(Ljava/lang/String;)V", (void*)jfr_set_output,
-      (char*)"setSampleThreads", (char*)"(Z)V", (void*)jfr_set_sample_threads,
       (char*)"setStackDepth", (char*)"(I)V", (void*)jfr_set_stack_depth,
       (char*)"setStackTraceEnabled", (char*)"(JZ)V", (void*)jfr_set_stacktrace_enabled,
       (char*)"setThreadBufferSize", (char*)"(J)V", (void*)jfr_set_thread_buffer_size,

--- a/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
@@ -54,7 +54,6 @@ static const ObsoleteOption OBSOLETE_OPTIONS[] = {
   {"dumponexit",           "Use -XX:StartFlightRecording:dumponexit=... instead."},
   {"dumponexitpath",       "Use -XX:StartFlightRecording:filename=... instead."},
   {"loglevel",             "Use -Xlog:jfr=... instead."}
-
 };
 
 jlong JfrOptionSet::max_chunk_size() {

--- a/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
@@ -54,6 +54,7 @@ static const ObsoleteOption OBSOLETE_OPTIONS[] = {
   {"dumponexit",           "Use -XX:StartFlightRecording:dumponexit=... instead."},
   {"dumponexitpath",       "Use -XX:StartFlightRecording:filename=... instead."},
   {"loglevel",             "Use -Xlog:jfr=... instead."}
+
 };
 
 jlong JfrOptionSet::max_chunk_size() {
@@ -116,14 +117,6 @@ void JfrOptionSet::set_stackdepth(u4 depth) {
   } else {
     _stack_depth = depth;
   }
-}
-
-bool JfrOptionSet::sample_threads() {
-  return _sample_threads == JNI_TRUE;
-}
-
-void JfrOptionSet::set_sample_threads(jboolean sample) {
-  _sample_threads = sample;
 }
 
 bool JfrOptionSet::can_retransform() {
@@ -315,7 +308,6 @@ jlong JfrOptionSet::_memory_size = 0;
 jlong JfrOptionSet::_num_global_buffers = 0;
 jlong JfrOptionSet::_old_object_queue_size = 0;
 u4 JfrOptionSet::_stack_depth = STACK_DEPTH_DEFAULT;
-jboolean JfrOptionSet::_sample_threads = JNI_TRUE;
 jboolean JfrOptionSet::_retransform = JNI_TRUE;
 #ifdef ASSERT
 jboolean JfrOptionSet::_sample_protection = JNI_FALSE;

--- a/src/hotspot/share/jfr/recorder/service/jfrOptionSet.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrOptionSet.hpp
@@ -45,7 +45,6 @@ class JfrOptionSet : public AllStatic {
   static jlong _num_global_buffers;
   static jlong _old_object_queue_size;
   static u4 _stack_depth;
-  static jboolean _sample_threads;
   static jboolean _retransform;
   static jboolean _sample_protection;
 
@@ -68,8 +67,6 @@ class JfrOptionSet : public AllStatic {
   static void set_old_object_queue_size(jlong value);
   static u4 stackdepth();
   static void set_stackdepth(u4 depth);
-  static bool sample_threads();
-  static void set_sample_threads(jboolean sample);
   static bool can_retransform();
   static void set_retransform(jboolean value);
   static bool compressed_integers();

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -1431,14 +1431,6 @@ By default, this parameter is enabled.
 .RS
 .RE
 .TP
-.B \f[CB]samplethreads=\f[R]{\f[CB]true\f[R]|\f[CB]false\f[R]}
-Specifies whether thread sampling is enabled.
-Thread sampling occurs only if the sampling event is enabled along with
-this parameter.
-By default, this parameter is enabled.
-.RS
-.RE
-.TP
 .B \f[CB]stackdepth=\f[R]\f[I]depth\f[R]
 Stack depth for stack traces.
 By default, the depth is set to 64 method calls.

--- a/src/jdk.jfr/share/classes/jdk/jfr/FlightRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/FlightRecorder.java
@@ -192,7 +192,6 @@ public final class FlightRecorder {
                     Logger.log(JFR, DEBUG, "globalbuffersize: " + Options.getGlobalBufferSize()+ " bytes");
                     Logger.log(JFR, DEBUG, "globalbuffercount: " + Options.getGlobalBufferCount());
                     Logger.log(JFR, DEBUG, "dumppath: " + Options.getDumpPath());
-                    Logger.log(JFR, DEBUG, "samplethreads: " + Options.getSampleThreads());
                     Logger.log(JFR, DEBUG, "stackdepth: " + Options.getStackDepth());
                     Logger.log(JFR, DEBUG, "threadbuffersize: " + Options.getThreadBufferSize());
                 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
@@ -302,15 +302,6 @@ public final class JVM {
     public native void setForceInstrumentation(boolean force);
 
     /**
-     * Turn on/off thread sampling.
-     *
-     * @param sampleThreads true if threads should be sampled, false otherwise.
-     *
-     * @throws IllegalStateException if state can't be changed.
-     */
-    public native void setSampleThreads(boolean sampleThreads) throws IllegalStateException;
-
-    /**
      * Turn on/off compressed integers.
      *
      * @param compressed true if compressed integers should be used, false

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Options.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Options.java
@@ -53,7 +53,6 @@ public final class Options {
     private static final long DEFAULT_MEMORY_SIZE = DEFAULT_GLOBAL_BUFFER_COUNT * DEFAULT_GLOBAL_BUFFER_SIZE;
     private static long DEFAULT_THREAD_BUFFER_SIZE;
     private static final int DEFAULT_STACK_DEPTH = 64;
-    private static final boolean DEFAULT_SAMPLE_THREADS = true;
     private static final long DEFAULT_MAX_CHUNK_SIZE = 12 * 1024 * 1024;
     private static final SafePath DEFAULT_DUMP_PATH = null;
 
@@ -62,7 +61,6 @@ public final class Options {
     private static long globalBufferCount;
     private static long threadBufferSize;
     private static int stackDepth;
-    private static boolean sampleThreads;
     private static long maxChunkSize;
 
     static {
@@ -143,15 +141,6 @@ public final class Options {
         return stackDepth;
     }
 
-    public static synchronized void setSampleThreads(Boolean sample) {
-        jvm.setSampleThreads(sample);
-        sampleThreads = sample;
-    }
-
-    public static synchronized boolean getSampleThreads() {
-        return sampleThreads;
-    }
-
     private static synchronized void reset() {
         setMaxChunkSize(DEFAULT_MAX_CHUNK_SIZE);
         setMemorySize(DEFAULT_MEMORY_SIZE);
@@ -162,7 +151,6 @@ public final class Options {
         } catch (IOException e) {
             // Ignore (depends on default value in JVM: it would be NULL)
         }
-        setSampleThreads(DEFAULT_SAMPLE_THREADS);
         setStackDepth(DEFAULT_STACK_DEPTH);
         setThreadBufferSize(DEFAULT_THREAD_BUFFER_SIZE);
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdConfigure.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdConfigure.java
@@ -69,8 +69,7 @@ final class DCmdConfigure extends AbstractDCmd {
             Long globalBufferSize,
             Long threadBufferSize,
             Long memorySize,
-            Long maxChunkSize,
-            Boolean sampleThreads
+            Long maxChunkSize
 
     ) throws DCmdException {
         if (Logger.shouldLog(LogTag.JFR_DCMD, LogLevel.DEBUG)) {
@@ -81,8 +80,7 @@ final class DCmdConfigure extends AbstractDCmd {
                     ", globalbuffersize=" + globalBufferSize +
                     ", thread_buffer_size=" + threadBufferSize +
                     ", memorysize=" + memorySize +
-                    ", maxchunksize=" + maxChunkSize +
-                    ", samplethreads=" + sampleThreads);
+                    ", maxchunksize=" + maxChunkSize);
         }
 
 
@@ -172,14 +170,6 @@ final class DCmdConfigure extends AbstractDCmd {
             updated = true;
         }
 
-        if (sampleThreads != null)  {
-            Options.setSampleThreads(sampleThreads);
-            Logger.log(LogTag.JFR, LogLevel.INFO, "Sample threads set to " + sampleThreads);
-            if (verbose) {
-                printSampleThreads();
-            }
-            updated = true;
-        }
         if (!verbose) {
             return new String[0];
         }
@@ -194,7 +184,6 @@ final class DCmdConfigure extends AbstractDCmd {
             printThreadBufferSize();
             printMemorySize();
             printMaxChunkSize();
-            printSampleThreads();
         }
         return getResult();
     }
@@ -209,10 +198,6 @@ final class DCmdConfigure extends AbstractDCmd {
         print("Dump path: ");
         printPath(Options.getDumpPath());
         println();
-    }
-
-    private void printSampleThreads() {
-        println("Sample threads: " + Options.getSampleThreads());
     }
 
     private void printStackDepth() {

--- a/test/jdk/jdk/jfr/jcmd/TestJcmdConfigure.java
+++ b/test/jdk/jdk/jfr/jcmd/TestJcmdConfigure.java
@@ -52,7 +52,6 @@ public class TestJcmdConfigure {
     private static final String GLOBAL_BUFFER_SIZE = "globalbuffersize";
     private static final String THREAD_BUFFER_SIZE = "thread_buffer_size";
     private static final String MAX_CHUNK_SIZE = "maxchunksize";
-    private static final String SAMPLE_THREADS = "samplethreads";
     private static final String UNSUPPORTED_OPTION = "unsupportedoption";
 
     private static final String REPOSITORYPATH_1 = "." + File.pathSeparator + "repo1";
@@ -80,8 +79,6 @@ public class TestJcmdConfigure {
         test(GLOBAL_BUFFER_SIZE, 6);
         test(THREAD_BUFFER_SIZE, 5);
         test(MAX_CHUNK_SIZE, 14 * 1000 * 1000);
-        test(SAMPLE_THREADS, false);
-        test(SAMPLE_THREADS, true);
         testNegative(UNSUPPORTED_OPTION, 100000);
         testNegative(MAX_CHUNK_SIZE, -500);
 
@@ -125,7 +122,6 @@ public class TestJcmdConfigure {
             case GLOBAL_BUFFER_SIZE: return Options.getGlobalBufferSize();
             case THREAD_BUFFER_SIZE: return Options.getThreadBufferSize();
             case MAX_CHUNK_SIZE: return Options.getMaxChunkSize();
-            case SAMPLE_THREADS: return Options.getSampleThreads();
             default: throw new RuntimeException("Unknown option " + name);
         }
     }


### PR DESCRIPTION
Hi,

Could I have a review of a removal of command line option that hasn't worked for the last five years. '

JDK 17 introduced .jfc options which allows the sampler to be disabled without a dedicated command line flag in native.

Testing: jdk/jdk/jfr + tier1 + tier2

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8259774](https://bugs.openjdk.java.net/browse/JDK-8259774): Deprecate -XX:FlightRecorderOptions:samplethreads
 * [JDK-8279650](https://bugs.openjdk.java.net/browse/JDK-8279650): Deprecate -XX:FlightRecorderOptions:samplethreads (**CSR**)


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**) ⚠️ Review applies to 9a84a97e9f718939d54aa4772d650f325870185e


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7018/head:pull/7018` \
`$ git checkout pull/7018`

Update a local copy of the PR: \
`$ git checkout pull/7018` \
`$ git pull https://git.openjdk.java.net/jdk pull/7018/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7018`

View PR using the GUI difftool: \
`$ git pr show -t 7018`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7018.diff">https://git.openjdk.java.net/jdk/pull/7018.diff</a>

</details>
