### PR TITLE
8280526: x86_32 Math.sqrt performance regression with -XX:UseSSE={0,1}

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1608,9 +1608,14 @@ const bool Matcher::match_rule_supported(int opcode) {
       }
       break;
     case Op_SqrtD:
+#ifdef _LP64
       if (UseSSE < 2) {
         return false;
       }
+#else
+      // x86_32.ad has a special match rule for SqrtD.
+      // Together with common x86 rules, this handles all UseSSE cases.
+#endif
       break;
   }
   return true;  // Match rules are supported by default.


### PR DESCRIPTION
See more details in the bug.

x86_32 performance:

```
# ---- Before JDK-8279076

# -XX:UseAVX=0 -XX:UseSSE=0
MathBench.sqrtDouble       0  thrpt    8  406540.546 ± 2299.428  ops/ms

# -XX:UseAVX=0 -XX:UseSSE=1
MathBench.sqrtDouble       0  thrpt    8  408018.332 ± 1423.456  ops/ms

# ---- Current mainline

# -XX:UseAVX=0 -XX:UseSSE=0
MathBench.sqrtDouble       0  thrpt    8    9983.414 ± 426.007  ops/ms

# -XX:UseAVX=0 -XX:UseSSE=1
MathBench.sqrtDouble       0  thrpt    8    9883.518 ± 513.648  ops/ms

# ---- Patched 

# -XX:UseAVX=0 -XX:UseSSE=0
MathBench.sqrtDouble       0  thrpt    8  407267.348 ± 1605.200  ops/ms

# -XX:UseAVX=0 -XX:UseSSE=1
MathBench.sqrtDouble       0  thrpt    8  407500.560 ± 739.249  ops/ms
```

While this is technically a regression in JDK 18, this is an edge case, so I would bring it to 18.0.1, instead of going into JDK 18 RDP2 process.

Additional testing:
 - [x] Linux x86_64 `compiler/c2/TestSqrt.java` with `-XX:UseAVX=0 -XX:UseSSE=2`
 - [x] Linux x86_32 `compiler/c2/TestSqrt.java` with `-XX:UseAVX=0 -XX:UseSSE=0`
 - [x] Linux x86_32 `compiler/c2/TestSqrt.java` with `-XX:UseAVX=0 -XX:UseSSE=1`
 - [x] Linux x86_32 `compiler/c2/TestSqrt.java` with `-XX:UseAVX=0 -XX:UseSSE=2`
 - [x] Linux x86_32 `compiler/loopopts/superword/SumRedSqrt_Double.java` with `-XX:UseAVX=0 -XX:UseSSE=0`
 - [x] Linux x86_32 `compiler/loopopts/superword/SumRedSqrt_Double.java` with `-XX:UseAVX=0 -XX:UseSSE=1`
 - [x] Linux x86_32 `compiler/loopopts/superword/SumRedSqrt_Double.java` with `-XX:UseAVX=0 -XX:UseSSE=2`
 - [x] Linux x86_32 `tier1` with `-XX:UseAVX=0 -XX:UseSSE=0`
 - [x] Linux x86_32 `tier1` with `-XX:UseAVX=0 -XX:UseSSE=1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280526](https://bugs.openjdk.java.net/browse/JDK-8280526): x86_32 Math.sqrt performance regression with -XX:UseSSE={0,1}


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7200/head:pull/7200` \
`$ git checkout pull/7200`

Update a local copy of the PR: \
`$ git checkout pull/7200` \
`$ git pull https://git.openjdk.java.net/jdk pull/7200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7200`

View PR using the GUI difftool: \
`$ git pr show -t 7200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7200.diff">https://git.openjdk.java.net/jdk/pull/7200.diff</a>

</details>
