### PR TITLE
8273139: C2: assert(f <= 1 && f >= 0) failed: Incorrect frequency

### DIFF
--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -1029,7 +1029,7 @@ private:
     // We do not perform an exact (f <= 1) check
     // this would be error prone with rounding of floats.
     // Performing a check like (f <= 1+eps) would be of benefit,
-    // however, it is not evident how to chose such an eps,
+    // however, it is not evident how to determine such an eps,
     // given that an arbitrary number of add/mul operations
     // are performed on these frequencies.
     return (f > 1) ? 1 : f;

--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -1024,13 +1024,15 @@ private:
   GrowableArray<float> _freqs; // cache frequencies
   PhaseIdealLoop* _phase;
 
-  void set_rounding(int mode) {
-    // fesetround is broken on windows
-    NOT_WINDOWS(fesetround(mode);)
-  }
-
-  void check_frequency(float f) {
-    NOT_WINDOWS(assert(f <= 1 && f >= 0, "Incorrect frequency");)
+  float check_and_truncate_frequency(float f) {
+    assert(f >= 0, "Incorrect frequency");
+    // We do not perform an exact (f <= 1) check
+    // this would be error prone with rounding of floats.
+    // Performing a check like (f <= 1+eps) would be of benefit,
+    // however, it is not evident how to chose such an eps,
+    // given that an arbitrary number of add/mul operations
+    // are performed on these frequencies.
+    return (f > 1) ? 1 : f;
   }
 
 public:
@@ -1040,7 +1042,6 @@ public:
 
   float to(Node* n) {
     // post order walk on the CFG graph from n to _dom
-    set_rounding(FE_TOWARDZERO); // make sure rounding doesn't push frequency above 1
     IdealLoopTree* loop = _phase->get_loop(_dom);
     Node* c = n;
     for (;;) {
@@ -1067,14 +1068,12 @@ public:
                 inner_head = inner_loop->_head->as_Loop();
                 inner_head->verify_strip_mined(1);
               }
-              set_rounding(FE_UPWARD);  // make sure rounding doesn't push frequency above 1
               float loop_exit_cnt = 0.0f;
               for (uint i = 0; i < inner_loop->_body.size(); i++) {
                 Node *n = inner_loop->_body[i];
                 float c = inner_loop->compute_profile_trip_cnt_helper(n);
                 loop_exit_cnt += c;
               }
-              set_rounding(FE_TOWARDZERO);
               float cnt = -1;
               if (n->in(0)->is_If()) {
                 IfNode* iff = n->in(0)->as_If();
@@ -1094,9 +1093,9 @@ public:
                 cnt = p * jmp->_fcnt;
               }
               float this_exit_f = cnt > 0 ? cnt / loop_exit_cnt : 0;
-              check_frequency(this_exit_f);
+              this_exit_f = check_and_truncate_frequency(this_exit_f);
               f = f * this_exit_f;
-              check_frequency(f);
+              f = check_and_truncate_frequency(f);
             } else {
               float p = -1;
               if (n->in(0)->is_If()) {
@@ -1109,7 +1108,7 @@ public:
                 p = n->in(0)->as_Jump()->_probs[n->as_JumpProj()->_con];
               }
               f = f * p;
-              check_frequency(f);
+              f = check_and_truncate_frequency(f);
             }
             _freqs.at_put_grow(n->_idx, (float)f, -1);
             _stack.pop();
@@ -1117,7 +1116,7 @@ public:
             float prev_f = _freqs_stack.pop();
             float new_f = f;
             f = new_f + prev_f;
-            check_frequency(f);
+            f = check_and_truncate_frequency(f);
             uint i = _stack.index();
             if (i < n->req()) {
               c = n->in(i);
@@ -1130,8 +1129,7 @@ public:
           }
         }
         if (_stack.size() == 0) {
-          set_rounding(FE_TONEAREST);
-          check_frequency(f);
+          f = check_and_truncate_frequency(f);
           return f;
         }
       } else if (c->is_Loop()) {

--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -1129,8 +1129,7 @@ public:
           }
         }
         if (_stack.size() == 0) {
-          f = check_and_truncate_frequency(f);
-          return f;
+          return check_and_truncate_frequency(f);
         }
       } else if (c->is_Loop()) {
         ShouldNotReachHere();


### PR DESCRIPTION
Relaxed assert which can be triggered falsely upon an unfortunate sequence of float additions, such that the sum of all probabilities exceeds 1 by some very small amount in the order of float precision.

Before: assert(f <= 1 && f >= 0)
Now: assert(f >= 0), truncate f to be <=1

Frequency computation is done with floats, which are calculated through counting occurrences and dividing by totals.
This is done in multiple locations in the code.

We considered three options (in conversation with @rwestrel @chhagedorn @tobiasholenstein ):
1. Consistently use `fesetround` to correctly round up/down (depends on context) if the results are ever used for frequency/probability calculations (many locations, multiple files). This option requires more code and maintainance. Implementing and testing is difficult. This is fragile if new code is added that impacts frequency computation - would have to remember to round correctly.
2. Modify assert to `f <= 1+eps && 1 >= 0`, where `eps` is related to float precision, and is as close to zero as possible. However, since there can be an arbitrary number of additions, this error could grow arbitrarily. It is thus not evident how to determine `eps`.
3. Drop the `f <= 1` condition (our choice). The exact comparison is inadequate for floats, and there is no evident replacement. This requires less code, is easier to maintain. Disadvantage: a developer may break something and not realize because the assert is no longer present. The impact would most likely be limited to performance, and not crash the VM or cause incorrect execution.

Checked that tests are not affected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273139](https://bugs.openjdk.java.net/browse/JDK-8273139): C2: assert(f <= 1 && f >= 0) failed: Incorrect frequency


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to a2a422909292683b5442173970125c8a1f33510b
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7113/head:pull/7113` \
`$ git checkout pull/7113`

Update a local copy of the PR: \
`$ git checkout pull/7113` \
`$ git pull https://git.openjdk.java.net/jdk pull/7113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7113`

View PR using the GUI difftool: \
`$ git pr show -t 7113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7113.diff">https://git.openjdk.java.net/jdk/pull/7113.diff</a>

</details>
