### PR TITLE
JDK-8280019: Remove unused code from metaspace

### DIFF
--- a/src/hotspot/share/memory/metaspace/blockTree.cpp
+++ b/src/hotspot/share/memory/metaspace/blockTree.cpp
@@ -101,7 +101,6 @@ void BlockTree::verify() const {
   // Traverse the tree and test that all nodes are in the correct order.
 
   MemRangeCounter counter;
-  int longest_edge = 0;
   if (_root != NULL) {
 
     ResourceMark rm;

--- a/src/hotspot/share/memory/metaspace/blockTree.cpp
+++ b/src/hotspot/share/memory/metaspace/blockTree.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/memory/metaspace/chunkManager.cpp
+++ b/src/hotspot/share/memory/metaspace/chunkManager.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/memory/metaspace/chunkManager.cpp
+++ b/src/hotspot/share/memory/metaspace/chunkManager.cpp
@@ -88,7 +88,6 @@ void ChunkManager::split_chunk_and_add_splinters(Metachunk* c, chunklevel_t targ
 
   DEBUG_ONLY(size_t committed_words_before = c->committed_words();)
 
-  const chunklevel_t orig_level = c->level();
   c->vsnode()->split(target_level, c, &_chunks);
 
   // Splitting should never fail.

--- a/src/hotspot/share/memory/metaspace/chunkManager.hpp
+++ b/src/hotspot/share/memory/metaspace/chunkManager.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/memory/metaspace/chunkManager.hpp
+++ b/src/hotspot/share/memory/metaspace/chunkManager.hpp
@@ -95,12 +95,6 @@ class ChunkManager : public CHeapObj<mtMetaspace> {
   //  chunks.
   void split_chunk_and_add_splinters(Metachunk* c, chunklevel_t target_level);
 
-  // See get_chunk(s,s,s)
-  Metachunk* get_chunk_locked(size_t preferred_word_size, size_t min_word_size, size_t min_committed_words);
-
-  // Uncommit all chunks equal or below the given level.
-  void uncommit_free_chunks(chunklevel_t max_level);
-
   // Return a single chunk to the freelist without doing any merging, and adjust accounting.
   void return_chunk_simple_locked(Metachunk* c);
 
@@ -160,9 +154,6 @@ public:
   // Run verifications. slow=true: verify chunk-internal integrity too.
   DEBUG_ONLY(void verify() const;)
   DEBUG_ONLY(void verify_locked() const;)
-
-  // Returns the name of this chunk manager.
-  const char* name() const                  { return _name; }
 
   // Returns total number of chunks
   int total_num_chunks() const              { return _chunks.num_chunks(); }

--- a/src/hotspot/share/memory/metaspace/commitMask.hpp
+++ b/src/hotspot/share/memory/metaspace/commitMask.hpp
@@ -94,7 +94,6 @@ public:
 
   const MetaWord* base() const  { return _base; }
   size_t word_size() const      { return _word_size; }
-  const MetaWord* end() const   { return _base + word_size(); }
 
   // Given an address, returns true if the address is committed, false if not.
   bool is_committed_address(const MetaWord* p) const {

--- a/src/hotspot/share/memory/metaspace/commitMask.hpp
+++ b/src/hotspot/share/memory/metaspace/commitMask.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/memory/metaspace/counters.hpp
+++ b/src/hotspot/share/memory/metaspace/counters.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/memory/metaspace/counters.hpp
+++ b/src/hotspot/share/memory/metaspace/counters.hpp
@@ -70,8 +70,6 @@ public:
     _c -= v;
   }
 
-  void reset()                { _c = 0; }
-
 #ifdef ASSERT
   void check(T expected) const {
     assert(_c == expected, "Counter mismatch: %d, expected: %d.",

--- a/src/hotspot/share/memory/metaspace/freeChunkList.cpp
+++ b/src/hotspot/share/memory/metaspace/freeChunkList.cpp
@@ -70,7 +70,6 @@ void FreeChunkList::verify() const {
   } else {
     assert(_last != NULL, "Sanity");
     int num = 0;
-    bool uncommitted = (_first->committed_words() == 0);
     for (Metachunk* c = _first; c != NULL; c = c->next()) {
       assert(c->is_free(), "Chunks in freelist should be free");
       assert(c->used_words() == 0, "Chunk in freelist should have not used words.");

--- a/src/hotspot/share/memory/metaspace/freeChunkList.cpp
+++ b/src/hotspot/share/memory/metaspace/freeChunkList.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/memory/metaspace/rootChunkArea.cpp
+++ b/src/hotspot/share/memory/metaspace/rootChunkArea.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/memory/metaspace/rootChunkArea.cpp
+++ b/src/hotspot/share/memory/metaspace/rootChunkArea.cpp
@@ -103,8 +103,6 @@ void RootChunkArea::split(chunklevel_t target_level, Metachunk* c, FreeChunkList
   DEBUG_ONLY(chunklevel::check_valid_level(target_level));
   assert(target_level > c->level(), "Wrong target level");
 
-  const chunklevel_t starting_level = c->level();
-
   while (c->level() < target_level) {
 
     log_trace(metaspace)("Splitting chunk: " METACHUNK_FULL_FORMAT ".", METACHUNK_FULL_FORMAT_ARGS(c));
@@ -198,8 +196,6 @@ Metachunk* RootChunkArea::merge(Metachunk* c, FreeChunkListVector* freelists) {
   DEBUG_ONLY(c->verify();)
 
   log_trace(metaspace)("Attempting to merge chunk " METACHUNK_FORMAT ".", METACHUNK_FORMAT_ARGS(c));
-
-  const chunklevel_t starting_level = c->level();
 
   bool stop = false;
   Metachunk* result = NULL;
@@ -389,7 +385,6 @@ void RootChunkArea::verify() const {
 
     const Metachunk* c = _first_chunk;
     const MetaWord* expected_next_base = _base;
-    const MetaWord* const area_end = _base + word_size();
 
     while (c != NULL) {
       assrt_(c->is_free() || c->is_in_use(),


### PR DESCRIPTION
Sonarcloud-inspired code grooming. Trivial removal of unused code in metaspace.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280019](https://bugs.openjdk.java.net/browse/JDK-8280019): Remove unused code from metaspace


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to a69dd0ebad1ccb9657fe656197ecc6642fa657c7
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**) ⚠️ Review applies to a69dd0ebad1ccb9657fe656197ecc6642fa657c7


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7085/head:pull/7085` \
`$ git checkout pull/7085`

Update a local copy of the PR: \
`$ git checkout pull/7085` \
`$ git pull https://git.openjdk.java.net/jdk pull/7085/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7085`

View PR using the GUI difftool: \
`$ git pr show -t 7085`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7085.diff">https://git.openjdk.java.net/jdk/pull/7085.diff</a>

</details>
