### PR TITLE
8278892: java.naming module description is missing @uses tags to document the services that it uses

### DIFF
--- a/src/java.naming/share/classes/module-info.java
+++ b/src/java.naming/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,9 +104,11 @@
  *  <li><a href="{@docRoot}/jdk.naming.dns/module-summary.html">DNS Naming Provider</a></li>
  *  <li><a href="{@docRoot}/jdk.naming.rmi/module-summary.html">RMI Naming Provider</a></li>
  * </ul>
- * @provides javax.naming.ldap.spi.LdapDnsProvider
+ * @provides java.security.Provider
  *
+ * @uses javax.naming.ldap.StartTlsResponse
  * @uses javax.naming.ldap.spi.LdapDnsProvider
+ * @uses javax.naming.spi.InitialContextFactory
  *
  * @moduleGraph
  * @since 9


### PR DESCRIPTION
I have fixed the javadoc comments as the definition. Could you review this fix?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278892](https://bugs.openjdk.java.net/browse/JDK-8278892): java.naming module description is missing @uses tags to document the services that it uses


### Reviewers
 * [Aleksei Efimov](https://openjdk.java.net/census#aefimov) (@AlekseiEfimov - Committer)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7041/head:pull/7041` \
`$ git checkout pull/7041`

Update a local copy of the PR: \
`$ git checkout pull/7041` \
`$ git pull https://git.openjdk.java.net/jdk pull/7041/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7041`

View PR using the GUI difftool: \
`$ git pr show -t 7041`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7041.diff">https://git.openjdk.java.net/jdk/pull/7041.diff</a>

</details>
