### PR TITLE
8279241: G1 Full GC does not always slide memory to bottom addresses 

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1FullCollector.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1FullCollector.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.hpp
@@ -110,7 +110,7 @@ public:
   G1FullGCCompactionPoint* serial_compaction_point() { return &_serial_compaction_point; }
   G1CMBitMap*              mark_bitmap();
   ReferenceProcessor*      reference_processor();
-  size_t live_words(uint region_index) {
+  size_t live_words(uint region_index) const {
     assert(region_index < _heap->max_regions(), "sanity");
     return _live_stats[region_index]._live_words;
   }
@@ -121,6 +121,9 @@ public:
   inline bool is_skip_compacting(uint region_index) const;
   inline bool is_skip_marking(oop obj) const;
 
+  // Are we (potentially) going to compact into this region?
+  inline bool is_compaction_target(uint region_index) const;
+
   inline void set_free(uint region_idx);
   inline bool is_free(uint region_idx) const;
   inline void update_from_compacting_to_skip_compacting(uint region_idx);
@@ -128,6 +131,11 @@ public:
 private:
   void phase1_mark_live_objects();
   void phase2_prepare_compaction();
+
+  bool phase2a_determine_worklists();
+  bool phase2b_forward_oops();
+  void phase2c_prepare_serial_compaction();
+
   void phase3_adjust_pointers();
   void phase4_do_compaction();
 

--- a/src/hotspot/share/gc/g1/g1FullCollector.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.hpp
@@ -132,7 +132,7 @@ private:
   void phase1_mark_live_objects();
   void phase2_prepare_compaction();
 
-  bool phase2a_determine_worklists();
+  void phase2a_determine_worklists();
   bool phase2b_forward_oops();
   void phase2c_prepare_serial_compaction();
 

--- a/src/hotspot/share/gc/g1/g1FullCollector.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1FullCollector.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.inline.hpp
@@ -43,6 +43,10 @@ bool G1FullCollector::is_skip_marking(oop obj) const {
   return _region_attr_table.is_skip_marking(cast_from_oop<HeapWord*>(obj));
 }
 
+bool G1FullCollector::is_compaction_target(uint region_index) const {
+  return _region_attr_table.is_compacting(region_index) || is_free(region_index);
+}
+
 void G1FullCollector::set_free(uint region_idx) {
   _region_attr_table.set_free(region_idx);
 }

--- a/src/hotspot/share/gc/g1/g1FullGCHeapRegionAttr.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCHeapRegionAttr.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1FullGCHeapRegionAttr.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCHeapRegionAttr.hpp
@@ -70,6 +70,10 @@ public:
     return get_by_address(obj) == Compacting;
   }
 
+  bool is_compacting(uint idx) const {
+    return get_by_index(idx) == Compacting;
+  }
+
   bool is_skip_compacting(uint idx) const {
     return get_by_index(idx) == SkipCompacting;
   }

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -23,7 +23,7 @@
  */
 
 #include "precompiled.hpp"
-#include "gc/g1/g1CollectedHeap.hpp"
+#include "gc/g1/g1CollectedHeap.inline.hpp"
 #include "gc/g1/g1ConcurrentMarkBitMap.inline.hpp"
 #include "gc/g1/g1FullCollector.inline.hpp"
 #include "gc/g1/g1FullGCCompactionPoint.hpp"
@@ -40,29 +40,64 @@
 #include "utilities/ticks.hpp"
 
 template<bool is_humongous>
