### PR TITLE
8280375: G1: Tighten mem region limit in G1RebuildRemSetHeapRegionClosure

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1957,7 +1957,7 @@ public:
       HeapWord* const top_at_mark_start = hr->prev_top_at_mark_start();
 
       HeapWord* cur = hr->bottom();
-      while (cur < hr->top()) {
+      while (true) {
         // After every iteration (yield point) we need to check whether the region's
         // TARS changed due to e.g. eager reclaim.
         HeapWord* const top_at_rebuild_start = _cm->top_at_rebuild_start(region_idx);

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1957,7 +1957,7 @@ public:
       HeapWord* const top_at_mark_start = hr->prev_top_at_mark_start();
 
       HeapWord* cur = hr->bottom();
-      while (cur < hr->end()) {
+      while (cur < hr->top()) {
         // After every iteration (yield point) we need to check whether the region's
         // TARS changed due to e.g. eager reclaim.
         HeapWord* const top_at_rebuild_start = _cm->top_at_rebuild_start(region_idx);


### PR DESCRIPTION
Currently, it uses `hr->end()` to guard the mem scan limit, but it should be top instead of end.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280375](https://bugs.openjdk.java.net/browse/JDK-8280375): G1: Tighten mem region limit in G1RebuildRemSetHeapRegionClosure


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7154/head:pull/7154` \
`$ git checkout pull/7154`

Update a local copy of the PR: \
`$ git checkout pull/7154` \
`$ git pull https://git.openjdk.java.net/jdk pull/7154/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7154`

View PR using the GUI difftool: \
`$ git pr show -t 7154`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7154.diff">https://git.openjdk.java.net/jdk/pull/7154.diff</a>

</details>
