### PR TITLE
8279947: Remove two redundant gvn.transform calls in Parse::do_one_bytecode()

### DIFF
--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2295,8 +2295,7 @@ void Parse::do_one_bytecode() {
       // out to memory to round, the machine instruction that implements
       // ConvL2D is responsible for rounding.
       // c = precision_rounding(b);
-      c = _gvn.transform(b);
-      push(c);
+      push(b);
     } else {
       l2f();
     }
@@ -2307,8 +2306,7 @@ void Parse::do_one_bytecode() {
     b = _gvn.transform( new ConvL2DNode(a));
     // For x86_32.ad, rounding is always necessary (see _l2f above).
     // c = dprecision_rounding(b);
-    c = _gvn.transform(b);
-    push_pair(c);
+    push_pair(b);
     break;
 
   case Bytecodes::_f2l:


### PR DESCRIPTION
Hi all,

May I get reviews for this small change?

The patch removes two `gvn.transform` calls in `Parse::do_one_bytecode()` which I think they are redundant.
Or am I missing something?

Testing:
  - tier1~3 on Linux/x64, no regression

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279947](https://bugs.openjdk.java.net/browse/JDK-8279947): Remove two redundant gvn.transform calls in Parse::do_one_bytecode()


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7059/head:pull/7059` \
`$ git checkout pull/7059`

Update a local copy of the PR: \
`$ git checkout pull/7059` \
`$ git pull https://git.openjdk.java.net/jdk pull/7059/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7059`

View PR using the GUI difftool: \
`$ git pr show -t 7059`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7059.diff">https://git.openjdk.java.net/jdk/pull/7059.diff</a>

</details>
