### PR TITLE
8279936: Change shared code to use os:: system API's

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1079,7 +1079,7 @@ public:
     // First read the generic header so we know the exact size of the actual header.
     GenericCDSFileMapHeader gen_header;
     size_t size = sizeof(GenericCDSFileMapHeader);
-    lseek(fd, 0, SEEK_SET);
+    os::lseek(fd, 0, SEEK_SET);
     size_t n = os::read(fd, (void*)&gen_header, (unsigned int)size);
     if (n != size) {
       FileMapInfo::fail_continue("Unable to read generic CDS file map header from shared archive");
@@ -1107,7 +1107,7 @@ public:
     // Read the actual header and perform more checks
     size = gen_header._header_size;
     _header = (GenericCDSFileMapHeader*)NEW_C_HEAP_ARRAY(char, size, mtInternal);
-    lseek(fd, 0, SEEK_SET);
+    os::lseek(fd, 0, SEEK_SET);
     n = os::read(fd, (void*)_header, (unsigned int)size);
     if (n != size) {
       FileMapInfo::fail_continue("Unable to read actual CDS file map header from shared archive");
@@ -1275,7 +1275,7 @@ bool FileMapInfo::init_from_file(int fd) {
   }
 
   _header = (FileMapHeader*)os::malloc(gen_header->_header_size, mtInternal);
-  lseek(fd, 0, SEEK_SET); // reset to begin of the archive
+  os::lseek(fd, 0, SEEK_SET); // reset to begin of the archive
   size_t size = gen_header->_header_size;
   size_t n = os::read(fd, (void*)_header, (unsigned int)size);
   if (n != size) {
@@ -1325,7 +1325,7 @@ bool FileMapInfo::init_from_file(int fd) {
   if (is_static()) {
     // just checking the last region is sufficient since the archive is written
     // in sequential order
-    size_t len = lseek(fd, 0, SEEK_END);
+    size_t len = os::lseek(fd, 0, SEEK_END);
     FileMapRegion* si = space_at(MetaspaceShared::last_valid_region);
     // The last space might be empty
     if (si->file_offset() > len || len - si->file_offset() < si->used()) {
@@ -1338,7 +1338,7 @@ bool FileMapInfo::init_from_file(int fd) {
 }
 
 void FileMapInfo::seek_to_position(size_t pos) {
-  if (lseek(_fd, (long)pos, SEEK_SET) < 0) {
+  if (os::lseek(_fd, (long)pos, SEEK_SET) < 0) {
     fail_stop("Unable to seek to position " SIZE_FORMAT, pos);
   }
 }
@@ -1658,7 +1658,7 @@ void FileMapInfo::write_bytes_aligned(const void* buffer, size_t nbytes) {
 
 void FileMapInfo::close() {
   if (_file_open) {
-    if (::close(_fd) < 0) {
+    if (os::close(_fd) < 0) {
       fail_stop("Unable to close the shared archive file.");
     }
     _file_open = false;
@@ -1749,7 +1749,7 @@ bool FileMapInfo::read_region(int i, char* base, size_t size, bool do_commit) {
       return false;
     }
   }
-  if (lseek(_fd, (long)si->file_offset(), SEEK_SET) != (int)si->file_offset() ||
+  if (os::lseek(_fd, (long)si->file_offset(), SEEK_SET) != (int)si->file_offset() ||
       read_bytes(base, size) != size) {
     return false;
   }

--- a/src/hotspot/share/classfile/compactHashtable.cpp
+++ b/src/hotspot/share/classfile/compactHashtable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -252,7 +252,7 @@ HashtableTextDump::HashtableTextDump(const char* filename) : _fd(-1) {
 HashtableTextDump::~HashtableTextDump() {
   os::unmap_memory((char*)_base, _size);
   if (_fd >= 0) {
-    close(_fd);
+    os::close(_fd);
   }
 }
 

--- a/src/hotspot/share/compiler/compileLog.cpp
+++ b/src/hotspot/share/compiler/compileLog.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -225,7 +225,7 @@ void CompileLog::finish_log_on_error(outputStream* file, char* buf, int buflen) 
         if (to_read < (julong)buflen)
               nr = (size_t)to_read;
         else  nr = buflen;
-        bytes_read = read(partial_fd, buf, (int)nr);
+        bytes_read = os::read(partial_fd, buf, (int)nr);
         if (bytes_read <= 0) break;
         nr = bytes_read;
         to_read -= (julong)nr;
@@ -235,7 +235,7 @@ void CompileLog::finish_log_on_error(outputStream* file, char* buf, int buflen) 
       // Copy any remaining data inside a quote:
       bool saw_slop = false;
       int end_cdata = 0;  // state machine [0..2] watching for too many "]]"
-      while ((bytes_read = read(partial_fd, buf, buflen-1)) > 0) {
+      while ((bytes_read = os::read(partial_fd, buf, buflen-1)) > 0) {
         nr = bytes_read;
         buf[buflen-1] = '\0';
         if (!saw_slop) {
@@ -285,7 +285,7 @@ void CompileLog::finish_log_on_error(outputStream* file, char* buf, int buflen) 
         file->print_raw_cr("</fragment>");
       }
       file->print_raw_cr("</compilation_log>");
-      close(partial_fd);
+      os::close(partial_fd);
     }
     CompileLog* next_log = log->_next;
     delete log; // Removes partial file

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1654,7 +1654,7 @@ void VMError::report_and_die(int id, const char* message, const char* detail_fmt
     _current_step_info = "";
 
     if (fd_log > 3) {
-      close(fd_log);
+      os::close(fd_log);
       fd_log = -1;
     }
 

--- a/test/hotspot/gtest/gtestMain.cpp
+++ b/test/hotspot/gtest/gtestMain.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -278,7 +278,7 @@ static void runUnitTestsInner(int argc, char** argv) {
     int ret;
     if ((ret = init_jvm(argc, argv, is_vmassert_test, &jvm)) != 0) {
       fprintf(stderr, "ERROR: JNI_CreateJavaVM failed: %d\n", ret);
-      abort();
+      os::abort();
     }
   } else {
     ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();

--- a/test/hotspot/gtest/gtestMain.cpp
+++ b/test/hotspot/gtest/gtestMain.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -278,7 +278,7 @@ static void runUnitTestsInner(int argc, char** argv) {
     int ret;
     if ((ret = init_jvm(argc, argv, is_vmassert_test, &jvm)) != 0) {
       fprintf(stderr, "ERROR: JNI_CreateJavaVM failed: %d\n", ret);
-      os::abort();
+      abort();
     }
   } else {
     ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();

--- a/test/hotspot/gtest/logging/logTestUtils.inline.hpp
+++ b/test/hotspot/gtest/logging/logTestUtils.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -138,8 +138,8 @@ static inline char* read_line(FILE* fp) {
 
 static bool file_contains_substrings_in_order(const char* filename, const char* substrs[]) {
   AsyncLogWriter::flush();
-  FILE* fp = fopen(filename, "r");
-  assert(fp != NULL, "error opening file %s: %s", filename, strerror(errno));
+  FILE* fp = os::fopen(filename, "r");
+  assert(fp != NULL, "error opening file %s: %s", filename, os::strerror(errno));
 
   size_t idx = 0;
   while (substrs[idx] != NULL) {

--- a/test/hotspot/gtest/logging/test_asynclog.cpp
+++ b/test/hotspot/gtest/logging/test_asynclog.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,7 +86,7 @@ LOG_LEVEL_LIST
 
   // stdout/stderr support
   bool write_to_file(const std::string& output) {
-    FILE* f = fopen(TestLogFileName, "w");
+    FILE* f = os::fopen(TestLogFileName, "w");
 
     if (f != NULL) {
       size_t sz = output.size();

--- a/test/hotspot/gtest/logging/test_log.cpp
+++ b/test/hotspot/gtest/logging/test_log.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ TEST_VM_F(LogTest, large_message) {
 
   AsyncLogWriter::flush();
   ResourceMark rm;
-  FILE* fp = fopen(TestLogFileName, "r");
+  FILE* fp = os::fopen(TestLogFileName, "r");
   ASSERT_NE((void*)NULL, fp);
   char* output = read_line(fp);
   fclose(fp);

--- a/test/hotspot/gtest/logging/test_logTagSetDescriptions.cpp
+++ b/test/hotspot/gtest/logging/test_logTagSetDescriptions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ TEST_VM(LogTagSetDescriptions, describe) {
 TEST_VM(LogTagSetDescriptions, command_line_help) {
   ResourceMark rm;
   const char* filename = prepend_temp_dir("logtagset_descriptions");
-  FILE* fp = fopen(filename, "w+");
+  FILE* fp = os::fopen(filename, "w+");
   ASSERT_NE((void*)NULL, fp);
   fileStream stream(fp);
   LogConfiguration::print_command_line_help(&stream);


### PR DESCRIPTION
Please review this small change to call os:: API's.  the changes were tested with Mach5 tiers 1-2 on Linux, Mac OS, and Windows, and Mach5 tiers 3-5 on Linux x64.  Most of these changes were for I/O related calls.  Changes to memory allocation calls such as malloc and free will be handled in a future change.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279936](https://bugs.openjdk.java.net/browse/JDK-8279936): Change shared code to use os:: system API's


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7055/head:pull/7055` \
`$ git checkout pull/7055`

Update a local copy of the PR: \
`$ git checkout pull/7055` \
`$ git pull https://git.openjdk.java.net/jdk pull/7055/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7055`

View PR using the GUI difftool: \
`$ git pr show -t 7055`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7055.diff">https://git.openjdk.java.net/jdk/pull/7055.diff</a>

</details>
