### PR TITLE
8280396: G1: Full gc mark stack draining should prefer to make work available to other threads

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullGCMarker.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.hpp
@@ -80,7 +80,8 @@ class G1FullGCMarker : public CHeapObj<mtGC> {
   inline void follow_array_chunk(objArrayOop array, int index);
 
   inline void drain_oop_stack();
-  // Transfer contents from the objArray overflow stack to the shared objArray stack.
+  // Transfer contents from the objArray task queue overflow stack to the shared
+  // objArray stack.
   // Returns true and a valid task if there has not been enough space in the shared
   // objArray stack, otherwise the task is invalid.
   inline bool transfer_objArray_overflow_stack(ObjArrayTask& task);
@@ -101,9 +102,6 @@ public:
   template <class T> inline void mark_and_push(T* p);
   inline void follow_klass(Klass* k);
   inline void follow_cld(ClassLoaderData* cld);
-
-  template <class T>
-  bool transfer_from_overflow_stack(T& elem);
 
   inline void drain_stack();
   void complete_marking(OopQueueSet* oop_stacks,

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.hpp
@@ -78,6 +78,13 @@ class G1FullGCMarker : public CHeapObj<mtGC> {
   inline void follow_object(oop obj);
   inline void follow_array(objArrayOop array);
   inline void follow_array_chunk(objArrayOop array, int index);
+
+  inline void drain_oop_stack();
+  // Transfer contents from the objArray overflow stack to the shared objArray stack.
+  // Returns true and a valid task if there has not been enough space in the shared
+  // objArray stack, otherwise the task is invalid.
+  inline bool transfer_objArray_overflow_stack(ObjArrayTask& task);
+
 public:
   G1FullGCMarker(G1FullCollector* collector,
                  uint worker_id,
@@ -94,6 +101,9 @@ public:
   template <class T> inline void mark_and_push(T* p);
   inline void follow_klass(Klass* k);
   inline void follow_cld(ClassLoaderData* cld);
+
+  template <class T>
+  bool transfer_from_overflow_stack(T& elem);
 
   inline void drain_stack();
   void complete_marking(OopQueueSet* oop_stacks,

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.hpp
@@ -71,8 +71,6 @@ class G1FullGCMarker : public CHeapObj<mtGC> {
   G1RegionMarkStatsCache _mark_stats_cache;
 
   inline bool is_empty();
-  inline bool pop_object(oop& obj);
-  inline bool pop_objarray(ObjArrayTask& array);
   inline void push_objarray(oop obj, size_t index);
   inline bool mark_object(oop obj);
 

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
@@ -91,18 +91,10 @@ inline bool G1FullGCMarker::is_empty() {
   return _oop_stack.is_empty() && _objarray_stack.is_empty();
 }
 
-inline bool G1FullGCMarker::pop_object(oop& oop) {
-  return _oop_stack.pop_overflow(oop) || _oop_stack.pop_local(oop);
-}
-
 inline void G1FullGCMarker::push_objarray(oop obj, size_t index) {
   ObjArrayTask task(obj, index);
   assert(task.is_valid(), "bad ObjArrayTask");
   _objarray_stack.push(task);
-}
-
-inline bool G1FullGCMarker::pop_objarray(ObjArrayTask& arr) {
-  return _objarray_stack.pop_overflow(arr) || _objarray_stack.pop_local(arr);
 }
 
 inline void G1FullGCMarker::follow_array(objArrayOop array) {

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -162,16 +162,31 @@ inline void G1FullGCMarker::follow_object(oop obj) {
 void G1FullGCMarker::drain_stack() {
   do {
     oop obj;
-    while (pop_object(obj)) {
+    while (_oop_stack.pop_overflow(obj)) {
+      if (!_oop_stack.try_push_to_taskqueue(obj)) {
+        assert(_bitmap->is_marked(obj), "must be marked");
+        follow_object(obj);
+      }
+    }
+    while (_oop_stack.pop_local(obj)) {
       assert(_bitmap->is_marked(obj), "must be marked");
       follow_object(obj);
     }
-    // Process ObjArrays one at a time to avoid marking stack bloat.
+    // Process ObjArrays one at a time to avoid marking stack bloat, but it is
+    // fine to try to move work from the overflow queue to the shared queue as
+    // quickly as possible.
     ObjArrayTask task;
-    if (pop_objarray(task)) {
+    while (_objarray_stack.pop_overflow(task)) {
+      if (!_objarray_stack.try_push_to_taskqueue(task)) {
+        follow_array_chunk(objArrayOop(task.obj()), task.index());
+        break;
+      }
+    }
+    if (_objarray_stack.pop_local(task)) {
       follow_array_chunk(objArrayOop(task.obj()), task.index());
     }
   } while (!is_empty());
+  return;
 }
 
 inline void G1FullGCMarker::follow_klass(Klass* k) {

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
@@ -178,16 +178,16 @@ inline bool G1FullGCMarker::transfer_objArray_overflow_stack(ObjArrayTask& task)
 
 void G1FullGCMarker::drain_stack() {
   do {
+    // First, drain regular oop stack.
     drain_oop_stack();
 
-    // Process ObjArrays one at a time to avoid marking stack bloat.
+    // Then process ObjArrays one at a time to avoid marking stack bloat.
     ObjArrayTask task;
     if (transfer_objArray_overflow_stack(task) ||
       _objarray_stack.pop_local(task)) {
       follow_array_chunk(objArrayOop(task.obj()), task.index());
     }
   } while (!is_empty());
-  return;
 }
 
 inline void G1FullGCMarker::follow_klass(Klass* k) {


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that fixes a significant performance problem with g1 full gc marking when the overflow queue is in use? Basically this case causes the threads never share their work from the overflow queue, resulting in very bad parallelization in some cases.

This is a problem that has been fixed already in [JDK-8152438](https://bugs.openjdk.java.net/browse/JDK-8152438), but when looking at this code on g1 and parallel full gc, they both showed that issue.

This is the change for g1.

The CR shows some numbers how bad this can be.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280396](https://bugs.openjdk.java.net/browse/JDK-8280396): G1: Full gc mark stack draining should prefer to make work available to other threads


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7175/head:pull/7175` \
`$ git checkout pull/7175`

Update a local copy of the PR: \
`$ git checkout pull/7175` \
`$ git pull https://git.openjdk.java.net/jdk pull/7175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7175`

View PR using the GUI difftool: \
`$ git pr show -t 7175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7175.diff">https://git.openjdk.java.net/jdk/pull/7175.diff</a>

</details>
