### PR TITLE
8280804: Parallel: Remove unused variables in PSPromotionManager::drain_stacks_depth

### DIFF
--- a/src/hotspot/share/gc/parallel/psPromotionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.cpp
@@ -244,12 +244,6 @@ void PSPromotionManager::restore_preserved_marks() {
 void PSPromotionManager::drain_stacks_depth(bool totally_drain) {
   totally_drain = totally_drain || _totally_drain;
 
-#ifdef ASSERT
-  ParallelScavengeHeap* heap = ParallelScavengeHeap::heap();
-  MutableSpace* to_space = heap->young_gen()->to_space();
-  MutableSpace* old_space = heap->old_gen()->object_space();
-#endif /* ASSERT */
-
   PSScannerTasksQueue* const tq = claimed_stack_depth();
   do {
     ScannerTask task;


### PR DESCRIPTION
Trivial change of removing dead code.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280804](https://bugs.openjdk.java.net/browse/JDK-8280804): Parallel: Remove unused variables in PSPromotionManager::drain_stacks_depth


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7245/head:pull/7245` \
`$ git checkout pull/7245`

Update a local copy of the PR: \
`$ git checkout pull/7245` \
`$ git pull https://git.openjdk.java.net/jdk pull/7245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7245`

View PR using the GUI difftool: \
`$ git pr show -t 7245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7245.diff">https://git.openjdk.java.net/jdk/pull/7245.diff</a>

</details>
