### PR TITLE
8240908: RetransformClass does not know about MethodParameters attribute

### DIFF
--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.hpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,6 +101,7 @@ class JvmtiClassFileReconstituter : public JvmtiConstantPoolReconstituter {
   void write_method_info(const methodHandle& method);
   void write_code_attribute(const methodHandle& method);
   void write_exceptions_attribute(ConstMethod* const_method);
+  void write_method_parameter_attribute(const ConstMethod* const_method);
   void write_synthetic_attribute();
   void write_class_attributes();
   void write_source_file_attribute();

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -3681,7 +3681,7 @@ void VM_RedefineClasses::set_new_constant_pool(
 
     // Update constant pool indices in the method's method_parameters.
     int mp_length = method->method_parameters_length();
-    if (mp_length >= 0) {
+    if (mp_length > 0) {
         MethodParametersElement* elem = method->method_parameters_start();
         for (int j = 0; j < mp_length; j++) {
             const int cp_index = elem[j].name_cp_index;

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -3682,14 +3682,14 @@ void VM_RedefineClasses::set_new_constant_pool(
     // Update constant pool indices in the method's method_parameters.
     int mp_length = method->method_parameters_length();
     if (mp_length > 0) {
-        MethodParametersElement* elem = method->method_parameters_start();
-        for (int j = 0; j < mp_length; j++) {
-            const int cp_index = elem[j].name_cp_index;
-            const int new_cp_index = find_new_index(cp_index);
-            if (new_cp_index != 0) {
-                elem[j].name_cp_index = new_cp_index;
-            }
+      MethodParametersElement* elem = method->method_parameters_start();
+      for (int j = 0; j < mp_length; j++) {
+        const int cp_index = elem[j].name_cp_index;
+        const int new_cp_index = find_new_index(cp_index);
+        if (new_cp_index != 0) {
+          elem[j].name_cp_index = (u2)new_cp_index;
         }
+      }
     }
 
     rewrite_cp_refs_in_stack_map_table(method);

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2266,21 +2266,6 @@ void VM_RedefineClasses::rewrite_cp_refs_in_method(methodHandle method,
         break;
     }
   } // end for each bytecode
-
-  // We also need to rewrite the parameter name indexes, if there is
-  // method parameter data present
-  if(method->has_method_parameters()) {
-    const int len = method->method_parameters_length();
-    MethodParametersElement* elem = method->method_parameters_start();
-
-    for (int i = 0; i < len; i++) {
-      const u2 cp_index = elem[i].name_cp_index;
-      const u2 new_cp_index = find_new_index(cp_index);
-      if (new_cp_index != 0) {
-        elem[i].name_cp_index = new_cp_index;
-      }
-    }
-  }
 } // end rewrite_cp_refs_in_method()
 
 
@@ -3693,6 +3678,19 @@ void VM_RedefineClasses::set_new_constant_pool(
         }
       } // end for each local variable table entry
     } // end if there are local variable table entries
+
+    // Update constant pool indices in the method's method_parameters.
+    int mp_length = method->method_parameters_length();
+    if (mp_length >= 0) {
+        MethodParametersElement* elem = method->method_parameters_start();
+        for (int j = 0; j < mp_length; j++) {
+            const int cp_index = elem[j].name_cp_index;
+            const int new_cp_index = find_new_index(cp_index);
+            if (new_cp_index != 0) {
+                elem[j].name_cp_index = new_cp_index;
+            }
+        }
+    }
 
     rewrite_cp_refs_in_stack_map_table(method);
   } // end for each method

--- a/test/jdk/java/lang/instrument/RetransformWithMethodParametersTest.java
+++ b/test/jdk/java/lang/instrument/RetransformWithMethodParametersTest.java
@@ -50,8 +50,9 @@ import jdk.test.lib.util.ClassTransformer;
 /*
  * The test verifies Instrumentation.retransformClasses() (and JVMTI function RetransformClasses)
  * correctly handles MethodParameter attribute:
- * - classfile bytes passed to transformers (and JVMTI ClassFileLoadHook event callback) contain the attribute;
- * - the attribute is updated.
+ * 1) classfile bytes passed to transformers (and JVMTI ClassFileLoadHook event callback) contain the attribute;
+ * 2) the attribute is updated if new version has the attribute with different values;
+ * 3) the attribute is removed if new version doesn't contain the attribute.
  */
 
 // See ClassTransformer.transform(int) comment for @1 tag explanations.

--- a/test/jdk/java/lang/instrument/RetransformWithMethodParametersTest.java
+++ b/test/jdk/java/lang/instrument/RetransformWithMethodParametersTest.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8240908
+ *
+ * @library /test/lib
+ * @run compile -g -parameters RetransformWithMethodParametersTest.java
+ * @run shell MakeJAR.sh retransformAgent
+ *
+ * @run main/othervm -javaagent:retransformAgent.jar RetransformWithMethodParametersTest
+ */
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.ProtectionDomain;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.util.ClassTransformer;
+
+class MethodParametersTarget {
+    public void method1(
+            int intParam1, String stringParam1 // @1 commentout
+            // @1 uncomment   int intParam2, String stringParam2
+            )
+    {
+        // @1 uncomment System.out.println(stringParam2);   // change CP
+    }
+}
+
+public class RetransformWithMethodParametersTest extends ATransformerManagementTestCase {
+
+    public static void main (String[] args) throws Throwable {
+        ATestCaseScaffold test = new RetransformWithMethodParametersTest();
+        test.runTest();
+    }
+
+    private String targetClassName = "MethodParametersTarget";
+    private String classFileName = targetClassName + ".class";
+    private String sourceFileName = "RetransformWithMethodParametersTest.java";
+    private Class targetClass;
+    private byte[] originalClassBytes;
+
+    private byte[] seenClassBytes;
+    private byte[] newClassBytes;
+
+    public RetransformWithMethodParametersTest() throws Throwable {
+        super("RetransformWithMethodParametersTest");
+
+        File origClassFile = new File(System.getProperty("test.classes", "."), classFileName);
+        log("Reading test class from " + origClassFile);
+        originalClassBytes = Files.readAllBytes(origClassFile.toPath());
+        log("Read " + originalClassBytes.length + " bytes.");
+
+        DisassembledClassbytes disasm = new DisassembledClassbytes(originalClassBytes);
+        log("original:");
+        disasm.print();
+        assertTrue("MethodParameters not found", !disasm.methodParameters().lines.isEmpty());
+    }
+
+    private void log(Object o) {
+        System.out.println(String.valueOf(o));
+    }
+
+    //
+    private void verifyMethodParams(boolean expectedPresent, String... expectedNames) throws Throwable {
+        Class cls = Class.forName(targetClassName);
+        // the class contains 1 method (method1)
+        Method method = cls.getDeclaredMethods()[0];
+        Parameter[] params = method.getParameters();
+        log("Params of " + method.getName() + " method (" + params.length + "):");
+        if (expectedPresent) {
+            assertEquals(expectedNames.length, params.length);
+        }
+        for (int i = 0; i < params.length; i++) {
+            log("  " + i + ": " + params[i].getName());
+            assertEquals(expectedPresent, params[i].isNamePresent());
+            if (expectedPresent) {
+                assertEquals(expectedNames[i], params[i].getName());
+            }
+        }
+    }
+
+    private void reset() {
+        seenClassBytes = null;
+        newClassBytes = null;
+    }
+
+    private byte[] getClassBytes() throws Throwable {
+        reset();
+        fInst.retransformClasses(targetClass);
+        assertTrue(targetClassName + " was not seen by transform()", seenClassBytes != null);
+        return seenClassBytes;
+    }
+
+    private void setClassBytes(byte[] classBytes) throws Throwable {
+        reset();
+        newClassBytes = classBytes;
+        fInst.retransformClasses(targetClass);
+        assertTrue(targetClassName + " was not seen by transform()", seenClassBytes != null);
+    }
+
+    private static final String[] expectedDifferentStrings = {
+            "^Classfile .+$",
+            "^[\\s]+SHA-256 checksum .[^\\s]+$"
+    };
+
+    private boolean expectedDifferent(String line) {
+        for (String s: expectedDifferentStrings) {
+            Pattern p = Pattern.compile(s);
+            if (p.matcher(line).find()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void compareClassBytes(byte[] bytes1, byte[] bytes2) throws Throwable {
+        if (bytes1.length != bytes2.length) {
+            log("Class bytes have different length: " + bytes1.length + " != " + bytes2.length);
+        } else {
+            int pos = Arrays.mismatch(bytes1, bytes2);
+            if (pos < 0) {
+                log("Class bytes are identical.");
+                return;
+            }
+            log("Class bytes are different (starting from " + pos + "): " + bytes1.length + " != " + bytes2.length);
+        }
+
+        log("Disassembly difference:");
+        // compare 'javap -v' output for the class files
+        List<String> out1 = new DisassembledClassbytes(bytes1).lines;
+        DisassembledClassbytes disasm2 = new DisassembledClassbytes(bytes2);
+        List<String> out2 = disasm2.lines;
+        boolean different = false;
+        boolean orderChanged = false;
+        int lineNum = 0;
+        for (String line: out1) {
+            if (!expectedDifferent(line)) {
+                if (!out2.contains(line)) {
+                    different = true;
+                    System.out.println("< (" + (lineNum + 1) + ") " + line);
+                } else {
+                    if (lineNum < out2.size() && !out1.get(lineNum).equals(out2.get(lineNum))) {
+                        // out2 contains line, but at different position
+                        System.out.println("orig (" + lineNum + "): " + line);
+                        orderChanged = true;
+                    }
+                }
+            }
+            lineNum++;
+        }
+        lineNum = 0;
+        for (String line: out2) {
+            if (!expectedDifferent(line)) {
+                if (!out1.contains(line)) {
+                    different = true;
+                    System.out.println("> (" + (lineNum + 1) + ") " + line);
+                }
+            }
+            lineNum++;
+        }
+
+        if (different) {
+            log("from transformer:");
+            disasm2.print();
+
+            fail(targetClassName + " did not match .class file");
+        }
+        log("Disassembled files are equals" + (orderChanged ? " (order changed)" : ""));
+    }
+
+    private class DisassembledClassbytes {
+        public final List<String> lines;
+
+        public DisassembledClassbytes(List<String> lines) {
+            this.lines = lines;
+        }
+        public DisassembledClassbytes(byte[] classBytes) throws Throwable {
+            this(disassembleClassBytes(classBytes));
+        }
+
+        public void print() {
+            log("DisassembledClassbytes -------------------");
+            lines.forEach(s -> log(s));
+            log("==========================================");
+        }
+
+        public boolean contains(String s) {
+            for (String line: lines) {
+                if (line.contains(s)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public DisassembledClassbytes getSection(String name) {
+            List<String> result = new ArrayList<>();
+            boolean inSection = false;
+            String sectionPrefix = "";
+            Pattern p = Pattern.compile("^( *)" + name + "\\b.*$");
+
+            for (String line: lines) {
+                if (inSection) {
+                    if (line.startsWith(sectionPrefix)) {
+                        result.add(line);
+                    } else {
+                        inSection = false; // and check if new section is started here
+                    }
+                }
+                if (!inSection) {
+                    Matcher m = p.matcher(line);
+                    if (m.find()) {
+                        inSection = true;
+                        sectionPrefix = m.group(1) + " ";
+                        // add section header as well
+                        result.add(line);
+                    }
+                }
+            }
+            return new DisassembledClassbytes(result);
+        }
+
+        public DisassembledClassbytes methodParameters() {
+            return getSection("MethodParameters");
+        }
+    }
+
+    private List<String> disassembleClassBytes(byte[] bytes) throws Throwable {
+        File f = new File(classFileName);
+        try (FileOutputStream fos = new FileOutputStream(f)) {
+            fos.write(bytes);
+        }
+
+        JDKToolLauncher javap = JDKToolLauncher.create("javap")
+                .addToolArg("-verbose")
+                .addToolArg("-p")       // Shows all classes and members.
+                //.addToolArg("-c")       // Prints out disassembled code
+                //.addToolArg("-s")       // Prints internal type signatures.
+                .addToolArg(f.toString());
+        ProcessBuilder pb = new ProcessBuilder(javap.getCommand());
+        OutputAnalyzer out = ProcessTools.executeProcess(pb);
+        out.shouldHaveExitValue(0);
+        try {
+            Files.delete(f.toPath());
+        } catch (Exception ex) {
+            // ignore
+        }
+        return out.asLines();
+    }
+
+
+    protected final void doRunTest() throws Throwable {
+        beVerbose();
+
+        ClassLoader loader = getClass().getClassLoader();
+        targetClass = loader.loadClass(targetClassName);
+        assertEquals(targetClassName, targetClass.getName());
+        verifyMethodParams(true, "intParam1", "stringParam1");
+
+        log("(-1)1st arg name = " + targetClass.getMethods()[0].getParameters()[0].getName());
+
+        addTransformerToManager(fInst, new Transformer(), true);
+
+        {
+            log("Testcase 1: ensure ClassFileReconstiruter restores MethodParameters attribute");
+            byte[] classBytes = getClassBytes();
+
+            compareClassBytes(originalClassBytes, classBytes);
+            log("");
+        }
+
+        {
+            log("Testcase 2: redefine class with changed parameter names");
+            byte[] classBytes = Files.readAllBytes(Paths.get(
+                    ClassTransformer.fromTestSource(sourceFileName)
+                            .transform(1, targetClassName, "-g", "-parameters")));
+            DisassembledClassbytes disasm = new DisassembledClassbytes(classBytes);
+            log("transformed class:");
+            disasm.print();
+            assertTrue("MethodParameters not found", !disasm.methodParameters().lines.isEmpty());
+
+            setClassBytes(classBytes);
+
+            verifyMethodParams(true, "intParam2", "stringParam2");
+        }
+
+        {
+            log("Testcase 3: redefine class with no parameter names");
+            byte[] classBytes = Files.readAllBytes(Paths.get(
+                    ClassTransformer.fromTestSource(sourceFileName)
+                            .transform(1, targetClassName, "-g")));
+            DisassembledClassbytes disasm = new DisassembledClassbytes(classBytes);
+            log("transformed class:");
+            disasm.print();
+            // ensure there is no MethodParameters attr.
+            assertTrue("MethodParameters found", disasm.methodParameters().lines.isEmpty());
+
+            setClassBytes(classBytes);
+
+            // MethodParameters attribute should be deleted.
+            verifyMethodParams(false);
+        }
+    }
+
+
+    public class Transformer implements ClassFileTransformer {
+        public Transformer() {
+        }
+
+        public String toString() {
+            return Transformer.this.getClass().getName();
+        }
+
+        public byte[] transform(ClassLoader loader, String className,
+            Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) {
+
+            if (className.equals(targetClassName)) {
+                log(this + ".transform() sees '" + className
+                        + "' of " + classfileBuffer.length + " bytes.");
+                seenClassBytes = classfileBuffer;
+                if (newClassBytes != null) {
+                    log(this + ".transform() sets new classbytes for '" + className
+                            + "' of " + newClassBytes.length + " bytes.");
+                }
+                return newClassBytes;
+            }
+
+            return null;
+        }
+    }
+}

--- a/test/jdk/java/lang/instrument/RetransformWithMethodParametersTest.java
+++ b/test/jdk/java/lang/instrument/RetransformWithMethodParametersTest.java
@@ -97,7 +97,7 @@ public class RetransformWithMethodParametersTest extends ATransformerManagementT
         System.out.println(String.valueOf(o));
     }
 
-    private Parameter[] getTargetClassParameters() throws ClassNotFoundException {
+    private Parameter[] getTargetMethodParameters() throws ClassNotFoundException {
         Class cls = Class.forName(targetClassName);
         // the class contains 1 method (method1)
         Method method = cls.getDeclaredMethods()[0];
@@ -112,7 +112,7 @@ public class RetransformWithMethodParametersTest extends ATransformerManagementT
 
     // Verifies MethodParameters attribute is present and contains the expected values.
     private void verifyPresentMethodParams(String... expectedNames) throws Throwable {
-        Parameter[] params = getTargetClassParameters();
+        Parameter[] params = getTargetMethodParameters();
         assertEquals(expectedNames.length, params.length);
         for (int i = 0; i < params.length; i++) {
             assertTrue(params[i].isNamePresent());
@@ -122,7 +122,7 @@ public class RetransformWithMethodParametersTest extends ATransformerManagementT
 
     // Verifies MethodParameters attribute is absent.
     private void verifyAbsentMethodParams() throws Throwable {
-        Parameter[] params = getTargetClassParameters();
+        Parameter[] params = getTargetMethodParameters();
         for (int i = 0; i < params.length; i++) {
             assertTrue(!params[i].isNamePresent());
         }

--- a/test/lib/jdk/test/lib/util/ClassTransformer.java
+++ b/test/lib/jdk/test/lib/util/ClassTransformer.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib.util;
+
+import jdk.test.lib.compiler.CompilerUtils;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+// ClassTransformer provides functionality to transform java source and compile it.
+// We cannot use InMemoryJavaCompiler as test files usually contain 2 classes (the test itself and debuggee)
+// and InMemoryJavaCompiler cannot compile them.
+public class ClassTransformer {
+
+    private final List<String> lines;
+    private String fileName;
+    private String workDir = "ver{0}";
+    private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+
+    private ClassTransformer(List<String> lines) {
+        this.lines = lines;
+    }
+
+    public ClassTransformer setFileName(String fileName) {
+        this.fileName = fileName;
+        return this;
+    }
+
+    // workDir is a MessageFormat pattern, id (int) is an {0} arg of the pattern.
+    // can be relative (relatively "scratch" dir) or absolute.
+    public ClassTransformer setWorkDir(String dir) {
+        workDir = dir;
+        return this;
+    }
+
+    public static ClassTransformer fromString(String content) {
+        return new ClassTransformer(Arrays.asList(content.split("\\R")));
+    }
+
+    public static ClassTransformer fromFile(Path filePath) {
+        try {
+            return new ClassTransformer(Files.readAllLines(filePath))
+                    .setFileName(filePath.getFileName().toString());
+        } catch (IOException e) {
+            throw new RuntimeException("failed to read " + filePath, e);
+        }
+    }
+    public static ClassTransformer fromFile(String filePath) {
+        return fromFile(Paths.get(filePath));
+    }
+
+    public static ClassTransformer fromTestSource(String fileName) {
+        return fromFile(Paths.get(System.getProperty("test.src")).resolve(fileName));
+    }
+
+    // returns path to the .class file of the transformed class
+    public String transform(int id, String className, String... compilerOptions) {
+        Path subdir = Paths.get(".").resolve(MessageFormat.format(workDir, id));
+        Path transformedSrc = subdir.resolve(fileName);
+        try {
+            Files.createDirectories(subdir);
+            Files.write(transformedSrc, transform(id).getBytes());
+        } catch (IOException e) {
+            throw new RuntimeException("failed to write transformed " + transformedSrc, e);
+        }
+        try {
+            // need to add extra classpath args
+            List<String> args = new LinkedList<>(Arrays.asList(compilerOptions));
+            args.add("-cp");
+            args.add(System.getProperty("java.class.path"));
+            CompilerUtils.compile(subdir, subdir, false, args.toArray(new String[args.size()]));
+        } catch (IOException e) {
+            throw new RuntimeException("failed to compile " + transformedSrc, e);
+        }
+        return subdir.resolve(className + ".class").toString();
+    }
+
+    /*
+    * To do RedefineClasses operations, embed @1 tags in the .java
+    * file to tell this script how to modify it to produce the 2nd
+    * version of the .class file to be used in the redefine operation.
+    * Here are examples of each editing tag and what change
+    * it causes in the new file.  Note that blanks are not preserved
+    * in these editing operations.
+    *
+    * @1 uncomment
+    *  orig:   // @1 uncomment   gus = 89;
+    *  new:         gus = 89;
+    *
+    * @1 commentout
+    *  orig:   gus = 89      // @1 commentout
+    *  new: // gus = 89      // @1 commentout
+    *
+    * @1 delete
+    *  orig:  gus = 89      // @1 delete
+    *  new:   entire line deleted
+    *
+    * @1 newline
+    *  orig:  gus = 89;     // @1 newline gus++;
+    *  new:   gus = 89;     //
+    *         gus++;
+    *
+    * @1 replace
+    *  orig:  gus = 89;     // @1 replace gus = 90;
+    *  new:   gus = 90;
+    */
+    public String transform(int id) {
+        Pattern delete = Pattern.compile("@" + id + " *delete");
+        Pattern uncomment = Pattern.compile("// *@" + id + " *uncomment (.*)");
+        Pattern commentout = Pattern.compile(".* @" + id + " *commentout");
+        Pattern newline = Pattern.compile("(.*) @" + id + " *newline (.*)");
+        Pattern replace = Pattern.compile("@" + id + " *replace (.*)");
+        return lines.stream()
+                .filter(s -> !delete.matcher(s).find())     // @1 delete
+                .map(s -> {
+                    Matcher m = uncomment.matcher(s);       // @1 uncomment
+                    return m.find() ? m.group(1) : s;
+                })
+                .map(s-> {
+                    Matcher m = commentout.matcher(s);      // @1 commentout
+                    return m.find() ? "//" + s : s;
+                })
+                .map(s -> {
+                    Matcher m = newline.matcher(s);         // @1 newline
+                    return m.find() ? m.group(1) + LINE_SEPARATOR + m.group(2) : s;
+                })
+                .map(s -> {
+                    Matcher m = replace.matcher(s);         // @1 replace
+                    return m.find() ? m.group(1) : s;
+                })
+                .collect(Collectors.joining(LINE_SEPARATOR));
+    }
+
+}


### PR DESCRIPTION
Changes:
- ClassFileReconstituter is updated to restore "MethodParameters" attribute;
- handling of the attribute in VM_RedefineClasses is moved to be consistent with other code (like local variable table);
- copied ClassTransformer class (from test/jdk/com/sun/jdi/lib/jdb) to /test/lib as it's used by tests from hotspot and jdk (and also by test from Valhalla repo); Will file a follow up issues to updates tests and remove the class from test/jdk/com/sun/jdi/lib/jdb

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8240908](https://bugs.openjdk.java.net/browse/JDK-8240908): RetransformClass does not know about MethodParameters attribute


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to 0f80f7657b93aed817c3e74e5e2a0ca5e7bb85dc
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to 0f80f7657b93aed817c3e74e5e2a0ca5e7bb85dc


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7180/head:pull/7180` \
`$ git checkout pull/7180`

Update a local copy of the PR: \
`$ git checkout pull/7180` \
`$ git pull https://git.openjdk.java.net/jdk pull/7180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7180`

View PR using the GUI difftool: \
`$ git pr show -t 7180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7180.diff">https://git.openjdk.java.net/jdk/pull/7180.diff</a>

</details>
