### PR TITLE
4750574: (se spec) Selector spec should clarify calculation of select return value

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/Selector.java
+++ b/src/java.base/share/classes/java/nio/channels/Selector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -355,7 +355,8 @@ public abstract class Selector implements Closeable {
      * of the {@link #wakeup wakeup} method.  </p>
      *
      * @return  The number of keys, possibly zero, whose ready-operation sets
-     *          were updated by the selection operation
+     *          now indicate readiness for at least one category of operations
+     *          for which the channel was not previously detected to be ready
      *
      * @throws  IOException
      *          If an I/O error occurs
@@ -383,8 +384,9 @@ public abstract class Selector implements Closeable {
      *                  channel to become ready; if zero, block indefinitely;
      *                  must not be negative
      *
-     * @return  The number of keys, possibly zero,
-     *          whose ready-operation sets were updated
+     * @return  The number of keys, possibly zero, whose ready-operation sets
+     *          now indicate readiness for at least one category of operations
+     *          for which the channel was not previously detected to be ready
      *
      * @throws  IOException
      *          If an I/O error occurs
@@ -406,8 +408,9 @@ public abstract class Selector implements Closeable {
      * this selector's {@link #wakeup wakeup} method is invoked, or the current
      * thread is interrupted, whichever comes first.  </p>
      *
-     * @return  The number of keys, possibly zero,
-     *          whose ready-operation sets were updated
+     * @return  The number of keys, possibly zero, whose ready-operation sets
+     *          now indicate readiness for at least one category of operations
+     *          for which the channel was not previously detected to be ready
      *
      * @throws  IOException
      *          If an I/O error occurs


### PR DESCRIPTION
Improve the description of the return value of each of the `Selector.select()` methods which do not accept an action parameter.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-4750574](https://bugs.openjdk.java.net/browse/JDK-4750574): (se spec) Selector spec should clarify calculation of select return value
 * [JDK-8280675](https://bugs.openjdk.java.net/browse/JDK-8280675): (se spec) Selector spec should clarify calculation of select return value (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7220/head:pull/7220` \
`$ git checkout pull/7220`

Update a local copy of the PR: \
`$ git checkout pull/7220` \
`$ git pull https://git.openjdk.java.net/jdk pull/7220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7220`

View PR using the GUI difftool: \
`$ git pr show -t 7220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7220.diff">https://git.openjdk.java.net/jdk/pull/7220.diff</a>

</details>
