### PR TITLE
8251466: test/java/io/File/GetXSpace.java fails on Windows with mapped network drives.

### DIFF
--- a/test/jdk/java/io/File/GetXSpace.java
+++ b/test/jdk/java/io/File/GetXSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,6 @@
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FilePermission;
 import java.io.InputStreamReader;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -108,8 +107,8 @@ public class GetXSpace {
 
         Space(String total, String free, String name) {
             try {
-                this.total = Long.valueOf(total) * KSIZE;
-                this.free = Long.valueOf(free) * KSIZE;
+                this.total = Long.parseLong(total) * KSIZE;
+                this.free = Long.parseLong(free) * KSIZE;
             } catch (NumberFormatException x) {
                 throw new RuntimeException("the regex should have caught this", x);
             }
@@ -157,7 +156,7 @@ public class GetXSpace {
                     }
                     al.add(new Space(m.group(2), m.group(3), name));;
                 }
-                j = m.end() + 1;
+                j = m.end();
             } else {
                 throw new RuntimeException("unrecognized df output format: "
                                            + "charAt(" + j + ") = '"
@@ -227,7 +226,7 @@ public class GetXSpace {
                 // On Linux, ignore the NSFE if the path is one of the
                 // /run/user/$UID mounts created by pam_systemd(8) as it
                 // might be deleted during the test
-                if (!Platform.isLinux() || s.name().indexOf("/run/user") == -1)
+                if (!Platform.isLinux() || !s.name().contains("/run/user"))
                     throw new RuntimeException(nsfe);
             } catch (IOException e) {
                 throw new RuntimeException(e);


### PR DESCRIPTION
Test `test/java/io/File/GetXSpace.java` always failed on my machine with this output:
```
----------System.out:(12/489)----------
--- Testing df
C:/Programs/cygwin64 292848636 49695320 243153316 17% /
D: 59672 59672 0 100% /cygdrive/d


SecurityManager = null
C:/Programs/cygwin64:
  df total= 299877003264 free = 0 usable = 248988995584
  getX total= 299877003264 free = 248988995584 usable = 248988995584
::
  df total= 61104128 free = 0 usable = 0
  getX total= 0 free = 0 usable = 0
----------System.err:(23/1617)----------
java.nio.file.InvalidPathException: Illegal char <:> at index 0: :
at java.base/sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153)
at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
at java.base/sun.nio.fs.WindowsPath.parse(WindowsPath.java:92)
at java.base/sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:232)
at java.base/java.io.File.toPath(File.java:2396)
at GetXSpace.compare(GetXSpace.java:223)
at GetXSpace.testDF(GetXSpace.java:403)
at GetXSpace.main(GetXSpace.java:437)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at java.base/java.lang.reflect.Method.invoke(Method.java:577)
at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
at java.base/java.lang.Thread.run(Thread.java:833) 
```
Parsing of df output is incorrect. It skips first symbols after matching of line.
https://github.com/openjdk/jdk/blob/293fb46f7cd28f2a08055e3eb8ec9459d64e9688/test/jdk/java/io/File/GetXSpace.java#L160

It means that after matching first line:
```
C:/Programs/cygwin64 292848636 49695320 243153316 17% /

```
It skips first symbols of next line - symbol `D` and then proceeds to match _corrupted_ line:
```
: 59672 59672 0 100% /cygdrive/d

```
Problems affects only Windows, because only in Windows case first group of matcher is used:

https://github.com/openjdk/jdk/blob/293fb46f7cd28f2a08055e3eb8ec9459d64e9688/test/jdk/java/io/File/GetXSpace.java#L155-L156


Testing:
* Windows x64 - always failed before. No errors after fix
* Linux x64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251466](https://bugs.openjdk.java.net/browse/JDK-8251466): test/java/io/File/GetXSpace.java fails on Windows with mapped network drives.


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7170/head:pull/7170` \
`$ git checkout pull/7170`

Update a local copy of the PR: \
`$ git checkout pull/7170` \
`$ git pull https://git.openjdk.java.net/jdk pull/7170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7170`

View PR using the GUI difftool: \
`$ git pr show -t 7170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7170.diff">https://git.openjdk.java.net/jdk/pull/7170.diff</a>

</details>
