### PR TITLE
8280554: resourcehogs/serviceability/sa/ClhsdbRegionDetailsScanOopsForG1.java can fail if GC is triggered

### DIFF
--- a/test/hotspot/jtreg/resourcehogs/serviceability/sa/ClhsdbRegionDetailsScanOopsForG1.java
+++ b/test/hotspot/jtreg/resourcehogs/serviceability/sa/ClhsdbRegionDetailsScanOopsForG1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,6 @@ public class ClhsdbRegionDetailsScanOopsForG1 {
             expStrMap.put("g1regiondetails", List.of(
                 "Region",
                 "Eden",
-                "Survivor",
                 "StartsHumongous",
                 "ContinuesHumongous",
                 "Free"));

--- a/test/hotspot/jtreg/resourcehogs/serviceability/sa/LingeredAppWithLargeStringArray.java
+++ b/test/hotspot/jtreg/resourcehogs/serviceability/sa/LingeredAppWithLargeStringArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,10 @@
 import jdk.test.lib.apps.LingeredApp;
 
 public class LingeredAppWithLargeStringArray extends LingeredApp {
+    public static String[] hugeArray;
+    public static String[] smallArray = {"Just", "for", "testing"};;
     public static void main(String args[]) {
-        String[] hugeArray = new String[Integer.MAX_VALUE/8];
-        String[] smallArray = {"Just", "for", "testing"};
+        hugeArray = new String[Integer.MAX_VALUE/8];
         for (int i = 0; i < hugeArray.length/16; i++) {
             hugeArray[i] = new String(smallArray[i%3]);
         }


### PR DESCRIPTION
When using -Xcomp, the liveness of some objects the test allocates is more precisely known, allowing the objects to be collected before the test expects. This became an issue in the loom repo because it has changes that result in a full GC when the codecache is swept. This is fixed by using statics to reference the objects. Also, if a GC does happen, this seems to get rid of the Survivor region, so the test was updated to no longer check for it.

I'm choosing to fix this in the jdk repo rather than the loom repo since it is a latent bug that theoretically could occur even without the loom changes, and also to help reduce the amount of changes to be reviewed when loom is integrated into jdk.