### PR TITLE
8280072: Remove unnecessary use of ParGCRareEvent_lock in Serial GC 

### DIFF
--- a/src/hotspot/share/gc/shared/blockOffsetTable.inline.hpp
+++ b/src/hotspot/share/gc/shared/blockOffsetTable.inline.hpp
@@ -66,9 +66,8 @@ inline HeapWord* BlockOffsetSharedArray::address_for_index(size_t index) const {
 inline void BlockOffsetSharedArray::check_reducing_assertion(bool reducing) {
     assert(reducing || !SafepointSynchronize::is_at_safepoint() || init_to_zero() ||
            Thread::current()->is_VM_thread() ||
-           Thread::current()->is_ConcurrentGC_thread() ||
-           ((!Thread::current()->is_ConcurrentGC_thread()) &&
-            ParGCRareEvent_lock->owned_by_self()), "Crack");
+           Thread::current()->is_ConcurrentGC_thread(),
+           "Crack");
 }
 
 #endif // SHARE_GC_SHARED_BLOCKOFFSETTABLE_INLINE_HPP


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that removes an always-false clause in an assert? In more detail, that clause refers to `ParGCRareEvent_lock` that is never held in this code that is only called by serial gc.

Testing: gha, tier1-3

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8280072](https://bugs.openjdk.java.net/browse/JDK-8280072): Remove unnecessary use of ParGCRareEvent_lock in Serial GC


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7107/head:pull/7107` \
`$ git checkout pull/7107`

Update a local copy of the PR: \
`$ git checkout pull/7107` \
`$ git pull https://git.openjdk.java.net/jdk pull/7107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7107`

View PR using the GUI difftool: \
`$ git pr show -t 7107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7107.diff">https://git.openjdk.java.net/jdk/pull/7107.diff</a>

</details>
