### PR TITLE
8280058: JFR: StreamUtils::getJfrRepository(Process) should print stdout and stderr

### DIFF
--- a/test/lib/jdk/test/lib/jfr/StreamingUtils.java
+++ b/test/lib/jdk/test/lib/jfr/StreamingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,8 +43,10 @@ public class StreamingUtils {
     public static Path getJfrRepository(Process process) throws Exception {
         while (true) {
             if (!process.isAlive()) {
-                String msg = String.format("Process (pid = %d) is no longer alive, exit value = %d",
+                String msg = String.format("Process (pid = %d) is no longer alive, exit value = %d\n",
                                            process.pid(), process.exitValue());
+                mes += "Stderr: " + new String(process.getErrorStream().readAllBytes()) + "\n";
+                mes += "Stdout: " + new String(process.getInputStream().readAllBytes()) + "\n";
                 throw new RuntimeException(msg);
             }
 

--- a/test/lib/jdk/test/lib/jfr/StreamingUtils.java
+++ b/test/lib/jdk/test/lib/jfr/StreamingUtils.java
@@ -45,8 +45,8 @@ public class StreamingUtils {
             if (!process.isAlive()) {
                 String msg = String.format("Process (pid = %d) is no longer alive, exit value = %d\n",
                                            process.pid(), process.exitValue());
-                mes += "Stderr: " + new String(process.getErrorStream().readAllBytes()) + "\n";
-                mes += "Stdout: " + new String(process.getInputStream().readAllBytes()) + "\n";
+                msg += "Stderr: " + new String(process.getErrorStream().readAllBytes()) + "\n";
+                msg += "Stdout: " + new String(process.getInputStream().readAllBytes()) + "\n";
                 throw new RuntimeException(msg);
             }
 


### PR DESCRIPTION
Hi,

Could I have review of a test change that makes it easier diagnose why tests such as TestOutOfProcessMigration.java and TestJVMCrash.java fails. 

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280058](https://bugs.openjdk.java.net/browse/JDK-8280058): JFR: StreamUtils::getJfrRepository(Process) should print stdout and stderr


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7101/head:pull/7101` \
`$ git checkout pull/7101`

Update a local copy of the PR: \
`$ git checkout pull/7101` \
`$ git pull https://git.openjdk.java.net/jdk pull/7101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7101`

View PR using the GUI difftool: \
`$ git pr show -t 7101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7101.diff">https://git.openjdk.java.net/jdk/pull/7101.diff</a>

</details>
