### PR TITLE
8280139: Report more detailed statistics about task stealing in task queue stats 

### DIFF
--- a/src/hotspot/share/gc/shared/taskqueue.cpp
+++ b/src/hotspot/share/gc/shared/taskqueue.cpp
@@ -35,8 +35,8 @@
 #if TASKQUEUE_STATS
 const char * const TaskQueueStats::_names[last_stat_id] = {
   "push", "pop", "pop-slow",
-  "st-attempt", "st-empty", "st-ctdd", "st-succ", "st-tasks", "st-ctdd-mx", "st-biasdrp",
-  "ovfl-push", "ovfl-max"
+  "st-attempt", "st-empty", "st-ctdd", "st-success", "st-ctdd-max", "st-biasdrop",
+  "ovflw-push", "ovflw-max"
 };
 
 TaskQueueStats & TaskQueueStats::operator +=(const TaskQueueStats & addend)

--- a/src/hotspot/share/gc/shared/taskqueue.cpp
+++ b/src/hotspot/share/gc/shared/taskqueue.cpp
@@ -34,7 +34,9 @@
 
 #if TASKQUEUE_STATS
 const char * const TaskQueueStats::_names[last_stat_id] = {
-  "qpush", "qpop", "qpop-s", "qattempt", "qsteal", "opush", "omax"
+  "push", "pop", "pop-slow",
+  "st-attempt", "st-empty", "st-ctdd", "st-succ", "st-tasks", "st-ctdd-mx", "st-biasdrp",
+  "ovfl-push", "ovfl-max"
 };
 
 TaskQueueStats & TaskQueueStats::operator +=(const TaskQueueStats & addend)
@@ -86,20 +88,29 @@ void TaskQueueStats::print(outputStream* stream, unsigned int width) const
 // quiescent; they do not hold at arbitrary times.
 void TaskQueueStats::verify() const
 {
-  assert(get(push) == get(pop) + get(steal),
-         "push=" SIZE_FORMAT " pop=" SIZE_FORMAT " steal=" SIZE_FORMAT,
-         get(push), get(pop), get(steal));
+  assert(get(push) == get(pop) + get(steal_success),
+         "push=%zu pop=%zu steal=%zu",
+         get(push), get(pop), get(steal_success));
   assert(get(pop_slow) <= get(pop),
-         "pop_slow=" SIZE_FORMAT " pop=" SIZE_FORMAT,
+         "pop_slow=%zu pop=%zu",
          get(pop_slow), get(pop));
-  assert(get(steal) <= get(steal_attempt),
-         "steal=" SIZE_FORMAT " steal_attempt=" SIZE_FORMAT,
-         get(steal), get(steal_attempt));
+  assert(get(steal_empty) <= get(steal_attempt),
+         "steal_empty=%zu steal_attempt=%zu",
+         get(steal_empty), get(steal_attempt));
+  assert(get(steal_contended) <= get(steal_attempt),
+         "steal_contended=%zu steal_attempt=%zu",
+         get(steal_contended), get(steal_attempt));
+  assert(get(steal_success) <= get(steal_attempt),
+         "steal_success=%zu steal_attempt=%zu",
+         get(steal_success), get(steal_attempt));
+  assert(get(steal_empty) + get(steal_contended) + get(steal_success) == get(steal_attempt),
+         "steal_empty=%zu steal_contended=%zu steal_success=%zu steal_attempt=%zu",
+         get(steal_empty), get(steal_contended), get(steal_success), get(steal_attempt));
   assert(get(overflow) == 0 || get(push) != 0,
-         "overflow=" SIZE_FORMAT " push=" SIZE_FORMAT,
+         "overflow=%zu push=%zu",
          get(overflow), get(push));
   assert(get(overflow_max_len) == 0 || get(overflow) != 0,
-         "overflow_max_len=" SIZE_FORMAT " overflow=" SIZE_FORMAT,
+         "overflow_max_len=%zu overflow=%zu",
          get(overflow_max_len), get(overflow));
 }
 #endif // ASSERT

