### PR TITLE
8076089: Cleanup: Inline & remove sun.management.Util.newException

### DIFF
--- a/src/java.management/share/classes/sun/management/LockInfoCompositeData.java
+++ b/src/java.management/share/classes/sun/management/LockInfoCompositeData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ public class LockInfoCompositeData extends LazyCompositeData {
             return new CompositeDataSupport(LOCK_INFO_COMPOSITE_TYPE, items);
         } catch (OpenDataException e) {
             // Should never reach here
-            throw Util.newException(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -79,7 +79,7 @@ public class LockInfoCompositeData extends LazyCompositeData {
                 MappedMXBeanType.toOpenType(LockInfo.class);
         } catch (OpenDataException e) {
             // Should never reach here
-            throw Util.newException(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/java.management/share/classes/sun/management/ManagementFactoryHelper.java
+++ b/src/java.management/share/classes/sun/management/ManagementFactoryHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -482,7 +482,7 @@ public class ManagementFactoryHelper {
                 }
             });
         } catch (PrivilegedActionException e) {
-            throw Util.newException(e.getException());
+            throw new RuntimeException(e.getException());
         }
     }
 
@@ -540,7 +540,7 @@ public class ManagementFactoryHelper {
                 }
             });
         } catch (PrivilegedActionException e) {
-            throw Util.newException(e.getException());
+            throw new RuntimeException(e.getException());
         }
     }
 

--- a/src/java.management/share/classes/sun/management/Util.java
+++ b/src/java.management/share/classes/sun/management/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,10 +33,6 @@ import javax.management.MalformedObjectNameException;
 
 public class Util {
     private Util() {}  // there are no instances of this class
-
-    static RuntimeException newException(Exception e) {
-        throw new RuntimeException(e);
-    }
 
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
     static String[] toStringArray(List<String> list) {


### PR DESCRIPTION
Can I please get a review for this cleanup that's requested in https://bugs.openjdk.java.net/browse/JDK-8076089?

The change here removes a package private method `sun.management.Util.newException(Exception e)` and inlines its implementation at the caller locations.

Given the nature of this change no new jtreg tests have been added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8076089](https://bugs.openjdk.java.net/browse/JDK-8076089): Cleanup: Inline & remove sun.management.Util.newException


### Reviewers
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7226/head:pull/7226` \
`$ git checkout pull/7226`

Update a local copy of the PR: \
`$ git checkout pull/7226` \
`$ git pull https://git.openjdk.java.net/jdk pull/7226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7226`

View PR using the GUI difftool: \
`$ git pr show -t 7226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7226.diff">https://git.openjdk.java.net/jdk/pull/7226.diff</a>

</details>
