### PR TITLE
JDK-8280193: summary javadoc for java.awt.GraphicsEnvironment#preferProportionalFonts broken

### DIFF
--- a/src/java.desktop/share/classes/java/awt/GraphicsEnvironment.java
+++ b/src/java.desktop/share/classes/java/awt/GraphicsEnvironment.java
@@ -357,9 +357,9 @@ public abstract class GraphicsEnvironment {
     }
 
     /**
-     * Indicates a preference for proportional over non-proportional (e.g.
-     * dual-spaced CJK fonts) fonts in the mapping of logical fonts to
-     * physical fonts. If the default mapping contains fonts for which
+     * Indicates a preference for proportional over non-proportional (for
+     * example dual-spaced CJK fonts) fonts in the mapping of logical fonts
+     * to physical fonts. If the default mapping contains fonts for which
      * proportional and non-proportional variants exist, then calling
      * this method indicates the mapping should use a proportional variant.
      * <p>


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8280193


Javadoc broke the first sentence at the full stop space (newline) so it rendered with `Indicates a preference for proportional over non-proportional (e.g.`

This is an incorrect sentence, and so this change fixes it by replacing the `e.g.` to `for example`

https://docs.oracle.com/en/java/javase/17/docs/api/java.desktop/java/awt/GraphicsEnvironment.html

<img width="706" alt="image" src="https://user-images.githubusercontent.com/494726/149952315-651a4231-d641-4b73-8fea-93c83e1aa257.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280193](https://bugs.openjdk.java.net/browse/JDK-8280193): summary javadoc for java.awt.GraphicsEnvironment#preferProportionalFonts broken


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7127/head:pull/7127` \
`$ git checkout pull/7127`

Update a local copy of the PR: \
`$ git checkout pull/7127` \
`$ git pull https://git.openjdk.java.net/jdk pull/7127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7127`

View PR using the GUI difftool: \
`$ git pr show -t 7127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7127.diff">https://git.openjdk.java.net/jdk/pull/7127.diff</a>

</details>
