### PR TITLE
8276472: align_metadata_size documents metadata alignment

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -717,9 +717,6 @@ public:
     return _nonstatic_oop_map_size / OopMapBlock::size_in_words();
   }
   int nonstatic_oop_map_size() const { return _nonstatic_oop_map_size; }
-  void set_nonstatic_oop_map_size(int words) {
-    _nonstatic_oop_map_size = words;
-  }
 
   bool has_contended_annotations() const {
     return ((_misc_flags & _misc_has_contended_annotations) != 0);

--- a/src/hotspot/share/utilities/align.hpp
+++ b/src/hotspot/share/utilities/align.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,8 +101,9 @@ inline bool is_aligned(T* ptr, A alignment) {
 
 // Align metaspace objects by rounding up to natural word boundary
 template <typename T>
-inline T align_metadata_size(T size) {
-  return align_up(size, 1);
+inline T align_metadata_size(T word_size) {
+  // size is already in words
+  return word_size;
 }
 
 // Align objects in the Java Heap by rounding up their size, in HeapWord units.


### PR DESCRIPTION
I just added a comment to this and took out the align_up call.  I like align_metadata_size where it is and changing to WordSize doesn't add more safety imo.  Also found unused function while looking for units of metadata size.
Tested with tier1 on Oracle supported platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8276472](https://bugs.openjdk.java.net/browse/JDK-8276472): align_metadata_size documents metadata alignment


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7150/head:pull/7150` \
`$ git checkout pull/7150`

Update a local copy of the PR: \
`$ git checkout pull/7150` \
`$ git pull https://git.openjdk.java.net/jdk pull/7150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7150`

View PR using the GUI difftool: \
`$ git pr show -t 7150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7150.diff">https://git.openjdk.java.net/jdk/pull/7150.diff</a>

</details>
