### PR TITLE
8258240: make vscode-project on Windows generates jdk.code-workspace file with unescaped '\' in paths

### DIFF
--- a/make/ide/vscode/hotspot/CreateVSCodeProject.gmk
+++ b/make/ide/vscode/hotspot/CreateVSCodeProject.gmk
@@ -30,6 +30,13 @@ include $(SPEC)
 include MakeBase.gmk
 
 ################################################################################
+# SedEscape
+#
+# Escape special characters for use in SED replacement string
+################################################################################
+SedEscape = $(subst !,\!,$(subst \,\\,$1))
+
+################################################################################
 # Return the full path to an indexer-specific file fragment.
 #
 # Param 1: Fragment name
@@ -78,15 +85,15 @@ define CreateFromTemplate
 	$(SED) -e '/{{INDEXER_EXTENSIONS}}/r $(call GetIndexerFragment,extensions)' \
 	    -e '/{{INDEXER_SETTINGS}}/r $(call GetIndexerFragment,settings)' \
 	    -e '/{{EXTRA_WORKSPACE_ROOT}}/r $(call GetExtraWorkspaceRoot)' $1 | \
-	$(SED) -e 's!{{TOPDIR}}!$(call FixPath,$(TOPDIR))!g' \
-	    -e 's!{{TOPDIR_RELATIVE}}!$(call FixPath,$(strip \
-	        $(call RelativePath,$(OUTPUTDIR),$(TOPDIR))))!g' \
-	    -e 's!{{WORKSPACE_ROOT}}!$(call FixPath,$(WORKSPACE_ROOT))!g' \
-	    -e 's!{{OUTPUTDIR}}!$(call FixPath,$(OUTPUTDIR))!g' \
+	$(SED) -e 's!{{TOPDIR}}!$(call SedEscape,$(call FixPath,$(TOPDIR)))!g' \
+	    -e 's!{{TOPDIR_RELATIVE}}!$(call SedEscape,$(call FixPath,$(strip \
+	        $(call RelativePath,$(OUTPUTDIR),$(TOPDIR)))))!g' \
+	    -e 's!{{WORKSPACE_ROOT}}!$(call SedEscape,$(call FixPath,$(WORKSPACE_ROOT)))!g' \
+	    -e 's!{{OUTPUTDIR}}!$(call SedEscape,$(call FixPath,$(OUTPUTDIR)))!g' \
 	    -e 's!{{CONF_NAME}}!$(CONF_NAME)!g' \
-	    -e 's!{{COMPILER}}!$(call FixPath,$(CXX)) $(SYSROOT_CFLAGS)!g' \
-	    -e 's!{{MAKE}}!$(call FixPath,$(MAKE))!g' \
-	    -e 's!{{PATH}}!$(call FixPath,$(PATH))!g' \
+	    -e 's!{{COMPILER}}!$(call SedEscape,$(call FixPath,$(CXX))) $(SYSROOT_CFLAGS)!g' \
+	    -e 's!{{MAKE}}!$(call SedEscape,$(call FixPath,$(MAKE)))!g' \
+	    -e 's!{{PATH}}!$(call SedEscape,$(call FixPath,$(PATH)))!g' \
 	    -e 's!{{DEBUGENGINENAME}}!$(call DebugEngineName)!g' \
 	    -e '/{{INDEXER_EXTENSIONS}}/d' \
 	    -e '/{{INDEXER_SETTINGS}}/d' \


### PR DESCRIPTION
Backslashes in `sed` replacement string are interpreted by `sed`. In order to output the strings we want, the replacement text needs to be escaped again. See https://stackoverflow.com/a/2705678

Verified that with this patch VSCode is able to open the workspace, and all files are visible in "Explorer".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258240](https://bugs.openjdk.java.net/browse/JDK-8258240): make vscode-project on Windows generates jdk.code-workspace file with unescaped '\' in paths


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7083/head:pull/7083` \
`$ git checkout pull/7083`

Update a local copy of the PR: \
`$ git checkout pull/7083` \
`$ git pull https://git.openjdk.java.net/jdk pull/7083/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7083`

View PR using the GUI difftool: \
`$ git pr show -t 7083`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7083.diff">https://git.openjdk.java.net/jdk/pull/7083.diff</a>

</details>
