### PR TITLE
8280401: [sspi] gss_accept_sec_context leaves output_token uninitialized

### DIFF
--- a/src/java.security.jgss/windows/native/libsspi_bridge/sspi.cpp
+++ b/src/java.security.jgss/windows/native/libsspi_bridge/sspi.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1043,6 +1043,10 @@ gss_accept_sec_context(OM_uint32 *minor_status,
 {
     PP(">>>> Calling UNIMPLEMENTED gss_accept_sec_context...");
     PP("gss_accept_sec_context is not supported in this initiator-only library");
+    if (output_token) {
+        output_token->length = 0;
+        output_token->value = NULL;
+    }
     return GSS_S_FAILURE;
 }
 


### PR DESCRIPTION
Set `output_token` to empty. It is always accessed (even for a `GSS_S_FAILURE`) at https://github.com/openjdk/jdk/blob/cfa3f7493149170f2b23a516bc95110dab43fd06/src/java.security.jgss/share/native/libj2gss/GSSLibStub.c#L1160.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280401](https://bugs.openjdk.java.net/browse/JDK-8280401): [sspi] gss_accept_sec_context leaves output_token uninitialized


### Reviewers
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7163/head:pull/7163` \
`$ git checkout pull/7163`

Update a local copy of the PR: \
`$ git checkout pull/7163` \
`$ git pull https://git.openjdk.java.net/jdk pull/7163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7163`

View PR using the GUI difftool: \
`$ git pr show -t 7163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7163.diff">https://git.openjdk.java.net/jdk/pull/7163.diff</a>

</details>
