### PR TITLE
JDK-8280835: jdk/javadoc/tool/CheckManPageOptions.java depends on source hierarchy

### DIFF
--- a/test/langtools/jdk/javadoc/tool/CheckManPageOptions.java
+++ b/test/langtools/jdk/javadoc/tool/CheckManPageOptions.java
@@ -54,8 +54,14 @@ import java.util.stream.Collectors;
  * of the javadoc man page against the set of options declared in the source code.
  */
 public class CheckManPageOptions {
+    static class SourceDirNotFound extends Error { }
+
     public static void main(String... args) throws Exception {
-        new CheckManPageOptions().run(args);
+        try {
+            new CheckManPageOptions().run(args);
+        } catch (SourceDirNotFound e) {
+            System.err.println("NOTE: Cannot find src directory; test skipped");
+        }
     }
 
     static final PrintStream out = System.err;
@@ -143,7 +149,7 @@ public class CheckManPageOptions {
             }
             dir = dir.getParent();
         }
-        throw new IllegalStateException("cannot find root dir");
+        throw new SourceDirNotFound();
     }
 
     List<String> getToolOptions() throws Error {


### PR DESCRIPTION
Please review a small test update to have this test pass if the main`src/` directory cannot be found. (Yes, apparently that happens in some testing scenarios.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280835](https://bugs.openjdk.java.net/browse/JDK-8280835): jdk/javadoc/tool/CheckManPageOptions.java depends on source hierarchy


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7240/head:pull/7240` \
`$ git checkout pull/7240`

Update a local copy of the PR: \
`$ git checkout pull/7240` \
`$ git pull https://git.openjdk.java.net/jdk pull/7240/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7240`

View PR using the GUI difftool: \
`$ git pr show -t 7240`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7240.diff">https://git.openjdk.java.net/jdk/pull/7240.diff</a>

</details>
