### PR TITLE
8280970: Cleanup dead code in java.security.Provider

### DIFF
--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -1116,11 +1116,6 @@ public abstract class Provider extends Properties {
         return new String[] {type, alg};
     }
 
-    // utility method for getting a String with service type and algorithm
-    private static String getKey(Service s) {
-        return s.getType() + "." + s.getAlgorithm();
-    }
-
     private static final String ALIAS_PREFIX = "Alg.Alias.";
     private static final String ALIAS_PREFIX_LOWER = "alg.alias.";
     private static final int ALIAS_LENGTH = ALIAS_PREFIX.length();
@@ -1544,20 +1539,11 @@ public abstract class Provider extends Properties {
         final String name;
         final boolean supportsParameter;
         final String constructorParameterClassName;
-        private volatile Class<?> constructorParameterClass;
 
         EngineDescription(String name, boolean sp, String paramName) {
             this.name = name;
             this.supportsParameter = sp;
             this.constructorParameterClassName = paramName;
-        }
-        Class<?> getConstructorParameterClass() throws ClassNotFoundException {
-            Class<?> clazz = constructorParameterClass;
-            if (clazz == null) {
-                clazz = Class.forName(constructorParameterClassName);
-                constructorParameterClass = clazz;
-            }
-            return clazz;
         }
     }
 


### PR DESCRIPTION
Method `Provider.getKey` was added in [JDK-8276660](https://bugs.openjdk.java.net/browse/JDK-8276660). It was unused since introduction.
Method `EngineDescription.getConstructorParameterClass()` and field `EngineDescription.constructorParameterClass` is unused since [JDK-7191662](https://bugs.openjdk.java.net/browse/JDK-7191662)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280970](https://bugs.openjdk.java.net/browse/JDK-8280970): Cleanup dead code in java.security.Provider


### Reviewers
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7164/head:pull/7164` \
`$ git checkout pull/7164`

Update a local copy of the PR: \
`$ git checkout pull/7164` \
`$ git pull https://git.openjdk.java.net/jdk pull/7164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7164`

View PR using the GUI difftool: \
`$ git pr show -t 7164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7164.diff">https://git.openjdk.java.net/jdk/pull/7164.diff</a>

</details>
