### PR TITLE
8280363: Minor correction of ALPN specification in SSLParameters

### DIFF
--- a/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
@@ -616,8 +616,8 @@ public class SSLParameters {
      * This method will return a new array each time it is invoked.
      *
      * @return a non-null, possibly zero-length array of application protocol
-     *         {@code String}s.  The array is ordered based on protocol
-     *         preference, with {@code protocols[0]} being the most preferred.
+     *         {@code String}s.  The array is placed in descending order of
+     *         application protocols preference.
      * @see #setApplicationProtocols
      * @since 9
      */

--- a/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
@@ -616,8 +616,8 @@ public class SSLParameters {
      * This method will return a new array each time it is invoked.
      *
      * @return a non-null, possibly zero-length array of application protocol
-     *         {@code String}s.  The array is placed in descending order of
-     *         application protocols preference.
+     *         {@code String}s.  The array is ordered based on protocol
+     *         preference, with the first entry being the most preferred.
      * @see #setApplicationProtocols
      * @since 9
      */


### PR DESCRIPTION
In the getApplicationProtocols() method in javax.net.ssl.SSLParameters, the return statement says that "The array is ordered based on protocol preference, with protocols[0] being the most preferred.". However, there is no "protocols" variable in this method.

The update is a minor correction so that the specification is not rely on the "protocols" variable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280363](https://bugs.openjdk.java.net/browse/JDK-8280363): Minor correction of ALPN specification in SSLParameters


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to c16bf6c69a9e24f008810b8d31a2a558153a9c63
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7152/head:pull/7152` \
`$ git checkout pull/7152`

Update a local copy of the PR: \
`$ git checkout pull/7152` \
`$ git pull https://git.openjdk.java.net/jdk pull/7152/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7152`

View PR using the GUI difftool: \
`$ git pr show -t 7152`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7152.diff">https://git.openjdk.java.net/jdk/pull/7152.diff</a>

</details>
