### PR TITLE
JDK-8280402: Add new convenience forms to HtmlTree

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -27,6 +27,7 @@ package jdk.javadoc.internal.doclets.formats.html;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -263,7 +264,7 @@ public class HtmlDocletWriter {
         do {
             int match = docrootMatcher.start();
             // append htmlstr up to start of next {@docroot}
-            buf.append(htmlstr.substring(prevEnd, match));
+            buf.append(htmlstr, prevEnd, match);
             prevEnd = docrootMatcher.end();
             if (options.docrootParent().length() > 0 && htmlstr.startsWith("/..", prevEnd)) {
                 // Insert the absolute link if {@docRoot} is followed by "/..".
@@ -549,8 +550,7 @@ public class HtmlDocletWriter {
     protected Content getNavLinkMainTree(String label) {
         Content mainTreeContent = links.createLink(pathToRoot.resolve(DocPaths.OVERVIEW_TREE),
                 Text.of(label));
-        Content li = HtmlTree.LI(mainTreeContent);
-        return li;
+        return HtmlTree.LI(mainTreeContent);
     }
 
     /**
@@ -623,7 +623,7 @@ public class HtmlDocletWriter {
         } else {
             flags = EnumSet.noneOf(ElementFlag.class);
         }
-        DocLink targetLink = null;
+        DocLink targetLink;
         if (included || packageElement == null) {
             targetLink = new DocLink(pathString(packageElement, DocPaths.PACKAGE_SUMMARY));
         } else {
@@ -1531,18 +1531,11 @@ public class HtmlDocletWriter {
                         return false;
                     }
                     sb.append("=");
-                    String quote;
-                    switch (node.getValueKind()) {
-                        case DOUBLE:
-                            quote = "\"";
-                            break;
-                        case SINGLE:
-                            quote = "'";
-                            break;
-                        default:
-                            quote = "";
-                            break;
-                    }
+                    String quote = switch (node.getValueKind()) {
+                        case DOUBLE -> "\"";
+                        case SINGLE -> "'";
+                        default -> "";
+                    };
                     sb.append(quote);
                     result.add(sb);
                     Content docRootContent = new ContentBuilder();
@@ -1794,9 +1787,9 @@ public class HtmlDocletWriter {
         if (detail.isEmpty() || detail.get().isEmpty()) {
             return HtmlTree.SPAN(HtmlStyle.invalidTag, Text.of(summary));
         }
-        return new HtmlTree(TagName.DETAILS).addStyle(HtmlStyle.invalidTag)
-                .add(new HtmlTree(TagName.SUMMARY).add(Text.of(summary)))
-                .add(new HtmlTree(TagName.PRE).add(detail.get()));
+        return HtmlTree.DETAILS(HtmlStyle.invalidTag)
+                .add(HtmlTree.SUMMARY(Text.of(summary)))
+                .add(HtmlTree.PRE(detail.get()));
     }
 
     /**
@@ -2226,17 +2219,13 @@ public class HtmlDocletWriter {
         for (Element e: chain) {
             String name;
             switch (e.getKind()) {
-                case MODULE:
-                case PACKAGE:
+                case MODULE, PACKAGE -> {
                     name = ((QualifiedNameable) e).getQualifiedName().toString();
                     if (name.length() == 0) {
                         name = "<unnamed>";
                     }
-                    break;
-
-                default:
-                    name = e.getSimpleName().toString();
-                    break;
+                }
+                default -> name = e.getSimpleName().toString();
             }
 
             if (sb.length() == 0) {
@@ -2445,8 +2434,7 @@ public class HtmlDocletWriter {
     private Content withPreviewFeatures(String key, String className, String featureName, List<String> features) {
         String[] sep = new String[] {""};
         ContentBuilder featureCodes = new ContentBuilder();
-        features.stream()
-                .forEach(c -> {
+        features.forEach(c -> {
                     featureCodes.add(sep[0]);
                     featureCodes.add(HtmlTree.CODE(new ContentBuilder().add(c)));
                     sep[0] = ", ";
@@ -2461,7 +2449,7 @@ public class HtmlDocletWriter {
         String[] sep = new String[] {""};
         ContentBuilder links = new ContentBuilder();
         elements.stream()
-                .sorted((te1, te2) -> te1.getSimpleName().toString().compareTo(te2.getSimpleName().toString()))
+                .sorted(Comparator.comparing(te -> te.getSimpleName().toString()))
                 .distinct()
                 .map(te -> getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.CLASS, te)
                         .label(HtmlTree.CODE(Text.of(te.getSimpleName()))).skipPreview(true)))

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlTree.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlTree.java
@@ -229,8 +229,8 @@ public class HtmlTree extends Content {
      * Adds each of a list of items, using a map function to create the content for each item.
      *
      * @param list   the list
-	 * @param mapper the map function to generate the content for each item
-	 *
+     * @param mapper the map function to generate the content for each item
+     *
      * @return this object
      */
     @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlTree.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlTree.java
@@ -226,16 +226,16 @@ public class HtmlTree extends Content {
     }
 
     /**
-     * Adds each of a list of items, using a map function to create the content for each item.
+     * Adds each of a collection of items, using a map function to create the content for each item.
      *
-     * @param list   the list
+     * @param items  the items
      * @param mapper the map function to generate the content for each item
      *
      * @return this object
      */
     @Override
-    public <T> HtmlTree addAll(Collection<T> list, Function<T, Content> mapper) {
-        list.forEach(item -> add(mapper.apply(item)));
+    public <T> HtmlTree addAll(Collection<T> items, Function<T, Content> mapper) {
+        items.forEach(item -> add(mapper.apply(item)));
         return this;
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlTree.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,14 +27,17 @@ package jdk.javadoc.internal.doclets.formats.html.markup;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlAttr.Role;
 import jdk.javadoc.internal.doclets.toolkit.Content;
@@ -222,6 +225,20 @@ public class HtmlTree extends Content {
         return this;
     }
 
+    /**
+     * Adds each of a list of items, using a map function to create the content for each item.
+     *
+     * @param list   the list
+	 * @param mapper the map function to generate the content for each item
+	 *
+     * @return this object
+     */
+    @Override
+    public <T> HtmlTree addAll(Collection<T> list, Function<T, Content> mapper) {
+        list.forEach(item -> add(mapper.apply(item)));
+        return this;
+    }
+
     @Override
     public int charCount() {
         int n = 0;
@@ -301,6 +318,7 @@ public class HtmlTree extends Content {
 
     /**
      * Creates an HTML {@code A} element.
+     * The {@code ref} argument will be URL-encoded for use as the attribute value.
      *
      * @param ref the value for the {@code href} attribute}
      * @param body the content for element
@@ -309,6 +327,22 @@ public class HtmlTree extends Content {
     public static HtmlTree A(String ref, Content body) {
         return new HtmlTree(TagName.A)
                 .put(HtmlAttr.HREF, encodeURL(ref))
+                .add(body);
+    }
+
+    /**
+     * Creates an HTML {@code A} element.
+     * The {@code ref} argument is assumed to be already suitably encoded,
+     * and will <i>not</i> be additionally URL-encoded, but will be
+     * {@link URI#toASCIIString() converted} to ASCII for use as the attribute value.
+     *
+     * @param ref the value for the {@code href} attribute}
+     * @param body the content for element
+     * @return the element
+     */
+    public static HtmlTree A(URI ref, Content body) {
+        return new HtmlTree(TagName.A)
+                .put(HtmlAttr.HREF, ref.toASCIIString())
                 .add(body);
     }
 
@@ -343,6 +377,16 @@ public class HtmlTree extends Content {
     public static HtmlTree DD(Content body) {
         return new HtmlTree(TagName.DD)
                 .add(body);
+    }
+
+    /**
+     * Creates an HTML {@code DETAILS} element.
+     *
+     * @return the element
+     */
+    public static HtmlTree DETAILS(HtmlStyle style) {
+        return new HtmlTree(TagName.DETAILS)
+                .setStyle(style);
     }
 
     /**
@@ -495,12 +539,10 @@ public class HtmlTree extends Content {
     }
 
     private static TagName checkHeading(TagName headingTag) {
-        switch (headingTag) {
-            case H1: case H2: case H3: case H4: case H5: case H6:
-                return headingTag;
-            default:
-                throw new IllegalArgumentException(headingTag.toString());
-        }
+        return switch (headingTag) {
+            case H1, H2, H3, H4, H5, H6 -> headingTag;
+            default -> throw new IllegalArgumentException(headingTag.toString());
+        };
     }
 
     /**
@@ -683,6 +725,16 @@ public class HtmlTree extends Content {
     }
 
     /**
+     * Creates an HTML {@code PRE} element with some content.
+     *
+     * @param body  the content
+     * @return the element
+     */
+    public static HtmlTree PRE(Content body) {
+        return new HtmlTree(TagName.PRE).add(body);
+    }
+
+    /**
      * Creates an HTML {@code SCRIPT} element with some script content.
      * The type of the script is set to {@code text/javascript}.
      *
@@ -783,6 +835,17 @@ public class HtmlTree extends Content {
     }
 
     /**
+     * Creates an HTML {@code SUMMARY} element with the given content.
+     *
+     * @param body the content
+     * @return the element
+     */
+    public static HtmlTree SUMMARY(Content body) {
+        return new HtmlTree(TagName.SUMMARY)
+                .add(body);
+    }
+
+    /**
      * Creates an HTML {@code SUP} element with the given content.
      *
      * @param body  the content
@@ -863,6 +926,21 @@ public class HtmlTree extends Content {
         return htmlTree;
     }
 
+    /**
+     * Creates an HTML {@code UL} element with the given style and content generated
+     * from a collection of items..
+     *
+     * @param style the style
+     * @param items the items to be added to the list
+     * @param mapper a mapper to create the content for each item
+     * @return the element
+     */
+    public static <T> HtmlTree UL(HtmlStyle style, Collection<T> items, Function<T,Content> mapper) {
+        return new HtmlTree(TagName.UL)
+                .setStyle(style)
+                .addAll(items, mapper);
+    }
+
     @Override
     public boolean isEmpty() {
         return (!hasContent() && !hasAttrs());
@@ -905,30 +983,29 @@ public class HtmlTree extends Content {
      */
     @Override
     public boolean isValid() {
-        switch (tagName) {
-            case A:
-                return (hasAttr(HtmlAttr.ID) || (hasAttr(HtmlAttr.HREF) && hasContent()));
-            case BR:
-                return (!hasContent() && (!hasAttrs() || hasAttr(HtmlAttr.CLEAR)));
-            case HR:
-            case INPUT:
-                return (!hasContent());
-            case IMG:
-                return (hasAttr(HtmlAttr.SRC) && hasAttr(HtmlAttr.ALT) && !hasContent());
-            case LINK:
-                return (hasAttr(HtmlAttr.HREF) && !hasContent());
-            case META:
-                return (hasAttr(HtmlAttr.CONTENT) && !hasContent());
-            case SCRIPT:
-                return ((hasAttr(HtmlAttr.TYPE) && hasAttr(HtmlAttr.SRC) && !hasContent()) ||
-                        (hasAttr(HtmlAttr.TYPE) && hasContent()));
-            case SPAN:
-                return (hasAttr(HtmlAttr.ID) || hasContent());
-            case WBR:
-                return (!hasContent());
-            default :
-                return hasContent();
-        }
+        return switch (tagName) {
+            case A ->
+                    hasAttr(HtmlAttr.ID) || (hasAttr(HtmlAttr.HREF) && hasContent());
+            case BR ->
+                    !hasContent() && (!hasAttrs() || hasAttr(HtmlAttr.CLEAR));
+            case HR, INPUT ->
+                    !hasContent();
+            case IMG ->
+                    hasAttr(HtmlAttr.SRC) && hasAttr(HtmlAttr.ALT) && !hasContent();
+            case LINK ->
+                    hasAttr(HtmlAttr.HREF) && !hasContent();
+            case META ->
+                    hasAttr(HtmlAttr.CONTENT) && !hasContent();
+            case SCRIPT ->
+                    (hasAttr(HtmlAttr.TYPE) && hasAttr(HtmlAttr.SRC) && !hasContent())
+                            || (hasAttr(HtmlAttr.TYPE) && hasContent());
+            case SPAN ->
+                    hasAttr(HtmlAttr.ID) || hasContent();
+            case WBR ->
+                    !hasContent();
+            default ->
+                    hasContent();
+        };
     }
 
     /**
@@ -939,14 +1016,10 @@ public class HtmlTree extends Content {
      * @see <a href="https://www.w3.org/TR/html51/dom.html#kinds-of-content-phrasing-content">Phrasing Content</a>
      */
     public boolean isInline() {
-        switch (tagName) {
-            case A: case BUTTON: case BR: case CODE: case EM: case I: case IMG:
-            case LABEL: case SMALL: case SPAN: case STRONG: case SUB: case SUP:
-            case WBR:
-                return true;
-            default:
-                return false;
-        }
+        return switch (tagName) {
+            case A, BUTTON, BR, CODE, EM, I, IMG, LABEL, SMALL, SPAN, STRONG, SUB, SUP, WBR -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -957,12 +1030,10 @@ public class HtmlTree extends Content {
      * @see <a href="https://www.w3.org/TR/html51/syntax.html#void-elements">Void Elements</a>
      */
     public boolean isVoid() {
-        switch (tagName) {
-            case BR: case HR: case IMG: case INPUT: case LINK: case META: case WBR:
-                return true;
-            default:
-                return false;
-        }
+        return switch (tagName) {
+            case BR, HR, IMG, INPUT, LINK, META, WBR -> true;
+            default -> false;
+        };
     }
 
     @Override

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/Content.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/Content.java
@@ -28,6 +28,8 @@ package jdk.javadoc.internal.doclets.toolkit;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.util.Collection;
+import java.util.function.Function;
 
 /**
  * A class to create content for javadoc output pages.
@@ -86,6 +88,23 @@ public abstract class Content {
      * @throws IllegalArgumentException      if the content is not suitable to be added
      */
     public Content add(CharSequence stringContent) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Adds content to the existing content, generated from a collection of items
+     * This is an optional operation.
+     *
+     * @param items  the items to be added
+     * @param mapper the function to create content for each item
+     *
+     * @return this object
+     * @throws UnsupportedOperationException if this operation is not supported by
+     *                                       a particular implementation
+     * @throws IllegalArgumentException      if the content is not suitable to be added
+     * @implSpec This implementation delegates to {@link #add(Content)}.
+     */
+    public <T> Content addAll(Collection<T> items, Function<T, Content> mapper) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/Content.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/Content.java
@@ -95,6 +95,8 @@ public abstract class Content {
      * Adds content to the existing content, generated from a collection of items
      * This is an optional operation.
      *
+     * @implSpec This implementation delegates to {@link #add(Content)}.
+     *
      * @param items  the items to be added
      * @param mapper the function to create content for each item
      *
@@ -102,10 +104,10 @@ public abstract class Content {
      * @throws UnsupportedOperationException if this operation is not supported by
      *                                       a particular implementation
      * @throws IllegalArgumentException      if the content is not suitable to be added
-     * @implSpec This implementation delegates to {@link #add(Content)}.
      */
     public <T> Content addAll(Collection<T> items, Function<T, Content> mapper) {
-        throw new UnsupportedOperationException();
+        items.forEach(item -> add(mapper.apply(item)));
+        return this;
     }
 
     /**


### PR DESCRIPTION
Please review a simple `noreg-clean` update to `HtmlTree` and a couple of friends.  The updates are to continue the trend towards the use of Facebook tory methods for `HtmlTree` objects, and to leverage generic methods and lambdas to generate composite content. The cleanup is mostly extracted from some parallel work for a separate PR.  Some of the more general cleanup was suggested by an IDE.

All javadoc tests pass locally; I have a job in  progress to validate the fix on all platforms, although there is no reason to believe there might be any issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280402](https://bugs.openjdk.java.net/browse/JDK-8280402): Add new convenience forms to HtmlTree


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**) ⚠️ Review applies to 7ee89e0e4e17caf4c5536517130bcb696aa60497


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7166/head:pull/7166` \
`$ git checkout pull/7166`

Update a local copy of the PR: \
`$ git checkout pull/7166` \
`$ git pull https://git.openjdk.java.net/jdk pull/7166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7166`

View PR using the GUI difftool: \
`$ git pr show -t 7166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7166.diff">https://git.openjdk.java.net/jdk/pull/7166.diff</a>

</details>
