### PR TITLE
JDK-8280738: Minor cleanup for HtmlStyle

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlStyle.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlStyle.java
@@ -49,7 +49,7 @@ import java.util.regex.Pattern;
  * The usage is made explicit when it is not clear from the surrounding context.
  *
  * @apiNote
- * The stylized use of {@code editor-fold} comments and line comments (beginning {@code //}
+ * The stylized use of {@code editor-fold} comments and line comments (beginning {@code //})
  * is to support extracting details of declarations with external tools.  Edit with care!
  *
  * @see <a href="https://html.spec.whatwg.org/#classes">WhatWG: {@code class} attribute</a>

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlStyle.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlStyle.java
@@ -48,19 +48,13 @@ import java.util.regex.Pattern;
  * or {@link javax.lang.model.element.Element "language model elements"}.
  * The usage is made explicit when it is not clear from the surrounding context.
  *
+ * @apiNote
+ * The stylized use of {@code editor-fold} comments and line comments (beginning {@code //}
+ * is to support extracting details of declarations with external tools.  Edit with care!
+ *
  * @see <a href="https://html.spec.whatwg.org/#classes">WhatWG: {@code class} attribute</a>
  */
 public enum HtmlStyle {
-
-    /**
-     * The class of the {@code div} element containing a snippet element.
-     */
-    snippetContainer,
-
-    /**
-     * The class of the {@code a} element to copy snippet content to the clipboard.
-     */
-    snippetCopy,
 
     //<editor-fold desc="navigation bar">
     //
@@ -325,17 +319,6 @@ public enum HtmlStyle {
     propertyDetails,
 
     /**
-     * The class for the list containing the {@code @see} tags of an element.
-     */
-    seeList,
-
-    /**
-     * The class for the list containing the {@code @see} tags of an element
-     * when some of the tags have longer labels.
-     */
-    seeListLong,
-
-    /**
      * The class for a {@code section} element containing details of the
      * serialized form of an element, on the "Serialized Form" page.
      */
@@ -390,6 +373,17 @@ public enum HtmlStyle {
      * of a declaration.
      */
     previewLabel,
+
+    /**
+     * The class for the list containing the {@code @see} tags of an element.
+     */
+    seeList,
+
+    /**
+     * The class for the list containing the {@code @see} tags of an element
+     * when some of the tags have longer labels.
+     */
+    seeListLong,
 
     //</editor-fold>
 
@@ -844,6 +838,44 @@ public enum HtmlStyle {
 
     //</editor-fold>
 
+    //<editor-fold desc="snippets">
+    //
+    // The following constants are used for the contents of snippets.
+    // In addition, the translation of a snippet may use the class
+    // {@code language-LANG} where LANG is either specified explicitly
+    // by the "lang" attribute in a snippet tag, or can be inferred
+    // from the kind of an external snippet.
+
+    /**
+     * The class of the {@code pre} element presenting a snippet.
+     */
+    snippet,
+
+    /**
+     * The class of the {@code div} element containing a snippet element.
+     */
+    snippetContainer,
+
+    /**
+     * The class of the UI element to copy snippet content to the clipboard.
+     */
+    snippetCopy,
+
+    /**
+     * The class of text highlighted with the type {@code bold}.
+     */
+    bold,
+
+    /**
+     * The class of text highlighted with the type {@code italic}.
+     */
+    italic,
+
+    /**
+     * The class of text highlighted with the type {@code highlighted}.
+     */
+    highlighted,
+
     //<editor-fold desc="miscellaneous">
     //
     // The following constants are used in various places across a variety of pages.
@@ -908,7 +940,8 @@ public enum HtmlStyle {
     inheritedList,
 
     /**
-     * The class of an element that acts as a notification for an invalid tag.
+     * The class of an element that acts as a notification for an invalid tag
+     * or other invalid items.
      */
     invalidTag,
 
@@ -923,7 +956,7 @@ public enum HtmlStyle {
     memberNameLink,
 
     /**
-     * The class for a {@code dl} element containing serial UID information in
+     * The class of a {@code dl} element containing serial UID information in
      * the serialized form page.
      */
     nameValue,
@@ -963,11 +996,6 @@ public enum HtmlStyle {
      * source page.
      */
     sourceLineNo,
-
-    /**
-     * The class of the {@code pre} element presenting a snippet.
-     */
-    snippet,
 
     /**
      * The class of an {@code a} element for a link to a class or interface.


### PR DESCRIPTION
Please review a simple update to reorder some members of the enum `HtmlStyle`, and to make some minor updates to the comments.

This is to facilitate automated extraction of information into an upcoming new spec for the output from the standard doclet.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280738](https://bugs.openjdk.java.net/browse/JDK-8280738): Minor cleanup for HtmlStyle


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**) ⚠️ Review applies to df8c810eba49c834da05bca0352d3333751d135f


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7235/head:pull/7235` \
`$ git checkout pull/7235`

Update a local copy of the PR: \
`$ git checkout pull/7235` \
`$ git pull https://git.openjdk.java.net/jdk pull/7235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7235`

View PR using the GUI difftool: \
`$ git pr show -t 7235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7235.diff">https://git.openjdk.java.net/jdk/pull/7235.diff</a>

</details>
