### PR TITLE
8280719: G1: Remove outdated comment in RemoveSelfForwardPtrObjClosure::apply

### DIFF
--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -77,7 +77,6 @@ public:
 
     zap_dead_objects(_last_forwarded_object_end, obj_addr);
 
-    // Zapping clears the bitmap, make sure it didn't clear too much.
     assert(_cm->is_marked_in_prev_bitmap(obj), "should be correctly marked");
     if (_during_concurrent_start) {
       // For the next marking info we'll only mark the


### PR DESCRIPTION
Hi all,

  can I have reviews for this trivial change that removes an obsolete comment after JDK-8280374? Zapping does not clear the bitmap any more.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280719](https://bugs.openjdk.java.net/browse/JDK-8280719): G1: Remove outdated comment in RemoveSelfForwardPtrObjClosure::apply


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7234/head:pull/7234` \
`$ git checkout pull/7234`

Update a local copy of the PR: \
`$ git checkout pull/7234` \
`$ git pull https://git.openjdk.java.net/jdk pull/7234/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7234`

View PR using the GUI difftool: \
`$ git pr show -t 7234`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7234.diff">https://git.openjdk.java.net/jdk/pull/7234.diff</a>

</details>
