### PR TITLE
8280553: resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java can fail if GC occurs

### DIFF
--- a/test/hotspot/jtreg/resourcehogs/serviceability/sa/LingeredAppWithLargeArray.java
+++ b/test/hotspot/jtreg/resourcehogs/serviceability/sa/LingeredAppWithLargeArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,9 @@
 import jdk.test.lib.apps.LingeredApp;
 
 public class LingeredAppWithLargeArray extends LingeredApp {
+    public static int[] hugeArray;
     public static void main(String args[]) {
-        int[] hugeArray = new int[Integer.MAX_VALUE/2];
+        hugeArray = new int[Integer.MAX_VALUE/2];
         LingeredApp.main(args);
     }
  }

--- a/test/hotspot/jtreg/resourcehogs/serviceability/sa/LingeredAppWithLargeArray.java
+++ b/test/hotspot/jtreg/resourcehogs/serviceability/sa/LingeredAppWithLargeArray.java
@@ -23,10 +23,12 @@
 
 import jdk.test.lib.apps.LingeredApp;
 
+import java.lang.ref.Reference;
+
 public class LingeredAppWithLargeArray extends LingeredApp {
-    public static int[] hugeArray;
     public static void main(String args[]) {
-        hugeArray = new int[Integer.MAX_VALUE/2];
+        int[] hugeArray = new int[Integer.MAX_VALUE/2];
         LingeredApp.main(args);
+        Reference.reachabilityFence(hugeArray);
     }
  }


### PR DESCRIPTION
This test is failing in the loom repo when using -Xcomp. The reason is because loom introduced doing a full GC in the codecache sweeper, which causes the large array that the test allocates to be GC'd before the heap dump is done. The fix is to make the large array static rather than a local variable.

I'm choosing to fix this in the jdk repo rather than the loom repo since it is a latent bug that theoretically could occur even without the loom changes, and also to help reduce the amount of changes to be reviewed when loom is integrated into jdk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280553](https://bugs.openjdk.java.net/browse/JDK-8280553): resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java can fail if GC occurs


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7236/head:pull/7236` \
`$ git checkout pull/7236`

Update a local copy of the PR: \
`$ git checkout pull/7236` \
`$ git pull https://git.openjdk.java.net/jdk pull/7236/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7236`

View PR using the GUI difftool: \
`$ git pr show -t 7236`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7236.diff">https://git.openjdk.java.net/jdk/pull/7236.diff</a>

</details>
