### PR TITLE
JDK-8279397: Update --release 18 symbol information for JDK 18 build 32

### DIFF
--- a/make/data/symbols/java.base-I.sym.txt
+++ b/make/data/symbols/java.base-I.sym.txt
@@ -393,6 +393,16 @@ header extends java/util/AbstractSet implements java/util/Set,java/lang/Cloneabl
 innerclass innerClass java/io/ObjectInputStream$GetField outerClass java/io/ObjectInputStream innerClassName GetField flags 409
 innerclass innerClass java/util/Map$Entry outerClass java/util/Map innerClassName Entry flags 609
 
+class name java/util/Hashtable
+header extends java/util/Dictionary implements java/util/Map,java/lang/Cloneable,java/io/Serializable flags 21 signature <K:Ljava/lang/Object;V:Ljava/lang/Object;>Ljava/util/Dictionary<TK;TV;>;Ljava/util/Map<TK;TV;>;Ljava/lang/Cloneable;Ljava/io/Serializable;
+innerclass innerClass java/util/Map$Entry outerClass java/util/Map innerClassName Entry flags 609
+innerclass innerClass java/io/ObjectInputStream$GetField outerClass java/io/ObjectInputStream innerClassName GetField flags 409
+
+class name java/util/IdentityHashMap
+header extends java/util/AbstractMap implements java/util/Map,java/io/Serializable,java/lang/Cloneable flags 21 signature <K:Ljava/lang/Object;V:Ljava/lang/Object;>Ljava/util/AbstractMap<TK;TV;>;Ljava/util/Map<TK;TV;>;Ljava/io/Serializable;Ljava/lang/Cloneable;
+innerclass innerClass java/util/Map$Entry outerClass java/util/Map innerClassName Entry flags 609
+innerclass innerClass java/io/ObjectInputStream$GetField outerClass java/io/ObjectInputStream innerClassName GetField flags 409
+
 class name java/util/Locale$IsoCountryCode
 header extends java/lang/Enum nestHost java/util/Locale sealed true flags 4421 signature Ljava/lang/Enum<Ljava/util/Locale$IsoCountryCode;>;
 innerclass innerClass java/util/Locale$IsoCountryCode outerClass java/util/Locale innerClassName IsoCountryCode flags 4409


### PR DESCRIPTION
Update of JDK 18 symbol information for build 32.

@lahodaj , can you take a look at the diff? Given the code changes for JDK-8270416: "Enhance construction of Identity maps" (https://github.com/openjdk/jdk/commit/5832a3440489d0967dc3b0542c1ace51eed292d6), I didn't see why the symbol update was triggered.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279397](https://bugs.openjdk.java.net/browse/JDK-8279397): Update --release 18 symbol information for JDK 18 build 32


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7165/head:pull/7165` \
`$ git checkout pull/7165`

Update a local copy of the PR: \
`$ git checkout pull/7165` \
`$ git pull https://git.openjdk.java.net/jdk pull/7165/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7165`

View PR using the GUI difftool: \
`$ git pr show -t 7165`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7165.diff">https://git.openjdk.java.net/jdk/pull/7165.diff</a>

</details>