--- a/src/hotspot/share/gc/shared/taskqueue.inline.hpp
+++ b/src/hotspot/share/gc/shared/taskqueue.inline.hpp
@@ -298,16 +298,15 @@ typename T::PopResult GenericTaskQueueSet<T, F>::steal_best_of_2(uint queue_num,
     if (sz2 > sz1) {
       sel_k = k2;
       suc = _queues[k2]->pop_global(t);
-      TASKQUEUE_STATS_ONLY(queue(queue_num)->stats.record_steal_attempt((uint)suc));
+      TASKQUEUE_STATS_ONLY(queue(queue_num)->stats.record_steal_attempt((uint)suc);)
     } else if (sz1 > 0) {
       sel_k = k1;
       suc = _queues[k1]->pop_global(t);
-      TASKQUEUE_STATS_ONLY(queue(queue_num)->stats.record_steal_attempt((uint)suc));
+      TASKQUEUE_STATS_ONLY(queue(queue_num)->stats.record_steal_attempt((uint)suc);)
     }
 
     if (suc == T::Success) {
       local_queue->set_last_stolen_queue_id(sel_k);
-      TASKQUEUE_STATS_ONLY(queue(queue_num)->stats.record_steal_tasks(1));
     } else {
       local_queue->invalidate_last_stolen_queue_id();
     }
@@ -317,14 +316,11 @@ typename T::PopResult GenericTaskQueueSet<T, F>::steal_best_of_2(uint queue_num,
     // Just try the other one.
     uint k = (queue_num + 1) % 2;
     PopResult res = _queues[k]->pop_global(t);
-    TASKQUEUE_STATS_ONLY(queue(queue_num)->stats.record_steal_attempt((uint)res));
-    if (res == T::Success) {
-      TASKQUEUE_STATS_ONLY(queue(queue_num)->stats.record_steal_tasks(1));
-    }
+    TASKQUEUE_STATS_ONLY(queue(queue_num)->stats.record_steal_attempt((uint)res);)
     return res;
   } else {
     assert(_n == 1, "can't be zero.");
-    TASKQUEUE_STATS_ONLY(queue(queue_num)->stats.record_steal_attempt((uint)T::Empty));
+    TASKQUEUE_STATS_ONLY(queue(queue_num)->stats.record_steal_attempt((uint)T::Empty);)
     return T::Empty;
   }
 }


### PR DESCRIPTION
Hi all,

  can I have reviews that improves task queue statistics?

This is a step to see problems with task queue in general and measure future task stealing improvements in GC; particularly contention on steal information has shown to be correlated to performance, so information about basic occurrences during stealing (how many empty, how many contended, how many contended in a row, max contended accesses in a row) in the task queue is very interesting for further performance work.

Old output of `gc+tasks+stats=trace` after compiling in these statistics:
```
thr      qpush       qpop     qpop-s   qattempt     qsteal      opush       omax
--- ---------- ---------- ---------- ---------- ---------- ---------- ----------
  0    3777115    3776816       3872      17434       9630          0          0
```
And new:
```
thr        push         pop    pop-slow  st-attempt    st-empty     st-ctdd  st-success st-ctdd-max st-biasdrop  ovflw-push   ovflw-max
--- ----------- ----------- ----------- ----------- ----------- ----------- ----------- ----------- ----------- ----------- -----------
  0     4616264     4616218        3608       12945           1        1650       11294           5        9405           0           0
[...]
```
The first four columns stayed the same, then the `qsteal` has been split up into the various steal results (empty/contended/success). `st_ctdd_max` gives the maximum amount of contended steal attempts in a row. `st_biasdrop` shows how many times the steal bias has been dropped (reset).
`ovflw-push` and `ovfl-max` are the same as before, just renamed a bit to use the available space.

There has been no intention to change anything about the algorithm, so there is no need for perf testing (I can see). Later changes will do that.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280139](https://bugs.openjdk.java.net/browse/JDK-8280139): Report more detailed statistics about task stealing in task queue stats


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7143/head:pull/7143` \
`$ git checkout pull/7143`

Update a local copy of the PR: \
`$ git checkout pull/7143` \
`$ git pull https://git.openjdk.java.net/jdk pull/7143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7143`

View PR using the GUI difftool: \
`$ git pr show -t 7143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7143.diff">https://git.openjdk.java.net/jdk/pull/7143.diff</a>

</details>
