### PR TITLE
8280437: Move G1BufferNodeList to gc/shared

### DIFF
--- a/src/hotspot/share/gc/g1/g1DirtyCardQueue.hpp
+++ b/src/hotspot/share/gc/g1/g1DirtyCardQueue.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,10 @@
 #ifndef SHARE_GC_G1_G1DIRTYCARDQUEUE_HPP
 #define SHARE_GC_G1_G1DIRTYCARDQUEUE_HPP
 
-#include "gc/g1/g1BufferNodeList.hpp"
 #include "gc/g1/g1FreeIdSet.hpp"
 #include "gc/g1/g1CardTable.hpp"
 #include "gc/g1/g1ConcurrentRefineStats.hpp"
+#include "gc/shared/bufferNodeList.hpp"
 #include "gc/shared/ptrQueue.hpp"
 #include "memory/allocation.hpp"
 #include "memory/padded.hpp"
@@ -69,7 +69,7 @@ public:
 
 class G1DirtyCardQueueSet: public PtrQueueSet {
   // Head and tail of a list of BufferNodes, linked through their next()
-  // fields.  Similar to G1BufferNodeList, but without the _entry_count.
+  // fields.  Similar to BufferNodeList, but without the _entry_count.
   struct HeadTail {
     BufferNode* _head;
     BufferNode* _tail;
@@ -275,7 +275,7 @@ public:
 
   void merge_bufferlists(G1RedirtyCardsQueueSet* src);
 
-  G1BufferNodeList take_all_completed_buffers();
+  BufferNodeList take_all_completed_buffers();
 
   void flush_queue(G1DirtyCardQueue& queue);
 

--- a/src/hotspot/share/gc/g1/g1RedirtyCardsQueue.cpp
+++ b/src/hotspot/share/gc/g1/g1RedirtyCardsQueue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ void G1RedirtyCardsLocalQueueSet::enqueue(void* value) {
 void G1RedirtyCardsLocalQueueSet::flush() {
   flush_queue(_queue);
   _shared_qset->add_bufferlist(_buffers);
-  _buffers = G1BufferNodeList();
+  _buffers = BufferNodeList();
 }
 
 // G1RedirtyCardsLocalQueueSet::Queue
@@ -109,9 +109,9 @@ BufferNode* G1RedirtyCardsQueueSet::all_completed_buffers() const {
   return _list.top();
 }
 
-G1BufferNodeList G1RedirtyCardsQueueSet::take_all_completed_buffers() {
+BufferNodeList G1RedirtyCardsQueueSet::take_all_completed_buffers() {
   DEBUG_ONLY(_collecting = false;)
-  G1BufferNodeList result(_list.pop_all(), _tail, _entry_count);
+  BufferNodeList result(_list.pop_all(), _tail, _entry_count);
   _tail = NULL;
   _entry_count = 0;
   DEBUG_ONLY(_collecting = true;)
@@ -135,7 +135,7 @@ void G1RedirtyCardsQueueSet::enqueue_completed_buffer(BufferNode* node) {
   update_tail(node);
 }
 
-void G1RedirtyCardsQueueSet::add_bufferlist(const G1BufferNodeList& buffers) {
+void G1RedirtyCardsQueueSet::add_bufferlist(const BufferNodeList& buffers) {
   assert(_collecting, "precondition");
   if (buffers._head != NULL) {
     assert(buffers._tail != NULL, "invariant");

--- a/src/hotspot/share/gc/g1/g1RedirtyCardsQueue.hpp
+++ b/src/hotspot/share/gc/g1/g1RedirtyCardsQueue.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 #ifndef SHARE_GC_G1_G1REDIRTYCARDSQUEUE_HPP
 #define SHARE_GC_G1_G1REDIRTYCARDSQUEUE_HPP
 
-#include "gc/g1/g1BufferNodeList.hpp"
+#include "gc/shared/bufferNodeList.hpp"
 #include "gc/shared/ptrQueue.hpp"
 #include "memory/padded.hpp"
 #include "utilities/macros.hpp"
@@ -42,7 +42,7 @@ class G1RedirtyCardsLocalQueueSet : private PtrQueueSet {
   };
 
   G1RedirtyCardsQueueSet* _shared_qset;
-  G1BufferNodeList _buffers;
+  BufferNodeList _buffers;
   Queue _queue;
 
   // Add the buffer to the local list.
@@ -84,12 +84,12 @@ public:
   // Collect buffers.  These functions are thread-safe.
   // precondition: Must not be concurrent with buffer processing.
   virtual void enqueue_completed_buffer(BufferNode* node);
-  void add_bufferlist(const G1BufferNodeList& buffers);
+  void add_bufferlist(const BufferNodeList& buffers);
 
   // Processing phase operations.
   // precondition: Must not be concurrent with buffer collection.
   BufferNode* all_completed_buffers() const;
-  G1BufferNodeList take_all_completed_buffers();
+  BufferNodeList take_all_completed_buffers();
 };
 
 #endif // SHARE_GC_G1_G1REDIRTYCARDSQUEUE_HPP

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,7 @@
 #include "gc/g1/heapRegion.inline.hpp"
 #include "gc/g1/heapRegionManager.inline.hpp"
 #include "gc/g1/heapRegionRemSet.inline.hpp"
+#include "gc/shared/bufferNodeList.hpp"
 #include "gc/shared/gcTraceTime.inline.hpp"
 #include "gc/shared/ptrQueue.hpp"
 #include "gc/shared/suspendibleThreadSet.hpp"
@@ -1429,7 +1430,7 @@ public:
   {
     if (initial_evacuation) {
       G1DirtyCardQueueSet& dcqs = G1BarrierSet::dirty_card_queue_set();
-      G1BufferNodeList buffers = dcqs.take_all_completed_buffers();
+      BufferNodeList buffers = dcqs.take_all_completed_buffers();
       if (buffers._entry_count != 0) {
         _dirty_card_buffers.prepend(*buffers._head, *buffers._tail);
       }

--- a/src/hotspot/share/gc/shared/bufferNodeList.cpp
+++ b/src/hotspot/share/gc/shared/bufferNodeList.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,21 +22,18 @@
  *
  */
 
-#ifndef SHARE_GC_G1_G1BUFFERNODELIST_HPP
-#define SHARE_GC_G1_G1BUFFERNODELIST_HPP
+#include "precompiled.hpp"
+#include "gc/shared/bufferNodeList.hpp"
+#include "utilities/debug.hpp"
 
-#include "utilities/globalDefinitions.hpp"
+BufferNodeList::BufferNodeList() :
+  _head(NULL), _tail(NULL), _entry_count(0) {}
 
-class BufferNode;
-
-struct G1BufferNodeList {
-  BufferNode* _head;            // First node in list or NULL if empty.
-  BufferNode* _tail;            // Last node in list or NULL if empty.
-  size_t _entry_count;          // Sum of entries in nodes in list.
-
-  G1BufferNodeList();
-  G1BufferNodeList(BufferNode* head, BufferNode* tail, size_t entry_count);
-};
-
-#endif // SHARE_GC_G1_G1BUFFERNODELIST_HPP
-
+BufferNodeList::BufferNodeList(BufferNode* head,
+                               BufferNode* tail,
+                               size_t entry_count) :
+  _head(head), _tail(tail), _entry_count(entry_count)
+{
+  assert((_head == NULL) == (_tail == NULL), "invariant");
+  assert((_head == NULL) == (_entry_count == 0), "invariant");
+}

--- a/src/hotspot/share/gc/shared/bufferNodeList.hpp
+++ b/src/hotspot/share/gc/shared/bufferNodeList.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,18 +22,20 @@
  *
  */
 
-#include "precompiled.hpp"
-#include "gc/g1/g1BufferNodeList.hpp"
-#include "utilities/debug.hpp"
+#ifndef SHARE_GC_SHARED_BUFFERNODELIST_HPP
+#define SHARE_GC_SHARED_BUFFERNODELIST_HPP
 
-G1BufferNodeList::G1BufferNodeList() :
-  _head(NULL), _tail(NULL), _entry_count(0) {}
+#include "utilities/globalDefinitions.hpp"
 
-G1BufferNodeList::G1BufferNodeList(BufferNode* head,
-                                   BufferNode* tail,
-                                   size_t entry_count) :
-  _head(head), _tail(tail), _entry_count(entry_count)
-{
-  assert((_head == NULL) == (_tail == NULL), "invariant");
-  assert((_head == NULL) == (_entry_count == 0), "invariant");
-}
+class BufferNode;
+
+struct BufferNodeList {
+  BufferNode* _head;            // First node in list or NULL if empty.
+  BufferNode* _tail;            // Last node in list or NULL if empty.
+  size_t _entry_count;          // Sum of entries in nodes in list.
+
+  BufferNodeList();
+  BufferNodeList(BufferNode* head, BufferNode* tail, size_t entry_count);
+};
+
+#endif // SHARE_GC_SHARED_BUFFERNODELIST_HPP


### PR DESCRIPTION
Please review this simple (trivial?) change, renaming G1BufferNodeList to
BufferNodeList and moving its files from gc/g1 to gc/shared.

Testing:
mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280437](https://bugs.openjdk.java.net/browse/JDK-8280437): Move G1BufferNodeList to gc/shared


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to 3761c3e4b9d8ae9c3ce69754108cacfc7cf0f90a
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**) ⚠️ Review applies to 3761c3e4b9d8ae9c3ce69754108cacfc7cf0f90a
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**) ⚠️ Review applies to 3761c3e4b9d8ae9c3ce69754108cacfc7cf0f90a


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7183/head:pull/7183` \
`$ git checkout pull/7183`

Update a local copy of the PR: \
`$ git checkout pull/7183` \
`$ git pull https://git.openjdk.java.net/jdk pull/7183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7183`

View PR using the GUI difftool: \
`$ git pr show -t 7183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7183.diff">https://git.openjdk.java.net/jdk/pull/7183.diff</a>

</details>