-void G1FullGCPrepareTask::G1CalculatePointersClosure::free_pinned_region(HeapRegion* hr) {
-  _regions_freed = true;
+void G1DetermineCompactionQueueClosure::free_pinned_region(HeapRegion* hr) {
+  _found_empty_regions = true;
   if (is_humongous) {
     _g1h->free_humongous_region(hr, nullptr);
   } else {
     _g1h->free_region(hr, nullptr);
   }
   _collector->set_free(hr->hrm_index());
-  prepare_for_compaction(hr);
+  add_to_compaction_queue(next_compaction_point(), hr);
 }
 
-bool G1FullGCPrepareTask::G1CalculatePointersClosure::do_heap_region(HeapRegion* hr) {
+bool G1DetermineCompactionQueueClosure::should_compact(HeapRegion* hr) const {
+  // There is no need to iterate and forward objects in pinned regions ie.
+  // prepare them for compaction.
+  if (hr->is_pinned()) {
+    return false;
+  }
+  size_t live_words = _collector->live_words(hr->hrm_index());
+  size_t live_words_threshold = _collector->scope()->region_compaction_threshold();
+  // High live ratio region will not be compacted.
+  return live_words <= live_words_threshold;
+}
+
+uint G1DetermineCompactionQueueClosure::next_worker() {
+  uint result = _cur_worker;
+  _cur_worker = (_cur_worker + 1) % _collector->workers();
+  return result;
+}
+
+G1FullGCCompactionPoint* G1DetermineCompactionQueueClosure::next_compaction_point() {
+  return _collector->compaction_point(next_worker());
+}
+
+void G1DetermineCompactionQueueClosure::add_to_compaction_queue(G1FullGCCompactionPoint* cp, HeapRegion* hr) {
+  hr->set_compaction_top(hr->bottom());
+  if (!cp->is_initialized()) {
+    cp->initialize(hr, true);
+  }
+  // Add region to the compaction queue.
+  cp->add(hr);
+}
+
+G1DetermineCompactionQueueClosure::G1DetermineCompactionQueueClosure(G1FullCollector* collector) :
+  _g1h(G1CollectedHeap::heap()),
+  _collector(collector),
+  _cur_worker(0),
+  _found_empty_regions(false) { }
+
+bool G1DetermineCompactionQueueClosure::do_heap_region(HeapRegion* hr) {
   if (should_compact(hr)) {
     assert(!hr->is_humongous(), "moving humongous objects not supported.");
-    prepare_for_compaction(hr);
+    add_to_compaction_queue(next_compaction_point(), hr);
   } else {
-    // There is no need to iterate and forward objects in pinned regions ie.
-    // prepare them for compaction. The adjust pointers phase will skip
-    // work for them.
     assert(hr->containing_set() == nullptr, "already cleared by PrepareRegionsClosure");
     if (hr->is_humongous()) {
       oop obj = cast_to_oop(hr->humongous_start_region()->bottom());
-      if (!_bitmap->is_marked(obj)) {
+      bool is_empty = !_collector->mark_bitmap()->is_marked(obj);
+      if (is_empty) {
         free_pinned_region<true>(hr);
       }
     } else if (hr->is_open_archive()) {
@@ -76,53 +111,73 @@ bool G1FullGCPrepareTask::G1CalculatePointersClosure::do_heap_region(HeapRegion*
       assert(MarkSweepDeadRatio > 0,
              "only skip compaction for other regions when MarkSweepDeadRatio > 0");
 
-      // Too many live objects; skip compacting it.
+      // Too many live objects in the region; skip compacting it.
       _collector->update_from_compacting_to_skip_compacting(hr->hrm_index());
-      if (hr->is_young()) {
-        // G1 updates the BOT for old region contents incrementally, but young regions
-        // lack BOT information for performance reasons.
-        // Recreate BOT information of high live ratio young regions here to keep expected
-        // performance during scanning their card tables in the collection pauses later.
-        hr->update_bot();
-      }
       log_trace(gc, phases)("Phase 2: skip compaction region index: %u, live words: " SIZE_FORMAT,
                             hr->hrm_index(), _collector->live_words(hr->hrm_index()));
     }
   }
 
-  // Reset data structures not valid after Full GC.
-  reset_region_metadata(hr);
+  return false;
+}
+
+bool G1FullGCPrepareTask::G1CalculatePointersClosure::do_heap_region(HeapRegion* hr) {
+  uint region_idx = hr->hrm_index();
+  assert(_collector->is_compaction_target(region_idx), "must be");
+
+  assert(!hr->is_pinned(), "must be");
+  assert(!hr->is_closed_archive(), "must be");
+  assert(!hr->is_open_archive(), "must be");
+
+  prepare_for_compaction(hr);
 
   return false;
 }
 
 G1FullGCPrepareTask::G1FullGCPrepareTask(G1FullCollector* collector) :
     G1FullGCTask("G1 Prepare Compact Task", collector),
-    _freed_regions(false),
+    _has_free_compaction_targets(false),
     _hrclaimer(collector->workers()) {
 }
 
-void G1FullGCPrepareTask::set_freed_regions() {
-  if (!_freed_regions) {
-    _freed_regions = true;
+void G1FullGCPrepareTask::set_has_free_compaction_targets() {
+  if (!_has_free_compaction_targets) {
+    _has_free_compaction_targets = true;
   }
 }
 
-bool G1FullGCPrepareTask::has_freed_regions() {
-  return _freed_regions;
+bool G1FullGCPrepareTask::has_free_compaction_targets() {
+  return _has_free_compaction_targets;
 }
 
 void G1FullGCPrepareTask::work(uint worker_id) {
   Ticks start = Ticks::now();
-  G1FullGCCompactionPoint* compaction_point = collector()->compaction_point(worker_id);
-  G1CalculatePointersClosure closure(collector(), compaction_point);
-  G1CollectedHeap::heap()->heap_region_par_iterate_from_start(&closure, &_hrclaimer);
+  // Calculate the target locations for the objects in the non-free regions of
+  // the compaction queues provided by the associate compaction point.
+  {
+    G1FullGCCompactionPoint* compaction_point = collector()->compaction_point(worker_id);
+    G1CalculatePointersClosure closure(collector(), compaction_point);
 
-  compaction_point->update();
+    for (GrowableArrayIterator<HeapRegion*> it = compaction_point->regions()->begin();
+         it != compaction_point->regions()->end();
+         ++it) {
+      closure.do_heap_region(*it);
+    }
+    compaction_point->update();
+    // Determine if there are any unused compaction targets. This is only the case if
+    // there are
+    // - any regions in queue, so no free ones either.
+    // - and the current region is not the last one in the list.
+    if (compaction_point->has_regions() &&
+        compaction_point->current_region() != compaction_point->regions()->last()) {
+      set_has_free_compaction_targets();
+    }
+  }
 
-  // Check if any regions was freed by this worker and store in task.
-  if (closure.freed_regions()) {
-    set_freed_regions();
+  // Clear region metadata that is invalid after GC for all regions.
+  {
+    G1ResetMetadataClosure closure(collector());
+    G1CollectedHeap::heap()->heap_region_par_iterate_from_start(&closure, &_hrclaimer);
   }
   log_task("Prepare compaction task", worker_id, start);
 }
@@ -132,20 +187,13 @@ G1FullGCPrepareTask::G1CalculatePointersClosure::G1CalculatePointersClosure(G1Fu
     _g1h(G1CollectedHeap::heap()),
     _collector(collector),
     _bitmap(collector->mark_bitmap()),
-    _cp(cp),
-    _regions_freed(false) { }
+    _cp(cp) { }
 
-bool G1FullGCPrepareTask::G1CalculatePointersClosure::should_compact(HeapRegion* hr) {
-  if (hr->is_pinned()) {
-    return false;
-  }
-  size_t live_words = _collector->live_words(hr->hrm_index());
-  size_t live_words_threshold = _collector->scope()->region_compaction_threshold();
-  // High live ratio region will not be compacted.
-  return live_words <= live_words_threshold;
-}
+G1FullGCPrepareTask::G1ResetMetadataClosure::G1ResetMetadataClosure(G1FullCollector* collector) :
+  _g1h(G1CollectedHeap::heap()),
+  _collector(collector) { }
 
-void G1FullGCPrepareTask::G1CalculatePointersClosure::reset_region_metadata(HeapRegion* hr) {
+void G1FullGCPrepareTask::G1ResetMetadataClosure::reset_region_metadata(HeapRegion* hr) {
   hr->rem_set()->clear();
   hr->clear_cardtable();
 
@@ -153,6 +201,26 @@ void G1FullGCPrepareTask::G1CalculatePointersClosure::reset_region_metadata(Heap
   if (hcc->use_cache()) {
     hcc->reset_card_counts(hr);
   }
+}
+
+bool G1FullGCPrepareTask::G1ResetMetadataClosure::do_heap_region(HeapRegion* hr) {
+  uint const region_idx = hr->hrm_index();
+  if (!_collector->is_compaction_target(region_idx)) {
+    assert(!hr->is_free(), "all free regions should be compaction targets");
+    assert(_collector->is_skip_compacting(region_idx) || hr->is_closed_archive(), "must be"); // FIXME: second clause
+    if (hr->is_young()) {
+      // G1 updates the BOT for old region contents incrementally, but young regions
+      // lack BOT information for performance reasons.
+      // Recreate BOT information of high live ratio young regions here to keep expected
+      // performance during scanning their card tables in the collection pauses later.
+      hr->update_bot();
+    }
+  }
+
+  // Reset data structures not valid after Full GC.
+  reset_region_metadata(hr);
+
+  return false;
 }
 
 G1FullGCPrepareTask::G1PrepareCompactLiveClosure::G1PrepareCompactLiveClosure(G1FullGCCompactionPoint* cp) :
@@ -164,87 +232,9 @@ size_t G1FullGCPrepareTask::G1PrepareCompactLiveClosure::apply(oop object) {
   return size;
 }
 
-size_t G1FullGCPrepareTask::G1RePrepareClosure::apply(oop obj) {
-  // We only re-prepare objects forwarded within the current region, so
-  // skip objects that are already forwarded to another region.
-  if (obj->is_forwarded() && !_current->is_in(obj->forwardee())) {
-    return obj->size();
-  }
-
-  // Get size and forward.
-  size_t size = obj->size();
-  _cp->forward(obj, size);
-
-  return size;
-}
-
-void G1FullGCPrepareTask::G1CalculatePointersClosure::prepare_for_compaction_work(G1FullGCCompactionPoint* cp,
-                                                                                  HeapRegion* hr) {
-  hr->set_compaction_top(hr->bottom());
+void G1FullGCPrepareTask::G1CalculatePointersClosure::prepare_for_compaction(HeapRegion* hr) {
   if (!_collector->is_free(hr->hrm_index())) {
-    G1PrepareCompactLiveClosure prepare_compact(cp);
+    G1PrepareCompactLiveClosure prepare_compact(_cp);
     hr->apply_to_marked_objects(_bitmap, &prepare_compact);
   }
-}
-
-void G1FullGCPrepareTask::G1CalculatePointersClosure::prepare_for_compaction(HeapRegion* hr) {
-  if (!_cp->is_initialized()) {
-    hr->set_compaction_top(hr->bottom());
-    _cp->initialize(hr, true);
-  }
-  // Add region to the compaction queue and prepare it.
-  _cp->add(hr);
-  prepare_for_compaction_work(_cp, hr);
-}
-
-void G1FullGCPrepareTask::prepare_serial_compaction() {
-  GCTraceTime(Debug, gc, phases) debug("Phase 2: Prepare Serial Compaction", collector()->scope()->timer());
-  // At this point we know that no regions were completely freed by
-  // the parallel compaction. That means that the last region of
-  // all compaction queues still have data in them. We try to compact
-  // these regions in serial to avoid a premature OOM.
-  for (uint i = 0; i < collector()->workers(); i++) {
-    G1FullGCCompactionPoint* cp = collector()->compaction_point(i);
-    if (cp->has_regions()) {
-      collector()->serial_compaction_point()->add(cp->remove_last());
-    }
-  }
-
-  // Update the forwarding information for the regions in the serial
-  // compaction point.
-  G1FullGCCompactionPoint* cp = collector()->serial_compaction_point();
-  for (GrowableArrayIterator<HeapRegion*> it = cp->regions()->begin(); it != cp->regions()->end(); ++it) {
-    HeapRegion* current = *it;
-    if (!cp->is_initialized()) {
-      // Initialize the compaction point. Nothing more is needed for the first heap region
-      // since it is already prepared for compaction.
-      cp->initialize(current, false);
-    } else {
-      assert(!current->is_humongous(), "Should be no humongous regions in compaction queue");
-      G1RePrepareClosure re_prepare(cp, current);
-      current->set_compaction_top(current->bottom());
-      current->apply_to_marked_objects(collector()->mark_bitmap(), &re_prepare);
-    }
-  }
-  cp->update();
-}
-
-bool G1FullGCPrepareTask::G1CalculatePointersClosure::freed_regions() {
-  if (_regions_freed) {
-    return true;
-  }
-
-  if (!_cp->has_regions()) {
-    // No regions in queue, so no free ones either.
-    return false;
-  }
-
-  if (_cp->current_region() != _cp->regions()->last()) {
-    // The current region used for compaction is not the last in the
-    // queue. That means there is at least one free region in the queue.
-    return true;
-  }
-
-  // No free regions in the queue.
-  return false;
 }

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
 #include "gc/g1/g1FullGCCompactionPoint.hpp"
 #include "gc/g1/g1FullGCMarker.hpp"
 #include "gc/g1/g1FullGCOopClosures.inline.hpp"
-#include "gc/g1/g1FullGCPrepareTask.hpp"
+#include "gc/g1/g1FullGCPrepareTask.inline.hpp"
 #include "gc/g1/g1HotCardCache.hpp"
 #include "gc/g1/heapRegion.inline.hpp"
 #include "gc/shared/gcTraceTime.inline.hpp"

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -42,8 +42,7 @@
 G1DetermineCompactionQueueClosure::G1DetermineCompactionQueueClosure(G1FullCollector* collector) :
   _g1h(G1CollectedHeap::heap()),
   _collector(collector),
-  _cur_worker(0),
-  _found_empty_regions(false) { }
+  _cur_worker(0) { }
 
 bool G1FullGCPrepareTask::G1CalculatePointersClosure::do_heap_region(HeapRegion* hr) {
   uint region_idx = hr->hrm_index();
@@ -131,7 +130,7 @@ bool G1FullGCPrepareTask::G1ResetMetadataClosure::do_heap_region(HeapRegion* hr)
   uint const region_idx = hr->hrm_index();
   if (!_collector->is_compaction_target(region_idx)) {
     assert(!hr->is_free(), "all free regions should be compaction targets");
-    assert(_collector->is_skip_compacting(region_idx) || hr->is_closed_archive(), "must be"); // FIXME: second clause
+    assert(_collector->is_skip_compacting(region_idx) || hr->is_closed_archive(), "must be");
     if (hr->is_young()) {
       // G1 updates the BOT for old region contents incrementally, but young regions
       // lack BOT information for performance reasons.

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,24 +44,24 @@ class G1DetermineCompactionQueueClosure : public HeapRegionClosure {
   bool _found_empty_regions;
 
   template<bool is_humongous>
-  void free_pinned_region(HeapRegion* hr);
+  inline void free_pinned_region(HeapRegion* hr);
 
-  bool should_compact(HeapRegion* hr) const;
+  inline bool should_compact(HeapRegion* hr) const;
 
   // Returns the current worker id to assign a compaction point to, and selects
   // the next one round-robin style.
-  uint next_worker();
+  inline uint next_worker();
 
-  G1FullGCCompactionPoint* next_compaction_point();
+  inline G1FullGCCompactionPoint* next_compaction_point();
 
-  void add_to_compaction_queue(G1FullGCCompactionPoint* cp, HeapRegion* hr);
+  inline void add_to_compaction_queue(G1FullGCCompactionPoint* cp, HeapRegion* hr);
 
 public:
   G1DetermineCompactionQueueClosure(G1FullCollector* collector);
 
-  bool do_heap_region(HeapRegion* hr) override;
+  inline bool do_heap_region(HeapRegion* hr) override;
 
-  bool found_empty_regions() { return _found_empty_regions; }
+  inline bool found_empty_regions() { return _found_empty_regions; }
 };
 
 class G1FullGCPrepareTask : public G1FullGCTask {
@@ -125,7 +125,7 @@ public:
     _cp(hrcp),
     _current(hr) { }
 
-  size_t apply(oop obj);
+  inline size_t apply(oop obj);
 };
 
 #endif // SHARE_GC_G1_G1FULLGCPREPARETASK_HPP

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
@@ -25,15 +25,15 @@
 #ifndef SHARE_GC_G1_G1FULLGCPREPARETASK_HPP
 #define SHARE_GC_G1_G1FULLGCPREPARETASK_HPP
 
-#include "gc/g1/g1FullGCCompactionPoint.hpp"
-#include "gc/g1/g1FullGCScope.hpp"
 #include "gc/g1/g1FullGCTask.hpp"
-#include "gc/g1/g1RootProcessor.hpp"
-#include "gc/g1/heapRegionManager.hpp"
-#include "gc/shared/referenceProcessor.hpp"
+#include "gc/g1/heapRegion.hpp"
+#include "memory/allocation.hpp"
 
+class G1CollectedHeap;
 class G1CMBitMap;
 class G1FullCollector;
+class G1FullGCCompactionPoint;
+class HeapRegion;
 
 // Determines the regions in the heap that should be part of the compaction and
 // distributes them among the compaction queues in round-robin fashion.
@@ -112,6 +112,20 @@ private:
     G1PrepareCompactLiveClosure(G1FullGCCompactionPoint* cp);
     size_t apply(oop object);
   };
+};
+
+// Closure to re-prepare objects in the serial compaction point queue regions for
+// serial compaction.
+class G1SerialRePrepareClosure : public StackObj {
+  G1FullGCCompactionPoint* _cp;
+  HeapRegion* _current;
+
+public:
+  G1SerialRePrepareClosure(G1FullGCCompactionPoint* hrcp, HeapRegion* hr) :
+    _cp(hrcp),
+    _current(hr) { }
+
+  size_t apply(oop obj);
 };
 
 #endif // SHARE_GC_G1_G1FULLGCPREPARETASK_HPP

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
@@ -41,7 +41,6 @@ class G1DetermineCompactionQueueClosure : public HeapRegionClosure {
   G1CollectedHeap* _g1h;
   G1FullCollector* _collector;
   uint _cur_worker;
-  bool _found_empty_regions;
 
   template<bool is_humongous>
   inline void free_pinned_region(HeapRegion* hr);
@@ -54,14 +53,12 @@ class G1DetermineCompactionQueueClosure : public HeapRegionClosure {
 
   inline G1FullGCCompactionPoint* next_compaction_point();
 
-  inline void add_to_compaction_queue(G1FullGCCompactionPoint* cp, HeapRegion* hr);
+  inline void add_to_compaction_queue(HeapRegion* hr);
 
 public:
   G1DetermineCompactionQueueClosure(G1FullCollector* collector);
 
   inline bool do_heap_region(HeapRegion* hr) override;
-
-  inline bool found_empty_regions() { return _found_empty_regions; }
 };
 
 class G1FullGCPrepareTask : public G1FullGCTask {

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.inline.hpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_GC_G1_G1FULLGCPREPARETASK_INLINE_HPP
+#define SHARE_GC_G1_G1FULLGCPREPARETASK_INLINE_HPP
+
+#include "gc/g1/g1FullGCPrepareTask.hpp"
+
+#include "gc/g1/g1CollectedHeap.inline.hpp"
+#include "gc/g1/g1FullCollector.hpp"
+#include "gc/g1/g1FullGCCompactionPoint.hpp"
+#include "gc/g1/g1FullGCScope.hpp"
+#include "gc/g1/heapRegion.inline.hpp"
+
+template<bool is_humongous>
+void G1DetermineCompactionQueueClosure::free_pinned_region(HeapRegion* hr) {
+  _found_empty_regions = true;
+  if (is_humongous) {
+    _g1h->free_humongous_region(hr, nullptr);
+  } else {
+    _g1h->free_region(hr, nullptr);
+  }
+  _collector->set_free(hr->hrm_index());
+  add_to_compaction_queue(next_compaction_point(), hr);
+}
+
+inline bool G1DetermineCompactionQueueClosure::should_compact(HeapRegion* hr) const {
+  // There is no need to iterate and forward objects in pinned regions ie.
+  // prepare them for compaction.
+  if (hr->is_pinned()) {
+    return false;
+  }
+  size_t live_words = _collector->live_words(hr->hrm_index());
+  size_t live_words_threshold = _collector->scope()->region_compaction_threshold();
+  // High live ratio region will not be compacted.
+  return live_words <= live_words_threshold;
+}
+
+inline uint G1DetermineCompactionQueueClosure::next_worker() {
+  uint result = _cur_worker;
+  _cur_worker = (_cur_worker + 1) % _collector->workers();
+  return result;
+}
+
+inline G1FullGCCompactionPoint* G1DetermineCompactionQueueClosure::next_compaction_point() {
+  return _collector->compaction_point(next_worker());
+}
+
+inline void G1DetermineCompactionQueueClosure::add_to_compaction_queue(G1FullGCCompactionPoint* cp, HeapRegion* hr) {
+  hr->set_compaction_top(hr->bottom());
+  if (!cp->is_initialized()) {
+    cp->initialize(hr, true);
+  }
+  // Add region to the compaction queue.
+  cp->add(hr);
+}
+
+inline bool G1DetermineCompactionQueueClosure::do_heap_region(HeapRegion* hr) {
+  if (should_compact(hr)) {
+    assert(!hr->is_humongous(), "moving humongous objects not supported.");
+    add_to_compaction_queue(next_compaction_point(), hr);
+  } else {
+    assert(hr->containing_set() == nullptr, "already cleared by PrepareRegionsClosure");
+    if (hr->is_humongous()) {
+      oop obj = cast_to_oop(hr->humongous_start_region()->bottom());
+      bool is_empty = !_collector->mark_bitmap()->is_marked(obj);
+      if (is_empty) {
+        free_pinned_region<true>(hr);
+      }
+    } else if (hr->is_open_archive()) {
+      bool is_empty = _collector->live_words(hr->hrm_index()) == 0;
+      if (is_empty) {
+        free_pinned_region<false>(hr);
+      }
+    } else if (hr->is_closed_archive()) {
+      // nothing to do with closed archive region
+    } else {
+      assert(MarkSweepDeadRatio > 0,
+             "only skip compaction for other regions when MarkSweepDeadRatio > 0");
+
+      // Too many live objects in the region; skip compacting it.
+      _collector->update_from_compacting_to_skip_compacting(hr->hrm_index());
+      log_trace(gc, phases)("Phase 2: skip compaction region index: %u, live words: " SIZE_FORMAT,
+                            hr->hrm_index(), _collector->live_words(hr->hrm_index()));
+    }
+  }
+
+  return false;
+}
+
+inline size_t G1SerialRePrepareClosure::apply(oop obj) {
+  // We only re-prepare objects forwarded within the current region, so
+  // skip objects that are already forwarded to another region.
+  if (obj->is_forwarded() && !_current->is_in(obj->forwardee())) {
+    return obj->size();
+  }
+
+  // Get size and forward.
+  size_t size = obj->size();
+  _cp->forward(obj, size);
+
+  return size;
+}
+
+#endif // SHARE_GC_G1_G1FULLGCPREPARETASK_INLINE_HPP

--- a/src/hotspot/share/gc/g1/g1FullGCScope.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCScope.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1FullGCScope.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCScope.cpp
@@ -70,6 +70,6 @@ G1FullGCTracer* G1FullGCScope::tracer() {
   return &_tracer;
 }
 
-size_t G1FullGCScope::region_compaction_threshold() {
+size_t G1FullGCScope::region_compaction_threshold() const {
   return _region_compaction_threshold;
 }

--- a/src/hotspot/share/gc/g1/g1FullGCScope.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCScope.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1FullGCScope.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCScope.hpp
@@ -71,7 +71,7 @@ public:
   STWGCTimer* timer();
   G1FullGCTracer* tracer();
   G1HeapTransition* heap_transition();
-  size_t region_compaction_threshold();
+  size_t region_compaction_threshold() const;
 };
 
 #endif // SHARE_GC_G1_G1FULLGCSCOPE_HPP


### PR DESCRIPTION
Hi all,

  can I get reviews for this change that completely fixes the possibility that during g1 full gc memory will not be slid to bottom addresses consistently in presence of threads.

The problem is that multiple thread compete for regions to compact into - it could happen that given live data somewhere "high up" the heap gets to be the bottom region for a particular thread, so all data will be compacted starting from that region.
The problem with that is region level fragmentation, i.e. that after gc there is not enough free contiguous space for a humongous object, leading to OOME.

The change splits the phase where determining the compaction point queue (the set of regions a particular thread compacts into) from the part of that phase where the new locations of the objects is determined (i.e. putting a forwarding pointer into the live objects in these regions) and other stuff best done in parallel.
This makes determining the compaction point queue deterministic (by distributing these regions we can compact into in a round-robin fashion) in a way that always slides live data consistently into the bottom heap area.

This change also makes it easier to, in the future, improve work distribution of the compaction phase (which directly uses the compaction point queues) by distributing them  according to live data, and also incorporate last-ditch moves of humongous objects.

The most important thing about this split is probably the changes in the parallel part: every thread must make sure that some work is done on the compaction point queue (i.e. the forwarding), and other work on all regions (clearing metadata, updating the BOT of young regions that are not moved).

Testing: tier1-5, checking performance on some simple full gc benchmarks with no particular difference

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279241](https://bugs.openjdk.java.net/browse/JDK-8279241): G1 Full GC does not always slide memory to bottom addresses


### Reviewers
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**) ⚠️ Review applies to 30ee70795617c6c91942c9c132cde11a1636392a
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to 30ee70795617c6c91942c9c132cde11a1636392a
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to 30ee70795617c6c91942c9c132cde11a1636392a


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7106/head:pull/7106` \
`$ git checkout pull/7106`

Update a local copy of the PR: \
`$ git checkout pull/7106` \
`$ git pull https://git.openjdk.java.net/jdk pull/7106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7106`

View PR using the GUI difftool: \
`$ git pr show -t 7106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7106.diff">https://git.openjdk.java.net/jdk/pull/7106.diff</a>

</details>
