### PR TITLE
8280397: Add task queue printing method to GenericTaskQueueSet 

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -37,6 +37,7 @@
 #include "gc/g1/heapRegionManager.inline.hpp"
 #include "gc/g1/heapRegionRemSet.hpp"
 #include "gc/g1/heapRegionSet.inline.hpp"
+#include "gc/shared/collectedHeap.inline.hpp"
 #include "gc/shared/markBitMap.inline.hpp"
 #include "gc/shared/taskqueue.inline.hpp"
 #include "runtime/atomic.hpp"

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -59,47 +59,6 @@
 #include "memory/resourceArea.hpp"
 #include "utilities/ticks.hpp"
 
-#if TASKQUEUE_STATS
-uint G1YoungCollector::num_task_queues() const {
-  return task_queues()->size();
-}
-
-void G1YoungCollector::print_taskqueue_stats_hdr(outputStream* const st) {
-  st->print_raw_cr("GC Task Stats");
-  st->print_raw("thr "); TaskQueueStats::print_header(1, st); st->cr();
-  st->print_raw("--- "); TaskQueueStats::print_header(2, st); st->cr();
-}
-
-void G1YoungCollector::print_taskqueue_stats() const {
-  if (!log_is_enabled(Trace, gc, task, stats)) {
-    return;
-  }
-  Log(gc, task, stats) log;
-  ResourceMark rm;
-  LogStream ls(log.trace());
-  outputStream* st = &ls;
-
-  print_taskqueue_stats_hdr(st);
-
-  TaskQueueStats totals;
-  const uint n = num_task_queues();
-  for (uint i = 0; i < n; ++i) {
-    st->print("%3u ", i); _g1h->task_queue(i)->stats.print(st); st->cr();
-    totals += _g1h->task_queue(i)->stats;
-  }
-  st->print_raw("tot "); totals.print(st); st->cr();
-
-  DEBUG_ONLY(totals.verify());
-}
-
-void G1YoungCollector::reset_taskqueue_stats() {
-  const uint n = num_task_queues();
-  for (uint i = 0; i < n; ++i) {
-    _g1h->task_queue(i)->stats.reset();
-  }
-}
-#endif // TASKQUEUE_STATS
-
 // GCTraceTime wrapper that constructs the message according to GC pause type and
 // GC cause.
 // The code relies on the fact that GCTraceTimeWrapper stores the string passed
@@ -1147,6 +1106,5 @@ void G1YoungCollector::collect() {
 
     policy()->record_young_collection_end(_concurrent_operation_is_full_mark, evacuation_failed());
   }
-  TASKQUEUE_STATS_ONLY(print_taskqueue_stats());
-  TASKQUEUE_STATS_ONLY(reset_taskqueue_stats());
+  TASKQUEUE_STATS_ONLY(_g1h->print_and_reset_taskqueue_stats(_g1h->task_queues(), "Oop Queue");)
 }

