### PR TITLE
8280030: [REDO] Parallel: More precise boundary in ObjectStartArray::object_starts_in_range

### DIFF
--- a/src/hotspot/share/gc/parallel/objectStartArray.cpp
+++ b/src/hotspot/share/gc/parallel/objectStartArray.cpp
@@ -132,8 +132,13 @@ bool ObjectStartArray::object_starts_in_range(HeapWord* start_addr,
          "Range is wrong. start_addr (" PTR_FORMAT ") is after end_addr (" PTR_FORMAT ")",
          p2i(start_addr), p2i(end_addr));
 
+  if (start_addr == end_addr) {
+    // empty
+    return false;
+  }
+
   jbyte* start_block = block_for_addr(start_addr);
-  jbyte* end_block = block_for_addr(end_addr);
+  jbyte* end_block = block_for_addr(end_addr - 1);
 
   for (jbyte* block = start_block; block <= end_block; block++) {
     if (*block != clean_block) {

--- a/src/hotspot/share/gc/parallel/objectStartArray.hpp
+++ b/src/hotspot/share/gc/parallel/objectStartArray.hpp
@@ -165,9 +165,11 @@ class ObjectStartArray : public CHeapObj<mtGC> {
     return *block != clean_block;
   }
 
-  // Return true if an object starts in the range of heap addresses.
-  // If an object starts at an address corresponding to
-  // "start", the method will return true.
+  // Return true iff an object starts in
+  //   [start_addr_aligned_down, end_addr_aligned_up)
+  // where
+  //   start_addr_aligned_down = align_down(start_addr, _card_size)
+  //   end_addr_aligned_up = align_up(end_addr, _card_size)
   bool object_starts_in_range(HeapWord* start_addr, HeapWord* end_addr) const;
 };
 


### PR DESCRIPTION
Second try in refining the range calculation in `ObjectStartArray::object_starts_in_range`.

Test: tier1-6