### PR TITLE
8278597: Remove outdated comments regarding RMISecurityManager in HotSpotAgent.java

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotAgent.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -389,17 +389,6 @@ public class HotSpotAgent {
             //
             // Remote mode (client attaching to server)
             //
-
-            // Create and install a security manager
-
-            // FIXME: currently commented out because we were having
-            // security problems since we're "in the sun.* hierarchy" here.
-            // Perhaps a permissive policy file would work around this. In
-            // the long run, will probably have to move into com.sun.*.
-
-            //    if (System.getSecurityManager() == null) {
-            //      System.setSecurityManager(new RMISecurityManager());
-            //    }
 
             connectRemoteDebugger();
         }


### PR DESCRIPTION
The HotSpotAgent.java setupDebugger method has a commmented out section relating to possibly using RMISecurityManager.
The comment is from pre-jdk7.  As RMISecurityManager has been deprecated for a while the comments should be removed.

This is a comment-only change, no impact on what we build, so seems trivial.

This is slightly more relevant today as with JEP411 and plans to remove the Security Mananger, it is natural to search the source for references to Security Manager.  Removing a false-positive from those results is a good thing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278597](https://bugs.openjdk.java.net/browse/JDK-8278597): Remove outdated comments regarding RMISecurityManager in HotSpotAgent.java


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7050/head:pull/7050` \
`$ git checkout pull/7050`

Update a local copy of the PR: \
`$ git checkout pull/7050` \
`$ git pull https://git.openjdk.java.net/jdk pull/7050/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7050`

View PR using the GUI difftool: \
`$ git pr show -t 7050`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7050.diff">https://git.openjdk.java.net/jdk/pull/7050.diff</a>

</details>
