### PR TITLE
JDK-6998249: Wrong behavior/Javadoc of JTable.tableChanged(TableModelEvent e)

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -4416,10 +4416,11 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
     /**
      * Invoked when this table's <code>TableModel</code> generates
      * a <code>TableModelEvent</code>.
-     * The <code>TableModelEvent</code> should be constructed in the
-     * coordinate system of the model; the appropriate mapping to the
-     * view coordinate system is performed by this <code>JTable</code>
-     * when it receives the event.
+     * The <code>TableModelEvent</code> should be constructed in
+     * the coordinate system of the model for the column and the
+     * coordinate system of the view for the row; the appropriate
+     * mapping to the view coordinate system is performed by this
+     * <code>JTable</code> when it receives the event.
      * <p>
      * Application code will not use these methods explicitly, they
      * are used internally by <code>JTable</code>.


### PR DESCRIPTION
Updated JTable's tableChanged() method docs to explicitly mention the coordinate system of the rows and columns.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed
- [ ] Change requires a CSR request to be approved

### Issue
 * [JDK-6998249](https://bugs.openjdk.java.net/browse/JDK-6998249): Wrong behavior/Javadoc of JTable.tableChanged(TableModelEvent e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7253/head:pull/7253` \
`$ git checkout pull/7253`

Update a local copy of the PR: \
`$ git checkout pull/7253` \
`$ git pull https://git.openjdk.java.net/jdk pull/7253/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7253`

View PR using the GUI difftool: \
`$ git pr show -t 7253`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7253.diff">https://git.openjdk.java.net/jdk/pull/7253.diff</a>

</details>