--- a/src/hotspot/share/gc/g1/g1YoungCollector.hpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.hpp
@@ -134,13 +134,6 @@ class G1YoungCollector {
   // True iff an evacuation has failed in the most-recent collection.
   bool evacuation_failed() const;
 
-#if TASKQUEUE_STATS
-  uint num_task_queues() const;
-  static void print_taskqueue_stats_hdr(outputStream* const st);
-  void print_taskqueue_stats() const;
-  void reset_taskqueue_stats();
-#endif // TASKQUEUE_STATS
-
 public:
   G1YoungCollector(GCCause::Cause gc_cause,
                    double target_pause_time_ms);

--- a/src/hotspot/share/gc/parallel/psPromotionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.cpp
@@ -147,37 +147,24 @@ static const char* const pm_stats_hdr[] = {
   "--- ---------- ---------- ---------- ----------"
 };
 
-void
-PSPromotionManager::print_taskqueue_stats() {
+void PSPromotionManager::print_taskqueue_stats() {
   if (!log_is_enabled(Trace, gc, task, stats)) {
     return;
   }
   Log(gc, task, stats) log;
   ResourceMark rm;
   LogStream ls(log.trace());
-  outputStream* out = &ls;
-  out->print_cr("== GC Tasks Stats, GC %3d",
-                ParallelScavengeHeap::heap()->total_collections());
 
-  TaskQueueStats totals;
-  out->print("thr "); TaskQueueStats::print_header(1, out); out->cr();
-  out->print("--- "); TaskQueueStats::print_header(2, out); out->cr();
-  for (uint i = 0; i < ParallelGCThreads + 1; ++i) {
-    TaskQueueStats& next = manager_array(i)->_claimed_stack_depth.stats;
-    out->print("%3d ", i); next.print(out); out->cr();
-    totals += next;
-  }
-  out->print("tot "); totals.print(out); out->cr();
+  stack_array_depth()->print_taskqueue_stats(&ls, "Oop Queue");
 
   const uint hlines = sizeof(pm_stats_hdr) / sizeof(pm_stats_hdr[0]);
-  for (uint i = 0; i < hlines; ++i) out->print_cr("%s", pm_stats_hdr[i]);
+  for (uint i = 0; i < hlines; ++i) ls.print_cr("%s", pm_stats_hdr[i]);
   for (uint i = 0; i < ParallelGCThreads + 1; ++i) {
-    manager_array(i)->print_local_stats(out, i);
+    manager_array(i)->print_local_stats(&ls, i);
   }
 }
 
-void
-PSPromotionManager::reset_stats() {
+void PSPromotionManager::reset_stats() {
   claimed_stack_depth()->stats.reset();
   _array_chunk_pushes = _array_chunk_steals = 0;
   _arrays_chunked = _array_chunks_processed = 0;
@@ -215,8 +202,6 @@ void PSPromotionManager::reset() {
   assert(stacks_empty(), "reset of non-empty stack");
 
   // We need to get an assert in here to make sure the labs are always flushed.
-
-  ParallelScavengeHeap* heap = ParallelScavengeHeap::heap();
 
   // Do not prefill the LAB's, save heap wastage!
   HeapWord* lab_base = young_space()->top();

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -27,6 +27,7 @@
 
 #include "gc/shared/gcCause.hpp"
 #include "gc/shared/gcWhen.hpp"
+#include "gc/shared/taskqueue.hpp"
 #include "gc/shared/verifyOption.hpp"
 #include "memory/allocation.hpp"
 #include "memory/metaspace.hpp"
@@ -462,6 +463,11 @@ class CollectedHeap : public CHeapObj<mtInternal> {
 
   void print_heap_before_gc();
   void print_heap_after_gc();
+
+#if TASKQUEUE_STATS
+  template <class T, MEMFLAGS F>
+  void print_and_reset_taskqueue_stats(GenericTaskQueueSet<T, F>* queue_set, const char* label) const;
+#endif // TASKQUEUE_STATS
 
   // Registering and unregistering an nmethod (compiled code) with the heap.
   virtual void register_nmethod(nmethod* nm) = 0;

--- a/src/hotspot/share/gc/shared/collectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.inline.hpp
@@ -28,6 +28,10 @@
 #include "gc/shared/collectedHeap.hpp"
 
 #include "gc/shared/memAllocator.hpp"
+#include "gc/shared/taskqueue.inline.hpp"
+#include "logging/log.hpp"
+#include "logging/logStream.hpp"
+#include "memory/resourceArea.hpp"
 #include "oops/oop.inline.hpp"
 #include "utilities/align.hpp"
 
@@ -45,5 +49,20 @@ inline oop CollectedHeap::class_allocate(Klass* klass, size_t size, TRAPS) {
   ClassAllocator allocator(klass, size, THREAD);
   return allocator.allocate();
 }
+
+#if TASKQUEUE_STATS
+template <class T, MEMFLAGS F>
+inline void CollectedHeap::print_and_reset_taskqueue_stats(GenericTaskQueueSet<T, F>* queue_set, const char* label) const {
+  if (!log_is_enabled(Trace, gc, task, stats)) {
+    return;
+  }
+  Log(gc, task, stats) log;
+  ResourceMark rm;
+  LogStream ls(log.trace());
+
+  queue_set->print_taskqueue_stats(&ls, label);
+  queue_set->reset_taskqueue_stats();
+}
+#endif // TASKQUEUE_STATS
 
 #endif // SHARE_GC_SHARED_COLLECTEDHEAP_INLINE_HPP

--- a/src/hotspot/share/gc/shared/taskqueue.hpp
+++ b/src/hotspot/share/gc/shared/taskqueue.hpp
@@ -473,6 +473,14 @@ public:
   virtual uint tasks() const;
 
   uint size() const { return _n; }
+
+#if TASKQUEUE_STATS
+private:
+  static void print_taskqueue_stats_hdr(outputStream* const st, const char* label);
+public:
+  void print_taskqueue_stats(outputStream* const st, const char* label);
+  void reset_taskqueue_stats();
+#endif // TASKQUEUE_STATS
 };
 
 template<class T, MEMFLAGS F> void


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that makes task queue (set) printing available in a central place so that not every user needs to reinvent the wheel?
As example I wired up existing G1/Parallel GC young collection statistics printing, but I intend to add this for full gcs too; since ZGC and Shenandoah do not print task queues at all I do not intend to do that at least initially.

Testing: gha (building), local testing

Thanks,
  Thomas