### PR TITLE
8278951: containers/cgroup/PlainRead.java fails on Ubuntu 21.10

### DIFF
--- a/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -157,8 +157,10 @@ PRAGMA_DIAG_POP
                                      NULL,                                \
                                      scan_fmt,                            \
                                      &variable);                          \
-  if (err != 0)                                                           \
+  if (err != 0) {                                                         \
+    log_trace(os, container)(logstring, (return_type) OSCONTAINER_ERROR); \
     return (return_type) OSCONTAINER_ERROR;                               \
+  }                                                                       \
                                                                           \
   log_trace(os, container)(logstring, variable);                          \
 }

--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Red Hat Inc.
+ * Copyright (c) 2020, 2022, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@
  */
 int CgroupV2Subsystem::cpu_shares() {
   GET_CONTAINER_INFO(int, _unified, "/cpu.weight",
-                     "Raw value for CPU shares is: %d", "%d", shares);
+                     "Raw value for CPU Shares is: %d", "%d", shares);
   // Convert default value of 100 to no shares setup
   if (shares == 100) {
     log_debug(os, container)("CPU Shares is: %d", -1);


### PR DESCRIPTION
When running on Ubuntu 21.10 (which has cgroupv2 enabled by default) but outside of a container, the VM was printing only this:

```
[0.114s][debug][os,container] 
   Open of file /sys/fs/cgroup/user.slice/user-529964.slice/session-1168.scope/cpu.weight failed,
   No such file or directory
```

After my fix, this is also printed to make the PlainRead.java test happy:

```
[0.114s][trace][os,container] Raw value for CPU Shares is: -2
```

Note that the `GET_CONTAINER_INFO_CPTR` and `GET_CONTAINER_INFO_LINE` macros still don't print the trace log when the requested file doesn't exist. I don't know whether I should change them or not. Since no tests seem to look for such a such a log message, I'll leave the code as-is for now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278951](https://bugs.openjdk.java.net/browse/JDK-8278951): containers/cgroup/PlainRead.java fails on Ubuntu 21.10


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7043/head:pull/7043` \
`$ git checkout pull/7043`

Update a local copy of the PR: \
`$ git checkout pull/7043` \
`$ git pull https://git.openjdk.java.net/jdk pull/7043/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7043`

View PR using the GUI difftool: \
`$ git pr show -t 7043`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7043.diff">https://git.openjdk.java.net/jdk/pull/7043.diff</a>

</details>
