### PR TITLE
8280123: C2: Infinite loop in CMoveINode::Ideal during IGVN

### DIFF
--- a/src/hotspot/share/opto/movenode.cpp
+++ b/src/hotspot/share/opto/movenode.cpp
@@ -84,19 +84,16 @@ Node *CMoveNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   }
   assert(in(Condition) != this &&
          in(IfFalse)   != this &&
-         in(IfTrue)    != this, "dead loop in CMoveNode::Ideal" );
+         in(IfTrue)    != this, "dead loop in CMoveNode::Ideal");
   if (phase->type(in(Condition)) == Type::TOP ||
       phase->type(in(IfFalse))   == Type::TOP ||
       phase->type(in(IfTrue))    == Type::TOP) {
     return NULL;
   }
   // Canonicalize the node by moving constants to the right input.
-  if (phase->type(in(IfFalse))->singleton() && !phase->type(in(IfTrue))->singleton()) {
-    if (in(Condition)->is_Bool()) {
-      BoolNode* b  = in(Condition)->as_Bool();
-      BoolNode* b2 = b->negate(phase);
-      return make(in(Control), phase->transform(b2), in(IfTrue), in(IfFalse), _type);
-    }
+  if (in(Condition)->is_Bool() && phase->type(in(IfFalse))->singleton() && !phase->type(in(IfTrue))->singleton()) {
+    BoolNode* b = in(Condition)->as_Bool()->negate(phase);
+    return make(in(Control), phase->transform(b), in(IfTrue), in(IfFalse), _type);
   }
   return NULL;
 }

