### PR TITLE
8280067: Incorrect code generated for unary - on char operand

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Items.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Items.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -669,7 +669,7 @@ public class Items {
             } else {
                 switch (targetcode) {
                 case INTcode:
-                    if (Code.truncate(typecode) == INTcode)
+                    if (Code.truncate(typecode) == INTcode && typecode != CHARcode)
                         return this;
                     else
                         return new ImmediateItem(

--- a/test/langtools/tools/javac/code/CharImmediateValue.java
+++ b/test/langtools/tools/javac/code/CharImmediateValue.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8280067
+ * @summary Verify constant/immediate char values are correctly enhanced to ints when used in unary
+ *          operators
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.code
+ *          jdk.compiler/com.sun.tools.javac.comp
+ *          jdk.compiler/com.sun.tools.javac.jvm
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.compiler/com.sun.tools.javac.tree
+ *          jdk.compiler/com.sun.tools.javac.util
+ *          jdk.jdeps/com.sun.tools.classfile
+ *          jdk.jdeps/com.sun.tools.javap
+ * @build toolbox.JarTask toolbox.JavacTask toolbox.JavapTask toolbox.ToolBox
+ * @compile CharImmediateValue.java
+ * @run main CharImmediateValue
+ */
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
+import com.sun.source.util.JavacTask;
+import com.sun.source.util.Plugin;
+import com.sun.source.util.TaskEvent;
+import com.sun.source.util.TaskListener;
+
+import com.sun.tools.classfile.Attribute;
+import com.sun.tools.classfile.ClassFile;
+import com.sun.tools.classfile.Code_attribute;
+import com.sun.tools.classfile.Instruction;
+import com.sun.tools.classfile.Opcode;
+
+import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
+import com.sun.tools.javac.tree.JCTree.JCIdent;
+import com.sun.tools.javac.tree.TreeScanner;
+
+import toolbox.JarTask;
+import toolbox.ToolBox;
+
+
+public class CharImmediateValue implements Plugin {
+    public static void main(String... args) throws Exception {
+        new CharImmediateValue().runSourceTest();
+        new CharImmediateValue().runReplacementTest();
+    }
+
+    void runSourceTest() throws Exception {
+        int param = 0;
+        Character var = (char) -(false ? (char) param : (char) 2);
+    }
+
+    void runReplacementTest() throws Exception {
+        ToolBox tb = new ToolBox();
+        Path pluginClasses = Path.of("plugin-classes");
+        tb.writeFile(pluginClasses.resolve("META-INF").resolve("services").resolve(Plugin.class.getName()),
+                CharImmediateValue.class.getName() + System.lineSeparator());
+        try (DirectoryStream<Path> ds = Files.newDirectoryStream(Path.of(ToolBox.testClasses))) {
+            for (Path p : ds) {
+                if (p.getFileName().toString().startsWith("CharImmediateValue") ||
+                    p.getFileName().toString().endsWith(".class")) {
+                    Files.copy(p, pluginClasses.resolve(p.getFileName()));
+                }
+            }
+        }
+
+        Path pluginJar = Path.of("plugin.jar");
+        new JarTask(tb, pluginJar)
+                .baseDir(pluginClasses)
+                .files(".")
+                .run();
+
+        Path src = Path.of("src");
+            tb.writeJavaFiles(src,
+                    """
+                    public class Test{
+                        private static char replace; //this will be replace with a constant "1" after constant folding is done
+                        public static String run() {
+                            char c = (char) - replace;
+                            if (c < 0) {
+                                throw new AssertionError("Incorrect value!");
+                            } else {
+                                return Integer.toString(c);
+                            }
+                        }
+                    }
+                    """);
+        Path classes = Files.createDirectories(Path.of("classes"));
+
+        new toolbox.JavacTask(tb)
+                .classpath(pluginJar)
+                .options("-XDaccessInternalAPI")
+                .outdir(classes)
+                .files(tb.findJavaFiles(src))
+                .run()
+                .writeAll();
+
+        URLClassLoader cl = new URLClassLoader(new URL[] {classes.toUri().toURL()});
+
+        String actual = (String) cl.loadClass("Test")
+                                   .getMethod("run")
+                                   .invoke(null);
+        String expected = "65535";
+        if (!Objects.equals(actual, expected)) {
+            throw new AssertionError("expected: " + expected + "; but got: " + actual);
+        }
+
+        Path testClass = classes.resolve("Test.class");
+        ClassFile cf = ClassFile.read(testClass);
+        Code_attribute codeAttr =
+                (Code_attribute) cf.methods[1].attributes.get(Attribute.Code);
+        boolean seenCast = false;
+        for (Instruction i : codeAttr.getInstructions()) {
+            if (i.getOpcode() == Opcode.I2C) {
+                seenCast = true;
+            }
+        }
+        if (!seenCast) {
+            throw new AssertionError("Missing cast!");
+        }
+    }
+
+    // Plugin impl...
+
+    @Override
+    public String getName() { return "CharImmediateValue"; }
+
+    @Override
+    public void init(JavacTask task, String... args) {
+        task.addTaskListener(new TaskListener() {
+            @Override
+            public void started(TaskEvent e) {
+                if (e.getKind() == TaskEvent.Kind.GENERATE) {
+                    convert((JCCompilationUnit) e.getCompilationUnit());
+                }
+            }
+        });
+    }
+
+    @Override
+    public boolean autoStart() {
+        return true;
+    }
+
+    private void convert(JCCompilationUnit toplevel) {
+        new TreeScanner() {
+            @Override
+            public void visitIdent(JCIdent tree) {
+                if (tree.name.contentEquals("replace")) {
+                    tree.type = tree.type.constType(1);
+                }
+                super.visitIdent(tree);
+            }
+        }.scan(toplevel);
+    }
+
+}


### PR DESCRIPTION
Consider the following snippet of code:
```
Character var = (char) -(false ? (char) param : (char) 2);
```

The `javac` frontend will not put a constant type on `false ? (char) param : (char) 2` (i.e. it will not constant-fold `(char) 2` to the whole conditional expression). This seems correct, as this is not (I think) a constant expression. But then, in the code generator:
-`Gen.visitUnary` is called, which requests to evaluate the argument, specifying the type should be `int`.
-when the argument (i.e. `false ? (char) param : (char) 2`) is evaluted, it produces an `ImmediateItem` with the constant, of type `char`, skipping the "then" expression, as that is never reached
-then the type of the `Item` is converted using `coerce` to the desired type (`int`). But in `ImmediateItem.coerce`, `char` is considered to be "equivalent" to `int`, and no conversion happens, and the same (`char`) `ImmediateItem` is returned
-`Gen.visitUnary` will push the constant  the stack and will produce the `ineg` instruction, but will (effectively) use the type of the parameter's `Item` for its result
-so the outermost `char` cast is a no-op, because the stack's top is considered to be `char` - but that is not correct, because `char` is unsigned, and the actual value at the top of the stack is `-2`.

This can then lead to various wrong behavior, including an exception from `Character.valueOf(char)`.

The proposal is to produce an `Item` with the correct type (i.e. `int`) in `ImmediateItem.coerce` for `char`-typed `ImmediateItem`s. `Item`s of type `byte`/`short` are kept as they are, even though it is not clear to me if simply producing an `int`-typed `Item` would not work equally well. But returning an `Item` with type `char` when `int` is requested seems wrong due to the unsigned property of `char`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280067](https://bugs.openjdk.java.net/browse/JDK-8280067): Incorrect code generated for unary - on char operand


### Reviewers
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**)
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7156/head:pull/7156` \
`$ git checkout pull/7156`

Update a local copy of the PR: \
`$ git checkout pull/7156` \
`$ git pull https://git.openjdk.java.net/jdk pull/7156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7156`

View PR using the GUI difftool: \
`$ git pr show -t 7156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7156.diff">https://git.openjdk.java.net/jdk/pull/7156.diff</a>

</details>
