### PR TITLE
8277926: [aarch64] Address constructors are lacking initialisation.

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2834,7 +2834,7 @@ typedef void (MacroAssembler::* mem_vector_insn)(FloatRegister Rt,
                         int size_in_memory)
   {
     Address addr = mem2address(opcode, base, index, scale, disp);
-    if (addr.getMode() == Address::base_plus_offset) {
+    if (addr.mode() == Address::base_plus_offset) {
       /* If we get an out-of-range offset it is a bug in the compiler,
          so we assert here. */
       assert(Address::offset_ok_for_immed(addr.offset(), exact_log2(size_in_memory)),

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -245,6 +245,8 @@ void Assembler::add_sub_immediate(Instruction_aarch64 &current_insn,
 Address::Address(address target, relocInfo::relocType rtype) :
   _mode(addr_literal), _is_lval(false), _target(target)
 {
+  precond(target != nullptr);
+
   switch (rtype) {
   case relocInfo::oop_type:
   case relocInfo::metadata_type:

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -131,6 +131,7 @@ void Address::lea(MacroAssembler *as, Register r) const {
 
   switch(_mode) {
   case base_plus_offset: {
+    assert(_ext.shift() == 0, "expected, was %d", _ext.shift());
     if (_offset == 0 && _base == r) // it's a nop
       break;
     if (_offset > 0)

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -144,7 +144,7 @@ void Address::lea(MacroAssembler *as, Register r) const {
     __ add(r, _base, _index, _ext.op(), MAX2(_ext.shift(), 0));
     break;
   }
-  case literal: {
+  case addr_literal: {
     if (rtype == relocInfo::none)
       __ mov(r, target());
     else
@@ -242,9 +242,9 @@ void Assembler::add_sub_immediate(Instruction_aarch64 &current_insn,
 
 #undef starti
 
-Address::Address(address target, relocInfo::relocType rtype) : _mode(literal){
-  _is_lval = false;
-  _target = target;
+Address::Address(address target, relocInfo::relocType rtype) :
+  _mode(addr_literal), _is_lval(false), _target(target)
+{
   switch (rtype) {
   case relocInfo::oop_type:
   case relocInfo::metadata_type:

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -131,17 +131,17 @@ void Address::lea(MacroAssembler *as, Register r) const {
 
   switch(_mode) {
   case base_plus_offset: {
-    assert(_ext.shift() == 0, "expected, was %d", _ext.shift());
-    if (_offset == 0 && _base == r) // it's a nop
+    assert(ext().shift() == 0, "expected, was %d", ext().shift());
+    if (offset() == 0 && base() == r) // it's a nop
       break;
-    if (_offset > 0)
-      __ add(r, _base, _offset);
+    if (offset() > 0)
+      __ add(r, base(), offset());
     else
-      __ sub(r, _base, -_offset);
-      break;
+      __ sub(r, base(), -offset());
+    break;
   }
   case base_plus_offset_reg: {
-    __ add(r, _base, _index, _ext.op(), MAX2(_ext.shift(), 0));
+    __ add(r, base(), index(), ext().op(), MAX2(ext().shift(), 0));
     break;
   }
   case addr_literal: {

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -349,9 +349,8 @@ namespace ext
 // Addressing modes
 class Address {
  public:
-
-  enum mode { no_mode, base_plus_offset, pre, post, post_reg, pcrel,
-              base_plus_offset_reg, addr_literal };
+  enum mode { no_mode, addr_literal, pre, post, post_reg,
+              base_plus_offset, base_plus_offset_reg };
 
   // Shift and extend for base reg + reg offset addressing
   class extend {

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -595,19 +595,17 @@ class Address {
 
 // Convience classes
 class RuntimeAddress: public Address {
-
-  public:
-
-  RuntimeAddress(address target) : Address(target, relocInfo::runtime_call_type) {}
-
+ public:
+  RuntimeAddress(address target) : Address(target, relocInfo::runtime_call_type) {
+    precond(target != nullptr);
+  }
 };
 
 class OopAddress: public Address {
-
-  public:
-
-  OopAddress(address target) : Address(target, relocInfo::oop_type){}
-
+ public:
+  OopAddress(address target) : Address(target, relocInfo::oop_type) {
+    precond(target != nullptr);
+  }
 };
 
 class ExternalAddress: public Address {
@@ -621,16 +619,16 @@ class ExternalAddress: public Address {
   }
 
  public:
-
-  ExternalAddress(address target) : Address(target, reloc_for_target(target)) {}
-
+  ExternalAddress(address target) : Address(target, reloc_for_target(target)) {
+    precond(target != nullptr);
+  }
 };
 
 class InternalAddress: public Address {
-
-  public:
-
-  InternalAddress(address target) : Address(target, relocInfo::internal_word_type) {}
+ public:
+  InternalAddress(address target) : Address(target, relocInfo::internal_word_type) {
+    precond(target != nullptr);
+  }
 };
 
 const int FPUStateSizeInWords = FloatRegisterImpl::number_of_registers *

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -398,34 +398,33 @@ class Address {
   address   _target;
 
  public:
-  Address()
-    : _mode(no_mode) { }
-  Address(Register r)
-    : _mode(base_plus_offset), _base(r), _index(noreg), _offset(0), _extend(lsl(0)), _target(nullptr) {}
+  Address() : _mode(no_mode) {}
+
+  Address(Register r) : Address(r, 0) {}
 
   template<typename T, ENABLE_IF(std::is_integral<T>::value)>
-  Address(Register r, T o)
-    : _mode(base_plus_offset), _base(r), _index(noreg), _offset(0), _extend(lsl(0)), _target(nullptr) {}
+  Address(Register r, T o) : _mode(base_plus_offset),
+    _base(r), _index(noreg), _offset(o), _extend(lsl(0)), _target(nullptr) {}
 
-  Address(Register r, ByteSize disp)
-    : Address(r, in_bytes(disp)) { }
-  Address(Register r, Register r1, extend ext = lsl(0))
-    : _mode(base_plus_offset_reg), _base(r), _index(r1), _offset(0),
-      _extend(ext), _target(nullptr) { }
-  Address(Pre p)
-    : _mode(pre), _base(p.reg()), _index(noreg), _offset(p.offset()) { }
-  Address(Post p)
-    : _mode(p.is_postreg() ? post_reg : post), _base(p.reg()), _index(p.idx_reg()), _offset(p.offset()),
-      _extend(lsl(0)), _target(nullptr) { }
-  Address(address target, RelocationHolder const& rspec)
-    : _mode(addr_literal),
-      _rspec(rspec),
-      _is_lval(false),
-      _target(target)  { }
+  Address(Register r, ByteSize disp) : Address(r, in_bytes(disp)) {}
+
+  Address(Register r, Register r1, extend ext = lsl(0)) : _mode(base_plus_offset_reg),
+    _base(r), _index(r1), _offset(0), _extend(ext), _target(nullptr) {}
+
+  Address(Pre p) : _mode(pre),
+    _base(p.reg()), _index(noreg), _offset(p.offset()),
+    _extend(lsl(0)), _target(nullptr) {}
+  Address(Post p) : _mode(p.is_postreg() ? post_reg : post),
+    _base(p.reg()), _index(p.idx_reg()), _offset(p.offset()),
+    _extend(lsl(0)), _target(nullptr) {}
+
+  Address(address target, RelocationHolder const& rspec) : _mode(addr_literal),
+    _rspec(rspec), _is_lval(false), _target(target)  {}
   Address(address target, relocInfo::relocType rtype = relocInfo::external_word_type);
+
   Address(Register base, RegisterOrConstant index, extend ext = lsl(0))
-    : _base(base), _index(noreg),
-      _offset(0), _extend(ext), _target(nullptr) {
+    : _base(base), _index(noreg), _offset(0), _extend(ext), _target(nullptr)
+  {
     if (index.is_register()) {
       _mode = base_plus_offset_reg;
       _index = index.as_register();

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -404,30 +404,30 @@ class Address {
   Address()
     : _mode(no_mode) { }
   Address(Register r)
-    : _base(r), _index(noreg), _offset(0), _mode(base_plus_offset), _target(0) { }
+    : _base(r), _index(noreg), _offset(0), _mode(base_plus_offset), _ext(lsl(0)), _target(0) { }
 
   template<typename T, ENABLE_IF(std::is_integral<T>::value)>
   Address(Register r, T o)
-    : _base(r), _index(noreg), _offset(o), _mode(base_plus_offset), _target(0) {}
+    : _base(r), _index(noreg), _offset(o), _mode(base_plus_offset), _ext(lsl(0)), _target(0) {}
 
   Address(Register r, ByteSize disp)
     : Address(r, in_bytes(disp)) { }
-  Address(Register r, Register r1, extend ext = lsl())
+  Address(Register r, Register r1, extend ext = lsl(0))
     : _base(r), _index(r1), _offset(0), _mode(base_plus_offset_reg),
       _ext(ext), _target(0) { }
   Address(Pre p)
-    : _base(p.reg()), _offset(p.offset()), _mode(pre) { }
+    : _base(p.reg()), _index(noreg), _offset(p.offset()), _mode(pre) { }
   Address(Post p)
-    : _base(p.reg()),  _index(p.idx_reg()), _offset(p.offset()),
-      _mode(p.is_postreg() ? post_reg : post), _target(0) { }
+    : _base(p.reg()), _index(p.idx_reg()), _offset(p.offset()),
+      _mode(p.is_postreg() ? post_reg : post), _ext(lsl(0)), _target(0) { }
   Address(address target, RelocationHolder const& rspec)
     : _mode(literal),
       _rspec(rspec),
       _is_lval(false),
       _target(target)  { }
   Address(address target, relocInfo::relocType rtype = relocInfo::external_word_type);
-  Address(Register base, RegisterOrConstant index, extend ext = lsl())
-    : _base (base),
+  Address(Register base, RegisterOrConstant index, extend ext = lsl(0))
+    : _base(base), _index(noreg),
       _offset(0), _ext(ext), _target(0) {
     if (index.is_register()) {
       _mode = base_plus_offset_reg;

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -351,7 +351,7 @@ class Address {
  public:
 
   enum mode { no_mode, base_plus_offset, pre, post, post_reg, pcrel,
-              base_plus_offset_reg, literal };
+              base_plus_offset_reg, addr_literal };
 
   // Shift and extend for base reg + reg offset addressing
   class extend {
@@ -421,7 +421,7 @@ class Address {
     : _base(p.reg()), _index(p.idx_reg()), _offset(p.offset()),
       _mode(p.is_postreg() ? post_reg : post), _ext(lsl(0)), _target(0) { }
   Address(address target, RelocationHolder const& rspec)
-    : _mode(literal),
+    : _mode(addr_literal),
       _rspec(rspec),
       _is_lval(false),
       _target(target)  { }
@@ -1425,7 +1425,7 @@ public:
     // down into Address::encode) because the encoding of this
     // instruction is too different from all of the other forms to
     // make it worth sharing.
-    if (adr.getMode() == Address::literal) {
+    if (adr.getMode() == Address::addr_literal) {
       assert(size == 0b10 || size == 0b11, "bad operand size in ldr");
       assert(op == 0b01, "literal form can only be used with loads");
       f(size & 0b01, 31, 30), f(0b011, 29, 27), f(0b00, 25, 24);

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -349,8 +349,8 @@ namespace ext
 // Addressing modes
 class Address {
  public:
-  enum mode { no_mode, addr_literal, pre, post, post_reg,
-              base_plus_offset, base_plus_offset_reg };
+  enum addr_mode { no_mode, addr_literal, pre, post, post_reg,
+                   base_plus_offset, base_plus_offset_reg };
 
   // Shift and extend for base reg + reg offset addressing
   class extend {
@@ -381,7 +381,7 @@ class Address {
   };
 
  private:
-  enum mode _mode;
+  addr_mode _mode;
   Register  _base;
   Register  _index;
   int64_t   _offset;
@@ -454,7 +454,7 @@ class Address {
     precond(_mode != no_mode && _mode != addr_literal);
     return _extend;
   }
-  mode getMode() const {
+  addr_mode mode() const {
     return _mode;
   }
   bool uses(Register reg) const {
@@ -1442,7 +1442,7 @@ public:
     // down into Address::encode) because the encoding of this
     // instruction is too different from all of the other forms to
     // make it worth sharing.
-    if (adr.getMode() == Address::addr_literal) {
+    if (adr.mode() == Address::addr_literal) {
       assert(size == 0b10 || size == 0b11, "bad operand size in ldr");
       assert(op == 0b01, "literal form can only be used with loads");
       f(size & 0b01, 31, 30), f(0b011, 29, 27), f(0b00, 25, 24);
@@ -2284,7 +2284,7 @@ public:
   }
 
   void ld_st(FloatRegister Vt, SIMD_Arrangement T, Address a, int op1, int op2, int regs) {
-    switch (a.getMode()) {
+    switch (a.mode()) {
     case Address::base_plus_offset:
       guarantee(a.offset() == 0, "no offset allowed here");
       ld_st(Vt, T, a.base(), op1, op2);
@@ -3206,7 +3206,7 @@ private:
   void sve_ld_st1(FloatRegister Zt, PRegister Pg,
               SIMD_RegVariant T, const Address &a,
               int op1, int type, int imm_op2, int scalar_op2) {
-    switch (a.getMode()) {
+    switch (a.mode()) {
     case Address::base_plus_offset:
       sve_ld_st1(Zt, a.base(), a.offset(), Pg, T, op1, type, imm_op2);
       break;

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -218,7 +218,7 @@ Address LIR_Assembler::as_Address_lo(LIR_Address* addr) {
 Address LIR_Assembler::stack_slot_address(int index, uint size, Register tmp, int adjust) {
   precond(size == 4 || size == 8);
   Address addr = frame_map()->address_for_slot(index, adjust);
-  precond(addr.getMode() == Address::base_plus_offset);
+  precond(addr.mode() == Address::base_plus_offset);
   precond(addr.base() == sp);
   precond(addr.offset() > 0);
   uint mask = size - 1;

--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
@@ -284,17 +284,16 @@ void C2_MacroAssembler::string_indexof(Register str2, Register str1,
     cmp(cnt1, (u1)16); // small patterns still should be handled by simple algorithm
     br(LT, LINEAR_MEDIUM);
     mov(result, zr);
-    RuntimeAddress stub = NULL;
+    address entry = nullptr;
     if (isL) {
-      stub = RuntimeAddress(StubRoutines::aarch64::string_indexof_linear_ll());
-      assert(stub.target() != NULL, "string_indexof_linear_ll stub has not been generated");
+      entry = StubRoutines::aarch64::string_indexof_linear_ll();
     } else if (str1_isL) {
-      stub = RuntimeAddress(StubRoutines::aarch64::string_indexof_linear_ul());
-       assert(stub.target() != NULL, "string_indexof_linear_ul stub has not been generated");
+      entry = StubRoutines::aarch64::string_indexof_linear_ul();
     } else {
-      stub = RuntimeAddress(StubRoutines::aarch64::string_indexof_linear_uu());
-      assert(stub.target() != NULL, "string_indexof_linear_uu stub has not been generated");
+      entry = StubRoutines::aarch64::string_indexof_linear_uu();
     }
+    assert(entry != nullptr, "string_indexof_linear stub has not been generated");
+    RuntimeAddress stub(entry);
     trampoline_call(stub);
     b(DONE);
   }
@@ -836,24 +835,25 @@ void C2_MacroAssembler::string_compare(Register str1, Register str2,
   }
 
   bind(STUB);
-    RuntimeAddress stub = NULL;
+    address entry = nullptr;
     switch(ae) {
       case StrIntrinsicNode::LL:
-        stub = RuntimeAddress(StubRoutines::aarch64::compare_long_string_LL());
+        entry = StubRoutines::aarch64::compare_long_string_LL();
         break;
       case StrIntrinsicNode::UU:
-        stub = RuntimeAddress(StubRoutines::aarch64::compare_long_string_UU());
+        entry = StubRoutines::aarch64::compare_long_string_UU();
         break;
       case StrIntrinsicNode::LU:
-        stub = RuntimeAddress(StubRoutines::aarch64::compare_long_string_LU());
+        entry = StubRoutines::aarch64::compare_long_string_LU();
         break;
       case StrIntrinsicNode::UL:
-        stub = RuntimeAddress(StubRoutines::aarch64::compare_long_string_UL());
+        entry = StubRoutines::aarch64::compare_long_string_UL();
         break;
       default:
         ShouldNotReachHere();
      }
-    assert(stub.target() != NULL, "compare_long_string stub has not been generated");
+    assert(entry != nullptr, "compare_long_string stub has not been generated");
+    RuntimeAddress stub(entry);
     trampoline_call(stub);
     b(DONE);
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1790,7 +1790,7 @@ void MacroAssembler::decrement(Register reg, int value)
 void MacroAssembler::decrementw(Address dst, int value)
 {
   assert(!dst.uses(rscratch1), "invalid dst for address decrement");
-  if (dst.getMode() == Address::literal) {
+  if (dst.getMode() == Address::addr_literal) {
     assert(abs(value) < (1 << 12), "invalid value and address mode combination");
     lea(rscratch2, dst);
     dst = Address(rscratch2);
@@ -1803,7 +1803,7 @@ void MacroAssembler::decrementw(Address dst, int value)
 void MacroAssembler::decrement(Address dst, int value)
 {
   assert(!dst.uses(rscratch1), "invalid address for decrement");
-  if (dst.getMode() == Address::literal) {
+  if (dst.getMode() == Address::addr_literal) {
     assert(abs(value) < (1 << 12), "invalid value and address mode combination");
     lea(rscratch2, dst);
     dst = Address(rscratch2);
@@ -1840,7 +1840,7 @@ void MacroAssembler::increment(Register reg, int value)
 void MacroAssembler::incrementw(Address dst, int value)
 {
   assert(!dst.uses(rscratch1), "invalid dst for address increment");
-  if (dst.getMode() == Address::literal) {
+  if (dst.getMode() == Address::addr_literal) {
     assert(abs(value) < (1 << 12), "invalid value and address mode combination");
     lea(rscratch2, dst);
     dst = Address(rscratch2);
@@ -1853,7 +1853,7 @@ void MacroAssembler::incrementw(Address dst, int value)
 void MacroAssembler::increment(Address dst, int value)
 {
   assert(!dst.uses(rscratch1), "invalid dst for address increment");
-  if (dst.getMode() == Address::literal) {
+  if (dst.getMode() == Address::addr_literal) {
     assert(abs(value) < (1 << 12), "invalid value and address mode combination");
     lea(rscratch2, dst);
     dst = Address(rscratch2);
@@ -4269,7 +4269,7 @@ void MacroAssembler::adrp(Register reg1, const Address &dest, uint64_t &byte_off
   int64_t offset_high = dest_page - high_page;
 
   assert(is_valid_AArch64_address(dest.target()), "bad address");
-  assert(dest.getMode() == Address::literal, "ADRP must be applied to a literal address");
+  assert(dest.getMode() == Address::addr_literal, "ADRP must be applied to a literal address");
 
   InstructionMark im(this);
   code_section()->relocate(inst_mark(), dest.rspec());

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -812,7 +812,11 @@ void MacroAssembler::lookup_interface_method(Register recv_klass,
     // Adjust recv_klass by scaled itable_index, so we can free itable_index.
     assert(itableMethodEntry::size() * wordSize == wordSize, "adjust the scaling in the code below");
     // lea(recv_klass, Address(recv_klass, itable_index, Address::times_ptr, itentry_off));
-    lea(recv_klass, Address(recv_klass, itable_index, Address::lsl(3)));
+    if (itable_index.is_constant()) {
+        lea(recv_klass, Address(recv_klass, itable_index.as_constant() * 8));
+    } else {
+        lea(recv_klass, Address(recv_klass, itable_index, Address::lsl(3)));
+    }
     if (itentry_off)
       add(recv_klass, recv_klass, itentry_off);
   }

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1658,7 +1658,7 @@ bool MacroAssembler::try_merge_ldst(Register rt, const Address &adr, size_t size
   } else {
     assert(size_in_bytes == 8 || size_in_bytes == 4, "only 8 bytes or 4 bytes load/store is supported.");
     const uint64_t mask = size_in_bytes - 1;
-    if (adr.getMode() == Address::base_plus_offset &&
+    if (adr.mode() == Address::base_plus_offset &&
         (adr.offset() & mask) == 0) { // only supports base_plus_offset.
       code()->set_last_insn(pc());
     }
@@ -1790,7 +1790,7 @@ void MacroAssembler::decrement(Register reg, int value)
 void MacroAssembler::decrementw(Address dst, int value)
 {
   assert(!dst.uses(rscratch1), "invalid dst for address decrement");
-  if (dst.getMode() == Address::addr_literal) {
+  if (dst.mode() == Address::addr_literal) {
     assert(abs(value) < (1 << 12), "invalid value and address mode combination");
     lea(rscratch2, dst);
     dst = Address(rscratch2);
@@ -1803,7 +1803,7 @@ void MacroAssembler::decrementw(Address dst, int value)
 void MacroAssembler::decrement(Address dst, int value)
 {
   assert(!dst.uses(rscratch1), "invalid address for decrement");
-  if (dst.getMode() == Address::addr_literal) {
+  if (dst.mode() == Address::addr_literal) {
     assert(abs(value) < (1 << 12), "invalid value and address mode combination");
     lea(rscratch2, dst);
     dst = Address(rscratch2);
@@ -1840,7 +1840,7 @@ void MacroAssembler::increment(Register reg, int value)
 void MacroAssembler::incrementw(Address dst, int value)
 {
   assert(!dst.uses(rscratch1), "invalid dst for address increment");
-  if (dst.getMode() == Address::addr_literal) {
+  if (dst.mode() == Address::addr_literal) {
     assert(abs(value) < (1 << 12), "invalid value and address mode combination");
     lea(rscratch2, dst);
     dst = Address(rscratch2);
@@ -1853,7 +1853,7 @@ void MacroAssembler::incrementw(Address dst, int value)
 void MacroAssembler::increment(Address dst, int value)
 {
   assert(!dst.uses(rscratch1), "invalid dst for address increment");
-  if (dst.getMode() == Address::addr_literal) {
+  if (dst.mode() == Address::addr_literal) {
     assert(abs(value) < (1 << 12), "invalid value and address mode combination");
     lea(rscratch2, dst);
     dst = Address(rscratch2);
@@ -2733,7 +2733,7 @@ bool MacroAssembler::ldst_can_merge(Register rt,
     return false;
   }
 
-  if (adr.getMode() != Address::base_plus_offset || prev != last) {
+  if (adr.mode() != Address::base_plus_offset || prev != last) {
     return false;
   }
 
@@ -3660,7 +3660,7 @@ SkipIfEqual::~SkipIfEqual() {
 
 void MacroAssembler::addptr(const Address &dst, int32_t src) {
   Address adr;
-  switch(dst.getMode()) {
+  switch(dst.mode()) {
   case Address::base_plus_offset:
     // This is the expected mode, although we allow all the other
     // forms below.
@@ -4269,7 +4269,7 @@ void MacroAssembler::adrp(Register reg1, const Address &dest, uint64_t &byte_off
   int64_t offset_high = dest_page - high_page;
 
   assert(is_valid_AArch64_address(dest.target()), "bad address");
-  assert(dest.getMode() == Address::addr_literal, "ADRP must be applied to a literal address");
+  assert(dest.mode() == Address::addr_literal, "ADRP must be applied to a literal address");
 
   InstructionMark im(this);
   code_section()->relocate(inst_mark(), dest.rspec());
@@ -5185,7 +5185,7 @@ void MacroAssembler::get_thread(Register dst) {
 }
 
 void MacroAssembler::cache_wb(Address line) {
-  assert(line.getMode() == Address::base_plus_offset, "mode should be base_plus_offset");
+  assert(line.mode() == Address::base_plus_offset, "mode should be base_plus_offset");
   assert(line.index() == noreg, "index should be noreg");
   assert(line.offset() == 0, "offset should be 0");
   // would like to assert this

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -123,7 +123,7 @@ class MacroAssembler: public Assembler {
   /* Sometimes we get misaligned loads and stores, usually from Unsafe
      accesses, and these can exceed the offset range. */
   Address legitimize_address(const Address &a, int size, Register scratch) {
-    if (a.getMode() == Address::base_plus_offset) {
+    if (a.mode() == Address::base_plus_offset) {
       if (! Address::offset_ok_for_immed(a.offset(), exact_log2(size))) {
         block_comment("legitimize_address {");
         lea(scratch, a);


### PR DESCRIPTION
Please review changes to secure proper initialisation in Address constructors.

Changes include (with additional clean-up):

Renamed '**literal**' to '**addr_literal**'.
Renamed '**_ext**' to '**_extend**'.
Renamed Address::mode enum to Address::addr_mode.
Renamed Address::getMode() to Address::mode().
Reorder _mode.

Initialise '**_extend**' to **lsl(0)**.
Initialise '**_target**' to **nullptr**.

Added preconditions to constructors.
Added preconditions to check 'target' address.

Removed '**pcrel**' addressing mode (unused).
Removed direct attribute use in Address.

Minor clean-up to RuntimeAddress use.

---8<---

Testing: tier1-6 (Linux), tier1-3 (MacOSX)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8277926](https://bugs.openjdk.java.net/browse/JDK-8277926): [aarch64] Address constructors are lacking initialisation.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7191/head:pull/7191` \
`$ git checkout pull/7191`

Update a local copy of the PR: \
`$ git checkout pull/7191` \
`$ git pull https://git.openjdk.java.net/jdk pull/7191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7191`

View PR using the GUI difftool: \
`$ git pr show -t 7191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7191.diff">https://git.openjdk.java.net/jdk/pull/7191.diff</a>

</details>
