### PR TITLE
JDK-8280373: Update Xalan serializer / SystemIDResolver to align with JDK-8270492

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/utils/SystemIDResolver.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/utils/SystemIDResolver.java
@@ -1,6 +1,5 @@
 /*
- * reserved comment block
- * DO NOT REMOVE OR ALTER!
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/utils/SystemIDResolver.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/utils/SystemIDResolver.java
@@ -41,6 +41,8 @@ import com.sun.org.apache.xml.internal.serializer.utils.URI.MalformedURIExceptio
  * used in com.sun.org.apache.xml.internal.serializer.
  *
  * @xsl.usage internal
+ *
+ * @LastModified: Jan 2022
  */
 public final class SystemIDResolver
 {

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/utils/SystemIDResolver.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/utils/SystemIDResolver.java
@@ -282,7 +282,7 @@ public final class SystemIDResolver
   public static String getAbsoluteURI(String urlString, String base)
           throws TransformerException
   {
-    if (base == null)
+    if (base == null || base.length() == 0)
       return getAbsoluteURI(urlString);
 
     String absoluteBase = getAbsoluteURI(base);


### PR DESCRIPTION
After 8270492
https://github.com/openjdk/jdk/commit/78b2c8419bc69436873e6fc9c542480949d140c5
has been pushed, we should adjust src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/utils/SystemIDResolver.java getAbsoluteURI to what has been done in 8270492 to src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/SystemIDResolver.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280373](https://bugs.openjdk.java.net/browse/JDK-8280373): Update Xalan serializer / SystemIDResolver to align with JDK-8270492


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**) ⚠️ Review applies to 666fdee0a71c0a4f8f1b5ff40758c2173d672f1e
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7155/head:pull/7155` \
`$ git checkout pull/7155`

Update a local copy of the PR: \
`$ git checkout pull/7155` \
`$ git pull https://git.openjdk.java.net/jdk pull/7155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7155`

View PR using the GUI difftool: \
`$ git pr show -t 7155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7155.diff">https://git.openjdk.java.net/jdk/pull/7155.diff</a>

</details>
