### PR TITLE
8280823: Remove NULL check in DumpTimeClassInfo::is_excluded

### DIFF
--- a/src/hotspot/share/cds/dumpTimeClassInfo.hpp
+++ b/src/hotspot/share/cds/dumpTimeClassInfo.hpp
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,8 +135,7 @@ public:
   }
 
   bool is_excluded() {
-    // _klass may become NULL due to DynamicArchiveBuilder::set_to_null
-    return _excluded || _failed_verification || _klass == NULL;
+    return _excluded || _failed_verification;
   }
 
   // Was this class loaded while JvmtiExport::is_early_phase()==true


### PR DESCRIPTION
Please review this trivial change. The NULL check is not needed anymore because the ``DumpTimeClassInfo::_klass` field is never set to NULL.

Passed Oracle IT tiers 1~4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280823](https://bugs.openjdk.java.net/browse/JDK-8280823): Remove NULL check in DumpTimeClassInfo::is_excluded


### Reviewers
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7249/head:pull/7249` \
`$ git checkout pull/7249`

Update a local copy of the PR: \
`$ git checkout pull/7249` \
`$ git pull https://git.openjdk.java.net/jdk pull/7249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7249`

View PR using the GUI difftool: \
`$ git pr show -t 7249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7249.diff">https://git.openjdk.java.net/jdk/pull/7249.diff</a>

</details>
