### PR TITLE
8277976: Break up SEQUENCE in X509Certificate::getSubjectAlternativeNames and X509Certificate::getIssuerAlternativeNames in otherName

### DIFF
--- a/src/java.base/share/classes/java/security/cert/X509Certificate.java
+++ b/src/java.base/share/classes/java/security/cert/X509Certificate.java
@@ -591,11 +591,12 @@ implements X509Extension {
      * X.400 names or EDI party names. They are returned as byte arrays
      * containing the ASN.1 DER encoded form of the name. otherNames are also
      * returned as byte arrays containing the ASN.1 DER encoded form of the
-     * name. There may be a third entry in the list for their {@code type-id}
-     * in string form, and a fourth entry for their {@code value} as either
-     * a string (if the value is a valid supported character string)
-     * or (otherwise) a byte array containing the ASN.1 DER encoded from of
-     * the value without the context-specific constructed tag with number 0.
+     * name. A third entry may also be present in the list containing the
+     * {@code type-id} of the otherName in string form, and a fourth entry
+     * containing its {@code value} as either a string (if the value is
+     * a valid supported character string) or a byte array containing the
+     * ASN.1 DER encoded form of the value without the context-specific
+     * constructed tag with number 0.
      * <p>
      * Note that the {@code Collection} returned may contain more
      * than one name of the same type. Also, note that the returned
@@ -609,7 +610,7 @@ implements X509Extension {
      * should override this method with a correct implementation.
      *
      * @implNote The JDK SUN provider supports the third and fourth
-     * otherName elements.
+     * otherName entries.
      *
      * @return an immutable {@code Collection} of subject alternative
      * names (or {@code null})

--- a/src/java.base/share/classes/java/security/cert/X509Certificate.java
+++ b/src/java.base/share/classes/java/security/cert/X509Certificate.java
@@ -587,7 +587,7 @@ implements X509Extension {
      * returned as {@code String}s represented as a series of nonnegative
      * integers separated by periods. Directory names (distinguished names)
      * are returned in <a href="http://www.ietf.org/rfc/rfc2253.txt">
-     * RFC 2253</a> string format. Othernames are returned as a byte array
+     * RFC 2253</a> string format. otherNames are returned as a byte array
      * containing the ASN.1 DER encoded form of the name, with a
      * third entry in the list containing its {@code type-id} in string
      * format, and a fourth entry containing the ASN.1 DER encoding of

--- a/src/java.base/share/classes/java/security/cert/X509Certificate.java
+++ b/src/java.base/share/classes/java/security/cert/X509Certificate.java
@@ -575,7 +575,7 @@ implements X509Extension {
      * {@code List} whose first entry is an {@code Integer}
      * (the name type, 0-8) and whose second entry is a {@code String}
      * or a byte array (the name, in string or ASN.1 DER encoded form,
-     * respectively). More entries can exist depending on the name type.
+     * respectively). More entries may exist depending on the name type.
      * <p>
      * <a href="http://www.ietf.org/rfc/rfc822.txt">RFC 822</a>, DNS, and URI
      * names are returned as {@code String}s,
@@ -640,7 +640,7 @@ implements X509Extension {
      * {@code List} whose first entry is an {@code Integer}
      * (the name type, 0-8) and whose second entry is a {@code String}
      * or a byte array (the name, in string or ASN.1 DER encoded form,
-     * respectively).  More entries can exist depending on the name type.
+     * respectively).  More entries may exist depending on the name type.
      * For more details about the formats used for each
      * name type, see the {@code getSubjectAlternativeNames} method.
      * <p>

--- a/src/java.base/share/classes/java/security/cert/X509Certificate.java
+++ b/src/java.base/share/classes/java/security/cert/X509Certificate.java
@@ -588,8 +588,8 @@ implements X509Extension {
      * integers separated by periods. Directory names (distinguished names)
      * are returned in <a href="http://www.ietf.org/rfc/rfc2253.txt">
      * RFC 2253</a> string format. otherNames are returned as a byte array
-     * containing the ASN.1 DER encoded form of the name, with a
-     * third entry in the list containing its {@code type-id} in string
+     * containing the ASN.1 DER encoded form of the name, and may also return
+     * a third entry in the list containing its {@code type-id} in string
      * format, and a fourth entry containing the ASN.1 DER encoding of
      * its {@code value} without the context-specific constructed tag
      * with number 0. No standard string format is
@@ -607,6 +607,9 @@ implements X509Extension {
      * service providers, this method is not {@code abstract}
      * and it provides a default implementation. Subclasses
      * should override this method with a correct implementation.
+     *
+     * @implNote The JDK SUN provider supports the third and fourth
+     * otherName elements.
      *
      * @return an immutable {@code Collection} of subject alternative
      * names (or {@code null})

--- a/src/java.base/share/classes/java/security/cert/X509Certificate.java
+++ b/src/java.base/share/classes/java/security/cert/X509Certificate.java
@@ -590,9 +590,11 @@ implements X509Extension {
      * RFC 2253</a> string format. otherNames are returned as a byte array
      * containing the ASN.1 DER encoded form of the name, and may also return
      * a third entry in the list containing its {@code type-id} in string
-     * format, and a fourth entry as a byte array containing the ASN.1 DER
-     * encoding of its {@code value} without the context-specific constructed
-     * tag with number 0. No standard string format is
+     * format, and a fourth entry as either a string (if {@code value} inside
+     * is a valid UTF8String, PrintableString, T61String, IA5String,
+     * UniversalString, BMPString, or GeneralString) or a byte array containing
+     * the ASN.1 DER encoding of {@code value} without the context-specific
+     * constructed tag with number 0 (otherwise). No standard string format is
      * defined for otherNames, X.400 names, EDI party names, or any
      * other type of names. They are returned as byte arrays
      * containing the ASN.1 DER encoded form of the name.

--- a/src/java.base/share/classes/java/security/cert/X509Certificate.java
+++ b/src/java.base/share/classes/java/security/cert/X509Certificate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -562,6 +562,10 @@ implements X509Extension {
      *      uniformResourceIdentifier       [6]     IA5String,
      *      iPAddress                       [7]     OCTET STRING,
      *      registeredID                    [8]     OBJECT IDENTIFIER}
+     *
+     * OtherName ::= SEQUENCE {
+     *      type-id    OBJECT IDENTIFIER,
+     *      value      [0] EXPLICIT ANY DEFINED BY type-id }
      * </pre>
      * <p>
      * If this certificate does not contain a {@code SubjectAltName}
@@ -571,7 +575,7 @@ implements X509Extension {
      * {@code List} whose first entry is an {@code Integer}
      * (the name type, 0-8) and whose second entry is a {@code String}
      * or a byte array (the name, in string or ASN.1 DER encoded form,
-     * respectively).
+     * respectively). More entries can exist depending on the name type.
      * <p>
      * <a href="http://www.ietf.org/rfc/rfc822.txt">RFC 822</a>, DNS, and URI
      * names are returned as {@code String}s,
@@ -581,9 +585,14 @@ implements X509Extension {
      * in the form "a1:a2:...:a8", where a1-a8 are hexadecimal values
      * representing the eight 16-bit pieces of the address. OID names are
      * returned as {@code String}s represented as a series of nonnegative
-     * integers separated by periods. And directory names (distinguished names)
+     * integers separated by periods. Directory names (distinguished names)
      * are returned in <a href="http://www.ietf.org/rfc/rfc2253.txt">
-     * RFC 2253</a> string format. No standard string format is
+     * RFC 2253</a> string format. Othernames are returned as a byte array
+     * containing the ASN.1 DER encoded form of the name, with a
+     * third entry in the list containing its {@code type-id} in string
+     * format, and a fourth entry containing the ASN.1 DER encoding of
+     * its {@code value} without the context-specific constructed tag
+     * with number 0. No standard string format is
      * defined for otherNames, X.400 names, EDI party names, or any
      * other type of names. They are returned as byte arrays
      * containing the ASN.1 DER encoded form of the name.
@@ -627,7 +636,8 @@ implements X509Extension {
      * {@code List} whose first entry is an {@code Integer}
      * (the name type, 0-8) and whose second entry is a {@code String}
      * or a byte array (the name, in string or ASN.1 DER encoded form,
-     * respectively). For more details about the formats used for each
+     * respectively).  More entries can exist depending on the name type.
+     * For more details about the formats used for each
      * name type, see the {@code getSubjectAlternativeNames} method.
      * <p>
      * Note that the {@code Collection} returned may contain more

--- a/src/java.base/share/classes/java/security/cert/X509Certificate.java
+++ b/src/java.base/share/classes/java/security/cert/X509Certificate.java
@@ -590,9 +590,9 @@ implements X509Extension {
      * RFC 2253</a> string format. otherNames are returned as a byte array
      * containing the ASN.1 DER encoded form of the name, and may also return
      * a third entry in the list containing its {@code type-id} in string
-     * format, and a fourth entry containing the ASN.1 DER encoding of
-     * its {@code value} without the context-specific constructed tag
-     * with number 0. No standard string format is
+     * format, and a fourth entry as a byte array containing the ASN.1 DER
+     * encoding of its {@code value} without the context-specific constructed
+     * tag with number 0. No standard string format is
      * defined for otherNames, X.400 names, EDI party names, or any
      * other type of names. They are returned as byte arrays
      * containing the ASN.1 DER encoded form of the name.

--- a/src/java.base/share/classes/java/security/cert/X509Certificate.java
+++ b/src/java.base/share/classes/java/security/cert/X509Certificate.java
@@ -587,17 +587,15 @@ implements X509Extension {
      * returned as {@code String}s represented as a series of nonnegative
      * integers separated by periods. Directory names (distinguished names)
      * are returned in <a href="http://www.ietf.org/rfc/rfc2253.txt">
-     * RFC 2253</a> string format. otherNames are returned as a byte array
-     * containing the ASN.1 DER encoded form of the name, and may also return
-     * a third entry in the list containing its {@code type-id} in string
-     * format, and a fourth entry as either a string (if {@code value} inside
-     * is a valid UTF8String, PrintableString, T61String, IA5String,
-     * UniversalString, BMPString, or GeneralString) or a byte array containing
-     * the ASN.1 DER encoding of {@code value} without the context-specific
-     * constructed tag with number 0 (otherwise). No standard string format is
-     * defined for otherNames, X.400 names, EDI party names, or any
-     * other type of names. They are returned as byte arrays
-     * containing the ASN.1 DER encoded form of the name.
+     * RFC 2253</a> string format. No standard string format is defined for
+     * X.400 names or EDI party names. They are returned as byte arrays
+     * containing the ASN.1 DER encoded form of the name. otherNames are also
+     * returned as byte arrays containing the ASN.1 DER encoded form of the
+     * name. There may be a third entry in the list for their {@code type-id}
+     * in string form, and a fourth entry for their {@code value} as either
+     * a string (if the value is a valid supported character string)
+     * or (otherwise) a byte array containing the ASN.1 DER encoded from of
+     * the value without the context-specific constructed tag with number 0.
      * <p>
      * Note that the {@code Collection} returned may contain more
      * than one name of the same type. Also, note that the returned

--- a/src/java.base/share/classes/sun/security/x509/OtherName.java
+++ b/src/java.base/share/classes/sun/security/x509/OtherName.java
@@ -90,7 +90,7 @@ public class OtherName implements GeneralNameInterface {
 
         oid = in.getOID();
         DerValue derValue1 = in.getDerValue();
-        if (!derValue1.isContextSpecific((byte)0)) {
+        if (!derValue1.isContextSpecific((byte)0) || !derValue1.isConstructed()) {
             throw new IOException("value is not [0]");
         }
         nameValue = derValue1.data.toByteArray();

--- a/src/java.base/share/classes/sun/security/x509/OtherName.java
+++ b/src/java.base/share/classes/sun/security/x509/OtherName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,10 +48,10 @@ import sun.security.util.*;
  */
 public class OtherName implements GeneralNameInterface {
 
-    private String name;
-    private ObjectIdentifier oid;
-    private byte[] nameValue = null;
-    private GeneralNameInterface gni = null;
+    private final ObjectIdentifier oid;
+    private final String name;
+    private final byte[] nameValue; // value inside [0]
+    private final GeneralNameInterface gni;
 
     private static final byte TAG_VALUE = 0;
 
@@ -89,8 +89,11 @@ public class OtherName implements GeneralNameInterface {
         DerInputStream in = derValue.toDerInputStream();
 
         oid = in.getOID();
-        DerValue val = in.getDerValue();
-        nameValue = val.toByteArray();
+        DerValue derValue1 = in.getDerValue();
+        if (!derValue1.isContextSpecific((byte)0)) {
+            throw new IOException("value is not [0]");
+        }
+        nameValue = derValue1.data.toByteArray();
         gni = getGNI(oid, nameValue);
         if (gni != null) {
             name = gni.toString();
@@ -125,12 +128,13 @@ public class OtherName implements GeneralNameInterface {
                 return null;
             }
             Class<?>[] params = { Object.class };
-            Constructor<?> cons = extClass.getConstructor(params);
-
-            Object[] passed = new Object[] { nameValue };
-            GeneralNameInterface gni =
-                       (GeneralNameInterface)cons.newInstance(passed);
-            return gni;
+            Constructor<?> cons;
+            try {
+                cons = extClass.getConstructor(Object.class);
+            } catch (NoSuchMethodException e) {
+                cons = extClass.getConstructor(byte[].class);
+            }
+            return (GeneralNameInterface)cons.newInstance(nameValue);
         } catch (Exception e) {
             throw new IOException("Instantiation error: " + e, e);
         }

--- a/src/java.base/share/classes/sun/security/x509/OtherName.java
+++ b/src/java.base/share/classes/sun/security/x509/OtherName.java
@@ -93,7 +93,7 @@ public class OtherName implements GeneralNameInterface {
         if (derValue1.isContextSpecific((byte) 0) && derValue1.isConstructed()) {
             nameValue = derValue1.data.toByteArray();
         } else {
-            throw new IOException("value is not [0]");
+            throw new IOException("value is not EXPLICTly tagged [0]");
         }
         gni = getGNI(oid, nameValue);
         if (gni != null) {

--- a/src/java.base/share/classes/sun/security/x509/OtherName.java
+++ b/src/java.base/share/classes/sun/security/x509/OtherName.java
@@ -90,10 +90,11 @@ public class OtherName implements GeneralNameInterface {
 
         oid = in.getOID();
         DerValue derValue1 = in.getDerValue();
-        if (!derValue1.isContextSpecific((byte)0) || !derValue1.isConstructed()) {
+        if (derValue1.isContextSpecific((byte) 0) && derValue1.isConstructed()) {
+            nameValue = derValue1.data.toByteArray();
+        } else {
             throw new IOException("value is not [0]");
         }
-        nameValue = derValue1.data.toByteArray();
         gni = getGNI(oid, nameValue);
         if (gni != null) {
             name = gni.toString();

--- a/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1584,6 +1584,11 @@ public class X509CertImpl extends X509Certificate implements DerEncoder {
                     throw new RuntimeException("name cannot be encoded", ioe);
                 }
                 nameEntry.add(derOut.toByteArray());
+                if (name.getType() == GeneralNameInterface.NAME_ANY
+                        && name instanceof OtherName oname) {
+                    nameEntry.add(oname.getOID().toString());
+                    nameEntry.add(oname.getNameValue());
+                }
                 break;
             }
             newNames.add(Collections.unmodifiableList(nameEntry));

--- a/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
@@ -1587,7 +1587,13 @@ public class X509CertImpl extends X509Certificate implements DerEncoder {
                 if (name.getType() == GeneralNameInterface.NAME_ANY
                         && name instanceof OtherName oname) {
                     nameEntry.add(oname.getOID().toString());
-                    nameEntry.add(oname.getNameValue());
+                    byte[] nameValue = oname.getNameValue();
+                    try {
+                        String v = new DerValue(nameValue).getAsString();
+                        nameEntry.add(v == null ? nameValue : v);
+                    } catch (IOException ioe) {
+                        nameEntry.add(nameValue);
+                    }
                 }
                 break;
             }

--- a/test/jdk/sun/security/x509/OtherName/Parse.java
+++ b/test/jdk/sun/security/x509/OtherName/Parse.java
@@ -24,7 +24,8 @@
 /*
  * @test
  * @bug 8277976
- * @summary Break up SEQUENCE in X509Certiticate#getSubjectAlternativeNames() in otherName
+ * @summary Break up SEQUENCE in X509Certiticate::getSubjectAlternativeNames
+ *          and X509Certiticate::getIssuerAlternativeNames in otherName
  * @modules java.base/sun.security.util
  *          java.base/sun.security.x509
  *          java.base/sun.security.tools.keytool

--- a/test/jdk/sun/security/x509/OtherName/Parse.java
+++ b/test/jdk/sun/security/x509/OtherName/Parse.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8277976
+ * @summary Break up SEQUENCE in X509Certiticate#getSubjectAlternativeNames() in otherName
+ * @modules java.base/sun.security.util
+ *          java.base/sun.security.x509
+ *          java.base/sun.security.tools.keytool
+ * @library /test/lib
+ */
+
+import jdk.test.lib.Asserts;
+import sun.security.tools.keytool.CertAndKeyGen;
+import sun.security.util.ObjectIdentifier;
+import sun.security.x509.CertificateExtensions;
+import sun.security.x509.DNSName;
+import sun.security.x509.GeneralName;
+import sun.security.x509.GeneralNames;
+import sun.security.x509.OIDMap;
+import sun.security.x509.OtherName;
+import sun.security.x509.SubjectAlternativeNameExtension;
+import sun.security.x509.X500Name;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Date;
+
+public class Parse {
+
+    public static class MyDNSName extends DNSName {
+        public MyDNSName(byte[] in) throws IOException {
+            super(new String(Arrays.copyOfRange(in, 2, in.length),
+                    StandardCharsets.US_ASCII));
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        OIDMap.addAttribute("n1", "1.2.3.6", MyDNSName.class);
+
+        CertificateExtensions exts = new CertificateExtensions();
+        GeneralNames names = new GeneralNames();
+
+        byte[] d1 = new byte[] { 5, 0 };
+        names.add(new GeneralName(
+                new OtherName(ObjectIdentifier.of("1.2.3.5"), d1)));
+
+        byte[] d2 = new byte[] { 4, 5, 'a', '.', 'c', 'o', 'm' };
+        names.add(new GeneralName(
+                new OtherName(ObjectIdentifier.of("1.2.3.6"), d2)));
+
+        exts.set("x", new SubjectAlternativeNameExtension(names));
+        CertAndKeyGen g = new CertAndKeyGen("Ed25519", "Ed25519");
+        g.generate(-1);
+        X509Certificate x = g.getSelfCertificate(new X500Name("CN=ME"),
+                new Date(),
+                100000,
+                exts);
+
+        int found = 0;
+        for (var san : x.getSubjectAlternativeNames()) {
+            if (san.get(2).equals("1.2.3.5")
+                    && Arrays.equals((byte[])san.get(3), d1)) {
+                found++;
+            }
+            if (san.get(2).equals("1.2.3.6")
+                    && Arrays.equals((byte[])san.get(3), d2)) {
+                found++;
+            }
+        }
+
+        Asserts.assertEQ(found, 2);
+    }
+}
+

--- a/test/jdk/sun/security/x509/OtherName/Parse.java
+++ b/test/jdk/sun/security/x509/OtherName/Parse.java
@@ -34,6 +34,7 @@
 
 import jdk.test.lib.Asserts;
 import sun.security.tools.keytool.CertAndKeyGen;
+import sun.security.util.DerValue;
 import sun.security.util.ObjectIdentifier;
 import sun.security.x509.CertificateExtensions;
 import sun.security.x509.DNSName;
@@ -65,11 +66,13 @@ public class Parse {
         CertificateExtensions exts = new CertificateExtensions();
         GeneralNames names = new GeneralNames();
 
-        byte[] d1 = new byte[] { 5, 0 };
+        byte[] d1 = new byte[] {
+                DerValue.tag_OctetString, 5, 'a', '.', 'c', 'o', 'm' };
         names.add(new GeneralName(
                 new OtherName(ObjectIdentifier.of("1.2.3.5"), d1)));
 
-        byte[] d2 = new byte[] { 4, 5, 'a', '.', 'c', 'o', 'm' };
+        byte[] d2 = new byte[] {
+                DerValue.tag_UTF8String, 5, 'a', '.', 'c', 'o', 'm' };
         names.add(new GeneralName(
                 new OtherName(ObjectIdentifier.of("1.2.3.6"), d2)));
 
@@ -83,13 +86,15 @@ public class Parse {
 
         int found = 0;
         for (var san : x.getSubjectAlternativeNames()) {
-            if (san.get(2).equals("1.2.3.5")
-                    && Arrays.equals((byte[])san.get(3), d1)) {
-                found++;
-            }
-            if (san.get(2).equals("1.2.3.6")
-                    && Arrays.equals((byte[])san.get(3), d2)) {
-                found++;
+            if (san.size() == 4) {
+                if (san.get(2).equals("1.2.3.5")
+                        && Arrays.equals((byte[]) san.get(3), d1)) {
+                    found++;
+                }
+                if (san.get(2).equals("1.2.3.6")
+                        && san.get(3).equals("a.com")) {
+                    found++;
+                }
             }
         }
 

--- a/test/jdk/sun/security/x509/OtherName/Parse.java
+++ b/test/jdk/sun/security/x509/OtherName/Parse.java
@@ -24,8 +24,8 @@
 /*
  * @test
  * @bug 8277976
- * @summary Break up SEQUENCE in X509Certiticate::getSubjectAlternativeNames
- *          and X509Certiticate::getIssuerAlternativeNames in otherName
+ * @summary Break up SEQUENCE in X509Certificate::getSubjectAlternativeNames
+ *          and X509Certificate::getIssuerAlternativeNames in otherName
  * @modules java.base/sun.security.util
  *          java.base/sun.security.x509
  *          java.base/sun.security.tools.keytool

--- a/test/jdk/sun/security/x509/OtherName/Parse.java
+++ b/test/jdk/sun/security/x509/OtherName/Parse.java
@@ -86,18 +86,16 @@ public class Parse {
 
         int found = 0;
         for (var san : x.getSubjectAlternativeNames()) {
-            if (san.size() == 4) {
-                if (san.get(2).equals("1.2.3.5")
-                        && Arrays.equals((byte[]) san.get(3), d1)) {
+            if (san.size() >= 4 && san.get(0).equals(0)) {
+                if (san.get(2).equals("1.2.3.5")) {
+                    Asserts.assertTrue(Arrays.equals((byte[]) san.get(3), d1));
                     found++;
-                }
-                if (san.get(2).equals("1.2.3.6")
-                        && san.get(3).equals("a.com")) {
+                } else if (san.get(2).equals("1.2.3.6")) {
+                    Asserts.assertEQ(san.get(3), "a.com");
                     found++;
                 }
             }
         }
-
         Asserts.assertEQ(found, 2);
     }
 }


### PR DESCRIPTION
The enhancement adds two extra items in the `getSubjectAlternativeNames()` output for an OtherName.

It also fix several errors:
1. In `OtherName.java`, `nameValue` should be the value inside `CONTEXT [0]` without the tag and length bytes.
2. The argument in constructor `extClass.getConstructor(Object.class)` is suspicious. Maybe it meant `byte[]`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8277976](https://bugs.openjdk.java.net/browse/JDK-8277976): Break up SEQUENCE in X509Certificate::getSubjectAlternativeNames and X509Certificate::getIssuerAlternativeNames in otherName
 * [JDK-6776681](https://bugs.openjdk.java.net/browse/JDK-6776681): Invalid encoding of an OtherName in X509Certificate.getAlternativeNames()
 * [JDK-8281606](https://bugs.openjdk.java.net/browse/JDK-8281606): Break up SEQUENCE in X509Certificate::getSubjectAlternativeNames and X509Certificate::getIssuerAlternativeNames in otherName (**CSR**)


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**) ⚠️ Review applies to bca0b6d3a54d14e747aba0b8bcb65bef2092d3c6


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7167/head:pull/7167` \
`$ git checkout pull/7167`

Update a local copy of the PR: \
`$ git checkout pull/7167` \
`$ git pull https://git.openjdk.java.net/jdk pull/7167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7167`

View PR using the GUI difftool: \
`$ git pr show -t 7167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7167.diff">https://git.openjdk.java.net/jdk/pull/7167.diff</a>

</details>
