### PR TITLE
8279488: ProcessBuilder inherits contextClassLoader when spawning a process reaper thread

### DIFF
--- a/src/java.base/share/classes/jdk/internal/misc/InnocuousThread.java
+++ b/src/java.base/share/classes/jdk/internal/misc/InnocuousThread.java
@@ -72,13 +72,15 @@ public final class InnocuousThread extends Thread {
      */
     public static Thread newThread(String name, Runnable target, int priority) {
         if (System.getSecurityManager() == null) {
-            return createThread(name, target, 0L, ClassLoader.getSystemClassLoader(), priority);
+            return createThread(name, target, 0L,
+                    ClassLoader.getSystemClassLoader(), priority);
         }
         return AccessController.doPrivileged(
                 new PrivilegedAction<Thread>() {
                     @Override
                     public Thread run() {
-                        return createThread(name, target, 0L, ClassLoader.getSystemClassLoader(), priority);
+                        return createThread(name, target, 0L,
+                                ClassLoader.getSystemClassLoader(), priority);
                     }
                 });
     }
@@ -110,7 +112,8 @@ public final class InnocuousThread extends Thread {
                 new PrivilegedAction<Thread>() {
                     @Override
                     public Thread run() {
-                        return createThread(name, target, 0L, null, priority);
+                        return createThread(name, target, 0L,
+                                null, priority);
                     }
                 });
     }
