### PR TITLE
5041655: (ch) FileLock: negative param and overflow issues

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/FileLock.java
+++ b/src/java.base/share/classes/java/nio/channels/FileLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -263,6 +263,12 @@ public abstract class FileLock implements AutoCloseable {
 
     /**
      * Tells whether or not this lock overlaps the given lock range.
+     *
+     * @implNote
+     * This method assumes that the parameters are non-negative and that
+     * their sum does not overflow a {@code long}, but does not enforce
+     * these preconditions as do the constructors; hence it is the caller's
+     * responsibility to ensure that these parameters are valid.
      *
      * @param   position
      *          The starting position of the lock range

--- a/test/jdk/java/nio/channels/FileLock/Overlaps.java
+++ b/test/jdk/java/nio/channels/FileLock/Overlaps.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 5041655
+ * @summary Verify FileLock.overlaps
+ * @run testng Overlaps
+ */
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.lang.Boolean.*;
+import static java.nio.file.StandardOpenOption.*;
+
+import static org.testng.Assert.assertEquals;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class Overlaps {
+    private static final long POSITION = 27;
+    private static final long SIZE = 42;
+
+    private static FileChannel fc;
+    private static FileLock lock;
+
+    @BeforeClass
+    public void before() throws IOException {
+        Path path = Files.createTempFile(Path.of("."), "foo", ".bar");
+        fc = FileChannel.open(path, CREATE, READ, WRITE, DELETE_ON_CLOSE);
+        lock = fc.lock(POSITION, SIZE, false);
+    }
+
+    @AfterClass
+    public void after() throws IOException {
+        fc.close();
+    }
+
+    @DataProvider
+    public Object[][] ranges() {
+        final long p = lock.position();
+        final long s = lock.size();
+
+        return new Object[][] {
+            {p + s/2, -2, FALSE},
+            {-1, p + s/2, TRUE},
+            {p - 2, 1, FALSE},
+            {p + 1, 1, TRUE},
+            {Long.MAX_VALUE, 2, FALSE}
+        };
+    }
+
+    @Test(dataProvider = "ranges")
+    public void overlaps(long position, long size, boolean overlaps) {
+        assertEquals(lock.overlaps(position, size), overlaps);
+    }
+}


### PR DESCRIPTION
Add an implementation note stating that `java.nio.channels.FileLock.overlaps(long,long)` does not validate its `position` and `size` parameters unlike the constructors. Changing the behavior of the method to check the parameters would be backward incompatible.