### PR TITLE
8280403: RegEx: String.split can fail with NPE in Pattern.CharPredicate::match

### DIFF
--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -2689,6 +2689,8 @@ loop:   for(int x=0, offset=0; x<nCodePoints; x++, offset+=len) {
                             else
                                 prev = right;
                         } else {
+                            if (curr == null)
+                                throw error("Bad intersection syntax");
                             prev = prev.and(curr);
                         }
                     } else {

--- a/test/jdk/java/util/regex/RegExTest.java
+++ b/test/jdk/java/util/regex/RegExTest.java
@@ -4547,4 +4547,13 @@ public class RegExTest {
                 Pattern.compile(pattern));
         assertTrue(e.getMessage().contains("Unescaped trailing backslash"));
     }
+
+    //This test is for
+    @Test
+    public static void badIntersectionSyntax() {
+        String pattern = "[˜\\H +F&&]";
+        var e = expectThrows(PatternSyntaxException.class, () ->
+                Pattern.compile(pattern));
+        assertTrue(e.getMessage().contains("Bad intersection syntax"));
+    }
 }


### PR DESCRIPTION
Replacing a buggy NPE with a PatternSyntaxException for cases with a bad intersection operator.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8280403](https://bugs.openjdk.java.net/browse/JDK-8280403): RegEx: String.split can fail with NPE in Pattern.CharPredicate::match


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7199/head:pull/7199` \
`$ git checkout pull/7199`

Update a local copy of the PR: \
`$ git checkout pull/7199` \
`$ git pull https://git.openjdk.java.net/jdk pull/7199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7199`

View PR using the GUI difftool: \
`$ git pr show -t 7199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7199.diff">https://git.openjdk.java.net/jdk/pull/7199.diff</a>

</details>
