### PR TITLE
8280413: ProblemList jdk/jfr/event/oldobject/TestLargeRootSet.java on all X64 platforms

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -825,7 +825,7 @@ jdk/jfr/event/compiler/TestCodeSweeper.java                     8225209 generic-
 jdk/jfr/event/os/TestThreadContextSwitches.java                 8247776 windows-all
 jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
-jdk/jfr/event/oldobject/TestLargeRootSet.java                   8276333 macosx-x64,windows-x64
+jdk/jfr/event/oldobject/TestLargeRootSet.java                   8276333 generic-x64
 jdk/jfr/api/consumer/recordingstream/TestOnEvent.java           8255404 linux-x64
 
 ############################################################################


### PR DESCRIPTION
A trivial fix to ProblemList jdk/jfr/event/oldobject/TestLargeRootSet.java on all X64 platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280413](https://bugs.openjdk.java.net/browse/JDK-8280413): ProblemList jdk/jfr/event/oldobject/TestLargeRootSet.java on all X64 platforms


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7168/head:pull/7168` \
`$ git checkout pull/7168`

Update a local copy of the PR: \
`$ git checkout pull/7168` \
`$ git pull https://git.openjdk.java.net/jdk pull/7168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7168`

View PR using the GUI difftool: \
`$ git pr show -t 7168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7168.diff">https://git.openjdk.java.net/jdk/pull/7168.diff</a>

</details>
