### PR TITLE
8280146: Parallel: Remove time log tag

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1735,10 +1735,6 @@ bool PSParallelCompact::invoke_no_policy(bool maximum_heap_compaction) {
   _gc_timer.register_gc_start();
   _gc_tracer.report_gc_start(heap->gc_cause(), _gc_timer.gc_start());
 
-  TimeStamp marking_start;
-  TimeStamp compaction_start;
-  TimeStamp collection_exit;
-
   GCCause::Cause gc_cause = heap->gc_cause();
   PSYoungGen* young_gen = heap->young_gen();
   PSOldGen* old_gen = heap->old_gen();
@@ -1791,7 +1787,6 @@ bool PSParallelCompact::invoke_no_policy(bool maximum_heap_compaction) {
 
     ref_processor()->start_discovery(maximum_heap_compaction);
 
-    marking_start.update();
     marking_phase(vmthread_cm, &_gc_tracer);
 
     bool max_on_system_gc = UseMaximumCompactionOnSystemGC
@@ -1807,7 +1802,6 @@ bool PSParallelCompact::invoke_no_policy(bool maximum_heap_compaction) {
     // needed by the compaction for filling holes in the dense prefix.
     adjust_roots();
 
-    compaction_start.update();
     compact();
 
     ParCompactionManager::verify_all_region_stack_empty();
@@ -1922,14 +1916,8 @@ bool PSParallelCompact::invoke_no_policy(bool maximum_heap_compaction) {
     old_gen->object_space()->check_mangled_unused_area_complete();
   }
 
-  collection_exit.update();
-
   heap->print_heap_after_gc();
   heap->trace_heap_after_gc(&_gc_tracer);
-
-  log_debug(gc, task, time)("VM-Thread " JLONG_FORMAT " " JLONG_FORMAT " " JLONG_FORMAT,
-                         marking_start.ticks(), compaction_start.ticks(),
-                         collection_exit.ticks());
 
   AdaptiveSizePolicyOutput::print(size_policy, heap->total_collections());
 

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -358,12 +358,6 @@ bool PSScavenge::invoke_no_policy() {
 
   _gc_timer.register_gc_start();
 
-  TimeStamp scavenge_entry;
-  TimeStamp scavenge_midpoint;
-  TimeStamp scavenge_exit;
-
-  scavenge_entry.update();
-
   if (GCLocker::check_active_before_gc()) {
     return false;
   }
@@ -462,8 +456,6 @@ bool PSScavenge::invoke_no_policy() {
       ScavengeRootsTask task(old_gen, active_workers);
       ParallelScavengeHeap::heap()->workers().run_task(&task);
     }
-
-    scavenge_midpoint.update();
 
     // Process reference objects discovered during scavenge
     {
@@ -668,12 +660,6 @@ bool PSScavenge::invoke_no_policy() {
 
   heap->print_heap_after_gc();
   heap->trace_heap_after_gc(&_gc_tracer);
-
-  scavenge_exit.update();
-
-  log_debug(gc, task, time)("VM-Thread " JLONG_FORMAT " " JLONG_FORMAT " " JLONG_FORMAT,
-                            scavenge_entry.ticks(), scavenge_midpoint.ticks(),
-                            scavenge_exit.ticks());
 
   AdaptiveSizePolicyOutput::print(size_policy, heap->total_collections());
 

--- a/src/hotspot/share/logging/logPrefix.hpp
+++ b/src/hotspot/share/logging/logPrefix.hpp
@@ -90,7 +90,6 @@ DEBUG_ONLY(size_t Test_log_prefix_prefixer(char* buf, size_t len);)
   LOG_PREFIX(GCId::print_prefix, LOG_TAGS(gc, task)) \
   LOG_PREFIX(GCId::print_prefix, LOG_TAGS(gc, task, start)) \
   LOG_PREFIX(GCId::print_prefix, LOG_TAGS(gc, task, stats)) \
-  LOG_PREFIX(GCId::print_prefix, LOG_TAGS(gc, task, time)) \
   DEBUG_ONLY(LOG_PREFIX(Test_log_prefix_prefixer, LOG_TAGS(logging, test))) \
   LOG_PREFIX(GCId::print_prefix, LOG_TAGS(gc, tlab)) \
   LOG_PREFIX(GCId::print_prefix, LOG_TAGS(gc, verify)) \

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -183,7 +183,6 @@
   DEBUG_ONLY(LOG_TAG(test)) \
   LOG_TAG(thread) \
   LOG_TAG(throttle) \
-  LOG_TAG(time) \
   LOG_TAG(timer) \
   LOG_TAG(tlab) \
   LOG_TAG(tracking) \


### PR DESCRIPTION
Simple change of removing some unhelpful logs in Parallel GC. Then, `time` log tag becomes unused and is removed as well.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280146](https://bugs.openjdk.java.net/browse/JDK-8280146): Parallel: Remove time log tag


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7128/head:pull/7128` \
`$ git checkout pull/7128`

Update a local copy of the PR: \
`$ git checkout pull/7128` \
`$ git pull https://git.openjdk.java.net/jdk pull/7128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7128`

View PR using the GUI difftool: \
`$ git pr show -t 7128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7128.diff">https://git.openjdk.java.net/jdk/pull/7128.diff</a>

</details>
