### PR TITLE
8280122: SupportedGroupsExtension should output "named groups" rather than "versions"

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SupportedGroupsExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/SupportedGroupsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,7 +112,7 @@ final class SupportedGroupsExtension {
         @Override
         public String toString() {
             MessageFormat messageFormat = new MessageFormat(
-                "\"versions\": '['{0}']'", Locale.ENGLISH);
+                "\"named groups\": '['{0}']'", Locale.ENGLISH);
 
             if (namedGroupsIds == null || namedGroupsIds.length == 0) {
                 Object[] messageFields = {


### PR DESCRIPTION
```
MessageFormat messageFormat = new MessageFormat(
    "\"versions\": '['{0}']'", Locale.ENGLISH);
```
In class SupportedGroupsExtension, the above "versions" should be "named groups".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280122](https://bugs.openjdk.java.net/browse/JDK-8280122): SupportedGroupsExtension should output "named groups" rather than "versions"


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7123/head:pull/7123` \
`$ git checkout pull/7123`

Update a local copy of the PR: \
`$ git checkout pull/7123` \
`$ git pull https://git.openjdk.java.net/jdk pull/7123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7123`

View PR using the GUI difftool: \
`$ git pr show -t 7123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7123.diff">https://git.openjdk.java.net/jdk/pull/7123.diff</a>

</details>
