### PR TITLE
8279958: Provide configure hints for Alpine/apk package managers

### DIFF
--- a/make/autoconf/help.m4
+++ b/make/autoconf/help.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 
 AC_DEFUN_ONCE([HELP_SETUP_DEPENDENCY_HELP],
 [
-  UTIL_LOOKUP_PROGS(PKGHANDLER, zypper apt-get yum brew port pkgutil pkgadd pacman)
+  UTIL_LOOKUP_PROGS(PKGHANDLER, zypper apt-get yum brew port pkgutil pkgadd pacman apk)
 ])
 
 AC_DEFUN([HELP_MSG_MISSING_DEPENDENCY],
@@ -58,6 +58,8 @@ AC_DEFUN([HELP_MSG_MISSING_DEPENDENCY],
         zypper_help  $MISSING_DEPENDENCY ;;
       *pacman)
         pacman_help  $MISSING_DEPENDENCY ;;
+      *apk)
+        apk_help     $MISSING_DEPENDENCY ;;
     esac
 
     if test "x$PKGHANDLER_COMMAND" != x; then
@@ -190,6 +192,27 @@ pkgutil_help() {
 
 pkgadd_help() {
   PKGHANDLER_COMMAND=""
+}
+
+apk_help() {
+  case $1 in
+    devkit)
+      PKGHANDLER_COMMAND="sudo apk add alpine-sdk linux-headers" ;;
+    alsa)
+      PKGHANDLER_COMMAND="sudo apk add alsa-lib-dev" ;;
+    cups)
+      PKGHANDLER_COMMAND="sudo apk add cups-dev" ;;
+    fontconfig)
+      PKGHANDLER_COMMAND="sudo apk add fontconfig-dev" ;;
+    freetype)
+      PKGHANDLER_COMMAND="sudo apk add freetype-dev" ;;
+    harfbuzz)
+      PKGHANDLER_COMMAND="sudo apk add harfbuzz-dev" ;;
+    x11)
+      PKGHANDLER_COMMAND="sudo apk add libxtst-dev libxt-dev libxrender-dev libxrandr-dev" ;;
+    ccache)
+      PKGHANDLER_COMMAND="sudo apk add ccache" ;;
+  esac
 }
 
 # This function will check if we're called from the "configure" wrapper while


### PR DESCRIPTION
Our build system provides helpful hints about the packages to install to resolve the build-time dependencies. It can be amended to include Alpine/apk package managers. Noticed this when trying to build mainline OpenJDK on Alpine 3. 

Additional testing:
 - [x] Was able to build on clean Alpine 3 with these hints