### PR TITLE
8277101: jcmd VM.cds dynamic_dump should not regenerate holder classes

### DIFF
--- a/src/hotspot/share/cds/dynamicArchive.cpp
+++ b/src/hotspot/share/cds/dynamicArchive.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -384,7 +384,7 @@ void DynamicArchive::check_for_dynamic_dump() {
 void DynamicArchive::prepare_for_dump_at_exit() {
   EXCEPTION_MARK;
   ResourceMark rm(THREAD);
-  MetaspaceShared::link_shared_classes(THREAD);
+  MetaspaceShared::link_shared_classes(false/*not from jcmd*/, THREAD);
   if (HAS_PENDING_EXCEPTION) {
     log_error(cds)("Dynamic dump has failed");
     log_error(cds)("%s: %s", PENDING_EXCEPTION->klass()->external_name(),
@@ -400,7 +400,7 @@ void DynamicArchive::dump_for_jcmd(const char* archive_name, TRAPS) {
   assert(UseSharedSpaces && RecordDynamicDumpInfo, "already checked in arguments.cpp");
   assert(ArchiveClassesAtExit == nullptr, "already checked in arguments.cpp");
   assert(DynamicDumpSharedSpaces, "already checked by check_for_dynamic_dump() during VM startup");
-  MetaspaceShared::link_shared_classes(CHECK);
+  MetaspaceShared::link_shared_classes(true/*from jcmd*/, CHECK);
   dump(archive_name, THREAD);
 }
 

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -642,8 +642,10 @@ bool MetaspaceShared::link_class_for_cds(InstanceKlass* ik, TRAPS) {
   return res;
 }
 
-void MetaspaceShared::link_shared_classes(TRAPS) {
-  LambdaFormInvokers::regenerate_holder_classes(CHECK);
+void MetaspaceShared::link_shared_classes(bool jcmd_request, TRAPS) {
+  if (!jcmd_request) {
+    LambdaFormInvokers::regenerate_holder_classes(CHECK);
+  }
 
   // Collect all loaded ClassLoaderData.
   CollectCLDClosure collect_cld(THREAD);
@@ -775,7 +777,7 @@ void MetaspaceShared::preload_and_dump_impl(TRAPS) {
   // were not explicitly specified in the classlist. E.g., if an interface implemented by class K
   // fails verification, all other interfaces that were not specified in the classlist but
   // are implemented by K are not verified.
-  link_shared_classes(CHECK);
+  link_shared_classes(false/*not from jcmd*/, CHECK);
   log_info(cds)("Rewriting and linking classes: done");
 
 #if INCLUDE_CDS_JAVA_HEAP

--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,7 +133,7 @@ public:
   }
 
   static bool try_link_class(JavaThread* current, InstanceKlass* ik);
-  static void link_shared_classes(TRAPS) NOT_CDS_RETURN;
+  static void link_shared_classes(bool jcmd_request, TRAPS) NOT_CDS_RETURN;
   static bool link_class_for_cds(InstanceKlass* ik, TRAPS) NOT_CDS_RETURN_(false);
   static bool may_be_eagerly_linked(InstanceKlass* ik) NOT_CDS_RETURN_(false);
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDynamicDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDynamicDump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -117,6 +117,17 @@ public class JCmdTestDynamicDump extends JCmdTestDumpBase {
                 throw new RuntimeException("The JCmdTestLingeredApp should not start up!");
             }
         }
+        // Test dynamic dump with -Xlog:cds to check lambda invoker class regeneration
+        print2ln(test_count++ + " Test dynamic dump with -Xlog:cds to check lambda invoker class regeneration");
+        app = createLingeredApp("-cp", allJars, "-XX:+RecordDynamicDumpInfo", "-Xlog:cds",
+                                "-XX:SharedArchiveFile=" + archiveFile);
+        pid = app.getPid();
+        test(null, pid, noBoot, EXPECT_PASS, DYNAMIC_MESSAGES);
+        String stdout = app.getProcessStdout();
+        if (stdout.contains("Regenerate MethodHandle Holder classes...")) {
+            throw new RuntimeException("jcmd VM.cds dump_dynamic should not regenerate MethodHandle Holder classes");
+        }
+        app.stopApp();
     }
 
     // Dump a static archive, not using TestCommon.dump(...), we do not take jtreg args.

--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDynamicDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDynamicDump.java
@@ -125,7 +125,7 @@ public class JCmdTestDynamicDump extends JCmdTestDumpBase {
         test(null, pid, noBoot, EXPECT_PASS, DYNAMIC_MESSAGES);
         String stdout = app.getProcessStdout();
         if (stdout.contains("Regenerate MethodHandle Holder classes...")) {
-            throw new RuntimeException("jcmd VM.cds dump_dynamic should not regenerate MethodHandle Holder classes");
+            throw new RuntimeException("jcmd VM.cds dynamic_dump should not regenerate MethodHandle Holder classes");
         }
         app.stopApp();
     }


### PR DESCRIPTION
Hi, Please review

  When using jcmd to do dynamic dump, lambda MethodHandle Holder classes are regenerated and added to system dictionary, which may cause problem since after the dump, the process continues and there may cause unexpected result.

  Fix to not regenerate method handle holder classes if the call is from jcmd.

Tests: tier1,tier4 

Thanks
Yumin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277101](https://bugs.openjdk.java.net/browse/JDK-8277101): jcmd VM.cds dynamic_dump should not regenerate holder classes


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7256/head:pull/7256` \
`$ git checkout pull/7256`

Update a local copy of the PR: \
`$ git checkout pull/7256` \
`$ git pull https://git.openjdk.java.net/jdk pull/7256/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7256`

View PR using the GUI difftool: \
`$ git pr show -t 7256`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7256.diff">https://git.openjdk.java.net/jdk/pull/7256.diff</a>

</details>
