### PR TITLE
JDK-8280503: Use allStatic.hpp instead of allocation.hpp where possible

### DIFF
--- a/src/hotspot/cpu/aarch64/bytes_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/bytes_aarch64.hpp
@@ -26,7 +26,7 @@
 #ifndef CPU_AARCH64_BYTES_AARCH64_HPP
 #define CPU_AARCH64_BYTES_AARCH64_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class Bytes: AllStatic {
  public:

--- a/src/hotspot/cpu/aarch64/bytes_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/bytes_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/aarch64/jniTypes_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/jniTypes_aarch64.hpp
@@ -27,7 +27,7 @@
 #define CPU_AARCH64_JNITYPES_AARCH64_HPP
 
 #include "jni.h"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "oops/oop.hpp"
 
 // This file holds platform-dependent routines used to write primitive jni

--- a/src/hotspot/cpu/aarch64/jniTypes_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/jniTypes_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/arm/bytes_arm.hpp
+++ b/src/hotspot/cpu/arm/bytes_arm.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/arm/bytes_arm.hpp
+++ b/src/hotspot/cpu/arm/bytes_arm.hpp
@@ -25,7 +25,7 @@
 #ifndef CPU_ARM_BYTES_ARM_HPP
 #define CPU_ARM_BYTES_ARM_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/macros.hpp"
 
 #ifndef VM_LITTLE_ENDIAN

--- a/src/hotspot/cpu/arm/jniTypes_arm.hpp
+++ b/src/hotspot/cpu/arm/jniTypes_arm.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/arm/jniTypes_arm.hpp
+++ b/src/hotspot/cpu/arm/jniTypes_arm.hpp
@@ -26,7 +26,7 @@
 #define CPU_ARM_JNITYPES_ARM_HPP
 
 #include "jni.h"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "oops/oop.hpp"
 
 // This file holds platform-dependent routines used to write primitive jni

--- a/src/hotspot/cpu/ppc/bytes_ppc.hpp
+++ b/src/hotspot/cpu/ppc/bytes_ppc.hpp
@@ -26,7 +26,7 @@
 #ifndef CPU_PPC_BYTES_PPC_HPP
 #define CPU_PPC_BYTES_PPC_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class Bytes: AllStatic {
  public:

--- a/src/hotspot/cpu/ppc/bytes_ppc.hpp
+++ b/src/hotspot/cpu/ppc/bytes_ppc.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2016 SAP SE. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/ppc/jniTypes_ppc.hpp
+++ b/src/hotspot/cpu/ppc/jniTypes_ppc.hpp
@@ -27,7 +27,7 @@
 #define CPU_PPC_JNITYPES_PPC_HPP
 
 #include "jni.h"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "oops/oop.hpp"
 
 // This file holds platform-dependent routines used to write primitive

--- a/src/hotspot/cpu/ppc/jniTypes_ppc.hpp
+++ b/src/hotspot/cpu/ppc/jniTypes_ppc.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2013 SAP SE. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/s390/bytes_s390.hpp
+++ b/src/hotspot/cpu/s390/bytes_s390.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016, 2018 SAP SE. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/s390/bytes_s390.hpp
+++ b/src/hotspot/cpu/s390/bytes_s390.hpp
@@ -26,7 +26,7 @@
 #ifndef CPU_S390_BYTES_S390_HPP
 #define CPU_S390_BYTES_S390_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class Bytes: AllStatic {
  public:

