### PR TITLE
8275318: loaded_classes_do may see ArrayKlass before InstanceKlass is loaded

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -1,5 +1,5 @@
  /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,6 +67,7 @@
 #include "memory/universe.hpp"
 #include "oops/access.inline.hpp"
 #include "oops/klass.inline.hpp"
+#include "oops/objArrayKlass.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/oopHandle.inline.hpp"
 #include "oops/weakHandle.inline.hpp"
@@ -358,15 +359,28 @@ void ClassLoaderData::loaded_classes_do(KlassClosure* klass_closure) {
 
   // Lock-free access requires load_acquire
   for (Klass* k = Atomic::load_acquire(&_klasses); k != NULL; k = k->next_link()) {
-    // Do not filter ArrayKlass oops here...
-    if (k->is_array_klass() || (k->is_instance_klass() && InstanceKlass::cast(k)->is_loaded())) {
-#ifdef ASSERT
-      oop m = k->java_mirror();
-      assert(m != NULL, "NULL mirror");
-      assert(m->is_a(vmClasses::Class_klass()), "invalid mirror");
-#endif
-      klass_closure->do_klass(k);
+    // Filter out InstanceKlasses (or their ObjArrayKlasses) that have not entered the
+    // loaded state.
+    if (k->is_instance_klass()) {
+      if (!InstanceKlass::cast(k)->is_loaded()) {
+        continue;
+      }
+    } else if (k->is_objArray_klass()) {
+      Klass* bottom = ObjArrayKlass::cast(k)->bottom_klass();
+      if (bottom->is_instance_klass() && !InstanceKlass::cast(bottom)->is_loaded()) {
+        // This could happen if <bottom> is a shared class that has been restored
+        // but is not yet marked as loaded. All archived array classes of the
+        // bottom class are already restored and placed in the _klasses list.
+        continue;
+      }
     }
+
+#ifdef ASSERT
+    oop m = k->java_mirror();
+    assert(m != NULL, "NULL mirror");
+    assert(m->is_a(vmClasses::Class_klass()), "invalid mirror");
+#endif
+    klass_closure->do_klass(k);
   }
 }
 

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -365,7 +365,7 @@ void ClassLoaderData::loaded_classes_do(KlassClosure* klass_closure) {
       if (!InstanceKlass::cast(k)->is_loaded()) {
         continue;
       }
-    } else if (k->is_objArray_klass()) {
+    } else if (k->is_shared() && k->is_objArray_klass()) {
       Klass* bottom = ObjArrayKlass::cast(k)->bottom_klass();
       if (bottom->is_instance_klass() && !InstanceKlass::cast(bottom)->is_loaded()) {
         // This could happen if <bottom> is a shared class that has been restored


### PR DESCRIPTION
When a shared class K is restored, all of its archived array classes K[], K[][], etc, are also restored as well. Such restored classes are placed in the ClassLoaderData::_klasses list.

For safety, ClassLoaderData::loaded_classes_do() should skip all these classes until K is marked as "loaded".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275318](https://bugs.openjdk.java.net/browse/JDK-8275318): loaded_classes_do may see ArrayKlass before InstanceKlass is loaded


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to e17ddbf764243a62c79f01796410f5449d6aaff2
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7069/head:pull/7069` \
`$ git checkout pull/7069`

Update a local copy of the PR: \
`$ git checkout pull/7069` \
`$ git pull https://git.openjdk.java.net/jdk pull/7069/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7069`

View PR using the GUI difftool: \
`$ git pr show -t 7069`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7069.diff">https://git.openjdk.java.net/jdk/pull/7069.diff</a>

</details>
