### PR TITLE
8279918: Fix various doc typos

### DIFF
--- a/src/java.base/share/classes/java/io/DataInput.java
+++ b/src/java.base/share/classes/java/io/DataInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -493,7 +493,7 @@ public interface DataInput {
      * is encountered, it is discarded and reading
      * ceases. If the character {@code '\r'}
      * is encountered, it is discarded and, if
-     * the following byte converts &#32;to the
+     * the following byte converts to the
      * character {@code '\n'}, then that is
      * discarded also; reading then ceases. If
      * end of file is encountered before either

--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -738,7 +738,7 @@ public class ObjectInputStream
      * restored a final set of validations can be performed.
      *
      * @param   obj the object to receive the validation callback.
-     * @param   prio controls the order of callbacks;zero is a good default.
+     * @param   prio controls the order of callbacks; zero is a good default.
      *          Use higher numbers to be called back earlier, lower numbers for
      *          later callbacks. Within a priority, callbacks are processed in
      *          no particular order.

--- a/src/java.base/share/classes/java/io/PipedInputStream.java
+++ b/src/java.base/share/classes/java/io/PipedInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -222,7 +222,7 @@ public class PipedInputStream extends InputStream {
      * @param    len the maximum number of bytes received
      * @throws   IOException If the pipe is <a href="#BROKEN"> broken</a>,
      *           {@link #connect(java.io.PipedOutputStream) unconnected},
-     *           closed,or if an I/O error occurs.
+     *           closed, or if an I/O error occurs.
      */
     synchronized void receive(byte[] b, int off, int len)  throws IOException {
         checkStateForReceive();

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1582,7 +1582,7 @@ public final class Class<T> implements java.io.Serializable,
      * representing the class in which it was declared.  This method returns
      * null if this class or interface is not a member of any other class.  If
      * this {@code Class} object represents an array class, a primitive
-     * type, or void,then this method returns null.
+     * type, or void, then this method returns null.
      *
      * @return the declaring class for this class
      * @throws SecurityException

--- a/src/java.base/share/classes/java/math/BigDecimal.java
+++ b/src/java.base/share/classes/java/math/BigDecimal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1791,7 +1791,7 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
      * @throws ArithmeticException if the result is inexact but the
      *         rounding mode is {@code UNNECESSARY} or
      *         {@code mc.precision == 0} and the quotient has a
-     *         non-terminating decimal expansion,including dividing by zero
+     *         non-terminating decimal expansion, including dividing by zero
      * @since  1.5
      */
     public BigDecimal divide(BigDecimal divisor, MathContext mc) {

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -778,7 +778,7 @@ public class MessageFormat extends Format {
      * {@code null} or has fewer than argumentIndex+1 elements.
      *
      * <table class="plain">
-     * <caption style="display:none">Examples of subformat,argument,and formatted text</caption>
+     * <caption style="display:none">Examples of subformat, argument, and formatted text</caption>
      * <thead>
      *    <tr>
      *       <th scope="col">Subformat

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2003,7 +2003,7 @@ public final class Locale implements Cloneable, Serializable {
     /**
      * Returns a name for the locale that is appropriate for display
      * to the user.  This will be the values returned by
-     * getDisplayLanguage(), getDisplayScript(),getDisplayCountry()
+     * getDisplayLanguage(), getDisplayScript(), getDisplayCountry(),
      * getDisplayVariant(), and optional <a href="./Locale.html#def_locale_extension">
      * Unicode extensions</a> assembled into a single string. The non-empty
      * values are used in order, with the second and subsequent names in

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -208,7 +208,7 @@ public class ZipFile implements ZipConstants, Closeable {
      *
      * @throws SecurityException
      *         if a security manager exists and its {@code checkRead}
-     *         method doesn't allow read access to the file,or its
+     *         method doesn't allow read access to the file, or its
      *         {@code checkDelete} method doesn't allow deleting the
      *         file when the {@code OPEN_DELETE} flag is set
      *

--- a/src/java.base/share/classes/sun/text/RuleBasedBreakIterator.java
+++ b/src/java.base/share/classes/sun/text/RuleBasedBreakIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,7 +70,7 @@ import sun.text.SupplementaryCharacterData;
  * expression defines a set of characters (the &quot;<em>ignore characters</em>&quot;) that
  * will be transparent to the BreakIterator.&nbsp; A sequence of characters will break the
  * same way it would if any ignore characters it contains are taken out.&nbsp; Break
- * positions never occur befoer ignore characters.</p>
+ * positions never occur before ignore characters.</p>
  *
  * <p>A regular expression uses a subset of the normal Unix regular-expression syntax, and
  * defines a sequence of characters to be kept together. With one significant exception, the
@@ -151,7 +151,7 @@ import sun.text.SupplementaryCharacterData;
  *       <td width="94%">If ! appears at the beginning of a regular expression, it tells the regexp
  *       parser that this expression specifies the backwards-iteration behavior of the iterator,
  *       and not its normal iteration behavior.&nbsp; This is generally only used in situations
- *       where the automatically-generated backwards-iteration brhavior doesn't produce
+ *       where the automatically-generated backwards-iteration behavior doesn't produce
  *       satisfactory results and must be supplemented with extra client-specified rules.</td>
  *     </tr>
  *     <tr>

--- a/src/java.base/share/classes/sun/text/spi/JavaTimeDateTimePatternProvider.java
+++ b/src/java.base/share/classes/sun/text/spi/JavaTimeDateTimePatternProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,12 +46,12 @@ public abstract class JavaTimeDateTimePatternProvider extends LocaleServiceProvi
      * Concrete implementation of this method will retrieve
      * a java.time specific dateTime Pattern from selected Locale Provider.
      *
-     * @param timeStyle an {@code int} value representing FormatStyle constant, -1
+     * @param timeStyle an {@code int} value, representing FormatStyle constant, -1
      * for date-only pattern
-     * @param dateStyle an {@code int} value,representing FormatStyle constant, -1
+     * @param dateStyle an {@code int} value, representing FormatStyle constant, -1
      * for time-only pattern
      * @param locale {@code locale}, non-null
-     * @param calType a {@code String},non-null representing CalendarType such as "japanese",
+     * @param calType a {@code String}, non-null representing CalendarType such as "japanese",
      * "iso8601"
      * @return  formatting pattern {@code String}
      * @see java.time.format.DateTimeFormatterBuilder#convertStyle(java.time.format.FormatStyle)

--- a/src/java.desktop/share/classes/com/sun/beans/TypeResolver.java
+++ b/src/java.desktop/share/classes/com/sun/beans/TypeResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,7 +104,7 @@ public final class TypeResolver {
      * of those parameters.  For example, Map&lt;K,V> is a generic class, and
      * a corresponding ParameterizedType might look like
      * Map&lt;K=String,V=Integer>.  Given such a ParameterizedType, this method
-     * will replace K with String, or List&lt;K> with List&ltString;, or
+     * will replace K with String, or List&lt;K> with List&lt;String>, or
      * List&lt;? super K> with List&lt;? super String>.</p>
      *
      * <p>The {@code actual} argument to this method can also be a Class.

--- a/src/java.desktop/share/classes/java/awt/List.java
+++ b/src/java.desktop/share/classes/java/awt/List.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1750,7 +1750,7 @@ public class List extends Component implements ItemSelectable, Accessible {
             /**
              * Get the Font of this object.
              *
-             * @return the Font,if supported, for the object; otherwise, null
+             * @return the Font, if supported, for the object; otherwise, null
              * @see #setFont
              */
             public Font getFont() {

--- a/src/java.desktop/share/classes/java/awt/MenuComponent.java
+++ b/src/java.desktop/share/classes/java/awt/MenuComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -742,7 +742,7 @@ public abstract class MenuComponent implements java.io.Serializable {
         /**
          * Gets the {@code Font} of this object.
          *
-         * @return the {@code Font},if supported, for the object;
+         * @return the {@code Font}, if supported, for the object;
          *     otherwise, {@code null}
          */
         public Font getFont() {

--- a/src/java.desktop/share/classes/java/awt/font/GlyphJustificationInfo.java
+++ b/src/java.desktop/share/classes/java/awt/font/GlyphJustificationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 1999, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -193,7 +193,7 @@ public final class GlyphJustificationInfo {
     public final int shrinkPriority;
 
     /**
-     * If {@code true},this glyph absorbs all remaining shrinkage at
+     * If {@code true}, this glyph absorbs all remaining shrinkage at
      * this and lower priority levels as it shrinks.
      */
     public final boolean shrinkAbsorb;

--- a/src/java.desktop/share/classes/java/awt/geom/Arc2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Arc2D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -777,7 +777,7 @@ public abstract class Arc2D extends RectangularShape {
      * elliptical boundary of the arc.
      *
      * @return A {@code Point2D} object representing the
-     * x,y coordinates  of the ending point of the arc.
+     * x,y coordinates of the ending point of the arc.
      * @since 1.2
      */
     public Point2D getEndPoint() {

--- a/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -393,7 +393,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      * zero-extension. If the character {@code '\n'} is
      * encountered, it is discarded and reading ceases. If the
      * character {@code '\r'} is encountered, it is discarded
-     * and, if the following byte converts &#32;to the character
+     * and, if the following byte converts to the character
      * {@code '\n'}, then that is discarded also; reading then
      * ceases. If end of file is encountered before either of the
      * characters {@code '\n'} and {@code '\r'} is

--- a/src/java.desktop/share/classes/javax/print/attribute/standard/JobStateReason.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/JobStateReason.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,7 +89,7 @@ public class JobStateReason extends EnumSyntax implements Attribute {
     /**
      * The printer could not access one or more documents passed by reference
      * (i.e., the print data representation object is a {@code URL}). This
-     * reason is intended to cover any file access problem,including file does
+     * reason is intended to cover any file access problem, including file does
      * not exist and access denied because of an access control problem. Whether
      * the printer aborts the job and moves the job to the {@code ABORTED} job
      * state or prints all documents that are accessible and moves the job to

--- a/src/java.desktop/share/classes/javax/sound/midi/Sequencer.java
+++ b/src/java.desktop/share/classes/javax/sound/midi/Sequencer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -472,7 +472,7 @@ public interface Sequencer extends MidiDevice {
     /**
      * Registers a meta-event listener to receive notification whenever a
      * meta-event is encountered in the sequence and processed by the sequencer.
-     * This method can fail if, for instance,this class of sequencer does not
+     * This method can fail if, for instance, this class of sequencer does not
      * support meta-event notification.
      *
      * @param  listener listener to add

--- a/src/java.desktop/share/classes/javax/swing/text/html/AccessibleHTML.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/AccessibleHTML.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -464,7 +464,7 @@ class AccessibleHTML implements Accessible {
         /**
          * Gets the Font of this object.
          *
-         * @return the Font,if supported, for the object; otherwise, null
+         * @return the Font, if supported, for the object; otherwise, null
          * @see #setFont
          */
         public Font getFont() {

--- a/src/java.logging/share/classes/java/util/logging/LogRecord.java
+++ b/src/java.logging/share/classes/java/util/logging/LogRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -179,7 +179,7 @@ public class LogRecord implements java.io.Serializable {
 
     /**
      * Synthesizes a pseudo unique integer value from a long {@code id} value.
-     * For backward compatibility with previous releases,the returned integer is
+     * For backward compatibility with previous releases, the returned integer is
      * such that for any positive long less than or equals to {@code Integer.MAX_VALUE},
      * the returned integer is equal to the original value.
      * Otherwise - it is synthesized with a best effort hashing algorithm,

--- a/src/java.management/share/classes/javax/management/MXBean.java
+++ b/src/java.management/share/classes/javax/management/MXBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -929,7 +929,7 @@ public interface ModuleMXBean {
       <li><p>Otherwise, if <em>J</em> has at least one public
         constructor with either {@link javax.management.ConstructorParameters
         &#64;javax.management.ConstructorParameters} or
-        {@code @java.beans.ConstructoProperties} annotation, then one of those
+        {@code @java.beans.ConstructorProperties} annotation, then one of those
         constructors (not necessarily always the same one) will be called to
         reconstruct an instance of <em>J</em>.
         If a constructor is annotated with both

--- a/src/java.security.sasl/share/classes/javax/security/sasl/SaslServer.java
+++ b/src/java.security.sasl/share/classes/javax/security/sasl/SaslServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,7 +105,7 @@ public abstract interface SaslServer {
      * by sending a challenge to the client, or if the authentication has
      * succeeded but challenge data needs to be processed by the client.
      * {@code isComplete()} should be called
-     * after each call to {@code evaluateResponse()},to determine if any further
+     * after each call to {@code evaluateResponse()}, to determine if any further
      * response is needed from the client.
      *
      * @param response The non-null (but possibly empty) response sent

--- a/src/java.sql/share/classes/java/sql/BatchUpdateException.java
+++ b/src/java.sql/share/classes/java/sql/BatchUpdateException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ import java.util.Arrays;
  * <P>
  * A JDBC driver implementation should use
  * the constructor {@code BatchUpdateException(String reason, String SQLState,
- * int vendorCode, long []updateCounts,Throwable cause) } instead of
+ * int vendorCode, long []updateCounts, Throwable cause) } instead of
  * constructors that take {@code int[]} for the update counts to avoid the
  * possibility of overflow.
  * <p>
@@ -78,7 +78,7 @@ public class BatchUpdateException extends SQLException {
    * <strong>Note:</strong> There is no validation of {@code updateCounts} for
    * overflow and because of this it is recommended that you use the constructor
    * {@code BatchUpdateException(String reason, String SQLState,
-   * int vendorCode, long []updateCounts,Throwable cause) }.
+   * int vendorCode, long []updateCounts, Throwable cause) }.
    * </p>
    * @param reason a description of the error
    * @param SQLState an XOPEN or SQL:2003 code identifying the exception
@@ -115,7 +115,7 @@ public class BatchUpdateException extends SQLException {
    * <strong>Note:</strong> There is no validation of {@code updateCounts} for
    * overflow and because of this it is recommended that you use the constructor
    * {@code BatchUpdateException(String reason, String SQLState,
-   * int vendorCode, long []updateCounts,Throwable cause) }.
+   * int vendorCode, long []updateCounts, Throwable cause) }.
    * </p>
    * @param reason a description of the exception
    * @param SQLState an XOPEN or SQL:2003 code identifying the exception
@@ -148,7 +148,7 @@ public class BatchUpdateException extends SQLException {
    * <strong>Note:</strong> There is no validation of {@code updateCounts} for
    * overflow and because of this it is recommended that you use the constructor
    * {@code BatchUpdateException(String reason, String SQLState,
-   * int vendorCode, long []updateCounts,Throwable cause) }.
+   * int vendorCode, long []updateCounts, Throwable cause) }.
    * </p>
    * @param reason a description of the exception
    * @param updateCounts an array of {@code int}, with each element
@@ -178,7 +178,7 @@ public class BatchUpdateException extends SQLException {
    * <strong>Note:</strong> There is no validation of {@code updateCounts} for
    * overflow and because of this it is recommended that you use the constructor
    * {@code BatchUpdateException(String reason, String SQLState,
-   * int vendorCode, long []updateCounts,Throwable cause) }.
+   * int vendorCode, long []updateCounts, Throwable cause) }.
    * </p>
    * @param updateCounts an array of {@code int}, with each element
    * indicating the update count, {@code Statement.SUCCESS_NO_INFO} or
@@ -244,7 +244,7 @@ public class BatchUpdateException extends SQLException {
    * <strong>Note:</strong> There is no validation of {@code updateCounts} for
    * overflow and because of this it is recommended that you use the constructor
    * {@code BatchUpdateException(String reason, String SQLState,
-   * int vendorCode, long []updateCounts,Throwable cause) }.
+   * int vendorCode, long []updateCounts, Throwable cause) }.
    * </p>
    * @param updateCounts an array of {@code int}, with each element
    * indicating the update count, {@code Statement.SUCCESS_NO_INFO} or
@@ -274,7 +274,7 @@ public class BatchUpdateException extends SQLException {
    * <strong>Note:</strong> There is no validation of {@code updateCounts} for
    * overflow and because of this it is recommended that you use the constructor
    * {@code BatchUpdateException(String reason, String SQLState,
-   * int vendorCode, long []updateCounts,Throwable cause) }.
+   * int vendorCode, long []updateCounts, Throwable cause) }.
    * </p>
    * @param reason a description of the exception
    * @param updateCounts an array of {@code int}, with each element
@@ -315,7 +315,7 @@ public class BatchUpdateException extends SQLException {
    * <strong>Note:</strong> There is no validation of {@code updateCounts} for
    * overflow and because of this it is recommended that you use the constructor
    * {@code BatchUpdateException(String reason, String SQLState,
-   * int vendorCode, long []updateCounts,Throwable cause) }.
+   * int vendorCode, long []updateCounts, Throwable cause) }.
    * </p>
    * @param cause the underlying reason for this {@code SQLException}
    * (which is saved for later retrieval by the {@code getCause()} method);
@@ -351,7 +351,7 @@ public class BatchUpdateException extends SQLException {
    * <strong>Note:</strong> There is no validation of {@code updateCounts} for
    * overflow and because of this it is recommended that you use the constructor
    * {@code BatchUpdateException(String reason, String SQLState,
-   * int vendorCode, long []updateCounts,Throwable cause) }.
+   * int vendorCode, long []updateCounts, Throwable cause) }.
    * </p>
    * @param cause the underlying reason for this {@code SQLException} (which is saved for later retrieval by the {@code getCause()} method);
    * may be null indicating

--- a/src/java.sql/share/classes/java/sql/Connection.java
+++ b/src/java.sql/share/classes/java/sql/Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -634,7 +634,7 @@ public interface Connection  extends Wrapper, AutoCloseable {
      * custom mapping of SQL structured types and distinct types.
      * <p>
      * You must set the values for the {@code TypeMap} prior to
-     * callng {@code setMap} as a JDBC driver may create an internal copy
+     * calling {@code setMap} as a JDBC driver may create an internal copy
      * of the {@code TypeMap}:
      *
      * <pre>
@@ -1594,7 +1594,7 @@ throws SQLException;
     /**
      * Sets and validates the sharding keys for this connection. A {@code null}
      * value may be specified for the sharding Key. The validity
-     * of a {@code null} sharding key is vendor-specific. Consult your vendor&#39;s
+     * of a {@code null} sharding key is vendor-specific. Consult your vendor's
      * documentation for additional information.
      * @implSpec
      * The default implementation will throw a
@@ -1616,7 +1616,7 @@ throws SQLException;
      * and set on this connection; false if the sharding keys are not valid or
      * the timeout period expires before the operation completes.
      * @throws SQLException if an error occurs while performing this validation;
-     * a {@code superSharedingKey} is specified
+     * a {@code superShardingKey} is specified
      * without a {@code shardingKey};
      * this method is called on a closed {@code connection}; or
      * the {@code timeout} value is negative.
@@ -1634,7 +1634,7 @@ throws SQLException;
     /**
      * Sets and validates the sharding key for this connection. A {@code null}
      * value may be specified for the sharding Key. The validity
-     * of a {@code null} sharding key is vendor-specific. Consult your vendor&#39;s
+     * of a {@code null} sharding key is vendor-specific. Consult your vendor's
      * documentation for additional information.
      * @implSpec
      * The default implementation will throw a
@@ -1680,7 +1680,7 @@ throws SQLException;
      * The super sharding key may be {@code null}
      * @throws SQLException if an error  occurs setting the sharding keys;
      * this method is called on a closed {@code connection}; or
-     * a {@code superSharedingKey} is specified without a {@code shardingKey}
+     * a {@code superShardingKey} is specified without a {@code shardingKey}
      * @throws SQLFeatureNotSupportedException if the driver does not support sharding
      * @since 9
      * @see ShardingKey

--- a/src/java.sql/share/classes/java/sql/DatabaseMetaData.java
+++ b/src/java.sql/share/classes/java/sql/DatabaseMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1513,7 +1513,7 @@ public interface DatabaseMetaData extends Wrapper {
      * @param tableNamePattern a table name pattern; must match the
      *        table name as it is stored in the database
      * @param types a list of table types, which must be from the list of table types
-     *         returned from {@link #getTableTypes},to include; {@code null} returns
+     *         returned from {@link #getTableTypes}, to include; {@code null} returns
      * all types
      * @return {@code ResultSet} - each row is a table description
      * @throws SQLException if a database access error occurs
@@ -3044,7 +3044,7 @@ public interface DatabaseMetaData extends Wrapper {
      *  <LI><B>SCOPE_TABLE</B> String {@code =>} table name that is the scope of a
      *      reference attribute ({@code null} if the DATA_TYPE isn't REF)
      * <LI><B>SOURCE_DATA_TYPE</B> short {@code =>} source type of a distinct type or user-generated
-     *      Ref type,SQL type from java.sql.Types ({@code null} if DATA_TYPE
+     *      Ref type, SQL type from java.sql.Types ({@code null} if DATA_TYPE
      *      isn't DISTINCT or user-generated REF)
      *  </OL>
      * @param catalog a catalog name; must match the catalog name as it

--- a/src/java.sql/share/classes/java/sql/Statement.java
+++ b/src/java.sql/share/classes/java/sql/Statement.java
@@ -960,7 +960,7 @@ public interface Statement extends Wrapper, AutoCloseable {
      *         object; {@code false} if it is an update count or there
      *         are no more results
      * @throws SQLException if a database access error occurs,
-     * this method is called on a closed {@code Statement},the
+     * this method is called on a closed {@code Statement}, the
      *          elements of the {@code String} array passed to this
      *          method are not valid column names, the method is called on a
      * {@code PreparedStatement} or {@code CallableStatement}

--- a/src/java.sql/share/classes/java/sql/Statement.java
+++ b/src/java.sql/share/classes/java/sql/Statement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -779,7 +779,7 @@ public interface Statement extends Wrapper, AutoCloseable {
      *
      * @throws SQLException if a database access error occurs,
      * this method is called on a closed {@code Statement}, the SQL
-     * statement returns a {@code ResultSet} object,the second argument
+     * statement returns a {@code ResultSet} object, the second argument
      * supplied to this method is not an
      * {@code int} array whose elements are valid column indexes, the method is called on a
      * {@code PreparedStatement} or {@code CallableStatement}

--- a/src/java.xml/share/classes/javax/xml/stream/XMLStreamReader.java
+++ b/src/java.xml/share/classes/javax/xml/stream/XMLStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,7 +85,7 @@ import javax.xml.namespace.QName;
  *       <td> getProperty(), hasNext(), require(), close(),
  *            getNamespaceURI(), isStartElement(),
  *            isEndElement(), isCharacters(), isWhiteSpace(),
- *            getNamespaceContext(), getEventType(),getLocation(),
+ *            getNamespaceContext(), getEventType(), getLocation(),
  *            hasText(), hasName()
  *       </td>
  *     </tr>

--- a/src/java.xml/share/classes/org/xml/sax/ext/DeclHandler.java
+++ b/src/java.xml/share/classes/org/xml/sax/ext/DeclHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ public interface DeclHandler
      * string "ANY", or a parenthesised group, optionally followed
      * by an occurrence indicator.  The model will be normalized so
      * that all parameter entities are fully resolved and all whitespace
-     * is removed,and will include the enclosing parentheses.  Other
+     * is removed, and will include the enclosing parentheses.  Other
      * normalization (such as removing redundant parentheses or
      * simplifying occurrence indicators) is at the discretion of the
      * parser.</p>

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ArgumentAttr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ArgumentAttr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -143,7 +143,7 @@ public class ArgumentAttr extends JCTree.Visitor {
 
     /**
      * Checks a type in the speculative tree against a given result; the type can be either a plain
-     * type or an argument type,in which case a more complex check is required.
+     * type or an argument type, in which case a more complex check is required.
      */
     Type checkSpeculative(JCTree expr, ResultInfo resultInfo) {
         return checkSpeculative(expr, expr.type, resultInfo);
@@ -151,7 +151,7 @@ public class ArgumentAttr extends JCTree.Visitor {
 
     /**
      * Checks a type in the speculative tree against a given result; the type can be either a plain
-     * type or an argument type,in which case a more complex check is required.
+     * type or an argument type, in which case a more complex check is required.
      */
     Type checkSpeculative(DiagnosticPosition pos, Type t, ResultInfo resultInfo) {
         if (t.hasTag(DEFERRED)) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/sjavac/Package.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/sjavac/Package.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ import com.sun.tools.sjavac.pubapi.PubApi;
 
 /**
  * The Package class maintains meta information about a package.
- * For example its sources, dependents,its pubapi and its artifacts.
+ * For example its sources, dependents, its pubapi and its artifacts.
  *
  * It might look odd that we track dependents/pubapi/artifacts on
  * a package level, but it makes sense since recompiling a full package

--- a/src/jdk.compiler/share/classes/com/sun/tools/sjavac/Transformer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/sjavac/Transformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import com.sun.tools.sjavac.pubapi.PubApi;
  * The transform interface is used to transform content inside a package, from one form to another.
  * Usually the output form is an unpredictable number of output files. (eg class files)
  * but can also be an unpredictable number of generated source files (eg idl2java)
- * or a single predictable output file (eg when copying,cleaning or compiling a properties file).
+ * or a single predictable output file (eg when copying, cleaning or compiling a properties file).
  *
  *  <p><b>This is NOT part of any supported API.
  *  If you write code that depends on this, you do so at your own risk.

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ParamTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -152,7 +152,7 @@ public class ParamTaglet extends BaseTaglet implements InheritableTaglet {
     }
 
     /**
-     * Given an array of {@code @param DocTree}s,return its string representation.
+     * Given an array of {@code @param DocTree}s, return its string representation.
      * Try to inherit the param tags that are missing.
      *
      * @param holder            the element that holds the param tags.

--- a/src/jdk.jdi/share/classes/com/sun/jdi/VirtualMachineManager.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/VirtualMachineManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,7 +97,7 @@ import com.sun.jdi.event.VMStartEvent;
  * {@code -agentlib:jdwp=transport=xxx,server=y}
  * </LI>
  * <LI>
- * Target VM generates and outputs the tranport-specific address at which it will
+ * Target VM generates and outputs the transport-specific address at which it will
  * listen for a connection.</LI>
  * <LI>
  * Debugger is launched. Debugger selects a connector in the list
@@ -158,7 +158,7 @@ import com.sun.jdi.event.VMStartEvent;
  * </LI>
  * <LI>
  * Later, an uncaught exception is thrown in the target VM. The target
- * VM generates the tranport-specific address at which it will
+ * VM generates the transport-specific address at which it will
  * listen for a connection.
  * <LI>Target VM launches the debugger with the following items concatenated
  * together (separated by spaces) to form the command line:

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/SecuritySupport.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/SecuritySupport.java
@@ -149,7 +149,7 @@ public final class SecuritySupport {
     }
 
     /**
-     * Path created by the default file provider,and not
+     * Path created by the default file provider, and not
      * a malicious provider.
      *
      */

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/module/KeyStoreLoginModule.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/module/KeyStoreLoginModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -712,7 +712,7 @@ public class KeyStoreLoginModule implements LoginModule {
      * {@code login} method), then this method associates a
      * {@code X500Principal} for the subject distinguished name of the
      * first certificate in the alias's credentials in the subject's
-     * principals,the alias's certificate path in the subject's public
+     * principals, the alias's certificate path in the subject's public
      * credentials, and a {@code X500PrivateCredential} whose certificate
      * is the first  certificate in the alias's certificate path and whose
      * private key is the alias's private key in the subject's private


### PR DESCRIPTION
- Most of the typos are of a trivial kind: missing whitespace.
- If any of the typos should be fixed in the upstream projects instead, please say so; I will drop those typos from the patch.
- As I understand it, `&#32;` in ImageInputStream and DataInput is an irrelevant formatting artefact and thus can be removed.
- `&#39;` is an apostrophe, which does not require to be encoded.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279918](https://bugs.openjdk.java.net/browse/JDK-8279918): Fix various doc typos


### Reviewers
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to fe81eeca2d4d29aed1c89b7c17beba381b01a731
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**) ⚠️ Review applies to fe81eeca2d4d29aed1c89b7c17beba381b01a731
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7063/head:pull/7063` \
`$ git checkout pull/7063`

Update a local copy of the PR: \
`$ git checkout pull/7063` \
`$ git pull https://git.openjdk.java.net/jdk pull/7063/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7063`

View PR using the GUI difftool: \
`$ git pr show -t 7063`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7063.diff">https://git.openjdk.java.net/jdk/pull/7063.diff</a>

</details>
