### PR TITLE
8279894: javax/swing/JInternalFrame/8020708/bug8020708.java timeouts on Windows 11

### DIFF
--- a/test/jdk/javax/swing/JInternalFrame/8020708/bug8020708.java
+++ b/test/jdk/javax/swing/JInternalFrame/8020708/bug8020708.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ import javax.swing.UIManager;
  * @summary NLS: mnemonics missing in SwingSet2/JInternalFrame demo
  * @library ../../regtesthelpers
  * @build Util
- * @run main bug8020708
+ * @run main/timeout=300 bug8020708
  */
 public class bug8020708 {
 
@@ -68,6 +68,7 @@ public class bug8020708 {
 
     public static void main(String[] args) throws Exception {
         for (Locale locale : SUPPORTED_LOCALES) {
+            System.out.println("locale: " + locale);
             for (String laf : LOOK_AND_FEELS) {
                 Locale.setDefault(locale);
                 if (!installLookAndFeel(laf)) {
@@ -80,7 +81,7 @@ public class bug8020708 {
 
     static void testInternalFrameMnemonic(Locale locale) throws Exception {
         Robot robot = new Robot();
-        robot.setAutoDelay(250);
+        robot.setAutoDelay(100);
         robot.setAutoWaitForIdle(true);
 
         SwingUtilities.invokeAndWait(new Runnable() {
@@ -142,6 +143,7 @@ public class bug8020708 {
         UIManager.LookAndFeelInfo[] infos = UIManager.getInstalledLookAndFeels();
         for (UIManager.LookAndFeelInfo info : infos) {
             if (info.getClassName().contains(lafName)) {
+                System.out.println("LookAndFeel: " + info.getClassName());
                 UIManager.setLookAndFeel(info.getClassName());
                 return true;
             }


### PR DESCRIPTION
Test is timing out on slower windows11 CI system. Increased the timeout and also adjusted autodelay time to more consistent time with other headful tests which makes test pass in windows11.
Test job link in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279894](https://bugs.openjdk.java.net/browse/JDK-8279894): javax/swing/JInternalFrame/8020708/bug8020708.java timeouts on Windows 11


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7060/head:pull/7060` \
`$ git checkout pull/7060`

Update a local copy of the PR: \
`$ git checkout pull/7060` \
`$ git pull https://git.openjdk.java.net/jdk pull/7060/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7060`

View PR using the GUI difftool: \
`$ git pr show -t 7060`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7060.diff">https://git.openjdk.java.net/jdk/pull/7060.diff</a>

</details>
