### PR TITLE
8276219: C2: ConnectionGraph::find_inst_mem() should not be recursive

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -4974,7 +4974,8 @@ Node* MergeMemNode::memory_at(uint alias_idx) const {
          "must avoid base_memory and AliasIdxTop");
 
   // Otherwise, it is a narrow slice.
-  Node *n = alias_idx < req() ? in(alias_idx) : empty_memory();
+  Node* n = alias_idx < req() ? in(alias_idx) : empty_memory();
+  Compile *C = Compile::current();
   if (is_empty_memory(n)) {
     // the array is sparse; empty slots are the "top" node
     n = base_memory();
@@ -4988,8 +4989,8 @@ Node* MergeMemNode::memory_at(uint alias_idx) const {
     // AliasLevel == 0 if we are organizing the memory states manually.
     // See verify_memory_slice for comments on TypeRawPtr::BOTTOM.
   } else {
-#ifdef ASSERT
     // make sure the stored slice is sane
+    #ifdef ASSERT
     if (VMError::is_error_reported() || Node::in_dump()) {
     } else if (might_be_same(n, base_memory())) {
       // Give it a pass:  It is a mostly harmless repetition of the base.
@@ -4997,7 +4998,7 @@ Node* MergeMemNode::memory_at(uint alias_idx) const {
     } else {
       verify_memory_slice(this, alias_idx, n);
     }
-#endif
+    #endif
   }
   return n;
 }

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -4974,8 +4974,7 @@ Node* MergeMemNode::memory_at(uint alias_idx) const {
          "must avoid base_memory and AliasIdxTop");
 
   // Otherwise, it is a narrow slice.
-  Node* n = alias_idx < req() ? in(alias_idx) : empty_memory();
-  Compile *C = Compile::current();
+  Node *n = alias_idx < req() ? in(alias_idx) : empty_memory();
   if (is_empty_memory(n)) {
     // the array is sparse; empty slots are the "top" node
     n = base_memory();
@@ -4989,8 +4988,8 @@ Node* MergeMemNode::memory_at(uint alias_idx) const {
     // AliasLevel == 0 if we are organizing the memory states manually.
     // See verify_memory_slice for comments on TypeRawPtr::BOTTOM.
   } else {
+#ifdef ASSERT
     // make sure the stored slice is sane
-    #ifdef ASSERT
     if (VMError::is_error_reported() || Node::in_dump()) {
     } else if (might_be_same(n, base_memory())) {
       // Give it a pass:  It is a mostly harmless repetition of the base.
@@ -4998,7 +4997,7 @@ Node* MergeMemNode::memory_at(uint alias_idx) const {
     } else {
       verify_memory_slice(this, alias_idx, n);
     }
-    #endif
+#endif
   }
   return n;
 }


### PR DESCRIPTION
This patch only eliminates the self-recursion. recursion may take place in split_memory_phi().
/cc hotspot-compiler

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8276219](https://bugs.openjdk.java.net/browse/JDK-8276219): C2: ConnectionGraph::find_inst_mem() should not be recursive


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7192/head:pull/7192` \
`$ git checkout pull/7192`

Update a local copy of the PR: \
`$ git checkout pull/7192` \
`$ git pull https://git.openjdk.java.net/jdk pull/7192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7192`

View PR using the GUI difftool: \
`$ git pr show -t 7192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7192.diff">https://git.openjdk.java.net/jdk/pull/7192.diff</a>

</details>
