### PR TITLE
8280686: Remove Compile::print_method_impl

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1892,7 +1892,7 @@ bool Compile::inline_incrementally_one() {
         return false;
       } else if (inlining_progress()) {
         _late_inlines_pos = i+1; // restore the position in case new elements were inserted
-        print_method(PHASE_INCREMENTAL_INLINE_STEP, cg->call_node(), 3);
+        print_method(PHASE_INCREMENTAL_INLINE_STEP, 3, cg->call_node());
         break; // process one call site at a time
       }
     } else {
@@ -2357,7 +2357,7 @@ void Compile::inline_vector_reboxing_calls() {
       CallGenerator* cg = _vector_reboxing_late_inlines.pop();
       cg->do_late_inline();
       if (failing())  return;
-      print_method(PHASE_INLINE_VECTOR_REBOX, cg->call_node(), 3);
+      print_method(PHASE_INLINE_VECTOR_REBOX, 3, cg->call_node());
     }
     _vector_reboxing_late_inlines.trunc_to(0);
   }
@@ -4814,11 +4814,7 @@ void Compile::sort_macro_nodes() {
   }
 }
 
-void Compile::print_method(CompilerPhaseType cpt, int level) {
-  print_method(cpt, NULL, level);
-}
-
-void Compile::print_method(CompilerPhaseType cpt, Node* n, int level) {
+void Compile::print_method(CompilerPhaseType cpt, int level, Node* n) {
   EventCompilerPhase event;
   if (event.should_commit()) {
     CompilerEvent::PhaseEvent::post(event, C->_latest_stage_start_counter, cpt, C->_compile_id, level);
@@ -4827,11 +4823,11 @@ void Compile::print_method(CompilerPhaseType cpt, Node* n, int level) {
   ResourceMark rm;
   stringStream ss;
   ss.print_raw(CompilerPhaseTypeHelper::to_string(cpt));
-  if (n != NULL) {
+  if (n != nullptr) {
     ss.print(": %d %s ", n->_idx, NodeClassNames[n->Opcode()]);
   }
 
-  const char *name = ss.as_string();
+  const char* name = ss.as_string();
   if (should_print_igv(level)) {
     _igv_printer->print_method(name, level);
   }

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4815,29 +4815,23 @@ void Compile::sort_macro_nodes() {
 }
 
 void Compile::print_method(CompilerPhaseType cpt, int level) {
-  print_method_impl(cpt, NOT_PRODUCT(CompilerPhaseTypeHelper::to_string(cpt) COMMA) level);
+  print_method(cpt, NULL, level);
 }
 
 void Compile::print_method(CompilerPhaseType cpt, Node* n, int level) {
+  EventCompilerPhase event;
+  if (event.should_commit()) {
+    CompilerEvent::PhaseEvent::post(event, C->_latest_stage_start_counter, cpt, C->_compile_id, level);
+  }
 #ifndef PRODUCT
   ResourceMark rm;
   stringStream ss;
   ss.print_raw(CompilerPhaseTypeHelper::to_string(cpt));
   if (n != NULL) {
     ss.print(": %d %s ", n->_idx, NodeClassNames[n->Opcode()]);
-  } else {
-    ss.print_raw(": NULL");
   }
-#endif
-  C->print_method_impl(cpt, NOT_PRODUCT(ss.as_string() COMMA) level);
-}
 
-void Compile::print_method_impl(CompilerPhaseType cpt, NOT_PRODUCT(const char* name COMMA) int level) {
-  EventCompilerPhase event;
-  if (event.should_commit()) {
-    CompilerEvent::PhaseEvent::post(event, C->_latest_stage_start_counter, cpt, C->_compile_id, level);
-  }
-#ifndef PRODUCT
+  const char *name = ss.as_string();
   if (should_print_igv(level)) {
     _igv_printer->print_method(name, level);
   }

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -655,8 +655,7 @@ class Compile : public Phase {
   void end_method();
   bool should_print_igv(int level);
 
-  void print_method(CompilerPhaseType cpt, int level);
-  void print_method(CompilerPhaseType cpt, Node* n, int level);
+  void print_method(CompilerPhaseType cpt, int level, Node* n = nullptr);
 
 #ifndef PRODUCT
   void igv_print_method_to_file(const char* phase_name = "Debug", bool append = false);

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -657,7 +657,6 @@ class Compile : public Phase {
 
   void print_method(CompilerPhaseType cpt, int level);
   void print_method(CompilerPhaseType cpt, Node* n, int level);
-  void print_method_impl(CompilerPhaseType cpt, NOT_PRODUCT(const char* name COMMA) int level);
 
 #ifndef PRODUCT
   void igv_print_method_to_file(const char* phase_name = "Debug", bool append = false);

--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,7 +96,7 @@ void PhaseVector::scalarize_vbox_nodes() {
       VectorBoxNode* vbox = static_cast<VectorBoxNode*>(n);
       scalarize_vbox_node(vbox);
       if (C->failing())  return;
-      C->print_method(PHASE_SCALARIZE_VBOX, vbox, 3);
+      C->print_method(PHASE_SCALARIZE_VBOX, 3, vbox);
     }
     if (C->failing())  return;
     macro_idx = MIN2(macro_idx - 1, C->macro_count() - 1);
@@ -131,7 +131,7 @@ void PhaseVector::expand_vunbox_nodes() {
       VectorUnboxNode* vec_unbox = static_cast<VectorUnboxNode*>(n);
       expand_vunbox_node(vec_unbox);
       if (C->failing())  return;
-      C->print_method(PHASE_EXPAND_VUNBOX, vec_unbox, 3);
+      C->print_method(PHASE_EXPAND_VUNBOX, 3, vec_unbox);
     }
     if (C->failing())  return;
     macro_idx = MIN2(macro_idx - 1, C->macro_count() - 1);
@@ -149,7 +149,7 @@ void PhaseVector::eliminate_vbox_alloc_nodes() {
       VectorBoxAllocateNode* vbox_alloc = static_cast<VectorBoxAllocateNode*>(n);
       eliminate_vbox_alloc_node(vbox_alloc);
       if (C->failing())  return;
-      C->print_method(PHASE_ELIMINATE_VBOX_ALLOC, vbox_alloc, 3);
+      C->print_method(PHASE_ELIMINATE_VBOX_ALLOC, 3, vbox_alloc);
     }
     if (C->failing())  return;
     macro_idx = MIN2(macro_idx - 1, C->macro_count() - 1);
@@ -297,7 +297,7 @@ void PhaseVector::expand_vbox_node(VectorBoxNode* vec_box) {
     Node* vect = vec_box->in(VectorBoxNode::Value);
     Node* result = expand_vbox_node_helper(vbox, vect, vec_box->box_type(), vec_box->vec_type());
     C->gvn_replace_by(vec_box, result);
-    C->print_method(PHASE_EXPAND_VBOX, vec_box, 3);
+    C->print_method(PHASE_EXPAND_VBOX, 3, vec_box);
   }
   C->remove_macro_node(vec_box);
 }


### PR DESCRIPTION
This is a follow-up task of JDK-8280274. I think it is still reasonable to only evaluate
"CompilerPhaseTypeHelper::to_string(cpt)" when NOT_PRODUCT is defined, but we can do
that in the function body. We should avoid from messing around interfaces with macros.

Actually, it's not necessary to have print_method_impl as a public interface at all.
The only client of it is print_method().

Here is the current interface of Compile::print_method
V1: print_method(CompilerPhaseType cpt, int level)
V2: print_method(CompilerPhaseType cpt, Node* n, int level)

The only client of V2 is vector.cpp. It attempts to dump the phase name and vec_box node. It's impossible to to have n=NULL. No one will consume property <"phase :NULL">.

I think we should go in this way.
```
void Compile::print_method(CompilerPhaseType cpt, int level) {
  print_method(cpt, NULL, level);
  }
```

Testing: 
Verify that igv is still working with PrintIdealGraphLevel=3/4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280686](https://bugs.openjdk.java.net/browse/JDK-8280686): Remove Compile::print_method_impl


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7229/head:pull/7229` \
`$ git checkout pull/7229`

Update a local copy of the PR: \
`$ git checkout pull/7229` \
`$ git pull https://git.openjdk.java.net/jdk pull/7229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7229`

View PR using the GUI difftool: \
`$ git pr show -t 7229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7229.diff">https://git.openjdk.java.net/jdk/pull/7229.diff</a>

</details>
