### PR TITLE
8280161: com/sun/net/httpserver/simpleserver/jwebserver/MaxRequestTimeTest.java fails with SSLException

### DIFF
--- a/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/MaxRequestTimeTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/MaxRequestTimeTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8278398 8280161
+ * @bug 8278398
  * @summary Tests the jwebserver's maximum request time
  * @modules jdk.httpserver
  * @library /test/lib

--- a/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/MaxRequestTimeTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/MaxRequestTimeTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8278398
+ * @bug 8278398 8280161
  * @summary Tests the jwebserver's maximum request time
  * @modules jdk.httpserver
  * @library /test/lib
@@ -41,7 +41,7 @@ import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLException;
 import jdk.test.lib.Platform;
 import jdk.test.lib.net.SimpleSSLContext;
 import jdk.test.lib.process.OutputAnalyzer;
@@ -140,8 +140,8 @@ public class MaxRequestTimeTest {
         var request = HttpRequest.newBuilder(URI.create("https://localhost:" + PORT.get() + "/")).build();
         try {
             client.send(request, HttpResponse.BodyHandlers.ofString());
-            throw new RuntimeException("Expected SSLHandshakeException not thrown");
-        } catch (SSLHandshakeException expected) {  // server closes connection when max request time is reached
+            throw new RuntimeException("Expected SSLException not thrown");
+        } catch (SSLException expected) {  // server closes connection when max request time is reached
             expected.printStackTrace(System.out);
         }
     }


### PR DESCRIPTION
Small test-only fix that generalizes the expected exception type from SSLHandshakeException to SSLException (a super class of the former).

Testing: tier 1-3 and repeated runs of test in question all clear

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280161](https://bugs.openjdk.java.net/browse/JDK-8280161): com/sun/net/httpserver/simpleserver/jwebserver/MaxRequestTimeTest.java fails with SSLException


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7144/head:pull/7144` \
`$ git checkout pull/7144`

Update a local copy of the PR: \
`$ git checkout pull/7144` \
`$ git pull https://git.openjdk.java.net/jdk pull/7144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7144`

View PR using the GUI difftool: \
`$ git pr show -t 7144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7144.diff">https://git.openjdk.java.net/jdk/pull/7144.diff</a>

</details>
