### PR TITLE
8280106: G1: Make reclaiming memory functionality more general in G1SegmentedArrayFreePool and G1SegmentedArrayFreeMemoryTask

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
@@ -201,8 +201,8 @@ size_t G1CardSetMemoryManager::wasted_mem_size() const {
   return result;
 }
 
-G1SegmentedArrayMemoryStats G1CardSetMemoryManager::memory_stats() const {
-  G1SegmentedArrayMemoryStats result;
+G1CardSetMemoryStats G1CardSetMemoryManager::memory_stats() const {
+  G1CardSetMemoryStats result;
   for (uint i = 0; i < num_mem_object_types(); i++) {
     result._num_mem_sizes[i] += _allocators[i].mem_size();
     result._num_segments[i] += _allocators[i].num_segments();

--- a/src/hotspot/share/gc/g1/g1CardSetMemory.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.hpp
@@ -138,7 +138,8 @@ public:
   void print(outputStream* os);
 };
 
-typedef G1SegmentedArrayFreePool<mtGCCardSet> G1CardSetFreePool;
+typedef G1SegmentedArrayFreePool<mtGCCardSet, G1CardSetConfiguration> G1CardSetFreePool;
+typedef G1SegmentedArrayMemoryStats<G1CardSetConfiguration::num_mem_object_types()> G1CardSetMemoryStats;
 
 class G1CardSetMemoryManager : public CHeapObj<mtGCCardSet> {
   G1CardSetConfiguration* _config;
@@ -167,7 +168,7 @@ public:
   size_t mem_size() const;
   size_t wasted_mem_size() const;
 
-  G1SegmentedArrayMemoryStats memory_stats() const;
+  G1CardSetMemoryStats memory_stats() const;
 };
 
 #endif // SHARE_GC_G1_G1CARDSETMEMORY_HPP

--- a/src/hotspot/share/gc/g1/g1CardSetMemory.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.hpp
@@ -139,7 +139,7 @@ public:
 };
 
 typedef G1SegmentedArrayFreePool<mtGCCardSet, G1CardSetConfiguration> G1CardSetFreePool;
-typedef G1SegmentedArrayMemoryStats<G1CardSetConfiguration::num_mem_object_types()> G1CardSetMemoryStats;
+typedef G1CardSetFreePool::G1SegmentedArrayMemoryStats G1CardSetMemoryStats;
 
 class G1CardSetMemoryManager : public CHeapObj<mtGCCardSet> {
   G1CardSetConfiguration* _config;

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1431,7 +1431,7 @@ G1CollectedHeap::G1CollectedHeap() :
   CollectedHeap(),
   _service_thread(NULL),
   _periodic_gc_task(NULL),
-  _free_segmented_array_memory_task(NULL),
+  _card_set_free_memory_task(NULL),
   _workers(NULL),
   _card_table(NULL),
   _collection_pause_end(Ticks::now()),
@@ -1723,8 +1723,8 @@ jint G1CollectedHeap::initialize() {
   _periodic_gc_task = new G1PeriodicGCTask("Periodic GC Task");
   _service_thread->register_task(_periodic_gc_task);
 
-  _free_segmented_array_memory_task = new G1SegmentedArrayFreeMemoryTask("Card Set Free Memory Task");
-  _service_thread->register_task(_free_segmented_array_memory_task);
+  _card_set_free_memory_task = new G1SegmentedArrayFreeMemoryTask<mtGCCardSet, G1CardSetConfiguration>("Card Set Free Memory Task");
+  _service_thread->register_task(_card_set_free_memory_task);
 
   {
     G1DirtyCardQueueSet& dcqs = G1BarrierSet::dirty_card_queue_set();
@@ -2616,8 +2616,8 @@ void G1CollectedHeap::gc_epilogue(bool full) {
 
   _collection_pause_end = Ticks::now();
 
-  _free_segmented_array_memory_task->notify_new_stats(&_young_gen_card_set_stats,
-                                                      &_collection_set_candidates_card_set_stats);
+  _card_set_free_memory_task->notify_new_stats(&_young_gen_card_set_stats,
+                                               &_collection_set_candidates_card_set_stats);
 }
 
 uint G1CollectedHeap::uncommit_regions(uint region_limit) {
@@ -2941,11 +2941,11 @@ bool G1CollectedHeap::should_sample_collection_set_candidates() const {
   return candidates != NULL && candidates->num_remaining() > 0;
 }
 
-void G1CollectedHeap::set_collection_set_candidates_stats(G1SegmentedArrayMemoryStats& stats) {
+void G1CollectedHeap::set_collection_set_candidates_stats(G1CardSetMemoryStats& stats) {
   _collection_set_candidates_card_set_stats = stats;
 }
 
-void G1CollectedHeap::set_young_gen_card_set_stats(const G1SegmentedArrayMemoryStats& stats) {
+void G1CollectedHeap::set_young_gen_card_set_stats(const G1CardSetMemoryStats& stats) {
   _young_gen_card_set_stats = stats;
 }
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -143,7 +143,7 @@ class G1CollectedHeap : public CollectedHeap {
 private:
   G1ServiceThread* _service_thread;
   G1ServiceTask* _periodic_gc_task;
-  G1SegmentedArrayFreeMemoryTask* _free_segmented_array_memory_task;
+  G1SegmentedArrayFreeMemoryTask<mtGCCardSet, G1CardSetConfiguration>* _card_set_free_memory_task;
 
   WorkerThreads* _workers;
   G1CardTable* _card_table;
@@ -160,9 +160,9 @@ private:
   HeapRegionSet _humongous_set;
 
   // Young gen memory statistics before GC.
-  G1SegmentedArrayMemoryStats _young_gen_card_set_stats;
+  G1CardSetMemoryStats _young_gen_card_set_stats;
   // Collection set candidates memory statistics after GC.
-  G1SegmentedArrayMemoryStats _collection_set_candidates_card_set_stats;
+  G1CardSetMemoryStats _collection_set_candidates_card_set_stats;
 
   // The block offset table for the G1 heap.
   G1BlockOffsetTable* _bot;
@@ -259,8 +259,8 @@ public:
   void set_humongous_stats(uint num_humongous_total, uint num_humongous_candidates);
 
   bool should_sample_collection_set_candidates() const;
-  void set_collection_set_candidates_stats(G1SegmentedArrayMemoryStats& stats);
-  void set_young_gen_card_set_stats(const G1SegmentedArrayMemoryStats& stats);
+  void set_collection_set_candidates_stats(G1CardSetMemoryStats& stats);
+  void set_young_gen_card_set_stats(const G1CardSetMemoryStats& stats);
 
 private:
 

--- a/src/hotspot/share/gc/g1/g1SegmentedArrayFreeMemoryTask.cpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArrayFreeMemoryTask.cpp
@@ -55,8 +55,8 @@ template<MEMFLAGS flag, typename Configuration>
 bool G1SegmentedArrayFreeMemoryTask<flag, Configuration>::calculate_return_infos(jlong deadline) {
   // Ignore the deadline in this step as it is very short.
 
-  G1SegmentedArrayMemoryStats<NUM> used = _total_used;
-  G1SegmentedArrayMemoryStats<NUM> free = G1SegmentedArrayFreePool<flag, Configuration>::free_list_sizes();
+  G1SegmentedArrayMemoryStats used = _total_used;
+  G1SegmentedArrayMemoryStats free = G1SegmentedArrayFreePool<flag, Configuration>::free_list_sizes();
 
   _return_info = new G1ReturnMemoryProcessorSet(NUM);
   for (uint i = 0; i < NUM; i++) {
@@ -204,8 +204,8 @@ void G1SegmentedArrayFreeMemoryTask<flag, Configuration>::execute() {
 }
 
 template<MEMFLAGS flag, typename Configuration>
-void G1SegmentedArrayFreeMemoryTask<flag, Configuration>::notify_new_stats(G1SegmentedArrayMemoryStats<NUM>* young_gen_stats,
-                                                                           G1SegmentedArrayMemoryStats<NUM>* collection_set_candidate_stats) {
+void G1SegmentedArrayFreeMemoryTask<flag, Configuration>::notify_new_stats(G1SegmentedArrayMemoryStats* young_gen_stats,
+                                                                           G1SegmentedArrayMemoryStats* collection_set_candidate_stats) {
   assert_at_safepoint_on_vm_thread();
 
   _total_used = *young_gen_stats;

--- a/src/hotspot/share/gc/g1/g1SegmentedArrayFreeMemoryTask.hpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArrayFreeMemoryTask.hpp
@@ -33,6 +33,7 @@
 #include "utilities/ticks.hpp"
 
 // Task handling deallocation of free segmented array memory.
+template<MEMFLAGS flag, typename Configuration>
 class G1SegmentedArrayFreeMemoryTask : public G1ServiceTask {
 
   enum class State : uint {
@@ -49,15 +50,17 @@ class G1SegmentedArrayFreeMemoryTask : public G1ServiceTask {
                                                   "ReturnToOS",
                                                   "Cleanup" };
 
+  static constexpr uint NUM = Configuration::num_mem_object_types();
+
   const char* get_state_name(State value) const;
 
   State _state;
 
   // Current total segmented array memory usage.
-  G1SegmentedArrayMemoryStats _total_used;
+  G1SegmentedArrayMemoryStats<Configuration::num_mem_object_types()> _total_used;
 
-  typedef G1SegmentedArrayFreePool<mtGCCardSet>::G1ReturnMemoryProcessor G1ReturnMemoryProcessor;
-  typedef G1SegmentedArrayFreePool<mtGCCardSet>::G1ReturnMemoryProcessorSet G1ReturnMemoryProcessorSet;
+  typedef typename G1SegmentedArrayFreePool<flag, Configuration>::G1ReturnMemoryProcessor G1ReturnMemoryProcessor;
+  typedef typename G1SegmentedArrayFreePool<flag, Configuration>::G1ReturnMemoryProcessorSet G1ReturnMemoryProcessorSet;
 
   G1ReturnMemoryProcessorSet* _return_info;
 
@@ -89,8 +92,8 @@ public:
 
   // Notify the task of new used remembered set memory statistics for the young
   // generation and the collection set candidate sets.
-  void notify_new_stats(G1SegmentedArrayMemoryStats* young_gen_stats,
-                        G1SegmentedArrayMemoryStats* collection_set_candidate_stats);
+  void notify_new_stats(G1SegmentedArrayMemoryStats<NUM>* young_gen_stats,
+                        G1SegmentedArrayMemoryStats<NUM>* collection_set_candidate_stats);
 };
 
 #endif // SHARE_GC_G1_G1SEGMENTEDARRAYFREEMEMORYTASK_HPP

--- a/src/hotspot/share/gc/g1/g1SegmentedArrayFreeMemoryTask.hpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArrayFreeMemoryTask.hpp
@@ -56,8 +56,9 @@ class G1SegmentedArrayFreeMemoryTask : public G1ServiceTask {
 
   State _state;
 
+  typedef typename G1SegmentedArrayFreePool<flag, Configuration>::G1SegmentedArrayMemoryStats G1SegmentedArrayMemoryStats;
   // Current total segmented array memory usage.
-  G1SegmentedArrayMemoryStats<Configuration::num_mem_object_types()> _total_used;
+  G1SegmentedArrayMemoryStats _total_used;
 
   typedef typename G1SegmentedArrayFreePool<flag, Configuration>::G1ReturnMemoryProcessor G1ReturnMemoryProcessor;
   typedef typename G1SegmentedArrayFreePool<flag, Configuration>::G1ReturnMemoryProcessorSet G1ReturnMemoryProcessorSet;
@@ -92,8 +93,8 @@ public:
 
   // Notify the task of new used remembered set memory statistics for the young
   // generation and the collection set candidate sets.
-  void notify_new_stats(G1SegmentedArrayMemoryStats<NUM>* young_gen_stats,
-                        G1SegmentedArrayMemoryStats<NUM>* collection_set_candidate_stats);
+  void notify_new_stats(G1SegmentedArrayMemoryStats* young_gen_stats,
+                        G1SegmentedArrayMemoryStats* collection_set_candidate_stats);
 };
 
 #endif // SHARE_GC_G1_G1SEGMENTEDARRAYFREEMEMORYTASK_HPP

--- a/src/hotspot/share/gc/g1/g1SegmentedArrayFreePool.cpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArrayFreePool.cpp
@@ -32,14 +32,14 @@
 #include "utilities/formatBuffer.hpp"
 #include "utilities/ostream.hpp"
 
-template<uint num>
-G1SegmentedArrayMemoryStats<num>::G1SegmentedArrayMemoryStats() {
+template<MEMFLAGS flag, typename Configuration>
+G1SegmentedArrayFreePool<flag, Configuration>::G1SegmentedArrayMemoryStats::G1SegmentedArrayMemoryStats() {
   clear();
 }
 
-template<uint num>
-void G1SegmentedArrayMemoryStats<num>::clear() {
-  for (uint i = 0; i < num; i++) {
+template<MEMFLAGS flag, typename Configuration>
+void G1SegmentedArrayFreePool<flag, Configuration>::G1SegmentedArrayMemoryStats::clear() {
+  for (uint i = 0; i < NUM; i++) {
     _num_mem_sizes[i] = 0;
     _num_segments[i] = 0;
   }
@@ -172,8 +172,9 @@ G1SegmentedArrayFreePool<flag, Configuration>::~G1SegmentedArrayFreePool() {
 }
 
 template<MEMFLAGS flag, typename Configuration>
-G1SegmentedArrayMemoryStats<Configuration::num_mem_object_types()> G1SegmentedArrayFreePool<flag, Configuration>::memory_sizes() const {
-  G1SegmentedArrayMemoryStats<NUM> free_list_stats;
+typename G1SegmentedArrayFreePool<flag, Configuration>::G1SegmentedArrayMemoryStats
+G1SegmentedArrayFreePool<flag, Configuration>::memory_sizes() const {
+  G1SegmentedArrayMemoryStats free_list_stats;
   for (uint i = 0; i < NUM; i++) {
     free_list_stats._num_mem_sizes[i] = _free_lists[i].mem_size();
     free_list_stats._num_segments[i] = _free_lists[i].num_segments();

--- a/src/hotspot/share/gc/g1/g1SegmentedArrayFreePool.hpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArrayFreePool.hpp
@@ -39,11 +39,7 @@ class G1SegmentedArrayFreePool {
 
   G1SegmentedArrayFreeList<flag>* _free_lists;
 
-  G1SegmentedArrayFreePool();
-  ~G1SegmentedArrayFreePool();
-
 public:
-
   class G1ReturnMemoryProcessor;
   typedef GrowableArrayCHeap<G1ReturnMemoryProcessor*, mtGC> G1ReturnMemoryProcessorSet;
   class G1SegmentedArrayMemoryStats;
@@ -52,6 +48,9 @@ public:
   static G1SegmentedArrayMemoryStats free_list_sizes() { return _freelist_pool.memory_sizes(); }
 
   static void update_unlink_processors(G1ReturnMemoryProcessorSet* unlink_processors);
+
+  G1SegmentedArrayFreePool();
+  ~G1SegmentedArrayFreePool();
 
   G1SegmentedArrayFreeList<flag>* free_list(uint i) {
     assert(i < NUM, "must be");
@@ -72,7 +71,6 @@ class G1SegmentedArrayFreePool<flag, Configuration>::G1SegmentedArrayMemoryStats
   static constexpr uint NUM = Configuration::num_mem_object_types();
 
 public:
-
   size_t _num_mem_sizes[NUM];
   size_t _num_segments[NUM];
 

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -330,7 +330,7 @@ class G1PrepareEvacuationTask : public WorkerTask {
     uint _worker_humongous_total;
     uint _worker_humongous_candidates;
 
-    G1SegmentedArrayMemoryStats _card_set_stats;
+    G1CardSetMemoryStats _card_set_stats;
 
     void sample_card_set_size(HeapRegion* hr) {
       // Sample card set sizes for young gen and humongous before GC: this makes
@@ -446,7 +446,7 @@ class G1PrepareEvacuationTask : public WorkerTask {
       return false;
     }
 
-    G1SegmentedArrayMemoryStats card_set_stats() const {
+    G1CardSetMemoryStats card_set_stats() const {
       return _card_set_stats;
     }
   };
@@ -456,7 +456,7 @@ class G1PrepareEvacuationTask : public WorkerTask {
   volatile uint _humongous_total;
   volatile uint _humongous_candidates;
 
-  G1SegmentedArrayMemoryStats _all_card_set_stats;
+  G1CardSetMemoryStats _all_card_set_stats;
 
 public:
   G1PrepareEvacuationTask(G1CollectedHeap* g1h) :
@@ -490,7 +490,7 @@ public:
     return _humongous_total;
   }
 
-  const G1SegmentedArrayMemoryStats all_card_set_stats() const {
+  const G1CardSetMemoryStats all_card_set_stats() const {
     return _all_card_set_stats;
   }
 };

--- a/src/hotspot/share/gc/g1/g1YoungCollector.hpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.hpp
@@ -48,7 +48,6 @@ class G1ParScanThreadStateSet;
 class G1Policy;
 class G1RedirtyCardsQueueSet;
 class G1RemSet;
-class G1SegmentedArrayMemoryStats;
 class G1SurvivorRegions;
 class G1YoungGCEvacFailureInjector;
 class STWGCTimer;

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -82,7 +82,7 @@ public:
 
     class G1SampleCollectionSetCandidatesClosure : public HeapRegionClosure {
     public:
-      G1SegmentedArrayMemoryStats _total;
+      G1CardSetMemoryStats _total;
 
       bool do_heap_region(HeapRegion* r) override {
         _total.add(r->rem_set()->card_set_memory_stats());

--- a/src/hotspot/share/gc/g1/heapRegionRemSet.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.cpp
@@ -81,7 +81,7 @@ HeapRegionRemSet::HeapRegionRemSet(HeapRegion* hr,
                                    G1CardSetConfiguration* config) :
   _m(Mutex::service - 1, FormatBuffer<128>("HeapRegionRemSet#%u_lock", hr->hrm_index())),
   _code_roots(),
-  _card_set_mm(config, G1SegmentedArrayFreePool<mtGCCardSet>::free_list_pool()),
+  _card_set_mm(config, G1CardSetFreePool::free_list_pool()),
   _card_set(config, &_card_set_mm),
   _hr(hr),
   _state(Untracked) { }
@@ -105,7 +105,7 @@ void HeapRegionRemSet::clear_locked(bool only_cardset) {
   assert(occupied() == 0, "Should be clear.");
 }
 
-G1SegmentedArrayMemoryStats HeapRegionRemSet::card_set_memory_stats() const {
+G1CardSetMemoryStats HeapRegionRemSet::card_set_memory_stats() const {
   return _card_set_mm.memory_stats();
 }
 

--- a/src/hotspot/share/gc/g1/heapRegionRemSet.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.hpp
@@ -126,7 +126,7 @@ public:
   void clear(bool only_cardset = false);
   void clear_locked(bool only_cardset = false);
 
-  G1SegmentedArrayMemoryStats card_set_memory_stats() const;
+  G1CardSetMemoryStats card_set_memory_stats() const;
 
   // The actual # of bytes this hr_remset takes up. Also includes the strong code
   // root set.

--- a/test/hotspot/gtest/gc/g1/test_g1CardSet.cpp
+++ b/test/hotspot/gtest/gc/g1/test_g1CardSet.cpp
@@ -214,7 +214,7 @@ void G1CardSetTest::cardset_basic_test() {
                                 FullCardSetThreshold,
                                 CardsPerRegion,
                                 0);
-  G1CardSetFreePool free_pool(config.num_mem_object_types());
+  G1CardSetFreePool free_pool;
   G1CardSetMemoryManager mm(&config, &free_pool);
 
   {
@@ -433,7 +433,7 @@ void G1CardSetTest::cardset_mt_test() {
                                 FullCardSetThreshold,
                                 CardsPerRegion,
                                 0);
-  G1CardSetFreePool free_pool(config.num_mem_object_types());
+  G1CardSetFreePool free_pool;
   G1CardSetMemoryManager mm(&config, &free_pool);
 
   G1CardSet card_set(&config, &mm);


### PR DESCRIPTION
We have planned to make memory reclaimation more general, and reuse it in evacuation failure processing after JDK-8254739.
Some of the work has already been done in JDK-8276670 and JDK-8277542.
But after JDK-8278917, there is no need to return the memory used by G1SegmentedArray in evacuation failure processing, as it uses another way to do it.
Currently, G1SegmentedArrayFreePool and G1SegmentedArrayFreeMemoryTask is half-bound to card set, and half-general, it should be made more general for the readability of the code and future possible reuse of this functionality returning memory (used by G1SegmentedArray) to OS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8280106](https://bugs.openjdk.java.net/browse/JDK-8280106): G1: Make reclaiming memory functionality more general in G1SegmentedArrayFreePool and G1SegmentedArrayFreeMemoryTask


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7121/head:pull/7121` \
`$ git checkout pull/7121`

Update a local copy of the PR: \
`$ git checkout pull/7121` \
`$ git pull https://git.openjdk.java.net/jdk pull/7121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7121`

View PR using the GUI difftool: \
`$ git pr show -t 7121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7121.diff">https://git.openjdk.java.net/jdk/pull/7121.diff</a>

</details>
