### PR TITLE
8279798: Javadoc for BasicTabbedPaneUI is inconsistent

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTabbedPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTabbedPaneUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,21 +25,59 @@
 
 package javax.swing.plaf.basic;
 
-import sun.swing.SwingUtilities2;
-
-import javax.swing.*;
-import javax.swing.event.*;
-import javax.swing.plaf.*;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Insets;
+import java.awt.LayoutManager;
+import java.awt.Point;
+import java.awt.Polygon;
+import java.awt.Rectangle;
+import java.awt.Shape;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.ContainerEvent;
+import java.awt.event.ContainerListener;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.MouseMotionListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.Hashtable;
+import java.util.Vector;
+import javax.swing.Action;
+import javax.swing.ActionMap;
+import javax.swing.Icon;
+import javax.swing.InputMap;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import javax.swing.JTabbedPane;
+import javax.swing.JViewport;
+import javax.swing.KeyStroke;
+import javax.swing.LookAndFeel;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.plaf.ComponentInputMapUIResource;
+import javax.swing.plaf.ComponentUI;
+import javax.swing.plaf.TabbedPaneUI;
+import javax.swing.plaf.UIResource;
 import javax.swing.text.View;
 
-import java.awt.*;
-import java.awt.event.*;
-import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeEvent;
-import java.util.Vector;
-import java.util.Hashtable;
-
 import sun.swing.DefaultLookup;
+import sun.swing.SwingUtilities2;
 import sun.swing.UIAction;
 
 /**
@@ -216,7 +254,7 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
     public BasicTabbedPaneUI() {}
 
     /**
-     * Create a UI.
+     * Creates a UI.
      * @param c a component
      * @return a UI
      */
@@ -386,7 +424,7 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
     }
 
     /**
-     * Install the defaults.
+     * Installs the defaults.
      */
     protected void installDefaults() {
         LookAndFeel.installColorsAndFont(tabPane, "TabbedPane.background",
@@ -423,7 +461,7 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
     }
 
     /**
-     * Uninstall the defaults.
+     * Uninstalls the defaults.
      */
     protected void uninstallDefaults() {
         highlight = null;
@@ -438,7 +476,7 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
     }
 
     /**
-     * Install the listeners.
+     * Installs the listeners.
      */
     protected void installListeners() {
         if ((propertyChangeListener = createPropertyChangeListener()) != null) {
@@ -461,7 +499,7 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
     }
 
     /**
-     * Uninstall the listeners.
+     * Uninstalls the listeners.
      */
     protected void uninstallListeners() {
         if (mouseListener != null) {
@@ -1090,9 +1128,9 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
     }
 
     /**
-     * Laysout a label.
+     * Lays out a label.
      * @param tabPlacement the tab placement
-     * @param metrics the font metric
+     * @param metrics the font metrics
      * @param tabIndex the tab index
      * @param title the title
      * @param icon the icon
@@ -1839,7 +1877,7 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
     }
 
     /**
-     * Assure the rectangles are created.
+     * Assures the rectangles are created.
      * @param tabCount the tab count
      */
     protected void assureRectsCreated(int tabCount) {
@@ -2144,7 +2182,7 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
 // Tab Navigation methods
 
     /**
-     * Navigate the selected tab.
+     * Navigates the selected tab.
      * @param direction the direction
      */
     protected void navigateSelectedTab(int direction) {
@@ -2226,7 +2264,7 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
     }
 
     /**
-     * Select the next tab in the run.
+     * Selects the next tab in the run.
      * @param current the current tab
      */
     protected void selectNextTabInRun(int current) {
@@ -2240,7 +2278,7 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
     }
 
     /**
-     * Select the previous tab in the run.
+     * Selects the previous tab in the run.
      * @param current the current tab
      */
     protected void selectPreviousTabInRun(int current) {
@@ -2254,7 +2292,7 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
     }
 
     /**
-     * Select the next tab.
+     * Selects the next tab.
      * @param current the current tab
      */
     protected void selectNextTab(int current) {
@@ -2267,7 +2305,7 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
     }
 
     /**
-     * Select the previous tab.
+     * Selects the previous tab.
      * @param current the current tab
      */
     protected void selectPreviousTab(int current) {
@@ -2772,7 +2810,7 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
          * Returns the preferred tab area width.
          * @param tabPlacement the tab placement
          * @param height the height
-         * @return the preferred tab area widty
+         * @return the preferred tab area width
          */
         protected int preferredTabAreaWidth(int tabPlacement, int height) {
             FontMetrics metrics = getFontMetrics();

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTabbedPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTabbedPaneUI.java
@@ -1877,7 +1877,7 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
     }
 
     /**
-     * Assures the rectangles are created.
+     * Assure the rectangles are created.
      * @param tabCount the tab count
      */
     protected void assureRectsCreated(int tabCount) {

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTabbedPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTabbedPaneUI.java
@@ -54,6 +54,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.Hashtable;
 import java.util.Vector;
+
 import javax.swing.Action;
 import javax.swing.ActionMap;
 import javax.swing.Icon;


### PR DESCRIPTION
A number of methods in BasicTabbedPaneUI uses the imperative form of the verb in the documentation instead of the third-person form which describes what the method does.

For consistency, I updated such descriptions to use the third-person form of the verb.

I fixed a couple of typos as well.

I also expanded all the wildcard imports into the specific ones.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279798](https://bugs.openjdk.java.net/browse/JDK-8279798): Javadoc for BasicTabbedPaneUI is inconsistent


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7031/head:pull/7031` \
`$ git checkout pull/7031`

Update a local copy of the PR: \
`$ git checkout pull/7031` \
`$ git pull https://git.openjdk.java.net/jdk pull/7031/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7031`

View PR using the GUI difftool: \
`$ git pr show -t 7031`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7031.diff">https://git.openjdk.java.net/jdk/pull/7031.diff</a>

</details>
