### PR TITLE
8280474: Garbage value passed to getLocaleInfoWrapper in HostLocaleProviderAdapter_md

### DIFF
--- a/src/java.base/windows/native/libjava/HostLocaleProviderAdapter_md.c
+++ b/src/java.base/windows/native/libjava/HostLocaleProviderAdapter_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/windows/native/libjava/HostLocaleProviderAdapter_md.c
+++ b/src/java.base/windows/native/libjava/HostLocaleProviderAdapter_md.c
@@ -835,7 +835,7 @@ void replaceCalendarArrayElems(JNIEnv *env, jstring jlangtag, jint calid, jobjec
     WCHAR name[BUFLEN];
     const jchar *langtag = (*env)->GetStringChars(env, jlangtag, JNI_FALSE);
     jstring tmp_string;
-    CALTYPE isGenitive;
+    CALTYPE isGenitive = 0;
 
     CHECK_NULL(langtag);
 


### PR DESCRIPTION
Reported by clang-tidy. Verified manually by running
```
        Calendar c = Calendar.getInstance();
        System.out.println (c.getDisplayNames(Calendar.MONTH, Calendar.SHORT_STANDALONE, Locale.getDefault()));
```
with `-Djava.locale.providers=HOST`

Without the fix the WINAPI functions fail, and [this block](https://github.com/openjdk/jdk/blame/739769c8fc4b496f08a92225a12d07414537b6c0/src/java.base/windows/native/libjava/HostLocaleProviderAdapter_md.c#L857) is never entered. With the fix this block is entered and sensible values are stored in the returned array.

No test because the observable effect with and without the fix was the same; apparently there's a fallback to another provider that works.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280474](https://bugs.openjdk.java.net/browse/JDK-8280474): Garbage value passed to getLocaleInfoWrapper in HostLocaleProviderAdapter_md


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7184/head:pull/7184` \
`$ git checkout pull/7184`

Update a local copy of the PR: \
`$ git checkout pull/7184` \
`$ git pull https://git.openjdk.java.net/jdk pull/7184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7184`

View PR using the GUI difftool: \
`$ git pr show -t 7184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7184.diff">https://git.openjdk.java.net/jdk/pull/7184.diff</a>

</details>
