### PR TITLE
8279887: 2 Null pointer dereference defect groups in os_posix.cpp

### DIFF
--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -762,6 +762,8 @@ static void post_thread_park_event(EventThreadPark* event, const oop obj, jlong 
 }
 
 UNSAFE_ENTRY(void, Unsafe_Park(JNIEnv *env, jobject unsafe, jboolean isAbsolute, jlong time)) {
+  // Only the current (non-null) thread can get parked but static analysis
+  // tools cannot determine that so check for null here.
   if (thread == NULL) return;
   HOTSPOT_THREAD_PARK_BEGIN((uintptr_t) thread->parker(), (int) isAbsolute, time);
   EventThreadPark event;

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -762,6 +762,7 @@ static void post_thread_park_event(EventThreadPark* event, const oop obj, jlong 
 }
 
 UNSAFE_ENTRY(void, Unsafe_Park(JNIEnv *env, jobject unsafe, jboolean isAbsolute, jlong time)) {
+  if (thread == NULL) return;
   HOTSPOT_THREAD_PARK_BEGIN((uintptr_t) thread->parker(), (int) isAbsolute, time);
   EventThreadPark event;
 


### PR DESCRIPTION
Please review this small fix to prevent possible Null pointer dereferences.  The fix adds a Null check to prevent trying to park a Null thread.  The Null check is needed because UNSAFE_ENTRY calls thread_from_jni_environment(), which returns NULL if the env thread is terminated. 

The fix was tested with Mach5 tiers 1-2 on Linux, Mac OS, and Windows, and Mach5 tiers 3-5 on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279887](https://bugs.openjdk.java.net/browse/JDK-8279887): 2 Null pointer dereference defect groups in os_posix.cpp


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to fcde3737703f9268f7237bdbadf2751ca053bbf3


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7129/head:pull/7129` \
`$ git checkout pull/7129`

Update a local copy of the PR: \
`$ git checkout pull/7129` \
`$ git pull https://git.openjdk.java.net/jdk pull/7129/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7129`

View PR using the GUI difftool: \
`$ git pr show -t 7129`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7129.diff">https://git.openjdk.java.net/jdk/pull/7129.diff</a>

</details>
