### PR TITLE
8036019: Improve alternatives listed in some errors

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -2035,7 +2035,7 @@ public class JavacParser implements Parser {
                     args.append(parseExpression());
                 }
             }
-            accept(RPAREN);
+            accept(RPAREN, tk -> Errors.Expected2(RPAREN, COMMA));
         } else {
             syntaxError(token.pos, Errors.Expected(LPAREN));
         }
@@ -2123,7 +2123,7 @@ public class JavacParser implements Parser {
                     nextToken();
                     break;
                 default:
-                    args.append(syntaxError(token.pos, Errors.Expected(GT)));
+                    args.append(syntaxError(token.pos, Errors.Expected2(GT, COMMA)));
                     break;
                 }
                 return args.toList();
@@ -3379,7 +3379,7 @@ public class JavacParser implements Parser {
                     buf.append(annotationValue());
                 }
             }
-            accept(RBRACE);
+            accept(RBRACE, tk -> Errors.AnnotationMissingElementValue);
             return toP(F.at(pos).NewArray(null, List.nil(), buf.toList()));
         default:
             selectExprMode();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -118,6 +118,9 @@ compiler.err.already.defined.static.single.import=\
 compiler.err.already.defined.this.unit=\
     {0} is already defined in this compilation unit
 
+compiler.err.annotation.missing.element.value=\
+    annotation is missing element value
+
 # 0: type, 1: list of name
 compiler.err.annotation.missing.default.value=\
     annotation @{0} is missing a default value for the element ''{1}''

--- a/test/langtools/tools/javac/T8036019.java
+++ b/test/langtools/tools/javac/T8036019.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8036019
+ * @summary Insufficient alternatives listed in some errors produced by the parser
+ * @compile/fail/ref=T8036019.out -XDrawDiagnostics T8036019.java
+ */
+
+
+public class T8036019 {
+    enum E {
+        E(String value) {  }
+    }
+
+    interface A {}
+    interface B {}
+    public class Foo<T> {
+        Foo<? extends A|B> foo1 = null;
+    }
+
+    @SuppressWarnings({,0})
+    public class AV {
+    }
+}

--- a/test/langtools/tools/javac/T8036019.out
+++ b/test/langtools/tools/javac/T8036019.out
@@ -1,0 +1,10 @@
+T8036019.java:34:17: compiler.err.expected2: ')', ','
+T8036019.java:34:23: compiler.err.expected3: ',', '}', ';'
+T8036019.java:34:25: compiler.err.enum.constant.expected
+T8036019.java:40:24: compiler.err.expected2: >, ','
+T8036019.java:40:26: compiler.err.expected: token.identifier
+T8036019.java:40:32: compiler.err.expected: token.identifier
+T8036019.java:43:25: compiler.err.annotation.missing.element.value
+T8036019.java:43:27: compiler.err.expected4: class, interface, enum, record
+T8036019.java:46:1: compiler.err.expected4: class, interface, enum, record
+9 errors

--- a/test/langtools/tools/javac/annotations/typeAnnotations/6967002/T6967002.out
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/6967002/T6967002.out
@@ -1,2 +1,2 @@
-T6967002.java:10:22: compiler.err.expected: ')'
+T6967002.java:10:22: compiler.err.expected2: ')', ','
 1 error

--- a/test/langtools/tools/javac/diags/examples/AnnotationMissingElementValue.java
+++ b/test/langtools/tools/javac/diags/examples/AnnotationMissingElementValue.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.err.annotation.missing.element.value
+
+@SuppressWarnings({,0})
+public class AV {
+}

--- a/test/langtools/tools/javac/enum/EnumMembersOrder.out
+++ b/test/langtools/tools/javac/enum/EnumMembersOrder.out
@@ -1,4 +1,4 @@
-EnumMembersOrder.java:11:16: compiler.err.expected: ')'
+EnumMembersOrder.java:11:16: compiler.err.expected2: ')', ','
 EnumMembersOrder.java:11:18: compiler.err.expected3: ',', '}', ';'
 EnumMembersOrder.java:11:20: compiler.err.enum.constant.expected
 3 errors

--- a/test/langtools/tools/javac/parser/7157165/T7157165.out
+++ b/test/langtools/tools/javac/parser/7157165/T7157165.out
@@ -1,4 +1,4 @@
-T7157165.java:11:20: compiler.err.expected: >
+T7157165.java:11:20: compiler.err.expected2: >, ','
 T7157165.java:11:22: compiler.err.expected: token.identifier
 T7157165.java:11:28: compiler.err.expected: token.identifier
 3 errors

--- a/test/langtools/tools/javac/parser/SingleCommaAnnotationValueFail.out
+++ b/test/langtools/tools/javac/parser/SingleCommaAnnotationValueFail.out
@@ -1,3 +1,3 @@
-SingleCommaAnnotationValueFail.java:11:12: compiler.err.expected: '}'
+SingleCommaAnnotationValueFail.java:11:12: compiler.err.annotation.missing.element.value
 SingleCommaAnnotationValueFail.java:11:14: compiler.err.expected4: class, interface, enum, record
 2 errors


### PR DESCRIPTION
Adjusts the corresponding "expected-" errors for `argumentOpt`,  `typeArgumentsOpt` and `annotationValue`.