### PR TITLE
8280035: Use Class.isInstance instead of Class.isAssignableFrom where applicable

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/AccessibleObject.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessibleObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -446,7 +446,7 @@ public class AccessibleObject implements AnnotatedElement {
             }
             // if this object is an instance member, the given object
             // must be a subclass of the declaring class of this reflected object
-            if (!declaringClass.isAssignableFrom(obj.getClass())) {
+            if (!declaringClass.isInstance(obj)) {
                 throw new IllegalArgumentException("object is not an instance of "
                                                    + declaringClass.getName());
             }

--- a/src/java.base/share/classes/jdk/internal/reflect/UnsafeObjectFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/UnsafeObjectFieldAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ class UnsafeObjectFieldAccessorImpl extends UnsafeFieldAccessorImpl {
             throwFinalFieldIllegalAccessException(value);
         }
         if (value != null) {
-            if (!field.getType().isAssignableFrom(value.getClass())) {
+            if (!field.getType().isInstance(value)) {
                 throwSetIllegalArgumentException(value);
             }
         }

--- a/src/java.base/share/classes/jdk/internal/reflect/UnsafeQualifiedObjectFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/UnsafeQualifiedObjectFieldAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,7 +79,7 @@ class UnsafeQualifiedObjectFieldAccessorImpl
             throwFinalFieldIllegalAccessException(value);
         }
         if (value != null) {
-            if (!field.getType().isAssignableFrom(value.getClass())) {
+            if (!field.getType().isInstance(value)) {
                 throwSetIllegalArgumentException(value);
             }
         }

--- a/src/java.base/share/classes/jdk/internal/reflect/UnsafeQualifiedStaticObjectFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/UnsafeQualifiedStaticObjectFieldAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ class UnsafeQualifiedStaticObjectFieldAccessorImpl
             throwFinalFieldIllegalAccessException(value);
         }
         if (value != null) {
-            if (!field.getType().isAssignableFrom(value.getClass())) {
+            if (!field.getType().isInstance(value)) {
                 throwSetIllegalArgumentException(value);
             }
         }

--- a/src/java.base/share/classes/jdk/internal/reflect/UnsafeStaticObjectFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/UnsafeStaticObjectFieldAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,7 @@ class UnsafeStaticObjectFieldAccessorImpl extends UnsafeStaticFieldAccessorImpl 
             throwFinalFieldIllegalAccessException(value);
         }
         if (value != null) {
-            if (!field.getType().isAssignableFrom(value.getClass())) {
+            if (!field.getType().isInstance(value)) {
                 throwSetIllegalArgumentException(value);
             }
         }

--- a/src/java.desktop/share/classes/com/sun/beans/decoder/NewElementHandler.java
+++ b/src/java.desktop/share/classes/com/sun/beans/decoder/NewElementHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -188,7 +188,7 @@ class NewElementHandler extends ElementHandler {
                 return arguments;
             }
             Class<?> type = types[index];
-            if (type.isAssignableFrom(argument.getClass())) {
+            if (type.isInstance(argument)) {
                 return arguments;
             }
         }

--- a/src/java.desktop/share/classes/javax/imageio/spi/ServiceRegistry.java
+++ b/src/java.desktop/share/classes/javax/imageio/spi/ServiceRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 
 package javax.imageio.spi;
 
-import java.io.File;
 import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -228,7 +227,7 @@ public class ServiceRegistry {
     private Iterator<SubRegistry> getSubRegistries(Object provider) {
         List<SubRegistry> l = new ArrayList<>();
         for (Class<?> c : categoryMap.keySet()) {
-            if (c.isAssignableFrom(provider.getClass())) {
+            if (c.isInstance(provider)) {
                 l.add(categoryMap.get(c));
             }
         }
@@ -270,7 +269,7 @@ public class ServiceRegistry {
         if (reg == null) {
             throw new IllegalArgumentException("category unknown!");
         }
-        if (!category.isAssignableFrom(provider.getClass())) {
+        if (!category.isInstance(provider)) {
             throw new ClassCastException();
         }
 
@@ -373,7 +372,7 @@ public class ServiceRegistry {
         if (reg == null) {
             throw new IllegalArgumentException("category unknown!");
         }
-        if (!category.isAssignableFrom(provider.getClass())) {
+        if (!category.isInstance(provider)) {
             throw new ClassCastException();
         }
         return reg.deregisterServiceProvider(provider);

--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/Defaults.template
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/Defaults.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,14 +50,12 @@ import java.awt.image.BufferedImage;
 import static java.awt.image.BufferedImage.*;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.lang.ref.WeakReference;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.WeakHashMap;
 import javax.swing.border.Border;
 import javax.swing.plaf.UIResource;
@@ -565,7 +563,7 @@ ${UI_DEFAULT_INIT}
                 //type registered, then check to make sure c is of the
                 //right type;
                 Class<?> clazz = parts[partIndex].c;
-                if (clazz != null && clazz.isAssignableFrom(c.getClass())) {
+                if (clazz != null && clazz.isInstance(c)) {
                     //so far so good, recurse
                     return matches(c.getParent(), partIndex - 1);
                 } else if (clazz == null &&

--- a/src/jdk.jconsole/share/classes/sun/tools/jconsole/inspector/Utils.java
+++ b/src/jdk.jconsole/share/classes/sun/tools/jconsole/inspector/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -140,7 +140,7 @@ public class Utils {
             return false;
         }
         for (Object o : c) {
-            if (o == null || !e.isAssignableFrom(o.getClass())) {
+            if (o == null || !e.isInstance(o)) {
                 return false;
             }
         }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/TypeLibrary.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/TypeLibrary.java
@@ -401,8 +401,8 @@ public final class TypeLibrary {
                     Class<?> ct = returnType.getComponentType();
                     if (Annotation.class.isAssignableFrom(ct) && ct.getAnnotation(Repeatable.class) != null) {
                         Object res = m.invoke(a, new Object[0]);
-                        if (res instanceof Annotation[]) {
-                            for (Annotation rep : (Annotation[]) m.invoke(a, new Object[0])) {
+                        if (res instanceof Annotation[] anns) {
+                            for (Annotation rep : anns) {
                                 annos.add(rep);
                             }
                             repeated = true;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/TypeLibrary.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/TypeLibrary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -401,7 +401,7 @@ public final class TypeLibrary {
                     Class<?> ct = returnType.getComponentType();
                     if (Annotation.class.isAssignableFrom(ct) && ct.getAnnotation(Repeatable.class) != null) {
                         Object res = m.invoke(a, new Object[0]);
-                        if (res != null && Annotation[].class.isAssignableFrom(res.getClass())) {
+                        if (res instanceof Annotation[]) {
                             for (Annotation rep : (Annotation[]) m.invoke(a, new Object[0])) {
                                 annos.add(rep);
                             }


### PR DESCRIPTION
Method `Class.isAssignableFrom` is often used in form of:

    if (clazz.isAssignableFrom(obj.getClass())) {
Such condition could be simplified to more shorter and performarnt code

    if (clazz.isInstance(obj)) {
    
Replacement is equivalent if it's known that `obj != null`.
In JDK codebase there are many such places.

I tried to measure performance via JMH
```
    Class<?> integerClass = Integer.class;
    Class<?> numberClass = Number.class;

    Object integerObject = 45666;
    Object doubleObject = 8777d;

    @Benchmark
    public boolean integerInteger_isInstance() {
        return integerClass.isInstance(integerObject);
    }

    @Benchmark
    public boolean integerInteger_isAssignableFrom() {
        return integerClass.isAssignableFrom(integerObject.getClass());
    }

    @Benchmark
    public boolean integerDouble_isInstance() {
        return integerClass.isInstance(doubleObject);
    }

    @Benchmark
    public boolean integerDouble_isAssignableFrom() {
        return integerClass.isAssignableFrom(doubleObject.getClass());
    }

    @Benchmark
    public boolean numberDouble_isInstance() {
        return numberClass.isInstance(doubleObject);
    }

    @Benchmark
    public boolean numberDouble_isAssignableFrom() {
        return numberClass.isAssignableFrom(doubleObject.getClass());
    }

    @Benchmark
    public boolean numberInteger_isInstance() {
        return numberClass.isInstance(integerObject);
    }

    @Benchmark
    public boolean numberInteger_isAssignableFrom() {
        return numberClass.isAssignableFrom(integerObject.getClass());
    }

    @Benchmark
    public void numberIntegerDouble_isInstance(Blackhole bh) {
        bh.consume(numberClass.isInstance(integerObject));
        bh.consume(numberClass.isInstance(doubleObject));
    }

    @Benchmark
    public void integerIntegerDouble_isAssignableFrom(Blackhole bh) {
        bh.consume(integerClass.isAssignableFrom(integerObject.getClass()));
        bh.consume(integerClass.isAssignableFrom(doubleObject.getClass()));
    }
```
`isInstance` is a bit faster than `isAssignableFrom`
```
Benchmark                              Mode  Cnt  Score   Error  Units
integerDouble_isAssignableFrom         avgt    5  1,173 ± 0,026  ns/op
integerDouble_isInstance               avgt    5  0,939 ± 0,038  ns/op
integerIntegerDouble_isAssignableFrom  avgt    5  2,106 ± 0,068  ns/op
numberIntegerDouble_isInstance         avgt    5  1,516 ± 0,046  ns/op
integerInteger_isAssignableFrom        avgt    5  1,175 ± 0,029  ns/op
integerInteger_isInstance              avgt    5  0,886 ± 0,017  ns/op
numberDouble_isAssignableFrom          avgt    5  1,172 ± 0,007  ns/op
numberDouble_isInstance                avgt    5  0,891 ± 0,030  ns/op
numberInteger_isAssignableFrom         avgt    5  1,169 ± 0,014  ns/op
numberInteger_isInstance               avgt    5  0,887 ± 0,016  ns/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8280035](https://bugs.openjdk.java.net/browse/JDK-8280035): Use Class.isInstance instead of Class.isAssignableFrom where applicable


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7061/head:pull/7061` \
`$ git checkout pull/7061`

Update a local copy of the PR: \
`$ git checkout pull/7061` \
`$ git pull https://git.openjdk.java.net/jdk pull/7061/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7061`

View PR using the GUI difftool: \
`$ git pr show -t 7061`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7061.diff">https://git.openjdk.java.net/jdk/pull/7061.diff</a>

</details>
