### PR TITLE
8280136: Serial: Remove unnecessary use of ExpandHeap_lock

### DIFF
--- a/src/hotspot/share/gc/parallel/mutableSpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.cpp
@@ -215,6 +215,15 @@ bool MutableSpace::cas_deallocate(HeapWord *obj, size_t size) {
   return Atomic::cmpxchg(top_addr(), expected_top, obj) == expected_top;
 }
 
+// Only used by oldgen allocation.
+bool MutableSpace::needs_expand(size_t word_size) const {
+  assert_lock_strong(ParallelExpandHeap_lock);
+  // Holding the lock means end is stable.  So while top may be advancing
+  // via concurrent allocations, there is no need to order the reads of top
+  // and end here, unlike in cas_allocate.
+  return pointer_delta(end(), top()) < word_size;
+}
+
 void MutableSpace::oop_iterate(OopIterateClosure* cl) {
   HeapWord* obj_addr = bottom();
   HeapWord* t = top();

--- a/src/hotspot/share/gc/parallel/mutableSpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.cpp
@@ -215,15 +215,6 @@ bool MutableSpace::cas_deallocate(HeapWord *obj, size_t size) {
   return Atomic::cmpxchg(top_addr(), expected_top, obj) == expected_top;
 }
 
-// Only used by oldgen allocation.
-bool MutableSpace::needs_expand(size_t word_size) const {
-  assert_lock_strong(ParallelExpandHeap_lock);
-  // Holding the lock means end is stable.  So while top may be advancing
-  // via concurrent allocations, there is no need to order the reads of top
-  // and end here, unlike in cas_allocate.
-  return pointer_delta(end(), top()) < word_size;
-}
-
 void MutableSpace::oop_iterate(OopIterateClosure* cl) {
   HeapWord* obj_addr = bottom();
   HeapWord* t = top();

--- a/src/hotspot/share/gc/parallel/mutableSpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.cpp
@@ -217,7 +217,7 @@ bool MutableSpace::cas_deallocate(HeapWord *obj, size_t size) {
 
 // Only used by oldgen allocation.
 bool MutableSpace::needs_expand(size_t word_size) const {
-  assert_lock_strong(ParallelExpandHeap_lock);
+  assert_lock_strong(PSOldGenExpand_lock);
   // Holding the lock means end is stable.  So while top may be advancing
   // via concurrent allocations, there is no need to order the reads of top
   // and end here, unlike in cas_allocate.

--- a/src/hotspot/share/gc/parallel/mutableSpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.cpp
@@ -217,7 +217,7 @@ bool MutableSpace::cas_deallocate(HeapWord *obj, size_t size) {
 
 // Only used by oldgen allocation.
 bool MutableSpace::needs_expand(size_t word_size) const {
-  assert_lock_strong(ExpandHeap_lock);
+  assert_lock_strong(ParallelExpandHeap_lock);
   // Holding the lock means end is stable.  So while top may be advancing
   // via concurrent allocations, there is no need to order the reads of top
   // and end here, unlike in cas_allocate.

--- a/src/hotspot/share/gc/parallel/mutableSpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.hpp
@@ -142,11 +142,6 @@ class MutableSpace: public CHeapObj<mtGC> {
   virtual HeapWord* cas_allocate(size_t word_size);
   // Optional deallocation. Used in NUMA-allocator.
   bool cas_deallocate(HeapWord *obj, size_t size);
-  // Return true if this space needs to be expanded in order to satisfy an
-  // allocation request of the indicated size.  Concurrent allocations and
-  // resizes may change the result of a later call.  Used by oldgen allocator.
-  // precondition: holding ParallelExpandHeap_lock
-  bool needs_expand(size_t word_size) const;
 
   // Iteration.
   void oop_iterate(OopIterateClosure* cl);

--- a/src/hotspot/share/gc/parallel/mutableSpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.hpp
@@ -145,7 +145,7 @@ class MutableSpace: public CHeapObj<mtGC> {
   // Return true if this space needs to be expanded in order to satisfy an
   // allocation request of the indicated size.  Concurrent allocations and
   // resizes may change the result of a later call.  Used by oldgen allocator.
-  // precondition: holding ParallelExpandHeap_lock
+  // precondition: holding PSOldGenExpand_lock
   bool needs_expand(size_t word_size) const;
 
   // Iteration.

--- a/src/hotspot/share/gc/parallel/mutableSpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.hpp
@@ -142,6 +142,11 @@ class MutableSpace: public CHeapObj<mtGC> {
   virtual HeapWord* cas_allocate(size_t word_size);
   // Optional deallocation. Used in NUMA-allocator.
   bool cas_deallocate(HeapWord *obj, size_t size);
+  // Return true if this space needs to be expanded in order to satisfy an
+  // allocation request of the indicated size.  Concurrent allocations and
+  // resizes may change the result of a later call.  Used by oldgen allocator.
+  // precondition: holding ParallelExpandHeap_lock
+  bool needs_expand(size_t word_size) const;
 
   // Iteration.
   void oop_iterate(OopIterateClosure* cl);

--- a/src/hotspot/share/gc/parallel/mutableSpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.hpp
@@ -145,7 +145,7 @@ class MutableSpace: public CHeapObj<mtGC> {
   // Return true if this space needs to be expanded in order to satisfy an
   // allocation request of the indicated size.  Concurrent allocations and
   // resizes may change the result of a later call.  Used by oldgen allocator.
-  // precondition: holding ExpandHeap_lock
+  // precondition: holding ParallelExpandHeap_lock
   bool needs_expand(size_t word_size) const;
 
   // Iteration.

--- a/src/hotspot/share/gc/parallel/psOldGen.cpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.cpp
@@ -163,7 +163,7 @@ bool PSOldGen::expand_for_allocate(size_t word_size) {
   assert(word_size > 0, "allocating zero words?");
   bool result = true;
   {
-    MutexLocker x(ExpandHeap_lock);
+    MutexLocker x(ParallelExpandHeap_lock);
     // Avoid "expand storms" by rechecking available space after obtaining
     // the lock, because another thread may have already made sufficient
     // space available.  If insufficient space available, that will remain
@@ -181,7 +181,7 @@ bool PSOldGen::expand_for_allocate(size_t word_size) {
 }
 
 bool PSOldGen::expand(size_t bytes) {
-  assert_lock_strong(ExpandHeap_lock);
+  assert_lock_strong(ParallelExpandHeap_lock);
   assert_locked_or_safepoint(Heap_lock);
   assert(bytes > 0, "precondition");
   const size_t alignment = virtual_space()->alignment();
@@ -219,7 +219,7 @@ bool PSOldGen::expand(size_t bytes) {
 }
 
 bool PSOldGen::expand_by(size_t bytes) {
-  assert_lock_strong(ExpandHeap_lock);
+  assert_lock_strong(ParallelExpandHeap_lock);
   assert_locked_or_safepoint(Heap_lock);
   assert(bytes > 0, "precondition");
   bool result = virtual_space()->expand_by(bytes);
@@ -255,7 +255,7 @@ bool PSOldGen::expand_by(size_t bytes) {
 }
 
 bool PSOldGen::expand_to_reserved() {
-  assert_lock_strong(ExpandHeap_lock);
+  assert_lock_strong(ParallelExpandHeap_lock);
   assert_locked_or_safepoint(Heap_lock);
 
   bool result = false;
@@ -268,12 +268,12 @@ bool PSOldGen::expand_to_reserved() {
 }
 
 void PSOldGen::shrink(size_t bytes) {
-  assert_lock_strong(ExpandHeap_lock);
+  assert_lock_strong(ParallelExpandHeap_lock);
   assert_locked_or_safepoint(Heap_lock);
 
   size_t size = align_down(bytes, virtual_space()->alignment());
   if (size > 0) {
-    assert_lock_strong(ExpandHeap_lock);
+    assert_lock_strong(ParallelExpandHeap_lock);
     virtual_space()->shrink_by(bytes);
     post_resize();
 
@@ -312,11 +312,11 @@ void PSOldGen::resize(size_t desired_free_space) {
   }
   if (new_size > current_size) {
     size_t change_bytes = new_size - current_size;
-    MutexLocker x(ExpandHeap_lock);
+    MutexLocker x(ParallelExpandHeap_lock);
     expand(change_bytes);
   } else {
     size_t change_bytes = current_size - new_size;
-    MutexLocker x(ExpandHeap_lock);
+    MutexLocker x(ParallelExpandHeap_lock);
     shrink(change_bytes);
   }
 

--- a/src/hotspot/share/gc/parallel/psOldGen.cpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.cpp
@@ -163,7 +163,7 @@ bool PSOldGen::expand_for_allocate(size_t word_size) {
   assert(word_size > 0, "allocating zero words?");
   bool result = true;
   {
-    MutexLocker x(ParallelExpandHeap_lock);
+    MutexLocker x(PSOldGenExpand_lock);
     // Avoid "expand storms" by rechecking available space after obtaining
     // the lock, because another thread may have already made sufficient
     // space available.  If insufficient space available, that will remain
@@ -181,7 +181,7 @@ bool PSOldGen::expand_for_allocate(size_t word_size) {
 }
 
 bool PSOldGen::expand(size_t bytes) {
-  assert_lock_strong(ParallelExpandHeap_lock);
+  assert_lock_strong(PSOldGenExpand_lock);
   assert_locked_or_safepoint(Heap_lock);
   assert(bytes > 0, "precondition");
   const size_t alignment = virtual_space()->alignment();
@@ -219,7 +219,7 @@ bool PSOldGen::expand(size_t bytes) {
 }
 
 bool PSOldGen::expand_by(size_t bytes) {
-  assert_lock_strong(ParallelExpandHeap_lock);
+  assert_lock_strong(PSOldGenExpand_lock);
   assert_locked_or_safepoint(Heap_lock);
   assert(bytes > 0, "precondition");
   bool result = virtual_space()->expand_by(bytes);
@@ -255,7 +255,7 @@ bool PSOldGen::expand_by(size_t bytes) {
 }
 
 bool PSOldGen::expand_to_reserved() {
-  assert_lock_strong(ParallelExpandHeap_lock);
+  assert_lock_strong(PSOldGenExpand_lock);
   assert_locked_or_safepoint(Heap_lock);
 
   bool result = false;
@@ -268,12 +268,11 @@ bool PSOldGen::expand_to_reserved() {
 }
 
 void PSOldGen::shrink(size_t bytes) {
-  assert_lock_strong(ParallelExpandHeap_lock);
+  assert_lock_strong(PSOldGenExpand_lock);
   assert_locked_or_safepoint(Heap_lock);
 
   size_t size = align_down(bytes, virtual_space()->alignment());
   if (size > 0) {
-    assert_lock_strong(ParallelExpandHeap_lock);
     virtual_space()->shrink_by(bytes);
     post_resize();
 
@@ -312,11 +311,11 @@ void PSOldGen::resize(size_t desired_free_space) {
   }
   if (new_size > current_size) {
     size_t change_bytes = new_size - current_size;
-    MutexLocker x(ParallelExpandHeap_lock);
+    MutexLocker x(PSOldGenExpand_lock);
     expand(change_bytes);
   } else {
     size_t change_bytes = current_size - new_size;
-    MutexLocker x(ParallelExpandHeap_lock);
+    MutexLocker x(PSOldGenExpand_lock);
     shrink(change_bytes);
   }
 

--- a/src/hotspot/share/gc/parallel/psOldGen.cpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.cpp
@@ -41,7 +41,11 @@ PSOldGen::PSOldGen(ReservedSpace rs, size_t initial_size, size_t min_size,
                    size_t max_size, const char* perf_data_name, int level):
   _min_gen_size(min_size),
   _max_gen_size(max_size),
+#ifdef ASSERT
   _Expand_lock(Heap_lock->rank()-1, "PSOldGenExpand_lock", true)
+#else
+  _Expand_lock(Mutex::safepoint, "PSOldGenExpand_lock", true)
+#endif
 {
   initialize(rs, initial_size, GenAlignment, perf_data_name, level);
 }

--- a/src/hotspot/share/gc/parallel/psOldGen.hpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.hpp
@@ -47,7 +47,7 @@ class PSOldGen : public CHeapObj<mtGC> {
   const size_t _min_gen_size;
   const size_t _max_gen_size;
 
-  PaddedMutex _Expand_lock;
+  PaddedMutex _expand_lock;
 
   // Block size for parallel iteration
   static const size_t IterateBlockSize = 1024 * 1024;

--- a/src/hotspot/share/gc/parallel/psOldGen.hpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.hpp
@@ -47,8 +47,6 @@ class PSOldGen : public CHeapObj<mtGC> {
   const size_t _min_gen_size;
   const size_t _max_gen_size;
 
-  PaddedMutex _expand_lock;
-
   // Block size for parallel iteration
   static const size_t IterateBlockSize = 1024 * 1024;
 

--- a/src/hotspot/share/gc/parallel/psOldGen.hpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.hpp
@@ -47,6 +47,8 @@ class PSOldGen : public CHeapObj<mtGC> {
   const size_t _min_gen_size;
   const size_t _max_gen_size;
 
+  PaddedMutex _Expand_lock;
+
   // Block size for parallel iteration
   static const size_t IterateBlockSize = 1024 * 1024;
 

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -288,7 +288,6 @@ void DefNewGeneration::swap_spaces() {
 }
 
 bool DefNewGeneration::expand(size_t bytes) {
-  MutexLocker x(ExpandHeap_lock);
   HeapWord* prev_high = (HeapWord*) _virtual_space.high();
   bool success = _virtual_space.expand_by(bytes);
   if (success && ZapUnusedHeapArea) {

--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -196,7 +196,6 @@ TenuredGeneration::expand_and_allocate(size_t word_size, bool is_tlab) {
 }
 
 bool TenuredGeneration::expand(size_t bytes, size_t expand_bytes) {
-  GCMutexLocker x(ExpandHeap_lock);
   return CardGeneration::expand(bytes, expand_bytes);
 }
 
@@ -209,7 +208,7 @@ size_t TenuredGeneration::contiguous_available() const {
 }
 
 void TenuredGeneration::assert_correct_size_change_locking() {
-  assert_locked_or_safepoint(ExpandHeap_lock);
+  assert_locked_or_safepoint(Heap_lock);
 }
 
 // Currently nothing to do.

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -55,7 +55,7 @@ Mutex*   JvmtiThreadState_lock        = NULL;
 Monitor* EscapeBarrier_lock           = NULL;
 Monitor* Heap_lock                    = NULL;
 #ifdef INCLUDE_PARALLELGC
-Mutex*   ParallelExpandHeap_lock      = NULL;
+Mutex*   PSOldGenExpand_lock      = NULL;
 #endif
 Mutex*   AdapterHandlerLibrary_lock   = NULL;
 Mutex*   SignatureHandlerLibrary_lock = NULL;
@@ -365,7 +365,7 @@ void mutex_init() {
   defl(CompileTaskAlloc_lock       , PaddedMutex ,  MethodCompileQueue_lock);
 #ifdef INCLUDE_PARALLELGC
   if (UseParallelGC) {
-    defl(ParallelExpandHeap_lock   , PaddedMutex , Heap_lock, true);
+    defl(PSOldGenExpand_lock   , PaddedMutex , Heap_lock, true);
   }
 #endif
   defl(OopMapCacheAlloc_lock       , PaddedMutex ,  Threads_lock, true);

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -55,7 +55,7 @@ Mutex*   JvmtiThreadState_lock        = NULL;
 Monitor* EscapeBarrier_lock           = NULL;
 Monitor* Heap_lock                    = NULL;
 #ifdef INCLUDE_PARALLELGC
-Mutex*   ExpandHeap_lock              = NULL;
+Mutex*   ParallelExpandHeap_lock      = NULL;
 #endif
 Mutex*   AdapterHandlerLibrary_lock   = NULL;
 Mutex*   SignatureHandlerLibrary_lock = NULL;
@@ -365,7 +365,7 @@ void mutex_init() {
   defl(CompileTaskAlloc_lock       , PaddedMutex ,  MethodCompileQueue_lock);
 #ifdef INCLUDE_PARALLELGC
   if (UseParallelGC) {
-    defl(ExpandHeap_lock             , PaddedMutex ,  Heap_lock, true);
+    defl(ParallelExpandHeap_lock   , PaddedMutex , Heap_lock, true);
   }
 #endif
   defl(OopMapCacheAlloc_lock       , PaddedMutex ,  Threads_lock, true);

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -54,6 +54,9 @@ Monitor* JNICritical_lock             = NULL;
 Mutex*   JvmtiThreadState_lock        = NULL;
 Monitor* EscapeBarrier_lock           = NULL;
 Monitor* Heap_lock                    = NULL;
+#ifdef INCLUDE_PARALLELGC
+Mutex*   ParallelExpandHeap_lock      = NULL;
+#endif
 Mutex*   AdapterHandlerLibrary_lock   = NULL;
 Mutex*   SignatureHandlerLibrary_lock = NULL;
 Mutex*   VtableStubs_lock             = NULL;
@@ -360,6 +363,11 @@ void mutex_init() {
     defl(G1OldGCCount_lock         , PaddedMonitor, Threads_lock, true);
   }
   defl(CompileTaskAlloc_lock       , PaddedMutex ,  MethodCompileQueue_lock);
+#ifdef INCLUDE_PARALLELGC
+  if (UseParallelGC) {
+    defl(ParallelExpandHeap_lock   , PaddedMutex , Heap_lock, true);
+  }
+#endif
   defl(OopMapCacheAlloc_lock       , PaddedMutex ,  Threads_lock, true);
   defl(Module_lock                 , PaddedMutex ,  ClassLoaderDataGraph_lock);
   defl(SystemDictionary_lock       , PaddedMonitor, Module_lock);

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -54,7 +54,9 @@ Monitor* JNICritical_lock             = NULL;
 Mutex*   JvmtiThreadState_lock        = NULL;
 Monitor* EscapeBarrier_lock           = NULL;
 Monitor* Heap_lock                    = NULL;
+#ifdef INCLUDE_PARALLELGC
 Mutex*   ExpandHeap_lock              = NULL;
+#endif
 Mutex*   AdapterHandlerLibrary_lock   = NULL;
 Mutex*   SignatureHandlerLibrary_lock = NULL;
 Mutex*   VtableStubs_lock             = NULL;
@@ -361,7 +363,11 @@ void mutex_init() {
     defl(G1OldGCCount_lock         , PaddedMonitor, Threads_lock, true);
   }
   defl(CompileTaskAlloc_lock       , PaddedMutex ,  MethodCompileQueue_lock);
-  defl(ExpandHeap_lock             , PaddedMutex ,  Heap_lock, true);
+#ifdef INCLUDE_PARALLELGC
+  if (UseParallelGC) {
+    defl(ExpandHeap_lock             , PaddedMutex ,  Heap_lock, true);
+  }
+#endif
   defl(OopMapCacheAlloc_lock       , PaddedMutex ,  Threads_lock, true);
   defl(Module_lock                 , PaddedMutex ,  ClassLoaderDataGraph_lock);
   defl(SystemDictionary_lock       , PaddedMonitor, Module_lock);

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -54,9 +54,6 @@ Monitor* JNICritical_lock             = NULL;
 Mutex*   JvmtiThreadState_lock        = NULL;
 Monitor* EscapeBarrier_lock           = NULL;
 Monitor* Heap_lock                    = NULL;
-#ifdef INCLUDE_PARALLELGC
-Mutex*   ParallelExpandHeap_lock      = NULL;
-#endif
 Mutex*   AdapterHandlerLibrary_lock   = NULL;
 Mutex*   SignatureHandlerLibrary_lock = NULL;
 Mutex*   VtableStubs_lock             = NULL;
@@ -363,11 +360,6 @@ void mutex_init() {
     defl(G1OldGCCount_lock         , PaddedMonitor, Threads_lock, true);
   }
   defl(CompileTaskAlloc_lock       , PaddedMutex ,  MethodCompileQueue_lock);
-#ifdef INCLUDE_PARALLELGC
-  if (UseParallelGC) {
-    defl(ParallelExpandHeap_lock   , PaddedMutex , Heap_lock, true);
-  }
-#endif
   defl(OopMapCacheAlloc_lock       , PaddedMutex ,  Threads_lock, true);
   defl(Module_lock                 , PaddedMutex ,  ClassLoaderDataGraph_lock);
   defl(SystemDictionary_lock       , PaddedMonitor, Module_lock);

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -46,9 +46,6 @@ extern Monitor* JNICritical_lock;                // a lock used while entering a
 extern Mutex*   JvmtiThreadState_lock;           // a lock on modification of JVMTI thread data
 extern Monitor* EscapeBarrier_lock;              // a lock to sync reallocating and relocking objects because of JVMTI access
 extern Monitor* Heap_lock;                       // a lock on the heap
-#ifdef INCLUDE_PARALLELGC
-extern Mutex*   ParallelExpandHeap_lock;         // a lock on expanding the heap
-#endif
 extern Mutex*   AdapterHandlerLibrary_lock;      // a lock on the AdapterHandlerLibrary
 extern Mutex*   SignatureHandlerLibrary_lock;    // a lock on the SignatureHandlerLibrary
 extern Mutex*   VtableStubs_lock;                // a lock on the VtableStubs

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -47,7 +47,7 @@ extern Mutex*   JvmtiThreadState_lock;           // a lock on modification of JV
 extern Monitor* EscapeBarrier_lock;              // a lock to sync reallocating and relocking objects because of JVMTI access
 extern Monitor* Heap_lock;                       // a lock on the heap
 #ifdef INCLUDE_PARALLELGC
-extern Mutex*   ExpandHeap_lock;                 // a lock on expanding the heap
+extern Mutex*   ParallelExpandHeap_lock;         // a lock on expanding the heap
 #endif
 extern Mutex*   AdapterHandlerLibrary_lock;      // a lock on the AdapterHandlerLibrary
 extern Mutex*   SignatureHandlerLibrary_lock;    // a lock on the SignatureHandlerLibrary

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -46,7 +46,9 @@ extern Monitor* JNICritical_lock;                // a lock used while entering a
 extern Mutex*   JvmtiThreadState_lock;           // a lock on modification of JVMTI thread data
 extern Monitor* EscapeBarrier_lock;              // a lock to sync reallocating and relocking objects because of JVMTI access
 extern Monitor* Heap_lock;                       // a lock on the heap
+#ifdef INCLUDE_PARALLELGC
 extern Mutex*   ExpandHeap_lock;                 // a lock on expanding the heap
+#endif
 extern Mutex*   AdapterHandlerLibrary_lock;      // a lock on the AdapterHandlerLibrary
 extern Mutex*   SignatureHandlerLibrary_lock;    // a lock on the SignatureHandlerLibrary
 extern Mutex*   VtableStubs_lock;                // a lock on the VtableStubs

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -47,7 +47,7 @@ extern Mutex*   JvmtiThreadState_lock;           // a lock on modification of JV
 extern Monitor* EscapeBarrier_lock;              // a lock to sync reallocating and relocking objects because of JVMTI access
 extern Monitor* Heap_lock;                       // a lock on the heap
 #ifdef INCLUDE_PARALLELGC
-extern Mutex*   ParallelExpandHeap_lock;         // a lock on expanding the heap
+extern Mutex*   PSOldGenExpand_lock;         // a lock on expanding the heap
 #endif
 extern Mutex*   AdapterHandlerLibrary_lock;      // a lock on the AdapterHandlerLibrary
 extern Mutex*   SignatureHandlerLibrary_lock;    // a lock on the SignatureHandlerLibrary

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -46,6 +46,9 @@ extern Monitor* JNICritical_lock;                // a lock used while entering a
 extern Mutex*   JvmtiThreadState_lock;           // a lock on modification of JVMTI thread data
 extern Monitor* EscapeBarrier_lock;              // a lock to sync reallocating and relocking objects because of JVMTI access
 extern Monitor* Heap_lock;                       // a lock on the heap
+#ifdef INCLUDE_PARALLELGC
+extern Mutex*   ParallelExpandHeap_lock;         // a lock on expanding the heap
+#endif
 extern Mutex*   AdapterHandlerLibrary_lock;      // a lock on the AdapterHandlerLibrary
 extern Mutex*   SignatureHandlerLibrary_lock;    // a lock on the SignatureHandlerLibrary
 extern Mutex*   VtableStubs_lock;                // a lock on the VtableStubs


### PR DESCRIPTION
This PR consists of two commits:

1. remove `ExpandHeap_lock` in Serial GC code.
2. rename it to `ParallelExpandHeap_lock` to indicate it's Parallel-GC only.

Test: tier1-6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280136](https://bugs.openjdk.java.net/browse/JDK-8280136): Serial: Remove unnecessary use of ExpandHeap_lock


### Reviewers
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**) ⚠️ Review applies to 16874ed0256116521d9cfd26be0182b72999dcb4
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7124/head:pull/7124` \
`$ git checkout pull/7124`

Update a local copy of the PR: \
`$ git checkout pull/7124` \
`$ git pull https://git.openjdk.java.net/jdk pull/7124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7124`

View PR using the GUI difftool: \
`$ git pr show -t 7124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7124.diff">https://git.openjdk.java.net/jdk/pull/7124.diff</a>

</details>
