### PR TITLE
4774868: (fc spec) Unclear spec for FileChannel.force

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -554,7 +554,10 @@ public abstract class FileChannel
      * actually done is system-dependent and is therefore unspecified.
      *
      * <p> This method is only guaranteed to force changes that were made to
-     * this channel's file via the methods defined in this class.  It may or
+     * this channel's file via the methods defined in this class or, if this
+     * channel was derived from a {@link FileOutputStream} or
+     * {@link RandomAccessFile} using the {@code getChannel} method,
+     * via the methods defined in those classes.  It may or
      * may not force changes that were made by modifying the content of a
      * {@link MappedByteBuffer <i>mapped byte buffer</i>} obtained by
      * invoking the {@link #map map} method.  Invoking the {@link

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -554,10 +554,9 @@ public abstract class FileChannel
      * actually done is system-dependent and is therefore unspecified.
      *
      * <p> This method is only guaranteed to force changes that were made to
-     * this channel's file via the methods defined in this class or, if this
-     * channel was derived from a {@link FileOutputStream} or
-     * {@link RandomAccessFile} using the {@code getChannel} method,
-     * via the methods defined in those classes.  It may or
+     * this channel's file via the methods defined in this class, or the methods
+     * defined by {@link FileOutputStream} or {@link RandomAccessFile} when the
+     * channel was obtained with the {@code getChannel} method. It may or
      * may not force changes that were made by modifying the content of a
      * {@link MappedByteBuffer <i>mapped byte buffer</i>} obtained by
      * invoking the {@link #map map} method.  Invoking the {@link


### PR DESCRIPTION
Add verbiage to `FileChannel.force()` indicating that if the FileChannel is derived from a FileOutputStream or a RandomAccessFile using `getChannel()`, then any modifications made to the channel's file by methods invoked on the parent object will also be forced.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-4774868](https://bugs.openjdk.java.net/browse/JDK-4774868): (fc spec) Unclear spec for FileChannel.force
 * [JDK-8280598](https://bugs.openjdk.java.net/browse/JDK-8280598): (fc spec) Unclear spec for FileChannel.force (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7207/head:pull/7207` \
`$ git checkout pull/7207`

Update a local copy of the PR: \
`$ git checkout pull/7207` \
`$ git pull https://git.openjdk.java.net/jdk pull/7207/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7207`

View PR using the GUI difftool: \
`$ git pr show -t 7207`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7207.diff">https://git.openjdk.java.net/jdk/pull/7207.diff</a>

</details>
