### PR TITLE
8279315: Add Git support to update_copyright_year.sh script

### DIFF
--- a/make/scripts/update_copyright_year.sh
+++ b/make/scripts/update_copyright_year.sh
@@ -39,6 +39,10 @@ set -e
 # To allow total changes counting
 shopt -s lastpipe
 
+# Get an absolute path to this script, since that determines the top-level directory.
+this_script_dir=`dirname $0`
+this_script_dir=`cd $this_script_dir > /dev/null && pwd`
+
 # Temp area
 tmp=/tmp/`basename $0`.${USER}.$$
 rm -f -r ${tmp}
@@ -58,7 +62,26 @@ else
 fi
 
 # VCS select
-case "$1" in
+vcs="$1"
+
+if [ -z "$vcs" ] ; then
+  git_found=false
+  hg_found=false
+
+  [ -d "${this_script_dir}/../../.git" ] && git_found=true
+  [ -d "${this_script_dir}/../../.hg" ] && hg_found=true
+
+  if [ "$git_found" == "true" ] && [ "$hg_found" == "false" ] ; then
+    vcs="git"
+  elif [ "$hg_found" == "true" ] && [ "$git_found" == "false" ] ; then
+    vcs="hg"
+  else
+    echo "Error: could not auto-detect version control system"
+    vcs=""
+  fi
+fi
+
+case "$vcs" in
   "git")
     echo "Using Git version control system"
     vcs_status=(git ls-files -m)

--- a/make/scripts/update_copyright_year.sh
+++ b/make/scripts/update_copyright_year.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -f
 
 #
-# Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -23,13 +23,21 @@
 # questions.
 #
 
-# Script to update the Copyright YEAR range in Mercurial sources.
+# Script to update the Copyright YEAR range in Mercurial & Git sources.
 #  (Originally from xdono, Thanks!)
 
-awk=awk
+#------------------------------------------------------------
+copyright="Copyright (c)"
+company="Oracle"
+#------------------------------------------------------------
+
+awk="awk"
 
 # Stop on any error
 set -e
+
+# To allow total changes counting
+shopt -s lastpipe
 
 # Temp area
 tmp=/tmp/`basename $0`.${USER}.$$
@@ -37,12 +45,41 @@ rm -f -r ${tmp}
 mkdir -p ${tmp}
 total=0
 
+# Default or supplied company name
+if [ "$3" != "" ] ; then
+  company="$3"
+fi
+
 # This year or supplied year
-if [ "$1" != "" ] ; then
-  year="$1"
+if [ "$2" != "" ] ; then
+  year="$2"
 else
   year=`date +%Y`
 fi
+
+# VCS select
+case "$1" in
+  "git")
+    echo "Using Git version control system"
+    vcs_status=(git ls-files -m)
+    vcs_list_changesets=(git log --no-merges --since="${year}-01-01T00:00:00Z" --until="${year}-12-31T23:59:59Z" --pretty=tformat:"%H")
+    vcs_changeset_message=(git log -1 --pretty=tformat:"%B") # followed by ${changeset}
+    vcs_changeset_files=(git diff-tree --no-commit-id --name-only -r) # followed by ${changeset}
+    ;;
+
+  "hg")
+    echo "Using Mercurial version control system"
+    vcs_status=(hg status)
+    vcs_list_changesets=(hg log --no-merges -v -d "${year}-01-01 to ${year}-12-31" --template '{node}\n')
+    vcs_changeset_message=(hg log -l1 --template '{desc}\n' --rev) # followed by ${changeset}
+    vcs_changeset_files=(hg log -l1 -v --template '{files}\n' --rev) # followed by ${changeset}
+    ;;
+
+  *)
+    echo "Usage: `basename "$0"` <git|hg> [year [company]]"
+    exit 1
+    ;;
+esac
 
 # Return true if it makes sense to edit this file
 saneFileToCheck()
