### PR TITLE
8279797: JFR: Show .jfc options in JFR.start help

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -42,6 +42,9 @@ import java.util.Set;
 import jdk.jfr.FlightRecorder;
 import jdk.jfr.Recording;
 import jdk.jfr.internal.JVM;
+import jdk.jfr.internal.LogLevel;
+import jdk.jfr.internal.LogTag;
+import jdk.jfr.internal.Logger;
 import jdk.jfr.internal.OldObjectSample;
 import jdk.jfr.internal.PlatformRecording;
 import jdk.jfr.internal.PrivateAccess;
@@ -434,6 +437,7 @@ final class DCmdStart extends AbstractDCmd {
             }
             return sb.toString();
         } catch (IOException | ParseException e) {
+            Logger.log(LogTag.JFR_DCMD, LogLevel.DEBUG, "Could not list .jfc options for JFR.start. " + e.getMessage());
             return "";
         }
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -426,7 +426,7 @@ final class DCmdStart extends AbstractDCmd {
             StringBuilder sb = new StringBuilder();
             for (SafePath s : SecuritySupport.getPredefinedJFCFiles()) {
                 String name = JFC.nameFromPath(s.toPath());
-                JFCModel model = new JFCModel(s, l -> {});
+                JFCModel model = JFCModel.create(s, l -> {});
                 sb.append('\n');
                 sb.append("Options for ").append(name).append(":\n");
                 sb.append('\n');


### PR DESCRIPTION
Hi,

Could I have review of an enhancement that shows available .jfc options in the help text for JFR.start. I also fixed a typo. 

I choose to return an empty string if the default.jfc or profile.jfc can't be parsed. This could potentially happen if a user modifies files in JAVA_HOME/lib/jfr. An alternative would be to return an error message in the help text, but I think it would be hard for users to understand. Likely they think the text describes the command somehow. When they use JFR.start, they will get a parse failure, and it's much more easier to understand at that point.

This PR has a conflict with https://github.com/openjdk/jdk/pull/7066, so "new JFCModel(s, l -> {});" might need to be changed to "JFCModel.create(s,  l -> {});" before checking in.


Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279797](https://bugs.openjdk.java.net/browse/JDK-8279797): JFR: Show .jfc options in JFR.start help


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**) ⚠️ Review applies to 3d99889f3e67db7596253a5aa061f287f6b717ec


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7073/head:pull/7073` \
`$ git checkout pull/7073`

Update a local copy of the PR: \
`$ git checkout pull/7073` \
`$ git pull https://git.openjdk.java.net/jdk pull/7073/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7073`

View PR using the GUI difftool: \
`$ git pr show -t 7073`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7073.diff">https://git.openjdk.java.net/jdk/pull/7073.diff</a>

</details>
