### PR TITLE
8279856: Parallel: Use PreservedMarks to record promotion-failed objects

### DIFF
--- a/src/hotspot/share/gc/parallel/psPromotionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.cpp
@@ -360,6 +360,9 @@ oop PSPromotionManager::oop_promotion_failed(oop obj, markWord obj_mark) {
 
     push_contents(obj);
 
+    // Save the markWord of promotion-failed objs in _preserved_marks for later
+    // restoration. This way we don't have to walk the young-gen to locate
+    // these promotion-failed objs.
     _preserved_marks->push_always(obj, obj_mark);
   }  else {
     // We lost, someone else "owns" this object

--- a/src/hotspot/share/gc/parallel/psPromotionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.cpp
@@ -360,7 +360,7 @@ oop PSPromotionManager::oop_promotion_failed(oop obj, markWord obj_mark) {
 
     push_contents(obj);
 
-    _preserved_marks->push_if_necessary(obj, obj_mark);
+    _preserved_marks->push_always(obj, obj_mark);
   }  else {
     // We lost, someone else "owns" this object
     guarantee(obj->is_forwarded(), "Object must be forwarded if the cas failed.");

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -697,16 +697,11 @@ bool PSScavenge::invoke_no_policy() {
   return !promotion_failure_occurred;
 }
 
-// This method iterates over all objects in the young generation,
-// removing all forwarding references. It then restores any preserved marks.
 void PSScavenge::clean_up_failed_promotion() {
-  ParallelScavengeHeap* heap = ParallelScavengeHeap::heap();
-  PSYoungGen* young_gen = heap->young_gen();
-
   PSPromotionManager::restore_preserved_marks();
 
   // Reset the PromotionFailureALot counters.
-  NOT_PRODUCT(heap->reset_promotion_should_fail();)
+  NOT_PRODUCT(ParallelScavengeHeap::heap()->reset_promotion_should_fail();)
 }
 
 bool PSScavenge::should_attempt_scavenge() {

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -703,9 +703,6 @@ void PSScavenge::clean_up_failed_promotion() {
   ParallelScavengeHeap* heap = ParallelScavengeHeap::heap();
   PSYoungGen* young_gen = heap->young_gen();
 
-  RemoveForwardedPointerClosure remove_fwd_ptr_closure;
-  young_gen->object_iterate(&remove_fwd_ptr_closure);
-
   PSPromotionManager::restore_preserved_marks();
 
   // Reset the PromotionFailureALot counters.

--- a/src/hotspot/share/gc/shared/preservedMarks.cpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.cpp
@@ -125,8 +125,10 @@ public:
 
   ~RestorePreservedMarksTask() {
     assert(_total_size == _total_size_before, "total_size = %zu before = %zu", _total_size, _total_size_before);
-
-    log_trace(gc)("Restored %zu marks", _total_size);
+    size_t mem_size = _total_size * (sizeof(oop) + sizeof(markWord));
+    log_trace(gc)("Restored %zu marks, occupying %zu %s", _total_size,
+                                                          byte_size_in_proper_unit(mem_size),
+                                                          proper_unit_for_byte_size(mem_size));
   }
 };
 

--- a/src/hotspot/share/gc/shared/preservedMarks.hpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.hpp
@@ -57,6 +57,7 @@ private:
 public:
   size_t size() const { return _stack.size(); }
   inline void push_if_necessary(oop obj, markWord m);
+  inline void push_always(oop obj, markWord m);
   // Iterate over the stack, restore all preserved marks, and
   // reclaim the memory taken up by the stack segments.
   void restore();

--- a/src/hotspot/share/gc/shared/preservedMarks.inline.hpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.inline.hpp
@@ -42,6 +42,12 @@ inline void PreservedMarks::push_if_necessary(oop obj, markWord m) {
   }
 }
 
+inline void PreservedMarks::push_always(oop obj, markWord m) {
+  assert(!m.is_marked(), "precondition");
+  OopAndMarkWord elem(obj, m);
+  _stack.push(elem);
+}
+
 inline void PreservedMarks::init_forwarded_mark(oop obj) {
   obj->init_mark();
 }


### PR DESCRIPTION
Simple change of using `PreservedMarks` to skip young-gen walking in finding promotion-failed objs.

Test: tier1-6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279856](https://bugs.openjdk.java.net/browse/JDK-8279856): Parallel: Use PreservedMarks to record promotion-failed objects


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7028/head:pull/7028` \
`$ git checkout pull/7028`

Update a local copy of the PR: \
`$ git checkout pull/7028` \
`$ git pull https://git.openjdk.java.net/jdk pull/7028/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7028`

View PR using the GUI difftool: \
`$ git pr show -t 7028`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7028.diff">https://git.openjdk.java.net/jdk/pull/7028.diff</a>

</details>
