### PR TITLE
8279946: (ch) java.nio.channels.FileChannel tryLock and write methods are missing @throws NonWritableChannelException

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,16 @@
 
 package java.nio.channels;
 
-import java.io.*;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.spi.AbstractInterruptibleChannel;
-import java.nio.file.*;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.FileAttribute;
-import java.nio.file.spi.*;
+import java.nio.file.spi.FileSystemProvider;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.Collections;
@@ -403,6 +406,9 @@ public abstract class FileChannel
      * with the number of bytes actually written.  Otherwise this method
      * behaves exactly as specified by the {@link WritableByteChannel}
      * interface. </p>
+     *
+     * @throws  NonWritableChannelException
+     *          If this channel was not opened for writing
      */
     public abstract int write(ByteBuffer src) throws IOException;
 
@@ -417,6 +423,9 @@ public abstract class FileChannel
      * with the number of bytes actually written.  Otherwise this method
      * behaves exactly as specified in the {@link GatheringByteChannel}
      * interface.  </p>
+     *
+     * @throws  NonWritableChannelException
+     *          If this channel was not opened for writing
      */
     public abstract long write(ByteBuffer[] srcs, int offset, int length)
         throws IOException;
@@ -431,6 +440,9 @@ public abstract class FileChannel
      * with the number of bytes actually written.  Otherwise this method
      * behaves exactly as specified in the {@link GatheringByteChannel}
      * interface.  </p>
+     *
+     * @throws  NonWritableChannelException
+     *          If this channel was not opened for writing
      */
     public final long write(ByteBuffer[] srcs) throws IOException {
         return write(srcs, 0, srcs.length);
@@ -1148,6 +1160,10 @@ public abstract class FileChannel
      *          blocked in this method and is attempting to lock an overlapping
      *          region of the same file
      *
+     * @throws  NonWritableChannelException
+     *          If {@code shared} is {@code false} but this channel was not
+     *          opened for writing
+     *
      * @throws  IOException
      *          If some other I/O error occurs
      *
@@ -1179,6 +1195,9 @@ public abstract class FileChannel
      *          this Java virtual machine, or if another thread is already
      *          blocked in this method and is attempting to lock an overlapping
      *          region
+     *
+     * @throws  NonWritableChannelException
+     *          If this channel was not opened for writing
      *
      * @throws  IOException
      *          If some other I/O error occurs


### PR DESCRIPTION
Please consider this change which would add `@throws` clauses for `NonWritableChannelException` to the various `tryLock()` and `write()` methods in `java.nio.channels.FileChannel`.