### PR TITLE
8280499: runtime/cds/appcds/TestDumpClassListSource.java fails on platforms without AppCDS custom class loaders support

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/TestDumpClassListSource.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestDumpClassListSource.java
@@ -28,6 +28,7 @@
  * @summary test dynamic dump meanwhile output loaded class list
  * @bug 8279009 8275084
  * @requires vm.cds
+ * @requires vm.cds.custom.loaders
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @compile test-classes/Hello.java ClassSpecializerTestApp.java ClassListWithCustomClassNoSource.java
  * @run main/othervm TestDumpClassListSource
@@ -54,7 +55,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.cds.CDSTestUtils;
@@ -175,10 +175,6 @@ public class TestDumpClassListSource {
 
         fileArchive.delete();
         fileList.delete();
-
-        if (!Platform.areCustomLoadersSupportedForCDS()) {
-            return;
-        }
 
         //    2.3 class loaded by custom loader from shared space.
         //      2.3.1 dump class list

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestDumpClassListSource.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestDumpClassListSource.java
@@ -54,6 +54,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.cds.CDSTestUtils;
@@ -174,6 +175,10 @@ public class TestDumpClassListSource {
 
         fileArchive.delete();
         fileList.delete();
+
+        if (!Platform.areCustomLoadersSupportedForCDS()) {
+            return;
+        }
 
         //    2.3 class loaded by custom loader from shared space.
         //      2.3.1 dump class list


### PR DESCRIPTION
Hi all,

runtime/cds/appcds/TestDumpClassListSource.java fails on x86_32.
This is because `ClassListParser::load_class_from_source` is not supported on x86_32.

It would be better to improve this test.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280499](https://bugs.openjdk.java.net/browse/JDK-8280499): runtime/cds/appcds/TestDumpClassListSource.java fails on platforms without AppCDS custom class loaders support


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7187/head:pull/7187` \
`$ git checkout pull/7187`

Update a local copy of the PR: \
`$ git checkout pull/7187` \
`$ git pull https://git.openjdk.java.net/jdk pull/7187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7187`

View PR using the GUI difftool: \
`$ git pr show -t 7187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7187.diff">https://git.openjdk.java.net/jdk/pull/7187.diff</a>

</details>
