### PR TITLE
8280458: G1: Remove G1BlockOffsetTablePart::_next_offset_threshold

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -111,9 +111,6 @@ class G1BlockOffsetTablePart {
   friend class HeapRegion;
   friend class VMStructs;
 private:
-  // allocation boundary at which offset array must be updated
-  HeapWord* _next_offset_threshold;
-
   // This is the global BlockOffsetTable.
   G1BlockOffsetTable* _bot;
 
@@ -146,13 +143,22 @@ private:
   // starting at "*threshold_", and for any other indices crossed by the
   // block.  Updates "*threshold_" to correspond to the first index after
   // the block end.
-  void alloc_block_work(HeapWord** threshold_,
-                        HeapWord* blk_start,
-                        HeapWord* blk_end);
+  void alloc_block_work(HeapWord* blk_start, HeapWord* blk_end);
 
   void check_all_cards(size_t left_card, size_t right_card) const;
 
 public:
+  static HeapWord* align_up_by_card_size(HeapWord* const addr) {
+    return align_up(addr, BOTConstants::card_size());
+  }
+
+  static bool is_crossing_card_boundary(HeapWord* const obj_start,
+                                        HeapWord* const obj_end) {
+    HeapWord* cur_card_boundary = align_up_by_card_size(obj_start);
+    // strictly greater-than
+    return obj_end > cur_card_boundary;
+  }
+
   //  The elements of the array are initialized to zero.
   G1BlockOffsetTablePart(G1BlockOffsetTable* array, HeapRegion* hr);
 
@@ -160,41 +166,19 @@ public:
 
   void verify() const;
 
-  inline HeapWord* align_up_by_card_size(HeapWord* const addr) const;
-
   // Returns the address of the start of the block containing "addr", or
   // else "null" if it is covered by no block.  (May have side effects,
   // namely updating of shared array entries that "point" too far
   // backwards.  This can occur, for example, when lab allocation is used
   // in a space covered by the table.)
   inline HeapWord* block_start(const void* addr);
-  // Same as above, but does not have any of the possible side effects
-  // discussed above.
-  inline HeapWord* block_start_const(const void* addr) const;
 
-  // Reset bot to be empty.
-  void reset_bot();
-
-  bool is_empty() const;
-
-  // Return the next threshold, the point at which the table should be
-  // updated.
-  HeapWord* threshold() const { return _next_offset_threshold; }
-
-  // Sets the threshold explicitly to keep it consistent with what has been
-  // updated. This needs to be done when the threshold is not used for updating
-  // the bot, for example when promoting to old in young collections.
-  void set_threshold(HeapWord* threshold) { _next_offset_threshold = threshold; }
-
-  // These must be guaranteed to work properly (i.e., do nothing)
-  // when "blk_start" ("blk" for second version) is "NULL".  In this
-  // implementation, that's true because NULL is represented as 0, and thus
-  // never exceeds the "_next_offset_threshold".
   void alloc_block(HeapWord* blk_start, HeapWord* blk_end) {
-    if (blk_end > _next_offset_threshold) {
-      alloc_block_work(&_next_offset_threshold, blk_start, blk_end);
+    if (is_crossing_card_boundary(blk_start, blk_end)) {
+      alloc_block_work(blk_start, blk_end);
     }
   }
+
   void alloc_block(HeapWord* blk, size_t size) {
     alloc_block(blk, blk+size);
   }

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -137,12 +137,7 @@ private:
   inline HeapWord* forward_to_block_containing_addr(HeapWord* q, HeapWord* n,
                                                     const void* addr) const;
 
-  // Requires that "*threshold_" be the first array entry boundary at or
-  // above "blk_start".  If the block starts at or crosses "*threshold_", records
-  // "blk_start" as the appropriate block start for the array index
-  // starting at "*threshold_", and for any other indices crossed by the
-  // block.  Updates "*threshold_" to correspond to the first index after
-  // the block end.
+  // Update BOT entries corresponding to the mem range [blk_start, blk_end).
   void alloc_block_work(HeapWord* blk_start, HeapWord* blk_end);
 
   void check_all_cards(size_t left_card, size_t right_card) const;
@@ -179,8 +174,8 @@ public:
     }
   }
 
