### PR TITLE
8269542: JDWP: EnableCollection support is no longer spec compliant after JDK-8255987

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/util.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,10 @@ typedef struct RefNode {
     jobject      ref;           /* could be strong or weak */
     struct RefNode *next;       /* next RefNode* in bucket chain */
     jint         count;         /* count of references */
-    unsigned     strongCount;   /* count of strong reference */
+    jboolean     isStrong;      /* true if this is a strong reference. Either or both of isPinAll
+                                   and isCommonPin will also be true */
+    jboolean     isPinAll;      /* true this is a strong reference due to a commonRef_pinAll() */
+    jboolean     isCommonPin;   /* true if this is a strong reference due to a commonRef_pin() */
 } RefNode;
 
 /* Value of a NULL ID */

--- a/src/jdk.jdwp.agent/share/native/libjdwp/util.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/util.h
@@ -65,9 +65,7 @@ typedef struct RefNode {
     jobject      ref;           /* could be strong or weak */
     struct RefNode *next;       /* next RefNode* in bucket chain */
     jint         count;         /* count of references */
-    jboolean     isStrong;      /* true if this is a strong reference. Either or both of isPinAll
-                                   and isCommonPin will also be true */
-    jboolean     isPinAll;      /* true this is a strong reference due to a commonRef_pinAll() */
+    jboolean     isPinAll;      /* true if this is a strong reference due to a commonRef_pinAll() */
     jboolean     isCommonPin;   /* true if this is a strong reference due to a commonRef_pin() */
 } RefNode;
 


### PR DESCRIPTION
The JDWP spec mentions nothing about `DisableCollection` and `EnableCollection` tracking the depth or nesting of the commands. This means that `EnableCollection` should enable collection no matter how many `DisableCollection` commands were done before it. This is how the debug agent used to work before [JDK-8255987](https://bugs.openjdk.java.net/browse/JDK-8255987). Now the commands' nesting level is tracked, meaning that if there are two `DisableCollection` commands, you need two `EnableCollection` commands to re-enable collection. This is contrary to what the spec says. Only one `EnableCollection` command should be needed to undo any number of `DisableCollection` commands.

Note, JDWP differs from JDI here. The JDI spec explicitly says you need an enable for each disable in order to enable collection again. JDI tracks the disable count. Also, JDI only does the JDWP `DisableCollection` for the first disable, and only does the JDWP `EnableCollection` when the count goes back to 0. For this reason this JDWP bug cannot be reproduced by using JDI. You have to use JDWP directly. Unfortunately we have very limited direct testing of JDWP. JDWP testing mostly is done via JDI. What little JDWP testing we do have pretty much just verifies that reply packets are as expected. They don't verify VM or application behavior. For example, we have no JDWP test that tests that `DisableCollection` actually disables the collecting of the object. For this reason I have not added a test for this CR.

Another issue is that support for `DisableCollection/EnableCollection` nesting was intermixed with the support for having `VM.Suspend` disable collection on all objects (which was the main purpose of [JDK-8255987](https://bugs.openjdk.java.net/browse/JDK-8255987)). As a result, if you do a `VM.Suspend` and then do a `DisableCollection` on an `ObjectReference`, that object can now be collected, even though the spec says it should not be during a `VM.Suspend`. This issues is documented in [JDK-8258071](https://bugs.openjdk.java.net/browse/JDK-8258071), and is also fixed by this PR.

To fix both of these issues, `node->strongCount` should go back to being a boolean (`node->isStrong`) like it was before [JDK-8255987](https://bugs.openjdk.java.net/browse/JDK-8255987). Also, separate flags should be maintained to indicate if the reference is strong due to a `DisableCollection` and/or due to `VM.Suspend`. We need a flag for each, because it's possible that both can be true at the same time. When `node->isStrong` is true, if there is an `EnableCollection` it only gets set false if there is no current `VM.Suspend`. Likewise was if `VM.Resume` is done, it only gets set false if there is no outstanding `DisableCollection`.

There should be no need for maintaining a count anymore since we aren't suppose to for `DisableCollection/EnableCollection`, and there is no need to for `VM.Suspend/Resume`, since it only calls `commonRef_pinAll()` code when the `suspendAllCount` is changed to/from 0.

Please also note [JDK-8269232](https://bugs.openjdk.java.net/browse/JDK-8269232), which was also introduced by this nesting level counting, but is being fixed in more direct manner to keep the changes simple. The fix for CR replaces the changes for [JDK-8269232](https://bugs.openjdk.java.net/browse/JDK-8269232).
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8269542](https://bugs.openjdk.java.net/browse/JDK-8269542): JDWP: EnableCollection support is no longer spec compliant after JDK-8255987
 * [JDK-8258071](https://bugs.openjdk.java.net/browse/JDK-8258071): Fix for JDK-8255987 can be subverted with ObjectReference.EnableCollection


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Per Liden](https://openjdk.java.net/census#pliden) (@pliden - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7134/head:pull/7134` \
`$ git checkout pull/7134`

Update a local copy of the PR: \
`$ git checkout pull/7134` \
`$ git pull https://git.openjdk.java.net/jdk pull/7134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7134`

View PR using the GUI difftool: \
`$ git pr show -t 7134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7134.diff">https://git.openjdk.java.net/jdk/pull/7134.diff</a>

</details>
