### PR TITLE
8278325: excluded class should not be checked again for exclusion

### DIFF
--- a/src/hotspot/share/cds/dumpTimeClassInfo.cpp
+++ b/src/hotspot/share/cds/dumpTimeClassInfo.cpp
@@ -173,7 +173,7 @@ class CountClassByCategory : StackObj {
 public:
   CountClassByCategory(DumpTimeSharedClassTable* table) : _table(table) {}
   bool do_entry(InstanceKlass* k, DumpTimeClassInfo& info) {
-    if (!info.is_excluded()) {
+    if (!info.should_be_excluded()) {
       if (info.is_builtin()) {
         _table->inc_builtin_count();
       } else {

--- a/src/hotspot/share/cds/dumpTimeClassInfo.hpp
+++ b/src/hotspot/share/cds/dumpTimeClassInfo.hpp
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -134,7 +134,8 @@ public:
     }
   }
 
-  bool is_excluded() {
+  bool is_excluded() { return _excluded; }
+  bool should_be_excluded() {
     // _klass may become NULL due to DynamicArchiveBuilder::set_to_null
     return _excluded || _failed_verification || _klass == NULL;
   }


### PR DESCRIPTION
Hi, Please review

  When LambdaFormInvoker regenerate lambda form holder class, the old class with the same name already loaded and is marked for excluded for dump. This class should not be checked against exclusion, or it will output unexpected warning like:
[0.394s][warning][cds] Skipping java/lang/invoke/BoundMethodHandle$Species_J: Unsupported location
[0.394s][warning][cds] Skipping java/lang/invoke/BoundMethodHandle$Species_JL: Unsupported location
[0.394s][warning][cds] Skipping java/lang/invoke/BoundMethodHandle$Species_FL: Unsupported location
[0.394s][warning][cds] Skipping java/lang/invoke/BoundMethodHandle$Species_F: Unsupported location
  The fix changed the order for checking exclusion of a class --- only check for those not already excluded ones. Original function DumpTimeClassInfo::is_excluded in fact is checking three conditions in logical OR, it does not tell which reason for exclusion. In this fix, we need check the exact reason which is set for _excluded. Original is_excluded is renamed to should_be_excluded.

Tests: tier1,tier4 (in testing)
           local jtreg passed for runtime/cds/appcds
Thanks
Yumin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8278325](https://bugs.openjdk.java.net/browse/JDK-8278325): excluded class should not be checked again for exclusion


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7224/head:pull/7224` \
`$ git checkout pull/7224`

Update a local copy of the PR: \
`$ git checkout pull/7224` \
`$ git pull https://git.openjdk.java.net/jdk pull/7224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7224`

View PR using the GUI difftool: \
`$ git pr show -t 7224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7224.diff">https://git.openjdk.java.net/jdk/pull/7224.diff</a>

</details>
