### PR TITLE
8214733: runtime/8176717/TestInheritFD.java timed out

### DIFF
--- a/test/hotspot/jtreg/runtime/8176717/TestInheritFD.java
+++ b/test/hotspot/jtreg/runtime/8176717/TestInheritFD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,6 +79,7 @@ public class TestInheritFD {
     public static final String RETAINS_FD = "VM RESULT => RETAINS FD";
     public static final String EXIT = "VM RESULT => VM EXIT";
     public static final String LOG_SUFFIX = ".strangelogsuffixthatcanbecheckedfor";
+    public static final String USER_DIR = System.getProperty("user.dir");
 
     // first VM
     public static void main(String[] args) throws Exception {
@@ -187,10 +188,9 @@ public class TestInheritFD {
 
     static Collection<String> outputContainingFilenames() {
         long pid = ProcessHandle.current().pid();
-
         String[] command = lsofCommand().orElseThrow(() -> new RuntimeException("lsof like command not found"));
-        System.out.println("using command: " + command[0] + " " + command[1]);
-        return run(command[0], command[1], "" + pid).collect(toList());
+        System.out.println("using command: " + command[0] + " -a +d " + USER_DIR + " " + command[1] + " " + pid);
+        return run(command[0], "-a", "+d", USER_DIR, command[1], "" + pid).collect(toList());
     }
 
     static boolean findOpenLogFile(Collection<String> fileNames) {

--- a/test/hotspot/jtreg/runtime/8176717/TestInheritFD.java
+++ b/test/hotspot/jtreg/runtime/8176717/TestInheritFD.java
@@ -189,6 +189,7 @@ public class TestInheritFD {
     static Collection<String> outputContainingFilenames() {
         long pid = ProcessHandle.current().pid();
         String[] command = lsofCommand().orElseThrow(() -> new RuntimeException("lsof like command not found"));
+        // Only search the directory in which the VM is running (user.dir property).
         System.out.println("using command: " + command[0] + " -a +d " + USER_DIR + " " + command[1] + " " + pid);
         return run(command[0], "-a", "+d", USER_DIR, command[1], "" + pid).collect(toList());
     }


### PR DESCRIPTION
Please review this small change to fix TestInheritFD.java.  The logs in the JBS bug indicate that the test probably timed out waiting for the lsof command to finish.  This fix adds the -a and +d <dir> options to the lsof command to limit its scope.  The +d option tells lsof to only look in the specified directory for open files.  The -a option combines the -p <pid> and the +d option.  (An alternative fix would be to use the -b option.)

The fix was tested by running the test 1000 times on Linux x64 and Mac OS aarch64.  The fix was also sanity tested on Linux aarch64, Mac OS x64, and windows.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8214733](https://bugs.openjdk.java.net/browse/JDK-8214733): runtime/8176717/TestInheritFD.java timed out


### Reviewers
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - **Reviewer**) ⚠️ Review applies to db0325d08054fa613e707a28d9d38f2c051b6bdc
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to db0325d08054fa613e707a28d9d38f2c051b6bdc
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7179/head:pull/7179` \
`$ git checkout pull/7179`

Update a local copy of the PR: \
`$ git checkout pull/7179` \
`$ git pull https://git.openjdk.java.net/jdk pull/7179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7179`

View PR using the GUI difftool: \
`$ git pr show -t 7179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7179.diff">https://git.openjdk.java.net/jdk/pull/7179.diff</a>

</details>
