### PR TITLE
JDK-8280703 CipherCore.doFinal(...) causes potentially massive byte[] allocations during decryption

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
@@ -811,8 +811,11 @@ final class CipherCore {
             // case of ShortBufferException.
             if (outputCapacity < estOutSize) {
                 cipher.save();
+            }
+            if (outputCapacity < estOutSize || padding != null) {
                 // create temporary output buffer if the estimated size is larger
-                // than the user-provided buffer.
+                // than the user-provided buffer or a padding needs to be removed
+                // before copying the unpadded result to the output buffer
                 internalOutput = new byte[estOutSize];
                 offset = 0;
             }

--- a/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
@@ -811,11 +811,11 @@ final class CipherCore {
             // case of ShortBufferException.
             if (outputCapacity < estOutSize) {
                 cipher.save();
+                // create temporary output buffer if the estimated size is larger
+                // than the user-provided buffer.
+                internalOutput = new byte[estOutSize];
+                offset = 0;
             }
-            // create temporary output buffer if the estimated size is larger
-            // than the user-provided buffer.
-            internalOutput = new byte[estOutSize];
-            offset = 0;
         }
 
         byte[] outBuffer = (internalOutput != null) ? internalOutput : output;


### PR DESCRIPTION
Related to #411, however it turns out that for unpadded ciphers, there is no need to allocate `internalOutput`, if `output` provides sufficient capacity.

For padded ciphers, only the unpadded cleartext is expected to be copied to the output buffer. In this case, there is no way around the temporary buffer (without major changes).

While a small change, please review with care, as I might be missing some security-relevant side effect (such as: don't copy cleartext to output buffer before validating the a tag - just as an example, even if there is no authentication involved in this method).

I have some test failures in Tier 1 tests, but these seem to be unrelated. Tests for `com.sun.crypto` and `javax.crypto` run fine:

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/jdk/com/sun/crypto                       141   141     0     0   
   jtreg:test/jdk/javax/crypto                          56    56     0     0   
==============================
TEST SUCCESS
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280703](https://bugs.openjdk.java.net/browse/JDK-8280703): CipherCore.doFinal(...) causes potentially massive byte[] allocations during decryption


### Reviewers
 * [Anthony Scarpino](https://openjdk.java.net/census#ascarpino) (@ascarpino - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7230/head:pull/7230` \
`$ git checkout pull/7230`

Update a local copy of the PR: \
`$ git checkout pull/7230` \
`$ git pull https://git.openjdk.java.net/jdk pull/7230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7230`

View PR using the GUI difftool: \
`$ git pr show -t 7230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7230.diff">https://git.openjdk.java.net/jdk/pull/7230.diff</a>

</details>
