### PR TITLE
8280189: JFR: TestPrintXML should print mismatching XML

### DIFF
--- a/test/jdk/jdk/jfr/tool/TestPrintXML.java
+++ b/test/jdk/jdk/jfr/tool/TestPrintXML.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -205,7 +205,7 @@ public class TestPrintXML {
             switch (qName) {
             case "event":
                 XMLEvent event = new XMLEvent(attrs.getValue("type"));
-                event.begin = locator.getLineNumber() -1;
+                event.begin = locator.getLineNumber() - 1;
                 objects.push(event);
                 break;
             case "struct":
@@ -243,7 +243,7 @@ public class TestPrintXML {
                 Object value = objects.pop();
                 if (objects.isEmpty()) {
                     XMLEvent event = (XMLEvent) value;
-                    event.end = locator.getLineNumber() -1;
+                    event.end = locator.getLineNumber() - 1;
                     events.add(event);
                     return;
                 }

--- a/test/jdk/jdk/jfr/tool/TestPrintXML.java
+++ b/test/jdk/jdk/jfr/tool/TestPrintXML.java
@@ -110,7 +110,7 @@ public class TestPrintXML {
                 System.out.println("----------------------");
                 if (xmlEvent.begin != -1 && xmlEvent.end != -1) {
                     String lines[] = xml.split("\\r?\\n");
-                    for (int i = xmlEvent.begin; i <= xmlEvent.end; i++) {
+                    for (int i = xmlEvent.begin; i < xmlEvent.end; i++) {
                         System.out.println(i + " " + lines[i]);
                     }
                 } else {
@@ -243,7 +243,7 @@ public class TestPrintXML {
                 Object value = objects.pop();
                 if (objects.isEmpty()) {
                     XMLEvent event = (XMLEvent) value;
-                    event.end = locator.getLineNumber() - 1;
+                    event.end = locator.getLineNumber();
                     events.add(event);
                     return;
                 }

--- a/test/jdk/jdk/jfr/tool/TestPrintXML.java
+++ b/test/jdk/jdk/jfr/tool/TestPrintXML.java
@@ -108,9 +108,9 @@ public class TestPrintXML {
                 System.out.println();
                 System.out.println("Was (XML)");
                 System.out.println("----------------------");
-                if (xmlEvent.begin != -1 && xmlEvent.end != -1) {
+                if (xmlEvent.begin > 0 && xmlEvent.end > 0) {
                     String lines[] = xml.split("\\r?\\n");
-                    for (int i = xmlEvent.begin; i < xmlEvent.end; i++) {
+                    for (int i = xmlEvent.begin - 1; i < xmlEvent.end; i++) {
                         System.out.println(i + " " + lines[i]);
                     }
                 } else {
@@ -205,7 +205,7 @@ public class TestPrintXML {
             switch (qName) {
             case "event":
                 XMLEvent event = new XMLEvent(attrs.getValue("type"));
-                event.begin = locator.getLineNumber() - 1;
+                event.begin = locator.getLineNumber();
                 objects.push(event);
                 break;
             case "struct":

--- a/test/jdk/jdk/jfr/tool/TestPrintXML.java
+++ b/test/jdk/jdk/jfr/tool/TestPrintXML.java
@@ -23,9 +23,7 @@
 
 package jdk.jfr.tool;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
 import java.io.StringReader;
 import java.nio.file.Path;
 import java.time.OffsetDateTime;


### PR DESCRIPTION
Hi,

Could I have a review of this improvement to TestPrintXML?

Testing: jdk/jfr/tool/TestPrintXML.java

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280189](https://bugs.openjdk.java.net/browse/JDK-8280189): JFR: TestPrintXML should print mismatching XML


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7140/head:pull/7140` \
`$ git checkout pull/7140`

Update a local copy of the PR: \
`$ git checkout pull/7140` \
`$ git pull https://git.openjdk.java.net/jdk pull/7140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7140`

View PR using the GUI difftool: \
`$ git pr show -t 7140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7140.diff">https://git.openjdk.java.net/jdk/pull/7140.diff</a>

</details>
