### PR TITLE
JDK-8270476: Make floating-point test infrastructure more lambda and method reference friendly

### DIFF
--- a/test/jdk/java/lang/Math/Atan2Tests.java
+++ b/test/jdk/java/lang/Math/Atan2Tests.java
@@ -32,10 +32,8 @@ public class Atan2Tests {
 
     static int testAtan2Case(double input1, double input2, double expected) {
         int failures = 0;
-        failures += Tests.test("StrictMath.atan2(double, double)", input1, input2,
-                               StrictMath::atan2, expected);
-        failures += Tests.test("Math.atan2(double, double)", input1, input2,
-                               Math::atan2, expected);
+        failures += Tests.test("StrictMath.atan2", input1, input2, StrictMath::atan2, expected);
+        failures += Tests.test("Math.atan2",       input1, input2, Math::atan2,       expected);
 
         return failures;
     }

--- a/test/jdk/java/lang/Math/Atan2Tests.java
+++ b/test/jdk/java/lang/Math/Atan2Tests.java
@@ -52,7 +52,7 @@ public class Atan2Tests {
         return failures;
     }
 
-    public static void main(String [] argv) {
+    public static void main(String... argv) {
         int failures = 0;
 
         failures += testAtan2();

--- a/test/jdk/java/lang/Math/Atan2Tests.java
+++ b/test/jdk/java/lang/Math/Atan2Tests.java
@@ -34,9 +34,9 @@ public class Atan2Tests {
     static int testAtan2Case(double input1, double input2, double expected) {
         int failures = 0;
         failures += Tests.test("StrictMath.atan2(double, double)", input1, input2,
-                               StrictMath.atan2(input1, input2), expected);
+                               StrictMath::atan2, expected);
         failures += Tests.test("Math.atan2(double, double)", input1, input2,
-                               Math.atan2(input1, input2), expected);
+                               Math::atan2, expected);
 
         return failures;
     }

--- a/test/jdk/java/lang/Math/Atan2Tests.java
+++ b/test/jdk/java/lang/Math/Atan2Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4984407
  * @summary Tests for {Math, StrictMath}.atan2
- * @author Joseph D. Darcy
  */
 
 public class Atan2Tests {

--- a/test/jdk/java/lang/Math/CeilAndFloorTests.java
+++ b/test/jdk/java/lang/Math/CeilAndFloorTests.java
@@ -30,15 +30,15 @@
 public class CeilAndFloorTests {
     private static int testCeilCase(double input, double expected) {
         int failures = 0;
-        failures += Tests.test("Math.ceil",  input, Math.ceil(input),   expected);
-        failures += Tests.test("StrictMath.ceil",  input, StrictMath.ceil(input), expected);
+        failures += Tests.test("Math.ceil",        input, Math::ceil,       expected);
+        failures += Tests.test("StrictMath.ceil",  input, StrictMath::ceil, expected);
         return failures;
     }
 
     private static int testFloorCase(double input, double expected) {
         int failures = 0;
-        failures += Tests.test("Math.floor",  input, Math.floor(input),   expected);
-        failures += Tests.test("StrictMath.floor",  input, StrictMath.floor(input), expected);
+        failures += Tests.test("Math.floor",        input, Math::floor,       expected);
+        failures += Tests.test("StrictMath.floor",  input, StrictMath::floor, expected);
         return failures;
     }
 

--- a/test/jdk/java/lang/Math/CeilAndFloorTests.java
+++ b/test/jdk/java/lang/Math/CeilAndFloorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/Math/CubeRootTests.java
+++ b/test/jdk/java/lang/Math/CubeRootTests.java
@@ -45,8 +45,6 @@ public class CubeRootTests {
     static int testCubeRootCase(double input, double expected) {
         int failures=0;
 
-        double minus_input = -input;
-
         failures+=Tests.test("Math.cbrt",        input, Math::cbrt,        expected);
         failures+=Tests.test("Math.cbrt",       -input, Math::cbrt,       -expected);
         failures+=Tests.test("StrictMath.cbrt",  input, StrictMath::cbrt,  expected);

--- a/test/jdk/java/lang/Math/CubeRootTests.java
+++ b/test/jdk/java/lang/Math/CubeRootTests.java
@@ -318,7 +318,7 @@ public class CubeRootTests {
         return failures;
     }
 
-    public static void main(String argv[]) {
+    public static void main(String... argv) {
         int failures = 0;
 
         failures += testCubeRoot();

--- a/test/jdk/java/lang/Math/CubeRootTests.java
+++ b/test/jdk/java/lang/Math/CubeRootTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@
  * @run main CubeRootTests
  * @bug 4347132 4939441 8078672
  * @summary Tests for {Math, StrictMath}.cbrt (use -Dseed=X to set PRNG seed)
- * @author Joseph D. Darcy
  * @key randomness
  */
 

--- a/test/jdk/java/lang/Math/CubeRootTests.java
+++ b/test/jdk/java/lang/Math/CubeRootTests.java
@@ -50,13 +50,13 @@ public class CubeRootTests {
         double minus_expected = -expected;
 
         failures+=Tests.test("Math.cbrt(double)", input,
-                             Math.cbrt(input), expected);
+                             Math::cbrt, expected);
         failures+=Tests.test("Math.cbrt(double)", minus_input,
-                             Math.cbrt(minus_input), minus_expected);
+                             Math::cbrt, minus_expected);
         failures+=Tests.test("StrictMath.cbrt(double)", input,
-                             StrictMath.cbrt(input), expected);
+                             StrictMath::cbrt, expected);
         failures+=Tests.test("StrictMath.cbrt(double)", minus_input,
-                             StrictMath.cbrt(minus_input), minus_expected);
+                             StrictMath::cbrt, minus_expected);
 
         return failures;
     }

--- a/test/jdk/java/lang/Math/CubeRootTests.java
+++ b/test/jdk/java/lang/Math/CubeRootTests.java
@@ -46,16 +46,11 @@ public class CubeRootTests {
         int failures=0;
 
         double minus_input = -input;
-        double minus_expected = -expected;
 
-        failures+=Tests.test("Math.cbrt(double)", input,
-                             Math::cbrt, expected);
-        failures+=Tests.test("Math.cbrt(double)", minus_input,
-                             Math::cbrt, minus_expected);
-        failures+=Tests.test("StrictMath.cbrt(double)", input,
-                             StrictMath::cbrt, expected);
-        failures+=Tests.test("StrictMath.cbrt(double)", minus_input,
-                             StrictMath::cbrt, minus_expected);
+        failures+=Tests.test("Math.cbrt",        input, Math::cbrt,        expected);
+        failures+=Tests.test("Math.cbrt",       -input, Math::cbrt,       -expected);
+        failures+=Tests.test("StrictMath.cbrt",  input, StrictMath::cbrt,  expected);
+        failures+=Tests.test("StrictMath.cbrt", -input, StrictMath::cbrt, -expected);
 
         return failures;
     }

--- a/test/jdk/java/lang/Math/ExpCornerCaseTests.java
+++ b/test/jdk/java/lang/Math/ExpCornerCaseTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/Math/ExpCornerCaseTests.java
+++ b/test/jdk/java/lang/Math/ExpCornerCaseTests.java
@@ -61,8 +61,8 @@ public class ExpCornerCaseTests {
 
     private static int testExp(double input, double expected) {
         int failures = 0;
-        failures += Tests.test("StrictMath.exp", input, StrictMath.exp(input), expected);
-        failures += Tests.test("Math.exp", input, Math.exp(input), expected);
+        failures += Tests.test("StrictMath.exp", input, StrictMath::exp, expected);
+        failures += Tests.test("Math.exp",       input, Math::exp,       expected);
         return failures;
     }
 }

--- a/test/jdk/java/lang/Math/Expm1Tests.java
+++ b/test/jdk/java/lang/Math/Expm1Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4851638 4900189 4939441
  * @summary Tests for {Math, StrictMath}.expm1
- * @author Joseph D. Darcy
  */
 
 /*

--- a/test/jdk/java/lang/Math/Expm1Tests.java
+++ b/test/jdk/java/lang/Math/Expm1Tests.java
@@ -213,7 +213,7 @@ public class Expm1Tests {
         return failures;
     }
 
-    public static void main(String argv[]) {
+    public static void main(String... argv) {
         int failures = 0;
 
         failures += testExpm1();

--- a/test/jdk/java/lang/Math/FusedMultiplyAddTests.java
+++ b/test/jdk/java/lang/Math/FusedMultiplyAddTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -366,15 +366,15 @@ public class FusedMultiplyAddTests {
     private static int testFusedMacCase(double input1, double input2, double input3, double expected) {
         int failures = 0;
         failures += Tests.test("Math.fma(double)", input1, input2, input3,
-                               Math.fma(input1, input2, input3), expected);
+                               Math::fma, expected);
         failures += Tests.test("StrictMath.fma(double)", input1, input2, input3,
-                               StrictMath.fma(input1, input2, input3), expected);
+                               StrictMath::fma, expected);
 
         // Permute first two inputs
         failures += Tests.test("Math.fma(double)", input2, input1, input3,
-                               Math.fma(input2, input1, input3), expected);
+                               Math::fma, expected);
         failures += Tests.test("StrictMath.fma(double)", input2, input1, input3,
-                               StrictMath.fma(input2, input1, input3), expected);
+                               StrictMath::fma, expected);
         return failures;
     }
 

--- a/test/jdk/java/lang/Math/FusedMultiplyAddTests.java
+++ b/test/jdk/java/lang/Math/FusedMultiplyAddTests.java
@@ -365,16 +365,12 @@ public class FusedMultiplyAddTests {
 
     private static int testFusedMacCase(double input1, double input2, double input3, double expected) {
         int failures = 0;
-        failures += Tests.test("Math.fma(double)", input1, input2, input3,
-                               Math::fma, expected);
-        failures += Tests.test("StrictMath.fma(double)", input1, input2, input3,
-                               StrictMath::fma, expected);
+        failures += Tests.test("Math.fma",       input1, input2, input3, Math::fma,       expected);
+        failures += Tests.test("StrictMath.fma", input1, input2, input3, StrictMath::fma, expected);
 
         // Permute first two inputs
-        failures += Tests.test("Math.fma(double)", input2, input1, input3,
-                               Math::fma, expected);
-        failures += Tests.test("StrictMath.fma(double)", input2, input1, input3,
-                               StrictMath::fma, expected);
+        failures += Tests.test("Math.fma",       input2, input1, input3, Math::fma,       expected);
+        failures += Tests.test("StrictMath.fma", input2, input1, input3, StrictMath::fma, expected);
         return failures;
     }
 

--- a/test/jdk/java/lang/Math/HyperbolicTests.java
+++ b/test/jdk/java/lang/Math/HyperbolicTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,26 @@
  * @test
  * @bug 4851625 4900189 4939441
  * @summary Tests for {Math, StrictMath}.{sinh, cosh, tanh}
- * @author Joseph D. Darcy
  */
 
 public class HyperbolicTests {
     private HyperbolicTests(){}
 
     static final double NaNd = Double.NaN;
+
+    public static void main(String argv[]) {
+        int failures = 0;
+
+        failures += testSinh();
+        failures += testCosh();
+        failures += testTanh();
+
+        if (failures > 0) {
+            System.err.println("Testing the hyperbolic functions incurred "
+                               + failures + " failures.");
+            throw new RuntimeException();
+        }
+    }
 
     /**
      * Test accuracy of {Math, StrictMath}.sinh.  The specified
@@ -355,19 +368,11 @@ public class HyperbolicTests {
                                                 double expected,
                                                 double tolerance) {
         int failures = 0;
-        failures += Tests.testTolerance("Math.sinh(double)",
-                                        input, Math.sinh(input),
-                                        expected, tolerance);
-        failures += Tests.testTolerance("Math.sinh(double)",
-                                        -input, Math.sinh(-input),
-                                        -expected, tolerance);
+        failures += Tests.testTolerance("Math.sinh",        input, Math::sinh,        expected, tolerance);
+        failures += Tests.testTolerance("Math.sinh",       -input, Math::sinh,       -expected, tolerance);
 
-        failures += Tests.testTolerance("StrictMath.sinh(double)",
-                                        input, StrictMath.sinh(input),
-                                        expected, tolerance);
-        failures += Tests.testTolerance("StrictMath.sinh(double)",
-                                        -input, StrictMath.sinh(-input),
-                                        -expected, tolerance);
+        failures += Tests.testTolerance("StrictMath.sinh",  input, StrictMath::sinh,  expected, tolerance);
+        failures += Tests.testTolerance("StrictMath.sinh", -input, StrictMath::sinh, -expected, tolerance);
         return failures;
     }
 
@@ -375,22 +380,13 @@ public class HyperbolicTests {
                                               double expected,
                                               double ulps) {
         int failures = 0;
-        failures += Tests.testUlpDiff("Math.sinh(double)",
-                                      input, Math.sinh(input),
-                                      expected, ulps);
-        failures += Tests.testUlpDiff("Math.sinh(double)",
-                                      -input, Math.sinh(-input),
-                                      -expected, ulps);
+        failures += Tests.testUlpDiff("Math.sinh",        input, Math::sinh,        expected, ulps);
+        failures += Tests.testUlpDiff("Math.sinh",       -input, Math::sinh,       -expected, ulps);
 
-        failures += Tests.testUlpDiff("StrictMath.sinh(double)",
-                                      input, StrictMath.sinh(input),
-                                      expected, ulps);
-        failures += Tests.testUlpDiff("StrictMath.sinh(double)",
-                                      -input, StrictMath.sinh(-input),
-                                      -expected, ulps);
+        failures += Tests.testUlpDiff("StrictMath.sinh",  input, StrictMath::sinh,  expected, ulps);
+        failures += Tests.testUlpDiff("StrictMath.sinh", -input, StrictMath::sinh, -expected, ulps);
         return failures;
     }
-
 
     /**
      * Test accuracy of {Math, StrictMath}.cosh.  The specified
@@ -594,7 +590,6 @@ public class HyperbolicTests {
                                                 3.0);
         }
 
-
         double [][] specialTestCases = {
             {0.0,                       1.0},
             {NaNd,                      NaNd},
@@ -733,22 +728,13 @@ public class HyperbolicTests {
                                               double expected,
                                               double ulps) {
         int failures = 0;
-        failures += Tests.testUlpDiff("Math.cosh(double)",
-                                      input, Math.cosh(input),
-                                      expected, ulps);
-        failures += Tests.testUlpDiff("Math.cosh(double)",
-                                      -input, Math.cosh(-input),
-                                      expected, ulps);
+        failures += Tests.testUlpDiff("Math.cosh",        input, Math::cosh,       expected, ulps);
+        failures += Tests.testUlpDiff("Math.cosh",       -input, Math::cosh,       expected, ulps);
 
-        failures += Tests.testUlpDiff("StrictMath.cosh(double)",
-                                      input, StrictMath.cosh(input),
-                                      expected, ulps);
-        failures += Tests.testUlpDiff("StrictMath.cosh(double)",
-                                      -input, StrictMath.cosh(-input),
-                                      expected, ulps);
+        failures += Tests.testUlpDiff("StrictMath.cosh",  input, StrictMath::cosh, expected, ulps);
+        failures += Tests.testUlpDiff("StrictMath.cosh", -input, StrictMath::cosh, expected, ulps);
         return failures;
     }
-
 
     /**
      * Test accuracy of {Math, StrictMath}.tanh.  The specified
@@ -952,7 +938,6 @@ public class HyperbolicTests {
                                                 3.0);
         }
 
-
         double [][] specialTestCases = {
             {0.0,                       0.0},
             {NaNd,                      NaNd},
@@ -1007,19 +992,11 @@ public class HyperbolicTests {
                                                 double expected,
                                                 double tolerance) {
         int failures = 0;
-        failures += Tests.testTolerance("Math.tanh(double",
-                                        input, Math.tanh(input),
-                                        expected, tolerance);
-        failures += Tests.testTolerance("Math.tanh(double",
-                                        -input, Math.tanh(-input),
-                                        -expected, tolerance);
+        failures += Tests.testTolerance("Math.tanh",       input, Math::tanh,         expected, tolerance);
+        failures += Tests.testTolerance("Math.tanh",      -input, Math::tanh,        -expected, tolerance);
 
-        failures += Tests.testTolerance("StrictMath.tanh(double",
-                                        input, StrictMath.tanh(input),
-                                        expected, tolerance);
-        failures += Tests.testTolerance("StrictMath.tanh(double",
-                                        -input, StrictMath.tanh(-input),
-                                        -expected, tolerance);
+        failures += Tests.testTolerance("StrictMath.tanh",  input, StrictMath::tanh,  expected, tolerance);
+        failures += Tests.testTolerance("StrictMath.tanh", -input, StrictMath::tanh, -expected, tolerance);
         return failures;
     }
 
@@ -1028,35 +1005,11 @@ public class HyperbolicTests {
                                               double ulps) {
         int failures = 0;
 
-        failures += Tests.testUlpDiffWithAbsBound("Math.tanh(double)",
-                                                  input, Math.tanh(input),
-                                                  expected, ulps, 1.0);
-        failures += Tests.testUlpDiffWithAbsBound("Math.tanh(double)",
-                                                  -input, Math.tanh(-input),
-                                                  -expected, ulps, 1.0);
+        failures += Tests.testUlpDiffWithAbsBound("Math.tanh",       input,  Math::tanh,       expected, ulps, 1.0);
+        failures += Tests.testUlpDiffWithAbsBound("Math.tanh",      -input,  Math::tanh,      -expected, ulps, 1.0);
 
-        failures += Tests.testUlpDiffWithAbsBound("StrictMath.tanh(double)",
-                                                  input, StrictMath.tanh(input),
-                                                  expected, ulps, 1.0);
-        failures += Tests.testUlpDiffWithAbsBound("StrictMath.tanh(double)",
-                                                  -input, StrictMath.tanh(-input),
-                                                  -expected, ulps, 1.0);
+        failures += Tests.testUlpDiffWithAbsBound("StrictMath.tanh",  input, StrictMath::tanh,  expected, ulps, 1.0);
+        failures += Tests.testUlpDiffWithAbsBound("StrictMath.tanh", -input, StrictMath::tanh, -expected, ulps, 1.0);
         return failures;
     }
-
-
-    public static void main(String argv[]) {
-        int failures = 0;
-
-        failures += testSinh();
-        failures += testCosh();
-        failures += testTanh();
-
-        if (failures > 0) {
-            System.err.println("Testing the hyperbolic functions incurred "
-                               + failures + " failures.");
-            throw new RuntimeException();
-        }
-    }
-
 }

--- a/test/jdk/java/lang/Math/HyperbolicTests.java
+++ b/test/jdk/java/lang/Math/HyperbolicTests.java
@@ -32,7 +32,7 @@ public class HyperbolicTests {
 
     static final double NaNd = Double.NaN;
 
-    public static void main(String argv[]) {
+    public static void main(String... argv) {
         int failures = 0;
 
         failures += testSinh();

--- a/test/jdk/java/lang/Math/HypotTests.java
+++ b/test/jdk/java/lang/Math/HypotTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@
  * @run main HypotTests
  * @bug 4851638 4939441 8078672 8240632
  * @summary Tests for {Math, StrictMath}.hypot (use -Dseed=X to set PRNG seed)
- * @author Joseph D. Darcy
  * @key randomness
  */
 
@@ -50,7 +49,6 @@ public class HypotTests {
         long M = m;
         long N = n;
         long result[] = new long[3];
-
 
         result[0] = Math.abs(M*M - N*N);
         result[1] = Math.abs(2*M*N);
@@ -188,12 +186,10 @@ public class HypotTests {
                                           pcNeighborsStrictHypot[j+1] );
                     }
 
-
                 }
 
             }
         }
-
 
         return failures;
     }
@@ -221,19 +217,15 @@ public class HypotTests {
         // each input negated singly, and both inputs negated.  Also
         // test inputs in reversed order.
 
-        for(int i = -1; i <= 1; i+=2) {
-            for(int j = -1; j <= 1; j+=2) {
+        for(int i = -1; i <= 1; i += 2) {
+            for(int j = -1; j <= 1; j += 2) {
                 double x = i * input1;
                 double y = j * input2;
-                failures += Tests.testUlpDiff("Math.hypot", x, y,
-                                              Math.hypot(x, y), expected, ulps);
-                failures += Tests.testUlpDiff("Math.hypot", y, x,
-                                              Math.hypot(y, x ), expected, ulps);
+                failures += Tests.testUlpDiff("Math.hypot",       x, y, Math::hypot,       expected, ulps);
+                failures += Tests.testUlpDiff("Math.hypot",       y, x, Math::hypot,       expected, ulps);
 
-                failures += Tests.testUlpDiff("StrictMath.hypot", x, y,
-                                              StrictMath.hypot(x, y), expected, ulps);
-                failures += Tests.testUlpDiff("StrictMath.hypot", y, x,
-                                              StrictMath.hypot(y, x), expected, ulps);
+                failures += Tests.testUlpDiff("StrictMath.hypot", x, y, StrictMath::hypot, expected, ulps);
+                failures += Tests.testUlpDiff("StrictMath.hypot", y, x, StrictMath::hypot, expected, ulps);
             }
         }
 
@@ -252,5 +244,4 @@ public class HypotTests {
             throw new RuntimeException();
         }
     }
-
 }

--- a/test/jdk/java/lang/Math/HypotTests.java
+++ b/test/jdk/java/lang/Math/HypotTests.java
@@ -232,7 +232,7 @@ public class HypotTests {
         return failures;
     }
 
-    public static void main(String argv[]) {
+    public static void main(String... argv) {
         int failures = 0;
 
         failures += testHypot();

--- a/test/jdk/java/lang/Math/Ieee754SpecialCaseTests.java
+++ b/test/jdk/java/lang/Math/Ieee754SpecialCaseTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/Math/Ieee754SpecialCaseTests.java
+++ b/test/jdk/java/lang/Math/Ieee754SpecialCaseTests.java
@@ -62,8 +62,8 @@ public class Ieee754SpecialCaseTests {
 
     private static int testCosCase(double input, double expected) {
         int failures = 0;
-        failures += Tests.test("Math.cos",       input, Math.cos(input),       expected);
-        failures += Tests.test("StrictMath.cos", input, StrictMath.cos(input), expected);
+        failures += Tests.test("Math.cos",       input, Math::cos,       expected);
+        failures += Tests.test("StrictMath.cos", input, StrictMath::cos, expected);
         return failures;
     }
 
@@ -82,8 +82,8 @@ public class Ieee754SpecialCaseTests {
 
     private static int testAcosCase(double input, double expected) {
         int failures = 0;
-        failures += Tests.test("Math.acos",       input, Math.acos(input),       expected);
-        failures += Tests.test("StrictMath.acos", input, StrictMath.acos(input), expected);
+        failures += Tests.test("Math.acos",       input, Math::acos,       expected);
+        failures += Tests.test("StrictMath.acos", input, StrictMath::acos, expected);
         return failures;
     }
 
@@ -103,8 +103,8 @@ public class Ieee754SpecialCaseTests {
 
     private static int testAtanCase(double input, double expected) {
         int failures = 0;
-        failures += Tests.test("Math.atan",       input, Math.atan(input),       expected);
-        failures += Tests.test("StrictMath.atan", input, StrictMath.atan(input), expected);
+        failures += Tests.test("Math.atan",       input, Math::atan,       expected);
+        failures += Tests.test("StrictMath.atan", input, StrictMath::atan, expected);
         return failures;
     }
 
@@ -123,8 +123,8 @@ public class Ieee754SpecialCaseTests {
 
     private static int testLogCase(double input, double expected) {
         int failures = 0;
-        failures += Tests.test("Math.log",       input, Math.log(input),       expected);
-        failures += Tests.test("StrictMath.log", input, StrictMath.log(input), expected);
+        failures += Tests.test("Math.log",       input, Math::log,       expected);
+        failures += Tests.test("StrictMath.log", input, StrictMath::log, expected);
         return failures;
     }
 }

--- a/test/jdk/java/lang/Math/IeeeRecommendedTests.java
+++ b/test/jdk/java/lang/Math/IeeeRecommendedTests.java
@@ -1672,7 +1672,7 @@ public class IeeeRecommendedTests {
     }
 
 
-    public static void main(String argv[]) {
+    public static void main(String... argv) {
         int failures = 0;
 
         failures += testFloatGetExponent();

--- a/test/jdk/java/lang/Math/IeeeRecommendedTests.java
+++ b/test/jdk/java/lang/Math/IeeeRecommendedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@
  * @run main IeeeRecommendedTests
  * @bug 4860891 4826732 4780454 4939441 4826652 8078672
  * @summary Tests for IEEE 754[R] recommended functions and similar methods (use -Dseed=X to set PRNG seed)
- * @author Joseph D. Darcy
  * @key randomness
  */
 

--- a/test/jdk/java/lang/Math/IeeeRecommendedTests.java
+++ b/test/jdk/java/lang/Math/IeeeRecommendedTests.java
@@ -364,14 +364,14 @@ public class IeeeRecommendedTests {
         double minus_expected = -expected;
 
         failures+=Tests.test("Math.nextAfter(double,double)", start, direction,
-                             Math.nextAfter(start, direction), expected);
+                             Math::nextAfter, expected);
         failures+=Tests.test("Math.nextAfter(double,double)", minus_start, minus_direction,
-                             Math.nextAfter(minus_start, minus_direction), minus_expected);
+                             Math::nextAfter, minus_expected);
 
         failures+=Tests.test("StrictMath.nextAfter(double,double)", start, direction,
-                             StrictMath.nextAfter(start, direction), expected);
+                             StrictMath::nextAfter, expected);
         failures+=Tests.test("StrictMath.nextAfter(double,double)", minus_start, minus_direction,
-                             StrictMath.nextAfter(minus_start, minus_direction), minus_expected);
+                             StrictMath::nextAfter, minus_expected);
         return failures;
     }
 
@@ -586,10 +586,10 @@ public class IeeeRecommendedTests {
 
         for(int i = 0; i < testCases.length; i++) {
             failures+=Tests.test("Math.nextUp(double)",
-                                 testCases[i][0], Math.nextUp(testCases[i][0]), testCases[i][1]);
+                                 testCases[i][0], Math::nextUp, testCases[i][1]);
 
             failures+=Tests.test("StrictMath.nextUp(double)",
-                                 testCases[i][0], StrictMath.nextUp(testCases[i][0]), testCases[i][1]);
+                                 testCases[i][0], StrictMath::nextUp, testCases[i][1]);
         }
 
         return failures;
@@ -665,10 +665,10 @@ public class IeeeRecommendedTests {
 
         for(int i = 0; i < testCases.length; i++) {
             failures+=Tests.test("Math.nextDown(double)",
-                                 testCases[i][0], Math.nextDown(testCases[i][0]), testCases[i][1]);
+                                 testCases[i][0], Math::nextDown, testCases[i][1]);
 
             failures+=Tests.test("StrictMath.nextDown(double)",
-                                 testCases[i][0], StrictMath.nextDown(testCases[i][0]), testCases[i][1]);
+                                 testCases[i][0], StrictMath::nextDown, testCases[i][1]);
         }
 
         return failures;
@@ -906,12 +906,12 @@ public class IeeeRecommendedTests {
                         // copySign(magnitude, sign)
                         failures+=Tests.test("MathcopySign(double,double)",
                                              testCases[i][m],testCases[j][n],
-                                             Math.copySign(testCases[i][m], testCases[j][n]),
+                                             Math::copySign,
                                              (j==0?1.0f:-1.0f)*Math.abs(testCases[i][m]) );
 
                         failures+=Tests.test("StrictMath.copySign(double,double)",
                                              testCases[i][m],testCases[j][n],
-                                             StrictMath.copySign(testCases[i][m], testCases[j][n]),
+                                             StrictMath::copySign,
                                              (j==0?1.0f:-1.0f)*Math.abs(testCases[i][m]) );
                     }
                 }
@@ -932,7 +932,7 @@ public class IeeeRecommendedTests {
 
                     failures+=Tests.test("StrictMath.copySign(double,double)",
                                          testCases[i][m], NaNs[j],
-                                         StrictMath.copySign(testCases[i][m], NaNs[j]),
+                                         StrictMath::copySign,
                                          Math.abs(testCases[i][m]) );
                 }
             }
@@ -1384,13 +1384,13 @@ public class IeeeRecommendedTests {
         int failures=0;
 
         failures+=Tests.test("Math.ulp(double)", d,
-                             Math.ulp(d), expected);
+                             Math::ulp, expected);
         failures+=Tests.test("Math.ulp(double)", minus_d,
-                             Math.ulp(minus_d), expected);
+                             Math::ulp, expected);
         failures+=Tests.test("StrictMath.ulp(double)", d,
-                             StrictMath.ulp(d), expected);
+                             StrictMath::ulp, expected);
         failures+=Tests.test("StrictMath.ulp(double)", minus_d,
-                             StrictMath.ulp(minus_d), expected);
+                             StrictMath::ulp, expected);
         return failures;
     }
 
