### PR TITLE
8279861: Clarify 'rect' parameters and description of paintTabBorder method in BasicTabbedPaneUI

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTabbedPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTabbedPaneUI.java
@@ -916,7 +916,7 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
      * Paints a tab.
      * @param g the graphics
      * @param tabPlacement the tab placement
-     * @param rects rectangles
+     * @param rects the tab rectangles
      * @param tabIndex the tab index
      * @param iconRect the icon rectangle
      * @param textRect the text rectangle
@@ -1262,7 +1262,7 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
      * Paints the focus indicator.
      * @param g the graphics
      * @param tabPlacement the tab placement
-     * @param rects rectangles
+     * @param rects the tab rectangles
      * @param tabIndex the tab index
      * @param iconRect the icon rectangle
      * @param textRect the text rectangle
@@ -1307,9 +1307,9 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
     }
 
     /**
-      * this function draws the border around each tab
-      * note that this function does now draw the background of the tab.
-      * that is done elsewhere
+      * Paints the border around a tab.
+      * Note that this function does not paint the background of the tab,
+      * that is done elsewhere.
       *
       * @param g             the graphics context in which to paint
       * @param tabPlacement  the placement (left, right, bottom, top) of the tab
@@ -1839,7 +1839,7 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
     }
 
     /**
-     * Assure the rectangles are created.
+     * Assures the tab rectangles are created.
      * @param tabCount the tab count
      */
     protected void assureRectsCreated(int tabCount) {


### PR DESCRIPTION
The protected methods `paintTab` and `paintFocusIndicator` accept the `rect` parameter which is documented as _“rectangles”_. I suggest updating this description to a more descriptive: _“the tab rectangles”_ as the array contains the coordinates of the tabs.

Similarly, the documentation for `assureRectsCreated` method could be updated to clarify which rectangles are created.

The documentation for `paintTabBorder` is inconsistent with other paint methods, it has no ending punctuation. I updated it to be consistent.

I split out these changes from [JDK-8279798](https://bugs.openjdk.java.net/browse/JDK-8279798) and #7031 because this issue will likely require a CSR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279861](https://bugs.openjdk.java.net/browse/JDK-8279861): Clarify 'rect' parameters and description of paintTabBorder method in BasicTabbedPaneUI


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7033/head:pull/7033` \
`$ git checkout pull/7033`

Update a local copy of the PR: \
`$ git checkout pull/7033` \
`$ git pull https://git.openjdk.java.net/jdk pull/7033/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7033`

View PR using the GUI difftool: \
`$ git pr show -t 7033`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7033.diff">https://git.openjdk.java.net/jdk/pull/7033.diff</a>

</details>
