### PR TITLE
8279301: c1 getObjectSize intrinsic should guard round mask constant

### DIFF
--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1420,7 +1420,9 @@ void LIRGenerator::do_getObjectSize(Intrinsic* x) {
 #else
   __ add(length_int, header_size, length_int);
   if (round_mask != 0) {
-    __ logical_and(length_int, LIR_OprFact::intConst(~round_mask), length_int);
+    // generates LIR_Const if mask fits instruction requirement
+    LIR_Opr round_mask_opr = load_immediate((~round_mask), T_INT);
+    __ logical_and(length_int, round_mask_opr, length_int);
   }
   __ convert(Bytecodes::_i2l, length_int, result_reg);
 #endif


### PR DESCRIPTION
This is the fix for the issue that was found during the test of arm32 (see JDK-8279300).  Constant verification was added to the arm32 specific code but root cause was not fixed: the constant for logical AND op  can't be encoded directly and should be loaded to a register. **load_immediate** function is sophisticated enough and able to generate LIR_Const on the platforms where it is possible, and load op for arm32.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279301](https://bugs.openjdk.java.net/browse/JDK-8279301): c1 getObjectSize intrinsic should guard round mask constant


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7076/head:pull/7076` \
`$ git checkout pull/7076`

Update a local copy of the PR: \
`$ git checkout pull/7076` \
`$ git pull https://git.openjdk.java.net/jdk pull/7076/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7076`

View PR using the GUI difftool: \
`$ git pr show -t 7076`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7076.diff">https://git.openjdk.java.net/jdk/pull/7076.diff</a>

</details>
