### PR TITLE
8139173: [macosx] JInternalFrame shadow is not properly drawn

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaInternalFrameBorder.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaInternalFrameBorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -379,8 +379,6 @@ public class AquaInternalFrameBorder implements Border, UIResource {
         final int y = inY;
         final int w = inW;
         int h = inH;
-
-        h = metrics.titleBarHeight + inH;
 
         // paint the background
         titleBarPainter.state.set(frame.isSelected() ? State.ACTIVE : State.INACTIVE);

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaInternalFrameBorder.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaInternalFrameBorder.java
@@ -378,7 +378,7 @@ public class AquaInternalFrameBorder implements Border, UIResource {
         final int x = inX;
         final int y = inY;
         final int w = inW;
-        int h = inH;
+        final int h = inH;
 
         // paint the background
         titleBarPainter.state.set(frame.isSelected() ? State.ACTIVE : State.INACTIVE);

--- a/test/jdk/javax/swing/plaf/aqua/JInternalFrameBorderTest.java
+++ b/test/jdk/javax/swing/plaf/aqua/JInternalFrameBorderTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key headful
+ * @bug 8139173
+ * @requires (os.family == "mac")
+ * @summary Verify JInternalFrame's border
+ * @run main JInternalFrameBorderTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import javax.swing.JDesktopPane;
+import javax.swing.JFrame;
+import javax.swing.JInternalFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+public class JInternalFrameBorderTest {
+
+    private static JFrame frame;
+    private static JDesktopPane desktopPane;
+    private static JInternalFrame internalFrame;
+    private static final int LIMIT = 100;
+    private static Robot robot;
+
+    public static void main(String[] args) throws Exception {
+        robot = new Robot();
+        try {
+            UIManager.setLookAndFeel("com.apple.laf.AquaLookAndFeel");
+        } catch (Exception e) {
+            throw new RuntimeException("Cannot initialize Aqua L&F");
+        }
+
+        createUI();
+        robot.waitForIdle();
+        robot.delay(1000);
+
+        Point p = internalFrame.getLocationOnScreen();
+        Rectangle rect = internalFrame.getBounds();
+        Insets insets = internalFrame.getInsets();
+
+        // bottom
+        int x = p.x + rect.x + rect.width/2;
+        int y = p.y + rect.y + rect.height - insets.bottom + 1;
+        Color colorBottom = robot.getPixelColor(x, y);
+
+        // left
+        x = p.x + rect.x + insets.left - 1;
+        y = p.y + rect.y + rect.height/2;
+        Color colorLeft = robot.getPixelColor(x, y);
+
+        // right
+        x = p.x + rect.x + rect.width - insets.left + 1;
+        y = p.y + rect.y + rect.height/2;
+        Color colorRight = robot.getPixelColor(x, y);
+
+        robot.waitForIdle();
+        cleanUp();
+
+        int diff = getDiff(colorLeft, colorBottom);
+        if (diff > LIMIT) {
+            throw new RuntimeException("Unexpected border bottom=" +
+                    colorBottom + " left=" + colorLeft);
+        }
+        diff = getDiff(colorRight, colorBottom);
+        if (diff > LIMIT) {
+            throw new RuntimeException("Unexpected border bottom=" +
+                    colorBottom + " right=" + colorRight);
+        }
+    }
+
+    private static void createUI() throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            desktopPane = new JDesktopPane() {
+                @Override
+                protected void paintComponent(Graphics g) {
+                    super.paintComponent(g);
+                    g.setColor(Color.BLUE);
+                    g.fillRect(0, 0, getWidth(), getHeight());
+                }
+            };
+            internalFrame = new JInternalFrame();
+            frame = new JFrame();
+            internalFrame.setSize(500, 200);
+            internalFrame.setVisible(true);
+            desktopPane.add(internalFrame);
+
+            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+            frame.getContentPane().setLayout(new BorderLayout());
+            frame.getContentPane().add(desktopPane, "Center");
+            frame.setSize(500, 500);
+            frame.setLocationRelativeTo(null);
+            frame.setVisible(true);
+            frame.toFront();
+        });
+    }
+
+    private static int getDiff(Color c1, Color c2) {
+        int r = Math.abs(c1.getRed()   - c2.getRed());
+        int g = Math.abs(c1.getGreen() - c2.getGreen());
+        int b = Math.abs(c1.getBlue()  - c2.getBlue());
+        return r + g + b;
+    }
+
+    private static void cleanUp() throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            frame.dispose();
+        });
+    }
+}

