### PR TITLE
5041655: (ch) FileLock: negative param and overflow issues

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/AsynchronousFileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/AsynchronousFileChannel.java
@@ -425,9 +425,9 @@ public abstract class AsynchronousFileChannel
      * required then a region starting at zero, and no smaller than the
      * expected maximum size of the file, should be locked.  The two-argument
      * {@link #lock(Object,CompletionHandler)} method simply locks a region
-     * of size {@link Long#MAX_VALUE}. If a lock is created with a valid
-     * {@code position} and a {@code size} parameter of zero, then a lock of
-     * size {@code Long.MAX_VALUE - position} is returned. If a lock that
+     * of size {@link Long#MAX_VALUE}.  If the {@code position} is non-negative
+     * and the {@code size} is zero, then a lock of size
+     * {@code Long.MAX_VALUE - position} is returned.  If a lock that
      * overlaps the requested region is already held by this Java virtual
      * machine, or this method has been invoked to lock an overlapping region
      * and that operation has not completed, then this method throws
@@ -596,9 +596,8 @@ public abstract class AsynchronousFileChannel
      * do so.  If it fails to acquire a lock because an overlapping lock is held
      * by another program then it returns {@code null}.  If it fails to acquire
      * a lock for any other reason then an appropriate exception is thrown.  If
-     * a lock is created with a valid {@code position} and a {@code size}
-     * parameter of zero, then a lock of size {@code Long.MAX_VALUE - position}
-     * is returned.
+     * the {@code position} is non-negative and the {@code size} is zero, then a
+     * lock of size {@code Long.MAX_VALUE - position} is returned.
      *
      * @param  position
      *         The position at which the locked region is to start; must be

--- a/src/java.base/share/classes/java/nio/channels/AsynchronousFileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/AsynchronousFileChannel.java
@@ -425,10 +425,13 @@ public abstract class AsynchronousFileChannel
      * required then a region starting at zero, and no smaller than the
      * expected maximum size of the file, should be locked.  The two-argument
      * {@link #lock(Object,CompletionHandler)} method simply locks a region
-     * of size {@link Long#MAX_VALUE}. If a lock that overlaps the requested
-     * region is already held by this Java virtual machine, or this method has
-     * been invoked to lock an overlapping region and that operation has not
-     * completed, then this method throws {@link OverlappingFileLockException}.
+     * of size {@link Long#MAX_VALUE}. If a lock is created with a valid
+     * {@code position} and a {@code size} parameter of zero, then a lock of
+     * size {@code Long.MAX_VALUE - position} is returned. If a lock that
+     * overlaps the requested region is already held by this Java virtual
+     * machine, or this method has been invoked to lock an overlapping region
+     * and that operation has not completed, then this method throws
+     * {@link OverlappingFileLockException}.
      *
      * <p> Some operating systems do not support a mechanism to acquire a file
      * lock in an asynchronous manner. Consequently an implementation may
@@ -592,7 +595,10 @@ public abstract class AsynchronousFileChannel
      * either having acquired a lock on the requested region or having failed to
      * do so.  If it fails to acquire a lock because an overlapping lock is held
      * by another program then it returns {@code null}.  If it fails to acquire
-     * a lock for any other reason then an appropriate exception is thrown.
+     * a lock for any other reason then an appropriate exception is thrown.  If
+     * a lock is created with a valid {@code position} and a {@code size}
+     * parameter of zero, then a lock of size {@code Long.MAX_VALUE - position}
+     * is returned.
      *
      * @param  position
      *         The position at which the locked region is to start; must be

--- a/src/java.base/share/classes/java/nio/channels/AsynchronousFileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/AsynchronousFileChannel.java
@@ -455,7 +455,9 @@ public abstract class AsynchronousFileChannel
      * @param   size
      *          The size of the locked region; must be non-negative, and the sum
      *          {@code position}&nbsp;+&nbsp;{@code size} must be non-negative.
-     *          A value of zero indicates the remainder of the file.
+     *          A value of zero means to lock all bytes from the specified
+     *          starting position to the end of the file, regardless of whether
+     *          the file is subsequently extended or truncated
      * @param   shared
      *          {@code true} to request a shared lock, in which case this
      *          channel must be open for reading (and possibly writing);
@@ -534,7 +536,9 @@ public abstract class AsynchronousFileChannel
      * @param   size
      *          The size of the locked region; must be non-negative, and the sum
      *          {@code position}&nbsp;+&nbsp;{@code size} must be non-negative.
-     *          A value of zero indicates the remainder of the file.
+     *          A value of zero means to lock all bytes from the specified
+     *          starting position to the end of the file, regardless of whether
+     *          the file is subsequently extended or truncated
      * @param   shared
      *          {@code true} to request a shared lock, in which case this
      *          channel must be open for reading (and possibly writing);
@@ -597,7 +601,9 @@ public abstract class AsynchronousFileChannel
      * @param  size
      *         The size of the locked region; must be non-negative, and the sum
      *         {@code position}&nbsp;+&nbsp;{@code size} must be non-negative.
-     *         A value of zero indicates the remainder of the file.
+     *         A value of zero means to lock all bytes from the specified
+     *         starting position to the end of the file, regardless of whether
+     *         the file is subsequently extended or truncated
      *
      * @param  shared
      *         {@code true} to request a shared lock,

--- a/src/java.base/share/classes/java/nio/channels/AsynchronousFileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/AsynchronousFileChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -454,7 +454,8 @@ public abstract class AsynchronousFileChannel
      *          non-negative
      * @param   size
      *          The size of the locked region; must be non-negative, and the sum
-     *          {@code position}&nbsp;+&nbsp;{@code size} must be non-negative
+     *          {@code position}&nbsp;+&nbsp;{@code size} must be non-negative.
+     *          A value of zero indicates the remainder of the file.
      * @param   shared
      *          {@code true} to request a shared lock, in which case this
      *          channel must be open for reading (and possibly writing);
@@ -532,7 +533,8 @@ public abstract class AsynchronousFileChannel
      *          non-negative
      * @param   size
      *          The size of the locked region; must be non-negative, and the sum
-     *          {@code position}&nbsp;+&nbsp;{@code size} must be non-negative
+     *          {@code position}&nbsp;+&nbsp;{@code size} must be non-negative.
+     *          A value of zero indicates the remainder of the file.
      * @param   shared
      *          {@code true} to request a shared lock, in which case this
      *          channel must be open for reading (and possibly writing);
@@ -594,7 +596,8 @@ public abstract class AsynchronousFileChannel
      *
      * @param  size
      *         The size of the locked region; must be non-negative, and the sum
-     *         {@code position}&nbsp;+&nbsp;{@code size} must be non-negative
+     *         {@code position}&nbsp;+&nbsp;{@code size} must be non-negative.
+     *         A value of zero indicates the remainder of the file.
      *
      * @param  shared
      *         {@code true} to request a shared lock,

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -981,8 +981,8 @@ public abstract class FileChannel
      * required then a region starting at zero, and no smaller than the
      * expected maximum size of the file, should be locked.  The zero-argument
      * {@link #lock()} method simply locks a region of size {@link
-     * Long#MAX_VALUE}.  If a lock is created with a valid {@code position}
-     * and a {@code size} parameter of zero, then a lock of size
+     * Long#MAX_VALUE}.  If the {@code position} is non-negative and the
+     * {@code size} is zero, then a lock of size
      * {@code Long.MAX_VALUE - position} is returned.
      *
      * <p> Some operating systems do not support shared locks, in which case a
@@ -1113,8 +1113,8 @@ public abstract class FileChannel
      * required then a region starting at zero, and no smaller than the
      * expected maximum size of the file, should be locked.  The zero-argument
      * {@link #tryLock()} method simply locks a region of size {@link
-     * Long#MAX_VALUE}.  If a lock is created with a valid {@code position}
-     * and a {@code size} parameter of zero, then a lock of size
+     * Long#MAX_VALUE}.  If the {@code position} is non-negative and the
+     * {@code size} is zero, then a lock of size
      * {@code Long.MAX_VALUE - position} is returned.
      *
      * <p> Some operating systems do not support shared locks, in which case a

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -981,7 +981,9 @@ public abstract class FileChannel
      * required then a region starting at zero, and no smaller than the
      * expected maximum size of the file, should be locked.  The zero-argument
      * {@link #lock()} method simply locks a region of size {@link
-     * Long#MAX_VALUE}.
+     * Long#MAX_VALUE}.  If a lock is created with a valid {@code position}
+     * and a {@code size} parameter of zero, then a lock of size
+     * {@code Long.MAX_VALUE - position} is returned.
      *
      * <p> Some operating systems do not support shared locks, in which case a
      * request for a shared lock is automatically converted into a request for
@@ -1111,7 +1113,9 @@ public abstract class FileChannel
      * required then a region starting at zero, and no smaller than the
      * expected maximum size of the file, should be locked.  The zero-argument
      * {@link #tryLock()} method simply locks a region of size {@link
-     * Long#MAX_VALUE}.
+     * Long#MAX_VALUE}.  If a lock is created with a valid {@code position}
+     * and a {@code size} parameter of zero, then a lock of size
+     * {@code Long.MAX_VALUE - position} is returned.
      *
      * <p> Some operating systems do not support shared locks, in which case a
      * request for a shared lock is automatically converted into a request for

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -1000,7 +1000,9 @@ public abstract class FileChannel
      * @param  size
      *         The size of the locked region; must be non-negative, and the sum
      *         {@code position}&nbsp;+&nbsp;{@code size} must be non-negative.
-     *         A value of zero indicates the remainder of the file.
+     *         A value of zero means to lock all bytes from the specified
+     *         starting position to the end of the file, regardless of whether
+     *         the file is subsequently extended or truncated
      *
      * @param  shared
      *         {@code true} to request a shared lock, in which case this
@@ -1128,7 +1130,9 @@ public abstract class FileChannel
      * @param  size
      *         The size of the locked region; must be non-negative, and the sum
      *         {@code position}&nbsp;+&nbsp;{@code size} must be non-negative.
-     *         A value of zero indicates the remainder of the file.
+     *         A value of zero means to lock all bytes from the specified
+     *         starting position to the end of the file, regardless of whether
+     *         the file is subsequently extended or truncated
      *
      * @param  shared
      *         {@code true} to request a shared lock,

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -999,7 +999,8 @@ public abstract class FileChannel
      *
      * @param  size
      *         The size of the locked region; must be non-negative, and the sum
-     *         {@code position}&nbsp;+&nbsp;{@code size} must be non-negative
+     *         {@code position}&nbsp;+&nbsp;{@code size} must be non-negative.
+     *         A value of zero indicates the remainder of the file.
      *
      * @param  shared
      *         {@code true} to request a shared lock, in which case this
@@ -1126,7 +1127,8 @@ public abstract class FileChannel
      *
      * @param  size
      *         The size of the locked region; must be non-negative, and the sum
-     *         {@code position}&nbsp;+&nbsp;{@code size} must be non-negative
+     *         {@code position}&nbsp;+&nbsp;{@code size} must be non-negative.
+     *         A value of zero indicates the remainder of the file.
      *
      * @param  shared
      *         {@code true} to request a shared lock,

--- a/src/java.base/share/classes/java/nio/channels/FileLock.java
+++ b/src/java.base/share/classes/java/nio/channels/FileLock.java
@@ -136,8 +136,7 @@ public abstract class FileLock implements AutoCloseable {
      *
      * @param  size
      *         The size of the locked region; must be non-negative, and the sum
-     *         {@code position}&nbsp;+&nbsp;{@code size} must be non-negative.
-     *         A value of zero indicates the remainder of the file.
+     *         {@code position}&nbsp;+&nbsp;{@code size} must be non-negative
      *
      * @param  shared
      *         {@code true} if this lock is shared,
@@ -174,8 +173,7 @@ public abstract class FileLock implements AutoCloseable {
      *
      * @param  size
      *         The size of the locked region; must be non-negative, and the sum
-     *         {@code position}&nbsp;+&nbsp;{@code size} must be non-negative.
-     *         A value of zero indicates the remainder of the file.
+     *         {@code position}&nbsp;+&nbsp;{@code size} must be non-negative
      *
      * @param  shared
      *         {@code true} if this lock is shared,
@@ -267,8 +265,7 @@ public abstract class FileLock implements AutoCloseable {
      * Tells whether or not this lock overlaps the given lock range.
      *
      * <p> If {@code size} is negative, {@code false} is returned regardless
-     * of the value of {@code position}. A {@code size} of zero indicates the
-     * remainder of the file.
+     * of the value of {@code position}.
      *
      * @param   position
      *          The starting position of the lock range

--- a/src/java.base/share/classes/java/nio/channels/FileLock.java
+++ b/src/java.base/share/classes/java/nio/channels/FileLock.java
@@ -264,16 +264,14 @@ public abstract class FileLock implements AutoCloseable {
     /**
      * Tells whether or not this lock overlaps the given lock range.
      *
-     * <p> If {@code size} is negative, {@code false} is returned regardless
-     * of the value of {@code position}.
-     *
      * @param   position
      *          The starting position of the lock range
      * @param   size
      *          The size of the lock range
      *
-     * @return  {@code true} if, and only if, this lock and the given lock
-     *          range overlap by at least one byte
+     * @return  {@code true} if this lock and the given lock range overlap
+     *          by at least one byte; {@code false} if {@code size} is
+     *          negative or the lock range does not overlap this lock
      */
     public final boolean overlaps(long position, long size) {
         if (size < 0)

--- a/src/java.base/share/classes/java/nio/channels/FileLock.java
+++ b/src/java.base/share/classes/java/nio/channels/FileLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -263,6 +263,12 @@ public abstract class FileLock implements AutoCloseable {
 
     /**
      * Tells whether or not this lock overlaps the given lock range.
+     *
+     * @implNote
+     * This method assumes that the parameters are non-negative and that
+     * their sum does not overflow a {@code long}, but does not enforce
+     * these preconditions as do the constructors; hence it is the caller's
+     * responsibility to ensure that these parameters are valid.
      *
      * @param   position
      *          The starting position of the lock range

--- a/src/java.base/share/classes/java/nio/channels/FileLock.java
+++ b/src/java.base/share/classes/java/nio/channels/FileLock.java
@@ -127,9 +127,6 @@ public abstract class FileLock implements AutoCloseable {
     /**
      * Initializes a new instance of this class.
      *
-     * <p> If {@code size} is zero, the entire file from {@code position}
-     * onward is locked.
-     *
      * @param  channel
      *         The file channel upon whose file this lock is held
      *
@@ -139,7 +136,8 @@ public abstract class FileLock implements AutoCloseable {
      *
      * @param  size
      *         The size of the locked region; must be non-negative, and the sum
-     *         {@code position}&nbsp;+&nbsp;{@code size} must be non-negative
+     *         {@code position}&nbsp;+&nbsp;{@code size} must be non-negative.
+     *         A value of zero indicates the remainder of the file.
      *
      * @param  shared
      *         {@code true} if this lock is shared,
@@ -160,15 +158,12 @@ public abstract class FileLock implements AutoCloseable {
             throw new IllegalArgumentException("Negative position + size");
         this.channel = channel;
         this.position = position;
-        this.size = size == 0 ? Long.MAX_VALUE - position : size;
+        this.size = size;
         this.shared = shared;
     }
 
     /**
      * Initializes a new instance of this class.
-     *
-     * <p> If {@code size} is zero, the entire file from {@code position}
-     * onward is locked.
      *
      * @param  channel
      *         The channel upon whose file this lock is held
@@ -179,7 +174,8 @@ public abstract class FileLock implements AutoCloseable {
      *
      * @param  size
      *         The size of the locked region; must be non-negative, and the sum
-     *         {@code position}&nbsp;+&nbsp;{@code size} must be non-negative
+     *         {@code position}&nbsp;+&nbsp;{@code size} must be non-negative.
+     *         A value of zero indicates the remainder of the file.
      *
      * @param  shared
      *         {@code true} if this lock is shared,
@@ -202,7 +198,7 @@ public abstract class FileLock implements AutoCloseable {
             throw new IllegalArgumentException("Negative position + size");
         this.channel = channel;
         this.position = position;
-        this.size = size == 0 ? Long.MAX_VALUE - position : size;
+        this.size = size;
         this.shared = shared;
     }
 
@@ -271,17 +267,16 @@ public abstract class FileLock implements AutoCloseable {
      * Tells whether or not this lock overlaps the given lock range.
      *
      * <p> If {@code size} is negative, {@code false} is returned regardless
-     * of the value of {@code position}. If {@code size} is zero, it means the
-     * lock range is unbounded.
+     * of the value of {@code position}. A {@code size} of zero indicates the
+     * remainder of the file.
      *
      * @param   position
      *          The starting position of the lock range
      * @param   size
      *          The size of the lock range
      *
-     * @return  {@code false} if, and only if, {@code size} is negative or this
-     *          lock and the given lock range do <em>not</em> overlap by at
-     *          least one byte
+     * @return  {@code true} if, and only if, this lock and the given lock
+     *          range overlap by at least one byte
      */
     public final boolean overlaps(long position, long size) {
         if (size < 0)

--- a/src/java.base/share/classes/java/nio/channels/FileLock.java
+++ b/src/java.base/share/classes/java/nio/channels/FileLock.java
@@ -277,9 +277,10 @@ public abstract class FileLock implements AutoCloseable {
         if (size < 0)
             return false;
 
+        // Test whether this is below that
         try {
             if (Math.addExact(this.position, this.size) <= position)
-                return false;               // This is below that
+                return false;
         } catch (ArithmeticException ignored) {
             // the sum of this.position and this.size overflows the range of
             // long hence their mathematical sum is greater than position
@@ -288,9 +289,10 @@ public abstract class FileLock implements AutoCloseable {
         // if size == 0 then the specified lock range is unbounded and
         // cannot be below the range of this lock
         if (size > 0) {
+            // Test whether that is below this
             try {
                 if (Math.addExact(position, size) <= this.position)
-                    return false;               // That is below this
+                    return false;
             } catch (ArithmeticException ignored) {
                 // the sum of position and size overflows the range of long
                 // hence their mathematical sum is greater than this.position

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1271,6 +1271,8 @@ public class FileChannelImpl
             throw new NonReadableChannelException();
         if (!shared && !writable)
             throw new NonWritableChannelException();
+        if (size == 0)
+            size = Long.MAX_VALUE - Math.max(0, position);
         FileLockImpl fli = new FileLockImpl(this, position, size, shared);
         FileLockTable flt = fileLockTable();
         flt.add(fli);
@@ -1316,6 +1318,8 @@ public class FileChannelImpl
             throw new NonReadableChannelException();
         if (!shared && !writable)
             throw new NonWritableChannelException();
+        if (size == 0)
+            size = Long.MAX_VALUE - Math.max(0, position);
         FileLockImpl fli = new FileLockImpl(this, position, size, shared);
         FileLockTable flt = fileLockTable();
         flt.add(fli);

--- a/src/java.base/share/classes/sun/nio/ch/SimpleAsynchronousFileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SimpleAsynchronousFileChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -181,8 +181,10 @@ public class SimpleAsynchronousFileChannelImpl
         if (!shared && !writing)
             throw new NonWritableChannelException();
 
+        long len = size != 0 ? size : Long.MAX_VALUE - Math.max(0, position);
+
         // add to lock table
-        final FileLockImpl fli = addToFileLockTable(position, size, shared);
+        final FileLockImpl fli = addToFileLockTable(position, len, shared);
         if (fli == null) {
             Throwable exc = new ClosedChannelException();
             if (handler == null)
@@ -203,7 +205,7 @@ public class SimpleAsynchronousFileChannelImpl
                     try {
                         begin();
                         do {
-                            n = nd.lock(fdObj, true, position, size, shared);
+                            n = nd.lock(fdObj, true, position, len, shared);
                         } while ((n == FileDispatcher.INTERRUPTED) && isOpen());
                         if (n != FileDispatcher.LOCKED || !isOpen()) {
                             throw new AsynchronousCloseException();
@@ -247,6 +249,9 @@ public class SimpleAsynchronousFileChannelImpl
             throw new NonReadableChannelException();
         if (!shared && !writing)
             throw new NonWritableChannelException();
+
+        if (size == 0)
+            size = Long.MAX_VALUE - Math.max(0, position);
 
         // add to lock table
         FileLockImpl fli = addToFileLockTable(position, size, shared);

--- a/src/java.base/share/classes/sun/nio/ch/SimpleAsynchronousFileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SimpleAsynchronousFileChannelImpl.java
@@ -181,7 +181,7 @@ public class SimpleAsynchronousFileChannelImpl
         if (!shared && !writing)
             throw new NonWritableChannelException();
 
-        long len = size != 0 ? size : Long.MAX_VALUE - Math.max(0, position);
+        long len = (size != 0) ? size : Long.MAX_VALUE - Math.max(0, position);
 
         // add to lock table
         final FileLockImpl fli = addToFileLockTable(position, len, shared);

--- a/src/java.base/windows/classes/sun/nio/ch/WindowsAsynchronousFileChannelImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/WindowsAsynchronousFileChannelImpl.java
@@ -299,7 +299,7 @@ public class WindowsAsynchronousFileChannelImpl
         if (!shared && !writing)
             throw new NonWritableChannelException();
 
-        long len = size != 0 ? size : Long.MAX_VALUE - Math.max(0, position);
+        long len = (size != 0) ? size : Long.MAX_VALUE - Math.max(0, position);
 
         // add to lock table
         FileLockImpl fli = addToFileLockTable(position, len, shared);

--- a/src/java.base/windows/classes/sun/nio/ch/WindowsAsynchronousFileChannelImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/WindowsAsynchronousFileChannelImpl.java
@@ -334,6 +334,9 @@ public class WindowsAsynchronousFileChannelImpl
         if (!shared && !writing)
             throw new NonWritableChannelException();
 
+        if (size == 0)
+            size = Long.MAX_VALUE - Math.max(0, position);
+
         // add to lock table
         final FileLockImpl fli = addToFileLockTable(position, size, shared);
         if (fli == null)

--- a/src/java.base/windows/classes/sun/nio/ch/WindowsAsynchronousFileChannelImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/WindowsAsynchronousFileChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -299,8 +299,10 @@ public class WindowsAsynchronousFileChannelImpl
         if (!shared && !writing)
             throw new NonWritableChannelException();
 
+        long len = size != 0 ? size : Long.MAX_VALUE - Math.max(0, position);
+
         // add to lock table
-        FileLockImpl fli = addToFileLockTable(position, size, shared);
+        FileLockImpl fli = addToFileLockTable(position, len, shared);
         if (fli == null) {
             Throwable exc = new ClosedChannelException();
             if (handler == null)

--- a/src/java.base/windows/native/libnio/ch/FileDispatcherImpl.c
+++ b/src/java.base/windows/native/libnio/ch/FileDispatcherImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -389,8 +389,15 @@ Java_sun_nio_ch_FileDispatcherImpl_lock0(JNIEnv *env, jobject this, jobject fdo,
     HANDLE h = (HANDLE)(handleval(env, fdo));
     DWORD lowPos = (DWORD)pos;
     long highPos = (long)(pos >> 32);
-    DWORD lowNumBytes = (DWORD)size;
-    DWORD highNumBytes = (DWORD)(size >> 32);
+    DWORD lowNumBytes;
+    DWORD highNumBytes;
+    if (size == 0) {
+        lowNumBytes = MAXDWORD;
+        highNumBytes = MAXDWORD;
+    } else {
+        lowNumBytes = (DWORD)size;
+        highNumBytes = (DWORD)(size >> 32);
+    }
     BOOL result;
     DWORD flags = 0;
     OVERLAPPED o;
@@ -434,8 +441,15 @@ Java_sun_nio_ch_FileDispatcherImpl_release0(JNIEnv *env, jobject this,
     HANDLE h = (HANDLE)(handleval(env, fdo));
     DWORD lowPos = (DWORD)pos;
     long highPos = (long)(pos >> 32);
-    DWORD lowNumBytes = (DWORD)size;
-    DWORD highNumBytes = (DWORD)(size >> 32);
+    DWORD lowNumBytes;
+    DWORD highNumBytes;
+    if (size == 0) {
+        lowNumBytes = MAXDWORD;
+        highNumBytes = MAXDWORD;
+    } else {
+        lowNumBytes = (DWORD)size;
+        highNumBytes = (DWORD)(size >> 32);
+    }
     BOOL result = 0;
     OVERLAPPED o;
     o.hEvent = 0;

--- a/src/java.base/windows/native/libnio/ch/FileDispatcherImpl.c
+++ b/src/java.base/windows/native/libnio/ch/FileDispatcherImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -389,15 +389,8 @@ Java_sun_nio_ch_FileDispatcherImpl_lock0(JNIEnv *env, jobject this, jobject fdo,
     HANDLE h = (HANDLE)(handleval(env, fdo));
     DWORD lowPos = (DWORD)pos;
     long highPos = (long)(pos >> 32);
-    DWORD lowNumBytes;
-    DWORD highNumBytes;
-    if (size == 0) {
-        lowNumBytes = MAXDWORD;
-        highNumBytes = MAXDWORD;
-    } else {
-        lowNumBytes = (DWORD)size;
-        highNumBytes = (DWORD)(size >> 32);
-    }
+    DWORD lowNumBytes = (DWORD)size;
+    DWORD highNumBytes = (DWORD)(size >> 32);
     BOOL result;
     DWORD flags = 0;
     OVERLAPPED o;
@@ -441,15 +434,8 @@ Java_sun_nio_ch_FileDispatcherImpl_release0(JNIEnv *env, jobject this,
     HANDLE h = (HANDLE)(handleval(env, fdo));
     DWORD lowPos = (DWORD)pos;
     long highPos = (long)(pos >> 32);
-    DWORD lowNumBytes;
-    DWORD highNumBytes;
-    if (size == 0) {
-        lowNumBytes = MAXDWORD;
-        highNumBytes = MAXDWORD;
-    } else {
-        lowNumBytes = (DWORD)size;
-        highNumBytes = (DWORD)(size >> 32);
-    }
+    DWORD lowNumBytes = (DWORD)size;
+    DWORD highNumBytes = (DWORD)(size >> 32);
     BOOL result = 0;
     OVERLAPPED o;
     o.hEvent = 0;

--- a/test/jdk/java/nio/channels/AsynchronousFileChannel/Basic.java
+++ b/test/jdk/java/nio/channels/AsynchronousFileChannel/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,18 +22,37 @@
  */
 
 /* @test
- * @bug 4607272 6822643 6830721 6842687
+ * @bug 4607272 5041655 6822643 6830721 6842687
  * @summary Unit test for AsynchronousFileChannel
  * @key randomness
  */
 
-import java.nio.file.*;
-import java.nio.channels.*;
-import java.nio.ByteBuffer;
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.*;
+import java.nio.ByteBuffer;
+import java.nio.channels.AsynchronousCloseException;
+import java.nio.channels.AsynchronousFileChannel;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.CompletionHandler;
+import java.nio.channels.FileLock;
+import java.nio.channels.NonWritableChannelException;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeoutException;;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import static java.nio.file.StandardOpenOption.*;
 
@@ -176,7 +195,12 @@ public class Basic {
             // test 1 - acquire lock and check that tryLock throws
             // OverlappingFileLockException
             try {
-                fl = ch.lock().get();
+                long pos = rand.nextInt(Integer.MAX_VALUE);
+                fl = ch.lock(pos, 0, false).get();
+                long expectedSize = Long.MAX_VALUE - pos;
+                if(fl.size() != expectedSize)
+                    throw new RuntimeException("Lock size not " +
+                        expectedSize + " for position " + pos);
             } catch (ExecutionException x) {
                 throw new RuntimeException(x);
             } catch (InterruptedException x) {
@@ -192,7 +216,12 @@ public class Basic {
             fl.release();
 
             // test 2 - acquire try and check that lock throws OverlappingFileLockException
-            fl = ch.tryLock();
+            long pos = rand.nextInt(Integer.MAX_VALUE);
+            fl = ch.tryLock(pos, 0, false);
+            long expectedSize = Long.MAX_VALUE - pos;
+            if(fl.size() != expectedSize)
+                throw new RuntimeException("Lock size not " + expectedSize +
+                    " for position " + pos);
             if (fl == null)
                 throw new RuntimeException("Unable to acquire lock");
             try {

--- a/test/jdk/java/nio/channels/AsynchronousFileChannel/Basic.java
+++ b/test/jdk/java/nio/channels/AsynchronousFileChannel/Basic.java
@@ -199,8 +199,8 @@ public class Basic {
                 fl = ch.lock(pos, 0, false).get();
                 long expectedSize = Long.MAX_VALUE - pos;
                 if(fl.size() != expectedSize)
-                    throw new RuntimeException("Lock size not " +
-                        expectedSize + " for position " + pos);
+                    throw new RuntimeException("Lock size " + fl.size() +
+                        " != " + expectedSize + " for position " + pos);
             } catch (ExecutionException x) {
                 throw new RuntimeException(x);
             } catch (InterruptedException x) {
@@ -220,8 +220,8 @@ public class Basic {
             fl = ch.tryLock(pos, 0, false);
             long expectedSize = Long.MAX_VALUE - pos;
             if(fl.size() != expectedSize)
-                throw new RuntimeException("Lock size not " + expectedSize +
-                    " for position " + pos);
+                throw new RuntimeException("Lock size " + fl.size() + " != " +
+                    expectedSize + " for position " + pos);
             if (fl == null)
                 throw new RuntimeException("Unable to acquire lock");
             try {

--- a/test/jdk/java/nio/channels/FileChannel/Lock.java
+++ b/test/jdk/java/nio/channels/FileChannel/Lock.java
@@ -144,7 +144,8 @@ public class Lock {
                 try (FileLock lock = b ? channel.lock(position, 0, false) :
                     channel.tryLock(position, 0, false)) {
                     if(lock.size() != expectedSize)
-                        throw new RuntimeException("Size not " + expectedSize +
+                        throw new RuntimeException("Lock size " + lock.size() +
+                            " != " + expectedSize +
                             " for position " + position + " of " +
                             (shared ? "exclusive" : "shared") + " lock");
                 }

--- a/test/jdk/java/nio/channels/FileChannel/Lock.java
+++ b/test/jdk/java/nio/channels/FileChannel/Lock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,12 +22,19 @@
  */
 
 /* @test
- * @bug 4429043 4493595 6332756 6709457 7146506
+ * @bug 4429043 4493595 5041655 6332756 6709457 7146506
  * @summary Test FileChannel file locking
  */
 
-import java.io.*;
-import java.nio.channels.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStreamReader;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.util.Random;
 import static java.nio.file.StandardOpenOption.*;
 
 /**
@@ -126,12 +133,22 @@ public class Lock {
     static void test2(File blah, boolean b) throws Exception {
         try (RandomAccessFile raf = new RandomAccessFile(blah, "rw")) {
             FileChannel channel = raf.getChannel();
-            FileLock lock;
-            if (b)
-                lock = channel.lock();
-            else
-                lock = channel.tryLock();
-            lock.release();
+            try (FileLock lock = b ? channel.lock() : channel.tryLock()) {
+            }
+
+            Random rnd = new Random(System.currentTimeMillis());
+            long position = rnd.nextInt(Integer.MAX_VALUE);
+            long expectedSize = Long.MAX_VALUE - position;
+
+            for (boolean shared : new boolean[] {false, true}) {
+                try (FileLock lock = b ? channel.lock(position, 0, false) :
+                    channel.tryLock(position, 0, false)) {
+                    if(lock.size() != expectedSize)
+                        throw new RuntimeException("Size not " + expectedSize +
+                            " for position " + position + " of " +
+                            (shared ? "exclusive" : "shared") + " lock");
+                }
+            }
         }
     }
 

--- a/test/jdk/java/nio/channels/FileLock/Overlaps.java
+++ b/test/jdk/java/nio/channels/FileLock/Overlaps.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 5041655
+ * @summary Verify FileLock.overlaps
+ * @run testng Overlaps
+ */
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.lang.Boolean.*;
+import static java.nio.file.StandardOpenOption.*;
+
+import static org.testng.Assert.assertEquals;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class Overlaps {
+    private static final long POS = 27;
+    private static final long SIZE = 42;
+
+    private static FileChannel fc;
+
+    @BeforeClass
+    public void before() throws IOException {
+        Path path = Files.createTempFile(Path.of("."), "foo", ".bar");
+        fc = FileChannel.open(path, CREATE, WRITE, DELETE_ON_CLOSE);
+        fc.position(POS);
+        fc.write(ByteBuffer.wrap(new byte[(int)SIZE]));
+    }
+
+    @AfterClass
+    public void after() throws IOException {
+        fc.close();
+    }
+
+    @DataProvider
+    public Object[][] ranges() {
+        return new Object[][] {
+            {POS, SIZE, -1,-1, FALSE},
+            {POS, SIZE, 0, -1, FALSE},
+            {POS, SIZE, POS - 1, -1, FALSE},
+            {POS, SIZE, POS + SIZE/2, -1, FALSE},
+            {POS, SIZE, POS + SIZE, -1, FALSE},
+            {POS, SIZE, -1, POS, FALSE},
+            {POS, SIZE, -1, POS + SIZE/2, TRUE},
+            {POS, SIZE, POS - 2, 1, FALSE},
+            {POS, SIZE, POS + 1, 1, TRUE},
+            {POS, SIZE, POS + SIZE/2, 0, TRUE},
+            {POS, SIZE, Long.MAX_VALUE, 2, FALSE},
+            {POS, SIZE, POS + SIZE / 2, Long.MAX_VALUE, TRUE},
+            {POS, SIZE, 0, 0, TRUE},
+            {Long.MAX_VALUE - SIZE/2, 0, 0, SIZE, FALSE},
+            {Long.MAX_VALUE - SIZE/2, 0, Long.MAX_VALUE - SIZE/4, SIZE, TRUE},
+            {Long.MAX_VALUE - SIZE/2, 0, Long.MAX_VALUE - SIZE, 0, TRUE},
+            {Long.MAX_VALUE - SIZE, 0, Long.MAX_VALUE - SIZE/2, 0, TRUE}
+        };
+    }
+
+    @Test(dataProvider = "ranges")
+    public void overlaps(long lockPos, long lockSize, long pos, long size,
+        boolean overlaps) throws IOException {
+        try (FileLock lock = fc.lock(lockPos, lockSize, false)) {
+            assertEquals(lock.overlaps(pos, size), overlaps);
+        }
+    }
+}


### PR DESCRIPTION
Add an implementation note to `java.nio.channels.FileLock.overlaps(long,long)` indicating that the method does not check its parameters. Adding such checks would be an incompatible change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-5041655](https://bugs.openjdk.java.net/browse/JDK-5041655): (ch) FileLock: negative param and overflow issues
 * [JDK-8281623](https://bugs.openjdk.java.net/browse/JDK-8281623): (ch) FileLock: negative param and overflow issues (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to ef5b46e853d8f495b8aa1a27b0f5106e4dc3dd90


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7254/head:pull/7254` \
`$ git checkout pull/7254`

Update a local copy of the PR: \
`$ git checkout pull/7254` \
`$ git pull https://git.openjdk.java.net/jdk pull/7254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7254`

View PR using the GUI difftool: \
`$ git pr show -t 7254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7254.diff">https://git.openjdk.java.net/jdk/pull/7254.diff</a>

</details>
