### PR TITLE
JDK-8280157: wrong texts Falied in a couple of tests

### DIFF
--- a/test/jdk/java/awt/Window/TranslucentShapedFrameTest/TranslucentShapedFrameTest.form
+++ b/test/jdk/java/awt/Window/TranslucentShapedFrameTest/TranslucentShapedFrameTest.form
@@ -158,7 +158,7 @@
           <Properties>
             <Property name="columns" type="int" value="20"/>
             <Property name="rows" type="int" value="5"/>
-            <Property name="text" type="java.lang.String" value="Create translucent and/or shaped, or&#xa;non-opaque frame. Make sure it behaves&#xa;correctly (no artifacts left on the screen&#xa;when dragging - if dragging is possible).&#xa;Click &quot;Passed&quot; if the test behaves correctly,&#xa;&quot;Falied&quot; otherwise."/>
+            <Property name="text" type="java.lang.String" value="Create translucent and/or shaped, or&#xa;non-opaque frame. Make sure it behaves&#xa;correctly (no artifacts left on the screen&#xa;when dragging - if dragging is possible).&#xa;Click &quot;Passed&quot; if the test behaves correctly,&#xa;&quot;Failed&quot; otherwise."/>
           </Properties>
         </Component>
       </SubComponents>

--- a/test/jdk/java/awt/Window/TranslucentShapedFrameTest/TranslucentShapedFrameTest.java
+++ b/test/jdk/java/awt/Window/TranslucentShapedFrameTest/TranslucentShapedFrameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,7 +122,7 @@ public class TranslucentShapedFrameTest extends javax.swing.JFrame {
 
         jTextArea1.setColumns(20);
         jTextArea1.setRows(5);
-        jTextArea1.setText("Create translucent and/or shaped, or\nnon-opaque frame. Make sure it behaves\ncorrectly (no artifacts left on the screen\nwhen dragging - if dragging is possible).\nClick \"Passed\" if the test behaves correctly,\n\"Falied\" otherwise.");
+        jTextArea1.setText("Create translucent and/or shaped, or\nnon-opaque frame. Make sure it behaves\ncorrectly (no artifacts left on the screen\nwhen dragging - if dragging is possible).\nClick \"Passed\" if the test behaves correctly,\n\"Failed\" otherwise.");
         jScrollPane1.setViewportView(jTextArea1);
 
         jLabel2.setText("Instructions:");

--- a/test/jdk/java/io/OutputStreamWriter/WriteAfterClose.java
+++ b/test/jdk/java/io/OutputStreamWriter/WriteAfterClose.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,7 +74,7 @@ public class WriteAfterClose {
 
         try {
             wtr.write("a", 0, 1);
-            System.out.println("FALIED: Allows string buf write on a closed stream");
+            System.out.println("FAILED: Allows string buf write on a closed stream");
             failed = true;
         } catch (Exception e) {
         }

--- a/test/jdk/jdk/jfr/api/consumer/TestRecordedFullStackTrace.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestRecordedFullStackTrace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,7 +119,7 @@ public class TestRecordedFullStackTrace {
             if (!isEventFound[i]) {
                // no assertion, let's retry.
                 // Could be race condition, i.e safe point during Thread.sleep
-                System.out.println("Falied to validate all threads, will retry.");
+                System.out.println("Failed to validate all threads, will retry.");
                 return false;
             }
         }

--- a/test/jdk/jdk/jfr/event/profiling/TestFullStackTrace.java
+++ b/test/jdk/jdk/jfr/event/profiling/TestFullStackTrace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,7 +111,7 @@ public class TestFullStackTrace {
             if(!isEventFound[i]) {
                // no assertion, let's retry.
                // Could be race condition, i.e safe point during Thread.sleep
-               System.out.println("Falied to validate all threads, will retry.");
+               System.out.println("Failed to validate all threads, will retry.");
                return false;
             }
         }


### PR DESCRIPTION
Very small change fixing wrong strings "Falied" in a couple of tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280157](https://bugs.openjdk.java.net/browse/JDK-8280157): wrong texts Falied in a couple of tests


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7142/head:pull/7142` \
`$ git checkout pull/7142`

Update a local copy of the PR: \
`$ git checkout pull/7142` \
`$ git pull https://git.openjdk.java.net/jdk pull/7142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7142`

View PR using the GUI difftool: \
`$ git pr show -t 7142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7142.diff">https://git.openjdk.java.net/jdk/pull/7142.diff</a>

</details>
