### PR TITLE
8280366: (fs) Restore Files.createTempFile javadoc

### DIFF
--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -823,11 +823,13 @@ public final class Files {
      * names in the same manner as the {@link
      * java.io.File#createTempFile(String,String,File)} method.
      *
-     * <p> The file may be opened using the {@link
+     * <p> As with the {@code File.createTempFile} methods, this method is only
+     * part of a temporary-file facility. Where the resulting file is used
+     * as a <em>work file</em> solely by a single instance of the Java virtual
+     * machine, it may be opened using the {@link
      * StandardOpenOption#DELETE_ON_CLOSE DELETE_ON_CLOSE} option so that the
-     * file is deleted when the appropriate {@code close} method is invoked
-     * either explicitly or via a try-with-resources statement. Alternatively,
-     * a {@link Runtime#addShutdownHook shutdown-hook}, or the
+     * file is deleted when the appropriate {@code close} method is invoked.
+     * Alternatively, a {@link Runtime#addShutdownHook shutdown-hook}, or the
      * {@link java.io.File#deleteOnExit} mechanism may be used to delete the
      * file automatically.
      *

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -824,9 +824,8 @@ public final class Files {
      * java.io.File#createTempFile(String,String,File)} method.
      *
      * <p> As with the {@code File.createTempFile} methods, this method is only
-     * part of a temporary-file facility. Where the resulting file is used
-     * as a <em>work file</em> solely by a single instance of the Java virtual
-     * machine, it may be opened using the {@link
+     * part of a temporary-file facility. Where used as a <em>work file</em>,
+     * the resulting file may be opened using the {@link
      * StandardOpenOption#DELETE_ON_CLOSE DELETE_ON_CLOSE} option so that the
      * file is deleted when the appropriate {@code close} method is invoked.
      * Alternatively, a {@link Runtime#addShutdownHook shutdown-hook}, or the


### PR DESCRIPTION
This change reverts commit fb8fdc0fbf17dd7e900cb688df4917b97b26b9ab and then makes a smaller change to the verbiage of `Files.createTempFile `.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280366](https://bugs.openjdk.java.net/browse/JDK-8280366): (fs) Restore Files.createTempFile javadoc


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7202/head:pull/7202` \
`$ git checkout pull/7202`

Update a local copy of the PR: \
`$ git checkout pull/7202` \
`$ git pull https://git.openjdk.java.net/jdk pull/7202/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7202`

View PR using the GUI difftool: \
`$ git pr show -t 7202`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7202.diff">https://git.openjdk.java.net/jdk/pull/7202.diff</a>

</details>
