### PR TITLE
8280579: Shenandoah: Skip regions in the back of sorted array when choosing cset

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -116,6 +116,10 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
       cset->add_region(r);
       cur_cset = new_cset;
       cur_garbage = new_garbage;
+    } else if (cur_garbage >= min_garbage) {
+      // Min garbage condition satisified, and the regions left don't have enough garbage
+      // to be considered worth collection.
+      break;
     }
   }
 }


### PR DESCRIPTION
Can I have review on this small change that skips some unnecessary work in cset choosing?

When choosing regions to add to cset, we sort the regions from most garbage to least garbage. We then iterate the sorted array. We can break early from the loop if we find a region with (garbage <= garbage_threshold). Because we know the regions left won't have enough garbage and won't be added anyway.