### PR TITLE
8280032: Update jib-profiles.js to use JMH 1.34 devkit

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1165,7 +1165,7 @@ var getJibProfilesDependencies = function (input, common) {
         jmh: {
             organization: common.organization,
             ext: "tar.gz",
-            revision: "1.33+1.0"
+            revision: "1.34+1.0"
         },
 
         jcov: {


### PR DESCRIPTION
Change so that jib users pick up and use the latest JMH devkit.

Testing: verified locally

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280032](https://bugs.openjdk.java.net/browse/JDK-8280032): Update jib-profiles.js to use JMH 1.34 devkit


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7090/head:pull/7090` \
`$ git checkout pull/7090`

Update a local copy of the PR: \
`$ git checkout pull/7090` \
`$ git pull https://git.openjdk.java.net/jdk pull/7090/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7090`

View PR using the GUI difftool: \
`$ git pr show -t 7090`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7090.diff">https://git.openjdk.java.net/jdk/pull/7090.diff</a>

</details>
