### PR TITLE
JDK-8280002: jmap -histo may leak stream

### DIFF
--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -292,6 +292,7 @@ static jint heap_inspection(AttachOperation* op, outputStream* out) {
     uintx num;
     if (!Arguments::parse_uintx(num_str, &num, 0)) {
       out->print_cr("Invalid parallel thread number: [%s]", num_str);
+      delete fs;
       return JNI_ERR;
     }
     parallel_thread_num = num == 0 ? parallel_thread_num : (uint)num;


### PR DESCRIPTION
Very trivial fix to a handle/memory leak. 

JDK-8215624 added parallel heap iteration to both `jmap -histo` and `jcmd GC.class_histogram`. When called with an explicit file and an invalid argument for number of threads, it leaks the file (bit of memory and a handle).

Reproduce with:

`jmap -histo:parallel=notanumber,file=xx.txt`

Can only be reproduced with jmap. jcmd is safe, arguments are handled correctly in shared code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280002](https://bugs.openjdk.java.net/browse/JDK-8280002): jmap -histo may leak stream


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to 4d27428ddcf3b2c69cdc0a11543578f755aa851c
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7078/head:pull/7078` \
`$ git checkout pull/7078`

Update a local copy of the PR: \
`$ git checkout pull/7078` \
`$ git pull https://git.openjdk.java.net/jdk pull/7078/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7078`

View PR using the GUI difftool: \
`$ git pr show -t 7078`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7078.diff">https://git.openjdk.java.net/jdk/pull/7078.diff</a>

</details>
