### PR TITLE
8274751: Drag And Drop hangs on Windows

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_DnDDS.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_DnDDS.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -267,13 +267,13 @@ void AwtDragSource::_DoDragDrop(void* param) {
     dragSource->Signal();
 
     AwtToolkit &toolkit = AwtToolkit::GetInstance();
-    toolkit.isInDoDragDropLoop = TRUE;
+    toolkit.isDnDSourceActive = TRUE;
     res = ::DoDragDrop(dragSource,
                        dragSource,
                        convertActionsToDROPEFFECT(dragSource->m_actions),
                        &effects
           );
-    toolkit.isInDoDragDropLoop = FALSE;
+    toolkit.isDnDSourceActive = FALSE;
 
     if (effects == DROPEFFECT_NONE && dragSource->m_dwPerformedDropEffect != DROPEFFECT_NONE) {
         effects = dragSource->m_dwPerformedDropEffect;

--- a/src/java.desktop/windows/native/libawt/windows/awt_DnDDT.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_DnDDT.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -141,7 +141,7 @@ static void ScaleDown(POINT &cp, HWND m_window) {
 
 HRESULT __stdcall AwtDropTarget::DragEnter(IDataObject __RPC_FAR *pDataObj, DWORD grfKeyState, POINTL pt, DWORD __RPC_FAR *pdwEffect) {
     TRY;
-    AwtToolkit::GetInstance().isInDoDragDropLoop = TRUE;
+    AwtToolkit::GetInstance().isDnDTargetActive = TRUE;
     if (NULL != m_pIDropTargetHelper) {
         m_pIDropTargetHelper->DragEnter(
             m_window,
@@ -161,7 +161,7 @@ HRESULT __stdcall AwtDropTarget::DragEnter(IDataObject __RPC_FAR *pDataObj, DWOR
         (IsLocalDnD()  && !IsLocalDataObject(pDataObj)))
     {
         *pdwEffect = retEffect;
-        AwtToolkit::GetInstance().isInDoDragDropLoop = FALSE;
+        AwtToolkit::GetInstance().isDnDTargetActive = FALSE;
         return ret;
     }
 
@@ -173,7 +173,7 @@ HRESULT __stdcall AwtDropTarget::DragEnter(IDataObject __RPC_FAR *pDataObj, DWOR
     }
 
     if (JNU_IsNull(env, m_dtcp) || !JNU_IsNull(env, safe_ExceptionOccurred(env))) {
-        AwtToolkit::GetInstance().isInDoDragDropLoop = FALSE;
+        AwtToolkit::GetInstance().isDnDTargetActive = FALSE;
         return ret;
     }
 
@@ -200,12 +200,12 @@ HRESULT __stdcall AwtDropTarget::DragEnter(IDataObject __RPC_FAR *pDataObj, DWOR
                 env->ExceptionDescribe();
                 env->ExceptionClear();
                 actions = java_awt_dnd_DnDConstants_ACTION_NONE;
-                AwtToolkit::GetInstance().isInDoDragDropLoop = FALSE;
+                AwtToolkit::GetInstance().isDnDTargetActive = FALSE;
             }
         } catch (std::bad_alloc&) {
             retEffect = ::convertActionsToDROPEFFECT(actions);
             *pdwEffect = retEffect;
-            AwtToolkit::GetInstance().isInDoDragDropLoop = FALSE;
+            AwtToolkit::GetInstance().isDnDTargetActive = FALSE;
             throw;
         }
 
@@ -421,7 +421,7 @@ void AwtDropTarget::DropDone(jboolean success, jint action) {
     m_dropSuccess = success;
     m_dropActions = action;
     AwtToolkit::GetInstance().QuitMessageLoop(AwtToolkit::EXIT_ENCLOSING_LOOP);
-    AwtToolkit::GetInstance().isInDoDragDropLoop = FALSE;
+    AwtToolkit::GetInstance().isDnDTargetActive = FALSE;
 }
 
 /**
@@ -1136,7 +1136,7 @@ void AwtDropTarget::UnloadCache() {
 
 void AwtDropTarget::DragCleanup(void) {
     UnloadCache();
-    AwtToolkit::GetInstance().isInDoDragDropLoop = FALSE;
+    AwtToolkit::GetInstance().isDnDTargetActive = FALSE;
 }
 
 BOOL AwtDropTarget::IsLocalDataObject(IDataObject __RPC_FAR *pDataObject) {

--- a/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -344,7 +344,8 @@ AwtToolkit::AwtToolkit() {
 
     m_waitEvent = ::CreateEvent(NULL, FALSE, FALSE, NULL);
     m_inputMethodWaitEvent = ::CreateEvent(NULL, FALSE, FALSE, NULL);
-    isInDoDragDropLoop = FALSE;
+    isDnDSourceActive = FALSE;
+    isDnDTargetActive = FALSE;
     eventNumber = 0;
 }
 
@@ -3012,7 +3013,7 @@ Java_sun_awt_windows_WToolkit_syncNativeQueue(JNIEnv *env, jobject self, jlong t
     tk.PostMessage(WM_SYNC_WAIT, 0, 0);
     for(long t = 2; t < timeout &&
                WAIT_TIMEOUT == ::WaitForSingleObject(tk.m_waitEvent, 2); t+=2) {
-        if (tk.isInDoDragDropLoop) {
+        if (tk.isDnDSourceActive || tk.isDnDTargetActive) {
             break;
         }
     }
@@ -3216,7 +3217,7 @@ LRESULT AwtToolkit::InvokeInputMethodFunction(UINT msg, WPARAM wParam, LPARAM lP
      * the IME completion.
      */
     CriticalSection::Lock lock(m_inputMethodLock);
-    if (isInDoDragDropLoop) {
+    if (isDnDSourceActive || isDnDTargetActive) {
         SendMessage(msg, wParam, lParam);
         ::ResetEvent(m_inputMethodWaitEvent);
         return m_inputMethodData;

--- a/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -441,7 +441,8 @@ public:
 
     HANDLE m_waitEvent;
     volatile DWORD eventNumber;
-    volatile BOOL isInDoDragDropLoop;
+    volatile BOOL isDnDSourceActive;
+    volatile BOOL isDnDTargetActive;
 private:
     HWND CreateToolkitWnd(LPCTSTR name);
 


### PR DESCRIPTION
When an object is moved from one window (DnD source) to another window (DnD target) the first window may also be considered as a DnD target and the native OS sends corresponding events to it. That event processing clears isInDoDragDropLoop flag, which is currently used to indicate DnD operation, and causes a hang.

Fix:
It is necessary to distinguish events related to the DnD source and events related to the DnD target, (i.e. use two indication flags).

Testing: mach5 green

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274751](https://bugs.openjdk.java.net/browse/JDK-8274751): Drag And Drop hangs on Windows


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7125/head:pull/7125` \
`$ git checkout pull/7125`

Update a local copy of the PR: \
`$ git checkout pull/7125` \
`$ git pull https://git.openjdk.java.net/jdk pull/7125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7125`

View PR using the GUI difftool: \
`$ git pr show -t 7125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7125.diff">https://git.openjdk.java.net/jdk/pull/7125.diff</a>

</details>
