### PR TITLE
8280601: ClhsdbThreadContext.java test is triggering codecache related asserts

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerFinder.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerFinder.java
@@ -135,7 +135,12 @@ public class PointerFinder {
       CodeCache c = VM.getVM().getCodeCache();
       if (c.contains(a)) {
         loc.inCodeCache = true;
-        loc.blob = c.findBlobUnsafe(a);
+        try {
+            loc.blob = c.findBlobUnsafe(a);
+        } catch (Exception e) {
+            // Since we potentially have a random address in the codecache and therefore could
+            // be dealing with a freed or partialy intialized blob, exceptions are possible.
+        }
         if (loc.blob == null) {
             // It's possible that there is no CodeBlob for this address. Let
             // PointerLocation deal with it.

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerFinder.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -136,8 +136,11 @@ public class PointerFinder {
       if (c.contains(a)) {
         loc.inCodeCache = true;
         loc.blob = c.findBlobUnsafe(a);
-        if (Assert.ASSERTS_ENABLED) {
-          Assert.that(loc.blob != null, "Should have found CodeBlob");
+        if (loc.blob == null) {
+            // It's possible that there is no CodeBlob for this address. Let
+            // PointerLocation deal with it.
+            loc.inBlobUnknownLocation = true;
+            return loc;
         }
         loc.inBlobCode = loc.blob.codeContains(a);
         loc.inBlobData = loc.blob.dataContains(a);

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -304,15 +304,18 @@ public class PointerLocation {
         if (Assert.ASSERTS_ENABLED) {
           Assert.that(isInBlobUnknownLocation(), "Should have known location in CodeBlob");
         }
-        tty.print("unknown location");
+        tty.print("unknown CodeCache location");
       }
-      tty.print(" in ");
-      if (verbose) {
-          b.printOn(tty); // includes "\n"
+      if (b == null) {
+          tty.println();
       } else {
-          tty.println(b.toString());
+          tty.print(" in ");
+          if (verbose) {
+              b.printOn(tty); // includes "\n"
+          } else {
+              tty.println(b.toString());
+          }
       }
-
       // FIXME: add more detail
     } else if (isInStrongGlobalJNIHandles()) {
       tty.println("In JNI strong global");

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
@@ -301,19 +301,23 @@ public class PointerLocation {
       } else if (isInBlobOops()) {
         tty.print("oops");
       } else {
-        if (Assert.ASSERTS_ENABLED) {
-          Assert.that(isInBlobUnknownLocation(), "Should have known location in CodeBlob");
-        }
         tty.print("unknown CodeCache location");
       }
       if (b == null) {
           tty.println();
       } else {
           tty.print(" in ");
-          if (verbose) {
-              b.printOn(tty); // includes "\n"
-          } else {
-              tty.println(b.toString());
+          // Since we potentially have a random address in the codecache and therefore could
+          // be dealing with a freed or partialy intialized blob, exceptions are possible.
+          // One known case is an NMethod where the method is still null, resulting in an NPE.
+          try {
+              if (verbose) {
+                  b.printOn(tty); // includes "\n"
+              } else {
+                  tty.println(b.toString());
+              }
+          } catch (Exception e) {
+              tty.println("<unknown>");
           }
       }
       // FIXME: add more detail


### PR DESCRIPTION
It's possible for an address to be in the codecache but not in any CodeBlob. Don't assert in this case.

Also I ran into a couple of other asserts listed below. It looks like since dumping the threadcontext can result in using PointerFinder with fairly random addresses, it is doing a much better job of stress testing PointerFinder than is done by other tests. The root issue in all these asserts is that a random address in the codecache can either be outside of any CodeBlob, or can map to a CodeBlob that is not yet initialized or could even have been freed. PointerFinder and PointerLocation need to be prepared to handled these asserts, and any other exception thrown. 

sun.jvm.hotspot.utilities.AssertionFailure: found wrong CodeBlob
at jdk.hotspot.agent/sun.jvm.hotspot.utilities.Assert.that(Assert.java:32)
at jdk.hotspot.agent/sun.jvm.hotspot.code.CodeCache.findBlobUnsafe(CodeCache.java:140)
at jdk.hotspot.agent/sun.jvm.hotspot.utilities.PointerFinder.find(PointerFinder.java:138)
at jdk.hotspot.agent/sun.jvm.hotspot.runtime.JavaThread.printThreadContextOn(JavaThread.java:493)
at jdk.hotspot.agent/sun.jvm.hotspot.CommandProcessor$46.doit(CommandProcessor.java:1702)
at jdk.hotspot.agent/sun.jvm.hotspot.CommandProcessor.executeCommand(CommandProcessor.java:2215)
at jdk.hotspot.agent/sun.jvm.hotspot.CommandProcessor.executeCommand(CommandProcessor.java:2185)
at jdk.hotspot.agent/sun.jvm.hotspot.CommandProcessor.run(CommandProcessor.java:2056)
at jdk.hotspot.agent/sun.jvm.hotspot.CLHSDB.run(CLHSDB.java:112)
at jdk.hotspot.agent/sun.jvm.hotspot.CLHSDB.main(CLHSDB.java:44)
at jdk.hotspot.agent/sun.jvm.hotspot.SALauncher.runCLHSDB(SALauncher.java:281)
at jdk.hotspot.agent/sun.jvm.hotspot.SALauncher.main(SALauncher.java:500)

sun.jvm.hotspot.utilities.AssertionFailure: Should have found CodeBlob
at jdk.hotspot.agent/sun.jvm.hotspot.utilities.Assert.that(Assert.java:32)
at jdk.hotspot.agent/sun.jvm.hotspot.utilities.PointerFinder.find(PointerFinder.java:140)
at jdk.hotspot.agent/sun.jvm.hotspot.runtime.JavaThread.printThreadContextOn(JavaThread.java:493)
at jdk.hotspot.agent/sun.jvm.hotspot.CommandProcessor$46.doit(CommandProcessor.java:1702)
at jdk.hotspot.agent/sun.jvm.hotspot.CommandProcessor.executeCommand(CommandProcessor.java:2215)
at jdk.hotspot.agent/sun.jvm.hotspot.CommandProcessor.executeCommand(CommandProcessor.java:2185)
at jdk.hotspot.agent/sun.jvm.hotspot.CommandProcessor.run(CommandProcessor.java:2056)
at jdk.hotspot.agent/sun.jvm.hotspot.CLHSDB.run(CLHSDB.java:112)
at jdk.hotspot.agent/sun.jvm.hotspot.CLHSDB.main(CLHSDB.java:44)
at jdk.hotspot.agent/sun.jvm.hotspot.SALauncher.runCLHSDB(SALauncher.java:281)
at jdk.hotspot.agent/sun.jvm.hotspot.SALauncher.main(SALauncher.java:500)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280601](https://bugs.openjdk.java.net/browse/JDK-8280601): ClhsdbThreadContext.java test is triggering codecache related asserts


### Reviewers
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7217/head:pull/7217` \
`$ git checkout pull/7217`

Update a local copy of the PR: \
`$ git checkout pull/7217` \
`$ git pull https://git.openjdk.java.net/jdk pull/7217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7217`

View PR using the GUI difftool: \
`$ git pr show -t 7217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7217.diff">https://git.openjdk.java.net/jdk/pull/7217.diff</a>

</details>
