### PR TITLE
8280079: Serial: Remove empty Generation::prepare_for_verify

### DIFF
--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -212,9 +212,6 @@ void TenuredGeneration::assert_correct_size_change_locking() {
   assert_locked_or_safepoint(ExpandHeap_lock);
 }
 
-// Currently nothing to do.
-void TenuredGeneration::prepare_for_verify() {}
-
 void TenuredGeneration::object_iterate(ObjectClosure* blk) {
   _the_space->object_iterate(blk);
 }

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -97,8 +97,6 @@ class TenuredGeneration: public CardGeneration {
 
   HeapWord* expand_and_allocate(size_t size, bool is_tlab);
 
-  virtual void prepare_for_verify();
-
   virtual void gc_prologue(bool full);
   virtual void gc_epilogue(bool full);
 

--- a/src/hotspot/share/gc/shared/cardGeneration.cpp
+++ b/src/hotspot/share/gc/shared/cardGeneration.cpp
@@ -301,9 +301,6 @@ void CardGeneration::compute_new_size() {
   }
 }
 
-// Currently nothing to do.
-void CardGeneration::prepare_for_verify() {}
-
 void CardGeneration::space_iterate(SpaceClosure* blk,
                                                  bool usedOnly) {
   blk->do_space(space());

--- a/src/hotspot/share/gc/shared/cardGeneration.hpp
+++ b/src/hotspot/share/gc/shared/cardGeneration.hpp
@@ -73,8 +73,6 @@ class CardGeneration: public Generation {
 
   virtual void invalidate_remembered_set();
 
-  virtual void prepare_for_verify();
-
   // Grow generation with specified size (returns false if unable to grow)
   bool grow_by(size_t bytes);
   // Grow generation to reserved size.

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -1045,16 +1045,8 @@ void GenCollectedHeap::release_scratch() {
   _old_gen->reset_scratch();
 }
 
-class GenPrepareForVerifyClosure: public GenCollectedHeap::GenClosure {
-  void do_generation(Generation* gen) {
-    gen->prepare_for_verify();
-  }
-};
-
 void GenCollectedHeap::prepare_for_verify() {
   ensure_parsability(false);        // no need to retire TLABs
-  GenPrepareForVerifyClosure blk;
-  generation_iterate(&blk, false);
 }
 
 void GenCollectedHeap::generation_iterate(GenClosure* cl,

--- a/src/hotspot/share/gc/shared/generation.hpp
+++ b/src/hotspot/share/gc/shared/generation.hpp
@@ -364,10 +364,6 @@ class Generation: public CHeapObj<mtGC> {
   virtual void post_compact() { ShouldNotReachHere(); }
 #endif
 
-  // Some generations may require some cleanup actions before allowing
-  // a verification.
-  virtual void prepare_for_verify() {}
-
   // Accessing "marks".
 
   // This function gives a generation a chance to note a point between


### PR DESCRIPTION
Simple change of removing some empty methods.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280079](https://bugs.openjdk.java.net/browse/JDK-8280079): Serial: Remove empty Generation::prepare_for_verify


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7112/head:pull/7112` \
`$ git checkout pull/7112`

Update a local copy of the PR: \
`$ git checkout pull/7112` \
`$ git pull https://git.openjdk.java.net/jdk pull/7112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7112`

View PR using the GUI difftool: \
`$ git pr show -t 7112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7112.diff">https://git.openjdk.java.net/jdk/pull/7112.diff</a>

</details>
