### PR TITLE
8279241: G1 Full GC does not always slide memory to bottom addresses

### DIFF
--- a/src/hotspot/share/gc/parallel/psCardTable.cpp
+++ b/src/hotspot/share/gc/parallel/psCardTable.cpp
@@ -158,182 +158,159 @@ class CheckForPreciseMarks : public BasicOopIterateClosure {
 // adding slice_stride to the start of stripe 0 in slice 0 to get to the start
 // of stride 0 in slice 1.
 
+static void prefetch_write(void *p) {
+  if (PrefetchScanIntervalInBytes >= 0) {
+    Prefetch::write(p, PrefetchScanIntervalInBytes);
+  }
+}
+
+// postcondition: ret is a dirty card or end_card
+CardTable::CardValue* PSCardTable::find_first_dirty_card(CardValue* const start_card,
+                                                         CardValue* const end_card) {
+  for (CardValue* i_card = start_card; i_card < end_card; ++i_card) {
+    if (*i_card != PSCardTable::clean_card_val()) {
+      return i_card;
+    }
+  }
+  return end_card;
+}
+
+// postcondition: ret is a clean card or end_card
+CardTable::CardValue* PSCardTable::find_first_clean_card(ObjectStartArray* const start_array,
+                                                         CardValue* const start_card,
+                                                         CardValue* const end_card) {
+  assert(start_card == end_card ||
+         *start_card != PSCardTable::clean_card_val(), "precondition");
+  // skip the first dirty card
+  CardValue* i_card = start_card + 1;
+  while (i_card < end_card) {
+    if (*i_card != PSCardTable::clean_card_val()) {
+      i_card++;
+      continue;
+    }
+    assert(i_card - 1 >= start_card, "inv");
+    // prev card must be dirty
+    assert(*(i_card - 1) != PSCardTable::clean_card_val(), "inv");
+    // find the final obj on the prev dirty card
+    HeapWord* obj_addr = start_array->object_start(addr_for(i_card)-1);
+    HeapWord* obj_end_addr = obj_addr + cast_to_oop(obj_addr)->size();
+    CardValue* final_card_by_obj = byte_for(obj_end_addr - 1);
+    assert(final_card_by_obj < end_card, "inv");
+    if (final_card_by_obj <= i_card) {
+      return i_card;
+    }
+    if (*final_card_by_obj == PSCardTable::clean_card_val()) {
+      return final_card_by_obj;
+    }
+    i_card = final_card_by_obj + 1;
+  }
+  return end_card;
+}
+
 void PSCardTable::scavenge_contents_parallel(ObjectStartArray* start_array,
                                              MutableSpace* sp,
                                              HeapWord* space_top,
                                              PSPromotionManager* pm,
-                                             uint stripe_number,
-                                             uint stripe_total) {
-  int ssize = 128; // Naked constant!  Work unit = 64k.
+                                             uint stripe_index,
+                                             uint n_stripes) {
+  const size_t num_cards_in_stripe = 128;
+  const size_t stripe_size_in_words = num_cards_in_stripe * _card_size_in_words;
+  const size_t slice_size_in_words = stripe_size_in_words * n_stripes;
 
-  // It is a waste to get here if empty.
-  assert(sp->bottom() < sp->top(), "Should not be called if empty");
-  oop* sp_top = (oop*)space_top;
-  CardValue* start_card = byte_for(sp->bottom());
-  CardValue* end_card   = byte_for(sp_top - 1) + 1;
-  oop* last_scanned = NULL; // Prevent scanning objects more than once
-  // The width of the stripe ssize*stripe_total must be
-  // consistent with the number of stripes so that the complete slice
-  // is covered.
-  size_t slice_width = ssize * stripe_total;
-  for (CardValue* slice = start_card; slice < end_card; slice += slice_width) {
-    CardValue* worker_start_card = slice + stripe_number * ssize;
-    if (worker_start_card >= end_card)
-      return; // We're done.
+  HeapWord* cur_stripe = sp->bottom() + stripe_index * stripe_size_in_words;
 
-    CardValue* worker_end_card = worker_start_card + ssize;
-    if (worker_end_card > end_card)
-      worker_end_card = end_card;
+  for (/* empty */; cur_stripe < space_top; cur_stripe += slice_size_in_words) {
+    // exclusive
+    HeapWord* const cur_stripe_end = MIN2(cur_stripe + stripe_size_in_words,
+                                          space_top);
 
-    // We do not want to scan objects more than once. In order to accomplish
-    // this, we assert that any object with an object head inside our 'slice'
-    // belongs to us. We may need to extend the range of scanned cards if the
-    // last object continues into the next 'slice'.
-    //
-    // Note! ending cards are exclusive!
-    HeapWord* slice_start = addr_for(worker_start_card);
-    HeapWord* slice_end = MIN2((HeapWord*) sp_top, addr_for(worker_end_card));
-
-    // If there are not objects starting within the chunk, skip it.
-    if (!start_array->object_starts_in_range(slice_start, slice_end)) {
+    // process a stripe iff it contains any obj-start
+    if (!start_array->object_starts_in_range(cur_stripe, cur_stripe_end)) {
       continue;
     }
-    // Update our beginning addr
-    HeapWord* first_object = start_array->object_start(slice_start);
-    debug_only(oop* first_object_within_slice = (oop*) first_object;)
-    if (first_object < slice_start) {
-      last_scanned = (oop*)(first_object + cast_to_oop(first_object)->size());
-      debug_only(first_object_within_slice = last_scanned;)
-      worker_start_card = byte_for(last_scanned);
+
+    // Constraints:
+    // 1. range of cards checked for being dirty or clean: [iter_limit_l, iter_limit_r)
+    // 2. range of cards can be cleared: [clear_limit_l, clear_limit_r)
+    // 3. range of objs (obj-start) can be scanned: [first_obj_addr, cur_stripe_end)
+
+    CardValue* iter_limit_l;
+    CardValue* iter_limit_r;
+    CardValue* clear_limit_l;
+    CardValue* clear_limit_r;
+
+    HeapWord* first_obj_addr = start_array->object_start(cur_stripe);
+    if (first_obj_addr < cur_stripe) {
+      // this obj belongs to previous stripe; can't clear any cards it occupies
+      first_obj_addr += cast_to_oop(first_obj_addr)->size();
+      clear_limit_l = byte_for(first_obj_addr - 1) + 1;
+      iter_limit_l = byte_for(first_obj_addr);
+    } else {
+      assert(first_obj_addr == cur_stripe, "inv");
+      iter_limit_l = clear_limit_l = byte_for(cur_stripe);
     }
 
-    // Update the ending addr
-    if (slice_end < (HeapWord*)sp_top) {
-      // The subtraction is important! An object may start precisely at slice_end.
-      HeapWord* last_object = start_array->object_start(slice_end - 1);
-      slice_end = last_object + cast_to_oop(last_object)->size();
-      // worker_end_card is exclusive, so bump it one past the end of last_object's
-      // covered span.
-      worker_end_card = byte_for(slice_end) + 1;
+    assert(cur_stripe <= first_obj_addr, "inside this stripe");
+    assert(first_obj_addr <= cur_stripe_end, "can be empty");
 
-      if (worker_end_card > end_card)
-        worker_end_card = end_card;
+    {
+      HeapWord* obj_addr = start_array->object_start(cur_stripe_end - 1);
+      HeapWord* obj_end_addr = obj_addr + cast_to_oop(obj_addr)->size();
+      assert(obj_end_addr >= cur_stripe_end, "inv");
+      clear_limit_r = byte_for(obj_end_addr);
+      iter_limit_r = byte_for(obj_end_addr - 1) + 1;
     }
 
-    assert(slice_end <= (HeapWord*)sp_top, "Last object in slice crosses space boundary");
-    assert(is_valid_card_address(worker_start_card), "Invalid worker start card");
-    assert(is_valid_card_address(worker_end_card), "Invalid worker end card");
-    // Note that worker_start_card >= worker_end_card is legal, and happens when
-    // an object spans an entire slice.
-    assert(worker_start_card <= end_card, "worker start card beyond end card");
-    assert(worker_end_card <= end_card, "worker end card beyond end card");
+    assert(iter_limit_l <= clear_limit_l, "inv");
+    assert(clear_limit_r <= iter_limit_r, "inv");
 
-    CardValue* current_card = worker_start_card;
-    while (current_card < worker_end_card) {
-      // Find an unclean card.
-      while (current_card < worker_end_card && card_is_clean(*current_card)) {
-        current_card++;
+    // iterate [iter_limit_l, iter_limit_r) to find consecutive dirty cards
+    CardValue* cur_card = iter_limit_l;
+
+    while (cur_card < iter_limit_r) {
+      CardValue* dirty_l = find_first_dirty_card(cur_card, iter_limit_r);
+      CardValue* dirty_r = find_first_clean_card(start_array, dirty_l, iter_limit_r);
+      assert(dirty_l <= dirty_r, "inv");
+
+      cur_card = dirty_r + 1;
+
+      // empty
+      if (dirty_l == dirty_r) {
+        assert(dirty_r == iter_limit_r, "no more dirty cards in this stripe");
+        break;
       }
-      CardValue* first_unclean_card = current_card;
 
-      // Find the end of a run of contiguous unclean cards
-      while (current_card < worker_end_card && !card_is_clean(*current_card)) {
-        while (current_card < worker_end_card && !card_is_clean(*current_card)) {
-          current_card++;
-        }
+      assert(*dirty_l != clean_card, "inv");
+      assert(*dirty_r == clean_card || dirty_r == iter_limit_r, "inv");
 
-        if (current_card < worker_end_card) {
-          // Some objects may be large enough to span several cards. If such
-          // an object has more than one dirty card, separated by a clean card,
-          // we will attempt to scan it twice. The test against "last_scanned"
-          // prevents the redundant object scan, but it does not prevent newly
-          // marked cards from being cleaned.
-          HeapWord* last_object_in_dirty_region = start_array->object_start(addr_for(current_card)-1);
-          size_t size_of_last_object = cast_to_oop(last_object_in_dirty_region)->size();
-          HeapWord* end_of_last_object = last_object_in_dirty_region + size_of_last_object;
-          CardValue* ending_card_of_last_object = byte_for(end_of_last_object);
-          assert(ending_card_of_last_object <= worker_end_card, "ending_card_of_last_object is greater than worker_end_card");
-          if (ending_card_of_last_object > current_card) {
-            // This means the object spans the next complete card.
-            // We need to bump the current_card to ending_card_of_last_object
-            current_card = ending_card_of_last_object;
-          }
+      {
+        // clear card in [dirty_l, dirty_r) subject to [clear_limit_l, clear_limit_r) constraint
+        CardValue* l = MAX2(dirty_l, clear_limit_l);
+        CardValue* r = MIN2(dirty_r, clear_limit_r);
+        for (CardValue* i_card = l; i_card < r; ++i_card) {
+          *i_card = clean_card;
         }
       }
-      CardValue* following_clean_card = current_card;
 
-      if (first_unclean_card < worker_end_card) {
-        oop* p = (oop*) start_array->object_start(addr_for(first_unclean_card));
-        assert((HeapWord*)p <= addr_for(first_unclean_card), "checking");
-        // "p" should always be >= "last_scanned" because newly GC dirtied
-        // cards are no longer scanned again (see comment at end
-        // of loop on the increment of "current_card").  Test that
-        // hypothesis before removing this code.
-        // If this code is removed, deal with the first time through
-        // the loop when the last_scanned is the object starting in
-        // the previous slice.
-        assert((p >= last_scanned) ||
-               (last_scanned == first_object_within_slice),
-               "Should no longer be possible");
-        if (p < last_scanned) {
-          // Avoid scanning more than once; this can happen because
-          // newgen cards set by GC may a different set than the
-          // originally dirty set
-          p = last_scanned;
+      {
+        // scan objs in [dirty_l, dirty_r) subject to [first_obj_addr, cur_stripe_end) constraint
+        HeapWord* obj_l = MAX2(start_array->object_start(addr_for(dirty_l)),
+                               first_obj_addr);
+
+        HeapWord* obj_r = MIN2(addr_for(dirty_r),
+                               cur_stripe_end);
+
+        // push objs with start-addr in [obj_l, obj_r)
+        HeapWord* obj_addr = obj_l;
+        while (obj_addr < obj_r) {
+          oop obj = cast_to_oop(obj_addr);
+          assert(oopDesc::is_oop(obj), "inv");
+          prefetch_write(obj_addr);
+          pm->push_contents(obj);
+          obj_addr += obj->size();
         }
-        oop* to = (oop*)addr_for(following_clean_card);
-
-        // Test slice_end first!
-        if ((HeapWord*)to > slice_end) {
-          to = (oop*)slice_end;
-        } else if (to > sp_top) {
-          to = sp_top;
-        }
-
-        // we know which cards to scan, now clear them
-        if (first_unclean_card <= worker_start_card+1)
-          first_unclean_card = worker_start_card+1;
-        if (following_clean_card >= worker_end_card-1)
-          following_clean_card = worker_end_card-1;
-
-        while (first_unclean_card < following_clean_card) {
-          *first_unclean_card++ = clean_card;
-        }
-
-        const int interval = PrefetchScanIntervalInBytes;
-        // scan all objects in the range
-        if (interval != 0) {
-          while (p < to) {
-            Prefetch::write(p, interval);
-            oop m = cast_to_oop(p);
-            assert(oopDesc::is_oop_or_null(m), "Expected an oop or NULL for header field at " PTR_FORMAT, p2i(m));
-            pm->push_contents(m);
-            p += m->size();
-          }
-          pm->drain_stacks_cond_depth();
-        } else {
-          while (p < to) {
-            oop m = cast_to_oop(p);
-            assert(oopDesc::is_oop_or_null(m), "Expected an oop or NULL for header field at " PTR_FORMAT, p2i(m));
-            pm->push_contents(m);
-            p += m->size();
-          }
-          pm->drain_stacks_cond_depth();
-        }
-        last_scanned = p;
+        pm->drain_stacks_cond_depth();
       }
-      // "current_card" is still the "following_clean_card" or
-      // the current_card is >= the worker_end_card so the
-      // loop will not execute again.
-      assert((current_card == following_clean_card) ||
-             (current_card >= worker_end_card),
-        "current_card should only be incremented if it still equals "
-        "following_clean_card");
-      // Increment current_card so that it is not processed again.
-      // It may now be dirty because a old-to-young pointer was
-      // found on it an updated.  If it is now dirty, it cannot be
-      // be safely cleaned in the next iteration.
-      current_card++;
     }
   }
 }

--- a/src/hotspot/share/gc/parallel/psCardTable.hpp
+++ b/src/hotspot/share/gc/parallel/psCardTable.hpp
@@ -50,6 +50,13 @@ class PSCardTable: public CardTable {
     verify_card       = CT_MR_BS_last_reserved + 5
   };
 
+  CardValue* find_first_dirty_card(CardValue* const start_card,
+                                   CardValue* const end_card);
+
+  CardValue* find_first_clean_card(ObjectStartArray* start_array,
+                                   CardValue* const start_card,
+                                   CardValue* const end_card);
+
  public:
   PSCardTable(MemRegion whole_heap) : CardTable(whole_heap) {}
 
@@ -61,8 +68,8 @@ class PSCardTable: public CardTable {
                                   MutableSpace* sp,
                                   HeapWord* space_top,
                                   PSPromotionManager* pm,
-                                  uint stripe_number,
-                                  uint stripe_total);
+                                  uint stripe_index,
+                                  uint n_stripes);
 
   bool addr_is_marked_imprecise(void *addr);
   bool addr_is_marked_precise(void *addr);


### PR DESCRIPTION
Hi all,

  can I get reviews for this change that completely fixes the possibility that during g1 full gc memory will not be slid to bottom addresses consistently in presence of threads.

The problem is that multiple thread compete for regions to compact into - it could happen that given live data somewhere "high up" the heap gets to be the bottom region for a particular thread, so all data will be compacted starting from that region.
The problem with that is region level fragmentation, i.e. that after gc there is not enough free contiguous space for a humongous object, leading to OOME.

The change splits the phase where determining the compaction point queue (the set of regions a particular thread compacts into) from the part of that phase where the new locations of the objects is determined (i.e. putting a forwarding pointer into the live objects in these regions) and other stuff best done in parallel.
This makes determining the compaction point queue deterministic (by distributing these regions we can compact into in a round-robin fashion) in a way that always slides live data consistently into the bottom heap area.

This change also makes it easier to, in the future, improve work distribution of the compaction phase (which directly uses the compaction point queues) by distributing them  according to live data, and also incorporate last-ditch moves of humongous objects.

The most important thing about this split is probably the changes in the parallel part: every thread must make sure that some work is done on the compaction point queue (i.e. the forwarding), and other work on all regions (clearing metadata, updating the BOT of young regions that are not moved).

Testing: tier1-5, checking performance on some simple full gc benchmarks with no particular difference

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8279241](https://bugs.openjdk.java.net/browse/JDK-8279241): G1 Full GC does not always slide memory to bottom addresses


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7081/head:pull/7081` \
`$ git checkout pull/7081`

Update a local copy of the PR: \
`$ git checkout pull/7081` \
`$ git pull https://git.openjdk.java.net/jdk pull/7081/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7081`

View PR using the GUI difftool: \
`$ git pr show -t 7081`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7081.diff">https://git.openjdk.java.net/jdk/pull/7081.diff</a>

</details>
