### PR TITLE
8279785: JFR: 'jfr configure' should show default values

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlElement.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlElement.java
@@ -104,7 +104,7 @@ class XmlElement {
         this.content = content;
     }
 
-    public final String getContent() {
+    final String getContent() {
         return content;
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlElement.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlElement.java
@@ -104,7 +104,7 @@ class XmlElement {
         this.content = content;
     }
 
-    final String getContent() {
+    public final String getContent() {
         return content;
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlFlag.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlFlag.java
@@ -29,7 +29,7 @@ final class XmlFlag extends XmlInput {
 
     @Override
     public String getOptionSyntax() {
-        return getName() + "=<true|false>";
+        return getName() + "=<true|false>" + "  (" + getContent() + ")";
     }
 
     @Override

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlSelection.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlSelection.java
@@ -36,7 +36,15 @@ final class XmlSelection extends XmlInput {
         for (XmlOption option : getOptions()) {
             sj.add(option.getName());
         }
-        return getName() + "=" + sj.toString();
+        StringBuilder sb = new StringBuilder();
+        sb.append(getName());
+        sb.append("=");
+        sb.append(sj.toString());
+        XmlOption selected = getSelected();
+        if (selected != null) {
+            sb.append("  (").append(selected.getName()).append(")");
+        }
+        return sb.toString();
     }
 
     @Override

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlText.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlText.java
@@ -34,6 +34,14 @@ final class XmlText extends XmlInput {
         sb.append("=<");
         sb.append(getContentType().orElse("text"));
         sb.append(">");
+        sb.append("  (");
+        String content = getContent();
+        if (isTimespan()) {
+            // "20 ms" becomes "20ms"
+            content = content.replaceAll("\\s", "");
+        }
+        sb.append(content);
+        sb.append(")");
         return sb.toString();
     }
 


### PR DESCRIPTION
Hi,

Could I have a review of an enhancement that shows the default values for the 'jfr configure' command. For example,

    Options for default.jfc:

      gc=<off|normal|detailed|high|all>  (normal)

      allocation-profiling=<off|low|medium|high|maximum>  (low)

      compiler=<off|normal|detailed|all>  (normal)

      method-profiling=<off|normal|high|max>  (normal)

      thread-dump=<off|once|60s|10s|1s>  (once)

      exceptions=<off|errors|all>  (errors)

      memory-leaks=<off|types|stack-traces|gc-roots>  (types)

      locking-threshold=<timespan>  (20ms)

      file-threshold=<timespan>  (20ms)

      socket-threshold=<timespan>  (20ms)

      class-loading=<true|false>  (false)

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279785](https://bugs.openjdk.java.net/browse/JDK-8279785): JFR: 'jfr configure' should show default values


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7020/head:pull/7020` \
`$ git checkout pull/7020`

Update a local copy of the PR: \
`$ git checkout pull/7020` \
`$ git pull https://git.openjdk.java.net/jdk pull/7020/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7020`

View PR using the GUI difftool: \
`$ git pr show -t 7020`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7020.diff">https://git.openjdk.java.net/jdk/pull/7020.diff</a>

</details>
