### PR TITLE
8278472: Invalid value set to CANDIDATEFORM structure

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3917,11 +3917,11 @@ void AwtComponent::SetCandidateWindow(int iCandType, int x, int y)
     HIMC hIMC = ImmGetContext(hwnd);
     if (hIMC) {
         CANDIDATEFORM cf;
-        cf.dwStyle = CFS_POINT;
+        cf.dwStyle = CFS_CANDIDATEPOS;
         ImmGetCandidateWindow(hIMC, 0, &cf);
         if (x != cf.ptCurrentPos.x || y != cf.ptCurrentPos.y) {
             cf.dwIndex = iCandType;
-            cf.dwStyle = CFS_POINT;
+            cf.dwStyle = CFS_CANDIDATEPOS;
             cf.ptCurrentPos = {x, y};
             cf.rcArea = {0, 0, 0, 0};
             ImmSetCandidateWindow(hIMC, &cf);


### PR DESCRIPTION
According to the Windows API reference, `dwStyle` of [`CANDIDATEFORM`](https://docs.microsoft.com/en-us/windows/win32/api/imm/ns-imm-candidateform) structure should be set to `CFS_CANDIDATEPOS` or `CFS_EXCLUDE`. So, `CFS_POINT` is wrong here.

There are two instances in `AwtComponent::SetCandidateWindow` in [`awt_Component.cpp`](https://github.com/openjdk/jdk/blob/f90425a1cbbc686045c87086af586e62f05f6c49/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp#L3914) where the incorrect value is used.

Initially, I created this PR for jdk18. [It was suggested](https://github.com/openjdk/jdk18/pull/54#issuecomment-1006432326) to place this fix into the mainline, so this a continuation to [jdk18/pull/54](https://github.com/openjdk/jdk18/pull/54).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278472](https://bugs.openjdk.java.net/browse/JDK-8278472): Invalid value set to CANDIDATEFORM structure


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7146/head:pull/7146` \
`$ git checkout pull/7146`

Update a local copy of the PR: \
`$ git checkout pull/7146` \
`$ git pull https://git.openjdk.java.net/jdk pull/7146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7146`

View PR using the GUI difftool: \
`$ git pr show -t 7146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7146.diff">https://git.openjdk.java.net/jdk/pull/7146.diff</a>

</details>