-  void alloc_block(HeapWord* blk, size_t size) {
-    alloc_block(blk, blk+size);
+  void alloc_block(HeapWord* blk_start, size_t size) {
+    alloc_block(blk_start, blk_start + size);
   }
 
   void set_for_starts_humongous(HeapWord* obj_top, size_t fill_size);

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
@@ -30,11 +30,7 @@
 #include "gc/g1/heapRegion.hpp"
 #include "gc/shared/memset_with_concurrent_readers.hpp"
 #include "runtime/atomic.hpp"
-
-inline HeapWord* G1BlockOffsetTablePart::align_up_by_card_size(HeapWord* const addr) const {
-  assert(addr >= _hr->bottom() && addr < _hr->top(), "invalid address");
-  return align_up(addr, BOTConstants::card_size());
-}
+#include "oops/oop.inline.hpp"
 
 inline HeapWord* G1BlockOffsetTablePart::block_start(const void* addr) {
   assert(addr >= _hr->bottom() && addr < _hr->top(), "invalid address");

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3295,7 +3295,6 @@ void G1CollectedHeap::retire_gc_alloc_region(HeapRegion* alloc_region,
   _bytes_used_during_gc += allocated_bytes;
   if (dest.is_old()) {
     old_set_add(alloc_region);
-    alloc_region->update_bot_threshold();
   } else {
     assert(dest.is_young(), "Retiring alloc region should be young (%d)", dest.type());
     _survivor.add_used_bytes(allocated_bytes);

--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -187,8 +187,6 @@ public:
     hr->note_self_forwarding_removal_start(during_concurrent_start,
                                            during_concurrent_mark);
 
-    hr->reset_bot();
-
     _phase_times->record_or_add_thread_work_item(G1GCPhaseTimes::RestoreRetainedRegions,
                                                    _worker_id,
                                                    1,

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
@@ -47,9 +47,6 @@ void G1FullGCCompactionPoint::update() {
 
 void G1FullGCCompactionPoint::initialize_values(bool init_threshold) {
   _compaction_top = _current_region->compaction_top();
-  if (init_threshold) {
-    _current_region->initialize_bot_threshold();
-  }
 }
 
 bool G1FullGCCompactionPoint::has_regions() {

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -437,7 +437,7 @@ void G1ParScanThreadState::undo_allocation(G1HeapRegionAttr dest_attr,
 void G1ParScanThreadState::update_bot_after_copying(oop obj, size_t word_sz) {
   HeapWord* obj_start = cast_from_oop<HeapWord*>(obj);
   HeapRegion* region = _g1h->heap_region_containing(obj_start);
-  region->update_bot_if_crossing_boundary(obj_start, word_sz);
+  region->update_bot_for_obj(obj_start, word_sz);
 }
 
 // Private inline function, for direct internal use and providing the

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -804,7 +804,7 @@ void HeapRegion::object_iterate(ObjectClosure* blk) {
 void HeapRegion::fill_with_dummy_object(HeapWord* address, size_t word_size, bool zap) {
   // Keep the BOT in sync for old generation regions.
   if (is_old()) {
-    update_bot_if_crossing_boundary(address, word_size);
+    update_bot_for_obj(address, word_size);
   }
   // Fill in the object.
   CollectedHeap::fill_with_object(address, word_size, zap);

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -260,7 +260,6 @@ void HeapRegion::initialize(bool clear_space, bool mangle_space) {
 
   set_top(bottom());
   set_compaction_top(bottom());
-  reset_bot();
 
   hr_clear(false /*clear_space*/);
 }
@@ -780,7 +779,6 @@ void HeapRegion::clear(bool mangle_space) {
   if (ZapUnusedHeapArea && mangle_space) {
     mangle_unused_area();
   }
-  reset_bot();
 }
 
 #ifndef PRODUCT
@@ -788,10 +786,6 @@ void HeapRegion::mangle_unused_area() {
   SpaceMangler::mangle_region(MemRegion(top(), end()));
 }
 #endif
-
-void HeapRegion::initialize_bot_threshold() {
-  _bot_part.reset_bot();
-}
 
 void HeapRegion::alloc_block_in_bot(HeapWord* start, HeapWord* end) {
   _bot_part.alloc_block(start, end);

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -163,7 +163,7 @@ public:
   inline HeapWord* allocate(size_t min_word_size, size_t desired_word_size, size_t* actual_size);
 
   // Update BOT if this obj is the first entering a new card (i.e. crossing the card boundary).
-  inline void update_bot_if_crossing_boundary(HeapWord* obj_start, size_t obj_size);
+  inline void update_bot_for_obj(HeapWord* obj_start, size_t obj_size);
 
   // Full GC support methods.
 

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -167,7 +167,6 @@ public:
 
   // Full GC support methods.
 
-  void initialize_bot_threshold();
   void alloc_block_in_bot(HeapWord* start, HeapWord* end);
 
   // Update heap region that has been compacted to be consistent after Full GC.
@@ -192,16 +191,8 @@ public:
   template<typename ApplyToMarkedClosure>
   inline void apply_to_marked_objects(G1CMBitMap* bitmap, ApplyToMarkedClosure* closure);
 
-  void reset_bot() {
-    _bot_part.reset_bot();
-  }
-
   void update_bot() {
     _bot_part.update();
-  }
-
-  void update_bot_threshold() {
-    _bot_part.set_threshold(top());
   }
 
 private:

--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -183,10 +183,6 @@ inline void HeapRegion::reset_skip_compacting_after_full_gc() {
 }
 
 inline void HeapRegion::reset_after_full_gc_common() {
-  if (is_empty()) {
-    reset_bot();
-  }
-
   // Clear unused heap memory in debug builds.
   if (ZapUnusedHeapArea) {
     mangle_unused_area();
@@ -234,24 +230,15 @@ inline HeapWord* HeapRegion::allocate(size_t min_word_size,
 inline void HeapRegion::update_bot_if_crossing_boundary(HeapWord* obj_start, size_t obj_size) {
   assert(is_old(), "should only do BOT updates for old regions");
 
-  HeapWord* obj_end   = obj_start + obj_size;
+  HeapWord* obj_end = obj_start + obj_size;
 
   assert(is_in(obj_start), "obj_start must be in this region: " HR_FORMAT
          " obj_start " PTR_FORMAT " obj_end " PTR_FORMAT,
          HR_FORMAT_PARAMS(this),
          p2i(obj_start), p2i(obj_end));
 
-  HeapWord* cur_card_boundary = _bot_part.align_up_by_card_size(obj_start);
-
-  // strictly greater-than
-  bool cross_card_boundary = (obj_end > cur_card_boundary);
-
-  if (cross_card_boundary) {
-    // Creating a dummy variable inside this `if` as the arg of `&`; this
-    // avoids unnecessary loads in the assembly code on the fast path (the
-    // bot-not-updating case).
-    HeapWord* dummy = cur_card_boundary;
-    _bot_part.alloc_block_work(&dummy, obj_start, obj_end);
+  if (G1BlockOffsetTablePart::is_crossing_card_boundary(obj_start, obj_end)) {
+    _bot_part.alloc_block_work(obj_start, obj_end);
   }
 }
 

--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -227,7 +227,7 @@ inline HeapWord* HeapRegion::allocate(size_t min_word_size,
   return allocate_impl(min_word_size, desired_word_size, actual_word_size);
 }
 
-inline void HeapRegion::update_bot_if_crossing_boundary(HeapWord* obj_start, size_t obj_size) {
+inline void HeapRegion::update_bot_for_obj(HeapWord* obj_start, size_t obj_size) {
   assert(is_old(), "should only do BOT updates for old regions");
 
   HeapWord* obj_end = obj_start + obj_size;
@@ -237,9 +237,7 @@ inline void HeapRegion::update_bot_if_crossing_boundary(HeapWord* obj_start, siz
          HR_FORMAT_PARAMS(this),
          p2i(obj_start), p2i(obj_end));
 
-  if (G1BlockOffsetTablePart::is_crossing_card_boundary(obj_start, obj_end)) {
-    _bot_part.alloc_block_work(obj_start, obj_end);
-  }
+  _bot_part.alloc_block(obj_start, obj_end);
 }
 
 inline void HeapRegion::note_start_of_marking() {


### PR DESCRIPTION
This PR consists of two commits:

1. the real change of removing the field and updating surrounding code.
2. refactoring only (rename, comment updates, method inline, etc).

PS: `oop.inline.hpp` is needed for `klass_or_null`; it worked before by accident. Changes to `G1FullGCCompactionPoint` is kept to minimal to avoid conflicts with #7106.

Test: tier1-6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280458](https://bugs.openjdk.java.net/browse/JDK-8280458): G1: Remove G1BlockOffsetTablePart::_next_offset_threshold


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7177/head:pull/7177` \
`$ git checkout pull/7177`

Update a local copy of the PR: \
`$ git checkout pull/7177` \
`$ git pull https://git.openjdk.java.net/jdk pull/7177/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7177`

View PR using the GUI difftool: \
`$ git pr show -t 7177`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7177.diff">https://git.openjdk.java.net/jdk/pull/7177.diff</a>

</details>
