### PR TITLE
8279903: Redundant modulo operation in ECDHKeyAgreement

### DIFF
--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDHKeyAgreement.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDHKeyAgreement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDHKeyAgreement.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDHKeyAgreement.java
@@ -197,7 +197,7 @@ public final class ECDHKeyAgreement extends KeyAgreementSpi {
         EllipticCurve curve = spec.getCurve();
         BigInteger rhs = x.modPow(BigInteger.valueOf(3), p).add(curve.getA()
             .multiply(x)).add(curve.getB()).mod(p);
-        BigInteger lhs = y.modPow(BigInteger.valueOf(2), p).mod(p);
+        BigInteger lhs = y.modPow(BigInteger.TWO, p);
         if (!rhs.equals(lhs)) {
             throw new InvalidKeyException("Point is not on curve");
         }


### PR DESCRIPTION
In class `sun.security.ec.ECDHKeyAgreement`, the last `mod()` in the below line looks redundant,
```
BigInteger lhs = y.modPow(BigInteger.valueOf(2), p).mod(p);
```
I think this tiny change just be a code cleanup, so no test for it and label `noreg-cleanup` is added for this JBS issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279903](https://bugs.openjdk.java.net/browse/JDK-8279903): Redundant modulo operation in ECDHKeyAgreement


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7042/head:pull/7042` \
`$ git checkout pull/7042`

Update a local copy of the PR: \
`$ git checkout pull/7042` \
`$ git pull https://git.openjdk.java.net/jdk pull/7042/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7042`

View PR using the GUI difftool: \
`$ git pr show -t 7042`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7042.diff">https://git.openjdk.java.net/jdk/pull/7042.diff</a>

</details>