@@ -119,7 +122,8 @@ public final class InnocuousThread extends Thread {
      * Returns a new InnocuousThread with null context class loader.
      * Thread priority is set to the given priority.
      */
-    public static Thread newSystemThread(String name, Runnable target, long stackSize, int priority) {
+    public static Thread newSystemThread(String name, Runnable target,
+                                         long stackSize, int priority) {
         if (System.getSecurityManager() == null) {
             return createThread(name, target, stackSize, null, priority);
         }
@@ -127,12 +131,14 @@ public final class InnocuousThread extends Thread {
                 new PrivilegedAction<Thread>() {
                     @Override
                     public Thread run() {
-                        return createThread(name, target, 0L, null, priority);
+                        return createThread(name, target, 0L,
+                                null, priority);
                     }
                 });
     }
 
-    private static Thread createThread(String name, Runnable target, long stackSize, ClassLoader loader, int priority) {
+    private static Thread createThread(String name, Runnable target, long stackSize,
+                                       ClassLoader loader, int priority) {
         Thread t = new InnocuousThread(INNOCUOUSTHREADGROUP,
                 target, name, stackSize, loader);
         if (priority >= 0) {

--- a/src/java.base/share/classes/jdk/internal/misc/InnocuousThread.java
+++ b/src/java.base/share/classes/jdk/internal/misc/InnocuousThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,13 +72,13 @@ public final class InnocuousThread extends Thread {
      */
     public static Thread newThread(String name, Runnable target, int priority) {
         if (System.getSecurityManager() == null) {
-            return createThread(name, target, ClassLoader.getSystemClassLoader(), priority);
+            return createThread(name, target, 0L, ClassLoader.getSystemClassLoader(), priority);
         }
         return AccessController.doPrivileged(
                 new PrivilegedAction<Thread>() {
                     @Override
                     public Thread run() {
-                        return createThread(name, target, ClassLoader.getSystemClassLoader(), priority);
+                        return createThread(name, target, 0L, ClassLoader.getSystemClassLoader(), priority);
                     }
                 });
     }
@@ -104,28 +104,46 @@ public final class InnocuousThread extends Thread {
      */
     public static Thread newSystemThread(String name, Runnable target, int priority) {
         if (System.getSecurityManager() == null) {
-            return createThread(name, target, null, priority);
+            return createThread(name, target, 0L, null, priority);
         }
         return AccessController.doPrivileged(
                 new PrivilegedAction<Thread>() {
                     @Override
                     public Thread run() {
-                        return createThread(name, target, null, priority);
+                        return createThread(name, target, 0L, null, priority);
                     }
                 });
     }
 
-    private static Thread createThread(String name, Runnable target, ClassLoader loader, int priority) {
+    /**
+     * Returns a new InnocuousThread with null context class loader.
+     * Thread priority is set to the given priority.
+     */
+    public static Thread newSystemThread(String name, Runnable target, long stackSize, int priority) {
+        if (System.getSecurityManager() == null) {
+            return createThread(name, target, stackSize, null, priority);
+        }
+        return AccessController.doPrivileged(
+                new PrivilegedAction<Thread>() {
+                    @Override
+                    public Thread run() {
+                        return createThread(name, target, 0L, null, priority);
+                    }
+                });
+    }
+
+    private static Thread createThread(String name, Runnable target, long stackSize, ClassLoader loader, int priority) {
         Thread t = new InnocuousThread(INNOCUOUSTHREADGROUP,
-                target, name, loader);
+                target, name, stackSize, loader);
         if (priority >= 0) {
             t.setPriority(priority);
         }
         return t;
     }
 
-    private InnocuousThread(ThreadGroup group, Runnable target, String name, ClassLoader tccl) {
-        super(group, target, name, 0L, false);
+    private InnocuousThread(ThreadGroup group, Runnable target, String name,
+                            long stackSize, ClassLoader tccl) {
+        super(group, target, name, stackSize, false);
         UNSAFE.putReferenceRelease(this, INHERITEDACCESSCONTROLCONTEXT, ACC);
         UNSAFE.putReferenceRelease(this, CONTEXTCLASSLOADER, tccl);
     }

--- a/test/jdk/java/lang/ProcessBuilder/ProcessReaperCCL.java
+++ b/test/jdk/java/lang/ProcessBuilder/ProcessReaperCCL.java
@@ -24,7 +24,6 @@
 /*
  * @test
  * @bug 8269488
- * @compile --release 17 ProcessReaperCCL.java
  * @summary verify that Process Reaper threads have a null CCL
  * @run testng ProcessReaperCCL
  */

--- a/test/jdk/java/lang/ProcessBuilder/ProcessReaperCCL.java
+++ b/test/jdk/java/lang/ProcessBuilder/ProcessReaperCCL.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8269488
+ * @compile --release 17 ProcessReaperCCL.java
+ * @summary verify that Process Reaper threads have a null CCL
+ * @run testng ProcessReaperCCL
+ */
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class ProcessReaperCCL {
+
+    @Test
+    static void test() throws Exception {
+        // create a class loader
+        File dir = new File(".");
+        URL[] urls = new URL[] {dir.toURI().toURL()};
+        ClassLoader cl = new URLClassLoader(urls);
+        Thread.currentThread().setContextClassLoader(cl);
+
+        // Invoke a subprocess with processBuilder
+        ProcessBuilder pb = new ProcessBuilder(List.of("echo", "abc", "xyz"));
+        Process p = pb.start();
+        CompletableFuture<Process> cf = p.onExit();
+        int exitValue = cf.get().exitValue();
+        Assert.assertEquals(exitValue, 0, "error exit value");
+
+        // Verify all "Process Reaper" threads have a null CCL
+        for (Thread th : Thread.getAllStackTraces().keySet()) {
+            if ("process reaper".equals(th.getName())) {
+                Assert.assertEquals(th.getContextClassLoader(), null, "CCL not null");
+            }
+        }
+    }
+}


### PR DESCRIPTION
The thread factory used to create the process reaper threads unnecessarily inherits the callers thread context classloader.
The result is retention of the class loader.

The thread factory used for the pool of process reaper threads is modified to use an InnocuousThread with a given stacksize.
The test verifies that the process reaper threads have a null context classloader.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279488](https://bugs.openjdk.java.net/browse/JDK-8279488): ProcessBuilder inherits contextClassLoader when spawning a process reaper thread


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7131/head:pull/7131` \
`$ git checkout pull/7131`

Update a local copy of the PR: \
`$ git checkout pull/7131` \
`$ git pull https://git.openjdk.java.net/jdk pull/7131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7131`

View PR using the GUI difftool: \
`$ git pr show -t 7131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7131.diff">https://git.openjdk.java.net/jdk/pull/7131.diff</a>

</details>
