### PR TITLE
8279879: [macos] ActionEvent triggered when right-clicking TrayIcon

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CTrayIcon.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CTrayIcon.java
@@ -276,14 +276,6 @@ public class CTrayIcon extends CFRetainedResource implements TrayIconPeer {
         mouseEvent.setSource(target);
         postEvent(mouseEvent);
 
-        // fire ACTION event
-        if (jeventType == MouseEvent.MOUSE_PRESSED && isPopupTrigger) {
-            final String cmd = target.getActionCommand();
-            final ActionEvent event = new ActionEvent(target,
-                    ActionEvent.ACTION_PERFORMED, cmd);
-            postEvent(event);
-        }
-
         // synthesize CLICKED event
         if (jeventType == MouseEvent.MOUSE_RELEASED) {
             if ((mouseClickButtons & eventButtonMask) != 0) {

--- a/test/jdk/java/awt/TrayIcon/RightClickWhenBalloonDisplayed/RightClickWhenBalloonDisplayed.java
+++ b/test/jdk/java/awt/TrayIcon/RightClickWhenBalloonDisplayed/RightClickWhenBalloonDisplayed.java
@@ -49,7 +49,7 @@ public class RightClickWhenBalloonDisplayed {
 
     TrayIcon icon;
     ExtendedRobot robot;
-    int actionPerformedCount = -1;
+    int actionPerformedCount = 0;
 
     public static void main(String[] args) throws Exception {
         if (!SystemTray.isSupported()) {
@@ -103,20 +103,14 @@ public class RightClickWhenBalloonDisplayed {
         if (iconPosition == null)
             throw new RuntimeException("Unable to find the icon location!");
 
-        // Do left click to start displaying the message
+        // Do right click
         robot.delay(50);
         robot.mouseMove(iconPosition.x, iconPosition.y);
-        robot.waitForIdle();
-        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-        robot.delay(50);
-        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-        robot.delay(1000);
-
-        // Do right click
         robot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
         robot.delay(50);
         robot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
-        robot.delay(50);
+        robot.delay(1000);
+        robot.waitForIdle();
 
         if (actionPerformedCount > 0)
             throw new RuntimeException("FAIL: ActionEvent triggered when " +


### PR DESCRIPTION
fixed test bug, removed extra ActionEvent from TrayIcon

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8279879](https://bugs.openjdk.java.net/browse/JDK-8279879): [macos] ActionEvent triggered when right-clicking TrayIcon


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7035/head:pull/7035` \
`$ git checkout pull/7035`

Update a local copy of the PR: \
`$ git checkout pull/7035` \
`$ git pull https://git.openjdk.java.net/jdk pull/7035/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7035`

View PR using the GUI difftool: \
`$ git pr show -t 7035`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7035.diff">https://git.openjdk.java.net/jdk/pull/7035.diff</a>

</details>
