### PR TITLE
8280403: RegEx: String.split can fail with NPE in Pattern.CharPredicate::match

### DIFF
--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -2689,6 +2689,8 @@ loop:   for(int x=0, offset=0; x<nCodePoints; x++, offset+=len) {
                             else
                                 prev = right;
                         } else {
+                            if (curr == null)
+                                throw error("Bad intersection syntax");
                             prev = prev.and(curr);
                         }
                     } else {

--- a/test/jdk/java/util/regex/RegExTest.java
+++ b/test/jdk/java/util/regex/RegExTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -4548,7 +4548,7 @@ public class RegExTest {
         assertTrue(e.getMessage().contains("Unescaped trailing backslash"));
     }
 
-    //This test is for
+    //This test is for 8280403
     @Test
     public static void badIntersectionSyntax() {
         String pattern = "[˜\\H +F&&]";

--- a/test/jdk/java/util/regex/RegExTest.java
+++ b/test/jdk/java/util/regex/RegExTest.java
@@ -4547,4 +4547,13 @@ public class RegExTest {
                 Pattern.compile(pattern));
         assertTrue(e.getMessage().contains("Unescaped trailing backslash"));
     }
+
+    //This test is for
+    @Test
+    public static void badIntersectionSyntax() {
+        String pattern = "[˜\\H +F&&]";
+        var e = expectThrows(PatternSyntaxException.class, () ->
+                Pattern.compile(pattern));
+        assertTrue(e.getMessage().contains("Bad intersection syntax"));
+    }
 }


### PR DESCRIPTION
Replacing a buggy NullPointerException in `Pattern.compile()` with the proper PatternSyntaxException

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280403](https://bugs.openjdk.java.net/browse/JDK-8280403): RegEx: String.split can fail with NPE in Pattern.CharPredicate::match


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to 9a64df4a618db723688cf7079e012c260d8fcce6
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to 9a64df4a618db723688cf7079e012c260d8fcce6
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to 9a64df4a618db723688cf7079e012c260d8fcce6
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to 9a64df4a618db723688cf7079e012c260d8fcce6


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7201/head:pull/7201` \
`$ git checkout pull/7201`

Update a local copy of the PR: \
`$ git checkout pull/7201` \
`$ git pull https://git.openjdk.java.net/jdk pull/7201/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7201`

View PR using the GUI difftool: \
`$ git pr show -t 7201`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7201.diff">https://git.openjdk.java.net/jdk/pull/7201.diff</a>

</details>
