### PR TITLE
8280010: Remove double buffering of InputStream for Properties.load

### DIFF
--- a/src/java.base/share/classes/java/security/Security.java
+++ b/src/java.base/share/classes/java/security/Security.java
@@ -91,8 +91,7 @@ public final class Security {
         if (propFile.exists()) {
             InputStream is = null;
             try {
-                FileInputStream fis = new FileInputStream(propFile);
-                is = new BufferedInputStream(fis);
+                is = new FileInputStream(propFile);
                 props.load(is);
                 loadedProps = true;
 
@@ -140,7 +139,7 @@ public final class Security {
             // now load the user-specified file so its values
             // will win if they conflict with the earlier values
             if (extraPropFile != null) {
-                BufferedInputStream bis = null;
+                InputStream is = null;
                 try {
                     URL propURL;
 
@@ -152,8 +151,8 @@ public final class Security {
                     } else {
                         propURL = new URL(extraPropFile);
                     }
-                    bis = new BufferedInputStream(propURL.openStream());
-                    props.load(bis);
+                    is = propURL.openStream();
+                    props.load(is);
                     loadedProps = true;
 
                     if (sdebug != null) {
@@ -172,9 +171,9 @@ public final class Security {
                         e.printStackTrace();
                     }
                 } finally {
-                    if (bis != null) {
+                    if (is != null) {
                         try {
-                            bis.close();
+                            is.close();
                         } catch (IOException ioe) {
                             if (sdebug != null) {
                                 sdebug.println("unable to close input stream");

--- a/src/java.base/share/classes/sun/net/NetProperties.java
+++ b/src/java.base/share/classes/sun/net/NetProperties.java
@@ -68,9 +68,8 @@ public class NetProperties {
             File f = new File(fname, "conf");
             f = new File(f, "net.properties");
             fname = f.getCanonicalPath();
-            try (FileInputStream in = new FileInputStream(fname);
-                 BufferedInputStream bin = new BufferedInputStream(in)) {
-                props.load(bin);
+            try (FileInputStream in = new FileInputStream(fname)) {
+                props.load(in);
             }
         } catch (Exception e) {
             // Do nothing. We couldn't find or access the file

--- a/src/java.base/share/classes/sun/net/www/MimeTable.java
+++ b/src/java.base/share/classes/sun/net/www/MimeTable.java
@@ -244,8 +244,8 @@ public class MimeTable implements FileNameMap {
                 throw new InternalError("default mime table not found");
         }
 
-        try (BufferedInputStream bin = new BufferedInputStream(in)) {
-            entries.load(bin);
+        try (in) {
+            entries.load(in);
         } catch (IOException e) {
             System.err.println("Warning: " + e.getMessage());
         }

--- a/src/java.desktop/share/classes/sun/print/PSPrinterJob.java
+++ b/src/java.desktop/share/classes/sun/print/PSPrinterJob.java
@@ -394,10 +394,8 @@ public class PSPrinterJob extends RasterPrinterJob {
 
                 // Load property file
                 Properties props = new Properties();
-                try (FileInputStream is = new FileInputStream(f.getPath());
-                     BufferedInputStream bis = new BufferedInputStream(is))
-                {
-                    props.load(bis);
+                try (FileInputStream in = new FileInputStream(f.getPath())) {
+                    props.load(in);
                 }
                 return props;
             } catch (Exception e){

--- a/src/java.logging/share/classes/java/util/logging/LogManager.java
+++ b/src/java.logging/share/classes/java/util/logging/LogManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1381,8 +1381,7 @@ public class LogManager {
 
         String fname = getConfigurationFileName();
         try (final InputStream in = new FileInputStream(fname)) {
-            final BufferedInputStream bin = new BufferedInputStream(in);
-            readConfiguration(bin);
+            readConfiguration(in);
         }
     }
 
@@ -1877,8 +1876,7 @@ public class LogManager {
 
         String fname = getConfigurationFileName();
         try (final InputStream in = new FileInputStream(fname)) {
-            final BufferedInputStream bin = new BufferedInputStream(in);
-            updateConfiguration(bin, mapper);
+            updateConfiguration(in, mapper);
         }
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/functions/FuncSystemProperty.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/functions/FuncSystemProperty.java
@@ -164,11 +164,8 @@ public class FuncSystemProperty extends FunctionOneArg
     try
     {
       // Use SecuritySupport class to provide privileged access to property file
-      InputStream is = SecuritySupport.getResourceAsStream(XSLT_PROPERTIES);
-
-      // get a buffered version
-      try (BufferedInputStream bis = new BufferedInputStream(is)) {
-          target.load(bis);  // and load up the property bag from this
+      try (InputStream is = SecuritySupport.getResourceAsStream(XSLT_PROPERTIES)) {
+          target.load(is);  // and load up the property bag from this
       }
     }
     catch (Exception ex)

--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/Agent.java
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/Agent.java
@@ -564,8 +564,7 @@ public class Agent {
         InputStream in = null;
         try {
             in = new FileInputStream(configFile);
-            BufferedInputStream bin = new BufferedInputStream(in);
-            p.load(bin);
+            p.load(in);
         } catch (FileNotFoundException e) {
             error(CONFIG_FILE_OPEN_FAILED, e.getMessage());
         } catch (IOException e) {

--- a/src/jdk.management.agent/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
+++ b/src/jdk.management.agent/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
@@ -692,8 +692,7 @@ public final class ConnectorBootstrap {
                 // Load the SSL keystore properties from the config file
                 Properties p = new Properties();
                 try (InputStream in = new FileInputStream(sslConfigFileName)) {
-                    BufferedInputStream bin = new BufferedInputStream(in);
-                    p.load(bin);
+                    p.load(in);
                 }
                 String keyStore =
                         p.getProperty("javax.net.ssl.keyStore");


### PR DESCRIPTION
`Properties.load` uses `java.util.Properties.LineReader`. LineReader already buffers input stream. Hence wrapping InputStream in BufferedInputStream is redundant.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280010](https://bugs.openjdk.java.net/browse/JDK-8280010): Remove double buffering of InputStream for Properties.load


### Reviewers
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7021/head:pull/7021` \
`$ git checkout pull/7021`

Update a local copy of the PR: \
`$ git checkout pull/7021` \
`$ git pull https://git.openjdk.java.net/jdk pull/7021/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7021`

View PR using the GUI difftool: \
`$ git pr show -t 7021`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7021.diff">https://git.openjdk.java.net/jdk/pull/7021.diff</a>

</details>
