### PR TITLE
8279794: Fix typos in BasicScrollBarUI: Laysouts a vertical scroll bar

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollBarUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollBarUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,17 +25,45 @@
 package javax.swing.plaf.basic;
 
 
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Insets;
+import java.awt.LayoutManager;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseMotionListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import javax.swing.BoundedRangeModel;
+import javax.swing.InputMap;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JList;
+import javax.swing.JScrollBar;
+import javax.swing.JScrollPane;
+import javax.swing.JViewport;
+import javax.swing.LookAndFeel;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+import javax.swing.Timer;
+import javax.swing.UIManager;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.plaf.ComponentUI;
+import javax.swing.plaf.ScrollBarUI;
+import javax.swing.plaf.UIResource;
+
 import sun.swing.DefaultLookup;
 import sun.swing.UIAction;
-
-import java.awt.*;
-import java.awt.event.*;
-
-import java.beans.*;
-
-import javax.swing.*;
-import javax.swing.event.*;
-import javax.swing.plaf.*;
 
 import static sun.swing.SwingUtilities2.drawHLine;
 import static sun.swing.SwingUtilities2.drawRect;
@@ -754,7 +782,7 @@ public class BasicScrollBarUI
     }
 
     /**
-     * Laysouts a  vertical scroll bar.
+     * Lays out a vertical scroll bar.
      * @param sb the scroll bar
      */
     protected void layoutVScrollbar(JScrollBar sb)
@@ -856,7 +884,7 @@ public class BasicScrollBarUI
     }
 
     /**
-     * Laysouts a  vertical scroll bar.
+     * Lays out a horizontal scroll bar.
      * @param sb the scroll bar
      */
     protected void layoutHScrollbar(JScrollBar sb)

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollBarUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollBarUI.java
@@ -43,6 +43,7 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+
 import javax.swing.BoundedRangeModel;
 import javax.swing.InputMap;
 import javax.swing.JButton;


### PR DESCRIPTION
Fixed the typo in the layout methods: “Laysouts a…” → “Lays out a…”.

The doc for `layoutHScrollbar` incorrectly referred to _vertical_ scroll bar rather than horizontal one.


I also expanded the wildcard imports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279794](https://bugs.openjdk.java.net/browse/JDK-8279794): Fix typos in BasicScrollBarUI: Laysouts a vertical scroll bar


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7032/head:pull/7032` \
`$ git checkout pull/7032`

Update a local copy of the PR: \
`$ git checkout pull/7032` \
`$ git pull https://git.openjdk.java.net/jdk pull/7032/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7032`

View PR using the GUI difftool: \
`$ git pr show -t 7032`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7032.diff">https://git.openjdk.java.net/jdk/pull/7032.diff</a>

</details>