@@ -1664,9 +1664,9 @@ public class IeeeRecommendedTests {
 
         for(int i = 0; i < testCases.length; i++) {
             failures+=Tests.test("Math.signum(double)",
-                                 testCases[i][0], Math.signum(testCases[i][0]), testCases[i][1]);
+                                 testCases[i][0], Math::signum, testCases[i][1]);
             failures+=Tests.test("StrictMath.signum(double)",
-                                 testCases[i][0], StrictMath.signum(testCases[i][0]), testCases[i][1]);
+                                 testCases[i][0], StrictMath::signum, testCases[i][1]);
         }
 
         return failures;

--- a/test/jdk/java/lang/Math/Log10Tests.java
+++ b/test/jdk/java/lang/Math/Log10Tests.java
@@ -117,8 +117,6 @@ public class Log10Tests {
                                            "log(input)/log(10): log10(input) = " + result +
                                            "\tlog(input)/log(10) = " + expected);
                     }
-
-
                 }
             }
         }
@@ -212,5 +210,4 @@ public class Log10Tests {
             throw new RuntimeException();
         }
     }
-
 }

--- a/test/jdk/java/lang/Math/Log10Tests.java
+++ b/test/jdk/java/lang/Math/Log10Tests.java
@@ -41,11 +41,8 @@ public class Log10Tests {
     static int testLog10Case(double input, double expected) {
         int failures=0;
 
-        failures+=Tests.test("Math.log10(double)", input,
-                             Math.log10(input), expected);
-
-        failures+=Tests.test("StrictMath.log10(double)", input,
-                             StrictMath.log10(input), expected);
+        failures+=Tests.test("Math.log10",       input, Math::log10,       expected);
+        failures+=Tests.test("StrictMath.log10", input, StrictMath::log10, expected);
 
         return failures;
     }

--- a/test/jdk/java/lang/Math/Log10Tests.java
+++ b/test/jdk/java/lang/Math/Log10Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4074599 4939441
  * @summary Tests for {Math, StrictMath}.log10
- * @author Joseph D. Darcy
  */
 
 public class Log10Tests {

--- a/test/jdk/java/lang/Math/Log10Tests.java
+++ b/test/jdk/java/lang/Math/Log10Tests.java
@@ -199,7 +199,7 @@ public class Log10Tests {
         return failures;
     }
 
-    public static void main(String argv[]) {
+    public static void main(String... argv) {
         int failures = 0;
 
         failures += testLog10();

--- a/test/jdk/java/lang/Math/Log1pTests.java
+++ b/test/jdk/java/lang/Math/Log1pTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@
  * @run main Log1pTests
  * @bug 4851638 4939441 8078672
  * @summary Tests for {Math, StrictMath}.log1p (use -Dseed=X to set PRNG seed)
- * @author Joseph D. Darcy
  * @key randomness
  */
 
@@ -167,9 +166,7 @@ public class Log1pTests {
                                           pcNeighborsStrictLog1p[j+1] );
                     }
 
-
                 }
-
             }
         }
 
