### PR TITLE
8279878: java/awt/font/JNICheck/JNICheck.sh test fails on Ubuntu 21.10

### DIFF
--- a/test/jdk/java/awt/font/JNICheck/JNICheck.sh
+++ b/test/jdk/java/awt/font/JNICheck/JNICheck.sh
@@ -49,7 +49,7 @@ else
 fi
 
 $JAVA_HOME/bin/java ${TESTVMOPTS} \
-    -cp "${CP}" -Xcheck:jni JNICheck | grep -v SIG | grep -v Signal | grep -v CallStatic > "${CP}"/log.txt
+    -cp "${CP}" -Xcheck:jni JNICheck | grep -v SIG | grep -v Signal | grep -v Handler | grep -v jsig | grep -v CallStatic > "${CP}"/log.txt
 
 # any messages logged may indicate a failure.
 if [ -s "${CP}"/log.txt ]; then


### PR DESCRIPTION
Some more signal handler related warning strings from the VM need to be excluded from what this test considers a failure 

See the bug for more info.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279878](https://bugs.openjdk.java.net/browse/JDK-8279878): java/awt/font/JNICheck/JNICheck.sh test fails on Ubuntu 21.10


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7091/head:pull/7091` \
`$ git checkout pull/7091`

Update a local copy of the PR: \
`$ git checkout pull/7091` \
`$ git pull https://git.openjdk.java.net/jdk pull/7091/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7091`

View PR using the GUI difftool: \
`$ git pr show -t 7091`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7091.diff">https://git.openjdk.java.net/jdk/pull/7091.diff</a>

</details>
