### PR TITLE
8280541: remove self-recursion of ConnectionGraph::find_inst_mem()

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -4975,7 +4975,6 @@ Node* MergeMemNode::memory_at(uint alias_idx) const {
 
   // Otherwise, it is a narrow slice.
   Node* n = alias_idx < req() ? in(alias_idx) : empty_memory();
-  Compile *C = Compile::current();
   if (is_empty_memory(n)) {
     // the array is sparse; empty slots are the "top" node
     n = base_memory();
@@ -4990,7 +4989,7 @@ Node* MergeMemNode::memory_at(uint alias_idx) const {
     // See verify_memory_slice for comments on TypeRawPtr::BOTTOM.
   } else {
     // make sure the stored slice is sane
-    #ifdef ASSERT
+#ifdef ASSERT
     if (VMError::is_error_reported() || Node::in_dump()) {
     } else if (might_be_same(n, base_memory())) {
       // Give it a pass:  It is a mostly harmless repetition of the base.
@@ -4998,7 +4997,7 @@ Node* MergeMemNode::memory_at(uint alias_idx) const {
     } else {
       verify_memory_slice(this, alias_idx, n);
     }
-    #endif
+#endif
   }
   return n;
 }


### PR DESCRIPTION
This is a follow-up task of JDK-8276219.

ConnectionGraph::find_inst_mem() contains a self-recursion for MergeMemNode.
It drills down into one input of MergeMemNode and tries to locate the memory node
which has the exact alias_idx. Once it returns, the result won't change from
recursion. Therefore, it's not necessary to use recursion in this case. We can
reset the initial state of this function and respin.

We can use a collection to remember all MergeMem Nodes and update them after then. 

This patch also makes a cleanup in MergeMemNode::memory_at(). C is not in use in
that function.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8280541](https://bugs.openjdk.java.net/browse/JDK-8280541): remove self-recursion of ConnectionGraph::find_inst_mem()


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7204/head:pull/7204` \
`$ git checkout pull/7204`

Update a local copy of the PR: \
`$ git checkout pull/7204` \
`$ git pull https://git.openjdk.java.net/jdk pull/7204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7204`

View PR using the GUI difftool: \
`$ git pr show -t 7204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7204.diff">https://git.openjdk.java.net/jdk/pull/7204.diff</a>

</details>
