### PR TITLE
8279910: G1: Simplify HeapRegionRemSet::add_reference

### DIFF
--- a/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
@@ -274,7 +274,9 @@ template <class T> void G1RebuildRemSetClosure::do_oop_work(T* p) {
 
   HeapRegion* to = _g1h->heap_region_containing(obj);
   HeapRegionRemSet* rem_set = to->rem_set();
-  rem_set->add_reference(p, _worker_id);
+  if (rem_set->is_tracked()) {
+    rem_set->add_reference(p, _worker_id);
+  }
 }
 
 #endif // SHARE_GC_G1_G1OOPCLOSURES_INLINE_HPP

--- a/src/hotspot/share/gc/g1/heapRegionRemSet.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.inline.hpp
@@ -123,10 +123,7 @@ void HeapRegionRemSet::split_card(OopOrNarrowOopStar from, uint& card_region, ui
 }
 
 void HeapRegionRemSet::add_reference(OopOrNarrowOopStar from, uint tid) {
-  RemSetState state = _state;
-  if (state == Untracked) {
-    return;
-  }
+  assert(_state != Untracked, "must be");
 
   uint cur_idx = _hr->hrm_index();
   uintptr_t from_card = uintptr_t(from) >> CardTable::card_shift();


### PR DESCRIPTION
HeapRegionRemSet::add_reference checks "state == Untracked" and return if true; it's called at G1RebuildRemSetClosure::do_oop_work and G1ConcurrentRefineOopClosure::do_oop_work respectively.

The check in HeapRegionRemSet::add_reference could be replaced with an assert, and move the check up to one of the caller G1RebuildRemSetClosure::do_oop_work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279910](https://bugs.openjdk.java.net/browse/JDK-8279910): G1: Simplify HeapRegionRemSet::add_reference


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7045/head:pull/7045` \
`$ git checkout pull/7045`

Update a local copy of the PR: \
`$ git checkout pull/7045` \
`$ git pull https://git.openjdk.java.net/jdk pull/7045/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7045`

View PR using the GUI difftool: \
`$ git pr show -t 7045`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7045.diff">https://git.openjdk.java.net/jdk/pull/7045.diff</a>

</details>