--- a/src/hotspot/share/opto/movenode.cpp
+++ b/src/hotspot/share/opto/movenode.cpp
@@ -75,17 +75,24 @@
 // Return a node which is more "ideal" than the current node.
 // Move constants to the right.
 Node *CMoveNode::Ideal(PhaseGVN *phase, bool can_reshape) {
-  if( in(0) && remove_dead_region(phase, can_reshape) ) return this;
+  if (in(0) != NULL && remove_dead_region(phase, can_reshape)) {
+    return this;
+  }
   // Don't bother trying to transform a dead node
-  if( in(0) && in(0)->is_top() )  return NULL;
+  if (in(0) != NULL && in(0)->is_top()) {
+    return NULL;
+  }
   assert(in(Condition) != this &&
-         in(IfFalse) != this &&
-         in(IfTrue) != this, "dead loop in CMoveNode::Ideal" );
-  if( phase->type(in(Condition)) == Type::TOP )
-  return NULL; // return NULL when Condition is dead
-
-  if( in(IfFalse)->is_Con() && !in(IfTrue)->is_Con() ) {
-    if( in(Condition)->is_Bool() ) {
+         in(IfFalse)   != this &&
+         in(IfTrue)    != this, "dead loop in CMoveNode::Ideal" );
+  if (phase->type(in(Condition)) == Type::TOP ||
+      phase->type(in(IfFalse))   == Type::TOP ||
+      phase->type(in(IfTrue))    == Type::TOP) {
+    return NULL;
+  }
+  // Canonicalize the node by moving constants to the right input.
+  if (phase->type(in(IfFalse))->singleton() && !phase->type(in(IfTrue))->singleton()) {
+    if (in(Condition)->is_Bool()) {
       BoolNode* b  = in(Condition)->as_Bool();
       BoolNode* b2 = b->negate(phase);
       return make(in(Control), phase->transform(b2), in(IfTrue), in(IfFalse), _type);
@@ -191,14 +198,10 @@ Node *CMoveINode::Ideal(PhaseGVN *phase, bool can_reshape) {
 
   // If zero is on the left (false-case, no-move-case) it must mean another
   // constant is on the right (otherwise the shared CMove::Ideal code would
-  // have moved the constant to the right).  This situation is bad for Intel
-  // and a don't-care for Sparc.  It's bad for Intel because the zero has to
-  // be manifested in a register with a XOR which kills flags, which are live
-  // on input to the CMoveI, leading to a situation which causes excessive
-  // spilling on Intel.  For Sparc, if the zero in on the left the Sparc will
-  // zero a register via G0 and conditionally-move the other constant.  If the
-  // zero is on the right, the Sparc will load the first constant with a
-  // 13-bit set-lo and conditionally move G0.  See bug 4677505.
+  // have moved the constant to the right). This situation is bad for x86 because
+  // the zero has to be manifested in a register with a XOR which kills flags,
+  // which are live on input to the CMoveI, leading to a situation which causes
+  // excessive spilling. See bug 4677505.
   if( phase->type(in(IfFalse)) == TypeInt::ZERO && !(phase->type(in(IfTrue)) == TypeInt::ZERO) ) {
     if( in(Condition)->is_Bool() ) {
       BoolNode* b  = in(Condition)->as_Bool();

--- a/test/hotspot/jtreg/compiler/c2/TestCMoveInfiniteGVN.java
+++ b/test/hotspot/jtreg/compiler/c2/TestCMoveInfiniteGVN.java
@@ -23,10 +23,15 @@
 
 /*
  * @test
+ * @key stress randomness
  * @bug 8280123
  * @run main/othervm -Xcomp -XX:-TieredCompilation
  *                   -XX:CompileCommand=compileonly,compiler.c2.TestCMoveInfiniteGVN::test
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:StressSeed=43739875
+ *                   compiler.c2.TestCMoveInfiniteGVN
+ * @run main/othervm -Xcomp -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,compiler.c2.TestCMoveInfiniteGVN::test
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN
  *                   compiler.c2.TestCMoveInfiniteGVN
  */
 

--- a/test/hotspot/jtreg/compiler/c2/TestCMoveInfiniteGVN.java
+++ b/test/hotspot/jtreg/compiler/c2/TestCMoveInfiniteGVN.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8280123
+ * @run main/othervm -Xcomp -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,compiler.c2.TestCMoveInfiniteGVN::test
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:StressSeed=43739875
+ *                   compiler.c2.TestCMoveInfiniteGVN
+ */
+
+package compiler.c2;
+
+public class TestCMoveInfiniteGVN {
+
+    static int test(boolean b, int i) {
+        int iArr[] = new int[2];
+
+        double d = Math.max(i, i);
+        for (int i1 = 1; i1 < 2; i1++) {
+            if (i1 != 0) {
+                return (b ? 1 : 0); // CMoveI
+            }
+            for (int i2 = 1; i2 < 2; i2++) {
+                switch (i2) {
+                    case 1: d -= Math.max(i1, i2); break;
+                }
+                d -= iArr[i1 - 1];
+            }
+        }
+        return 0;
+    }
+
+    static void test() {
+        test(true, 234);
+    }
+
+    public static void main(String[] strArr) {
+        test(); // compilation, then nmethod invalidation during execution
+        test(); // trigger crashing recompilation
+    }
+}


### PR DESCRIPTION
There's a discrepancy between `CMoveNode::Ideal()` and `CMoveINode::Ideal()` in the way how constants are detected:
the former looks for `Con` nodes (`in(IfFalse)->is_Con()`) while the latter checks node types (e.g., `phase->type(in(IfFalse)) == TypeInt::ZERO`). It leads to infinite loop during IGVN (where  `CMoveNode::Ideal()` and `CMoveINode::Ideal()` repeatedly rotate `CMoveI` node) because `CMoveNode::Ideal()` don't consider `CastII` to a constant as a constant while `CMoveINode::Ideal()` does.

The fix migrates `CMoveNode::Ideal()` away from `Node::is_Con()` to node types.

Testing: hs-tier1 - hs-tier4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280123](https://bugs.openjdk.java.net/browse/JDK-8280123): C2: Infinite loop in CMoveINode::Ideal during IGVN


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to d29bbdd159cb80c267be182e68866c64239ff2e9
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to d29bbdd159cb80c267be182e68866c64239ff2e9
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to d29bbdd159cb80c267be182e68866c64239ff2e9


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7133/head:pull/7133` \
`$ git checkout pull/7133`

Update a local copy of the PR: \
`$ git checkout pull/7133` \
`$ git pull https://git.openjdk.java.net/jdk pull/7133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7133`

View PR using the GUI difftool: \
`$ git pr show -t 7133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7133.diff">https://git.openjdk.java.net/jdk/pull/7133.diff</a>

</details>
