### PR TITLE
8280374: G1: Remove unnecessary prev bitmap mark

### DIFF
--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -134,6 +134,8 @@ public:
 #endif
       }
     }
+    assert(!_cm->is_marked_in_prev_bitmap(cast_to_oop(start)), "should not be marked in prev bitmap");
+    assert(!_cm->is_marked_in_next_bitmap(cast_to_oop(start)), "should not be marked in next bitmap");
   }
 
   void zap_remainder() {

--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -133,7 +133,6 @@ public:
 #endif
       }
     }
-    _cm->clear_range_in_prev_bitmap(mr);
   }
 
   void zap_remainder() {

--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -135,7 +135,6 @@ public:
       }
     }
     assert(!_cm->is_marked_in_prev_bitmap(cast_to_oop(start)), "should not be marked in prev bitmap");
-    assert(!_cm->is_marked_in_next_bitmap(cast_to_oop(start)), "should not be marked in next bitmap");
   }
 
   void zap_remainder() {

--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -104,7 +104,8 @@ public:
   }
 
   // Fill the memory area from start to end with filler objects, and update the BOT
-  // and the mark bitmap accordingly.
+  // accordingly. Since we clear and use the prev bitmap for marking objects that
+  // failed evacuation, there is no work to be done there.
   void zap_dead_objects(HeapWord* start, HeapWord* end) {
     if (start == end) {
       return;


### PR DESCRIPTION
In JDK-8278917, the prev bitmap is used to mark evac failure objs, so at the post of evacuation, the evacuation failure objects are already marked during pss evacuation, so there is no need to mark them again in remove self forwardee phase.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280374](https://bugs.openjdk.java.net/browse/JDK-8280374): G1: Remove unnecessary prev bitmap mark


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to 2fa41ad283a16c2be3a0655ecf456d653f58e281


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7153/head:pull/7153` \
`$ git checkout pull/7153`

Update a local copy of the PR: \
`$ git checkout pull/7153` \
`$ git pull https://git.openjdk.java.net/jdk pull/7153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7153`

View PR using the GUI difftool: \
`$ git pr show -t 7153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7153.diff">https://git.openjdk.java.net/jdk/pull/7153.diff</a>

</details>