@@ -68,8 +105,6 @@ updateFile() # file
 {
   changed="false"
   if [ `saneFileToCheck "$1"` = "true" ] ; then
-    copyright="Copyright (c)"
-    company="Oracle"
     rm -f $1.OLD
     mv $1 $1.OLD
     cat $1.OLD | \
@@ -94,12 +129,10 @@ updateChangesetFiles() # changeset
   count=0
   files=${tmp}/files.$1
   rm -f ${files}
-  hg log -l1 --rev $1 -v --template '{files}\n' | expand \
+  "${vcs_changeset_files[@]}" "$1" | expand \
     | ${awk} -F' ' '{for(i=1;i<=NF;i++)print $i}' \
     > ${files}
   if [ -f "${files}" -a -s "${files}" ] ; then
-    copyright="Copyright (c)"
-    company="Oracle"
     fcount=`cat ${files}| wc -l`
     for i in `cat ${files}` ; do
       if [ `updateFile "${i}"` = "true" ] ; then
@@ -116,8 +149,8 @@ updateChangesetFiles() # changeset
     printf "  ERROR: No files changed in the changeset? Must be a mistake.\n"
     set -x
     ls -al ${files}
-    hg log -l1 --rev $1 -v --template '{files}\n'
-    hg log -l1 --rev $1 -v --template '{files}\n' | expand \
+    "${vcs_changeset_files[@]}" "$1"
+    "${vcs_changeset_files[@]}" "$1" | expand \
       | ${awk} -F' ' '{for(i=1;i<=NF;i++)print $i}'
     set +x
     exit 1
@@ -126,16 +159,16 @@ updateChangesetFiles() # changeset
 }
 
 # Check if repository is clean
-previous=`hg status|wc -l`
+previous=`"${vcs_status[@]}"|wc -l`
 if [ ${previous} -ne 0 ] ; then
   echo "WARNING: This repository contains previously edited working set files."
-  echo "  hg status | wc -l = `hg status | wc -l`"
+  echo "  ${vcs_status[*]} | wc -l = `"${vcs_status[@]}" | wc -l`"
 fi
 
 # Get all changesets this year
 all_changesets=${tmp}/all_changesets
 rm -f ${all_changesets}
-hg log --no-merges -v -d "${year}-01-01 to ${year}-12-31" --template '{node}\n' > ${all_changesets}
+"${vcs_list_changesets[@]}" > ${all_changesets}
 
 # Check changeset to see if it is Copyright only changes, filter changesets
 if [ -s ${all_changesets} ] ; then
@@ -146,7 +179,7 @@ if [ -s ${all_changesets} ] ; then
     desc=${tmp}/desc.${changeset}
     rm -f ${desc}
     echo "------------------------------------------------"
-    hg log -l1 --rev ${changeset} --template '{desc}\n' > ${desc}
+    "${vcs_changeset_message[@]}" "${changeset}" > ${desc}
     printf "%d: %s\n%s\n" ${index} "${changeset}" "`cat ${desc}|head -1`"
     if [ "${year}" = "2010" ] ; then
       if cat ${desc} | fgrep -i "Added tag" > /dev/null ; then
@@ -175,18 +208,18 @@ if [ ${total} -gt 0 ] ; then
    echo "---------------------------------------------"
    echo "Updated the copyright year on a total of ${total} files."
    if [ ${previous} -eq 0 ] ; then
-     echo "This count should match the count of modified files in the repository: hg status -m"
+     echo "This count should match the count of modified files in the repository: ${vcs_status[*]}"
    else
      echo "WARNING: This repository contained previously edited working set files."
    fi
-   echo "  hg status -m | wc -l = `hg status -m | wc -l`"
+   echo "  ${vcs_status[*]} | wc -l = `"${vcs_status[@]}" | wc -l`"
 else
    echo "---------------------------------------------"
    echo "No files were changed"
    if [ ${previous} -ne 0 ] ; then
      echo "WARNING: This repository contained previously edited working set files."
    fi
-   echo "  hg status -m | wc -l = `hg status -m | wc -l`"
+   echo "  ${vcs_status[*]} | wc -l = `"${vcs_status[@]}" | wc -l`"
 fi
 
 # Cleanup


### PR DESCRIPTION
Modified the `make/scripts/update_copyright_year.sh` script to support Git as well as Mercurial, as per [JDK-8279315](https://bugs.openjdk.java.net/browse/JDK-8279315). Also added the ability to specify company name as a command line argument instead of being hard-coded into the script.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279315](https://bugs.openjdk.java.net/browse/JDK-8279315): Add Git support to update_copyright_year.sh script


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7027/head:pull/7027` \
`$ git checkout pull/7027`

Update a local copy of the PR: \
`$ git checkout pull/7027` \
`$ git pull https://git.openjdk.java.net/jdk pull/7027/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7027`

View PR using the GUI difftool: \
`$ git pr show -t 7027`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7027.diff">https://git.openjdk.java.net/jdk/pull/7027.diff</a>

</details>
