### PR TITLE
8280047: Broken link to Swing Connection document from javax.swing package docs

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/package-info.java
+++ b/src/java.desktop/share/classes/javax/swing/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/package-info.java
+++ b/src/java.desktop/share/classes/javax/swing/package-info.java
@@ -139,8 +139,6 @@
  *     <li><a href="https://www.oracle.com/java/technologies/javase/training-support.html"
  *     target="_top">Java SE Training and Certification</a>
  *     at the Java Developer Connection <sup>SM</sup></li>
- *     <li><a href="https://www.oracle.com/java/technologies/java-foundation-classes.html"
- *     target="_top">Java Foundation Classes (JFC)</a> home page</li>
  * </ul>
  *
  * @serial exclude

--- a/src/java.desktop/share/classes/javax/swing/package-info.java
+++ b/src/java.desktop/share/classes/javax/swing/package-info.java
@@ -136,10 +136,10 @@
  *     target="_top">A Swing Architecture Overview</a></li>
  *     <li><a href="https://docs.oracle.com/javase/tutorial/"
  *     target="_top">The Java Tutorial</a></li>
- *     <li><a href="http://www.oracle.com/technetwork/java/javase/training/index.html"
- *     target="_top">Online Training</a>
+ *     <li><a href="https://www.oracle.com/java/technologies/javase/training-support.html"
+ *     target="_top">Java SE Training and Certification</a>
  *     at the Java Developer Connection <sup>SM</sup></li>
- *     <li><a href="http://www.oracle.com/technetwork/java/javase/tech/index-jsp-142216.html"
+ *     <li><a href="https://www.oracle.com/java/technologies/java-foundation-classes.html"
  *     target="_top">Java Foundation Classes (JFC)</a> home page</li>
  * </ul>
  *

--- a/src/java.desktop/share/classes/javax/swing/package-info.java
+++ b/src/java.desktop/share/classes/javax/swing/package-info.java
@@ -132,7 +132,7 @@
  * For overviews, tutorials, examples, guides, and other documentation,
  * please see:
  * <ul>
- *     <li><a href=""https://www.oracle.com/java/technologies/a-swing-architecture.html"
+ *     <li><a href="https://www.oracle.com/java/technologies/a-swing-architecture.html"
  *     target="_top">A Swing Architecture Overview</a></li>
  *     <li><a href="https://docs.oracle.com/javase/tutorial/"
  *     target="_top">The Java Tutorial</a></li>

--- a/src/java.desktop/share/classes/javax/swing/package-info.java
+++ b/src/java.desktop/share/classes/javax/swing/package-info.java
@@ -138,7 +138,6 @@
  *     target="_top">The Java Tutorial</a></li>
  *     <li><a href="https://www.oracle.com/java/technologies/javase/training-support.html"
  *     target="_top">Java SE Training and Certification</a>
- *     at the Java Developer Connection <sup>SM</sup></li>
  * </ul>
  *
  * @serial exclude

--- a/src/java.desktop/share/classes/javax/swing/package-info.java
+++ b/src/java.desktop/share/classes/javax/swing/package-info.java
@@ -137,7 +137,7 @@
  *     <li><a href="https://docs.oracle.com/javase/tutorial/"
  *     target="_top">The Java Tutorial</a></li>
  *     <li><a href="https://www.oracle.com/java/technologies/javase/training-support.html"
- *     target="_top">Java SE Training and Certification</a>
+ *     target="_top">Java SE Training and Certification</a></li>
  * </ul>
  *
  * @serial exclude

--- a/src/java.desktop/share/classes/javax/swing/package-info.java
+++ b/src/java.desktop/share/classes/javax/swing/package-info.java
@@ -132,8 +132,8 @@
  * For overviews, tutorials, examples, guides, and other documentation,
  * please see:
  * <ul>
- *     <li><a href="http://www.oracle.com/technetwork/java/javase/tech/articles-jsp-139072.html"
- *     target="_top">The Swing Connection</a></li>
+ *     <li><a href=""https://www.oracle.com/java/technologies/a-swing-architecture.html"
+ *     target="_top">A Swing Architecture Overview</a></li>
  *     <li><a href="https://docs.oracle.com/javase/tutorial/"
  *     target="_top">The Java Tutorial</a></li>
  *     <li><a href="http://www.oracle.com/technetwork/java/javase/training/index.html"


### PR DESCRIPTION
Fixed the broken link with appropriate link to swing document.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280047](https://bugs.openjdk.java.net/browse/JDK-8280047): Broken link to Swing Connection document from javax.swing package docs


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Author) ⚠️ Review applies to efcf062cd2556b2ae0ec1d7ab141b15966a54c56
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7104/head:pull/7104` \
`$ git checkout pull/7104`

Update a local copy of the PR: \
`$ git checkout pull/7104` \
`$ git pull https://git.openjdk.java.net/jdk pull/7104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7104`

View PR using the GUI difftool: \
`$ git pr show -t 7104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7104.diff">https://git.openjdk.java.net/jdk/pull/7104.diff</a>

</details>
