### PR TITLE
JDK-8279954 - java/lang/StringBuffer(StringBuilder)/HugeCapacity.java intermittently fails

### DIFF
--- a/test/jdk/java/lang/StringBuffer/HugeCapacity.java
+++ b/test/jdk/java/lang/StringBuffer/HugeCapacity.java
@@ -26,8 +26,8 @@
  * @bug 8218227
  * @summary StringBuilder/StringBuffer constructor throws confusing
  *          NegativeArraySizeException
- * @requires (sun.arch.data.model == "64" & os.maxMemory >= 6G)
- * @run main/othervm -Xms5G -Xmx5G HugeCapacity
+ * @requires (sun.arch.data.model == "64" & os.maxMemory >= 8G)
+ * @run main/othervm -Xms6G -Xmx6G HugeCapacity
  */
 
 public class HugeCapacity {

--- a/test/jdk/java/lang/StringBuilder/HugeCapacity.java
+++ b/test/jdk/java/lang/StringBuilder/HugeCapacity.java
@@ -26,9 +26,9 @@
  * @bug 8149330 8218227
  * @summary Capacity should not get close to Integer.MAX_VALUE unless
  *          necessary
- * @requires (sun.arch.data.model == "64" & os.maxMemory >= 6G)
- * @run main/othervm -Xms5G -Xmx5G -XX:+CompactStrings HugeCapacity true
- * @run main/othervm -Xms5G -Xmx5G -XX:-CompactStrings HugeCapacity false
+ * @requires (sun.arch.data.model == "64" & os.maxMemory >= 8G)
+ * @run main/othervm -Xms6G -Xmx6G -XX:+CompactStrings HugeCapacity true
+ * @run main/othervm -Xms6G -Xmx6G -XX:-CompactStrings HugeCapacity false
  */
 
 public class HugeCapacity {


### PR DESCRIPTION
Tests were fatally failing (windows) on Github actions. Pumping up the memory requirements will hopefully alleviate.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279954](https://bugs.openjdk.java.net/browse/JDK-8279954): java/lang/StringBuffer(StringBuilder)/HugeCapacity.java intermittently fails


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7086/head:pull/7086` \
`$ git checkout pull/7086`

Update a local copy of the PR: \
`$ git checkout pull/7086` \
`$ git pull https://git.openjdk.java.net/jdk pull/7086/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7086`

View PR using the GUI difftool: \
`$ git pr show -t 7086`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7086.diff">https://git.openjdk.java.net/jdk/pull/7086.diff</a>

</details>
