### PR TITLE
8279801: EC KeyFactory and KeyPairGenerator do not have aliases for OID format

### DIFF
--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/SunEC.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/SunEC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -208,9 +208,8 @@ public final class SunEC extends Provider {
         /*
          *  Key Factory engine
          */
-        putService(new ProviderService(this, "KeyFactory",
-            "EC", "sun.security.ec.ECKeyFactory",
-            List.of("EllipticCurve"), ATTRS));
+        putService(new ProviderServiceA(this, "KeyFactory",
+            "EC", "sun.security.ec.ECKeyFactory", ATTRS));
 
         /*
          * Algorithm Parameter engine
@@ -319,9 +318,8 @@ public final class SunEC extends Provider {
         /*
          *  Key Pair Generator engine
          */
-        putService(new ProviderService(this, "KeyPairGenerator",
-            "EC", "sun.security.ec.ECKeyPairGenerator",
-            List.of("EllipticCurve"), ATTRS));
+        putService(new ProviderServiceA(this, "KeyPairGenerator",
+            "EC", "sun.security.ec.ECKeyPairGenerator", ATTRS));
 
         /*
          * Key Agreement engine

--- a/test/jdk/sun/security/ec/OidInstance.java
+++ b/test/jdk/sun/security/ec/OidInstance.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8279801
+ * @summary EC KeyFactory and KeyPairGenerator do not have aliases for OID format
+ * @modules java.base/sun.security.util
+ *          jdk.crypto.ec
+ */
+
+import sun.security.util.KnownOIDs;
+
+import java.security.AlgorithmParameters;
+import java.security.KeyFactory;
+import java.security.KeyPairGenerator;
+
+public class OidInstance {
+    public static void main(String[] args) throws Exception {
+        String oid = KnownOIDs.EC.value();
+        KeyFactory.getInstance(oid, "SunEC");
+        KeyPairGenerator.getInstance(oid, "SunEC");
+        AlgorithmParameters.getInstance(oid, "SunEC");
+    }
+}


### PR DESCRIPTION
Add OID aliases for the 2 service. This makes sure KeyFactory can be created and read an encoded key without knowing what the OID in the encoding is for.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279801](https://bugs.openjdk.java.net/browse/JDK-8279801): EC KeyFactory and KeyPairGenerator do not have aliases for OID format


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7036/head:pull/7036` \
`$ git checkout pull/7036`

Update a local copy of the PR: \
`$ git checkout pull/7036` \
`$ git pull https://git.openjdk.java.net/jdk pull/7036/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7036`

View PR using the GUI difftool: \
`$ git pr show -t 7036`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7036.diff">https://git.openjdk.java.net/jdk/pull/7036.diff</a>

</details>
