### PR TITLE
8280784: VM_Cleanup unnecessarily processes all thread oops

### DIFF
--- a/src/hotspot/share/runtime/vmOperations.hpp
+++ b/src/hotspot/share/runtime/vmOperations.hpp
@@ -45,6 +45,10 @@ class VM_Cleanup: public VM_Operation {
  public:
   VMOp_Type type() const { return VMOp_Cleanup; }
   void doit() {};
+  virtual bool skip_thread_oop_barriers() const {
+    // None of the safepoint cleanup tasks read oops in the Java threads.
+    return true;
+  }
 };
 
 class VM_ClearICs: public VM_Operation {


### PR DESCRIPTION
While looking at ZGC latencies in a benchmark with >20000 Java threads, I noticed that the Cleanup VM operation could take up to 500 ms. It turned out that the time was spent processing the oops in all Java threads. Since none of the safepoint cleanup tasks use the oops in the threads, I propose that we stop processing the oops in this VM Operation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280784](https://bugs.openjdk.java.net/browse/JDK-8280784): VM_Cleanup unnecessarily processes all thread oops


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7246/head:pull/7246` \
`$ git checkout pull/7246`

Update a local copy of the PR: \
`$ git checkout pull/7246` \
`$ git pull https://git.openjdk.java.net/jdk pull/7246/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7246`

View PR using the GUI difftool: \
`$ git pr show -t 7246`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7246.diff">https://git.openjdk.java.net/jdk/pull/7246.diff</a>

</details>
