### PR TITLE
8279833: Loop optimization issue in String.encodeUTF8_UTF16

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -1285,11 +1285,11 @@ public final class String
         int sl = val.length >> 1;
         byte[] dst = new byte[sl * 3];
         while (sp < sl) {
+            // ascii fast loop;
             char c = StringUTF16.getChar(val, sp);
             if (c >= '\u0080') {
                 break;
             }
-            // ascii fast loop;
             dst[dp++] = (byte)c;
             sp++;
         }

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -1284,14 +1284,17 @@ public final class String
         int sp = 0;
         int sl = val.length >> 1;
         byte[] dst = new byte[sl * 3];
-        char c;
-        while (sp < sl && (c = StringUTF16.getChar(val, sp)) < '\u0080') {
+        while (sp < sl) {
+            char c = StringUTF16.getChar(val, sp);
+            if (c >= '\u0080') {
+                break;
+            }
             // ascii fast loop;
             dst[dp++] = (byte)c;
             sp++;
         }
         while (sp < sl) {
-            c = StringUTF16.getChar(val, sp++);
+            char c = StringUTF16.getChar(val, sp++);
             if (c < 0x80) {
                 dst[dp++] = (byte)c;
             } else if (c < 0x800) {

--- a/test/micro/org/openjdk/bench/java/lang/StringEncode.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringEncode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/lang/StringEncode.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringEncode.java
@@ -94,7 +94,7 @@ public class StringEncode {
     }
 
     @Benchmark
-    public byte[] encodeAsciiCharsetName(Blackhole bh) throws Exception {
+    public byte[] encodeAsciiCharsetName() throws Exception {
         return asciiString.getBytes(charset);
     }
 
@@ -110,17 +110,17 @@ public class StringEncode {
     }
 
     @Benchmark
-    public byte[] encodeUTF16LongEnd(Blackhole bh) throws Exception {
+    public byte[] encodeUTF16LongEnd() throws Exception {
         return longUtf16String.getBytes(charset);
     }
 
     @Benchmark
-    public byte[] encodeUTF16LongStart(Blackhole bh) throws Exception {
+    public byte[] encodeUTF16LongStart() throws Exception {
         return longUtf16StartString.getBytes(charset);
     }
 
     @Benchmark
-    public byte[] encodeUTF16(Blackhole bh) throws Exception {
+    public byte[] encodeUTF16() throws Exception {
         return utf16String.getBytes(charset);
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/StringEncode.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringEncode.java
@@ -30,59 +30,97 @@ import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgs = "-Xmx1g")
+@Fork(value = 3)
 @Warmup(iterations = 5, time = 2)
 @Measurement(iterations = 5, time = 3)
 @State(Scope.Thread)
 public class StringEncode {
 
-    @BenchmarkMode(Mode.AverageTime)
-    @OutputTimeUnit(TimeUnit.NANOSECONDS)
-    @Fork(value = 3, jvmArgs = "-Xmx1g")
-    @Warmup(iterations = 5, time = 2)
-    @Measurement(iterations = 5, time = 2)
-    @State(Scope.Thread)
-    public static class WithCharset {
-
-        @Param({"US-ASCII", "ISO-8859-1", "UTF-8", "MS932", "ISO-8859-6"})
-        private String charsetName;
-
-        private Charset charset;
-        private String asciiString;
-        private String utf16String;
-
-        @Setup
-        public void setup() {
-            charset = Charset.forName(charsetName);
-            asciiString = "ascii string";
-            utf16String = "UTF-\uFF11\uFF16 string";
-        }
-
-        @Benchmark
-        public void encodeCharsetName(Blackhole bh) throws Exception {
-            bh.consume(asciiString.getBytes(charsetName));
-            bh.consume(utf16String.getBytes(charsetName));
-        }
-
-        @Benchmark
-        public void encodeCharset(Blackhole bh) throws Exception {
-            bh.consume(asciiString.getBytes(charset));
-            bh.consume(utf16String.getBytes(charset));
-        }
-    }
-
-    private String asciiDefaultString;
-    private String utf16DefaultString;
+    @Param({"US-ASCII", "ISO-8859-1", "UTF-8", "MS932", "ISO-8859-6"})
+    private String charsetName;
+    private Charset charset;
+    private String asciiString;
+    private String utf16String;
+    private String longUtf16String;
+    private String longUtf16StartString;
 
     @Setup
     public void setup() {
-        asciiDefaultString = "ascii string";
-        utf16DefaultString = "UTF-\uFF11\uFF16 string";
+        charset = Charset.forName(charsetName);
+        asciiString = "ascii string";
+        utf16String = "UTF-\uFF11\uFF16 string";
+        longUtf16String = """
+                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ac sem eu
+                 urna egestas placerat. Etiam finibus ipsum nulla, non mattis dolor cursus a.
+                 Nulla nec nisl consectetur, lacinia neque id, accumsan ante. Curabitur et
+                 sapien in magna porta ultricies. Sed vel pellentesque nibh. Pellentesque dictum
+                 dignissim diam eu ultricies. Class aptent taciti sociosqu ad litora torquent
+                 per conubia nostra, per inceptos himenaeos. Suspendisse erat diam, fringilla
+                 sed massa sed, posuere viverra orci. Suspendisse tempor libero non gravida
+                 efficitur. Vivamus lacinia risus non orci viverra, at consectetur odio laoreet.
+                 Suspendisse potenti.
+
+                 Phasellus vel nisi iaculis, accumsan quam sed, bibendum eros. Sed venenatis
+                 nulla tortor, et eleifend urna sodales id. Nullam tempus ac metus sit amet
+                 sollicitudin. Nam sed ex diam. Praesent vitae eros et neque condimentum
+                 consectetur eget non tortor. Praesent bibendum vel felis nec dignissim.
+                 Maecenas a enim diam. Suspendisse quis ligula at nisi accumsan lacinia id
+                 hendrerit sapien. Donec aliquam mattis lectus eu ultrices. Duis eu nisl
+                 euismod, blandit mauris vel, placerat urna. Etiam malesuada enim purus,
+                 tristique mollis odio blandit quis. Vivamus posuere.
+                 \uFF11
+                """;
+        longUtf16StartString = """
+                 \uFF11
+                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ac sem eu
+                 urna egestas placerat. Etiam finibus ipsum nulla, non mattis dolor cursus a.
+                 Nulla nec nisl consectetur, lacinia neque id, accumsan ante. Curabitur et
+                 sapien in magna porta ultricies. Sed vel pellentesque nibh. Pellentesque dictum
+                 dignissim diam eu ultricies. Class aptent taciti sociosqu ad litora torquent
+                 per conubia nostra, per inceptos himenaeos. Suspendisse erat diam, fringilla
+                 sed massa sed, posuere viverra orci. Suspendisse tempor libero non gravida
+                 efficitur. Vivamus lacinia risus non orci viverra, at consectetur odio laoreet.
+                 Suspendisse potenti.
+
+                 Phasellus vel nisi iaculis, accumsan quam sed, bibendum eros. Sed venenatis
+                 nulla tortor, et eleifend urna sodales id. Nullam tempus ac metus sit amet
+                 sollicitudin. Nam sed ex diam. Praesent vitae eros et neque condimentum
+                 consectetur eget non tortor. Praesent bibendum vel felis nec dignissim.
+                 Maecenas a enim diam. Suspendisse quis ligula at nisi accumsan lacinia id
+                 hendrerit sapien. Donec aliquam mattis lectus eu ultrices. Duis eu nisl
+                 euismod, blandit mauris vel, placerat urna. Etiam malesuada enim purus,
+                 tristique mollis odio blandit quis. Vivamus posuere.
+                """;
     }
 
     @Benchmark
-    public void encodeDefault(Blackhole bh) throws Exception {
-        bh.consume(asciiDefaultString.getBytes());
-        bh.consume(utf16DefaultString.getBytes());
+    public byte[] encodeAsciiCharsetName(Blackhole bh) throws Exception {
+        return asciiString.getBytes(charset);
+    }
+
+    @Benchmark
+    public byte[] encodeAscii() throws Exception {
+        return asciiString.getBytes(charset);
+    }
+
+    @Benchmark
+    public void encodeMix(Blackhole bh) throws Exception {
+        bh.consume(asciiString.getBytes(charset));
+        bh.consume(utf16String.getBytes(charset));
+    }
+
+    @Benchmark
+    public byte[] encodeUTF16LongEnd(Blackhole bh) throws Exception {
+        return longUtf16String.getBytes(charset);
+    }
+
+    @Benchmark
+    public byte[] encodeUTF16LongStart(Blackhole bh) throws Exception {
+        return longUtf16StartString.getBytes(charset);
+    }
+
+    @Benchmark
+    public byte[] encodeUTF16(Blackhole bh) throws Exception {
+        return utf16String.getBytes(charset);
     }
 }


### PR DESCRIPTION
In `String.encodeUTF8_UTF16`, making the `char c` local to each loop helps the performance of the method by helping C2 optimize each individual loop better.

Results on the updated micros:
19-b04:
```
Benchmark                          (charsetName)  Mode  Cnt     Score     Error  Units
StringEncode.encodeUTF16                   UTF-8  avgt   15   164.457 ±   7.296  ns/op
StringEncode.encodeUTF16LongEnd            UTF-8  avgt   15  2294.160 ±  40.580  ns/op
StringEncode.encodeUTF16LongStart          UTF-8  avgt   15  9128.698 ± 124.636  ns/op
```

Patch:
```
Benchmark                          (charsetName)  Mode  Cnt     Score    Error  Units
StringEncode.encodeUTF16                   UTF-8  avgt   15   131.296 ±  6.693  ns/op
StringEncode.encodeUTF16LongEnd            UTF-8  avgt   15  2282.750 ± 46.891  ns/op
StringEncode.encodeUTF16LongStart          UTF-8  avgt   15  4786.965 ± 64.896  ns/op
```

Going back this seem to have been an issue since this method was introduced with JEP 254 in JDK 9:

8u311:
```
Benchmark                          (charsetName)  Mode  Cnt     Score     Error  Units
StringEncode.encodeUTF16                   UTF-8  avgt   15   194.057 ±   3.913  ns/op
StringEncode.encodeUTF16LongEnd            UTF-8  avgt   15  3024.860 ±  88.386  ns/op
StringEncode.encodeUTF16LongStart          UTF-8  avgt   15  5282.849 ± 247.230  ns/op
```
9:
```
Benchmark                          (charsetName)  Mode  Cnt      Score     Error  Units
StringEncode.encodeUTF16                   UTF-8  avgt   15    148.481 ±   9.374  ns/op
StringEncode.encodeUTF16LongEnd            UTF-8  avgt   15   2832.754 ± 263.372  ns/op
StringEncode.encodeUTF16LongStart          UTF-8  avgt   15  10447.115 ± 408.338  ns/op
```

(Interestingly JDK 9 seem faster on some of the micros than later iterations, while slower on others. The main issue is the slow non-ASCII loop, where the patch speeds things up ~2x. With the patch we're significantly faster than both JDK 8 and 9 on all measures.)

There's a JIT compiler bug hiding in plain sight here where the potentially uninitialized local `char c` appears to mess up optimization of the second loop. I'll file a separate bug for this (a standalone reproducer should be straightforward to produce). I think this patch is reasonable to put back into the JDK while we investigate if/how C2 can better handle this kind of condition. It might also be easier to backport, depending on whether the C2 fix is trivial or not.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279833](https://bugs.openjdk.java.net/browse/JDK-8279833): Loop optimization issue in String.encodeUTF8_UTF16


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to 70d0c5c6e04622f8e806debae650c704a1d24d5e
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7026/head:pull/7026` \
`$ git checkout pull/7026`

Update a local copy of the PR: \
`$ git checkout pull/7026` \
`$ git pull https://git.openjdk.java.net/jdk pull/7026/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7026`

View PR using the GUI difftool: \
`$ git pr show -t 7026`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7026.diff">https://git.openjdk.java.net/jdk/pull/7026.diff</a>

</details>
