### PR TITLE
8280174: Possible NPE in Thread.dispatchUncaughtException

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1976,8 +1976,8 @@ public class Thread implements Runnable {
      * @return the uncaught exception handler for this thread
      */
     public UncaughtExceptionHandler getUncaughtExceptionHandler() {
-        return uncaughtExceptionHandler != null ?
-            uncaughtExceptionHandler : group;
+        UncaughtExceptionHandler handler = this.uncaughtExceptionHandler;
+        return handler != null ? handler : group;
     }
 
     /**


### PR DESCRIPTION
Method `Thread.dispatchUncaughtException` (called by VM) uses result of of `getUncaughtExceptionHandler`. Field `uncaughtExceptionHandler` is volatile and can be changed by another Thread. Which could lead to NPE.
https://github.com/openjdk/jdk/blob/7b6738fa02023825ed9e602555bd5ed2b87a6ca6/src/java.base/share/classes/java/lang/Thread.java#L2007-L2009
Read field to local variable to avoid double volatile read.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280174](https://bugs.openjdk.java.net/browse/JDK-8280174): Possible NPE in Thread.dispatchUncaughtException


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7117/head:pull/7117` \
`$ git checkout pull/7117`

Update a local copy of the PR: \
`$ git checkout pull/7117` \
`$ git pull https://git.openjdk.java.net/jdk pull/7117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7117`

View PR using the GUI difftool: \
`$ git pr show -t 7117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7117.diff">https://git.openjdk.java.net/jdk/pull/7117.diff</a>

</details>
