### PR TITLE
8280377: MethodHandleProxies does not correctly invoke default methods with varags

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleProxies.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleProxies.java
@@ -203,7 +203,7 @@ public class MethodHandleProxies {
                         return callObjectMethod(proxy, method, args);
                     if (isDefaultMethod(method)) {
                         // no additional access check is performed
-                        return JLRA.invokeDefault(proxy, method, null, args);
+                        return JLRA.invokeDefault(proxy, method, args, null);
                     }
                     throw newInternalError("bad proxy method: "+method);
                 }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleProxies.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleProxies.java
@@ -28,6 +28,9 @@ package java.lang.invoke;
 import java.lang.reflect.*;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+
+import jdk.internal.access.JavaLangReflectAccess;
+import jdk.internal.access.SharedSecrets;
 import sun.invoke.WrapperInstance;
 import java.util.ArrayList;
 
@@ -199,7 +202,8 @@ public class MethodHandleProxies {
                     if (isObjectMethod(method))
                         return callObjectMethod(proxy, method, args);
                     if (isDefaultMethod(method)) {
-                        return InvocationHandler.invokeDefault(proxy, method, args);
+                        // no additional access check is performed
+                        return JLRA.invokeDefault(proxy, method, null, args);
                     }
                     throw newInternalError("bad proxy method: "+method);
                 }
@@ -316,4 +320,6 @@ public class MethodHandleProxies {
     private static boolean isDefaultMethod(Method m) {
         return !Modifier.isAbstract(m.getModifiers());
     }
+
+    private static final JavaLangReflectAccess JLRA = SharedSecrets.getJavaLangReflectAccess();
 }

--- a/src/java.base/share/classes/java/lang/reflect/ReflectAccess.java
+++ b/src/java.base/share/classes/java/lang/reflect/ReflectAccess.java
@@ -127,4 +127,9 @@ class ReflectAccess implements jdk.internal.access.JavaLangReflectAccess {
     {
         return ctor.newInstanceWithCaller(args, true, caller);
     }
+
+    public Object invokeDefault(Object proxy, Method method, Object[] args, Class<?> caller)
+            throws Throwable {
+        return Proxy.invokeDefault(proxy, method, args, caller);
+    }
 }

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangReflectAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangReflectAccess.java
@@ -102,4 +102,7 @@ public interface JavaLangReflectAccess {
     /** Returns a new instance created by the given constructor with access check */
     public <T> T newInstance(Constructor<T> ctor, Object[] args, Class<?> caller)
         throws IllegalAccessException, InstantiationException, InvocationTargetException;
+
+    public Object invokeDefault(Object proxy, Method method, Object[] args, Class<?> caller)
+        throws Throwable;
 }

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangReflectAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangReflectAccess.java
@@ -103,6 +103,10 @@ public interface JavaLangReflectAccess {
     public <T> T newInstance(Constructor<T> ctor, Object[] args, Class<?> caller)
         throws IllegalAccessException, InstantiationException, InvocationTargetException;
 
+    /** Invokes the given default method if the method's declaring interface is
+     *  accessible to the given caller.  Otherwise, IllegalAccessException will
+     *  be thrown.  If the caller is null, no access check is performed.
+     */
     public Object invokeDefault(Object proxy, Method method, Object[] args, Class<?> caller)
         throws Throwable;
 }

--- a/test/jdk/java/lang/invoke/MethodHandleProxies/Driver.java
+++ b/test/jdk/java/lang/invoke/MethodHandleProxies/Driver.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8280377
+ * @build m1/* m2/* Unnamed
+ * @run testng/othervm m1/p1.Main
+ * @run testng/othervm Unnamed
+ * @summary Test MethodHandleProxies::asInterfaceInstance with a default
+ *          method with varargs
+ */

