### PR TITLE
8280089: compiler/c2/irTests/TestIRAbs.java fails on some arches

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestIRAbs.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestIRAbs.java
@@ -28,8 +28,9 @@ import compiler.lib.ir_framework.*;
 
 /*
  * @test
- * @bug 8276673
+ * @bug 8276673 8280089
  * @summary Test abs nodes optimization in C2.
+ * @requires os.arch=="amd64" | os.arch=="x86_64"
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestIRAbs
  */

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestIRAbs.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestIRAbs.java
@@ -30,7 +30,7 @@ import compiler.lib.ir_framework.*;
  * @test
  * @bug 8276673 8280089
  * @summary Test abs nodes optimization in C2.
- * @requires os.arch=="amd64" | os.arch=="x86_64"
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestIRAbs
  */


### PR DESCRIPTION
This new test is apparently fails in GHA. 

The trouble is that AbsL parts of the test are arch-specific, as only {x86_64,aarch64,ppc64,s390}.ad have the match rules for AbsL. x86_32.ad does not have it, so C2 never actually emits AbsL in x86_32 case. AbsI, AbsF, AbsD are also not supported by arm.ad.

I wonder if IR Test Framework might be able to disable subtests based on arch... It is probably all around easier to make this test x86_64 specific. It tests shared C2 code, so testing one architecture is probably enough. 

Open for other suggestions, though.

Additional testing:
 - [x] Linux x86_64 fastdebug, test still passes
 - [x] Linux x86_32 fastdebug, test used to fail, now is skipped

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280089](https://bugs.openjdk.java.net/browse/JDK-8280089): compiler/c2/irTests/TestIRAbs.java fails on some arches


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Fei Gao](https://openjdk.java.net/census#fgao) (@fg1417 - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7116/head:pull/7116` \
`$ git checkout pull/7116`

Update a local copy of the PR: \
`$ git checkout pull/7116` \
`$ git pull https://git.openjdk.java.net/jdk pull/7116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7116`

View PR using the GUI difftool: \
`$ git pr show -t 7116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7116.diff">https://git.openjdk.java.net/jdk/pull/7116.diff</a>

</details>
