### PR TITLE
8280555: serviceability/sa/TestObjectMonitorIterate.java is failing due to ObjectMonitor referencing a null Object

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/TestObjectMonitorIterate.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestObjectMonitorIterate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, NTT DATA.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -59,8 +59,12 @@ public class TestObjectMonitorIterate {
 
             while (itr.hasNext()) {
                 ObjectMonitor mon = (ObjectMonitor)itr.next();
-                Oop oop = heap.newOop(mon.object());
-                System.out.println("Monitor found: " + oop.getKlass().getName().asString());
+                if (mon.object() == null) {
+                    System.out.println("Monitor found: object is null");
+                } else {
+                    Oop oop = heap.newOop(mon.object());
+                    System.out.println("Monitor found: " + oop.getKlass().getName().asString());
+                }
             }
         } finally {
             agent.detach();


### PR DESCRIPTION
This test is failing in the loom repo when using -Xcomp. The reason is because loom introduced doing a full GC in the codecache sweeper, which causes some of the Objects referenced by ObjectMonitors to be GC'd. The fix is to check for the null Objects so we don't get an NPE.

I'm choosing to fix this in the jdk repo rather than the loom repo since it is a latent bug that theoretically could occur even without the loom changes, and also to help reduce the amount of changes to be reviewed when loom is integrated into jdk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280555](https://bugs.openjdk.java.net/browse/JDK-8280555): serviceability/sa/TestObjectMonitorIterate.java is failing due to ObjectMonitor referencing a null Object


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7238/head:pull/7238` \
`$ git checkout pull/7238`

Update a local copy of the PR: \
`$ git checkout pull/7238` \
`$ git pull https://git.openjdk.java.net/jdk pull/7238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7238`

View PR using the GUI difftool: \
`$ git pr show -t 7238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7238.diff">https://git.openjdk.java.net/jdk/pull/7238.diff</a>

</details>
