### PR TITLE
8280496: Remove unused G1PageBasedVirtualSpace::pretouch_internal

### DIFF
--- a/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.cpp
+++ b/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -176,13 +176,6 @@ void G1PageBasedVirtualSpace::commit_internal(size_t start_page, size_t end_page
 
 char* G1PageBasedVirtualSpace::bounded_end_addr(size_t end_page) const {
   return MIN2(_high_boundary, page_start(end_page));
-}
-
-void G1PageBasedVirtualSpace::pretouch_internal(size_t start_page, size_t end_page) {
-  guarantee(start_page < end_page,
-            "Given start page " SIZE_FORMAT " is larger or equal to end page " SIZE_FORMAT, start_page, end_page);
-
-  os::pretouch_memory(page_start(start_page), bounded_end_addr(end_page), _page_size);
 }
 
 bool G1PageBasedVirtualSpace::commit(size_t start_page, size_t size_in_pages) {

--- a/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.hpp
+++ b/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,9 +86,6 @@ class G1PageBasedVirtualSpace {
 
   // Uncommit the given memory range.
   void uncommit_internal(size_t start_page, size_t end_page);
-
-  // Pretouch the given memory range.
-  void pretouch_internal(size_t start_page, size_t end_page);
 
   // Returns the index of the page which contains the given address.
   size_t  addr_to_page_index(char* addr) const;


### PR DESCRIPTION
Please review this trivial change to remove an unused function.

Testing:
mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280496](https://bugs.openjdk.java.net/browse/JDK-8280496): Remove unused G1PageBasedVirtualSpace::pretouch_internal


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to eeca4c3e88a7e6476322f129e324ee60b4888657
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to eeca4c3e88a7e6476322f129e324ee60b4888657
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**) ⚠️ Review applies to eeca4c3e88a7e6476322f129e324ee60b4888657


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7186/head:pull/7186` \
`$ git checkout pull/7186`

Update a local copy of the PR: \
`$ git checkout pull/7186` \
`$ git pull https://git.openjdk.java.net/jdk pull/7186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7186`

View PR using the GUI difftool: \
`$ git pr show -t 7186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7186.diff">https://git.openjdk.java.net/jdk/pull/7186.diff</a>

</details>
