### PR TITLE
8279921: Dump the .class file in jlink debug mode for any failure during transform() of a plugin

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/AbstractPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/AbstractPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import jdk.internal.org.objectweb.asm.ClassReader;
+import jdk.tools.jlink.plugin.ResourcePoolEntry;
 
 public abstract class AbstractPlugin implements Plugin {
 
@@ -83,16 +84,31 @@ public abstract class AbstractPlugin implements Plugin {
         }
     }
 
+    ClassReader newClassReader(String path, ResourcePoolEntry resource) {
+        byte[] content = resource.contentBytes();
+        try {
+            return new ClassReader(content);
+        } catch (Exception e) {
+            if (JlinkTask.DEBUG) {
+                System.err.printf("Failed to parse class file: %s from resource of type %s\n", path,
+                        resource.getClass().getName());
+                e.printStackTrace();
+                dumpClassFile(path, content);
+            }
+            throw e;
+        }
+    }
+
     protected ClassReader newClassReader(String path, byte[] buf) {
         try {
             return new ClassReader(buf);
-        } catch (IllegalArgumentException iae) {
+        } catch (Exception e) {
             if (JlinkTask.DEBUG) {
                 System.err.printf("Failed to parse class file: %s\n", path);
-                iae.printStackTrace();
+                e.printStackTrace();
                 dumpClassFile(path, buf);
             }
-            throw iae;
+            throw e;
         }
     }
 

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/StripJavaDebugAttributesPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/StripJavaDebugAttributesPlugin.java
@@ -59,7 +59,7 @@ public final class StripJavaDebugAttributesPlugin extends AbstractPlugin {
                     if (path.endsWith("module-info.class")) {
                         // XXX. Do we have debug info? Is Asm ready for module-info?
                     } else {
-                        ClassReader reader = newClassReader(path, resource.contentBytes());
+                        ClassReader reader = newClassReader(path, resource);
                         ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
                         reader.accept(writer, ClassReader.SKIP_DEBUG);
                         byte[] content = writer.toByteArray();


### PR DESCRIPTION
Can I please get a review for this change which addresses https://bugs.openjdk.java.net/browse/JDK-8279921?

The change here builds upon the debugging enhancement that was done in https://github.com/openjdk/jdk/pull/6696 to try and narrow down the problem behind intermittent failures on macos ARM systems. The previous change caught only `IllegalArgumentException` to dump the class file, but as seen in a recent  failure, the exception type itself isn't guaranteed to be the same due to the nature of the issue. So, this commit catches `Exception` to dump the class file. Additionally, the change here also prints out the underlying `ResourcePoolEntry` type to see if that provides any additional hints on why the class content could end being corrupt.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279921](https://bugs.openjdk.java.net/browse/JDK-8279921): Dump the .class file in jlink debug mode for any failure during transform() of a plugin


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7049/head:pull/7049` \
`$ git checkout pull/7049`

Update a local copy of the PR: \
`$ git checkout pull/7049` \
`$ git pull https://git.openjdk.java.net/jdk pull/7049/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7049`

View PR using the GUI difftool: \
`$ git pr show -t 7049`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7049.diff">https://git.openjdk.java.net/jdk/pull/7049.diff</a>

</details>
