### PR TITLE
8279570: IGV: Add source/destination property for load and store nodes with an associated field

### DIFF
--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -480,6 +480,8 @@ void IdealGraphPrinter::visit_node(Node *n, bool edges, VectorSet* temp_set) {
       print_prop("idealOpcode", (const char *)NodeClassNames[node->as_Mach()->ideal_Opcode()]);
     }
 
+    print_field(node);
+
     buffer[0] = 0;
     stringStream s2(buffer, sizeof(buffer) - 1);
 
@@ -628,9 +630,99 @@ void IdealGraphPrinter::visit_node(Node *n, bool edges, VectorSet* temp_set) {
   }
 }
 
-void IdealGraphPrinter::walk_nodes(Node *start, bool edges, VectorSet* temp_set) {
+void IdealGraphPrinter::print_field(const Node* node) {
+  buffer[0] = 0;
+  stringStream ss(buffer, sizeof(buffer) - 1);
+  ciField* field = get_field(node);
+  uint depth = 0;
+  if (field == NULL) {
+    depth++;
+    field = find_source_field_of_array_access(node, depth);
+  }
 
+  if (field != NULL) {
+    // Either direct field access or array access
+    field->print_name_on(&ss);
+    for (uint i = 0; i < depth; i++) {
+      // For arrays: Add [] for each dimension
+      ss.print("[]");
+    }
+    if (node->is_Store()) {
+      print_prop("destination", buffer);
+    } else {
+      print_prop("source", buffer);
+    }
+  }
+}
 
+ciField* IdealGraphPrinter::get_field(const Node* node) {
+  const TypePtr* adr_type = node->adr_type();
+  Compile::AliasType* atp = NULL;
+  if (C->have_alias_type(adr_type)) {
+    atp = C->alias_type(adr_type);
+  }
+  if (atp != NULL) {
+    ciField* field = atp->field();
+    if (field != NULL) {
+      // Found field associated with 'node'.
+      return field;
+    }
+  }
+  return NULL;
+}
+
+// Try to find the field that is associated with a memory node belonging to an array access.
+ciField* IdealGraphPrinter::find_source_field_of_array_access(const Node* node, uint& depth) {
+  if (!node->is_Mem()) {
+    // Not an array access
+    return NULL;
+  }
+
+  do {
+    if (node->adr_type() != NULL && node->adr_type()->isa_aryptr()) {
+      // Only process array accesses. Pattern match to find actual field source access.
+      node = get_load_node(node);
+      if (node != NULL) {
+        ciField* field = get_field(node);
+        if (field != NULL) {
+          return field;
+        }
+        // Could be a multi-dimensional array. Repeat loop.
+        depth++;
+        continue;
+      }
+    }
+    // Not an array access with a field source.
+    break;
+  } while (depth < 256); // Cannot have more than 255 dimensions
+
+  return NULL;
+}
+
+// Pattern match on the inputs of 'node' to find load node for the field access.
+Node* IdealGraphPrinter::get_load_node(const Node* node) {
+  Node* load = NULL;
+  Node* addr = node->as_Mem()->in(MemNode::Address);
+  if (addr != NULL && addr->is_AddP()) {
+    Node* base = addr->as_AddP()->base_node();
+    if (base != NULL) {
+      if (base->Opcode() == Op_CastPP) {
+        // CastPP node could have been removed.
+        base = base->in(1);
+      }
+      if (base->is_Load()) {
+        // Mem(AddP([CastPP](LoadP))) for non-compressed oops.
+        load = base;
+      } else if (base->is_DecodeN() && base->in(1)->is_Load()) {
+        // Mem(AddP([CastPP](DecodeN(LoadN)))) for compressed oops.
+        load = base->in(1);
+      }
+    }
+  }
+  return load;
+}
+
+void IdealGraphPrinter::walk_nodes(Node* start, bool edges, VectorSet* temp_set) {
   VectorSet visited;
   GrowableArray<Node *> nodeStack(Thread::current()->resource_area(), 0, 0, NULL);
   nodeStack.push(start);

--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -706,15 +706,12 @@ Node* IdealGraphPrinter::get_load_node(const Node* node) {
   if (addr != NULL && addr->is_AddP()) {
     Node* base = addr->as_AddP()->base_node();
     if (base != NULL) {
-      if (base->Opcode() == Op_CastPP) {
-        // CastPP node could have been removed.
-        base = base->in(1);
-      }
+      base = base->uncast();
       if (base->is_Load()) {
-        // Mem(AddP([CastPP](LoadP))) for non-compressed oops.
+        // Mem(AddP([ConstraintCast*](LoadP))) for non-compressed oops.
         load = base;
       } else if (base->is_DecodeN() && base->in(1)->is_Load()) {
-        // Mem(AddP([CastPP](DecodeN(LoadN)))) for compressed oops.
+        // Mem(AddP([ConstraintCast*](DecodeN(LoadN)))) for compressed oops.
         load = base->in(1);
       }
     }

--- a/src/hotspot/share/opto/idealGraphPrinter.hpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.hpp
@@ -99,6 +99,10 @@ class IdealGraphPrinter : public CHeapObj<mtCompiler> {
   void print_method(ciMethod *method, int bci, InlineTree *tree);
   void print_inline_tree(InlineTree *tree);
   void visit_node(Node *n, bool edges, VectorSet* temp_set);
+  void print_field(const Node* node);
+  ciField* get_field(const Node* node);
+  ciField* find_source_field_of_array_access(const Node* node, uint& depth);
+  static Node* get_load_node(const Node* node);
   void walk_nodes(Node *start, bool edges, VectorSet* temp_set);
   void begin_elem(const char *s);
   void end_elem();


### PR DESCRIPTION
This patch adds a source/destination property field in the "Properties" view for a load/store node associated with a field in IGV. This simplifies the analysis of graphs when dealing with multiple loads/stores from/to fields.

For each node, we are trying to get the associated `ciField` (`get_field()`). This works fine for direct field load/stores nodes. However, when facing an array access, we need to find the actual node doing the field access to get the `ciField` from. For that purpose, I added an additional search based on pattern matching (`find_source_field_of_array_access()`). It follows the address input of a load/store to find the field `LoadN` (compressed oops) or `LoadP` (non-compressed oops) from which we can get the `ciField`.

Example:
```
iFld = 1; // StoreI 25 (not shown in graph)
iArrFld[2] = 3; // StoreI 67
x = iArrFld2[4][5]; // LoadI 138
```
![Screenshot from 2022-01-07 15-12-41](https://user-images.githubusercontent.com/17833009/149097102-6192f9c1-72a5-4941-bf92-ff0f59018e08.png)

![Screenshot from 2022-01-07 15-18-15](https://user-images.githubusercontent.com/17833009/149098172-0d750445-9e26-42da-82ff-7627428a4c12.png)

- `StoreI 25`: Can directly fetch the field `iFld` with `get_field()`.
- `StoreI 67`: For the store to an array, we follow the address input `AddP 66` -> `46 CastPP` -> `29 DecodeN` -> `28 LoadN` to get the field `iFldArr` from `28 LoadN` (done in `find_source_field_of_array_access()`)
- `LoadI 138`: Same as for `StoreI 67` but we repeat the loop in `find_source_field_of_array_access()` when reaching `LoadI 138` -> ... -> `104 LoadN` to get the field `iArrFld2` eventually from `70 LoadN`.

I additionally ran the following sanity testing with a Hello World program:
```
java -XX:-TieredCompilation -Xcomp -XX:+PrintIdealGraph -XX:PrintIdealGraphLevel=3 -XX:PrintIdealGraphFile=graph.xml HelloWorld.java
```
Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279570](https://bugs.openjdk.java.net/browse/JDK-8279570): IGV: Add source/destination property for load and store nodes with an associated field


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 315b3806b1051031a19626a9e39f0fbee09ce856
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7048/head:pull/7048` \
`$ git checkout pull/7048`

Update a local copy of the PR: \
`$ git checkout pull/7048` \
`$ git pull https://git.openjdk.java.net/jdk pull/7048/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7048`

View PR using the GUI difftool: \
`$ git pr show -t 7048`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7048.diff">https://git.openjdk.java.net/jdk/pull/7048.diff</a>

</details>
