### PR TITLE
8280070: G1: Fix template parameters in G1SegmentedArraySegment

### DIFF
--- a/src/hotspot/share/gc/g1/g1SegmentedArray.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArray.inline.hpp
@@ -34,12 +34,12 @@ template<MEMFLAGS flag>
 G1SegmentedArraySegment<flag>::G1SegmentedArraySegment(uint slot_size, uint num_slots, G1SegmentedArraySegment* next) :
   _slot_size(slot_size), _num_slots(num_slots), _next(next), _next_allocate(0) {
 
-  _segment = NEW_C_HEAP_ARRAY(char, (size_t)_num_slots * slot_size, mtGCCardSet);
+  _segment = NEW_C_HEAP_ARRAY(char, (size_t)_num_slots * slot_size, flag);
 }
 
 template<MEMFLAGS flag>
 G1SegmentedArraySegment<flag>::~G1SegmentedArraySegment() {
-  FREE_C_HEAP_ARRAY(mtGCCardSet, _segment);
+  FREE_C_HEAP_ARRAY(flag, _segment);
 }
 
 template<MEMFLAGS flag>


### PR DESCRIPTION
This is a simple fix of template parameters in G1SegmentedArraySegment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280070](https://bugs.openjdk.java.net/browse/JDK-8280070): G1: Fix template parameters in G1SegmentedArraySegment


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7114/head:pull/7114` \
`$ git checkout pull/7114`

Update a local copy of the PR: \
`$ git checkout pull/7114` \
`$ git pull https://git.openjdk.java.net/jdk pull/7114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7114`

View PR using the GUI difftool: \
`$ git pr show -t 7114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7114.diff">https://git.openjdk.java.net/jdk/pull/7114.diff</a>

</details>
