### PR TITLE
JDK-8280274: Guard printing code of Compile::print_method in PRODUCT

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4832,7 +4832,7 @@ void Compile::print_method(CompilerPhaseType cpt, Node* n, int level) {
   C->print_method_impl(cpt, NOT_PRODUCT(ss.as_string() COMMA) level);
 }
 
-void Compile::print_method_impl(CompilerPhaseType cpt, NOT_PRODUCT(const char *name COMMA) int level) {
+void Compile::print_method_impl(CompilerPhaseType cpt, NOT_PRODUCT(const char* name COMMA) int level) {
   EventCompilerPhase event;
   if (event.should_commit()) {
     CompilerEvent::PhaseEvent::post(event, C->_latest_stage_start_counter, cpt, C->_compile_id, level);

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2357,7 +2357,7 @@ void Compile::inline_vector_reboxing_calls() {
       CallGenerator* cg = _vector_reboxing_late_inlines.pop();
       cg->do_late_inline();
       if (failing())  return;
-      print_method(PHASE_INLINE_VECTOR_REBOX, cg->call_node());
+      print_method(PHASE_INLINE_VECTOR_REBOX, cg->call_node(), 3);
     }
     _vector_reboxing_late_inlines.trunc_to(0);
   }
@@ -4815,10 +4815,11 @@ void Compile::sort_macro_nodes() {
 }
 
 void Compile::print_method(CompilerPhaseType cpt, int level) {
-  print_method_impl(cpt, CompilerPhaseTypeHelper::to_string(cpt), level);
+  print_method_impl(cpt, NOT_PRODUCT(CompilerPhaseTypeHelper::to_string(cpt) COMMA) level);
 }
 
 void Compile::print_method(CompilerPhaseType cpt, Node* n, int level) {
+#ifndef PRODUCT
   ResourceMark rm;
   stringStream ss;
   ss.print_raw(CompilerPhaseTypeHelper::to_string(cpt));
@@ -4827,10 +4828,11 @@ void Compile::print_method(CompilerPhaseType cpt, Node* n, int level) {
   } else {
     ss.print_raw(": NULL");
   }
-  C->print_method_impl(cpt, ss.as_string(), level);
+#endif
+  C->print_method_impl(cpt, NOT_PRODUCT(ss.as_string() COMMA) level);
 }
 
-void Compile::print_method_impl(CompilerPhaseType cpt, const char *name, int level) {
+void Compile::print_method_impl(CompilerPhaseType cpt, NOT_PRODUCT(const char *name COMMA) int level) {
   EventCompilerPhase event;
   if (event.should_commit()) {
     CompilerEvent::PhaseEvent::post(event, C->_latest_stage_start_counter, cpt, C->_compile_id, level);

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -656,8 +656,8 @@ class Compile : public Phase {
   bool should_print_igv(int level);
 
   void print_method(CompilerPhaseType cpt, int level);
-  void print_method(CompilerPhaseType cpt, Node* n, int level = 3);
-  void print_method_impl(CompilerPhaseType cpt, const char *name, int level);
+  void print_method(CompilerPhaseType cpt, Node* n, int level);
+  void print_method_impl(CompilerPhaseType cpt, NOT_PRODUCT(const char *name COMMA) int level);
 
 #ifndef PRODUCT
   void igv_print_method_to_file(const char* phase_name = "Debug", bool append = false);

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -657,7 +657,7 @@ class Compile : public Phase {
 
   void print_method(CompilerPhaseType cpt, int level);
   void print_method(CompilerPhaseType cpt, Node* n, int level);
-  void print_method_impl(CompilerPhaseType cpt, NOT_PRODUCT(const char *name COMMA) int level);
+  void print_method_impl(CompilerPhaseType cpt, NOT_PRODUCT(const char* name COMMA) int level);
 
 #ifndef PRODUCT
   void igv_print_method_to_file(const char* phase_name = "Debug", bool append = false);


### PR DESCRIPTION
In `Compile::print_method(CompilerPhaseType cpt, Node* n, int level)` the code 
``` 
ResourceMark rm; 
stringStream ss; 
ss.print_raw(CompilerPhaseTypeHelper::to_string(cpt)); 
if (n != NULL) { 
  ss.print(": %d %s ", n->_idx, NodeClassNames[n->Opcode()]); 
} else { 
  ss.print_raw(": NULL"); 
} 
``` 
should to be guarded by a `#ifndef PRODUCT` since the usage of the string is also guarded in `Compile::print_method_impl`

Tested on Tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280274](https://bugs.openjdk.java.net/browse/JDK-8280274): Guard printing code of Compile::print_method in PRODUCT


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**) ⚠️ Review applies to dce24e2aae4fe355952b34e5bc514891bcc9a986


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7158/head:pull/7158` \
`$ git checkout pull/7158`

Update a local copy of the PR: \
`$ git checkout pull/7158` \
`$ git pull https://git.openjdk.java.net/jdk pull/7158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7158`

View PR using the GUI difftool: \
`$ git pr show -t 7158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7158.diff">https://git.openjdk.java.net/jdk/pull/7158.diff</a>

</details>