--- a/test/jdk/java/lang/invoke/MethodHandleProxies/MethodHandlesProxiesTest.java
+++ b/test/jdk/java/lang/invoke/MethodHandleProxies/MethodHandlesProxiesTest.java
@@ -43,14 +43,12 @@ public class MethodHandlesProxiesTest {
         default String a() {
             return "A";
         }
-        default String aConcat(Object... objs) { return Arrays.deepToString(objs); }
     }
 
     public interface B {
         default String b() {
             return "B";
         }
-        default String bConcat(Object[] objs) { return Arrays.deepToString(objs); }
     }
 
     public interface C extends A, B {
@@ -91,11 +89,6 @@ public class MethodHandlesProxiesTest {
         assertEquals(proxy.b(), "B");
         assertEquals(proxy.c(), "C");
         assertEquals(proxy.concat(), "ABC");
-
-        // test varargs
-        assertEquals(proxy.aConcat("a", "b", "c"), "[a, b, c]");
-        assertEquals(proxy.aConcat(new Object[] { "a", "b", "c" }), "[a, b, c]");
-        assertEquals(proxy.bConcat(new Object[] { "a", "b", "c" }), "[a, b, c]");
     }
 
     @Test

--- a/test/jdk/java/lang/invoke/MethodHandleProxies/MethodHandlesProxiesTest.java
+++ b/test/jdk/java/lang/invoke/MethodHandleProxies/MethodHandlesProxiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 8206955 8269351 8280377
+ * @bug 8206955 8269351
  * @run testng/othervm -ea -esa test.java.lang.invoke.MethodHandlesProxiesTest
  */
 
@@ -33,7 +33,6 @@ import org.testng.annotations.Test;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandleProxies;
 import java.lang.invoke.MethodHandles;
-import java.util.Arrays;
 
 import static org.testng.Assert.assertEquals;
 

--- a/test/jdk/java/lang/invoke/MethodHandleProxies/Unnamed.java
+++ b/test/jdk/java/lang/invoke/MethodHandleProxies/Unnamed.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandleProxies;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+
+import static org.testng.Assert.*;
+
+/*
+ * Test MethodHandleProxies::asInterfaceInstance with an inaccessible interface
+ */
+public class Unnamed {
+    public static void main(String... args) throws Throwable {
+        MethodHandle target = MethodHandles.constant(String.class, "test");
+        Class<?> intf = Class.forName("p2.TestIntf");
+        Object t = MethodHandleProxies.asInterfaceInstance(intf, target);
+
+        // verify that the caller has no access to the proxy created on an
+        // inaccessible interface
+        Method m = intf.getMethod("test", Object[].class);
+        assertFalse(m.canAccess(null));
+    }
+}

--- a/test/jdk/java/lang/invoke/MethodHandleProxies/m1/module-info.java
+++ b/test/jdk/java/lang/invoke/MethodHandleProxies/m1/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+module m1 {
+    requires m2;
+    requires org.testng;
+    exports p1;
+}

--- a/test/jdk/java/lang/invoke/MethodHandleProxies/m1/p1/Main.java
+++ b/test/jdk/java/lang/invoke/MethodHandleProxies/m1/p1/Main.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package p1;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandleProxies;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import p2.TestIntf;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class Main {
+    public interface A {
+        default String aConcat(Object... objs) { return Arrays.deepToString(objs); }
+    }
+
+    public interface B {
+        default String bConcat(Object[] objs) { return Arrays.deepToString(objs); }
+    }
+
+    public interface C extends A, B {
+        String c(Object... objs);
+    }
+
+    private static String concat(Object... objs) {
+        return Arrays.stream(objs).map(Object::toString).collect(Collectors.joining());
+    }
+
+    /*
+     * Test the invocation of default methods with varargs
+     */
+    @Test
+    public static void testVarargsMethods() throws Throwable {
+        MethodHandle target = MethodHandles.lookup().findStatic(Main.class,
+                "concat", MethodType.methodType(String.class, Object[].class));
+        C proxy = MethodHandleProxies.asInterfaceInstance(C.class, target);
+
+        assertEquals(proxy.c("a", "b", "c"), "abc");
+        assertEquals(proxy.aConcat("a", "b", "c"), "[a, b, c]");
+        assertEquals(proxy.aConcat(new Object[] { "a", "b", "c" }), "[a, b, c]");
+        assertEquals(proxy.bConcat(new Object[] { "a", "b", "c" }), "[a, b, c]");
+    }
+
+    /*
+     * Test the invocation of a default method of an accessible interface
+     */
+    @Test
+    public static void modulePrivateInterface() {
+        MethodHandle target = MethodHandles.constant(String.class, "test");
+        TestIntf t = MethodHandleProxies.asInterfaceInstance(TestIntf.class, target);
+        assertEquals(t.test(), "test");
+    }
+}

--- a/test/jdk/java/lang/invoke/MethodHandleProxies/m2/module-info.java
+++ b/test/jdk/java/lang/invoke/MethodHandleProxies/m2/module-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+module m2 {
+    exports p2 to m1;
+}

--- a/test/jdk/java/lang/invoke/MethodHandleProxies/m2/p2/TestIntf.java
+++ b/test/jdk/java/lang/invoke/MethodHandleProxies/m2/p2/TestIntf.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package p2;
+
+public interface TestIntf {
+    String test();
+}

--- a/test/jdk/java/lang/invoke/MethodHandlesProxiesTest.java
+++ b/test/jdk/java/lang/invoke/MethodHandlesProxiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 8206955 8269351
+ * @bug 8206955 8269351 8280377
  * @run testng/othervm -ea -esa test.java.lang.invoke.MethodHandlesProxiesTest
  */
 
@@ -33,6 +33,7 @@ import org.testng.annotations.Test;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandleProxies;
 import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
 
 import static org.testng.Assert.assertEquals;
 
@@ -42,12 +43,14 @@ public class MethodHandlesProxiesTest {
         default String a() {
             return "A";
         }
+        default String aConcat(Object... objs) { return Arrays.deepToString(objs); }
     }
 
     public interface B {
         default String b() {
             return "B";
         }
+        default String bConcat(Object[] objs) { return Arrays.deepToString(objs); }
     }
 
     public interface C extends A, B {
@@ -88,6 +91,11 @@ public class MethodHandlesProxiesTest {
         assertEquals(proxy.b(), "B");
         assertEquals(proxy.c(), "C");
         assertEquals(proxy.concat(), "ABC");
+
+        // test varargs
+        assertEquals(proxy.aConcat("a", "b", "c"), "[a, b, c]");
+        assertEquals(proxy.aConcat(new Object[] { "a", "b", "c" }), "[a, b, c]");
+        assertEquals(proxy.bConcat(new Object[] { "a", "b", "c" }), "[a, b, c]");
     }
 
     @Test


### PR DESCRIPTION
The MethodHandle of a default method should be made as a fixed arity method handle because it is invoked via Proxy's invocation handle with a non-vararg array of arguments.  On the other hand, the `InvocationHandle::invokeDefault` method  was added in Java 16 to invoke a default method of a proxy instance.  This patch simply converts the implementation to call `InvocationHandle::invokeDefault` instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280377](https://bugs.openjdk.java.net/browse/JDK-8280377): MethodHandleProxies does not correctly invoke default methods with varags


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to 30f1a05e3a4c20d9f137655b53fbcd8537445c3b


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7185/head:pull/7185` \
`$ git checkout pull/7185`

Update a local copy of the PR: \
`$ git checkout pull/7185` \
`$ git pull https://git.openjdk.java.net/jdk pull/7185/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7185`

View PR using the GUI difftool: \
`$ git pr show -t 7185`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7185.diff">https://git.openjdk.java.net/jdk/pull/7185.diff</a>

</details>