--- a/src/hotspot/cpu/s390/jniTypes_s390.hpp
+++ b/src/hotspot/cpu/s390/jniTypes_s390.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2016 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/s390/jniTypes_s390.hpp
+++ b/src/hotspot/cpu/s390/jniTypes_s390.hpp
@@ -30,7 +30,7 @@
 // jni types to the array of arguments passed into JavaCalls::call.
 
 #include "jni.h"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "oops/oop.hpp"
 
 class JNITypes : AllStatic {

--- a/src/hotspot/cpu/x86/bytes_x86.hpp
+++ b/src/hotspot/cpu/x86/bytes_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/bytes_x86.hpp
+++ b/src/hotspot/cpu/x86/bytes_x86.hpp
@@ -25,7 +25,7 @@
 #ifndef CPU_X86_BYTES_X86_HPP
 #define CPU_X86_BYTES_X86_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/align.hpp"
 #include "utilities/macros.hpp"
 

--- a/src/hotspot/cpu/x86/c2_intelJccErratum_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_intelJccErratum_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/c2_intelJccErratum_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_intelJccErratum_x86.hpp
@@ -25,7 +25,7 @@
 #ifndef CPU_X86_INTELJCCERRATUM_X86_HPP
 #define CPU_X86_INTELJCCERRATUM_X86_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 class Block;

--- a/src/hotspot/cpu/x86/jniTypes_x86.hpp
+++ b/src/hotspot/cpu/x86/jniTypes_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/jniTypes_x86.hpp
+++ b/src/hotspot/cpu/x86/jniTypes_x86.hpp
@@ -26,7 +26,7 @@
 #define CPU_X86_JNITYPES_X86_HPP
 
 #include "jni.h"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "oops/oop.hpp"
 
 // This file holds platform-dependent routines used to write primitive jni

--- a/src/hotspot/cpu/x86/rdtsc_x86.hpp
+++ b/src/hotspot/cpu/x86/rdtsc_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/rdtsc_x86.hpp
+++ b/src/hotspot/cpu/x86/rdtsc_x86.hpp
@@ -25,7 +25,8 @@
 #ifndef CPU_X86_RDTSC_X86_HPP
 #define CPU_X86_RDTSC_X86_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 
 // Interface to the x86 rdtsc() time counter, if available.

--- a/src/hotspot/cpu/zero/bytes_zero.hpp
+++ b/src/hotspot/cpu/zero/bytes_zero.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2007, 2008, 2009 Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/cpu/zero/bytes_zero.hpp
+++ b/src/hotspot/cpu/zero/bytes_zero.hpp
@@ -26,7 +26,7 @@
 #ifndef CPU_ZERO_BYTES_ZERO_HPP
 #define CPU_ZERO_BYTES_ZERO_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 typedef union unaligned {
   u4 u;

--- a/src/hotspot/cpu/zero/jniTypes_zero.hpp
+++ b/src/hotspot/cpu/zero/jniTypes_zero.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/zero/jniTypes_zero.hpp
+++ b/src/hotspot/cpu/zero/jniTypes_zero.hpp
@@ -26,7 +26,7 @@
 #define CPU_ZERO_JNITYPES_ZERO_HPP
 
 #include "jni.h"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "oops/oop.hpp"
 
 // This file holds platform-dependent routines used to write primitive jni

--- a/src/hotspot/os/bsd/gc/z/zNUMA_bsd.cpp
+++ b/src/hotspot/os/bsd/gc/z/zNUMA_bsd.cpp
@@ -23,6 +23,7 @@
 
 #include "precompiled.hpp"
 #include "gc/z/zNUMA.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 void ZNUMA::pd_initialize() {
   _enabled = false;

--- a/src/hotspot/os/linux/gc/z/zSyscall_linux.hpp
+++ b/src/hotspot/os/linux/gc/z/zSyscall_linux.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/os/linux/gc/z/zSyscall_linux.hpp
+++ b/src/hotspot/os/linux/gc/z/zSyscall_linux.hpp
@@ -24,7 +24,8 @@
 #ifndef OS_LINUX_GC_Z_ZSYSCALL_LINUX_HPP
 #define OS_LINUX_GC_Z_ZSYSCALL_LINUX_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 // Flags for get_mempolicy()
 #ifndef MPOL_F_NODE

--- a/src/hotspot/os/linux/osContainer_linux.hpp
+++ b/src/hotspot/os/linux/osContainer_linux.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/os/linux/osContainer_linux.hpp
+++ b/src/hotspot/os/linux/osContainer_linux.hpp
@@ -27,7 +27,7 @@
 
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 #define OSCONTAINER_ERROR (-2)
 

--- a/src/hotspot/os/posix/signals_posix.hpp
+++ b/src/hotspot/os/posix/signals_posix.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/os/posix/signals_posix.hpp
+++ b/src/hotspot/os/posix/signals_posix.hpp
@@ -25,7 +25,7 @@
 #ifndef OS_POSIX_SIGNALS_POSIX_HPP
 #define OS_POSIX_SIGNALS_POSIX_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 class outputStream;

--- a/src/hotspot/os/posix/threadLocalStorage_posix.cpp
+++ b/src/hotspot/os/posix/threadLocalStorage_posix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/os/posix/threadLocalStorage_posix.cpp
+++ b/src/hotspot/os/posix/threadLocalStorage_posix.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "runtime/threadLocalStorage.hpp"
+#include "utilities/debug.hpp"
 #include <pthread.h>
 
 static pthread_key_t _thread_key;

--- a/src/hotspot/os/windows/gc/z/zMapper_windows.hpp
+++ b/src/hotspot/os/windows/gc/z/zMapper_windows.hpp
@@ -24,7 +24,7 @@
 #ifndef OS_WINDOWS_GC_Z_ZMAPPER_WINDOWS_HPP
 #define OS_WINDOWS_GC_Z_ZMAPPER_WINDOWS_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 #include <Windows.h>

--- a/src/hotspot/os/windows/iphlp_interface.hpp
+++ b/src/hotspot/os/windows/iphlp_interface.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/os/windows/iphlp_interface.hpp
+++ b/src/hotspot/os/windows/iphlp_interface.hpp
@@ -25,7 +25,7 @@
 #ifndef OS_WINDOWS_IPHLP_INTERFACE_HPP
 #define OS_WINDOWS_IPHLP_INTERFACE_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/macros.hpp"
 #include <WinSock2.h>
 #include <ws2ipdef.h>

--- a/src/hotspot/os/windows/pdh_interface.hpp
+++ b/src/hotspot/os/windows/pdh_interface.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/os/windows/pdh_interface.hpp
+++ b/src/hotspot/os/windows/pdh_interface.hpp
@@ -25,7 +25,7 @@
 #ifndef OS_WINDOWS_PDH_INTERFACE_HPP
 #define OS_WINDOWS_PDH_INTERFACE_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include <pdh.h>
 #include <pdhmsg.h>
 

--- a/src/hotspot/os/windows/threadLocalStorage_windows.cpp
+++ b/src/hotspot/os/windows/threadLocalStorage_windows.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "runtime/threadLocalStorage.hpp"
+#include "utilities/debug.hpp"
 #include <windows.h>
 
 static DWORD _thread_key;

--- a/src/hotspot/share/c1/c1_Runtime1.hpp
+++ b/src/hotspot/share/c1/c1_Runtime1.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/c1/c1_Runtime1.hpp
+++ b/src/hotspot/share/c1/c1_Runtime1.hpp
@@ -28,7 +28,7 @@
 #include "c1/c1_FrameMap.hpp"
 #include "code/stubs.hpp"
 #include "interpreter/interpreter.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "runtime/deoptimization.hpp"
 
 class StubAssembler;

--- a/src/hotspot/share/cds/archiveUtils.cpp
+++ b/src/hotspot/share/cds/archiveUtils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/cds/archiveUtils.cpp
+++ b/src/hotspot/share/cds/archiveUtils.cpp
@@ -39,7 +39,9 @@
 #include "oops/compressedOops.inline.hpp"
 #include "runtime/arguments.hpp"
 #include "utilities/bitMap.inline.hpp"
+#include "utilities/debug.hpp"
 #include "utilities/formatBuffer.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 CHeapBitMap* ArchivePtrMarker::_ptrmap = NULL;
 VirtualSpace* ArchivePtrMarker::_vs;

--- a/src/hotspot/share/cds/dynamicArchive.hpp
+++ b/src/hotspot/share/cds/dynamicArchive.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/cds/dynamicArchive.hpp
+++ b/src/hotspot/share/cds/dynamicArchive.hpp
@@ -27,7 +27,7 @@
 
 #include "cds/filemap.hpp"
 #include "classfile/compactHashtable.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "memory/memRegion.hpp"
 #include "memory/virtualspace.hpp"
 #include "oops/oop.hpp"

--- a/src/hotspot/share/classfile/altHashing.hpp
+++ b/src/hotspot/share/classfile/altHashing.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/classfile/altHashing.hpp
+++ b/src/hotspot/share/classfile/altHashing.hpp
@@ -26,7 +26,8 @@
 #define SHARE_CLASSFILE_ALTHASHING_HPP
 
 #include "jni.h"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 /**
  * Implementation of alternate more secure hashing.

--- a/src/hotspot/share/classfile/klassFactory.hpp
+++ b/src/hotspot/share/classfile/klassFactory.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_CLASSFILE_KLASSFACTORY_HPP
 #define SHARE_CLASSFILE_KLASSFACTORY_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "runtime/handles.hpp"
 
 class ClassFileStream;

--- a/src/hotspot/share/classfile/klassFactory.hpp
+++ b/src/hotspot/share/classfile/klassFactory.hpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/classfile/modules.hpp
+++ b/src/hotspot/share/classfile/modules.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_CLASSFILE_MODULES_HPP
 #define SHARE_CLASSFILE_MODULES_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "runtime/handles.hpp"
 
 class ModuleEntryTable;

--- a/src/hotspot/share/classfile/modules.hpp
+++ b/src/hotspot/share/classfile/modules.hpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/code/vtableStubs.hpp
+++ b/src/hotspot/share/code/vtableStubs.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/code/vtableStubs.hpp
+++ b/src/hotspot/share/code/vtableStubs.hpp
@@ -27,7 +27,7 @@
 
 #include "asm/macroAssembler.hpp"
 #include "code/vmreg.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 // A VtableStub holds an individual code stub for a pair (vtable index, #args) for either itables or vtables
 // There's a one-to-one relationship between a VtableStub and such a pair.

--- a/src/hotspot/share/compiler/compilerDefinitions.hpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/compiler/compilerDefinitions.hpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.hpp
@@ -27,7 +27,7 @@
 
 #include "compiler/compiler_globals.hpp"
 #include "jvmci/jvmci_globals.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "runtime/globals.hpp"
 
 // The (closed set) of concrete compiler classes.

--- a/src/hotspot/share/compiler/compilerEvent.hpp
+++ b/src/hotspot/share/compiler/compilerEvent.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/compiler/compilerEvent.hpp
+++ b/src/hotspot/share/compiler/compilerEvent.hpp
@@ -26,7 +26,7 @@
 
 #include "jni.h"
 #include "compiler/compilerDefinitions.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/ticks.hpp"
 

--- a/src/hotspot/share/compiler/compilerOracle.hpp
+++ b/src/hotspot/share/compiler/compilerOracle.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/compiler/compilerOracle.hpp
+++ b/src/hotspot/share/compiler/compilerOracle.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_COMPILER_COMPILERORACLE_HPP
 #define SHARE_COMPILER_COMPILERORACLE_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "oops/oopsHierarchy.hpp"
 
 class methodHandle;

--- a/src/hotspot/share/gc/g1/g1CollectionSetChooser.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetChooser.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1CollectionSetChooser.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetChooser.hpp
@@ -26,7 +26,7 @@
 #define SHARE_GC_G1_G1COLLECTIONSETCHOOSER_HPP
 
 #include "gc/g1/heapRegion.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "runtime/globals.hpp"
 
 class G1CollectionSetCandidates;

--- a/src/hotspot/share/gc/g1/g1FromCardCache.hpp
+++ b/src/hotspot/share/gc/g1/g1FromCardCache.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1FromCardCache.hpp
+++ b/src/hotspot/share/gc/g1/g1FromCardCache.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_GC_G1_G1FROMCARDCACHE_HPP
 #define SHARE_GC_G1_G1FROMCARDCACHE_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/ostream.hpp"
 
 // G1FromCardCache remembers the most recently processed card on the heap on

--- a/src/hotspot/share/gc/g1/g1HeapRegionEventSender.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionEventSender.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1HeapRegionEventSender.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionEventSender.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_GC_G1_G1HEAPREGIONEVENTSENDER_HPP
 #define SHARE_GC_G1_G1HEAPREGIONEVENTSENDER_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class G1HeapRegionEventSender : public AllStatic {
 public:

--- a/src/hotspot/share/gc/g1/g1HeapRegionTraceType.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionTraceType.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1HeapRegionTraceType.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionTraceType.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_GC_G1_G1HEAPREGIONTRACETYPE_HPP
 #define SHARE_GC_G1_G1HEAPREGIONTRACETYPE_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/debug.hpp"
 
 class G1HeapRegionTraceType : AllStatic {

--- a/src/hotspot/share/gc/g1/heapRegionBounds.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionBounds.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/heapRegionBounds.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionBounds.hpp
@@ -25,7 +25,8 @@
 #ifndef SHARE_GC_G1_HEAPREGIONBOUNDS_HPP
 #define SHARE_GC_G1_HEAPREGIONBOUNDS_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 class HeapRegionBounds : public AllStatic {
 private:

--- a/src/hotspot/share/gc/g1/heapRegionTracer.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionTracer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/heapRegionTracer.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionTracer.hpp
@@ -26,7 +26,8 @@
 #define SHARE_GC_G1_HEAPREGIONTRACER_HPP
 
 #include "gc/g1/g1HeapRegionTraceType.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 class HeapRegionTracer : AllStatic {
   public:

--- a/src/hotspot/share/gc/g1/heapRegionType.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionType.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/heapRegionType.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionType.hpp
@@ -26,6 +26,7 @@
 #define SHARE_GC_G1_HEAPREGIONTYPE_HPP
 
 #include "gc/g1/g1HeapRegionTraceType.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 #define hrt_assert_is_valid(tag) \
   assert(is_valid((tag)), "invalid HR type: %u", (uint) (tag))

--- a/src/hotspot/share/gc/parallel/psRootType.hpp
+++ b/src/hotspot/share/gc/parallel/psRootType.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/parallel/psRootType.hpp
+++ b/src/hotspot/share/gc/parallel/psRootType.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_GC_PARALLEL_PSROOTTYPE_HPP
 #define SHARE_GC_PARALLEL_PSROOTTYPE_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/macros.hpp"
 
 class ParallelRootType : public AllStatic {

--- a/src/hotspot/share/gc/parallel/psScavenge.hpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/parallel/psScavenge.hpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.hpp
@@ -29,7 +29,7 @@
 #include "gc/parallel/psVirtualspace.hpp"
 #include "gc/shared/collectorCounters.hpp"
 #include "gc/shared/gcTrace.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "oops/oop.hpp"
 #include "utilities/stack.hpp"
 

--- a/src/hotspot/share/gc/shared/accessBarrierSupport.hpp
+++ b/src/hotspot/share/gc/shared/accessBarrierSupport.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/accessBarrierSupport.hpp
+++ b/src/hotspot/share/gc/shared/accessBarrierSupport.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_GC_SHARED_ACCESSBARRIERSUPPORT_HPP
 #define SHARE_GC_SHARED_ACCESSBARRIERSUPPORT_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "oops/access.hpp"
 
 class AccessBarrierSupport: AllStatic {

--- a/src/hotspot/share/gc/shared/ageTableTracer.hpp
+++ b/src/hotspot/share/gc/shared/ageTableTracer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/ageTableTracer.hpp
+++ b/src/hotspot/share/gc/shared/ageTableTracer.hpp
@@ -25,7 +25,8 @@
 #ifndef SHARE_GC_SHARED_AGETABLETRACER_HPP
 #define SHARE_GC_SHARED_AGETABLETRACER_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 class AgeTableTracer : AllStatic {
   public:

--- a/src/hotspot/share/gc/shared/allocTracer.hpp
+++ b/src/hotspot/share/gc/shared/allocTracer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/allocTracer.hpp
+++ b/src/hotspot/share/gc/shared/allocTracer.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_GC_SHARED_ALLOCTRACER_HPP
 #define SHARE_GC_SHARED_ALLOCTRACER_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "runtime/handles.hpp"
 
 class AllocTracer : AllStatic {

--- a/src/hotspot/share/gc/shared/blockOffsetTable.hpp
+++ b/src/hotspot/share/gc/shared/blockOffsetTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/blockOffsetTable.hpp
+++ b/src/hotspot/share/gc/shared/blockOffsetTable.hpp
@@ -28,7 +28,7 @@
 #include "gc/shared/gc_globals.hpp"
 #include "gc/shared/memset_with_concurrent_readers.hpp"
 #include "gc/shared/cardTable.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "memory/memRegion.hpp"
 #include "memory/virtualspace.hpp"
 #include "runtime/globals.hpp"

--- a/src/hotspot/share/gc/shared/concurrentGCBreakpoints.hpp
+++ b/src/hotspot/share/gc/shared/concurrentGCBreakpoints.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/concurrentGCBreakpoints.hpp
+++ b/src/hotspot/share/gc/shared/concurrentGCBreakpoints.hpp
@@ -26,7 +26,7 @@
 #define SHARE_GC_SHARED_CONCURRENTGCBREAKPOINTS_HPP
 
 #include "gc/shared/gcCause.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 class Monitor;

--- a/src/hotspot/share/gc/shared/gcCause.hpp
+++ b/src/hotspot/share/gc/shared/gcCause.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/gcCause.hpp
+++ b/src/hotspot/share/gc/shared/gcCause.hpp
@@ -25,7 +25,8 @@
 #ifndef SHARE_GC_SHARED_GCCAUSE_HPP
 #define SHARE_GC_SHARED_GCCAUSE_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
+#include "utilities/debug.hpp"
 
 //
 // This class exposes implementation details of the various

--- a/src/hotspot/share/gc/shared/gcConfig.hpp
+++ b/src/hotspot/share/gc/shared/gcConfig.hpp
@@ -26,7 +26,7 @@
 #define SHARE_GC_SHARED_GCCONFIG_HPP
 
 #include "gc/shared/collectedHeap.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class GCArguments;
 

--- a/src/hotspot/share/gc/shared/gcLocker.hpp
+++ b/src/hotspot/share/gc/shared/gcLocker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/gcLocker.hpp
+++ b/src/hotspot/share/gc/shared/gcLocker.hpp
@@ -26,7 +26,7 @@
 #define SHARE_GC_SHARED_GCLOCKER_HPP
 
 #include "gc/shared/gcCause.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 

--- a/src/hotspot/share/gc/shared/gcLogPrecious.hpp
+++ b/src/hotspot/share/gc/shared/gcLogPrecious.hpp
@@ -26,7 +26,7 @@
 
 #include "utilities/globalDefinitions.hpp"
 #include "logging/logHandle.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/debug.hpp"
 
 class Mutex;

--- a/src/hotspot/share/gc/shared/gcWhen.hpp
+++ b/src/hotspot/share/gc/shared/gcWhen.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/gcWhen.hpp
+++ b/src/hotspot/share/gc/shared/gcWhen.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_GC_SHARED_GCWHEN_HPP
 #define SHARE_GC_SHARED_GCWHEN_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/debug.hpp"
 
 class GCWhen : AllStatic {

--- a/src/hotspot/share/gc/shared/locationPrinter.hpp
+++ b/src/hotspot/share/gc/shared/locationPrinter.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_GC_SHARED_LOCATIONPRINTER_HPP
 #define SHARE_GC_SHARED_LOCATIONPRINTER_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "oops/oopsHierarchy.hpp"
 #include "utilities/globalDefinitions.hpp"
 

--- a/src/hotspot/share/gc/shared/objectCountEventSender.hpp
+++ b/src/hotspot/share/gc/shared/objectCountEventSender.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/objectCountEventSender.hpp
+++ b/src/hotspot/share/gc/shared/objectCountEventSender.hpp
@@ -26,7 +26,7 @@
 #define SHARE_GC_SHARED_OBJECTCOUNTEVENTSENDER_HPP
 
 #include "gc/shared/gcTrace.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/ticks.hpp"

--- a/src/hotspot/share/gc/shared/scavengableNMethods.hpp
+++ b/src/hotspot/share/gc/shared/scavengableNMethods.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/scavengableNMethods.hpp
+++ b/src/hotspot/share/gc/shared/scavengableNMethods.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_GC_SHARED_SCAVENGABLENMETHODS_HPP
 #define SHARE_GC_SHARED_SCAVENGABLENMETHODS_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/macros.hpp"
 
 class BoolObjectClosure;

--- a/src/hotspot/share/gc/shared/spaceDecorator.hpp
+++ b/src/hotspot/share/gc/shared/spaceDecorator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/spaceDecorator.hpp
+++ b/src/hotspot/share/gc/shared/spaceDecorator.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_GC_SHARED_SPACEDECORATOR_HPP
 #define SHARE_GC_SHARED_SPACEDECORATOR_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "memory/memRegion.hpp"
 #include "utilities/globalDefinitions.hpp"
 

--- a/src/hotspot/share/gc/shared/weakProcessor.hpp
+++ b/src/hotspot/share/gc/shared/weakProcessor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/weakProcessor.hpp
+++ b/src/hotspot/share/gc/shared/weakProcessor.hpp
@@ -28,7 +28,7 @@
 #include "gc/shared/oopStorageParState.hpp"
 #include "gc/shared/oopStorageSetParState.hpp"
 #include "gc/shared/workerThread.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class WeakProcessorTimes;
 class WorkerThreads;

--- a/src/hotspot/share/gc/shared/workerPolicy.hpp
+++ b/src/hotspot/share/gc/shared/workerPolicy.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/workerPolicy.hpp
+++ b/src/hotspot/share/gc/shared/workerPolicy.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_GC_SHARED_WORKERPOLICY_HPP
 #define SHARE_GC_SHARED_WORKERPOLICY_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 class WorkerPolicy : public AllStatic {

--- a/src/hotspot/share/gc/shenandoah/shenandoahBreakpoint.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBreakpoint.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shenandoah/shenandoahBreakpoint.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBreakpoint.hpp
@@ -26,7 +26,7 @@
 #ifndef SHARE_GC_SHENANDOAH_SHENANDOAHBREAKPOINT_HPP
 #define SHARE_GC_SHENANDOAH_SHENANDOAHBREAKPOINT_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class ShenandoahBreakpoint : public AllStatic {
 private:

--- a/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.hpp
@@ -29,7 +29,7 @@
 #include "gc/shenandoah/shenandoahSharedVariables.hpp"
 #include "gc/shenandoah/shenandoahLock.hpp"
 #include "gc/shenandoah/shenandoahPadding.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "memory/iterator.hpp"
 #include "utilities/globalDefinitions.hpp"
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2017, 2022, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shenandoah/shenandoahRuntime.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRuntime.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2018, 2022, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shenandoah/shenandoahRuntime.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRuntime.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_GC_SHENANDOAH_SHENANDOAHRUNTIME_HPP
 #define SHARE_GC_SHENANDOAH_SHENANDOAHRUNTIME_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "oops/oopsHierarchy.hpp"
 
 class JavaThread;

--- a/src/hotspot/share/gc/shenandoah/shenandoahWorkerPolicy.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahWorkerPolicy.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2017, 2022, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shenandoah/shenandoahWorkerPolicy.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahWorkerPolicy.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_GC_SHENANDOAH_SHENANDOAHWORKERPOLICY_HPP
 #define SHARE_GC_SHENANDOAH_SHENANDOAHWORKERPOLICY_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class ShenandoahWorkerPolicy : AllStatic {
 private:

--- a/src/hotspot/share/gc/z/zAbort.hpp
+++ b/src/hotspot/share/gc/z/zAbort.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zAbort.hpp
+++ b/src/hotspot/share/gc/z/zAbort.hpp
@@ -24,7 +24,7 @@
 #ifndef SHARE_GC_Z_ZABORT_HPP
 #define SHARE_GC_Z_ZABORT_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class ZAbort : public AllStatic {
 private:

--- a/src/hotspot/share/gc/z/zAddress.hpp
+++ b/src/hotspot/share/gc/z/zAddress.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zAddress.hpp
+++ b/src/hotspot/share/gc/z/zAddress.hpp
@@ -24,7 +24,8 @@
 #ifndef SHARE_GC_Z_ZADDRESS_HPP
 #define SHARE_GC_Z_ZADDRESS_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 class ZAddress : public AllStatic {
   friend class ZAddressTest;

--- a/src/hotspot/share/gc/z/zAddressSpaceLimit.hpp
+++ b/src/hotspot/share/gc/z/zAddressSpaceLimit.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zAddressSpaceLimit.hpp
+++ b/src/hotspot/share/gc/z/zAddressSpaceLimit.hpp
@@ -24,7 +24,8 @@
 #ifndef SHARE_GC_Z_ZADDRESSSPACELIMIT_HPP
 #define SHARE_GC_Z_ZADDRESSSPACELIMIT_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 class ZAddressSpaceLimit : public AllStatic {
 public:

--- a/src/hotspot/share/gc/z/zBarrier.hpp
+++ b/src/hotspot/share/gc/z/zBarrier.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zBarrier.hpp
+++ b/src/hotspot/share/gc/z/zBarrier.hpp
@@ -24,7 +24,7 @@
 #ifndef SHARE_GC_Z_ZBARRIER_HPP
 #define SHARE_GC_Z_ZBARRIER_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "memory/iterator.hpp"
 #include "oops/oop.hpp"
 

--- a/src/hotspot/share/gc/z/zBarrierSetRuntime.hpp
+++ b/src/hotspot/share/gc/z/zBarrierSetRuntime.hpp
@@ -24,7 +24,7 @@
 #ifndef SHARE_GC_Z_ZBARRIERSETRUNTIME_HPP
 #define SHARE_GC_Z_ZBARRIERSETRUNTIME_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "oops/accessDecorators.hpp"
 #include "utilities/globalDefinitions.hpp"
 

--- a/src/hotspot/share/gc/z/zBitField.hpp
+++ b/src/hotspot/share/gc/z/zBitField.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zBitField.hpp
+++ b/src/hotspot/share/gc/z/zBitField.hpp
@@ -24,8 +24,9 @@
 #ifndef SHARE_GC_Z_ZBITFIELD_HPP
 #define SHARE_GC_Z_ZBITFIELD_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 //
 //  Example

--- a/src/hotspot/share/gc/z/zBreakpoint.hpp
+++ b/src/hotspot/share/gc/z/zBreakpoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zBreakpoint.hpp
+++ b/src/hotspot/share/gc/z/zBreakpoint.hpp
@@ -24,7 +24,7 @@
 #ifndef SHARE_GC_Z_ZBREAKPOINT_HPP
 #define SHARE_GC_Z_ZBREAKPOINT_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class ZBreakpoint : public AllStatic {
 private:

--- a/src/hotspot/share/gc/z/zCPU.hpp
+++ b/src/hotspot/share/gc/z/zCPU.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zCPU.hpp
+++ b/src/hotspot/share/gc/z/zCPU.hpp
@@ -24,7 +24,7 @@
 #ifndef SHARE_GC_Z_ZCPU_HPP
 #define SHARE_GC_Z_ZCPU_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "memory/padded.hpp"
 #include "utilities/globalDefinitions.hpp"
 

--- a/src/hotspot/share/gc/z/zHash.hpp
+++ b/src/hotspot/share/gc/z/zHash.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zHash.hpp
+++ b/src/hotspot/share/gc/z/zHash.hpp
@@ -24,7 +24,7 @@
 #ifndef SHARE_GC_Z_ZHASH_HPP
 #define SHARE_GC_Z_ZHASH_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 class ZHash : public AllStatic {

--- a/src/hotspot/share/gc/z/zHeuristics.hpp
+++ b/src/hotspot/share/gc/z/zHeuristics.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zHeuristics.hpp
+++ b/src/hotspot/share/gc/z/zHeuristics.hpp
@@ -24,7 +24,7 @@
 #ifndef SHARE_GC_Z_ZHEURISTICS_HPP
 #define SHARE_GC_Z_ZHEURISTICS_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class ZHeuristics : public AllStatic {
 public:

--- a/src/hotspot/share/gc/z/zLargePages.hpp
+++ b/src/hotspot/share/gc/z/zLargePages.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zLargePages.hpp
+++ b/src/hotspot/share/gc/z/zLargePages.hpp
@@ -24,7 +24,7 @@
 #ifndef SHARE_GC_Z_ZLARGEPAGES_HPP
 #define SHARE_GC_Z_ZLARGEPAGES_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class ZLargePages : public AllStatic {
 private:

--- a/src/hotspot/share/gc/z/zNMethod.hpp
+++ b/src/hotspot/share/gc/z/zNMethod.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zNMethod.hpp
+++ b/src/hotspot/share/gc/z/zNMethod.hpp
@@ -24,7 +24,7 @@
 #ifndef SHARE_GC_Z_ZNMETHOD_HPP
 #define SHARE_GC_Z_ZNMETHOD_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class nmethod;
 class NMethodClosure;

--- a/src/hotspot/share/gc/z/zNMethodTable.hpp
+++ b/src/hotspot/share/gc/z/zNMethodTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zNMethodTable.hpp
+++ b/src/hotspot/share/gc/z/zNMethodTable.hpp
@@ -26,7 +26,7 @@
 
 #include "gc/z/zNMethodTableIteration.hpp"
 #include "gc/z/zSafeDelete.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class nmethod;
 class NMethodClosure;

--- a/src/hotspot/share/gc/z/zNUMA.hpp
+++ b/src/hotspot/share/gc/z/zNUMA.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zNUMA.hpp
+++ b/src/hotspot/share/gc/z/zNUMA.hpp
@@ -25,6 +25,7 @@
 #define SHARE_GC_Z_ZNUMA_HPP
 
 #include "memory/allStatic.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 class ZNUMA : public AllStatic {
 private:

--- a/src/hotspot/share/gc/z/zNUMA.hpp
+++ b/src/hotspot/share/gc/z/zNUMA.hpp
@@ -24,7 +24,7 @@
 #ifndef SHARE_GC_Z_ZNUMA_HPP
 #define SHARE_GC_Z_ZNUMA_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class ZNUMA : public AllStatic {
 private:

--- a/src/hotspot/share/gc/z/zOop.hpp
+++ b/src/hotspot/share/gc/z/zOop.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zOop.hpp
+++ b/src/hotspot/share/gc/z/zOop.hpp
@@ -24,7 +24,7 @@
 #ifndef SHARE_GC_Z_ZOOP_HPP
 #define SHARE_GC_Z_ZOOP_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "oops/oopsHierarchy.hpp"
 
 class ZOop : public AllStatic {

--- a/src/hotspot/share/gc/z/zResurrection.hpp
+++ b/src/hotspot/share/gc/z/zResurrection.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zResurrection.hpp
+++ b/src/hotspot/share/gc/z/zResurrection.hpp
@@ -24,7 +24,7 @@
 #ifndef SHARE_GC_Z_ZRESURRECTION_HPP
 #define SHARE_GC_Z_ZRESURRECTION_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class ZResurrection : public AllStatic {
 private:

--- a/src/hotspot/share/gc/z/zThread.hpp
+++ b/src/hotspot/share/gc/z/zThread.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zThread.hpp
+++ b/src/hotspot/share/gc/z/zThread.hpp
@@ -24,7 +24,7 @@
 #ifndef SHARE_GC_Z_ZTHREAD_HPP
 #define SHARE_GC_Z_ZTHREAD_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 class ZThread : public AllStatic {

--- a/src/hotspot/share/gc/z/zThreadLocalAllocBuffer.hpp
+++ b/src/hotspot/share/gc/z/zThreadLocalAllocBuffer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zThreadLocalAllocBuffer.hpp
+++ b/src/hotspot/share/gc/z/zThreadLocalAllocBuffer.hpp
@@ -26,7 +26,7 @@
 
 #include "gc/shared/threadLocalAllocBuffer.hpp"
 #include "gc/z/zValue.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class JavaThread;
 

--- a/src/hotspot/share/gc/z/zUtils.hpp
+++ b/src/hotspot/share/gc/z/zUtils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zUtils.hpp
+++ b/src/hotspot/share/gc/z/zUtils.hpp
@@ -24,7 +24,8 @@
 #ifndef SHARE_GC_Z_ZUTILS_HPP
 #define SHARE_GC_Z_ZUTILS_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 class ZUtils : public AllStatic {
 public:

--- a/src/hotspot/share/gc/z/zValue.hpp
+++ b/src/hotspot/share/gc/z/zValue.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zValue.hpp
+++ b/src/hotspot/share/gc/z/zValue.hpp
@@ -24,7 +24,7 @@
 #ifndef SHARE_GC_Z_ZVALUE_HPP
 #define SHARE_GC_Z_ZVALUE_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 //

--- a/src/hotspot/share/gc/z/zVerify.hpp
+++ b/src/hotspot/share/gc/z/zVerify.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/zVerify.hpp
+++ b/src/hotspot/share/gc/z/zVerify.hpp
@@ -24,7 +24,7 @@
 #ifndef SHARE_GC_Z_ZVERIFY_HPP
 #define SHARE_GC_Z_ZVERIFY_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class frame;
 class ZPageAllocator;

--- a/src/hotspot/share/interpreter/bytecodeHistogram.hpp
+++ b/src/hotspot/share/interpreter/bytecodeHistogram.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/interpreter/bytecodeHistogram.hpp
+++ b/src/hotspot/share/interpreter/bytecodeHistogram.hpp
@@ -26,7 +26,7 @@
 #define SHARE_INTERPRETER_BYTECODEHISTOGRAM_HPP
 
 #include "interpreter/bytecodes.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 // BytecodeCounter counts the number of bytecodes executed
 

--- a/src/hotspot/share/interpreter/bytecodeTracer.hpp
+++ b/src/hotspot/share/interpreter/bytecodeTracer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/interpreter/bytecodeTracer.hpp
+++ b/src/hotspot/share/interpreter/bytecodeTracer.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_INTERPRETER_BYTECODETRACER_HPP
 #define SHARE_INTERPRETER_BYTECODETRACER_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/ostream.hpp"
 
 // The BytecodeTracer is a helper class used by the interpreter for run-time

--- a/src/hotspot/share/interpreter/bytecodeUtils.hpp
+++ b/src/hotspot/share/interpreter/bytecodeUtils.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019 SAP SE. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/interpreter/bytecodeUtils.hpp
+++ b/src/hotspot/share/interpreter/bytecodeUtils.hpp
@@ -26,7 +26,7 @@
 #ifndef SHARE_INTERPRETER_BYTECODEUTILS_HPP
 #define SHARE_INTERPRETER_BYTECODEUTILS_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 class Method;

--- a/src/hotspot/share/interpreter/bytecodes.hpp
+++ b/src/hotspot/share/interpreter/bytecodes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/interpreter/bytecodes.hpp
+++ b/src/hotspot/share/interpreter/bytecodes.hpp
@@ -25,7 +25,8 @@
 #ifndef SHARE_INTERPRETER_BYTECODES_HPP
 #define SHARE_INTERPRETER_BYTECODES_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 // Bytecodes specifies all bytecodes used in the VM and
 // provides utility functions to get bytecode attributes.

--- a/src/hotspot/share/interpreter/templateTable.hpp
+++ b/src/hotspot/share/interpreter/templateTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/interpreter/templateTable.hpp
+++ b/src/hotspot/share/interpreter/templateTable.hpp
@@ -26,7 +26,7 @@
 #define SHARE_INTERPRETER_TEMPLATETABLE_HPP
 
 #include "interpreter/bytecodes.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "runtime/frame.hpp"
 #include "utilities/macros.hpp"
 

--- a/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.hpp
+++ b/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.hpp
+++ b/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_JFR_INSTRUMENTATION_JFREVENTCLASSTRANSFORMER_HPP
 #define SHARE_JFR_INSTRUMENTATION_JFREVENTCLASSTRANSFORMER_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/exceptions.hpp"
 
 class ClassFileParser;

--- a/src/hotspot/share/jfr/jfr.hpp
+++ b/src/hotspot/share/jfr/jfr.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/jfr.hpp
+++ b/src/hotspot/share/jfr/jfr.hpp
@@ -26,11 +26,13 @@
 #define SHARE_JFR_JFR_HPP
 
 #include "jni.h"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 class JavaThread;
 class Thread;
 class Klass;
+class outputStream;
 
 extern "C" void JNICALL jfr_register_natives(JNIEnv*, jclass);
 

--- a/src/hotspot/share/jfr/leakprofiler/chains/edgeUtils.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/edgeUtils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/leakprofiler/chains/edgeUtils.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/edgeUtils.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_JFR_LEAKPROFILER_CHAINS_EDGEUTILS_HPP
 #define SHARE_JFR_LEAKPROFILER_CHAINS_EDGEUTILS_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class Edge;
 class Symbol;

--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_JFR_LEAKPROFILER_CHECKPOINT_OBJECTSAMPLECHECKPOINT_HPP
 #define SHARE_JFR_LEAKPROFILER_CHECKPOINT_OBJECTSAMPLECHECKPOINT_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "jfr/utilities/jfrTypes.hpp"
 
 class EdgeStore;

--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/rootResolver.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/rootResolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/rootResolver.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/rootResolver.hpp
@@ -27,7 +27,7 @@
 
 #include "jfr/leakprofiler/utilities/rootType.hpp"
 #include "jfr/leakprofiler/utilities/unifiedOopRef.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "oops/oopsHierarchy.hpp"
 
 struct RootCallbackInfo {

--- a/src/hotspot/share/jfr/leakprofiler/leakProfiler.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/leakProfiler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/leakprofiler/leakProfiler.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/leakProfiler.hpp
@@ -25,7 +25,8 @@
 #ifndef SHARE_JFR_LEAKPROFILER_LEAKPROFILER_HPP
 #define SHARE_JFR_LEAKPROFILER_LEAKPROFILER_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 class JavaThread;
 

--- a/src/hotspot/share/jfr/leakprofiler/utilities/granularTimer.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/utilities/granularTimer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/leakprofiler/utilities/granularTimer.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/utilities/granularTimer.hpp
@@ -26,7 +26,7 @@
 #define SHARE_JFR_LEAKPROFILER_UTILITIES_GRANULARTIMER_HPP
 
 #include "jfr/utilities/jfrTime.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class GranularTimer : public AllStatic {
  private:

--- a/src/hotspot/share/jfr/leakprofiler/utilities/rootType.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/utilities/rootType.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/leakprofiler/utilities/rootType.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/utilities/rootType.hpp
@@ -26,7 +26,7 @@
 #define SHARE_JFR_LEAKPROFILER_UTILITIES_ROOTTYPE_HPP
 
 #include "gc/shared/oopStorageSet.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/enumIterator.hpp"
 
 class OldObjectRoot : public AllStatic {

--- a/src/hotspot/share/jfr/periodic/jfrFinalizerStatisticsEvent.hpp
+++ b/src/hotspot/share/jfr/periodic/jfrFinalizerStatisticsEvent.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/periodic/jfrFinalizerStatisticsEvent.hpp
+++ b/src/hotspot/share/jfr/periodic/jfrFinalizerStatisticsEvent.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_JFR_PERIODIC_JFRFINALIZERSTATISTICSEVENT_HPP
 #define SHARE_JFR_PERIODIC_JFRFINALIZERSTATISTICSEVENT_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class InstanceKlass;
 

--- a/src/hotspot/share/jfr/periodic/jfrModuleEvent.hpp
+++ b/src/hotspot/share/jfr/periodic/jfrModuleEvent.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/periodic/jfrModuleEvent.hpp
+++ b/src/hotspot/share/jfr/periodic/jfrModuleEvent.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_JFR_PERIODIC_JFRMODULEEVENT_HPP
 #define SHARE_JFR_PERIODIC_JFRMODULEEVENT_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class JfrModuleEvent : AllStatic {
  public:

--- a/src/hotspot/share/jfr/periodic/jfrNetworkUtilization.hpp
+++ b/src/hotspot/share/jfr/periodic/jfrNetworkUtilization.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/periodic/jfrNetworkUtilization.hpp
+++ b/src/hotspot/share/jfr/periodic/jfrNetworkUtilization.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_JFR_PERIODIC_JFRNETWORKUTILIZATION_HPP
 #define SHARE_JFR_PERIODIC_JFRNETWORKUTILIZATION_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class NetworkInterface;
 

--- a/src/hotspot/share/jfr/periodic/jfrThreadCPULoadEvent.hpp
+++ b/src/hotspot/share/jfr/periodic/jfrThreadCPULoadEvent.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/periodic/jfrThreadCPULoadEvent.hpp
+++ b/src/hotspot/share/jfr/periodic/jfrThreadCPULoadEvent.hpp
@@ -26,7 +26,7 @@
 #define SHARE_JFR_PERIODIC_JFRTHREADCPULOADEVENT_HPP
 
 #include "jni.h"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class JavaThread;
 class EventThreadCPULoad;

--- a/src/hotspot/share/jfr/periodic/jfrThreadDumpEvent.hpp
+++ b/src/hotspot/share/jfr/periodic/jfrThreadDumpEvent.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/periodic/jfrThreadDumpEvent.hpp
+++ b/src/hotspot/share/jfr/periodic/jfrThreadDumpEvent.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_JFR_PERIODIC_JFRTHREADDUMPEVENT_HPP
 #define SHARE_JFR_PERIODIC_JFRTHREADDUMPEVENT_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 /*
  *  Helper for generating jfr events using output data from Dcmd's.

--- a/src/hotspot/share/jfr/recorder/checkpoint/jfrMetadataEvent.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/jfrMetadataEvent.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/recorder/checkpoint/jfrMetadataEvent.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/jfrMetadataEvent.hpp
@@ -26,7 +26,7 @@
 #define SHARE_JFR_RECORDER_CHECKPOINT_JFRMETADATAEVENT_HPP
 
 #include "jni.h"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class JfrChunkWriter;
 

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrThreadState.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrThreadState.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_JFR_RECORDER_CHECKPOINT_TYPES_JFRTHREADSTATE_HPP
 #define SHARE_JFR_RECORDER_CHECKPOINT_TYPES_JFRTHREADSTATE_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class JfrCheckpointWriter;
 class Thread;

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrThreadState.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrThreadState.hpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceId.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceId.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceId.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceId.hpp
@@ -27,7 +27,7 @@
 
 #include "jni.h"
 #include "jfr/utilities/jfrTypes.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class ClassLoaderData;
 class Klass;

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdBits.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdBits.hpp
@@ -27,7 +27,7 @@
 
 #include "jni.h"
 #include "jfr/utilities/jfrTypes.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class JfrTraceIdBits : AllStatic {
  public:

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdEpoch.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdEpoch.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdEpoch.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdEpoch.hpp
@@ -27,7 +27,7 @@
 
 #include "jfr/utilities/jfrSignal.hpp"
 #include "jfr/utilities/jfrTypes.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "runtime/atomic.hpp"
 
 #define BIT                                  1

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdLoadBarrier.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdLoadBarrier.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdLoadBarrier.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceIdLoadBarrier.hpp
@@ -26,7 +26,7 @@
 #define SHARE_JFR_RECORDER_CHECKPOINT_TYPES_TRACEID_JFRTRACEIDLOADBARRIER_HPP
 
 #include "jfr/utilities/jfrTypes.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class ClassLoaderData;
 class JfrBuffer;

--- a/src/hotspot/share/jfr/recorder/repository/jfrChunkRotation.hpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrChunkRotation.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/recorder/repository/jfrChunkRotation.hpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrChunkRotation.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_JFR_RECORDER_REPOSITORY_JFRCHUNKROTATION_HPP
 #define SHARE_JFR_RECORDER_REPOSITORY_JFRCHUNKROTATION_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class JfrChunkWriter;
 

--- a/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.hpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.hpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_JFR_RECORDER_REPOSITORY_JFREMERGENCYDUMP_HPP
 #define SHARE_JFR_RECORDER_REPOSITORY_JFREMERGENCYDUMP_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/ostream.hpp"
 
 //

--- a/src/hotspot/share/jfr/recorder/service/jfrMemorySizer.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrMemorySizer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/recorder/service/jfrMemorySizer.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrMemorySizer.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_JFR_RECORDER_SERVICE_JFRMEMORYSIZER_HPP
 #define SHARE_JFR_RECORDER_SERVICE_JFRMEMORYSIZER_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 extern const julong MIN_BUFFER_COUNT;

--- a/src/hotspot/share/jfr/recorder/service/jfrOptionSet.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrOptionSet.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/recorder/service/jfrOptionSet.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrOptionSet.hpp
@@ -26,7 +26,7 @@
 #define SHARE_JFR_RECORDER_SERVICE_JFROPTIONSET_HPP
 
 #include "jni.h"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/exceptions.hpp"
 
 template <typename>

--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderThread.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_JFR_RECORDER_SERVICE_JFRRECORDERTHREAD_HPP
 #define SHARE_JFR_RECORDER_SERVICE_JFRRECORDERTHREAD_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/debug.hpp"
 
 class JavaThread;

--- a/src/hotspot/share/jfr/support/jfrJdkJfrEvent.hpp
+++ b/src/hotspot/share/jfr/support/jfrJdkJfrEvent.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/support/jfrJdkJfrEvent.hpp
+++ b/src/hotspot/share/jfr/support/jfrJdkJfrEvent.hpp
@@ -26,7 +26,7 @@
 #define SHARE_JFR_SUPPORT_JFRJDKJFREVENT_HPP
 
 #include "jni.h"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/exceptions.hpp"
 
 class Klass;

--- a/src/hotspot/share/jfr/support/jfrKlassUnloading.hpp
+++ b/src/hotspot/share/jfr/support/jfrKlassUnloading.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/support/jfrKlassUnloading.hpp
+++ b/src/hotspot/share/jfr/support/jfrKlassUnloading.hpp
@@ -26,7 +26,7 @@
 #define SHARE_JFR_SUPPORT_JFRKLASSUNLOADING_HPP
 
 #include "jfr/utilities/jfrTypes.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class Klass;
 

--- a/src/hotspot/share/jfr/support/jfrMethodLookup.hpp
+++ b/src/hotspot/share/jfr/support/jfrMethodLookup.hpp
@@ -26,7 +26,7 @@
 #define SHARE_JFR_SUPPORT_JFRMETHODLOOKUP_HPP
 
 #include "jfr/utilities/jfrTypes.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class InstanceKlass;
 class Method;

--- a/src/hotspot/share/jfr/support/jfrObjectAllocationSample.hpp
+++ b/src/hotspot/share/jfr/support/jfrObjectAllocationSample.hpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/support/jfrObjectAllocationSample.hpp
+++ b/src/hotspot/share/jfr/support/jfrObjectAllocationSample.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_JFR_SUPPORT_JFROBJECTALLOCATIONSAMPLE_HPP
 #define SHARE_JFR_SUPPORT_JFROBJECTALLOCATIONSAMPLE_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class Klass;
 class Thread;

--- a/src/hotspot/share/jfr/utilities/jfrBigEndian.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrBigEndian.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/utilities/jfrBigEndian.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrBigEndian.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_JFR_UTILITIES_JFRBIGENDIAN_HPP
 #define SHARE_JFR_UTILITIES_JFRBIGENDIAN_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/bytes.hpp"
 #include "utilities/macros.hpp"
 

--- a/src/hotspot/share/jfr/utilities/jfrJavaLog.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrJavaLog.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/utilities/jfrJavaLog.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrJavaLog.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_JFR_UTILITIES_JFRJAVALOG_HPP
 #define SHARE_JFR_UTILITIES_JFRJAVALOG_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/exceptions.hpp"
 
 /*

--- a/src/hotspot/share/jfr/utilities/jfrPredicate.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrPredicate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/utilities/jfrPredicate.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrPredicate.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_JFR_UTILITIES_JFRPREDICATE_HPP
 #define SHARE_JFR_UTILITIES_JFRPREDICATE_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/growableArray.hpp"
 
 /*

--- a/src/hotspot/share/jfr/utilities/jfrTimeConverter.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrTimeConverter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/utilities/jfrTimeConverter.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrTimeConverter.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_JFR_UTILITIES_JFRTIMECONVERTER_HPP
 #define SHARE_JFR_UTILITIES_JFRTIMECONVERTER_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 class JfrTimeConverter : AllStatic {

--- a/src/hotspot/share/jfr/writers/jfrEncoding.hpp
+++ b/src/hotspot/share/jfr/writers/jfrEncoding.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/writers/jfrEncoding.hpp
+++ b/src/hotspot/share/jfr/writers/jfrEncoding.hpp
@@ -26,7 +26,7 @@
 #define SHARE_JFR_WRITERS_JFRENCODING_HPP
 
 #include "jfr/writers/jfrEncoders.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 enum JfrStringEncoding {

--- a/src/hotspot/share/jfr/writers/jfrJavaEventWriter.hpp
+++ b/src/hotspot/share/jfr/writers/jfrJavaEventWriter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/writers/jfrJavaEventWriter.hpp
+++ b/src/hotspot/share/jfr/writers/jfrJavaEventWriter.hpp
@@ -26,7 +26,7 @@
 #define SHARE_JFR_WRITERS_JFRJAVAEVENTWRITER_HPP
 
 #include "jni.h"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class JavaThread;
 class Thread;

--- a/src/hotspot/share/logging/logConfiguration.hpp
+++ b/src/hotspot/share/logging/logConfiguration.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/logging/logConfiguration.hpp
+++ b/src/hotspot/share/logging/logConfiguration.hpp
@@ -25,12 +25,13 @@
 #define SHARE_LOGGING_LOGCONFIGURATION_HPP
 
 #include "logging/logLevel.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 class LogOutput;
 class LogDecorators;
 class LogSelectionList;
+class outputStream;
 
 // Global configuration of logging. Handles parsing and configuration of the logging framework,
 // and manages the list of configured log outputs. The actual tag and level configuration is

--- a/src/hotspot/share/logging/logLevel.hpp
+++ b/src/hotspot/share/logging/logLevel.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/logging/logLevel.hpp
+++ b/src/hotspot/share/logging/logLevel.hpp
@@ -24,7 +24,8 @@
 #ifndef SHARE_LOGGING_LOGLEVEL_HPP
 #define SHARE_LOGGING_LOGLEVEL_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
+#include "utilities/debug.hpp"
 #include "utilities/macros.hpp"
 
 // The list of log levels:

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -24,8 +24,10 @@
 #ifndef SHARE_LOGGING_LOGTAG_HPP
 #define SHARE_LOGGING_LOGTAG_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
+
+class outputStream;
 
 // List of available logging tags. New tags should be added here, in
 // alphabetical order.

--- a/src/hotspot/share/memory/metaspace/internalStats.hpp
+++ b/src/hotspot/share/memory/metaspace/internalStats.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/memory/metaspace/internalStats.hpp
+++ b/src/hotspot/share/memory/metaspace/internalStats.hpp
@@ -26,7 +26,7 @@
 #ifndef SHARE_MEMORY_METASPACE_INTERNALSTATS_HPP
 #define SHARE_MEMORY_METASPACE_INTERNALSTATS_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "runtime/atomic.hpp"
 #include "utilities/globalDefinitions.hpp"
 

--- a/src/hotspot/share/memory/metaspace/metaspaceReporter.hpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceReporter.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/memory/metaspace/metaspaceReporter.hpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceReporter.hpp
@@ -26,7 +26,7 @@
 #ifndef SHARE_MEMORY_METASPACE_METASPACEREPORTER_HPP
 #define SHARE_MEMORY_METASPACE_METASPACEREPORTER_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 namespace metaspace {
 

--- a/src/hotspot/share/memory/metaspace/metaspaceSettings.hpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceSettings.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/memory/metaspace/metaspaceSettings.hpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceSettings.hpp
@@ -26,7 +26,7 @@
 #ifndef SHARE_MEMORY_METASPACE_METASPACESETTINGS_HPP
 #define SHARE_MEMORY_METASPACE_METASPACESETTINGS_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "memory/metaspace/chunklevel.hpp"
 #include "utilities/globalDefinitions.hpp"
 

--- a/src/hotspot/share/memory/metaspace/runningCounters.hpp
+++ b/src/hotspot/share/memory/metaspace/runningCounters.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/memory/metaspace/runningCounters.hpp
+++ b/src/hotspot/share/memory/metaspace/runningCounters.hpp
@@ -26,7 +26,7 @@
 #ifndef SHARE_MEMORY_METASPACE_RUNNINGCOUNTERS_HPP
 #define SHARE_MEMORY_METASPACE_RUNNINGCOUNTERS_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "memory/metaspace/counters.hpp"
 
 namespace metaspace {

--- a/src/hotspot/share/memory/metaspaceCounters.hpp
+++ b/src/hotspot/share/memory/metaspaceCounters.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/share/memory/metaspaceCounters.hpp
+++ b/src/hotspot/share/memory/metaspaceCounters.hpp
@@ -26,7 +26,7 @@
 #ifndef SHARE_MEMORY_METASPACECOUNTERS_HPP
 #define SHARE_MEMORY_METASPACECOUNTERS_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 // Perf Counters for Metaspace
 

--- a/src/hotspot/share/memory/metaspaceCriticalAllocation.hpp
+++ b/src/hotspot/share/memory/metaspaceCriticalAllocation.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_MEMORY_METASPACECRITICALALLOCATION_HPP
 #define SHARE_MEMORY_METASPACECRITICALALLOCATION_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "memory/metaspace.hpp"
 
 class MetadataAllocationRequest;

--- a/src/hotspot/share/metaprogramming/conditional.hpp
+++ b/src/hotspot/share/metaprogramming/conditional.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/metaprogramming/conditional.hpp
+++ b/src/hotspot/share/metaprogramming/conditional.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_METAPROGRAMMING_CONDITIONAL_HPP
 #define SHARE_METAPROGRAMMING_CONDITIONAL_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 // This trait evaluates its typedef called "type" to TrueType iff the condition
 // is true. Otherwise it evaluates to FalseType.

--- a/src/hotspot/share/metaprogramming/decay.hpp
+++ b/src/hotspot/share/metaprogramming/decay.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/metaprogramming/decay.hpp
+++ b/src/hotspot/share/metaprogramming/decay.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_METAPROGRAMMING_DECAY_HPP
 #define SHARE_METAPROGRAMMING_DECAY_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "metaprogramming/removeCV.hpp"
 #include "metaprogramming/removeReference.hpp"
 

--- a/src/hotspot/share/metaprogramming/removeCV.hpp
+++ b/src/hotspot/share/metaprogramming/removeCV.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/metaprogramming/removeCV.hpp
+++ b/src/hotspot/share/metaprogramming/removeCV.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_METAPROGRAMMING_REMOVECV_HPP
 #define SHARE_METAPROGRAMMING_REMOVECV_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 template <typename T>
 struct RemoveCV: AllStatic {

--- a/src/hotspot/share/metaprogramming/removeExtent.hpp
+++ b/src/hotspot/share/metaprogramming/removeExtent.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/metaprogramming/removeExtent.hpp
+++ b/src/hotspot/share/metaprogramming/removeExtent.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_METAPROGRAMMING_REMOVEEXTENT_HPP
 #define SHARE_METAPROGRAMMING_REMOVEEXTENT_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 template <typename T> struct RemoveExtent: AllStatic { typedef T type; };
 

--- a/src/hotspot/share/metaprogramming/removePointer.hpp
+++ b/src/hotspot/share/metaprogramming/removePointer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/metaprogramming/removePointer.hpp
+++ b/src/hotspot/share/metaprogramming/removePointer.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_METAPROGRAMMING_REMOVEPOINTER_HPP
 #define SHARE_METAPROGRAMMING_REMOVEPOINTER_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 // This metafunction returns for a type T either the underlying type behind
 // the pointer iff T is a pointer type (irrespective of CV qualifiers),

--- a/src/hotspot/share/metaprogramming/removeReference.hpp
+++ b/src/hotspot/share/metaprogramming/removeReference.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/metaprogramming/removeReference.hpp
+++ b/src/hotspot/share/metaprogramming/removeReference.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_METAPROGRAMMING_REMOVEREFERENCE_HPP
 #define SHARE_METAPROGRAMMING_REMOVEREFERENCE_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 // This metafunction returns for a type T either the underlying type behind
 // the reference iff T is a reference type, or the same type T if T is not

--- a/src/hotspot/share/oops/access.hpp
+++ b/src/hotspot/share/oops/access.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/oops/access.hpp
+++ b/src/hotspot/share/oops/access.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_OOPS_ACCESS_HPP
 #define SHARE_OOPS_ACCESS_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "oops/accessBackend.hpp"
 #include "oops/accessDecorators.hpp"
 #include "oops/oopsHierarchy.hpp"

--- a/src/hotspot/share/oops/accessDecorators.hpp
+++ b/src/hotspot/share/oops/accessDecorators.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/oops/accessDecorators.hpp
+++ b/src/hotspot/share/oops/accessDecorators.hpp
@@ -26,7 +26,7 @@
 #define SHARE_OOPS_ACCESSDECORATORS_HPP
 
 #include "gc/shared/barrierSetConfig.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "metaprogramming/integralConstant.hpp"
 #include "utilities/globalDefinitions.hpp"
 

--- a/src/hotspot/share/oops/compressedOops.hpp
+++ b/src/hotspot/share/oops/compressedOops.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/oops/compressedOops.hpp
+++ b/src/hotspot/share/oops/compressedOops.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_OOPS_COMPRESSEDOOPS_HPP
 #define SHARE_OOPS_COMPRESSEDOOPS_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "memory/memRegion.hpp"
 #include "oops/oopsHierarchy.hpp"
 #include "utilities/globalDefinitions.hpp"

--- a/src/hotspot/share/prims/jniFastGetField.hpp
+++ b/src/hotspot/share/prims/jniFastGetField.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/prims/jniFastGetField.hpp
+++ b/src/hotspot/share/prims/jniFastGetField.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_PRIMS_JNIFASTGETFIELD_HPP
 #define SHARE_PRIMS_JNIFASTGETFIELD_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "prims/jvm_misc.hpp"
 
 // Basic logic of a fast version of jni_Get<Primitive>Field:

--- a/src/hotspot/share/prims/jvmtiEventController.hpp
+++ b/src/hotspot/share/prims/jvmtiEventController.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/prims/jvmtiEventController.hpp
+++ b/src/hotspot/share/prims/jvmtiEventController.hpp
@@ -26,7 +26,7 @@
 #define SHARE_PRIMS_JVMTIEVENTCONTROLLER_HPP
 
 #include "jvmtifiles/jvmti.h"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 // forward declaration

--- a/src/hotspot/share/prims/jvmtiExtensions.hpp
+++ b/src/hotspot/share/prims/jvmtiExtensions.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/prims/jvmtiExtensions.hpp
+++ b/src/hotspot/share/prims/jvmtiExtensions.hpp
@@ -27,7 +27,7 @@
 
 #include "jvmtifiles/jvmti.h"
 #include "jvmtifiles/jvmtiEnv.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 // JvmtiExtensions
 //

--- a/src/hotspot/share/prims/jvmtiManageCapabilities.hpp
+++ b/src/hotspot/share/prims/jvmtiManageCapabilities.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/prims/jvmtiManageCapabilities.hpp
+++ b/src/hotspot/share/prims/jvmtiManageCapabilities.hpp
@@ -26,7 +26,7 @@
 #define SHARE_PRIMS_JVMTIMANAGECAPABILITIES_HPP
 
 #include "jvmtifiles/jvmti.h"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class JvmtiManageCapabilities : public AllStatic {
 

--- a/src/hotspot/share/prims/nativeLookup.hpp
+++ b/src/hotspot/share/prims/nativeLookup.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/prims/nativeLookup.hpp
+++ b/src/hotspot/share/prims/nativeLookup.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_PRIMS_NATIVELOOKUP_HPP
 #define SHARE_PRIMS_NATIVELOOKUP_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "runtime/handles.hpp"
 
 // NativeLookup provides an interface for finding DLL entry points for

--- a/src/hotspot/share/prims/resolvedMethodTable.hpp
+++ b/src/hotspot/share/prims/resolvedMethodTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/prims/resolvedMethodTable.hpp
+++ b/src/hotspot/share/prims/resolvedMethodTable.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_PRIMS_RESOLVEDMETHODTABLE_HPP
 #define SHARE_PRIMS_RESOLVEDMETHODTABLE_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "oops/symbol.hpp"
 #include "oops/weakHandle.hpp"
 

--- a/src/hotspot/share/prims/vectorSupport.hpp
+++ b/src/hotspot/share/prims/vectorSupport.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/prims/vectorSupport.hpp
+++ b/src/hotspot/share/prims/vectorSupport.hpp
@@ -27,7 +27,7 @@
 
 #include "jni.h"
 #include "code/debugInfo.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "oops/typeArrayOop.hpp"
 #include "runtime/registerMap.hpp"
 #include "utilities/exceptions.hpp"

--- a/src/hotspot/share/runtime/abstract_vm_version.hpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/abstract_vm_version.hpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_RUNTIME_ABSTRACT_VM_VERSION_HPP
 #define SHARE_RUNTIME_ABSTRACT_VM_VERSION_HPP
 
-#include "memory/allocation.hpp"  // For declaration of class AllStatic
+#include "memory/allStatic.hpp"  // For declaration of class AllStatic
 #include "utilities/globalDefinitions.hpp"
 
 typedef enum {

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -27,7 +27,7 @@
 
 #include "logging/logLevel.hpp"
 #include "logging/logTag.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/java.hpp"
 #include "runtime/os.hpp"

--- a/src/hotspot/share/runtime/handshake.hpp
+++ b/src/hotspot/share/runtime/handshake.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/handshake.hpp
+++ b/src/hotspot/share/runtime/handshake.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_RUNTIME_HANDSHAKE_HPP
 #define SHARE_RUNTIME_HANDSHAKE_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "memory/iterator.hpp"
 #include "runtime/flags/flagSetting.hpp"
 #include "runtime/mutex.hpp"

--- a/src/hotspot/share/runtime/icache.hpp
+++ b/src/hotspot/share/runtime/icache.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/icache.hpp
+++ b/src/hotspot/share/runtime/icache.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_RUNTIME_ICACHE_HPP
 #define SHARE_RUNTIME_ICACHE_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "runtime/stubCodeGenerator.hpp"
 #include "utilities/macros.hpp"
 

--- a/src/hotspot/share/runtime/jniHandles.hpp
+++ b/src/hotspot/share/runtime/jniHandles.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/jniHandles.hpp
+++ b/src/hotspot/share/runtime/jniHandles.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_RUNTIME_JNIHANDLES_HPP
 #define SHARE_RUNTIME_JNIHANDLES_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "runtime/handles.hpp"
 
 class JavaThread;

--- a/src/hotspot/share/runtime/orderAccess.hpp
+++ b/src/hotspot/share/runtime/orderAccess.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/orderAccess.hpp
+++ b/src/hotspot/share/runtime/orderAccess.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_RUNTIME_ORDERACCESS_HPP
 #define SHARE_RUNTIME_ORDERACCESS_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "runtime/vm_version.hpp"
 #include "utilities/macros.hpp"
 

--- a/src/hotspot/share/runtime/prefetch.hpp
+++ b/src/hotspot/share/runtime/prefetch.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/prefetch.hpp
+++ b/src/hotspot/share/runtime/prefetch.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_RUNTIME_PREFETCH_HPP
 #define SHARE_RUNTIME_PREFETCH_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 // If calls to prefetch methods are in a loop, the loop should be cloned
 // such that if Prefetch{Scan,Copy}Interval and/or PrefetchFieldInterval

--- a/src/hotspot/share/runtime/reflectionUtils.hpp
+++ b/src/hotspot/share/runtime/reflectionUtils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/reflectionUtils.hpp
+++ b/src/hotspot/share/runtime/reflectionUtils.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_RUNTIME_REFLECTIONUTILS_HPP
 #define SHARE_RUNTIME_REFLECTIONUTILS_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "oops/instanceKlass.hpp"
 #include "oops/objArrayOop.hpp"
 #include "oops/oopsHierarchy.hpp"

--- a/src/hotspot/share/runtime/safepoint.hpp
+++ b/src/hotspot/share/runtime/safepoint.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_RUNTIME_SAFEPOINT_HPP
 #define SHARE_RUNTIME_SAFEPOINT_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "runtime/os.hpp"
 #include "runtime/thread.hpp"
 #include "runtime/vmOperation.hpp"

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -29,7 +29,7 @@
 #include "code/vmreg.hpp"
 #include "interpreter/bytecodeTracer.hpp"
 #include "interpreter/linkResolver.hpp"
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "memory/resourceArea.hpp"
 #include "utilities/hashtable.hpp"
 #include "utilities/macros.hpp"

--- a/src/hotspot/share/runtime/stackWatermark.hpp
+++ b/src/hotspot/share/runtime/stackWatermark.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/stackWatermark.hpp
+++ b/src/hotspot/share/runtime/stackWatermark.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_RUNTIME_STACKWATERMARK_HPP
 #define SHARE_RUNTIME_STACKWATERMARK_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "runtime/mutex.hpp"
 #include "runtime/stackWatermarkKind.hpp"
 

--- a/src/hotspot/share/runtime/threadLocalStorage.hpp
+++ b/src/hotspot/share/runtime/threadLocalStorage.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/threadLocalStorage.hpp
+++ b/src/hotspot/share/runtime/threadLocalStorage.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_RUNTIME_THREADLOCALSTORAGE_HPP
 #define SHARE_RUNTIME_THREADLOCALSTORAGE_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 // forward-decl as we can't have an include cycle
 class Thread;

--- a/src/hotspot/share/services/attachListener.hpp
+++ b/src/hotspot/share/services/attachListener.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/services/attachListener.hpp
+++ b/src/hotspot/share/services/attachListener.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_SERVICES_ATTACHLISTENER_HPP
 #define SHARE_SERVICES_ATTACHLISTENER_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "runtime/atomic.hpp"
 #include "runtime/globals.hpp"
 #include "utilities/debug.hpp"

--- a/src/hotspot/share/services/gcNotifier.hpp
+++ b/src/hotspot/share/services/gcNotifier.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/services/gcNotifier.hpp
+++ b/src/hotspot/share/services/gcNotifier.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_SERVICES_GCNOTIFIER_HPP
 #define SHARE_SERVICES_GCNOTIFIER_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "services/memoryPool.hpp"
 #include "services/memoryService.hpp"
 #include "services/memoryManager.hpp"

--- a/src/hotspot/share/services/lowMemoryDetector.hpp
+++ b/src/hotspot/share/services/lowMemoryDetector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/services/lowMemoryDetector.hpp
+++ b/src/hotspot/share/services/lowMemoryDetector.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_SERVICES_LOWMEMORYDETECTOR_HPP
 #define SHARE_SERVICES_LOWMEMORYDETECTOR_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "oops/oopHandle.hpp"
 #include "runtime/atomic.hpp"
 #include "services/memoryPool.hpp"

--- a/src/hotspot/share/services/nmtCommon.hpp
+++ b/src/hotspot/share/services/nmtCommon.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/services/nmtCommon.hpp
+++ b/src/hotspot/share/services/nmtCommon.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_SERVICES_NMTCOMMON_HPP
 #define SHARE_SERVICES_NMTCOMMON_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allocation.hpp" // for MEMFLAGS only
 #include "utilities/align.hpp"
 #include "utilities/globalDefinitions.hpp"
 

--- a/src/hotspot/share/services/threadIdTable.hpp
+++ b/src/hotspot/share/services/threadIdTable.hpp
@@ -26,7 +26,7 @@
 #ifndef SHARE_SERVICES_THREADIDTABLE_HPP
 #define SHARE_SERVICES_THREADIDTABLE_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class JavaThread;
 class ThreadsList;

--- a/src/hotspot/share/utilities/decoder.hpp
+++ b/src/hotspot/share/utilities/decoder.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/utilities/decoder.hpp
+++ b/src/hotspot/share/utilities/decoder.hpp
@@ -26,7 +26,7 @@
 #ifndef SHARE_UTILITIES_DECODER_HPP
 #define SHARE_UTILITIES_DECODER_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "runtime/mutex.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "utilities/ostream.hpp"

--- a/src/hotspot/share/utilities/globalCounter.hpp
+++ b/src/hotspot/share/utilities/globalCounter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/utilities/globalCounter.hpp
+++ b/src/hotspot/share/utilities/globalCounter.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_UTILITIES_GLOBALCOUNTER_HPP
 #define SHARE_UTILITIES_GLOBALCOUNTER_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "memory/padded.hpp"
 
 class Thread;

--- a/src/hotspot/share/utilities/quickSort.hpp
+++ b/src/hotspot/share/utilities/quickSort.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/utilities/quickSort.hpp
+++ b/src/hotspot/share/utilities/quickSort.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_UTILITIES_QUICKSORT_HPP
 #define SHARE_UTILITIES_QUICKSORT_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "runtime/globals.hpp"
 #include "utilities/debug.hpp"
 

--- a/src/hotspot/share/utilities/stringUtils.cpp
+++ b/src/hotspot/share/utilities/stringUtils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/utilities/stringUtils.cpp
+++ b/src/hotspot/share/utilities/stringUtils.cpp
@@ -26,6 +26,8 @@
 #include "utilities/debug.hpp"
 #include "utilities/stringUtils.hpp"
 
+#include <string.h>
+
 int StringUtils::replace_no_expand(char* string, const char* from, const char* to) {
   int replace_count = 0;
   size_t from_len = strlen(from);

--- a/src/hotspot/share/utilities/stringUtils.hpp
+++ b/src/hotspot/share/utilities/stringUtils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/utilities/stringUtils.hpp
+++ b/src/hotspot/share/utilities/stringUtils.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_UTILITIES_STRINGUTILS_HPP
 #define SHARE_UTILITIES_STRINGUTILS_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 
 class StringUtils : AllStatic {
 public:

--- a/src/hotspot/share/utilities/utf8.cpp
+++ b/src/hotspot/share/utilities/utf8.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/utilities/utf8.cpp
+++ b/src/hotspot/share/utilities/utf8.cpp
@@ -23,7 +23,11 @@
  */
 
 #include "precompiled.hpp"
+#include "memory/allocation.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "utilities/utf8.hpp"
+
 
 // Assume the utf8 string is in legal form and has been
 // checked in the class file parser/format checker.

--- a/src/hotspot/share/utilities/utf8.hpp
+++ b/src/hotspot/share/utilities/utf8.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/utilities/utf8.hpp
+++ b/src/hotspot/share/utilities/utf8.hpp
@@ -25,7 +25,9 @@
 #ifndef SHARE_UTILITIES_UTF8_HPP
 #define SHARE_UTILITIES_UTF8_HPP
 
-#include "memory/allocation.hpp"
+#include "jni.h"
+#include "memory/allStatic.hpp"
+#include "utilities/debug.hpp"
 
 // Low-level interface for UTF8 strings
 

--- a/test/hotspot/gtest/classfile/test_AltHashing.cpp
+++ b/test/hotspot/gtest/classfile/test_AltHashing.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/gtest/classfile/test_AltHashing.cpp
+++ b/test/hotspot/gtest/classfile/test_AltHashing.cpp
@@ -24,6 +24,7 @@
 #include "classfile/altHashing.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/formatBuffer.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "unittest.hpp"
 
 class AltHashingTest : public ::testing::Test {


### PR DESCRIPTION
JDK-8249944 moved AllStatic to its own header. We should use that one instead of allocation.hpp where possible to reduce header dependencies.

This patch:
- replaces includes of allocation.hpp with allstatic.hpp where appropiate
- fixes up resulting errors since this changes uncovers missing dependencies. Mainly, missing includes of debug.hpp, of globalDefinitions.hpp, and missing outputStream definitions.

Changes are trivial but onerous. Done partly with a script, partly manually.

Test:
- Checked the build with gtests on Linux x86, x64, minimal, zero, aarch64, for both fastdebug and release. All builds of course without PCH.
- GHAs

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280503](https://bugs.openjdk.java.net/browse/JDK-8280503): Use allStatic.hpp instead of allocation.hpp where possible


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 37fd8fdbb53972f0717de03212cd5ea47e0c8270
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7188/head:pull/7188` \
`$ git checkout pull/7188`

Update a local copy of the PR: \
`$ git checkout pull/7188` \
`$ git pull https://git.openjdk.java.net/jdk pull/7188/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7188`

View PR using the GUI difftool: \
`$ git pr show -t 7188`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7188.diff">https://git.openjdk.java.net/jdk/pull/7188.diff</a>

</details>
