### PR TITLE
8279900: compiler/vectorization/TestPopCountVectorLong.java fails due to vpopcntdq is not supported

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/TestPopCountVectorLong.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestPopCountVectorLong.java
@@ -25,6 +25,7 @@
 * @test
 * @summary Test vectorization of popcount for Long
 * @requires vm.cpu.features ~= ".*avx512dq.*"
+* @requires vm.cpu.features ~= ".*vpopcntdq.*"
 * @requires vm.compiler2.enabled
 * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64"
 * @library /test/lib /


### PR DESCRIPTION
Hi all,

The test fails on our AVX512 machines due to `VM_Version::supports_avx512_vpopcntdq()` [1] is false.
So the test should not run if `vpopcntdq` is not supported.

Thanks.
Best regards,
Jie

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/x86/x86.ad#L1409

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279900](https://bugs.openjdk.java.net/browse/JDK-8279900): compiler/vectorization/TestPopCountVectorLong.java fails due to vpopcntdq is not supported


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7040/head:pull/7040` \
`$ git checkout pull/7040`

Update a local copy of the PR: \
`$ git checkout pull/7040` \
`$ git pull https://git.openjdk.java.net/jdk pull/7040/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7040`

View PR using the GUI difftool: \
`$ git pr show -t 7040`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7040.diff">https://git.openjdk.java.net/jdk/pull/7040.diff</a>

</details>
