### PR TITLE
8282551: Properly initialize L32X64MixRandom state

### DIFF
--- a/src/jdk.random/share/classes/jdk/random/L32X64MixRandom.java
+++ b/src/jdk.random/share/classes/jdk/random/L32X64MixRandom.java
@@ -155,6 +155,8 @@ public final class L32X64MixRandom extends AbstractSplittableWithBrineGenerator 
         // Force a to be odd.
         this.a = a | 1;
         this.s = s;
+        this.x0 = x0;
+        this.x1 = x1;
         // If x0 and x1 are both zero, we must choose nonzero values.
         if ((x0 | x1) == 0) {
        int v = s;


### PR DESCRIPTION
Did a cursory review of the other generators, they seem to set the state correctly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282551](https://bugs.openjdk.java.net/browse/JDK-8282551): Properly initialize L32X64MixRandom state


### Reviewers
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7120/head:pull/7120` \
`$ git checkout pull/7120`

Update a local copy of the PR: \
`$ git checkout pull/7120` \
`$ git pull https://git.openjdk.java.net/jdk pull/7120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7120`

View PR using the GUI difftool: \
`$ git pr show -t 7120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7120.diff">https://git.openjdk.java.net/jdk/pull/7120.diff</a>

</details>
