### PR TITLE
8280353: -XX:ArchiveClassesAtExit should print warning if base archive failed to load

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -955,6 +955,9 @@ void MetaspaceShared::initialize_runtime_shared_and_meta_spaces() {
     }
   } else {
     set_shared_metaspace_range(NULL, NULL, NULL);
+    if (DynamicDumpSharedSpaces) {
+      warning("-XX:ArchiveClassesAtExit is unsupported when base CDS archive is not loaded. Run with -Xlog:cds for more info.");
+    }
     UseSharedSpaces = false;
     // The base archive cannot be mapped. We cannot dump the dynamic shared archive.
     AutoCreateSharedArchive = false;


### PR DESCRIPTION
Hi, Please review

Before fix of 8261455 (https://bugs.openjdk.java.net/browse/JDK-8261455), when -XX:ArchiveClassesAtExit=<archive_name> used to dump dynamic archive, if base archive failed to load due to some reason with 'auto'  share mode, the process exit with information like:

Error occurred during initialization of VM
-XX:ArchiveClassesAtExit is unsupported when base CDS archive is not loaded. Run with -Xlog:cds for more info.

This behavior is not correct. Under 'auto' mode, if shared archive failed to map, CDS should be disabled and run without sharing.
After the fix of 8261455, the behavior is correct: if base archive failed to load under 'auto' mode, CDS is disabled and continue without sharing. Print out VM warning if -XX:ArchiveClassesAtExit=<archive_name> in option to do dynamic dump, the archive will not be created.

Tests: tier1,tier4
Also manually execute the examples in bug description.

Thanks
Yumin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280353](https://bugs.openjdk.java.net/browse/JDK-8280353): -XX:ArchiveClassesAtExit should print warning if base archive failed to load


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7241/head:pull/7241` \
`$ git checkout pull/7241`

Update a local copy of the PR: \
`$ git checkout pull/7241` \
`$ git pull https://git.openjdk.java.net/jdk pull/7241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7241`

View PR using the GUI difftool: \
`$ git pr show -t 7241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7241.diff">https://git.openjdk.java.net/jdk/pull/7241.diff</a>

</details>
