### PR TITLE
8280048: Missing comma in copyright header

### DIFF
--- a/test/jdk/java/awt/Graphics2D/CopyAreaOOB.java
+++ b/test/jdk/java/awt/Graphics2D/CopyAreaOOB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Missing comma in test/jdk/java/awt/Graphics2D/CopyAreaOOB.java after JDK-7001973.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280048](https://bugs.openjdk.java.net/browse/JDK-8280048): Missing comma in copyright header


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7095/head:pull/7095` \
`$ git checkout pull/7095`

Update a local copy of the PR: \
`$ git checkout pull/7095` \
`$ git pull https://git.openjdk.java.net/jdk pull/7095/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7095`

View PR using the GUI difftool: \
`$ git pr show -t 7095`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7095.diff">https://git.openjdk.java.net/jdk/pull/7095.diff</a>

</details>
