### PR TITLE
JDK-8280583: Always build NMT

### DIFF
--- a/make/autoconf/jvm-features.m4
+++ b/make/autoconf/jvm-features.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/autoconf/jvm-features.m4
+++ b/make/autoconf/jvm-features.m4
@@ -45,7 +45,7 @@ m4_define(jvm_features_valid, m4_normalize( \
     ifdef([custom_jvm_features_valid], custom_jvm_features_valid) \
     \
     cds compiler1 compiler2 dtrace epsilongc g1gc jfr jni-check \
-    jvmci jvmti link-time-opt management minimal nmt opt-size parallelgc \
+    jvmci jvmti link-time-opt management minimal opt-size parallelgc \
     serialgc services shenandoahgc static-build vm-structs zero zgc \
 ))
 
@@ -68,7 +68,6 @@ m4_define(jvm_feature_desc_jvmti, [enable Java Virtual Machine Tool Interface (J
 m4_define(jvm_feature_desc_link_time_opt, [enable link time optimization])
 m4_define(jvm_feature_desc_management, [enable java.lang.management API support])
 m4_define(jvm_feature_desc_minimal, [support building variant 'minimal'])
-m4_define(jvm_feature_desc_nmt, [include native memory tracking (NMT)])
 m4_define(jvm_feature_desc_opt_size, [optimize the JVM library for size])
 m4_define(jvm_feature_desc_parallelgc, [include the parallel garbage collector])
 m4_define(jvm_feature_desc_serialgc, [include the serial garbage collector])
@@ -443,7 +442,7 @@ AC_DEFUN([JVM_FEATURES_PREPARE_VARIANT],
     JVM_FEATURES_VARIANT_FILTER="compiler2 jvmci link-time-opt opt-size"
   elif test "x$variant" = "xminimal"; then
     JVM_FEATURES_VARIANT_FILTER="cds compiler2 dtrace epsilongc g1gc \
-        jfr jni-check jvmci jvmti management nmt parallelgc services \
+        jfr jni-check jvmci jvmti management parallelgc services \
         shenandoahgc vm-structs zgc"
     if test "x$OPENJDK_TARGET_CPU" = xarm ; then
       JVM_FEATURES_VARIANT_FILTER="$JVM_FEATURES_VARIANT_FILTER opt-size"
@@ -536,10 +535,6 @@ AC_DEFUN([JVM_FEATURES_VERIFY],
 
   if JVM_FEATURES_IS_ACTIVE(jvmti) && ! JVM_FEATURES_IS_ACTIVE(services); then
     AC_MSG_ERROR([Specified JVM feature 'jvmti' requires feature 'services' for variant '$variant'])
-  fi
-
-  if JVM_FEATURES_IS_ACTIVE(management) && ! JVM_FEATURES_IS_ACTIVE(nmt); then
-    AC_MSG_ERROR([Specified JVM feature 'management' requires feature 'nmt' for variant '$variant'])
   fi
 
   # For backwards compatibility, disable a feature "globally" if one variant

--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -130,13 +130,6 @@ ifneq ($(call check-jvm-feature, cds), true)
   JVM_EXCLUDE_PATTERNS += cds/
 endif
 
-ifneq ($(call check-jvm-feature, nmt), true)
-  JVM_CFLAGS_FEATURES += -DINCLUDE_NMT=0
-  JVM_EXCLUDE_FILES += \
-      memBaseline.cpp memReporter.cpp mallocTracker.cpp virtualMemoryTracker.cpp nmtCommon.cpp \
-      memTracker.cpp nmtDCmd.cpp mallocSiteTable.cpp threadStackTracker.cpp
-endif
-
 ifneq ($(call check-jvm-feature, g1gc), true)
   JVM_CFLAGS_FEATURES += -DINCLUDE_G1GC=0
   JVM_EXCLUDE_PATTERNS += gc/g1

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -170,15 +170,7 @@ MEMORY_TYPES_DO(MEMORY_TYPE_SHORTNAME)
 // Make an int version of the sentinel end value.
 constexpr int mt_number_of_types = static_cast<int>(MEMFLAGS::mt_number_of_types);
 
-#if INCLUDE_NMT
-
 extern bool NMT_track_callsite;
-
-#else
-
-const bool NMT_track_callsite = false;
-
-#endif // INCLUDE_NMT
 
 class NativeCallStack;
 

--- a/src/hotspot/share/memory/metaspace/metaspaceDCmd.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceDCmd.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/memory/metaspace/metaspaceDCmd.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceDCmd.cpp
@@ -77,7 +77,7 @@ void MetaspaceDCmd::execute(DCmdSource source, TRAPS) {
     if (strcasecmp("dynamic", scale_value) == 0) {
       scale = 0;
     } else {
-      scale = NMT_ONLY(NMTUtil::scale_from_name(scale_value)) NOT_NMT(0);
+      scale = NMTUtil::scale_from_name(scale_value);
       if (scale == 0) {
         output()->print_cr("Invalid scale: \"%s\". Will use dynamic scaling.", scale_value);
       }

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -87,12 +87,15 @@
 #include "runtime/threadSMR.hpp"
 #include "runtime/vframe.hpp"
 #include "runtime/vm_version.hpp"
+#include "services/mallocSiteTable.hpp"
 #include "services/memoryService.hpp"
+#include "services/memTracker.hpp"
 #include "utilities/align.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/elfFile.hpp"
 #include "utilities/exceptions.hpp"
 #include "utilities/macros.hpp"
+#include "utilities/nativeCallStack.hpp"
 #include "utilities/ostream.hpp"
 #if INCLUDE_G1GC
 #include "gc/g1/g1Arguments.hpp"
@@ -105,11 +108,6 @@
 #if INCLUDE_PARALLELGC
 #include "gc/parallel/parallelScavengeHeap.inline.hpp"
 #endif // INCLUDE_PARALLELGC
-#if INCLUDE_NMT
-#include "services/mallocSiteTable.hpp"
-#include "services/memTracker.hpp"
-#include "utilities/nativeCallStack.hpp"
-#endif // INCLUDE_NMT
 #if INCLUDE_JVMCI
 #include "jvmci/jvmciEnv.hpp"
 #include "jvmci/jvmciRuntime.hpp"
@@ -646,7 +644,6 @@ WB_END
 
 #endif // INCLUDE_G1GC
 
-#if INCLUDE_NMT
 // Alloc memory using the test memory type so that we can use that to see if
 // NMT picks it up correctly
 WB_ENTRY(jlong, WB_NMTMalloc(JNIEnv* env, jobject o, jlong size))
@@ -724,7 +721,6 @@ WB_ENTRY(void, WB_NMTArenaMalloc(JNIEnv* env, jobject o, jlong arena, jlong size
   Arena* a = (Arena*)arena;
   a->Amalloc(size_t(size));
 WB_END
-#endif // INCLUDE_NMT
 
 static jmethodID reflected_method_to_jmid(JavaThread* thread, JNIEnv* env, jobject method) {
   assert(method != NULL, "method should not be null");
@@ -2545,7 +2541,6 @@ static JNINativeMethod methods[] = {
   {CC"psVirtualSpaceAlignment",CC"()J",               (void*)&WB_PSVirtualSpaceAlignment},
   {CC"psHeapGenerationAlignment",CC"()J",             (void*)&WB_PSHeapGenerationAlignment},
 #endif
-#if INCLUDE_NMT
   {CC"NMTMalloc",           CC"(J)J",                 (void*)&WB_NMTMalloc          },
   {CC"NMTMallocWithPseudoStack", CC"(JI)J",           (void*)&WB_NMTMallocWithPseudoStack},
   {CC"NMTMallocWithPseudoStackAndType", CC"(JII)J",   (void*)&WB_NMTMallocWithPseudoStackAndType},
@@ -2559,7 +2554,6 @@ static JNINativeMethod methods[] = {
   {CC"NMTNewArena",         CC"(J)J",                 (void*)&WB_NMTNewArena        },
   {CC"NMTFreeArena",        CC"(J)V",                 (void*)&WB_NMTFreeArena       },
   {CC"NMTArenaMalloc",      CC"(JJ)V",                (void*)&WB_NMTArenaMalloc     },
-#endif // INCLUDE_NMT
   {CC"deoptimizeFrames",   CC"(Z)I",                  (void*)&WB_DeoptimizeFrames  },
   {CC"isFrameDeoptimized", CC"(I)Z",                  (void*)&WB_IsFrameDeoptimized},
   {CC"deoptimizeAll",      CC"()V",                   (void*)&WB_DeoptimizeAll     },

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -4012,7 +4012,6 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
   no_shared_spaces("CDS Disabled");
 #endif // INCLUDE_CDS
 
-#if INCLUDE_NMT
   // Verify NMT arguments
   const NMT_TrackingLevel lvl = NMTUtil::parse_tracking_level(NativeMemoryTracking);
   if (lvl == NMT_unknown) {
@@ -4024,13 +4023,6 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
     warning("PrintNMTStatistics is disabled, because native memory tracking is not enabled");
     FLAG_SET_DEFAULT(PrintNMTStatistics, false);
   }
-#else
-  if (!FLAG_IS_DEFAULT(NativeMemoryTracking) || PrintNMTStatistics) {
-    warning("Native Memory Tracking is not supported in this VM");
-    FLAG_SET_DEFAULT(NativeMemoryTracking, "off");
-    FLAG_SET_DEFAULT(PrintNMTStatistics, false);
-  }
-#endif // INCLUDE_NMT
 
   if (TraceDependencies && VerifyDependencies) {
     if (!FLAG_IS_DEFAULT(TraceDependencies)) {

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -137,9 +137,8 @@ Monitor* ThreadsSMRDelete_lock        = NULL;
 Mutex*   ThreadIdTableCreate_lock     = NULL;
 Mutex*   SharedDecoder_lock           = NULL;
 Mutex*   DCmdFactory_lock             = NULL;
-#if INCLUDE_NMT
 Mutex*   NMTQuery_lock                = NULL;
-#endif
+
 #if INCLUDE_CDS
 #if INCLUDE_JVMTI
 Mutex*   CDSClassFileStream_lock      = NULL;
@@ -320,9 +319,7 @@ void mutex_init() {
   def(ThreadIdTableCreate_lock     , PaddedMutex  , safepoint);
   def(SharedDecoder_lock           , PaddedMutex  , tty-1);
   def(DCmdFactory_lock             , PaddedMutex  , nosafepoint);
-#if INCLUDE_NMT
   def(NMTQuery_lock                , PaddedMutex  , safepoint);
-#endif
 #if INCLUDE_CDS
 #if INCLUDE_JVMTI
   def(CDSClassFileStream_lock      , PaddedMutex  , safepoint);

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -114,9 +114,7 @@ extern Monitor* ThreadsSMRDelete_lock;           // Used by ThreadsSMRSupport to
 extern Mutex*   ThreadIdTableCreate_lock;        // Used by ThreadIdTable to lazily create the thread id table
 extern Mutex*   SharedDecoder_lock;              // serializes access to the decoder during normal (not error reporting) use
 extern Mutex*   DCmdFactory_lock;                // serialize access to DCmdFactory information
-#if INCLUDE_NMT
 extern Mutex*   NMTQuery_lock;                   // serialize NMT Dcmd queries
-#endif
 #if INCLUDE_CDS
 #if INCLUDE_JVMTI
 extern Mutex*   CDSClassFileStream_lock;         // FileMapInfo::open_stream_for_jvmti

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -631,14 +631,11 @@ void* os::malloc(size_t size, MEMFLAGS flags) {
 
 void* os::malloc(size_t size, MEMFLAGS memflags, const NativeCallStack& stack) {
 
-#if INCLUDE_NMT
-  {
-    void* rc = NULL;
-    if (NMTPreInit::handle_malloc(&rc, size)) {
-      return rc;
-    }
+  // Special handling for NMT preinit phase before arguments are parsed
+  void* rc = NULL;
+  if (NMTPreInit::handle_malloc(&rc, size)) {
+    return rc;
   }
-#endif
 
   DEBUG_ONLY(check_crash_protection());
 
@@ -677,14 +674,11 @@ void* os::realloc(void *memblock, size_t size, MEMFLAGS flags) {
 
 void* os::realloc(void *memblock, size_t size, MEMFLAGS memflags, const NativeCallStack& stack) {
 
-#if INCLUDE_NMT
-  {
-    void* rc = NULL;
-    if (NMTPreInit::handle_realloc(&rc, memblock, size)) {
-      return rc;
-    }
+  // Special handling for NMT preinit phase before arguments are parsed
+  void* rc = NULL;
+  if (NMTPreInit::handle_realloc(&rc, memblock, size)) {
+    return rc;
   }
-#endif
 
   if (memblock == NULL) {
     return os::malloc(size, memflags, stack);
@@ -723,11 +717,10 @@ void* os::realloc(void *memblock, size_t size, MEMFLAGS memflags, const NativeCa
 
 void  os::free(void *memblock) {
 
-#if INCLUDE_NMT
+  // Special handling for NMT preinit phase before arguments are parsed
   if (NMTPreInit::handle_free(memblock)) {
     return;
   }
-#endif
 
   if (memblock == NULL) {
     return;

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -317,7 +317,6 @@ void Thread::record_stack_base_and_size() {
   }
 }
 
-#if INCLUDE_NMT
 void Thread::register_thread_stack_with_NMT() {
   MemTracker::record_thread_stack(stack_end(), stack_size());
 }
@@ -325,7 +324,6 @@ void Thread::register_thread_stack_with_NMT() {
 void Thread::unregister_thread_stack_with_NMT() {
   MemTracker::release_thread_stack(stack_end(), stack_size());
 }
-#endif // INCLUDE_NMT
 
 void Thread::call_run() {
   DEBUG_ONLY(_run_state = CALL_RUN;)
@@ -2704,10 +2702,8 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   jint parse_result = Arguments::parse(args);
   if (parse_result != JNI_OK) return parse_result;
 
-#if INCLUDE_NMT
   // Initialize NMT right after argument parsing to keep the pre-NMT-init window small.
   MemTracker::initialize();
-#endif // INCLUDE_NMT
 
   os::init_before_ergo();
 

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -550,8 +550,8 @@ protected:
   void    set_stack_size(size_t size)  { _stack_size = size; }
   address stack_end()  const           { return stack_base() - stack_size(); }
   void    record_stack_base_and_size();
-  void    register_thread_stack_with_NMT() NOT_NMT_RETURN;
-  void    unregister_thread_stack_with_NMT() NOT_NMT_RETURN;
+  void    register_thread_stack_with_NMT();
+  void    unregister_thread_stack_with_NMT();
 
   int     lgrp_id() const        { return _lgrp_id; }
   void    set_lgrp_id(int value) { _lgrp_id = value; }

--- a/src/hotspot/share/services/mallocSiteTable.hpp
+++ b/src/hotspot/share/services/mallocSiteTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/services/mallocSiteTable.hpp
+++ b/src/hotspot/share/services/mallocSiteTable.hpp
@@ -25,15 +25,12 @@
 #ifndef SHARE_SERVICES_MALLOCSITETABLE_HPP
 #define SHARE_SERVICES_MALLOCSITETABLE_HPP
 
-#include "utilities/macros.hpp"
-
-#if INCLUDE_NMT
-
 #include "memory/allocation.hpp"
 #include "runtime/atomic.hpp"
 #include "services/allocationSite.hpp"
 #include "services/mallocTracker.hpp"
 #include "services/nmtCommon.hpp"
+#include "utilities/macros.hpp"
 #include "utilities/nativeCallStack.hpp"
 
 // MallocSite represents a code path that eventually calls
@@ -199,5 +196,4 @@ class MallocSiteTable : AllStatic {
   static const MallocSiteHashtableEntry*  _hash_entry_allocation_site;
 };
 
-#endif // INCLUDE_NMT
 #endif // SHARE_SERVICES_MALLOCSITETABLE_HPP

--- a/src/hotspot/share/services/mallocTracker.hpp
+++ b/src/hotspot/share/services/mallocTracker.hpp
@@ -25,8 +25,6 @@
 #ifndef SHARE_SERVICES_MALLOCTRACKER_HPP
 #define SHARE_SERVICES_MALLOCTRACKER_HPP
 
-#if INCLUDE_NMT
-
 #include "memory/allocation.hpp"
 #include "runtime/atomic.hpp"
 #include "runtime/threadCritical.hpp"
@@ -447,8 +445,5 @@ class MallocTracker : AllStatic {
     return header;
   }
 };
-
-#endif // INCLUDE_NMT
-
 
 #endif // SHARE_SERVICES_MALLOCTRACKER_HPP

--- a/src/hotspot/share/services/memBaseline.hpp
+++ b/src/hotspot/share/services/memBaseline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/services/memBaseline.hpp
+++ b/src/hotspot/share/services/memBaseline.hpp
@@ -25,8 +25,6 @@
 #ifndef SHARE_SERVICES_MEMBASELINE_HPP
 #define SHARE_SERVICES_MEMBASELINE_HPP
 
-#if INCLUDE_NMT
-
 #include "memory/metaspaceStats.hpp"
 #include "runtime/mutex.hpp"
 #include "services/mallocSiteTable.hpp"
@@ -211,7 +209,5 @@ class MemBaseline {
   // Sort allocation sites in call site address order
   void virtual_memory_sites_to_reservation_site_order();
 };
-
-#endif // INCLUDE_NMT
 
 #endif // SHARE_SERVICES_MEMBASELINE_HPP

--- a/src/hotspot/share/services/memReporter.hpp
+++ b/src/hotspot/share/services/memReporter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/services/memReporter.hpp
+++ b/src/hotspot/share/services/memReporter.hpp
@@ -25,8 +25,6 @@
 #ifndef SHARE_SERVICES_MEMREPORTER_HPP
 #define SHARE_SERVICES_MEMREPORTER_HPP
 
-#if INCLUDE_NMT
-
 #include "memory/metaspace.hpp"
 #include "oops/instanceKlass.hpp"
 #include "services/memBaseline.hpp"
@@ -238,7 +236,5 @@ class MemDetailDiffReporter : public MemSummaryDiffReporter {
   void diff_virtual_memory_site(const NativeCallStack* stack, size_t current_reserved,
     size_t current_committed, size_t early_reserved, size_t early_committed, MEMFLAGS flag) const;
 };
-
-#endif // INCLUDE_NMT
 
 #endif // SHARE_SERVICES_MEMREPORTER_HPP

--- a/src/hotspot/share/services/memTracker.hpp
+++ b/src/hotspot/share/services/memTracker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/services/memTracker.hpp
+++ b/src/hotspot/share/services/memTracker.hpp
@@ -25,67 +25,13 @@
 #ifndef SHARE_SERVICES_MEMTRACKER_HPP
 #define SHARE_SERVICES_MEMTRACKER_HPP
 
-#include "services/nmtCommon.hpp"
-#include "utilities/nativeCallStack.hpp"
-
-
-#if !INCLUDE_NMT
-
-#define CURRENT_PC   NativeCallStack::empty_stack()
-#define CALLER_PC    NativeCallStack::empty_stack()
-
-class Tracker : public StackObj {
- public:
-  enum TrackerType {
-     uncommit,
-     release
-  };
-  Tracker(enum TrackerType type) : _type(type) { }
-  void record(address addr, size_t size) { }
- private:
-  enum TrackerType  _type;
-};
-
-class MemTracker : AllStatic {
- public:
-  static inline NMT_TrackingLevel tracking_level() { return NMT_off; }
-  static inline bool enabled() { return false; }
-  static inline void init() { }
-  static bool check_launcher_nmt_support(const char* value) { return true; }
-  static bool verify_nmt_option() { return true; }
-
-  static inline void* record_malloc(void* mem_base, size_t size, MEMFLAGS flag,
-    const NativeCallStack& stack, NMT_TrackingLevel level) { return mem_base; }
-  static inline size_t malloc_header_size(NMT_TrackingLevel level) { return 0; }
-  static inline size_t malloc_header_size(void* memblock) { return 0; }
-  static inline size_t malloc_footer_size(NMT_TrackingLevel level) { return 0; }
-  static inline void* malloc_base(void* memblock) { return memblock; }
-  static inline void* record_free(void* memblock, NMT_TrackingLevel level) { return memblock; }
-
-  static inline void record_new_arena(MEMFLAGS flag) { }
-  static inline void record_arena_free(MEMFLAGS flag) { }
-  static inline void record_arena_size_change(ssize_t diff, MEMFLAGS flag) { }
-  static inline void record_virtual_memory_reserve(void* addr, size_t size, const NativeCallStack& stack,
-                       MEMFLAGS flag = mtNone) { }
-  static inline void record_virtual_memory_reserve_and_commit(void* addr, size_t size,
-    const NativeCallStack& stack, MEMFLAGS flag = mtNone) { }
-  static inline void record_virtual_memory_split_reserved(void* addr, size_t size, size_t split) { }
-  static inline void record_virtual_memory_commit(void* addr, size_t size, const NativeCallStack& stack) { }
-  static inline void record_virtual_memory_type(void* addr, MEMFLAGS flag) { }
-  static inline void record_thread_stack(void* addr, size_t size) { }
-  static inline void release_thread_stack(void* addr, size_t size) { }
-
-  static void final_report(outputStream*) { }
-  static void error_report(outputStream*) { }
-};
-
-#else
-
 #include "runtime/mutexLocker.hpp"
 #include "runtime/threadCritical.hpp"
 #include "services/mallocTracker.hpp"
+#include "services/nmtCommon.hpp"
 #include "services/threadStackTracker.hpp"
 #include "services/virtualMemoryTracker.hpp"
+#include "utilities/nativeCallStack.hpp"
 
 #define CURRENT_PC ((MemTracker::tracking_level() == NMT_detail) ? \
                     NativeCallStack(0) : NativeCallStack::empty_stack())
@@ -308,7 +254,5 @@ class MemTracker : AllStatic {
   // Query lock
   static Mutex*           _query_lock;
 };
-
-#endif // INCLUDE_NMT
 
 #endif // SHARE_SERVICES_MEMTRACKER_HPP

--- a/src/hotspot/share/services/nmtDCmd.hpp
+++ b/src/hotspot/share/services/nmtDCmd.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/services/nmtDCmd.hpp
+++ b/src/hotspot/share/services/nmtDCmd.hpp
@@ -25,8 +25,6 @@
 #ifndef SHARE_SERVICES_NMTDCMD_HPP
 #define SHARE_SERVICES_NMTDCMD_HPP
 
-#if INCLUDE_NMT
-
 #include "services/diagnosticArgument.hpp"
 #include "services/diagnosticFramework.hpp"
 #include "services/memBaseline.hpp"
@@ -70,7 +68,5 @@ class NMTDCmd: public DCmdWithParser {
   // check if NMT running at detail tracking level
   bool check_detail_tracking_level(outputStream* out);
 };
-
-#endif // INCLUDE_NMT
 
 #endif // SHARE_SERVICES_NMTDCMD_HPP

--- a/src/hotspot/share/services/nmtPreInit.cpp
+++ b/src/hotspot/share/services/nmtPreInit.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021 SAP SE. All rights reserved.
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/services/nmtPreInit.cpp
+++ b/src/hotspot/share/services/nmtPreInit.cpp
@@ -31,8 +31,6 @@
 #include "utilities/ostream.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-#if INCLUDE_NMT
-
 // Obviously we cannot use os::malloc for any dynamic allocation during pre-NMT-init, so we must use
 // raw malloc; to make this very clear, wrap them.
 static void* raw_malloc(size_t s)               { return ::malloc(s); }
@@ -190,5 +188,3 @@ void NMTPreInit::print_state(outputStream* st) {
   st->print_cr("pre-init mallocs: %u, pre-init reallocs: %u, pre-init frees: %u",
                _num_mallocs_pre, _num_reallocs_pre, _num_frees_pre);
 }
-
-#endif // INCLUDE_NMT

--- a/src/hotspot/share/services/nmtPreInit.hpp
+++ b/src/hotspot/share/services/nmtPreInit.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021 SAP SE. All rights reserved.
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/services/nmtPreInit.hpp
+++ b/src/hotspot/share/services/nmtPreInit.hpp
@@ -34,8 +34,6 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 
-#if INCLUDE_NMT
-
 class outputStream;
 
 // NMTPreInit is the solution to a specific problem:
@@ -352,8 +350,6 @@ public:
   static void print_map(outputStream* st);
   DEBUG_ONLY(static void verify();)
 };
-
-#endif // INCLUDE_NMT
 
 #endif // SHARE_SERVICES_NMT_PREINIT_HPP
 

--- a/src/hotspot/share/services/threadStackTracker.hpp
+++ b/src/hotspot/share/services/threadStackTracker.hpp
@@ -25,8 +25,6 @@
 #ifndef SHARE_SERVICES_THREADSTACKTRACKER_HPP
 #define SHARE_SERVICES_THREADSTACKTRACKER_HPP
 
-#if INCLUDE_NMT
-
 #include "services/allocationSite.hpp"
 #include "services/mallocSiteTable.hpp"
 #include "services/nmtCommon.hpp"
@@ -84,5 +82,5 @@ public:
   static bool walk_simple_thread_stack_site(MallocSiteWalker* walker);
 };
 
-#endif // INCLUDE_NMT
 #endif // SHARE_SERVICES_THREADSTACKTRACKER_HPP
+

--- a/src/hotspot/share/services/virtualMemoryTracker.hpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.hpp
@@ -25,8 +25,6 @@
 #ifndef SHARE_SERVICES_VIRTUALMEMORYTRACKER_HPP
 #define SHARE_SERVICES_VIRTUALMEMORYTRACKER_HPP
 
-#if INCLUDE_NMT
-
 #include "memory/allocation.hpp"
 #include "memory/metaspace.hpp" // For MetadataType
 #include "memory/metaspaceStats.hpp"
@@ -396,6 +394,5 @@ class VirtualMemoryTracker : AllStatic {
   static SortedLinkedList<ReservedMemoryRegion, compare_reserved_region_base>* _reserved_regions;
 };
 
-#endif // INCLUDE_NMT
-
 #endif // SHARE_SERVICES_VIRTUALMEMORYTRACKER_HPP
+

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -483,8 +483,6 @@ extern "C" JNIEXPORT void pp(void* p) {
     oop obj = cast_to_oop(p);
     obj->print();
   } else {
-#if INCLUDE_NMT
-    // With NMT
     if (MemTracker::enabled()) {
       const NMT_TrackingLevel tracking_level = MemTracker::tracking_level();
       ReservedMemoryRegion region(0, 0);
@@ -517,7 +515,6 @@ extern "C" JNIEXPORT void pp(void* p) {
         }
       }
     }
-#endif // INCLUDE_NMT
     tty->print(PTR_FORMAT, p2i(p));
   }
 }

--- a/src/hotspot/share/utilities/macros.hpp
+++ b/src/hotspot/share/utilities/macros.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/utilities/macros.hpp
+++ b/src/hotspot/share/utilities/macros.hpp
@@ -241,22 +241,6 @@
 #define NOT_ZGC_RETURN_(code) { return code; }
 #endif // INCLUDE_ZGC
 
-#ifndef INCLUDE_NMT
-#define INCLUDE_NMT 1
-#endif // INCLUDE_NMT
-
-#if INCLUDE_NMT
-#define NOT_NMT_RETURN        /* next token must be ; */
-#define NOT_NMT_RETURN_(code) /* next token must be ; */
-#define NMT_ONLY(x) x
-#define NOT_NMT(x)
-#else
-#define NOT_NMT_RETURN        {}
-#define NOT_NMT_RETURN_(code) { return code; }
-#define NMT_ONLY(x)
-#define NOT_NMT(x) x
-#endif // INCLUDE_NMT
-
 #ifndef INCLUDE_JFR
 #define INCLUDE_JFR 1
 #endif

--- a/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
@@ -31,13 +31,9 @@
 #include "unittest.hpp"
 #include "testutils.hpp"
 
-#if INCLUDE_NMT
-
 // This prefix shows up on any c heap corruption NMT detects. If unsure which assert will
 // come, just use this one.
 #define COMMON_NMT_HEAP_CORRUPTION_MESSAGE_PREFIX "NMT corruption"
-
-
 
 #define DEFINE_TEST(test_function, expected_assertion_message)                            \
   TEST_VM_FATAL_ERROR_MSG(NMT, test_function, ".*" expected_assertion_message ".*") {     \
@@ -165,5 +161,3 @@ TEST_VM(NMT, test_realloc) {
     }
   }
 }
-
-#endif // INCLUDE_NMT

--- a/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021 SAP SE. All rights reserved.
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/gtest/nmt/test_nmtpreinit.cpp
+++ b/test/hotspot/gtest/nmt/test_nmtpreinit.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021 SAP SE. All rights reserved.
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/gtest/nmt/test_nmtpreinit.cpp
+++ b/test/hotspot/gtest/nmt/test_nmtpreinit.cpp
@@ -54,8 +54,6 @@
 //   us. So inside that scope VM initialization ran and with it the NMT initialization.
 // To be sure, we assert those assumptions.
 
-#if INCLUDE_NMT
-
 // Some shorts to save writing out the flags every time
 static void* os_malloc(size_t s)              { return os::malloc(s, mtTest); }
 static void* os_realloc(void* old, size_t s)  { return os::realloc(old, s, mtTest); }
@@ -127,5 +125,3 @@ TEST_VM(NMTPreInit, pre_to_post_allocs) {
   g_test_allocations.test_post();
   g_test_allocations.free_all();
 }
-
-#endif // INCLUDE_NMT

--- a/test/hotspot/gtest/nmt/test_nmtpreinitmap.cpp
+++ b/test/hotspot/gtest/nmt/test_nmtpreinitmap.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021 SAP SE. All rights reserved.
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/gtest/nmt/test_nmtpreinitmap.cpp
+++ b/test/hotspot/gtest/nmt/test_nmtpreinitmap.cpp
@@ -31,8 +31,6 @@
 #include "utilities/ostream.hpp"
 #include "unittest.hpp"
 
-#if INCLUDE_NMT
-
 // This tests the NMTPreInitAllocationTable hash table used to store C-heap allocations before NMT initialization ran.
 
 static size_t small_random_nonzero_size() {
@@ -132,5 +130,3 @@ TEST_VM_ASSERT_MSG(NMTPreInit, assert_on_lu_table_overflow, ".*NMT preinit looku
   table.verify();
 }
 #endif // ASSERT
-
-#endif // INCLUDE_NMT

--- a/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
+++ b/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
+++ b/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
@@ -26,8 +26,6 @@
 // Included early because the NMT flags don't include it.
 #include "utilities/macros.hpp"
 
-#if INCLUDE_NMT
-
 #include "runtime/thread.hpp"
 #include "services/memTracker.hpp"
 #include "services/virtualMemoryTracker.hpp"
@@ -223,5 +221,3 @@ TEST_VM(CommittedVirtualMemoryTracker, test_committed_virtualmemory_region) {
   }
 
 }
-
-#endif // INCLUDE_NMT

--- a/test/hotspot/gtest/runtime/test_virtualMemoryTracker.cpp
+++ b/test/hotspot/gtest/runtime/test_virtualMemoryTracker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/gtest/runtime/test_virtualMemoryTracker.cpp
+++ b/test/hotspot/gtest/runtime/test_virtualMemoryTracker.cpp
@@ -32,16 +32,13 @@
 
 #include "precompiled.hpp"
 
-// Included early because the NMT flags don't include it.
-#include "utilities/macros.hpp"
-
-#if INCLUDE_NMT
-
 #include "memory/virtualspace.hpp"
 #include "services/memTracker.hpp"
 #include "services/virtualMemoryTracker.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "utilities/macros.hpp"
 #include "unittest.hpp"
+
 #include <stdio.h>
 
 // #define LOG(...) printf(__VA_ARGS__); printf("\n"); fflush(stdout);
@@ -566,5 +563,3 @@ TEST_VM(NMT_VirtualMemoryTracker, remove_uncommitted_region) {
     tty->print_cr("skipped.");
   }
 }
-
-#endif // INCLUDE_NMT


### PR DESCRIPTION
After discussing this on hotspot-runtime-dev [1], the general opinion seems to be that it would be worthwhile to get rid of INCLUDE_NMT and make NMT unconditional. This affects minimal builds only. As pointed out in the mail thread, the overhead is very small and it would get rid of one configuration to build and test.

[1] https://mail.openjdk.java.net/pipermail/hotspot-runtime-dev/2022-January/053504.html

Patch removes INCLUDE_NMT from hotspot, as well as dependent macros, as well as the associated build option.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280583](https://bugs.openjdk.java.net/browse/JDK-8280583): Always build NMT


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7213/head:pull/7213` \
`$ git checkout pull/7213`

Update a local copy of the PR: \
`$ git checkout pull/7213` \
`$ git pull https://git.openjdk.java.net/jdk pull/7213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7213`

View PR using the GUI difftool: \
`$ git pr show -t 7213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7213.diff">https://git.openjdk.java.net/jdk/pull/7213.diff</a>

</details>
