### PR TITLE
8279884: Use better file for cygwin source permission check

### DIFF
--- a/make/autoconf/basic.m4
+++ b/make/autoconf/basic.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -438,7 +438,9 @@ AC_DEFUN([BASIC_CHECK_DIR_ON_LOCAL_DISK],
 AC_DEFUN_ONCE([BASIC_CHECK_SRC_PERMS],
 [
   if test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.cygwin"; then
-    file_to_test="$TOPDIR/LICENSE"
+    # The choice of file here is somewhat arbitrary, it just needs to be there
+    # in the source tree when configure runs
+    file_to_test="$TOPDIR/Makefile"
     if test `$STAT -c '%a' "$file_to_test"` -lt 400; then
       AC_MSG_ERROR([Bad file permissions on src files. This is usually caused by cloning the repositories with a non cygwin hg in a directory not created in cygwin.])
     fi


### PR DESCRIPTION
For sanity, configure tries to verify that source files have the right permissions by checking the LICENSE file in TOPDIR. That file may not always be available, and for builds where it isn't configure will generate a (harmless) error along the lines of: 

/usr/bin/stat: cannot stat '/cygdrive/t/workspace/LICENSE': No such file or directory 
/cygdrive/t/workspace/build/.configure-support/generated-configure.sh: line 138173: test: -lt: unary operator expected 

Testing: tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279884](https://bugs.openjdk.java.net/browse/JDK-8279884): Use better file for cygwin source permission check


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7038/head:pull/7038` \
`$ git checkout pull/7038`

Update a local copy of the PR: \
`$ git checkout pull/7038` \
`$ git pull https://git.openjdk.java.net/jdk pull/7038/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7038`

View PR using the GUI difftool: \
`$ git pr show -t 7038`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7038.diff">https://git.openjdk.java.net/jdk/pull/7038.diff</a>

</details>
