### PR TITLE
JDK-8279956: Useless method Scheduling::ComputeLocalLatenciesForward()

### DIFF
--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -22,6 +22,12 @@
  *
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2022. These
+ * modifications are Copyright (c) 2022, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 #include "precompiled.hpp"
 #include "asm/assembler.inline.hpp"
 #include "asm/macroAssembler.inline.hpp"
@@ -96,10 +102,6 @@ private:
   // Free list for pinch nodes.
   Node_List _pinch_free_list;
 
-  // Latency from the beginning of the containing basic block (base 1)
-  // for each node.
-  unsigned short *_node_latency;
-
   // Number of uses of this node within the containing basic block.
   short *_uses;
 
@@ -161,10 +163,6 @@ public:
 
   // Do the scheduling
   void DoScheduling();
-
-  // Compute the local latencies walking forward over the list of
-  // nodes for a basic block
-  void ComputeLocalLatenciesForward(const Block *bb);
 
   // Compute the register antidependencies within a basic block
   void ComputeRegisterAntidependencies(Block *bb);
@@ -2027,7 +2025,6 @@ Scheduling::Scheduling(Arena *arena, Compile &compile)
   _node_bundling_base = NEW_ARENA_ARRAY(compile.comp_arena(), Bundle, node_max);
 
   // Allocate space for fixed-size arrays
-  _node_latency    = NEW_ARENA_ARRAY(arena, unsigned short, node_max);
   _uses            = NEW_ARENA_ARRAY(arena, short,          node_max);
   _current_latency = NEW_ARENA_ARRAY(arena, unsigned short, node_max);
 
@@ -2035,7 +2032,6 @@ Scheduling::Scheduling(Arena *arena, Compile &compile)
   for (uint i = 0; i < node_max; i++) {
     ::new (&_node_bundling_base[i]) Bundle();
   }
-  memset(_node_latency,       0, node_max * sizeof(unsigned short));
   memset(_uses,               0, node_max * sizeof(short));
   memset(_current_latency,    0, node_max * sizeof(unsigned short));
 
@@ -2140,54 +2136,6 @@ void PhaseOutput::ScheduleAndBundle() {
   }
 #endif
 }
-
-// Compute the latency of all the instructions.  This is fairly simple,
-// because we already have a legal ordering.  Walk over the instructions
-// from first to last, and compute the latency of the instruction based
-// on the latency of the preceding instruction(s).
-void Scheduling::ComputeLocalLatenciesForward(const Block *bb) {
-#ifndef PRODUCT
-  if (_cfg->C->trace_opto_output())
-    tty->print("# -> ComputeLocalLatenciesForward\n");
-#endif
-
-  // Walk over all the schedulable instructions
-  for( uint j=_bb_start; j < _bb_end; j++ ) {
-
-    // This is a kludge, forcing all latency calculations to start at 1.
-    // Used to allow latency 0 to force an instruction to the beginning
-    // of the bb
-    uint latency = 1;
-    Node *use = bb->get_node(j);
-    uint nlen = use->len();
-
-    // Walk over all the inputs
-    for ( uint k=0; k < nlen; k++ ) {
-      Node *def = use->in(k);
-      if (!def)
-        continue;
-
-      uint l = _node_latency[def->_idx] + use->latency(k);
-      if (latency < l)
-        latency = l;
-    }
-
-    _node_latency[use->_idx] = latency;
-
-#ifndef PRODUCT
-    if (_cfg->C->trace_opto_output()) {
-      tty->print("# latency %4d: ", latency);
-      use->dump();
-    }
-#endif
-  }
-
-#ifndef PRODUCT
-  if (_cfg->C->trace_opto_output())
-    tty->print("# <- ComputeLocalLatenciesForward\n");
-#endif
-
-} // end ComputeLocalLatenciesForward
 
 // See if this node fits into the present instruction bundle
 bool Scheduling::NodeFitsInBundle(Node *n) {
@@ -2763,9 +2711,6 @@ void Scheduling::DoScheduling() {
     // Compute the register antidependencies for the basic block
     ComputeRegisterAntidependencies(bb);
     if (C->failing())  return;  // too many D-U pinch points
-
-    // Compute intra-bb latencies for the nodes
-    ComputeLocalLatenciesForward(bb);
 
     // Compute the usage within the block, and set the list of all nodes
     // in the block that have no uses within the block.

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,12 +20,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  *
- */
-
-/*
- * This file has been modified by Loongson Technology in 2022. These
- * modifications are Copyright (c) 2022, Loongson Technology, and are made
- * available on the same license terms set forth above.
  */
 
 #include "precompiled.hpp"


### PR DESCRIPTION
Method `Scheduling::ComputeLocalLatenciesForward()` be used for compute the latency of all the instructions and write the result to `_node_latency`. But I found that `_node_latency` was never used. So I think method `Scheduling::ComputeLocalLatenciesForward()` can be deleted, which is also an enhancement to the efficiency of compilation threads.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279956](https://bugs.openjdk.java.net/browse/JDK-8279956): Useless method Scheduling::ComputeLocalLatenciesForward()


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7062/head:pull/7062` \
`$ git checkout pull/7062`

Update a local copy of the PR: \
`$ git checkout pull/7062` \
`$ git pull https://git.openjdk.java.net/jdk pull/7062/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7062`

View PR using the GUI difftool: \
`$ git pr show -t 7062`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7062.diff">https://git.openjdk.java.net/jdk/pull/7062.diff</a>

</details>