@@ -185,16 +182,12 @@ public class Log1pTests {
                                                double expected,
                                                double ulps) {
         int failures = 0;
-        failures += Tests.testUlpDiff("Math.lop1p(double",
-                                      input, Math.log1p(input),
-                                      expected, ulps);
-        failures += Tests.testUlpDiff("StrictMath.log1p(double",
-                                      input, StrictMath.log1p(input),
-                                      expected, ulps);
+        failures += Tests.testUlpDiff("Math.lop1p",       input, Math::log1p,       expected, ulps);
+        failures += Tests.testUlpDiff("StrictMath.log1p", input, StrictMath::log1p, expected, ulps);
         return failures;
     }
 
-    public static void main(String argv[]) {
+    public static void main(String... argv) {
         int failures = 0;
 
         failures += testLog1p();

--- a/test/jdk/java/lang/Math/PowTests.java
+++ b/test/jdk/java/lang/Math/PowTests.java
@@ -34,35 +34,29 @@ public class PowTests {
 
     static int testPowCase(double input1, double input2, double expected) {
         int failures = 0;
-        failures += Tests.test("StrictMath.pow(double, double)", input1, input2,
-                               StrictMath::pow, expected);
-        failures += Tests.test("Math.pow(double, double)", input1, input2,
-                               Math::pow, expected);
+        failures += Tests.test("StrictMath.pow", input1, input2, StrictMath::pow, expected);
+        failures += Tests.test("Math.pow",       input1, input2, Math::pow,       expected);
         return failures;
     }
 
-
     static int testStrictPowCase(double input1, double input2, double expected) {
         int failures = 0;
-        failures += Tests.test("StrictMath.pow(double, double)", input1, input2,
+        failures += Tests.test("StrictMath.pow", input1, input2,
                                StrictMath::pow, expected);
         return failures;
     }
 
     static int testNonstrictPowCase(double input1, double input2, double expected) {
         int failures = 0;
-        failures += Tests.test("Math.pow(double, double)", input1, input2,
+        failures += Tests.test("Math.pow", input1, input2,
                                Math::pow, expected);
         return failures;
     }
 
     static int testStrictVsNonstrictPowCase(double input1, double input2) {
-        double smResult = StrictMath.pow(input1, input2);
-        double mResult = Math.pow(input1, input2);
         return Tests.testUlpDiff(
             "StrictMath.pow(double, double) vs Math.pow(double, double)",
-            input1, input2, mResult, smResult, 2.0
-        );
+            input1, input2, Math::pow, StrictMath.pow(input1, input2), 2.0);
     }
 
     /*
@@ -312,7 +306,7 @@ public class PowTests {
         }
     }
 
-    public static void main(String [] argv) {
+    public static void main(String... argv) {
         int failures = 0;
 
         failures += testPow();

--- a/test/jdk/java/lang/Math/PowTests.java
+++ b/test/jdk/java/lang/Math/PowTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4984407 5033578 8134795
  * @summary Tests for {Math, StrictMath}.pow
- * @author Joseph D. Darcy
  */
 
 public class PowTests {

--- a/test/jdk/java/lang/Math/PowTests.java
+++ b/test/jdk/java/lang/Math/PowTests.java
@@ -36,9 +36,9 @@ public class PowTests {
     static int testPowCase(double input1, double input2, double expected) {
         int failures = 0;
         failures += Tests.test("StrictMath.pow(double, double)", input1, input2,
-                               StrictMath.pow(input1, input2), expected);
+                               StrictMath::pow, expected);
         failures += Tests.test("Math.pow(double, double)", input1, input2,
-                               Math.pow(input1, input2), expected);
+                               Math::pow, expected);
         return failures;
     }
 
@@ -46,14 +46,14 @@ public class PowTests {
     static int testStrictPowCase(double input1, double input2, double expected) {
         int failures = 0;
         failures += Tests.test("StrictMath.pow(double, double)", input1, input2,
-                               StrictMath.pow(input1, input2), expected);
+                               StrictMath::pow, expected);
         return failures;
     }
 
     static int testNonstrictPowCase(double input1, double input2, double expected) {
         int failures = 0;
         failures += Tests.test("Math.pow(double, double)", input1, input2,
-                               Math.pow(input1, input2), expected);
+                               Math::pow, expected);
         return failures;
     }
 

--- a/test/jdk/java/lang/Math/Rint.java
+++ b/test/jdk/java/lang/Math/Rint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/Math/Rint.java
+++ b/test/jdk/java/lang/Math/Rint.java
@@ -32,15 +32,12 @@ public class Rint {
     static int testRintCase(double input, double expected) {
         int failures = 0;
         double result;
-        failures += Tests.test("Math.rint",  input, Math.rint(input),   expected);
-        failures += Tests.test("Math.rint", -input, Math.rint(-input), -expected);
-        failures += Tests.test("StrictMath.rint",
-                               input, StrictMath.rint(input),   expected);
-        failures += Tests.test("StrictMath.rint", -input,
-                               StrictMath.rint(-input), -expected);
+        failures += Tests.test("Math.rint",        input, Math::rint,        expected);
+        failures += Tests.test("Math.rint",       -input, Math::rint,       -expected);
+        failures += Tests.test("StrictMath.rint",  input, StrictMath::rint,  expected);
+        failures += Tests.test("StrictMath.rint", -input, StrictMath::rint, -expected);
         return failures;
     }
-
 
     public static void main(String args[]) {
         int failures = 0;
@@ -96,7 +93,6 @@ public class Rint {
             {Double.NaN,                        Double.NaN}
 
         };
-
 
         for(int i = 0; i < testCases.length; i++) {
             failures += testRintCase(testCases[i][0], testCases[i][1]);

--- a/test/jdk/java/lang/Math/Rint.java
+++ b/test/jdk/java/lang/Math/Rint.java
@@ -39,7 +39,7 @@ public class Rint {
         return failures;
     }
 
-    public static void main(String args[]) {
+    public static void main(String... args) {
         int failures = 0;
         double twoToThe52 = Math.scalb(1.0, 52); // 2^52
 

--- a/test/jdk/java/lang/Math/RoundTests.java
+++ b/test/jdk/java/lang/Math/RoundTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/Math/RoundTests.java
+++ b/test/jdk/java/lang/Math/RoundTests.java
@@ -64,8 +64,8 @@ public class RoundTests {
     private static int testNearHalfCases(double input, double expected) {
         int failures = 0;
 
-        failures += Tests.test("Math.round",        input, Math.round(input),       expected);
-        failures += Tests.test("StrictMath.round",  input, StrictMath.round(input), expected);
+        failures += Tests.test("Math.round",        input, Math::round,       expected);
+        failures += Tests.test("StrictMath.round",  input, StrictMath::round, expected);
 
         return failures;
     }
@@ -145,20 +145,14 @@ public class RoundTests {
         failures += Tests.test("Math.round", -Float.MIN_VALUE,
                 Math.round(-Float.MIN_VALUE), 0.0F);
 
-        failures += Tests.test("Math.round", Double.NaN, Math.round(Double.NaN), 0.0);
-        failures += Tests.test("Math.round", Double.POSITIVE_INFINITY,
-                Math.round(Double.POSITIVE_INFINITY), Long.MAX_VALUE);
-        failures += Tests.test("Math.round", Double.NEGATIVE_INFINITY,
-                Math.round(Double.NEGATIVE_INFINITY), Long.MIN_VALUE);
-        failures += Tests.test("Math.round", -(double)Long.MIN_VALUE,
-                Math.round(-(double)Long.MIN_VALUE), Long.MAX_VALUE);
-        failures += Tests.test("Math.round", (double) Long.MIN_VALUE,
-                Math.round((double) Long.MIN_VALUE), Long.MIN_VALUE);
-        failures += Tests.test("Math.round", 0, Math.round(0), 0.0);
-        failures += Tests.test("Math.round", Double.MIN_VALUE,
-                Math.round(Double.MIN_VALUE), 0.0);
-        failures += Tests.test("Math.round", -Double.MIN_VALUE,
-                Math.round(-Double.MIN_VALUE), 0.0);
+        failures += Tests.test("Math.round", Double.NaN,               Math::round, 0.0);
+        failures += Tests.test("Math.round", Double.POSITIVE_INFINITY, Math::round, Long.MAX_VALUE);
+        failures += Tests.test("Math.round", Double.NEGATIVE_INFINITY, Math::round, Long.MIN_VALUE);
+        failures += Tests.test("Math.round", -(double)Long.MIN_VALUE,  Math::round, Long.MAX_VALUE);
+        failures += Tests.test("Math.round", (double) Long.MIN_VALUE,  Math::round, Long.MIN_VALUE);
+        failures += Tests.test("Math.round", 0,                        Math::round, 0.0);
+        failures += Tests.test("Math.round", Double.MIN_VALUE,         Math::round, 0.0);
+        failures += Tests.test("Math.round", -Double.MIN_VALUE,        Math::round, 0.0);
 
         return failures;
     }

--- a/test/jdk/java/lang/Math/SinCosCornerCasesTests.java
+++ b/test/jdk/java/lang/Math/SinCosCornerCasesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@
  * @build Tests
  * @build SinCosCornerCasesTests
  * @run main SinCosCornerCasesTests
- * @author Vivek Deshpande
  */
 
 public class SinCosCornerCasesTests {
@@ -1502,7 +1501,7 @@ public class SinCosCornerCasesTests {
 
     private static int testSinCase(double input, double bound1, double bound2) {
         int failures = 0;
-        failures += Tests.testBounds("Math.sin", input, Math.sin(input), bound1, bound2);
+        failures += Tests.testBounds("Math.sin", input, Math::sin, bound1, bound2);
         return failures;
     }
 
@@ -2921,7 +2920,7 @@ public class SinCosCornerCasesTests {
 
     private static int testCosCase(double input, double bound1, double bound2) {
         int failures = 0;
-        failures += Tests.testBounds("Math.cos", input, Math.cos(input), bound1, bound2);
+        failures += Tests.testBounds("Math.cos", input, Math::cos, bound1, bound2);
         return failures;
     }
 }

--- a/test/jdk/java/lang/Math/TanTests.java
+++ b/test/jdk/java/lang/Math/TanTests.java
@@ -170,7 +170,7 @@ public class TanTests {
         return failures;
     }
 
-    public static void main(String [] argv) {
+    public static void main(String... argv) {
         int failures = 0;
 
         failures += testTan();

--- a/test/jdk/java/lang/Math/TanTests.java
+++ b/test/jdk/java/lang/Math/TanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 5033578
  * @summary Tests for {Math, StrictMath}.tan
- * @author Joseph D. Darcy
  */
 
 public class TanTests {
@@ -33,10 +32,8 @@ public class TanTests {
 
     static int testTanCase(double input, double expected, double ulps) {
         int failures = 0;
-        failures += Tests.testUlpDiff("StrictMath.tan(double, double)", input,
-                               StrictMath.tan(input), expected, ulps);
-        failures += Tests.testUlpDiff("Math.tan(double, double)", input,
-                               Math.tan(input), expected, ulps);
+        failures += Tests.testUlpDiff("StrictMath.tan", input, StrictMath::tan, expected, ulps);
+        failures += Tests.testUlpDiff("Math.tan",       input, Math::tan,       expected, ulps);
         return failures;
     }
 

--- a/test/jdk/java/lang/Math/Tests.java
+++ b/test/jdk/java/lang/Math/Tests.java
@@ -438,7 +438,7 @@ public class Tests {
                            double input1, double input2, double input3,
                            DoubleTernaryOperator func, double expected) {
         return test(testName, input1, input2, input3, func.applyAsDouble(input1, input2, input3), expected);
-        
+
     }
 
     public static int test(String testName,
@@ -592,7 +592,7 @@ public class Tests {
     public static int testTolerance(String testName, double input,
                                     DoubleUnaryOperator func, double expected, double tolerance) {
         return testTolerance(testName, input, func.applyAsDouble(input), expected, tolerance);
-        
+
     }
     public static int testTolerance(String testName, double input,
                                     double result, double expected, double tolerance) {

--- a/test/jdk/java/lang/Math/Tests.java
+++ b/test/jdk/java/lang/Math/Tests.java
@@ -333,18 +333,18 @@ public class Tests {
         return test(testName, input, func.applyAsDouble(input), expected);
     }
 
-     public static int test(String testName, double input,
-                            double result, double expected) {
-         if (Double.compare(expected, result ) != 0) {
-             System.err.println("Failure for " + testName + ":\n" +
-                                "\tFor input " + input    + "\t(" + toHexString(input) + ")\n" +
-                                "\texpected  " + expected + "\t(" + toHexString(expected) + ")\n" +
-                                "\tgot       " + result   + "\t(" + toHexString(result) + ").");
-             return 1;
-         } else {
-             return 0;
-         }
-     }
+    public static int test(String testName, double input,
+                           double result, double expected) {
+        if (Double.compare(expected, result ) != 0) {
+            System.err.println("Failure for " + testName + ":\n" +
+                               "\tFor input " + input    + "\t(" + toHexString(input) + ")\n" +
+                               "\texpected  " + expected + "\t(" + toHexString(expected) + ")\n" +
+                               "\tgot       " + result   + "\t(" + toHexString(result) + ").");
+            return 1;
+        } else {
+            return 0;
+        }
+    }
 
     public static int test(String testName,
                            float input1, double input2,
@@ -485,6 +485,11 @@ public class Tests {
 
     // One input argument.
     public static int testUlpDiff(String testName, double input,
+                                  DoubleUnaryOperator func, double expected, double ulps) {
+        return testUlpDiff(testName, input, func.applyAsDouble(input), expected, ulps);
+    }
+
+    public static int testUlpDiff(String testName, double input,
                                   double result, double expected, double ulps) {
         int code = testUlpCore(result, expected, ulps);
         if (code == 1) {
@@ -498,6 +503,11 @@ public class Tests {
     }
 
     // Two input arguments.
+    public static int testUlpDiff(String testName, double input1, double input2,
+                                  DoubleBinaryOperator func, double expected, double ulps) {
+        return testUlpDiff(testName, input1, input2, func.applyAsDouble(input1, input2), expected, ulps);
+    }
+
     public static int testUlpDiff(String testName, double input1, double input2,
                                   double result, double expected, double ulps) {
         int code = testUlpCore(result, expected, ulps);
@@ -515,6 +525,14 @@ public class Tests {
     // For a successful test, the result must be within the ulp bound of
     // expected AND the result must have absolute value less than or
     // equal to absBound.
+    public static int testUlpDiffWithAbsBound(String testName, double input,
+                                              DoubleUnaryOperator func, double expected,
+                                              double ulps, double absBound) {
+        return testUlpDiffWithAbsBound(testName, input,
+                                       func.applyAsDouble(input), expected,
+                                       ulps, absBound);
+    }
+
     public static int testUlpDiffWithAbsBound(String testName, double input,
                                               double result, double expected,
                                               double ulps, double absBound) {
@@ -541,6 +559,14 @@ public class Tests {
     // expected AND the result must have absolute value greater than
     // or equal to the lowerBound.
     public static int testUlpDiffWithLowerBound(String testName, double input,
+                                                DoubleUnaryOperator func, double expected,
+                                                double ulps, double lowerBound) {
+        return testUlpDiffWithLowerBound(testName, input,
+                                         func.applyAsDouble(input), expected,
+                                         ulps, lowerBound);
+    }
+
+    public static int testUlpDiffWithLowerBound(String testName, double input,
                                                 double result, double expected,
                                                 double ulps, double lowerBound) {
         int code = 0;   // return code value
@@ -564,6 +590,11 @@ public class Tests {
     }
 
     public static int testTolerance(String testName, double input,
+                                    DoubleUnaryOperator func, double expected, double tolerance) {
+        return testTolerance(testName, input, func.applyAsDouble(input), expected, tolerance);
+        
+    }
+    public static int testTolerance(String testName, double input,
                                     double result, double expected, double tolerance) {
         if (Double.compare(expected, result ) != 0) {
             double difference = expected - result;
@@ -586,6 +617,11 @@ public class Tests {
 
     // For a successful test, the result must be within the upper and
     // lower bounds.
+    public static int testBounds(String testName, double input, DoubleUnaryOperator func,
+                                 double bound1, double bound2) {
+        return testBounds(testName, input, func.applyAsDouble(input), bound1, bound2);
+    }
+
     public static int testBounds(String testName, double input, double result,
                                  double bound1, double bound2) {
         if ((result >= bound1 && result <= bound2) ||

--- a/test/jdk/java/lang/Math/Tests.java
+++ b/test/jdk/java/lang/Math/Tests.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-import java.util.function.*;
+import java.util.function.DoubleBinaryOperator;
+import java.util.function.DoubleUnaryOperator;
+import java.util.function.DoubleToIntFunction;
 
 /*
  * Shared static test methods for numerical tests.  Sharing these

--- a/test/jdk/java/lang/Math/Tests.java
+++ b/test/jdk/java/lang/Math/Tests.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+import java.util.function.*;
+
 /*
  * Shared static test methods for numerical tests.  Sharing these
  * helper test methods avoids repeated functions in the various test
@@ -279,6 +281,18 @@ public class Tests {
         return 0;
     }
 
+    @FunctionalInterface
+    public interface FloatToIntFunction {
+        int applyAsInt(float value);
+    }
+
+    public static int test(String testName,
+                           float input,
+                           FloatToIntFunction func,
+                           int expected) {
+        return test(testName, input, func.applyAsInt(input), expected);
+    }
+
     public static int test(String testName, float input,
                            int result, int expected) {
         if (expected != result) {
@@ -289,6 +303,13 @@ public class Tests {
             return 1;
         }
         return 0;
+    }
+
+    public static int test(String testName,
+                           double input,
+                           DoubleToIntFunction func,
+                           int expected) {
+        return test(testName, input, func.applyAsInt(input), expected);
     }
 
     public  static int test(String testName, double input,
@@ -304,6 +325,18 @@ public class Tests {
             return 0;
     }
 
+     @FunctionalInterface
+     public interface FloatUnaryOperator {
+         float applyAsFloat(float operand);
+     }
+
+     public static int test(String testName,
+                            float input,
+                            FloatUnaryOperator func,
+                            float expected) {
+         return test(testName, input, func.applyAsFloat(input), expected);
+     }
+
     public static int test(String testName, float input,
                            float result, float expected) {
         if (Float.compare(expected, result) != 0 ) {
@@ -317,18 +350,36 @@ public class Tests {
             return 0;
     }
 
+    public static int test(String testName,
+                           double input,
+                           DoubleUnaryOperator func,
+                           double expected) {
+        return test(testName, input, func.applyAsDouble(input), expected);
+    }
 
-    public static int test(String testName, double input,
-                           double result, double expected) {
-        if (Double.compare(expected, result ) != 0) {
-            System.err.println("Failure for " + testName + ":\n" +
-                               "\tFor input " + input    + "\t(" + toHexString(input) + ")\n" +
-                               "\texpected  " + expected + "\t(" + toHexString(expected) + ")\n" +
-                               "\tgot       " + result   + "\t(" + toHexString(result) + ").");
-            return 1;
-        }
-        else
-            return 0;
+     public static int test(String testName, double input,
+                            double result, double expected) {
+         if (Double.compare(expected, result ) != 0) {
+             System.err.println("Failure for " + testName + ":\n" +
+                                "\tFor input " + input    + "\t(" + toHexString(input) + ")\n" +
+                                "\texpected  " + expected + "\t(" + toHexString(expected) + ")\n" +
+                                "\tgot       " + result   + "\t(" + toHexString(result) + ").");
+             return 1;
+         } else {
+             return 0;
+         }
+     }
+
+    @FunctionalInterface
+    public interface FloatBinaryOperator {
+        float applyAsFloat(float left, float right);
+    }
+
+    public static int test(String testName,
+                           float input1, float input2,
+                           FloatBinaryOperator func,
+                           float expected) {
+        return test(testName, input1, input2, func.applyAsFloat(input1, input2), expected);
     }
 
     public static int test(String testName,
@@ -341,9 +392,16 @@ public class Tests {
                                "\texpected  "  + expected + "\t(" + toHexString(expected) + ")\n" +
                                "\tgot       "  + result   + "\t(" + toHexString(result) + ").");
             return 1;
-        }
-        else
+        } else {
             return 0;
+        }
+    }
+
+    public static int test(String testName,
+                           double input1, double input2,
+                           DoubleBinaryOperator func,
+                           double expected) {
+        return test(testName, input1, input2, func.applyAsDouble(input1, input2), expected);
     }
 
     public static int test(String testName,
@@ -356,9 +414,9 @@ public class Tests {
                                "\texpected  "  + expected + "\t(" + toHexString(expected) + ")\n" +
                                "\tgot       "  + result   + "\t(" + toHexString(result) + ").");
             return 1;
-        }
-        else
+        } else {
             return 0;
+        }
     }
 
     public static int test(String testName,
@@ -371,9 +429,9 @@ public class Tests {
                                "\texpected  "  + expected + "\t(" + toHexString(expected) + ")\n" +
                                "\tgot       "  + result   + "\t(" + toHexString(result) + ").");
             return 1;
-        }
-        else
+        } else {
             return 0;
+        }
     }
 
     public static int test(String testName,
@@ -386,9 +444,9 @@ public class Tests {
                                "\texpected  "  + expected + "\t(" + toHexString(expected) + ")\n" +
                                "\tgot       "  + result   + "\t(" + toHexString(result) + ").");
             return 1;
-        }
-        else
+        } else {
             return 0;
+        }
     }
 
     public static int test(String testName,
@@ -402,9 +460,9 @@ public class Tests {
                                "\texpected  "  + expected + "\t(" + toHexString(expected) + ")\n" +
                                "\tgot       "  + result   + "\t(" + toHexString(result) + ").");
             return 1;
-        }
-        else
+        } else {
             return 0;
+        }
     }
 
     public static int test(String testName,
@@ -418,9 +476,9 @@ public class Tests {
                                "\texpected  "  + expected + "\t(" + toHexString(expected) + ")\n" +
                                "\tgot       "  + result   + "\t(" + toHexString(result) + ").");
             return 1;
-        }
-        else
+        } else {
             return 0;
+        }
     }
 
     static int testUlpCore(double result, double expected, double ulps) {
@@ -442,9 +500,9 @@ public class Tests {
                     // fail if greater than or unordered
                     !(Math.abs( difference/Math.ulp(expected) ) <= Math.abs(ulps)) ) {
                     return 1;
-                }
-                else
+                } else {
                     return 0;
+                }
             }
         }
     }
@@ -544,9 +602,9 @@ public class Tests {
                 return 1;
             }
             return 0;
-        }
-        else
+        } else {
             return 0;
+        }
     }
 
     // For a successful test, the result must be within the upper and

--- a/test/jdk/java/lang/Math/Tests.java
+++ b/test/jdk/java/lang/Math/Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -237,9 +237,9 @@ public class Tests {
                                "\texpected  " + expected + "\n"  +
                                "\tgot       " + result   + ").");
             return 1;
-        }
-        else
+        } else {
             return 0;
+        }
     }
 
     public static int test(String testName, double input,
@@ -250,9 +250,9 @@ public class Tests {
                                "\texpected  " + expected + "\n"  +
                                "\tgot       " + result   + ").");
             return 1;
-        }
-        else
+        } else {
             return 0;
+        }
     }
 
     public static int test(String testName, float input1, float input2,
@@ -279,18 +279,6 @@ public class Tests {
             return 1;
         }
         return 0;
-    }
-
-    @FunctionalInterface
-    public interface FloatToIntFunction {
-        int applyAsInt(float value);
-    }
-
-    public static int test(String testName,
-                           float input,
-                           FloatToIntFunction func,
-                           int expected) {
-        return test(testName, input, func.applyAsInt(input), expected);
     }
 
     public static int test(String testName, float input,
@@ -320,22 +308,10 @@ public class Tests {
                                "\texpected  " + expected + "\n"  +
                                "\tgot       " + result   + ").");
             return 1;
-        }
-        else
+        } else {
             return 0;
+        }
     }
-
-     @FunctionalInterface
-     public interface FloatUnaryOperator {
-         float applyAsFloat(float operand);
-     }
-
-     public static int test(String testName,
-                            float input,
-                            FloatUnaryOperator func,
-                            float expected) {
-         return test(testName, input, func.applyAsFloat(input), expected);
-     }
 
     public static int test(String testName, float input,
                            float result, float expected) {
@@ -345,9 +321,9 @@ public class Tests {
                                "\texpected  " + expected + "\t(" + toHexString(expected) + ")\n" +
                                "\tgot       " + result   + "\t(" + toHexString(result) + ").");
             return 1;
-        }
-        else
+        } else {
             return 0;
+        }
     }
 
     public static int test(String testName,
@@ -369,18 +345,6 @@ public class Tests {
              return 0;
          }
      }
-
-    @FunctionalInterface
-    public interface FloatBinaryOperator {
-        float applyAsFloat(float left, float right);
-    }
-
-    public static int test(String testName,
-                           float input1, float input2,
-                           FloatBinaryOperator func,
-                           float expected) {
-        return test(testName, input1, input2, func.applyAsFloat(input1, input2), expected);
-    }
 
     public static int test(String testName,
                            float input1, double input2,
@@ -463,6 +427,18 @@ public class Tests {
         } else {
             return 0;
         }
+    }
+
+    @FunctionalInterface
+    public interface DoubleTernaryOperator {
+        double applyAsDouble(double input1, double input2, double input3);
+    }
+
+    public static int test(String testName,
+                           double input1, double input2, double input3,
+                           DoubleTernaryOperator func, double expected) {
+        return test(testName, input1, input2, input3, func.applyAsDouble(input1, input2, input3), expected);
+        
     }
 
     public static int test(String testName,
@@ -571,8 +547,9 @@ public class Tests {
 
         if (!(result >= lowerBound) && !Double.isNaN(expected)) {
             code = 1;
-        } else
+        } else {
             code = testUlpCore(result, expected, ulps);
+        }
 
         if (code == 1) {
             System.err.println("Failure for " + testName +

--- a/test/jdk/java/lang/Math/WorstCaseTests.java
+++ b/test/jdk/java/lang/Math/WorstCaseTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  * @build WorstCaseTests
  * @run main WorstCaseTests
  * @run main/othervm -Xcomp WorstCaseTests
- * @author Joseph D. Darcy
  */
 
 /**
@@ -126,8 +125,8 @@ public class WorstCaseTests {
     private static int testExpCase(double input, double expected) {
         int failures = 0;
         double out = Tests.nextOut(expected);
-        failures += Tests.testBounds("Math.exp",       input, Math.exp(input),       expected, out);
-        failures += Tests.testBounds("StrictMath.exp", input, StrictMath.exp(input), expected, out);
+        failures += Tests.testBounds("Math.exp",       input, Math::exp,       expected, out);
+        failures += Tests.testBounds("StrictMath.exp", input, StrictMath::exp, expected, out);
         return failures;
     }
 
@@ -158,8 +157,8 @@ public class WorstCaseTests {
     private static int testLogCase(double input, double expected) {
         int failures = 0;
         double out = Tests.nextOut(expected);
-        failures += Tests.testBounds("Math.log",       input, Math.log(input),       expected, out);
-        failures += Tests.testBounds("StrictMath.log", input, StrictMath.log(input), expected, out);
+        failures += Tests.testBounds("Math.log",       input, Math::log,       expected, out);
+        failures += Tests.testBounds("StrictMath.log", input, StrictMath::log, expected, out);
         return failures;
     }
 
@@ -191,8 +190,8 @@ public class WorstCaseTests {
     private static int testSinCase(double input, double expected) {
         int failures = 0;
         double out = Tests.nextOut(expected);
-        failures += Tests.testBounds("Math.sin",       input, Math.sin(input),       expected, out);
-        failures += Tests.testBounds("StrictMath.sin", input, StrictMath.sin(input), expected, out);
+        failures += Tests.testBounds("Math.sin",       input, Math::sin,       expected, out);
+        failures += Tests.testBounds("StrictMath.sin", input, StrictMath::sin, expected, out);
         return failures;
     }
 
@@ -223,8 +222,8 @@ public class WorstCaseTests {
     private static int testAsinCase(double input, double expected) {
         int failures = 0;
         double out = Tests.nextOut(expected);
-        failures += Tests.testBounds("Math.asin",       input, Math.asin(input),       expected, out);
-        failures += Tests.testBounds("StrictMath.asin", input, StrictMath.asin(input), expected, out);
+        failures += Tests.testBounds("Math.asin",       input, Math::asin,       expected, out);
+        failures += Tests.testBounds("StrictMath.asin", input, StrictMath::asin, expected, out);
         return failures;
     }
 
@@ -256,8 +255,8 @@ public class WorstCaseTests {
     private static int testCosCase(double input, double expected) {
         int failures = 0;
         double out = Tests.nextOut(expected);
-        failures += Tests.testBounds("Math.cos",       input, Math.cos(input),       expected, out);
-        failures += Tests.testBounds("StrictMath.cos", input, StrictMath.cos(input), expected, out);
+        failures += Tests.testBounds("Math.cos",       input, Math::cos,       expected, out);
+        failures += Tests.testBounds("StrictMath.cos", input, StrictMath::cos, expected, out);
         return failures;
     }
 
@@ -280,8 +279,8 @@ public class WorstCaseTests {
     private static int testAcosCase(double input, double expected) {
         int failures = 0;
         double out = Tests.nextOut(expected);
-        failures += Tests.testBounds("Math.acos",       input, Math.acos(input),       expected, out);
-        failures += Tests.testBounds("StrictMath.acos", input, StrictMath.acos(input), expected, out);
+        failures += Tests.testBounds("Math.acos",       input, Math::acos,       expected, out);
+        failures += Tests.testBounds("StrictMath.acos", input, StrictMath::acos, expected, out);
         return failures;
     }
 
@@ -309,8 +308,8 @@ public class WorstCaseTests {
     private static int testTanCase(double input, double expected) {
         int failures = 0;
         double out = Tests.nextOut(expected);
-        failures += Tests.testBounds("Math.tan",       input, Math.tan(input),       expected, out);
-        failures += Tests.testBounds("StrictMath.tan", input, StrictMath.tan(input), expected, out);
+        failures += Tests.testBounds("Math.tan",       input, Math::tan,       expected, out);
+        failures += Tests.testBounds("StrictMath.tan", input, StrictMath::tan, expected, out);
         return failures;
     }
 
@@ -341,8 +340,8 @@ public class WorstCaseTests {
     private static int testAtanCase(double input, double expected) {
         int failures = 0;
         double out = Tests.nextOut(expected);
-        failures += Tests.testBounds("Math.atan",       input, Math.atan(input),       expected, out);
-        failures += Tests.testBounds("StrictMath.atan", input, StrictMath.atan(input), expected, out);
+        failures += Tests.testBounds("Math.atan",       input, Math::atan,       expected, out);
+        failures += Tests.testBounds("StrictMath.atan", input, StrictMath::atan, expected, out);
         return failures;
     }
 
@@ -367,8 +366,8 @@ public class WorstCaseTests {
     private static int testPow2Case(double input, double expected) {
         int failures = 0;
         double out = Tests.nextOut(expected);
-        failures += Tests.testBounds("Math.pow2",       input, Math.pow(2, input),       expected, out);
-        failures += Tests.testBounds("StrictMath.pow2", input, StrictMath.pow(2, input), expected, out);
+        failures += Tests.testBounds("Math.pow2",       input, d -> Math.pow(2, d),       expected, out);
+        failures += Tests.testBounds("StrictMath.pow2", input, d -> StrictMath.pow(2, d), expected, out);
         return failures;
     }
 
@@ -400,8 +399,8 @@ public class WorstCaseTests {
     private static int testSinhCase(double input, double expected) {
         int failures = 0;
         double out = Tests.nextOut(expected);
-        failures += Tests.testBounds("Math.sinh",       input, Math.sinh(input),       expected, out);
-        failures += Tests.testBounds("StrictMath.sinh", input, StrictMath.sinh(input), expected, out);
+        failures += Tests.testBounds("Math.sinh",       input, Math::sinh,       expected, out);
+        failures += Tests.testBounds("StrictMath.sinh", input, StrictMath::sinh, expected, out);
         return failures;
     }
 
@@ -428,8 +427,8 @@ public class WorstCaseTests {
     private static int testCoshCase(double input, double expected) {
         int failures = 0;
         double out = Tests.nextOut(expected);
-        failures += Tests.testBounds("Math.cosh",       input, Math.cosh(input),       expected, out);
-        failures += Tests.testBounds("StrictMath.cosh", input, StrictMath.cosh(input), expected, out);
+        failures += Tests.testBounds("Math.cosh",       input, Math::cosh,       expected, out);
+        failures += Tests.testBounds("StrictMath.cosh", input, StrictMath::cosh, expected, out);
         return failures;
     }
 }

--- a/test/jdk/java/lang/StrictMath/CubeRootTests.java
+++ b/test/jdk/java/lang/StrictMath/CubeRootTests.java
@@ -71,9 +71,9 @@ public class CubeRootTests {
         double minus_expected = -expected;
 
         failures+=Tests.test("StrictMath.cbrt(double)", input,
-                             StrictMath.cbrt(input), expected);
+                             StrictMath::cbrt, expected);
         failures+=Tests.test("StrictMath.cbrt(double)", minus_input,
-                             StrictMath.cbrt(minus_input), minus_expected);
+                             StrictMath::cbrt, minus_expected);
         return failures;
     }
 

--- a/test/jdk/java/lang/StrictMath/CubeRootTests.java
+++ b/test/jdk/java/lang/StrictMath/CubeRootTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@
  * @build CubeRootTests
  * @run main CubeRootTests
  * @summary Tests specifically for StrictMath.cbrt
- * @author Joseph D. Darcy
  */
 
 import jdk.test.lib.RandomFactory;

--- a/test/jdk/java/lang/StrictMath/Expm1Tests.java
+++ b/test/jdk/java/lang/StrictMath/Expm1Tests.java
@@ -26,6 +26,8 @@
  * @bug 4851638
  * @summary Tests for StrictMath.expm1
  * @author Joseph D. Darcy
+ * @compile -Xdiags:verbose Expm1Tests.java
+ * @run main Expm1Tests
  */
 
 /**
@@ -44,7 +46,7 @@ public class Expm1Tests {
 
     static int testExpm1Case(double input, double expected) {
         return Tests.test("StrictMath.expm1(double)", input,
-                          StrictMath.expm1(input), expected);
+                          StrictMath::expm1, expected);
     }
 
     static int testExpm1() {

--- a/test/jdk/java/lang/StrictMath/Expm1Tests.java
+++ b/test/jdk/java/lang/StrictMath/Expm1Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4851638
  * @summary Tests for StrictMath.expm1
- * @author Joseph D. Darcy
  * @compile -Xdiags:verbose Expm1Tests.java
  * @run main Expm1Tests
  */

--- a/test/jdk/java/lang/StrictMath/HyperbolicTests.java
+++ b/test/jdk/java/lang/StrictMath/HyperbolicTests.java
@@ -45,17 +45,17 @@ public class HyperbolicTests {
 
     static int testSinhCase(double input, double expected) {
         return Tests.test("StrictMath.sinh(double)", input,
-                          StrictMath.sinh(input), expected);
+                          StrictMath::sinh, expected);
     }
 
     static int testCoshCase(double input, double expected) {
         return Tests.test("StrictMath.cosh(double)", input,
-                          StrictMath.cosh(input), expected);
+                          StrictMath::cosh, expected);
     }
 
     static int testTanhCase(double input, double expected) {
         return Tests.test("StrictMath.tanh(double)", input,
-                          StrictMath.tanh(input), expected);
+                          StrictMath::tanh, expected);
     }
 
     static int testSinh() {

--- a/test/jdk/java/lang/StrictMath/HyperbolicTests.java
+++ b/test/jdk/java/lang/StrictMath/HyperbolicTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4851625
  * @summary Tests for StrictMath.{sinh, cosh, tanh}
- * @author Joseph D. Darcy
  */
 
 /**

--- a/test/jdk/java/lang/StrictMath/HypotTests.java
+++ b/test/jdk/java/lang/StrictMath/HypotTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@
  * @build FdlibmTranslit
  * @build HypotTests
  * @run main HypotTests
- * @author Joseph D. Darcy
  */
 
 import jdk.test.lib.RandomFactory;

--- a/test/jdk/java/lang/StrictMath/HypotTests.java
+++ b/test/jdk/java/lang/StrictMath/HypotTests.java
@@ -72,28 +72,28 @@ public class HypotTests {
     static int testHypotCase(double input1, double input2, double expected) {
         int failures = 0;
         failures += Tests.test("StrictMath.hypot(double)", input1, input2,
-                               StrictMath.hypot(input1, input2), expected);
+                               StrictMath::hypot, expected);
 
         failures += Tests.test("StrictMath.hypot(double)", input2, input1,
-                          StrictMath.hypot(input2, input1), expected);
+                               StrictMath::hypot, expected);
 
         failures += Tests.test("StrictMath.hypot(double)", -input1, input2,
-                               StrictMath.hypot(-input1, input2), expected);
+                               StrictMath::hypot, expected);
 
         failures += Tests.test("StrictMath.hypot(double)", input2, -input1,
-                          StrictMath.hypot(input2, -input1), expected);
+                               StrictMath::hypot, expected);
 
         failures += Tests.test("StrictMath.hypot(double)", input1, -input2,
-                               StrictMath.hypot(input1, -input2), expected);
+                               StrictMath::hypot, expected);
 
         failures += Tests.test("StrictMath.hypot(double)", -input2, input1,
-                          StrictMath.hypot(-input2, input1), expected);
+                               StrictMath::hypot, expected);
 
         failures += Tests.test("StrictMath.hypot(double)", -input1, -input2,
-                               StrictMath.hypot(-input1, -input2), expected);
+                               StrictMath::hypot, expected);
 
         failures +=  Tests.test("StrictMath.hypot(double)", -input2, -input1,
-                          StrictMath.hypot(-input2, -input1), expected);
+                                StrictMath::hypot, expected);
         return failures;
     }
 

--- a/test/jdk/java/lang/StrictMath/Log10Tests.java
+++ b/test/jdk/java/lang/StrictMath/Log10Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4074599
  * @summary Tests for StrictMath.log10
- * @author Joseph D. Darcy
  */
 
 

--- a/test/jdk/java/lang/StrictMath/Log10Tests.java
+++ b/test/jdk/java/lang/StrictMath/Log10Tests.java
@@ -45,7 +45,7 @@ public class Log10Tests {
 
     static int testLog10Case(double input, double expected) {
         return Tests.test("StrictMath.log10(double)", input,
-                          StrictMath.log10(input), expected);
+                          StrictMath::log10, expected);
     }
 
     static int testLog10() {

--- a/test/jdk/java/lang/StrictMath/Log1pTests.java
+++ b/test/jdk/java/lang/StrictMath/Log1pTests.java
@@ -44,7 +44,7 @@ public class Log1pTests {
 
     static int testLog1pCase(double input, double expected) {
         return Tests.test("StrictMath.log1p(double)", input,
-                          StrictMath.log1p(input), expected);
+                          StrictMath::log1p, expected);
     }
 
     static int testLog1p() {

--- a/test/jdk/java/lang/StrictMath/Log1pTests.java
+++ b/test/jdk/java/lang/StrictMath/Log1pTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4851638
  * @summary Tests for StrictMath.log1p
- * @author Joseph D. Darcy
  */
 
 /**

--- a/test/jdk/java/lang/StrictMath/PowTests.java
+++ b/test/jdk/java/lang/StrictMath/PowTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 8136874
  * @summary Tests for StrictMath.pow
- * @author Joseph D. Darcy
  */
 
 /**

--- a/test/jdk/java/lang/StrictMath/PowTests.java
+++ b/test/jdk/java/lang/StrictMath/PowTests.java
@@ -295,7 +295,7 @@ public class PowTests {
     private static int testPowCase(double input1, double input2, double expected) {
         int failures = 0;
         failures += Tests.test("StrictMath.pow(double)", input1, input2,
-                               StrictMath.pow(input1, input2), expected);
+                               StrictMath::pow, expected);
         return failures;
     }
 }

--- a/test/jdk/java/lang/StrictMath/Tests.java
+++ b/test/jdk/java/lang/StrictMath/Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@ import java.util.function.*;
 /*
  * Shared static test method for StrictMath tests.
  */
-
 
 public class Tests {
     private Tests(){}

--- a/test/jdk/java/lang/StrictMath/Tests.java
+++ b/test/jdk/java/lang/StrictMath/Tests.java
@@ -21,9 +21,9 @@
  * questions.
  */
 
+import java.util.function.*;
+
 /*
- *
- *
  * Shared static test method for StrictMath tests.
  */
 
@@ -31,23 +31,38 @@
 public class Tests {
     private Tests(){}
 
-    static int test(String testName,
-                    double input,
-                    double result,
-                    double expected) {
+    public static int test(String testName,
+                           double input,
+                           DoubleUnaryOperator func,
+                           double expected) {
+        return test(testName, input, func.applyAsDouble(input), expected);
+    }
+
+    public static int test(String testName,
+                           double input,
+                           double result,
+                           double expected) {
         if (Double.compare(expected, result ) != 0) {
             System.err.println("Failure for " + testName + ":\n" +
                                "\tFor input "   + input    + "\t(" + Double.toHexString(input) + ")\n" +
                                "\texpected  " + expected + "\t(" + Double.toHexString(expected) + ")\n" +
                                "\tgot       " + result   + "\t(" + Double.toHexString(result) + ").");
             return 1;
-        }
-        else
+        } else {
             return 0;
+        }
     }
 
-    static int test(String testName, double input1,  double input2,
-                    double result, double expected) {
+    public static int test(String testName,
+                           double input1,
+                           double input2,
+                           DoubleBinaryOperator func,
+                           double expected) {
+        return test(testName, input1, input2, func.applyAsDouble(input1, input2), expected);
+    }
+
+    public static int test(String testName, double input1, double input2,
+                           double result, double expected) {
         if (Double.compare(expected, result ) != 0) {
             System.err.println("Failure for " + testName + ":\n" +
                                "\tFor input "   + input1   + "\t(" + Double.toHexString(input1) + "), " +
@@ -55,9 +70,9 @@ public class Tests {
                                "\texpected  " + expected + "\t(" + Double.toHexString(expected) + ")\n" +
                                "\tgot       " + result   + "\t(" + Double.toHexString(result) + ").");
             return 1;
-        }
-        else
+        } else {
             return 0;
+        }
     }
 
     /**

--- a/test/jdk/java/lang/StrictMath/Tests.java
+++ b/test/jdk/java/lang/StrictMath/Tests.java
@@ -21,7 +21,8 @@
  * questions.
  */
 
-import java.util.function.*;
+import java.util.function.DoubleBinaryOperator;
+import java.util.function.DoubleUnaryOperator;
 
 /*
  * Shared static test method for StrictMath tests.


### PR DESCRIPTION
Update the java.lang.{Math, StrictMath} regression test helper library to accept method references. This allows the test programs to be DRY-er as the inputs to the method under test don't have to be repeated. The float test method were not updated due to limitations in type inference if both float and double methods with functional interface parameters are present.

Also did some general tidying up for the test code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270476](https://bugs.openjdk.java.net/browse/JDK-8270476): Make floating-point test infrastructure more lambda and method reference friendly


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to 789782ce1f19df291e9df6a5421df2a7196cf7ea


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7216/head:pull/7216` \
`$ git checkout pull/7216`

Update a local copy of the PR: \
`$ git checkout pull/7216` \
`$ git pull https://git.openjdk.java.net/jdk pull/7216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7216`

View PR using the GUI difftool: \
`$ git pr show -t 7216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7216.diff">https://git.openjdk.java.net/jdk/pull/7216.diff</a>

</details>
