### PR TITLE
8279675: CDS cannot handle non-existent JAR file in bootclassapth

### DIFF
--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -554,6 +554,7 @@ public:
   void  seek_to_position(size_t pos);
   char* skip_first_path_entry(const char* path) NOT_CDS_RETURN_(NULL);
   int   num_paths(const char* path) NOT_CDS_RETURN_(0);
+  bool  check_paths_existence(const char* paths) NOT_CDS_RETURN_(false);
   GrowableArray<const char*>* create_path_array(const char* path) NOT_CDS_RETURN_(NULL);
   bool  classpath_failure(const char* msg, const char* name) NOT_CDS_RETURN_(false);
   bool  check_paths(int shared_path_start_idx, int num_paths,

--- a/test/hotspot/jtreg/runtime/cds/appcds/PrintSharedArchiveAndExit.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/PrintSharedArchiveAndExit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,16 +87,16 @@ public class PrintSharedArchiveAndExit {
     TestCommon.run("-cp", cp, "-XX:+PrintSharedArchiveAndExit", "Hello")
       .ifNoMappingFailure(output -> check(output, 0, true, lastCheckMsg));
 
-    log("Execution with simple errors -- with 'simple' errors like missing or modified\n" +
-        "JAR files, the VM should try to continue to print the remaining information.\n" +
-        "Use an invalid Boot CP -- all the JAR paths should be checked");
+    log("Non-existent boot cp should be ignored, test should pass.");
     TestCommon.run(
         "-cp", cp,
         "-Xbootclasspath/a:foo.jar",
         "-XX:+PrintSharedArchiveAndExit")
-      .ifNoMappingFailure(output -> check(output, 1, true, lastCheckMsg, "[BOOT classpath mismatch, "));
+      .ifNoMappingFailure(output -> check(output, 0, true, lastCheckMsg));
 
-    log("Use an App CP shorter than the one at dump time -- all the JAR paths should be checked");
+    log("Execution with simple errors -- with 'simple' errors like missing or modified\n" +
+        "JAR files, the VM should try to continue to print the remaining information.\n" +
+        "Use an App CP shorter than the one at dump time -- all the JAR paths should be checked");
     TestCommon.run(
         "-cp", ".",
         "-XX:+PrintSharedArchiveAndExit")

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/OptimizeModuleHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/OptimizeModuleHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -217,6 +217,16 @@ public class OptimizeModuleHandlingTest {
         tty("10. run with CDS on, --module-path, with -Xbootclasspath/a: .");
         TestCommon.run("-Xlog:cds",
                        "-Xbootclasspath/a:", ".",
+                       "--module-path", libsDir.toString(),
+                       MAIN_CLASS)
+            .assertAbnormalExit(out -> {
+                out.shouldNotContain(CLASS_FOUND_MESSAGE)
+                   .shouldContain(OPTIMIZE_DISABLED)           // mapping info
+                   .shouldContain("Error: Could not find or load main class .");
+            });
+        tty("11. run with CDS on, --module-path, with -Xbootclasspath/a:.");
+        TestCommon.run("-Xlog:cds",
+                       "-Xbootclasspath/a:.",
                        "--module-path", libsDir.toString(),
                        MAIN_CLASS)
             .assertAbnormalExit(out -> {


### PR DESCRIPTION
Non-existent boot class path and file with zero size won't be recorded during CDS dump time.
This fix excludes checking of the above paths and files during runtime to avoid a false mismatch.

The proposed fix passed CI tiers 1-4 testing.