--- a/test/jdk/javax/swing/plaf/aqua/JInternalFrameBorderTest.java
+++ b/test/jdk/javax/swing/plaf/aqua/JInternalFrameBorderTest.java
@@ -50,36 +50,36 @@ public class JInternalFrameBorderTest {
     private static JInternalFrame internalFrame;
     private static final int LIMIT = 100;
     private static Robot robot;
+    private static Point pos;
+    private static Rectangle rect;
+    private static Insets insets;
 
     public static void main(String[] args) throws Exception {
         robot = new Robot();
-        try {
-            UIManager.setLookAndFeel("com.apple.laf.AquaLookAndFeel");
-        } catch (Exception e) {
-            throw new RuntimeException("Cannot initialize Aqua L&F");
-        }
-
         createUI();
         robot.waitForIdle();
         robot.delay(1000);
 
-        Point p = internalFrame.getLocationOnScreen();
-        Rectangle rect = internalFrame.getBounds();
-        Insets insets = internalFrame.getInsets();
+        SwingUtilities.invokeAndWait(() -> {
+            pos = internalFrame.getLocationOnScreen();
+            rect = internalFrame.getBounds();
+            insets = internalFrame.getInsets();
+        });
+        robot.waitForIdle();
 
         // bottom
-        int x = p.x + rect.x + rect.width/2;
-        int y = p.y + rect.y + rect.height - insets.bottom + 1;
+        int x = pos.x + rect.x + rect.width/2;
+        int y = pos.y + rect.y + rect.height - insets.bottom + 1;
         Color colorBottom = robot.getPixelColor(x, y);
 
         // left
-        x = p.x + rect.x + insets.left - 1;
-        y = p.y + rect.y + rect.height/2;
+        x = pos.x + rect.x + insets.left - 1;
+        y = pos.y + rect.y + rect.height/2;
         Color colorLeft = robot.getPixelColor(x, y);
 
         // right
-        x = p.x + rect.x + rect.width - insets.left + 1;
-        y = p.y + rect.y + rect.height/2;
+        x = pos.x + rect.x + rect.width - insets.left + 1;
+        y = pos.y + rect.y + rect.height/2;
         Color colorRight = robot.getPixelColor(x, y);
 
         robot.waitForIdle();
@@ -99,6 +99,11 @@ public class JInternalFrameBorderTest {
 
     private static void createUI() throws Exception {
         SwingUtilities.invokeAndWait(() -> {
+            try {
+                UIManager.setLookAndFeel("com.apple.laf.AquaLookAndFeel");
+            } catch (Exception e) {
+                throw new RuntimeException("Cannot initialize Aqua L&F");
+            }
             desktopPane = new JDesktopPane() {
                 @Override
                 protected void paintComponent(Graphics g) {


### PR DESCRIPTION
JInternalFrame's bottom area is not properly drawn with Aqua LAF.
This problem remained for long time, but we recognized it recently.

According to the bug report, it depends on MacOS's version. I don't have old ones (10.10 and 10.11 in the report), but the current MacOS can recreate the issue. I confirmed the following OS versions recreated this issue and this patch could solve it.

Mojave 10.14.6
Catalina 10.15.7
Big Sur 11.6.2
Monterey 12.1

jtreg "javax/swing" and "java/awt" have no regression.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8139173](https://bugs.openjdk.java.net/browse/JDK-8139173): [macosx] JInternalFrame shadow is not properly drawn


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to 44ea0e12708666e3972bc3e4c64396cb91a06e11
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7228/head:pull/7228` \
`$ git checkout pull/7228`

Update a local copy of the PR: \
`$ git checkout pull/7228` \
`$ git pull https://git.openjdk.java.net/jdk pull/7228/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7228`

View PR using the GUI difftool: \
`$ git pr show -t 7228`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7228.diff">https://git.openjdk.java.net/jdk/pull/7228.diff</a>

</details>
