### PR TITLE
8280000: Remove unused CardTable::find_covering_region_containing

### DIFF
--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -162,16 +162,6 @@ int CardTable::find_covering_region_by_base(HeapWord* base) {
   return res;
 }
 
-int CardTable::find_covering_region_containing(HeapWord* addr) {
-  for (int i = 0; i < _cur_covered_regions; i++) {
-    if (_covered[i].contains(addr)) {
-      return i;
-    }
-  }
-  assert(0, "address outside of heap?");
-  return -1;
-}
-
 HeapWord* CardTable::largest_prev_committed_end(int ind) const {
   HeapWord* max_end = NULL;
   for (int j = 0; j < ind; j++) {

--- a/src/hotspot/share/gc/shared/cardTable.hpp
+++ b/src/hotspot/share/gc/shared/cardTable.hpp
@@ -78,10 +78,6 @@ protected:
   // covered regions defined in the constructor are ever in use.
   int find_covering_region_by_base(HeapWord* base);
 
-  // Same as above, but finds the region containing the given address
-  // instead of starting at a given base address.
-  int find_covering_region_containing(HeapWord* addr);
-
   // Returns the leftmost end of a committed region corresponding to a
   // covered region before covered region "ind", or else "NULL" if "ind" is
   // the first covered region.


### PR DESCRIPTION
Trivial change of removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280000](https://bugs.openjdk.java.net/browse/JDK-8280000): Remove unused CardTable::find_covering_region_containing


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7074/head:pull/7074` \
`$ git checkout pull/7074`

Update a local copy of the PR: \
`$ git checkout pull/7074` \
`$ git pull https://git.openjdk.java.net/jdk pull/7074/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7074`

View PR using the GUI difftool: \
`$ git pr show -t 7074`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7074.diff">https://git.openjdk.java.net/jdk/pull/7074.diff</a>

</details>
