### PR TITLE
8279795: Fix typo in BasicFileChooserUI: Constucts -> Constructs

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicFileChooserUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicFileChooserUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,21 +25,57 @@
 
 package javax.swing.plaf.basic;
 
-import javax.swing.*;
-import javax.swing.filechooser.*;
-import javax.swing.filechooser.FileFilter;
-import javax.swing.event.*;
-import javax.swing.plaf.*;
-import java.awt.*;
-import java.awt.event.*;
-import java.awt.datatransfer.*;
-import java.beans.*;
-import java.io.*;
-import java.util.*;
+import java.awt.BorderLayout;
+import java.awt.Toolkit;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.event.ActionEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.beans.PropertyChangeListener;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Hashtable;
 import java.util.List;
-import java.util.regex.*;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.ActionMap;
+import javax.swing.Icon;
+import javax.swing.InputMap;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JFileChooser;
+import javax.swing.JList;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JTable;
+import javax.swing.LookAndFeel;
+import javax.swing.SwingUtilities;
+import javax.swing.TransferHandler;
+import javax.swing.UIDefaults;
+import javax.swing.UIManager;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
+import javax.swing.filechooser.FileFilter;
+import javax.swing.filechooser.FileSystemView;
+import javax.swing.filechooser.FileView;
+import javax.swing.plaf.ActionMapUIResource;
+import javax.swing.plaf.ComponentUI;
+import javax.swing.plaf.FileChooserUI;
+import javax.swing.plaf.UIResource;
+
 import sun.awt.shell.ShellFolder;
-import sun.swing.*;
+import sun.swing.DefaultLookup;
+import sun.swing.FilePane;
+import sun.swing.SwingUtilities2;
+import sun.swing.UIAction;
 
 /**
  * Basic L&amp;F implementation of a FileChooser.
@@ -723,11 +759,12 @@ public class BasicFileChooserUI extends FileChooserUI {
         // new functionality add it to the Handler, but make sure this
         // class calls into the Handler.
         Handler handler;
+
         /**
-         * Constucts a {@code DoubleClickListener}.
-         * @param list the lsit
+         * Constructs a {@code DoubleClickListener}.
+         * @param list the list
          */
-        public  DoubleClickListener(JList<?> list) {
+        public DoubleClickListener(JList<?> list) {
             handler = new Handler(list);
         }
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicFileChooserUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicFileChooserUI.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.ActionMap;


### PR DESCRIPTION
Fix the typo in the constructor for BasicFileChooserUI.DoubleClickListener: ‘Constucts’ → ‘Constructs’.
Also fixed the typo in the parameter of the constructor: ‘the lsit’ → ‘the list’.

I also organised the imports which replaced all wildcard imports with specific class imports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279795](https://bugs.openjdk.java.net/browse/JDK-8279795): Fix typo in BasicFileChooserUI: Constucts -> Constructs


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7030/head:pull/7030` \
`$ git checkout pull/7030`

Update a local copy of the PR: \
`$ git checkout pull/7030` \
`$ git pull https://git.openjdk.java.net/jdk pull/7030/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7030`

View PR using the GUI difftool: \
`$ git pr show -t 7030`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7030.diff">https://git.openjdk.java.net/jdk/pull/7030.diff</a>

</details>
