### PR TITLE
8072070: Improve interpreter stack banging

### DIFF
--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -713,23 +713,57 @@ address TemplateInterpreterGenerator::generate_Reference_get_entry(void) {
 }
 
 void TemplateInterpreterGenerator::bang_stack_shadow_pages(bool native_call) {
-  // Quick & dirty stack overflow checking: bang the stack & handle trap.
+  // See more discussion in stackOverflow.hpp.
+
   // Note that we do the banging after the frame is setup, since the exception
   // handling code expects to find a valid interpreter frame on the stack.
   // Doing the banging earlier fails if the caller frame is not an interpreter
   // frame.
   // (Also, the exception throwing code expects to unlock any synchronized
-  // method receiever, so do the banging after locking the receiver.)
+  // method receiver, so do the banging after locking the receiver.)
 
-  // Bang each page in the shadow zone. We can't assume it's been done for
-  // an interpreter frame with greater than a page of locals, so each page
-  // needs to be checked.  Only true for non-native.
+  const int shadow_zone_size = checked_cast<int>(StackOverflow::stack_shadow_zone_size());
   const int page_size = os::vm_page_size();
-  const int n_shadow_pages = ((int)StackOverflow::stack_shadow_zone_size()) / page_size;
-  const int start_page = native_call ? n_shadow_pages : 1;
-  for (int pages = start_page; pages <= n_shadow_pages; pages++) {
-    __ bang_stack_with_offset(pages*page_size);
-  }
+  const int n_shadow_pages = shadow_zone_size / page_size;
+
+  const Register thread = NOT_LP64(rsi) LP64_ONLY(r15_thread);
+#ifndef _LP64
+  __ push(thread);
+  __ get_thread(thread);
+#endif
+
+#ifdef ASSERT
+  Label L_good_limit;
+  __ cmpptr(Address(thread, JavaThread::shadow_zone_safe_limit()), (int32_t)NULL_WORD);
+  __ jcc(Assembler::notEqual, L_good_limit);
+    __ stop("shadow zone safe limit is not initialized");
+  __ bind(L_good_limit);
+
+  Label L_good_watermark;
+  __ cmpptr(Address(thread, JavaThread::shadow_zone_growth_watermark()), (int32_t)NULL_WORD);
+  __ jcc(Assembler::notEqual, L_good_watermark);
+    __ stop("shadow zone growth watermark is not initialized");
+  __ bind(L_good_watermark);
+#endif
+
+  Label L_done;
+
+  __ cmpptr(rsp, Address(thread, JavaThread::shadow_zone_growth_watermark()));
+  __ jcc(Assembler::above, L_done);
+
+    for (int p = 1; p <= n_shadow_pages; p++) {
+      __ bang_stack_with_offset(p*page_size);
+    }
+
+    __ cmpptr(rsp, Address(thread, JavaThread::shadow_zone_safe_limit()));
+    __ jccb(Assembler::belowEqual, L_done);
+      __ movptr(Address(thread, JavaThread::shadow_zone_growth_watermark()), rsp);
+
+  __ bind(L_done);
+
+#ifndef _LP64
+  __ pop(thread);
+#endif
 }
 
 // Interpreter stub for calling a native method. (asm interpreter)

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -736,13 +736,13 @@ void TemplateInterpreterGenerator::bang_stack_shadow_pages(bool native_call) {
   Label L_good_limit;
   __ cmpptr(Address(thread, JavaThread::shadow_zone_safe_limit()), (int32_t)NULL_WORD);
   __ jcc(Assembler::notEqual, L_good_limit);
-    __ stop("shadow zone safe limit is not initialized");
+  __ stop("shadow zone safe limit is not initialized");
   __ bind(L_good_limit);
 
   Label L_good_watermark;
   __ cmpptr(Address(thread, JavaThread::shadow_zone_growth_watermark()), (int32_t)NULL_WORD);
   __ jcc(Assembler::notEqual, L_good_watermark);
-    __ stop("shadow zone growth watermark is not initialized");
+  __ stop("shadow zone growth watermark is not initialized");
   __ bind(L_good_watermark);
 #endif
 
@@ -751,15 +751,15 @@ void TemplateInterpreterGenerator::bang_stack_shadow_pages(bool native_call) {
   __ cmpptr(rsp, Address(thread, JavaThread::shadow_zone_growth_watermark()));
   __ jcc(Assembler::above, L_done);
 
-    for (int p = 1; p <= n_shadow_pages; p++) {
-      __ bang_stack_with_offset(p*page_size);
-    }
+  for (int p = 1; p <= n_shadow_pages; p++) {
+    __ bang_stack_with_offset(p*page_size);
+  }
 
-    // Record a new watermark, unless the update is above the safe limit.
-    // Otherwise, the next time around a check above would pass the safe limit.
-    __ cmpptr(rsp, Address(thread, JavaThread::shadow_zone_safe_limit()));
-    __ jccb(Assembler::belowEqual, L_done);
-      __ movptr(Address(thread, JavaThread::shadow_zone_growth_watermark()), rsp);
+  // Record a new watermark, unless the update is above the safe limit.
+  // Otherwise, the next time around a check above would pass the safe limit.
+  __ cmpptr(rsp, Address(thread, JavaThread::shadow_zone_safe_limit()));
+  __ jccb(Assembler::belowEqual, L_done);
+  __ movptr(Address(thread, JavaThread::shadow_zone_growth_watermark()), rsp);
 
   __ bind(L_done);
 

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -755,6 +755,8 @@ void TemplateInterpreterGenerator::bang_stack_shadow_pages(bool native_call) {
       __ bang_stack_with_offset(p*page_size);
     }
 
+    // Record a new watermark, unless the update is above the safe limit.
+    // Otherwise, the next time around a check above would pass the safe limit.
     __ cmpptr(rsp, Address(thread, JavaThread::shadow_zone_safe_limit()));
     __ jccb(Assembler::belowEqual, L_done);
       __ movptr(Address(thread, JavaThread::shadow_zone_growth_watermark()), rsp);

--- a/src/hotspot/share/runtime/javaCalls.cpp
+++ b/src/hotspot/share/runtime/javaCalls.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/share/runtime/javaCalls.cpp
+++ b/src/hotspot/share/runtime/javaCalls.cpp
@@ -380,7 +380,7 @@ void JavaCalls::call_helper(JavaValue* result, const methodHandle& method, JavaC
 
   // Check that there are shadow pages available before changing thread state
   // to Java. Calculate current_stack_pointer here to make sure
-  // stack_shadow_pages_available() and bang_stack_shadow_pages() use the same sp.
+  // stack_shadow_pages_available() and map_stack_shadow_pages() use the same sp.
   address sp = os::current_stack_pointer();
   if (!os::stack_shadow_pages_available(THREAD, method, sp)) {
     // Throw stack overflow exception with preinitialized exception.

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1384,7 +1384,7 @@ char** os::split_path(const char* path, size_t* elements, size_t file_name_lengt
 // pages, false otherwise.
 bool os::stack_shadow_pages_available(Thread *thread, const methodHandle& method, address sp) {
   if (!thread->is_Java_thread()) return false;
-  // Check if we have StackShadowPages above the yellow zone.  This parameter
+  // Check if we have StackShadowPages above the guard zone. This parameter
   // is dependent on the depth of the maximum VM call stack possible from
   // the handler for stack overflow.  'instanceof' in the stack overflow
   // handler or a println uses at least 8k stack of VM and native code
@@ -1392,9 +1392,7 @@ bool os::stack_shadow_pages_available(Thread *thread, const methodHandle& method
   const int framesize_in_bytes =
     Interpreter::size_top_interpreter_activation(method()) * wordSize;
 
-  address limit = JavaThread::cast(thread)->stack_end() +
-                  (StackOverflow::stack_guard_zone_size() + StackOverflow::stack_shadow_zone_size());
-
+  address limit = JavaThread::cast(thread)->stack_overflow_state()->shadow_zone_safe_limit();
   return sp > (limit + framesize_in_bytes);
 }
 

--- a/src/hotspot/share/runtime/stackOverflow.hpp
+++ b/src/hotspot/share/runtime/stackOverflow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/stackOverflow.hpp
+++ b/src/hotspot/share/runtime/stackOverflow.hpp
@@ -195,7 +195,8 @@ class StackOverflow {
   // 3. Check the current SP in relation to the shadow zone growth watermark.
   //
   // Define "shadow zone growth watermark" as the highest SP where we banged already.
-  // Note that growth watermark is always above the safe limit.
+  // Invariant: growth watermark is always above the safe limit, which allows testing
+  // for watermark and safe limit at the same time in the most frequent case.
   //
   // Easy and overwhelmingly frequent case: SP is above the growth watermark, and
   // by extension above the safe limit. In this case, we know that the guard zone is far away

--- a/src/hotspot/share/runtime/stackOverflow.hpp
+++ b/src/hotspot/share/runtime/stackOverflow.hpp
@@ -111,14 +111,23 @@ class StackOverflow {
   //                                               |   size
   //                                               v
   //                                              ---   <--  shadow_zone_safe_limit()
+  // (Here and below: not yet touched stack)
   //
-  // (some usable, but not yet touched memory)
+  //
+  // (Here and below: touched at least once)      ---
+  //                                               ^
+  //                                               |  shadow
+  //                                               |   zone
+  //                                               |   size
+  //                                               v
+  //                                              ---   <--  shadow_zone_growth_watermark()
+  //
   //
   //  --
   //  |
   //  |  shadow zone
   //  |
-  //  --                                          ---   <--  shadow_zone_growth_watermark()
+  //  --
   //  x    frame n
   //  --
   //  x    frame n-1

--- a/src/hotspot/share/runtime/stackOverflow.hpp
+++ b/src/hotspot/share/runtime/stackOverflow.hpp
@@ -163,8 +163,10 @@ class StackOverflow {
   //     If SP is very low, banging at the edge of shadow zone (SP+shadow-zone-size) can slip
   //     into adjacent thread stack, or even into other readable memory. This would potentially
   //     pass the check by accident.
-  //  c) Allow for incremental stack growth by handling traps from not yet committed thread
-  //     stacks. See for example handling of os::map_stack_shadow_pages().
+  //  c) Allow for incremental stack growth on some OSes. This is enabled by handling traps
+  //     from not yet committed thread stacks, even outside the guard zone. The banging should
+  //     not allow uncommitted "gaps" on thread stack. See for example the uses of
+  //     os::map_stack_shadow_pages().
   //  d) Make sure the stack overflow trap happens in the code that is known to runtime, so
   //     the traps can be reasonably handled: handling a spurious trap from executing Java code
   //     is hard, while properly handling the trap from VM/native code is nearly impossible.

--- a/src/hotspot/share/runtime/stackOverflow.hpp
+++ b/src/hotspot/share/runtime/stackOverflow.hpp
@@ -51,6 +51,8 @@ class StackOverflow {
     _stack_guard_state(stack_guard_unused),
     _stack_overflow_limit(nullptr),
     _reserved_stack_activation(nullptr),  // stack base not known yet
+    _shadow_zone_safe_limit(nullptr),
+    _shadow_zone_growth_watermark(nullptr),
     _stack_base(nullptr), _stack_end(nullptr) {}
 
   // Initialization after thread is started.
@@ -58,6 +60,7 @@ class StackOverflow {
      _stack_base = base;
      _stack_end = end;
     set_stack_overflow_limit();
+    set_shadow_zone_limits();
     set_reserved_stack_activation(base);
   }
  private:
@@ -68,6 +71,8 @@ class StackOverflow {
   // We load it from here to simplify the stack overflow check in assembly.
   address          _stack_overflow_limit;
   address          _reserved_stack_activation;
+  address          _shadow_zone_safe_limit;
+  address          _shadow_zone_growth_watermark;
 
   // Support for stack overflow handling, copied down from thread.
   address          _stack_base;
@@ -77,6 +82,9 @@ class StackOverflow {
   address stack_base() const           { assert(_stack_base != nullptr, "Sanity check"); return _stack_base; }
 
   // Stack overflow support
+  // --------------------------------------------------------------------------------
+  //
+  // The Java thread stack is structured as follows:
   //
   //  (low addresses)
   //
@@ -95,18 +103,22 @@ class StackOverflow {
   //  |                                      |
   //  |  reserved zone                       |
   //  |                                      |
-  //  --  <-- stack_reserved_zone_base()    ---      ---
-  //                                                 /|\  shadow     <--  stack_overflow_limit() (somewhere in here)
-  //                                                  |   zone
-  //                                                 \|/  size
-  //  some untouched memory                          ---
+  //  --  <-- stack_reserved_zone_base()    ---   ---
+  //                                               ^
+  //                                               |    <--  stack_overflow_limit() [somewhere in here]
+  //                                               |  shadow
+  //                                               |   zone
+  //                                               |   size
+  //                                               v
+  //                                              ---   <--  shadow_zone_safe_limit()
   //
+  // (some usable, but not yet touched memory)
   //
   //  --
   //  |
   //  |  shadow zone
   //  |
-  //  --
+  //  --                                          ---   <--  shadow_zone_growth_watermark()
   //  x    frame n
   //  --
   //  x    frame n-1
@@ -120,6 +132,81 @@ class StackOverflow {
   //
   //  (high addresses)
   //
+  //
+  // The stack overflow mechanism detects overflows by touching ("banging") the stack
+  // ahead of current stack pointer (SP). The entirety of guard zone is memory protected,
+  // therefore such access would trap when touching the guard zone, and one of the following
+  // things would happen.
+  //
+  // Access in the red zone: unrecoverable stack overflow. Crash the VM, generate a report,
+  // crash dump, and other diagnostics.
+  //
+  // Access in the yellow zone: recoverable, reportable stack overflow. Create and throw
+  // a StackOverflowError, remove the protection of yellow zone temporarily to let exception
+  // handlers run. If exception handlers themselves run out of stack, they will crash VM due
+  // to access to red zone.
+  //
+  // Access in the reserved zone: recoverable, reportable, transparent for privileged methods
+  // stack overflow. Perform a stack walk to check if there's a method annotated with
+  // @ReservedStackAccess on the call stack. If such method is found, remove the protection of
+  // reserved zone temporarily, and let the method run. If not, handle the access like a yellow
+  // zone trap.
+  //
+  // The banging itself happens within the "shadow zone" that extends from the current SP.
+  //
+  // The goals for properly implemented shadow zone banging are:
+  //
+  //  a) Allow native/VM methods to run without stack overflow checks within some reasonable
+  //     headroom. Default shadow zone size should accommodate the largest normally expected
+  //     native/VM stack use.
+  //  b) Guarantee the stack overflow checks work even if SP is dangerously close to guard zone.
+  //     If SP is very low, banging at the edge of shadow zone (SP+shadow-zone-size) can slip
+  //     into adjacent thread stack, or even into other readable memory. This would potentially
+  //     pass the check by accident.
+  //  c) Allow for incremental stack growth by handling traps from not yet committed thread
+  //     stacks. See for example handling of os::map_stack_shadow_pages().
+  //  d) Make sure the stack overflow trap happens in the code that is known to runtime, so
+  //     the traps can be reasonably handled: handling a spurious trap from executing Java code
+  //     is hard, while properly handling the trap from VM/native code is nearly impossible.
+  //
+  // The simplest code that satisfies all these requirements is banging the shadow zone
+  // page by page at every Java/native method entry.
+  //
+  // While that code is sufficient, it comes with the large performance cost. This performance
+  // cost can be reduced by several *optional* techniques:
+  //
+  // 1. Guarantee that stack would not take another page. If so, the current bang was
+  // enough to verify we are not near the guard zone. This kind of insight is usually only
+  // available for compilers that can know the size of the frame exactly.
+  //
+  // Examples: PhaseOutput::need_stack_bang.
+  //
+  // 2. Check the current SP in relation to shadow zone safe limit.
+  //
+  // Define "safe limit" as the highest SP where banging would not touch the guard zone.
+  // Then, do the page-by-page bang only if current SP is above that safe limit, OR some
+  // OS-es need it to get the stack mapped.
+  //
+  // Examples: AbstractAssembler::generate_stack_overflow_check, JavaCalls::call_helper,
+  // os::stack_shadow_pages_available, os::map_stack_shadow_pages and their uses.
+  //
+  // 3. Check the current SP in relation to the shadow zone growth watermark.
+  //
+  // Define "shadow zone growth watermark" as the highest SP where we banged already.
+  // Note that growth watermark is always above the safe limit.
+  //
+  // Easy and overwhelmingly frequent case: SP is above the growth watermark, and
+  // by extension above the safe limit. In this case, we know that the guard zone is far away
+  // (safe limit), and that the stack was banged before for stack growth (growth watermark).
+  // Therefore, we can skip the banging altogether.
+  //
+  // Harder cases: SP is below the growth watermark. In might be due to two things:
+  // we have not banged the stack for growth (below growth watermark only), or we are
+  // close to guard zone (also below safe limit). Do the full banging. Once done, we
+  // can adjust the growth watermark, thus recording the bang for stack growth had
+  // happened.
+  //
+  // Examples: TemplateInterpreterGenerator::bang_stack_shadow_pages on x86 and others.
 
  private:
   // These values are derived from flags StackRedPages, StackYellowPages,
@@ -189,6 +276,11 @@ class StackOverflow {
     return _stack_shadow_zone_size;
   }
 
+  address shadow_zone_safe_limit() const {
+    assert(_shadow_zone_safe_limit != nullptr, "Don't call this before the field is initialized.");
+    return _shadow_zone_safe_limit;
+  }
+
   void create_stack_guard_pages();
   void remove_stack_guard_pages();
 
@@ -241,6 +333,13 @@ class StackOverflow {
   void set_stack_overflow_limit() {
     _stack_overflow_limit =
       stack_end() + MAX2(stack_guard_zone_size(), stack_shadow_zone_size());
+  }
+
+  void set_shadow_zone_limits() {
+    _shadow_zone_safe_limit =
+      stack_end() + stack_guard_zone_size() + stack_shadow_zone_size();
+    _shadow_zone_growth_watermark =
+      stack_base();
   }
 };
 

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1299,6 +1299,12 @@ class JavaThread: public Thread {
   static ByteSize reserved_stack_activation_offset() {
     return byte_offset_of(JavaThread, _stack_overflow_state._reserved_stack_activation);
   }
+  static ByteSize shadow_zone_safe_limit()  {
+    return byte_offset_of(JavaThread, _stack_overflow_state._shadow_zone_safe_limit);
+  }
+  static ByteSize shadow_zone_growth_watermark()  {
+    return byte_offset_of(JavaThread, _stack_overflow_state._shadow_zone_growth_watermark);
+  }
 
   static ByteSize suspend_flags_offset()         { return byte_offset_of(JavaThread, _suspend_flags); }
 

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -75,34 +75,6 @@ hotspot_native_sanity = \
 hotspot_containers = \
   containers
 
-# Temporary group for stack banging changes
-hotspot_stack = \
-  compiler/interpreter/TestVerifyStackAfterDeopt.java \
-  compiler/interpreter/cr7116216/StackOverflow.java \
-  compiler/osr/TestOSRWithNonEmptyStack.java \
-  compiler/runtime/TestFloatsOnStackDeopt.java \
-  compiler/runtime/StackOverflowBug.java \
-  compiler/uncommontrap/StackOverflowGuardPagesOff.java \
-  compiler/uncommontrap/TestStackBangRbp.java \
-  compiler/uncommontrap/TestStackBangMonitorOwned.java \
-  compiler/uncommontrap/UncommonTrapStackBang.java \
-  runtime/ErrorHandling/BadNativeStackInErrorHandlingTest.java \
-  runtime/Locals/TestLargeLocalVarsStackRegion.java \
-  runtime/ReservedStack \
-  runtime/NMT/CheckForProperDetailStackTrace.java \
-  runtime/StackGuardPages \
-  runtime/StackTrace \
-  runtime/Thread/TestThreadStackSizes.java \
-  runtime/Thread/TooSmallStackSize.java \
-  runtime/Throwable/TestMaxJavaStackTraceDepth.java \
-  runtime/Throwable/StackTraceLogging.java \
-  runtime/handshake/ \
-  runtime/logging/StackWalkTest.java \
-  runtime/reflect/ReflectStackOverflow.java \
-  runtime/whitebox/WBStackSize.java \
-  serviceability/jvmti/GetLocalVariable/GetLocalWithoutSuspendTest.java \
-  serviceability/threads/TestFalseDeadLock.java
-
 # Test sets for running inside container environment
 hotspot_containers_extended = \
   runtime \

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -75,6 +75,34 @@ hotspot_native_sanity = \
 hotspot_containers = \
   containers
 
+# Temporary group for stack banging changes
+hotspot_stack = \
+  compiler/interpreter/TestVerifyStackAfterDeopt.java \
+  compiler/interpreter/cr7116216/StackOverflow.java \
+  compiler/osr/TestOSRWithNonEmptyStack.java \
+  compiler/runtime/TestFloatsOnStackDeopt.java \
+  compiler/runtime/StackOverflowBug.java \
+  compiler/uncommontrap/StackOverflowGuardPagesOff.java \
+  compiler/uncommontrap/TestStackBangRbp.java \
+  compiler/uncommontrap/TestStackBangMonitorOwned.java \
+  compiler/uncommontrap/UncommonTrapStackBang.java \
+  runtime/ErrorHandling/BadNativeStackInErrorHandlingTest.java \
+  runtime/Locals/TestLargeLocalVarsStackRegion.java \
+  runtime/ReservedStack \
+  runtime/NMT/CheckForProperDetailStackTrace.java \
+  runtime/StackGuardPages \
+  runtime/StackTrace \
+  runtime/Thread/TestThreadStackSizes.java \
+  runtime/Thread/TooSmallStackSize.java \
+  runtime/Throwable/TestMaxJavaStackTraceDepth.java \
+  runtime/Throwable/StackTraceLogging.java \
+  runtime/handshake/ \
+  runtime/logging/StackWalkTest.java \
+  runtime/reflect/ReflectStackOverflow.java \
+  runtime/whitebox/WBStackSize.java \
+  serviceability/jvmti/GetLocalVariable/GetLocalWithoutSuspendTest.java \
+  serviceability/threads/TestFalseDeadLock.java
+
 # Test sets for running inside container environment
 hotspot_containers_extended = \
   runtime \


### PR DESCRIPTION
This is an old issue, I submitted the first RFE about this back in 2015. This shows up every time I benchmark the interpreter-only code. Most recently, it showed up in my work to get `java.lang.invoke` infra work reasonably fast when cold, which includes lots of interpreter paths.

The underlying problem is that template interpreters rebang the entire shadow zone on every method entry. This takes tens of instructions, blows out TLB caches with accessing tens of pages (on some implementations, I reckon, almost the entire L1 TLB cache!), etc. I think we can make it universally better for all template interpreters by introducing the safe limit / growth watermarks for thread stacks, so that we bang only when needed. It also drops the need for special-casing the `native_call`, because we might as well bang the entire shadow zone in native case as well.

This patch makes a pilot change for x86, without touching other architectures. Other architectures can follow this example later. This is why `native_call` argument persists, even though it is not used in x86 case anymore. There is also a new test group that I found useful when debugging on Windows, that group is going to go away before integration.

I tried to capture the current mechanics of stack banging in `stackOverflow.hpp`, hoping the change becomes more obvious, and so that arch-specific template interpreter codes could just reference it without copy-pasting it around.

I think it is fairly complete, and so would like to solicit more feedback and testing here.

Point runs on SPECjvm2008 with `-Xint` shows huge improvements on half of the tests, without any regressions:

```
 compiler.compiler: +77%
 compiler.sunflow: +69%
 compress: +166%
 crypto.rsa: +15%
 crypto.signverify: +70%
 mpegaudio: +8%
 serial: +50%
 sunflow: +57%
 xml.transform: +61%
 xml.validation: +43%
```

My new `java.lang.invoke` benchmarks improve a lot as well:

```
Benchmark              Mode  Cnt    Score    Error  Units

# Mainline
MHInvoke.methodHandle  avgt    5  799.671 ± 9.087  ns/op
MHInvoke.plain         avgt    5  261.947 ± 1.421  ns/op
VHGet.plain            avgt    5  231.372 ± 3.044  ns/op
VHGet.varHandle        avgt    5  924.880 ± 6.026  ns/op

# This WIP
MHInvoke.methodHandle  avgt    5  240.456 ± 3.931  ns/op
MHInvoke.plain         avgt    5   70.851 ± 1.986  ns/op
VHGet.plain            avgt    5   52.506 ± 3.768  ns/op
VHGet.varHandle        avgt    5  335.785 ± 4.398  ns/op
```

It also palpably improves startup even on small HelloWorld, _even when compilers are present_:

```
$ perf stat -r 5000 build/baseline/bin/java -Xms128m -Xmx128m Hello > /dev/null

 Performance counter stats for 'build/baseline/bin/java -Xms128m -Xmx128m Hello' (5000 runs):

             22.06 msec task-clock                #    1.030 CPUs utilized            ( +-  0.04% )
                96      context-switches          #    4.353 K/sec                    ( +-  0.07% )
                 7      cpu-migrations            #  333.181 /sec                     ( +-  0.32% )
             2,437      page-faults               #  110.469 K/sec                    ( +-  0.00% )
        78,763,038      cycles                    #    3.571 GHz                      ( +-  0.05% )  (77.30%)
         2,107,182      stalled-cycles-frontend   #    2.68% frontend cycles idle     ( +-  0.41% )  (77.40%)
         2,235,371      stalled-cycles-backend    #    2.84% backend cycles idle      ( +-  1.05% )  (71.39%)
        67,296,528      instructions              #    0.85  insn per cycle         
                                                  #    0.03  stalled cycles per insn  ( +-  0.03% )  (89.79%)
        12,483,022      branches                  #  565.911 M/sec                    ( +-  0.01% )  (99.73%)
           384,412      branch-misses             #    3.08% of all branches          ( +-  0.07% )  (85.91%)

         0.0214224 +- 0.0000875 seconds time elapsed  ( +-  0.41% )

$ perf stat -r 5000 build/interp-bang/bin/java -Xms128m -Xmx128m Hello > /dev/null

 Performance counter stats for 'build/interp-bang/bin/java -Xms128m -Xmx128m Hello' (5000 runs):

             21.78 msec task-clock                #    1.031 CPUs utilized            ( +-  0.05% )
                98      context-switches          #    4.519 K/sec                    ( +-  0.07% )
                 7      cpu-migrations            #  339.292 /sec                     ( +-  0.31% )
             2,434      page-faults               #  111.755 K/sec                    ( +-  0.00% )
        77,746,317      cycles                    #    3.569 GHz                      ( +-  0.05% )  (76.94%)
         2,143,121      stalled-cycles-frontend   #    2.76% frontend cycles idle     ( +-  0.45% )  (76.03%)
         2,059,440      stalled-cycles-backend    #    2.65% backend cycles idle      ( +-  1.11% )  (71.82%)
        66,742,892      instructions              #    0.86  insn per cycle         
                                                  #    0.03  stalled cycles per insn  ( +-  0.03% )  (91.40%)
        12,494,797      branches                  #  573.634 M/sec                    ( +-  0.01% )  (99.80%)
           386,145      branch-misses             #    3.09% of all branches          ( +-  0.08% )  (85.56%)

         0.0211278 +- 0.0000877 seconds time elapsed  ( +-  0.42% )
```

Additional testing:
 - [x] Linux x86_64 fastdebug, `tier1`
 - [x] Linux x86_64 fastdebug, `tier2`
 - [x] Linux x86_64 fastdebug, `tier3`
 - [x] Linux x86_64 fastdebug, `tier4`
 - [x] Linux x86_32 fastdebug, `tier1`
 - [x] Linux x86_32 fastdebug, `tier2`
 - [x] Linux x86_32 fastdebug, `tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8072070](https://bugs.openjdk.java.net/browse/JDK-8072070): Improve interpreter stack banging


### Reviewers
 * [Xin Liu](https://openjdk.java.net/census#xliu) (@navyxliu - Committer)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to c398381971449005c3b5524770eb5c75f8b68c4b
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7247/head:pull/7247` \
`$ git checkout pull/7247`

Update a local copy of the PR: \
`$ git checkout pull/7247` \
`$ git pull https://git.openjdk.java.net/jdk pull/7247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7247`

View PR using the GUI difftool: \
`$ git pr show -t 7247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7247.diff">https://git.openjdk.java.net/jdk/pull/7247.diff</a>

</details>
