### PR TITLE
8279821: JFR: Log warnings properly when loading a misconfigured .jfc file

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -240,7 +240,7 @@ final class DCmdStart extends AbstractDCmd {
             paths.add(JFC.createSafePath(setting));
         }
         try {
-            JFCModel model = new JFCModel(paths);
+            JFCModel model = new JFCModel(paths, l -> logWarning(l));
             Set<String> jfcOptions = new HashSet<>();
             for (XmlInput input : model.getInputs()) {
                 jfcOptions.add(input.getName());

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Configure.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Configure.java
@@ -127,7 +127,7 @@ final class Configure extends Command {
     }
 
     private void displayParameters(PrintStream stream, SafePath path, String name) throws ParseException, IOException {
-        JFCModel parameters = new JFCModel(path);
+        JFCModel parameters = new JFCModel(path, l -> stream.println("Warning! " + l));
         stream.println();
         stream.println("Options for " + name + ":");
         stream.println();
@@ -195,7 +195,7 @@ final class Configure extends Command {
                 output = new SafePath(Path.of("custom.jfc"));
             }
             UserInterface ui = new UserInterface();
-            JFCModel model = new JFCModel(inputFiles);
+            JFCModel model = new JFCModel(inputFiles, l -> ui.println("Warning! " + l));
             model.setLabel("Custom");
             if (log) {
                 SettingsLog.enable();


### PR DESCRIPTION
Hi,
Could I have a review of a fix that redirects a log warning from standard out to unified logging and dcmd output. For details, see bug.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279821](https://bugs.openjdk.java.net/browse/JDK-8279821): JFR: Log warnings properly when loading a misconfigured .jfc file


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7024/head:pull/7024` \
`$ git checkout pull/7024`

Update a local copy of the PR: \
`$ git checkout pull/7024` \
`$ git pull https://git.openjdk.java.net/jdk pull/7024/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7024`

View PR using the GUI difftool: \
`$ git pr show -t 7024`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7024.diff">https://git.openjdk.java.net/jdk/pull/7024.diff</a>

</details>
