### PR TITLE
8280045: ProblemList 2 AppCDS tests until JDK-8279970 is fixed

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -104,7 +104,7 @@ runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
 runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java 8279970  generic-all
-runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java#custom-cl-zgc generic-all
+runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java#custom-cl-zgc 8279970 generic-all
 
 applications/jcstress/copy.java 8229852 linux-all
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -103,6 +103,8 @@ runtime/os/TestTracePageSizes.java#G1 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
+runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java 8279970  generic-all
+runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java#custom-cl-zgc generic-all
 
 applications/jcstress/copy.java 8229852 linux-all
 


### PR DESCRIPTION
A trivial fix to ProblemList 2 AppCDS tests until JDK-8279970 is fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280045](https://bugs.openjdk.java.net/browse/JDK-8280045): ProblemList 2 AppCDS tests until JDK-8279970 is fixed


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7093/head:pull/7093` \
`$ git checkout pull/7093`

Update a local copy of the PR: \
`$ git checkout pull/7093` \
`$ git pull https://git.openjdk.java.net/jdk pull/7093/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7093`

View PR using the GUI difftool: \
`$ git pr show -t 7093`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7093.diff">https://git.openjdk.java.net/jdk/pull/7093.diff</a>

</details>
