### PR TITLE
JDK-8280525: Per-metaspace-arena alignment handling

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -216,8 +216,10 @@ bool ArchiveBuilder::gather_klass_and_symbol(MetaspaceClosure::Ref* ref, bool re
     if (!is_excluded(klass)) {
       _klasses->append(klass);
     }
-    // See RunTimeClassInfo::get_for()
-    _estimated_metaspaceobj_bytes += align_up(BytesPerWord, SharedSpaceObjectAlignment);
+    // See ArchiveBuilder::make_shallow_copies: make sure we have enough space for both maximum
+    // Klass alignment as well as the RuntimeInfo* pointer we will embed in front of a Klass.
+    _estimated_metaspaceobj_bytes += align_up(BytesPerWord, KlassAlignmentInBytes) +
+        align_up(sizeof(void*), SharedSpaceObjectAlignment);
   } else if (ref->msotype() == MetaspaceObj::SymbolType) {
     // Make sure the symbol won't be GC'ed while we are dumping the archive.
     Symbol* sym = (Symbol*)ref->obj();
@@ -613,17 +615,20 @@ void ArchiveBuilder::make_shallow_copy(DumpRegion *dump_region, SourceObjInfo* s
 
   oldtop = dump_region->top();
   if (ref->msotype() == MetaspaceObj::ClassType) {
-    // Save a pointer immediate in front of an InstanceKlass, so
-    // we can do a quick lookup from InstanceKlass* -> RunTimeClassInfo*
-    // without building another hashtable. See RunTimeClassInfo::get_for()
-    // in systemDictionaryShared.cpp.
+    // Reserve space for a pointer immediately in front of an InstanceKlass. That space will
+    // later be used to store the RuntimeClassInfo* pointer directly in front of the archived
+    // InstanceKlass, in order to have a quick lookup InstanceKlass* -> RunTimeClassInfo*
+    // without building another hashtable. See RunTimeClassInfo::get_for()/::set_for() for
+    // details.
     Klass* klass = (Klass*)src;
     if (klass->is_instance_klass()) {
       SystemDictionaryShared::validate_before_archiving(InstanceKlass::cast(klass));
       dump_region->allocate(sizeof(address));
     }
+    dest = dump_region->allocate(bytes, KlassAlignmentInBytes);
+  } else {
+    dest = dump_region->allocate(bytes);
   }
-  dest = dump_region->allocate(bytes);
   newtop = dump_region->top();
 
   memcpy(dest, src, bytes);
@@ -634,10 +639,13 @@ void ArchiveBuilder::make_shallow_copy(DumpRegion *dump_region, SourceObjInfo* s
     ArchivePtrMarker::mark_pointer((address*)dest);
   }
 
-  log_trace(cds)("Copy: " PTR_FORMAT " ==> " PTR_FORMAT " %d", p2i(src), p2i(dest), bytes);
+  log_trace(cds)("Copy: " PTR_FORMAT " ==> " PTR_FORMAT " %d (%s)", p2i(src), p2i(dest), bytes,
+                 MetaspaceObj::type_name(ref->msotype()));
   src_info->set_dumped_addr((address)dest);
 
   _alloc_stats.record(ref->msotype(), int(newtop - oldtop), src_info->read_only());
+
+  DEBUG_ONLY(_alloc_stats.verify((int)dump_region->used(), src_info->read_only()));
 }
 
 address ArchiveBuilder::get_dumped_addr(address src_obj) const {

--- a/src/hotspot/share/cds/archiveUtils.hpp
+++ b/src/hotspot/share/cds/archiveUtils.hpp
@@ -142,10 +142,14 @@ private:
 public:
   DumpRegion(const char* name, uintx max_delta = 0)
     : _name(name), _base(NULL), _top(NULL), _end(NULL),
-      _max_delta(max_delta), _is_packed(false) {}
+      _max_delta(max_delta), _is_packed(false),
+      _rs(NULL), _vs(NULL) {}
 
   char* expand_top_to(char* newtop);
+  // Allocate with default alignment (SharedSpaceObjectAlignment)
   char* allocate(size_t num_bytes);
+  // Allocate with an arbitrary alignment.
+  char* allocate(size_t num_bytes, size_t alignment);
 
   void append_intptr_t(intptr_t n, bool need_to_mark = false);
 

--- a/src/hotspot/share/cds/dumpAllocStats.cpp
+++ b/src/hotspot/share/cds/dumpAllocStats.cpp
@@ -102,3 +102,15 @@ void DumpAllocStats::print_stats(int ro_all, int rw_all) {
 
 #undef fmt_stats
 }
+
+#ifdef ASSERT
+void DumpAllocStats::verify(int expected_byte_size, bool read_only) const {
+  int bytes = 0;
+  const int what = (int)(read_only ? RO : RW);
+  for (int type = 0; type < int(_number_of_types); type ++) {
+    bytes += _bytes[what][type];
+  }
+  assert(bytes == expected_byte_size, "counter mismatch (%s: %d vs %d)",
+         (read_only ? "RO" : "RW"), bytes, expected_byte_size);
+}
+#endif // ASSERT

--- a/src/hotspot/share/cds/dumpAllocStats.hpp
+++ b/src/hotspot/share/cds/dumpAllocStats.hpp
@@ -83,6 +83,8 @@ public:
     _bytes [which][type] += byte_size;
   }
 
+  DEBUG_ONLY(void verify(int expected_byte_size, bool read_only) const;)
+
   void record_modules(int byte_size, bool read_only) {
     int which = (read_only) ? RO : RW;
     _bytes [which][ModulesNativesType] += byte_size;

--- a/src/hotspot/share/memory/classLoaderMetaspace.cpp
+++ b/src/hotspot/share/memory/classLoaderMetaspace.cpp
@@ -28,6 +28,7 @@
 #include "memory/classLoaderMetaspace.hpp"
 #include "memory/metaspace.hpp"
 #include "memory/metaspaceUtils.hpp"
+#include "memory/metaspace/metaspaceAlignment.hpp"
 #include "memory/metaspace/chunkManager.hpp"
 #include "memory/metaspace/internalStats.hpp"
 #include "memory/metaspace/metaspaceArena.hpp"
@@ -36,7 +37,9 @@
 #include "memory/metaspace/metaspaceStatistics.hpp"
 #include "memory/metaspace/runningCounters.hpp"
 #include "memory/metaspaceTracer.hpp"
+#include "utilities/align.hpp"
 #include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 using metaspace::ChunkManager;
 using metaspace::MetaspaceArena;
@@ -56,24 +59,34 @@ ClassLoaderMetaspace::ClassLoaderMetaspace(Mutex* lock, Metaspace::MetaspaceType
   ChunkManager* const non_class_cm =
           ChunkManager::chunkmanager_nonclass();
 
+  const int klass_alignment_words = KlassAlignmentInBytes / BytesPerWord;
+
   // Initialize non-class Arena
   _non_class_space_arena = new MetaspaceArena(
       non_class_cm,
       ArenaGrowthPolicy::policy_for_space_type(space_type, false),
+      metaspace::MetaspaceMinAlignmentWords,
       lock,
       RunningCounters::used_nonclass_counter(),
       "non-class sm");
 
   // If needed, initialize class arena
   if (Metaspace::using_class_space()) {
+    // Klass instances live in class space and must be aligned correctly.
     ChunkManager* const class_cm =
             ChunkManager::chunkmanager_class();
     _class_space_arena = new MetaspaceArena(
         class_cm,
         ArenaGrowthPolicy::policy_for_space_type(space_type, true),
+        klass_alignment_words,
         lock,
         RunningCounters::used_class_counter(),
         "class sm");
+  } else {
+    // If we do not use a class space, Klass alignment does not matter, so KlassAlignmentInBytes
+    // should be the same as the standard metaspace minimal alignment to avoid tripping alignment
+    // checks after Klass allocation.
+// STATIC_ASSERT(metaspace::MetaspaceMinAlignmentBytes == KlassAlignmentInBytes);
   }
 
   UL2(debug, "born (nonclass arena: " PTR_FORMAT ", class arena: " PTR_FORMAT ".",

--- a/src/hotspot/share/memory/metaspace/freeBlocks.cpp
+++ b/src/hotspot/share/memory/metaspace/freeBlocks.cpp
@@ -52,6 +52,11 @@ MetaWord* FreeBlocks::remove_block(size_t requested_word_size) {
   if (p != NULL) {
     // Blocks which are larger than a certain threshold are split and
     //  the remainder is handed back to the manager.
+    // Attention alignment: the remainder block which we add back must have the
+    //  correct alignment, matching that of the enclosing Arena. ATM this works,
+    //  since MetaspaceArena only requests block from FreeBlocks in correctly
+    //  aligned sizes. So, requested_word_size would always be aligned to the
+    //  arena's notion of alignment. See MetaspaceArena::allocate.
     const size_t waste = real_size - requested_word_size;
     if (waste > MinWordSize) {
       add_block(p + requested_word_size, waste);

--- a/src/hotspot/share/memory/metaspace/metaspaceAlignment.hpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceAlignment.hpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_MEMORY_METASPACE_ALIGNMENT_HPP
+#define SHARE_MEMORY_METASPACE_ALIGNMENT_HPP
+
+#include "memory/metaspace/chunklevel.hpp"
+#include "memory/metaspace/freeBlocks.hpp"
+#include "utilities/align.hpp"
+#include "utilities/powerOfTwo.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+namespace metaspace {
+
+// The minimal alignment: Good enough to properly store structures with 64bit wide members
+//  (also on 32-bit) in metaspace.
+//  Should we ever store PODs larger than 64-bit, or structures containing such PODs,
+//  we will need to increase this alignment.
+static const int LogMetaspaceMinimalAlignment = LogBytesPerLong;
+static const int MetaspaceMinAlignmentBytes = 1 << LogMetaspaceMinimalAlignment;
+static const int MetaspaceMinAlignmentWords = MetaspaceMinAlignmentBytes / BytesPerWord;
+
+// The maximum possible alignment is the smallest chunk size (note that the buddy allocator places
+// chunks at chunk-size-aligned boundaries, therefore the start address is guaranteed to be aligned).
+// We cannot guarantee allocation alignment beyond this value.
+static const int MetaspaceMaxAlignmentWords = chunklevel::MIN_CHUNK_WORD_SIZE;
+
+// Given a net allocation word size and an alignment value, return the raw word size we actually
+// allocate internally.
+inline size_t get_raw_word_size_for_requested_word_size(size_t net_word_size,
+                                                        size_t alignment_words) {
+
+  // The alignment should be between the minimum alignment but cannot be larger than the smallest chunk size
+  assert(is_power_of_2(alignment_words), "invalid alignment");
+  assert(alignment_words >= MetaspaceMinAlignmentWords &&
+         alignment_words <= MetaspaceMaxAlignmentWords,
+         "invalid alignment (" SIZE_FORMAT ")", alignment_words);
+
+  // Deallocated metablocks are kept in a binlist which means blocks need to have
+  // a minimal size
+  size_t raw_word_size = MAX2(net_word_size, FreeBlocks::MinWordSize);
+
+  raw_word_size = align_up(raw_word_size, alignment_words);
+
+  return raw_word_size;
+}
+
+} // namespace metaspace
+
+#endif // SHARE_MEMORY_METASPACE_ALIGNMENT_HPP

--- a/src/hotspot/share/memory/metaspace/metaspaceArena.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceArena.cpp
@@ -31,6 +31,7 @@
 #include "memory/metaspace/freeBlocks.hpp"
 #include "memory/metaspace/internalStats.hpp"
 #include "memory/metaspace/metachunk.hpp"
+#include "memory/metaspace/metaspaceAlignment.hpp"
 #include "memory/metaspace/metaspaceArena.hpp"
 #include "memory/metaspace/metaspaceArenaGrowthPolicy.hpp"
 #include "memory/metaspace/metaspaceCommon.hpp"
@@ -107,19 +108,21 @@ void MetaspaceArena::add_allocation_to_fbl(MetaWord* p, size_t word_size) {
   _fbl->add_block(p, word_size);
 }
 
-MetaspaceArena::MetaspaceArena(ChunkManager* chunk_manager, const ArenaGrowthPolicy* growth_policy,
+MetaspaceArena::MetaspaceArena(ChunkManager* chunk_manager, const ArenaGrowthPolicy* growth_policy, int alignment_words,
                                Mutex* lock, SizeAtomicCounter* total_used_words_counter,
                                const char* name) :
   _lock(lock),
   _chunk_manager(chunk_manager),
   _growth_policy(growth_policy),
   _chunks(),
+  _alignment_words(alignment_words),
   _fbl(NULL),
   _total_used_words_counter(total_used_words_counter),
   _name(name)
 #ifdef ASSERT
   , _first_fence(NULL)
 #endif
+
 {
   UL(debug, ": born.");
 
@@ -224,12 +227,14 @@ MetaWord* MetaspaceArena::allocate(size_t requested_word_size) {
   UL2(trace, "requested " SIZE_FORMAT " words.", requested_word_size);
 
   MetaWord* p = NULL;
-  const size_t raw_word_size = get_raw_word_size_for_requested_word_size(requested_word_size);
+  const size_t raw_word_size = get_raw_word_size_for_requested_word_size(requested_word_size, _alignment_words);
 
   // Before bothering the arena proper, attempt to re-use a block from the free blocks list
   if (_fbl != NULL && !_fbl->is_empty()) {
     p = _fbl->remove_block(raw_word_size);
     if (p != NULL) {
+      assert(is_aligned(p, _alignment_words * BytesPerWord),
+             "Wrong alignment from freeblocks");
       DEBUG_ONLY(InternalStats::inc_num_allocs_from_deallocated_blocks();)
       UL2(trace, "taken from fbl (now: %d, " SIZE_FORMAT ").",
           _fbl->count(), _fbl->total_size());
@@ -268,7 +273,7 @@ MetaWord* MetaspaceArena::allocate_inner(size_t requested_word_size) {
 
   assert_lock_strong(lock());
 
-  const size_t raw_word_size = get_raw_word_size_for_requested_word_size(requested_word_size);
+  const size_t raw_word_size = get_raw_word_size_for_requested_word_size(requested_word_size, _alignment_words);
   MetaWord* p = NULL;
   bool current_chunk_too_small = false;
   bool commit_failure = false;
@@ -368,7 +373,7 @@ void MetaspaceArena::deallocate_locked(MetaWord* p, size_t word_size) {
   UL2(trace, "deallocating " PTR_FORMAT ", word size: " SIZE_FORMAT ".",
       p2i(p), word_size);
 
-  size_t raw_word_size = get_raw_word_size_for_requested_word_size(word_size);
+  size_t raw_word_size = get_raw_word_size_for_requested_word_size(word_size, _alignment_words);
   add_allocation_to_fbl(p, raw_word_size);
 
   DEBUG_ONLY(verify_locked();)
@@ -482,8 +487,8 @@ void MetaspaceArena::print_on_locked(outputStream* st) const {
                _chunks.count(), _chunks.calc_word_size(), _chunks.calc_committed_word_size());
   _chunks.print_on(st);
   st->cr();
-  st->print_cr("growth-policy " PTR_FORMAT ", lock " PTR_FORMAT ", cm " PTR_FORMAT ", fbl " PTR_FORMAT,
-                p2i(_growth_policy), p2i(_lock), p2i(_chunk_manager), p2i(_fbl));
+  st->print_cr("growth-policy " PTR_FORMAT ", alignment %d, lock " PTR_FORMAT ", cm " PTR_FORMAT ", fbl " PTR_FORMAT,
+                p2i(_growth_policy), _alignment_words * BytesPerWord, p2i(_lock), p2i(_chunk_manager), p2i(_fbl));
 }
 
 } // namespace metaspace

--- a/src/hotspot/share/memory/metaspace/metaspaceArena.hpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceArena.hpp
@@ -94,6 +94,9 @@ class MetaspaceArena : public CHeapObj<mtClass> {
   // List of chunks. Head of the list is the current chunk.
   MetachunkList _chunks;
 
+  // Alignment alignment, in words.
+  const int _alignment_words;
+
   // Structure to take care of leftover/deallocated space in used chunks.
   // Owned by the Arena. Gets allocated on demand only.
   FreeBlocks* _fbl;
@@ -164,7 +167,7 @@ class MetaspaceArena : public CHeapObj<mtClass> {
 
 public:
 
-  MetaspaceArena(ChunkManager* chunk_manager, const ArenaGrowthPolicy* growth_policy,
+  MetaspaceArena(ChunkManager* chunk_manager, const ArenaGrowthPolicy* growth_policy, int alignment_words,
                  Mutex* lock, SizeAtomicCounter* total_used_words_counter,
                  const char* name);
 

--- a/src/hotspot/share/memory/metaspace/metaspaceCommon.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceCommon.cpp
@@ -25,6 +25,7 @@
 
 #include "precompiled.hpp"
 #include "memory/metaspace/freeBlocks.hpp"
+#include "memory/metaspace/metaspaceAlignment.hpp"
 #include "memory/metaspace/metaspaceCommon.hpp"
 #include "memory/metaspace/metaspaceSettings.hpp"
 #include "memory/metaspace/virtualSpaceNode.hpp"
@@ -166,24 +167,6 @@ void print_number_of_classes(outputStream* out, uintx classes, uintx classes_sha
   if (classes_shared > 0) {
     out->print(" (" UINTX_FORMAT " shared)", classes_shared);
   }
-}
-
-// Given a net allocation word size, return the raw word size we actually allocate.
-// Note: externally visible for gtests.
-//static
-size_t get_raw_word_size_for_requested_word_size(size_t word_size) {
-  size_t byte_size = word_size * BytesPerWord;
-
-  // Deallocated metablocks are kept in a binlist which limits their minimal
-  //  size to at least the size of a binlist item (2 words).
-  byte_size = MAX2(byte_size, FreeBlocks::MinWordSize * BytesPerWord);
-
-  // Metaspace allocations are aligned to word size.
-  byte_size = align_up(byte_size, AllocationAlignmentByteSize);
-
-  size_t raw_word_size = byte_size / BytesPerWord;
-  assert(raw_word_size * BytesPerWord == byte_size, "Sanity");
-  return raw_word_size;
 }
 
 } // namespace metaspace

--- a/src/hotspot/share/memory/metaspace/metaspaceCommon.hpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceCommon.hpp
@@ -35,27 +35,6 @@ class outputStream;
 
 namespace metaspace {
 
-// Metaspace allocation alignment:
-
-// 1) Metaspace allocations have to be aligned such that 64bit values are aligned
-//  correctly.
-//
-// 2) Klass* structures allocated from Metaspace have to be aligned to KlassAlignmentInBytes.
-//
-// At the moment LogKlassAlignmentInBytes is 3, so KlassAlignmentInBytes == 8,
-//  so (1) and (2) can both be fulfilled with an alignment of 8. Should we increase
-//  KlassAlignmentInBytes at any time this will increase the necessary alignment as well. In
-//  that case we may think about introducing a separate alignment just for the class space
-//  since that alignment would only be needed for Klass structures.
-
-static const size_t AllocationAlignmentByteSize = 8;
-STATIC_ASSERT(AllocationAlignmentByteSize == (size_t)KlassAlignmentInBytes);
-
-static const size_t AllocationAlignmentWordSize = AllocationAlignmentByteSize / BytesPerWord;
-
-// Returns the raw word size allocated for a given net allocation
-size_t get_raw_word_size_for_requested_word_size(size_t word_size);
-
 // Utility functions
 
 // Print a size, in words, scaled.

--- a/src/hotspot/share/memory/metaspace/metaspaceReporter.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceReporter.cpp
@@ -38,6 +38,7 @@
 #include "memory/metaspace/runningCounters.hpp"
 #include "memory/metaspace/virtualSpaceList.hpp"
 #include "memory/metaspaceUtils.hpp"
+#include "oops/compressedOops.hpp"
 #include "runtime/os.hpp"
 
 namespace metaspace {
@@ -102,13 +103,22 @@ static void print_settings(outputStream* out, size_t scale) {
     print_human_readable_size(out, MaxMetaspaceSize, scale);
   }
   out->cr();
+#ifdef _LP64
   if (Metaspace::using_class_space()) {
     out->print("CompressedClassSpaceSize: ");
     print_human_readable_size(out, CompressedClassSpaceSize, scale);
+    out->cr();
+    out->print_cr("KlassAlignmentInBytes: %d", KlassAlignmentInBytes);
+    out->print("KlassEncodingMetaspaceMax: ");
+    print_human_readable_size(out, KlassEncodingMetaspaceMax, scale);
+    out->cr();
+    CompressedKlassPointers::print_mode(out);
   } else {
-    out->print("No class space");
+    out->print_cr("No class space");
   }
-  out->cr();
+#else
+  out->print_cr("32-bit VM: No class space");
+#endif // _LP64
   out->print("Initial GC threshold: ");
   print_human_readable_size(out, MetaspaceSize, scale);
   out->cr();

--- a/src/hotspot/share/memory/metaspace/testHelpers.cpp
+++ b/src/hotspot/share/memory/metaspace/testHelpers.cpp
@@ -24,6 +24,7 @@
  */
 
 #include "precompiled.hpp"
+#include "memory/metaspace/metaspaceAlignment.hpp"
 #include "memory/metaspace/metaspaceArena.hpp"
 #include "memory/metaspace/metaspaceArenaGrowthPolicy.hpp"
 #include "memory/metaspace/metaspaceContext.hpp"
@@ -96,7 +97,8 @@ MetaspaceTestArena* MetaspaceTestContext::create_arena(Metaspace::MetaspaceType 
   MetaspaceArena* arena = NULL;
   {
     MutexLocker ml(lock,  Mutex::_no_safepoint_check_flag);
-    arena = new MetaspaceArena(_context->cm(), growth_policy, lock, &_used_words_counter, _name);
+    arena = new MetaspaceArena(_context->cm(), growth_policy, MetaspaceMinAlignmentWords,
+                               lock, &_used_words_counter, _name);
   }
   return new MetaspaceTestArena(lock, arena);
 }

--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -48,7 +48,9 @@
 #include "prims/jvmtiExport.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/atomic.hpp"
+#include "runtime/globals.hpp"
 #include "runtime/handles.inline.hpp"
+#include "utilities/align.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/powerOfTwo.hpp"
 #include "utilities/stack.inline.hpp"
@@ -194,7 +196,10 @@ Method* Klass::uncached_lookup_method(const Symbol* name, const Symbol* signatur
 }
 
 void* Klass::operator new(size_t size, ClassLoaderData* loader_data, size_t word_size, TRAPS) throw() {
-  return Metaspace::allocate(loader_data, word_size, MetaspaceObj::ClassType, THREAD);
+  MetaWord* p = Metaspace::allocate(loader_data, word_size, MetaspaceObj::ClassType, THREAD);
+  assert(!UseCompressedClassPointers || is_aligned(p, KlassAlignmentInBytes),
+         "metaspace returned badly aligned memory (" PTR_FORMAT ").", p2i(p));
+  return p;
 }
 
 // "Normal" instantiation is preceeded by a MetaspaceObj allocation
@@ -766,6 +771,9 @@ void Klass::verify_on(outputStream* st) {
   // This can be expensive, but it is worth checking that this klass is actually
   // in the CLD graph but not in production.
   assert(Metaspace::contains((address)this), "Should be");
+
+  assert(!UseCompressedClassPointers || is_aligned(this, KlassAlignmentInBytes),
+         "misaligned Klass structure (" PTR_FORMAT ").", p2i(this));
 
   guarantee(this->is_klass(),"should be klass");
 


### PR DESCRIPTION
To simplify work on Lilliput, I'd like to integrate some parts to mainline that make sense outside of Lilliput. This RFE is one of these parts.

In Lilliput, we use different (much higher) alignment requirements for the placement of Klass structures in class space and in CDS. For details about this please see the original lilliput change [1].

In Lilliput, the class space uses a different alignment than non-class metaspace. That allows us to use a higher LogKlassAlignment value while not affecting storage of non-Klass metadata. We did this by switching from a global metaspace alignment to each metaspace arena having its own alignment. Then, class space uses the larger KlassAlignment whereas other metaspace arenas keep using the small 8-byte standard alignment. Beyond lilliput, this could also be used in the future to store data more densely which does not need 8 byte alignment.

This patch brings the let-alignment-be-a-per-arena-feature to mainline JDK: we step away from the notion of one single global allocation alignment and instead allow a metaspace arena to have its own alignment.

In addition to that, this patch fixes CDS in various places where implicit assumptions were made about alignment. Mainly, CDS had to get used to - and handle efficiently - LogKlassAlignment being different than 3 bit. See also [2].

Note that this patch does *not* change the value of LogKlassAlignmentInBytes itself. It remains 3. So nothing really changes. Also note that this patch in itself is not sufficient to run with larger LogKlassAlignmentInBytes, at least not on x64. Some small changes to the JIT are needed too, which I will bring in with a separate RFE.

Advantages:

- simplifies merging between lilliput and mainline
- cleanly factors out alignment handling
- allows us to have metaspace arenas with different alignment requirements, which may be useful beyond Lilliput
- prepares the way to experiment with larger values for LogKlassAlignmentInBytes values in mainline
- in the future, hopefully, prevent changes in mainline in CDS and metaspace to break lilliput.

[1] https://github.com/openjdk/lilliput/pull/13

Tests:
- Test builds Linux x64, x86, zero, minimal, aarch64.
- As a test, I increased LogKlassAlignmentInBytes to 5 (needed aforementioned JIT fix) and ran tests on x64. It worked, which is nice since the standard LogKlassAlignmentInBytes=3 is equal to the metaspace alignment and the CDS standard alignment, and all these alignments being the same can hide implicit assumptions.
- GHAs
- SAP nightlies

Thank you,

Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8280525](https://bugs.openjdk.java.net/browse/JDK-8280525): Per-metaspace-arena alignment handling


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7198/head:pull/7198` \
`$ git checkout pull/7198`

Update a local copy of the PR: \
`$ git checkout pull/7198` \
`$ git pull https://git.openjdk.java.net/jdk pull/7198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7198`

View PR using the GUI difftool: \
`$ git pr show -t 7198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7198.diff">https://git.openjdk.java.net/jdk/pull/7198.diff</a>

</details>
