### PR TITLE
8280470: Confusing instanceof check in HijrahChronology.range

### DIFF
--- a/src/java.base/share/classes/java/time/chrono/HijrahChronology.java
+++ b/src/java.base/share/classes/java/time/chrono/HijrahChronology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/time/chrono/HijrahChronology.java
+++ b/src/java.base/share/classes/java/time/chrono/HijrahChronology.java
@@ -533,18 +533,14 @@ public final class HijrahChronology extends AbstractChronology implements Serial
     @Override
     public ValueRange range(ChronoField field) {
         checkCalendarInit();
-        if (field instanceof ChronoField) {
-            ChronoField f = field;
-            return switch (f) {
-                case DAY_OF_MONTH -> ValueRange.of(1, 1, getMinimumMonthLength(), getMaximumMonthLength());
-                case DAY_OF_YEAR -> ValueRange.of(1, getMaximumDayOfYear());
-                case ALIGNED_WEEK_OF_MONTH -> ValueRange.of(1, 5);
-                case YEAR, YEAR_OF_ERA -> ValueRange.of(getMinimumYear(), getMaximumYear());
-                case ERA -> ValueRange.of(1, 1);
-                default -> field.range();
-            };
-        }
-        return field.range();
+        return switch (field) {
+            case DAY_OF_MONTH -> ValueRange.of(1, 1, getMinimumMonthLength(), getMaximumMonthLength());
+            case DAY_OF_YEAR -> ValueRange.of(1, getMaximumDayOfYear());
+            case ALIGNED_WEEK_OF_MONTH -> ValueRange.of(1, 5);
+            case YEAR, YEAR_OF_ERA -> ValueRange.of(getMinimumYear(), getMaximumYear());
+            case ERA -> ValueRange.of(1, 1);
+            default -> field.range();
+        };
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
Parameter `ChronoField field` is checked by `if (field instanceof ChronoField)`. Such check is confusing, because only one case, when this could be `false` is when `field == null`.
But if condition is not satisfied we will get immediate NullPointerException anyway in `return field.range();`.
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280470](https://bugs.openjdk.java.net/browse/JDK-8280470): Confusing instanceof check in HijrahChronology.range


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7118/head:pull/7118` \
`$ git checkout pull/7118`

Update a local copy of the PR: \
`$ git checkout pull/7118` \
`$ git pull https://git.openjdk.java.net/jdk pull/7118/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7118`

View PR using the GUI difftool: \
`$ git pr show -t 7118`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7118.diff">https://git.openjdk.java.net/jdk/pull/7118.diff</a>

</details>
