### PR TITLE
8280018: Remove obsolete VM_GenCollectFullConcurrent

### DIFF
--- a/src/hotspot/share/gc/shared/gcVMOperations.hpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.hpp
@@ -42,7 +42,6 @@
 //        VM_GC_HeapInspection
 //        VM_PopulateDynamicDumpSharedSpace
 //        VM_GenCollectFull
-//        VM_GenCollectFullConcurrent
 //        VM_ParallelGCSystemGC
 //        VM_CollectForAllocation
 //          VM_GenCollectForAllocation
@@ -71,7 +70,6 @@
 //     allocate afterwards;
 //
 //  VM_GenCollectFull
-//  VM_GenCollectFullConcurrent
 //  VM_ParallelGCSystemGC
 //   - these operations preform full collection of heaps of
 //     different kind

--- a/src/hotspot/share/gc/shared/genCollectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.hpp
@@ -48,7 +48,6 @@ class GenCollectedHeap : public CollectedHeap {
   friend class GenMarkSweep;
   friend class VM_GenCollectForAllocation;
   friend class VM_GenCollectFull;
-  friend class VM_GenCollectFullConcurrent;
   friend class VM_GC_HeapInspection;
   friend class VM_HeapDumper;
   friend class HeapInspection;

--- a/src/hotspot/share/runtime/vmOperation.hpp
+++ b/src/hotspot/share/runtime/vmOperation.hpp
@@ -52,7 +52,6 @@
   template(CollectForMetadataAllocation)          \
   template(GC_HeapInspection)                     \
   template(GenCollectFull)                        \
-  template(GenCollectFullConcurrent)              \
   template(GenCollectForAllocation)               \
   template(ParallelGCFailedAllocation)            \
   template(ParallelGCSystemGC)                    \


### PR DESCRIPTION
Trivial change of removing dead code.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280018](https://bugs.openjdk.java.net/browse/JDK-8280018): Remove obsolete VM_GenCollectFullConcurrent


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7084/head:pull/7084` \
`$ git checkout pull/7084`

Update a local copy of the PR: \
`$ git checkout pull/7084` \
`$ git pull https://git.openjdk.java.net/jdk pull/7084/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7084`

View PR using the GUI difftool: \
`$ git pr show -t 7084`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7084.diff">https://git.openjdk.java.net/jdk/pull/7084.diff</a>

</details>
