### PR TITLE
8268033: compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java fails with "fatal error: Not compilable at tier 3: CodeBuffer overflow"

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -27,8 +27,6 @@
 #
 #############################################################################
 
-compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java 8268033 generic-x64
-
 vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java 8205957 generic-all
 
 vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java 8265295 linux-x64,windows-x64

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java
@@ -31,6 +31,7 @@
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/bootclasspath/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+AbortVMOnCompilationFailure
+ *      -XX:CompileCommand=compileonly,compiler.intrinsics.bmi.*::*
  *      -XX:+IgnoreUnrecognizedVMOptions -XX:+UseBMI2Instructions
  *      compiler.intrinsics.bmi.verifycode.BzhiTestI2L
  */


### PR DESCRIPTION
…th "fatal error: Not compilable at tier 3: CodeBuffer overflow"

**Problem:**
When `BzhiTestI2L.java` is compiled with flag `-Xcomp` and `-XX:+VerifyOops`, it happens that also `sun.security.util.KnownOIDs::<clinit>` is compiled. This class is an `enum` with many string values. This generates a rather large code size for the `<clinit>` method. The additional code for verifying oops pushes it over the CodeBuffer limit (`NMethodSizeLimit`). Because of the overflow, the compilation hits a bailout. Because of `-XX:+AbortVMOnCompilationFailure` this aborts the test, it fails.

**Analysis:**
We can not control the size of library classes/enums, and the size of the generated code from the respective `<clinit>`.
`-Xcomp` and `-XX:+VerifyOops` are helpful flags for tests in general.
However, it does not make sense to require all methods to be compiled.

**Solution:**
Restrict compilation to the relevant classes in the test files.
Removed test from `test/hotspot/jtreg/ProblemList-Xcomp.txt` (List of quarantined tests for testing in Xcomp mode).

**Alternative Solutions:**
1. Increase `NMethodSizeLimit`. The concrete value would be arbitrary, and if any class/enum exceeds it in the future, this same test bug reappears.
2. Drop `-XX:+AbortVMOnCompilationFailure`. This would accept bailouts, and the test would pass despite bailouts. This helps with the current testing bug. But in the future, unexpected bailouts would not be detected. This is problematic, because the test compiles code with the WhiteBox API, to check if it compiles correctly. Thus, bailouts are an important sign that something might have gone wrong.

The Test now passes (initialized with the same parameters as reported in issue).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268033](https://bugs.openjdk.java.net/browse/JDK-8268033): compiler/intrinsics/bmi/verifycode/BzhiTestI2L.java fails with "fatal error: Not compilable at tier 3: CodeBuffer overflow"


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7214/head:pull/7214` \
`$ git checkout pull/7214`

Update a local copy of the PR: \
`$ git checkout pull/7214` \
`$ git pull https://git.openjdk.java.net/jdk pull/7214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7214`

View PR using the GUI difftool: \
`$ git pr show -t 7214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7214.diff">https://git.openjdk.java.net/jdk/pull/7214.diff</a>

</details>
