### PR TITLE
8280059: Incorrect glibc version is used in a comment in os_linux.cpp

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -806,7 +806,7 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
 
   // Calculate stack size if it's not specified by caller.
   size_t stack_size = os::Posix::get_initial_stack_size(thr_type, req_stack_size);
-  // In glibc versions prior to 2.7 the guard size mechanism
+  // In glibc versions prior to 2.27 the guard size mechanism
   // is not implemented properly. The posix standard requires adding
   // the size of the guard pages to the stack size, instead Linux
   // takes the space out of 'stacksize'. Thus we adapt the requested


### PR DESCRIPTION
Please review this trivial correction:

s/2.7/2.27/

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280059](https://bugs.openjdk.java.net/browse/JDK-8280059): Incorrect glibc version is used in a comment in os_linux.cpp


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7103/head:pull/7103` \
`$ git checkout pull/7103`

Update a local copy of the PR: \
`$ git checkout pull/7103` \
`$ git pull https://git.openjdk.java.net/jdk pull/7103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7103`

View PR using the GUI difftool: \
`$ git pr show -t 7103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7103.diff">https://git.openjdk.java.net/jdk/pull/7103.diff</a>

</details>
