### PR TITLE
8280178: Remove os:: API's that just call system API's

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -689,10 +689,6 @@ ssize_t os::read_at(int fd, void *buf, unsigned int nBytes, jlong offset) {
   return ::pread(fd, buf, nBytes, offset);
 }
 
-int os::close(int fd) {
-  return ::close(fd);
-}
-
 void os::flockfile(FILE* fp) {
   ::flockfile(fp);
 }
@@ -718,10 +714,6 @@ int os::closedir(DIR *dirp) {
 
 int os::socket_close(int fd) {
   return ::close(fd);
-}
-
-int os::socket(int domain, int type, int protocol) {
-  return ::socket(domain, type, protocol);
 }
 
 int os::recv(int fd, char* buf, size_t nBytes, uint flags) {

--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -124,7 +124,7 @@ static void save_memory_to_file(char* addr, size_t size) {
       addr += result;
     }
 
-    result = os::close(fd);
+    result = ::close(fd);
     if (PrintMiscellaneous && Verbose) {
       if (result == OS_ERR) {
         warning("Could not close %s: %s\n", destfile, os::strerror(errno));
@@ -330,7 +330,7 @@ static DIR *open_directory_secure(const char* dirname) {
   // Determine if the open directory is secure.
   if (!is_dirfd_secure(fd)) {
     // The directory is not a secure directory.
-    os::close(fd);
+    ::close(fd);
     return dirp;
   }
 
@@ -338,21 +338,21 @@ static DIR *open_directory_secure(const char* dirname) {
   dirp = ::opendir(dirname);
   if (dirp == NULL) {
     // The directory doesn't exist, close fd and return.
-    os::close(fd);
+    ::close(fd);
     return dirp;
   }
 
   // Check to make sure fd and dirp are referencing the same file system object.
   if (!is_same_fsobject(fd, AIX_ONLY(dirp->dd_fd) NOT_AIX(dirfd(dirp)))) {
     // The directory is not secure.
-    os::close(fd);
+    ::close(fd);
     os::closedir(dirp);
     dirp = NULL;
     return dirp;
   }
 
   // Close initial open now that we know directory is secure
-  os::close(fd);
+  ::close(fd);
 
   return dirp;
 }
@@ -905,7 +905,7 @@ static int create_sharedmem_resources(const char* dirname, const char* filename,
   if (result != -1) {
     return fd;
   } else {
-    os::close(fd);
+    ::close(fd);
     return -1;
   }
 }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1553,7 +1553,7 @@ void * os::dll_load(const char *name, char *ebuf, int ebuflen) {
      ||
      // Read location of signature
      (sizeof(signature_offset) !=
-     (os::read(fd, (void*)&signature_offset, sizeof(signature_offset))))
+     (::read(fd, (void*)&signature_offset, sizeof(signature_offset))))
      ||
      // Go to COFF File Header in dll
      // that is located after "signature" (4 bytes long)
@@ -1562,7 +1562,7 @@ void * os::dll_load(const char *name, char *ebuf, int ebuflen) {
      ||
      // Read field that contains code of architecture
      // that dll was built for
-     (sizeof(lib_arch) != (os::read(fd, (void*)&lib_arch, sizeof(lib_arch))))
+     (sizeof(lib_arch) != (::read(fd, (void*)&lib_arch, sizeof(lib_arch))))
     );
 
   ::close(fd);
@@ -4762,10 +4762,6 @@ ssize_t os::write(int fd, const void *buf, unsigned int nBytes) {
   return ::write(fd, buf, nBytes);
 }
 
-int os::close(int fd) {
-  return ::close(fd);
-}
-
 void os::exit(int num) {
   win32::exit_process_or_thread(win32::EPT_PROCESS, num);
 }
@@ -5723,10 +5719,6 @@ struct hostent* os::get_host_by_name(char* name) {
 
 int os::socket_close(int fd) {
   return ::closesocket(fd);
-}
-
-int os::socket(int domain, int type, int protocol) {
-  return ::socket(domain, type, protocol);
 }
 
 int os::connect(int fd, struct sockaddr* him, socklen_t len) {

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -174,8 +174,8 @@ static bool read_fully(const char *fname, char *buf, size_t buflen) {
   assert(buflen >= 1, "invalid argument");
   int fd = os::open(fname, O_RDONLY, 0);
   if (fd != -1) {
-    ssize_t read_sz = os::read(fd, buf, buflen);
-    os::close(fd);
+    ssize_t read_sz = ::read(fd, buf, buflen);
+    ::close(fd);
 
     // Skip if the contents is just "\n" because some machine only sets
     // '\n' to the board name.

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -190,7 +190,7 @@ FileMapInfo::~FileMapInfo() {
     _dynamic_archive_info = NULL;
   }
   if (_file_open) {
-    os::close(_fd);
+    ::close(_fd);
   }
 }
 
@@ -1070,7 +1070,7 @@ public:
 
   ~FileHeaderHelper() {
     if (_fd != -1) {
-      os::close(_fd);
+      ::close(_fd);
     }
   }
 
@@ -1092,7 +1092,7 @@ public:
     GenericCDSFileMapHeader gen_header;
     size_t size = sizeof(GenericCDSFileMapHeader);
     os::lseek(fd, 0, SEEK_SET);
-    size_t n = os::read(fd, (void*)&gen_header, (unsigned int)size);
+    size_t n = ::read(fd, (void*)&gen_header, (unsigned int)size);
     if (n != size) {
       FileMapInfo::fail_continue("Unable to read generic CDS file map header from shared archive");
       return false;
@@ -1125,7 +1125,7 @@ public:
     size = gen_header._header_size;
     _header = (GenericCDSFileMapHeader*)NEW_C_HEAP_ARRAY(char, size, mtInternal);
     os::lseek(fd, 0, SEEK_SET);
-    n = os::read(fd, (void*)_header, (unsigned int)size);
+    n = ::read(fd, (void*)_header, (unsigned int)size);
     if (n != size) {
       FileMapInfo::fail_continue("Unable to read actual CDS file map header from shared archive");
       return false;
@@ -1279,7 +1279,7 @@ bool FileMapInfo::init_from_file(int fd) {
   _header = (FileMapHeader*)os::malloc(gen_header->_header_size, mtInternal);
   os::lseek(fd, 0, SEEK_SET); // reset to begin of the archive
   size_t size = gen_header->_header_size;
-  size_t n = os::read(fd, (void*)_header, (unsigned int)size);
+  size_t n = ::read(fd, (void*)_header, (unsigned int)size);
   if (n != size) {
     fail_continue("Failed to read file header from the top archive file\n");
     return false;
@@ -1650,7 +1650,7 @@ void FileMapInfo::write_bytes_aligned(const void* buffer, size_t nbytes) {
 
 void FileMapInfo::close() {
   if (_file_open) {
-    if (os::close(_fd) < 0) {
+    if (::close(_fd) < 0) {
       fail_stop("Unable to close the shared archive file.");
     }
     _file_open = false;
@@ -1778,7 +1778,7 @@ MapArchiveResult FileMapInfo::map_region(int i, intx addr_delta, char* mapped_ba
   if (MetaspaceShared::use_windows_memory_mapping() && rs.is_reserved()) {
     // This is the second time we try to map the archive(s). We have already created a ReservedSpace
     // that covers all the FileMapRegions to ensure all regions can be mapped. However, Windows
-    // can't mmap into a ReservedSpace, so we just os::read() the data. We're going to patch all the
+    // can't mmap into a ReservedSpace, so we just ::read() the data. We're going to patch all the
     // regions anyway, so there's no benefit for mmap anyway.
     if (!read_region(i, requested_addr, size, /* do_commit = */ true)) {
       log_info(cds)("Failed to read %s shared space into reserved space at " INTPTR_FORMAT,
@@ -1884,7 +1884,7 @@ bool FileMapInfo::relocate_pointers_in_core_regions(intx addr_delta) {
 
 size_t FileMapInfo::read_bytes(void* buffer, size_t count) {
   assert(_file_open, "Archive file is not open");
-  size_t n = os::read(_fd, buffer, (unsigned int)count);
+  size_t n = ::read(_fd, buffer, (unsigned int)count);
   if (n != count) {
     // Close the file if there's a problem reading it.
     close();

--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -253,9 +253,9 @@ ClassFileStream* ClassPathDirEntry::open_stream(JavaThread* current, const char*
     if (file_handle != -1) {
       // read contents into resource array
       u1* buffer = NEW_RESOURCE_ARRAY(u1, st.st_size);
-      size_t num_read = os::read(file_handle, (char*) buffer, st.st_size);
+      size_t num_read = ::read(file_handle, (char*) buffer, st.st_size);
       // close file
-      os::close(file_handle);
+      ::close(file_handle);
       // construct ClassFileStream
       if (num_read == (size_t)st.st_size) {
         if (UsePerfData) {

--- a/src/hotspot/share/classfile/compactHashtable.cpp
+++ b/src/hotspot/share/classfile/compactHashtable.cpp
@@ -252,7 +252,7 @@ HashtableTextDump::HashtableTextDump(const char* filename) : _fd(-1) {
 HashtableTextDump::~HashtableTextDump() {
   os::unmap_memory((char*)_base, _size);
   if (_fd >= 0) {
-    os::close(_fd);
+    ::close(_fd);
   }
 }
 

--- a/src/hotspot/share/compiler/compileLog.cpp
+++ b/src/hotspot/share/compiler/compileLog.cpp
@@ -225,7 +225,7 @@ void CompileLog::finish_log_on_error(outputStream* file, char* buf, int buflen) 
         if (to_read < (julong)buflen)
               nr = (size_t)to_read;
         else  nr = buflen;
-        bytes_read = os::read(partial_fd, buf, (int)nr);
+        bytes_read = ::read(partial_fd, buf, (int)nr);
         if (bytes_read <= 0) break;
         nr = bytes_read;
         to_read -= (julong)nr;
@@ -235,7 +235,7 @@ void CompileLog::finish_log_on_error(outputStream* file, char* buf, int buflen) 
       // Copy any remaining data inside a quote:
       bool saw_slop = false;
       int end_cdata = 0;  // state machine [0..2] watching for too many "]]"
-      while ((bytes_read = os::read(partial_fd, buf, buflen-1)) > 0) {
+      while ((bytes_read = ::read(partial_fd, buf, buflen-1)) > 0) {
         nr = bytes_read;
         buf[buflen-1] = '\0';
         if (!saw_slop) {
@@ -285,7 +285,7 @@ void CompileLog::finish_log_on_error(outputStream* file, char* buf, int buflen) 
         file->print_raw_cr("</fragment>");
       }
       file->print_raw_cr("</compilation_log>");
-      os::close(partial_fd);
+      ::close(partial_fd);
     }
     CompileLog* next_log = log->_next;
     delete log; // Removes partial file

--- a/src/hotspot/share/compiler/directivesParser.cpp
+++ b/src/hotspot/share/compiler/directivesParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,11 +94,11 @@ bool DirectivesParser::parse_from_file_inner(const char* filename, outputStream*
     if (file_handle != -1) {
       // read contents into resource array
       char* buffer = NEW_RESOURCE_ARRAY(char, st.st_size+1);
-      ssize_t num_read = os::read(file_handle, (char*) buffer, st.st_size);
+      ssize_t num_read = ::read(file_handle, (char*) buffer, st.st_size);
       if (num_read >= 0) {
         buffer[num_read] = '\0';
         // close file
-        os::close(file_handle);
+        ::close(file_handle);
         return parse_string(buffer, stream) > 0;
       }
     }

--- a/src/hotspot/share/include/cds.h
+++ b/src/hotspot/share/include/cds.h
@@ -48,7 +48,7 @@ typedef struct CDSFileMapRegion {
   int     _is_heap_region;    // Used by SA and debug build.
   int     _is_bitmap_region;  // Relocation bitmap for RO/RW regions (used by SA and debug build).
   int     _mapped_from_file;  // Is this region mapped from a file?
-                              // If false, this region was initialized using os::read().
+                              // If false, this region was initialized using ::read().
   size_t  _file_offset;       // Data for this region starts at this offset in the archive file.
   size_t  _mapping_offset;    // This region should be mapped at this offset from the base address
                               // - for non-heap regions, the base address is SharedBaseAddress

--- a/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,7 +105,7 @@ static bool open_emergency_dump_fd(const char* path) {
 
 static void close_emergency_dump_file() {
   if (is_emergency_dump_file_open()) {
-    os::close(emergency_fd);
+    ::close(emergency_fd);
   }
 }
 
@@ -298,7 +298,7 @@ const char* RepositoryIterator::filter(const char* file_name) const {
     return NULL;
   }
   const int64_t size = file_size(fd);
-  os::close(fd);
+  ::close(fd);
   if (size <= chunk_file_header_size) {
     return NULL;
   }
@@ -389,7 +389,7 @@ static void write_repository_files(const RepositoryIterator& iterator, char* con
         bytes_written += (int64_t)os::write(emergency_fd, copy_block, bytes_read - bytes_written);
         assert(bytes_read == bytes_written, "invariant");
       }
-      os::close(current_fd);
+      ::close(current_fd);
     }
   }
 }

--- a/src/hotspot/share/jfr/writers/jfrStreamWriterHost.inline.hpp
+++ b/src/hotspot/share/jfr/writers/jfrStreamWriterHost.inline.hpp
@@ -135,7 +135,7 @@ inline bool StreamWriterHost<Adapter, AP>::is_valid() const {
 template <typename Adapter, typename AP>
 inline void StreamWriterHost<Adapter, AP>::close_fd() {
   assert(this->has_valid_fd(), "closing invalid fd!");
-  os::close(_fd);
+  ::close(_fd);
   _fd = invalid_fd;
 }
 

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -628,7 +628,7 @@ ReservedHeapSpace::ReservedHeapSpace(size_t size, size_t alignment, size_t page_
   }
 
   if (_fd_for_heap != -1) {
-    os::close(_fd_for_heap);
+    ::close(_fd_for_heap);
   }
 }
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3323,13 +3323,13 @@ jint Arguments::parse_vm_options_file(const char* file_name, ScopedVMInitArgs* v
     jio_fprintf(defaultStream::error_stream(),
                 "Could not stat options file '%s'\n",
                 file_name);
-    os::close(fd);
+    ::close(fd);
     return JNI_ERR;
   }
 
   if (stbuf.st_size == 0) {
     // tell caller there is no option data and that is ok
-    os::close(fd);
+    ::close(fd);
     return JNI_OK;
   }
 
@@ -3340,15 +3340,15 @@ jint Arguments::parse_vm_options_file(const char* file_name, ScopedVMInitArgs* v
   if (NULL == buf) {
     jio_fprintf(defaultStream::error_stream(),
                 "Could not allocate read buffer for options file parse\n");
-    os::close(fd);
+    ::close(fd);
     return JNI_ENOMEM;
   }
 
   memset(buf, 0, bytes_alloc);
 
   // Fill buffer
-  ssize_t bytes_read = os::read(fd, (void *)buf, (unsigned)bytes_alloc);
-  os::close(fd);
+  ssize_t bytes_read = ::read(fd, (void *)buf, (unsigned)bytes_alloc);
+  ::close(fd);
   if (bytes_read < 0) {
     FREE_C_HEAP_ARRAY(char, buf);
     jio_fprintf(defaultStream::error_stream(),

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1292,10 +1292,6 @@ FILE* os::fopen(const char* path, const char* mode) {
 #endif
 
   return file;
-}
-
-ssize_t os::read(int fd, void *buf, unsigned int nBytes) {
-  return ::read(fd, buf, nBytes);
 }
 
 bool os::set_boot_path(char fileSep, char pathSep) {

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -543,7 +543,6 @@ class os: AllStatic {
   static int open(const char *path, int oflag, int mode);
   static FILE* fdopen(int fd, const char* mode);
   static FILE* fopen(const char* path, const char* mode);
-  static int close(int fd);
   static jlong lseek(int fd, jlong offset, int whence);
   static bool file_exists(const char* file);
   // This function, on Windows, canonicalizes a given path (see os_windows.cpp for details).
@@ -563,7 +562,6 @@ class os: AllStatic {
 
   //File i/o operations
 
-  static ssize_t read(int fd, void *buf, unsigned int nBytes);
   static ssize_t read_at(int fd, void *buf, unsigned int nBytes, jlong offset);
   static ssize_t write(int fd, const void *buf, unsigned int nBytes);
 
@@ -785,7 +783,6 @@ class os: AllStatic {
   static char* strdup_check_oom(const char*, MEMFLAGS flags = mtInternal);
 
   // SocketInterface (ex HPI SocketInterface )
-  static int socket(int domain, int type, int protocol);
   static int socket_close(int fd);
   static int recv(int fd, char* buf, size_t nBytes, uint flags);
   static int send(int fd, char* buf, size_t nBytes, uint flags);

--- a/src/hotspot/share/services/heapDumperCompression.cpp
+++ b/src/hotspot/share/services/heapDumperCompression.cpp
@@ -46,7 +46,7 @@ char const* FileWriter::open_writer() {
 
 FileWriter::~FileWriter() {
   if (_fd >= 0) {
-    os::close(_fd);
+    ::close(_fd);
     _fd = -1;
   }
 }

--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -1079,7 +1079,7 @@ networkStream::networkStream() : bufferedStream(1024*10, 1024*10) {
 
   _socket = -1;
 
-  int result = os::socket(AF_INET, SOCK_STREAM, 0);
+  int result = ::socket(AF_INET, SOCK_STREAM, 0);
   if (result <= 0) {
     assert(false, "Socket could not be created!");
   } else {

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1654,7 +1654,7 @@ void VMError::report_and_die(int id, const char* message, const char* detail_fmt
     _current_step_info = "";
 
     if (fd_log > 3) {
-      os::close(fd_log);
+      ::close(fd_log);
       fd_log = -1;
     }
 


### PR DESCRIPTION
Please review this change to remove unneeded definitions for close(), read(), and socket() from class os in os.hpp.  The definitions aren't needed because, for all platforms, these functions just call the host operating system versions.

The fix was tested with Mach5 tiers 1-2 on Linux, Mac OS, and Windows, and Mach5 tiers 3-5 on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280178](https://bugs.openjdk.java.net/browse/JDK-8280178): Remove os:: API's that just call system API's


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7145/head:pull/7145` \
`$ git checkout pull/7145`

Update a local copy of the PR: \
`$ git checkout pull/7145` \
`$ git pull https://git.openjdk.java.net/jdk pull/7145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7145`

View PR using the GUI difftool: \
`$ git pr show -t 7145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7145.diff">https://git.openjdk.java.net/jdk/pull/7145.diff</a>

</details>
