### PR TITLE
8279990: (fs) Awkward verbiage in description of Files.createTempFile(Path,String,String,FileAttribute)

### DIFF
--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -823,8 +823,7 @@ public final class Files {
      * names in the same manner as the {@link
      * java.io.File#createTempFile(String,String,File)} method.
      *
-     * <p> The resulting file should be deleted once it is no longer needed.
-     * The file may be opened using the {@link
+     * <p> The file may be opened using the {@link
      * StandardOpenOption#DELETE_ON_CLOSE DELETE_ON_CLOSE} option so that the
      * file is deleted when the appropriate {@code close} method is invoked
      * either explicitly or via a try-with-resources statement. Alternatively,

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -823,12 +823,12 @@ public final class Files {
      * names in the same manner as the {@link
      * java.io.File#createTempFile(String,String,File)} method.
      *
-     * <p> As with the {@code File.createTempFile} methods, this method is only
-     * part of a temporary-file facility. Where used as a <em>work files</em>,
-     * the resulting file may be opened using the {@link
+     * <p> The resulting file should be deleted once it is no longer needed.
+     * The file may be opened using the {@link
      * StandardOpenOption#DELETE_ON_CLOSE DELETE_ON_CLOSE} option so that the
-     * file is deleted when the appropriate {@code close} method is invoked.
-     * Alternatively, a {@link Runtime#addShutdownHook shutdown-hook}, or the
+     * file is deleted when the appropriate {@code close} method is invoked
+     * either explicitly or via a try-with-resources statement. Alternatively,
+     * a {@link Runtime#addShutdownHook shutdown-hook}, or the
      * {@link java.io.File#deleteOnExit} mechanism may be used to delete the
      * file automatically.
      *


### PR DESCRIPTION
This change would improve the description of `java.nio.file.Files.createTempFile(Path,String,String,FileAttribute)`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279990](https://bugs.openjdk.java.net/browse/JDK-8279990): (fs) Awkward verbiage in description of Files.createTempFile(Path,String,String,FileAttribute)


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7071/head:pull/7071` \
`$ git checkout pull/7071`

Update a local copy of the PR: \
`$ git checkout pull/7071` \
`$ git pull https://git.openjdk.java.net/jdk pull/7071/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7071`

View PR using the GUI difftool: \
`$ git pr show -t 7071`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7071.diff">https://git.openjdk.java.net/jdk/pull/7071.diff</a>

</details>
