### PR TITLE
8280817: Clean up and unify empty VM operations

### DIFF
--- a/src/hotspot/share/runtime/vmOperation.hpp
+++ b/src/hotspot/share/runtime/vmOperation.hpp
@@ -35,20 +35,19 @@
 
 // Note: When new VM_XXX comes up, add 'XXX' to the template table.
 #define VM_OPS_DO(template)                       \
-  template(None)                                  \
+  template(Halt)                                  \
+  template(SafepointALot)                         \
   template(Cleanup)                               \
   template(ThreadDump)                            \
   template(PrintThreads)                          \
   template(FindDeadlocks)                         \
   template(ClearICs)                              \
   template(ForceSafepoint)                        \
-  template(ForceAsyncSafepoint)                   \
   template(DeoptimizeFrame)                       \
   template(DeoptimizeAll)                         \
   template(ZombieAll)                             \
   template(Verify)                                \
   template(HeapDumper)                            \
-  template(DeoptimizeTheWorld)                    \
   template(CollectForMetadataAllocation)          \
   template(GC_HeapInspection)                     \
   template(GenCollectFull)                        \
@@ -64,9 +63,7 @@
   template(ZMarkEnd)                              \
   template(ZRelocateStart)                        \
   template(ZVerify)                               \
-  template(HandshakeOneThread)                    \
   template(HandshakeAllThreads)                   \
-  template(HandshakeFallback)                     \
   template(PopulateDumpSharedSpace)               \
   template(JNIFunctionTableCopier)                \
   template(RedefineClasses)                       \
@@ -89,7 +86,6 @@
   template(ShenandoahDegeneratedGC)               \
   template(Exit)                                  \
   template(LinuxDllLoad)                          \
-  template(RotateGCLog)                           \
   template(WhiteBoxOperation)                     \
   template(JVMCIResizeCounters)                   \
   template(ClassLoaderStatsOperation)             \
@@ -99,12 +95,10 @@
   template(CleanClassLoaderDataMetaspaces)        \
   template(PrintCompileQueue)                     \
   template(PrintClassHierarchy)                   \
-  template(ThreadSuspend)                         \
-  template(ThreadsSuspendJVMTI)                   \
   template(ICBufferFull)                          \
-  template(ScavengeMonitors)                      \
   template(PrintMetadata)                         \
   template(GTestExecuteAtSafepoint)               \
+  template(GTestStopSafepoint)                    \
   template(JFROldObject)                          \
   template(JvmtiPostObjectFree)
 

--- a/src/hotspot/share/runtime/vmOperations.hpp
+++ b/src/hotspot/share/runtime/vmOperations.hpp
@@ -32,23 +32,41 @@
 
 // A hodge podge of commonly used VM Operations
 
-class VM_None: public VM_Operation {
-  const char* _reason;
- public:
-  VM_None(const char* reason) : _reason(reason) {}
-  const char* name() const { return _reason; }
-  VMOp_Type type() const { return VMOp_None; }
-  void doit() {};
-};
-
-class VM_Cleanup: public VM_Operation {
- public:
-  VMOp_Type type() const { return VMOp_Cleanup; }
-  void doit() {};
-  virtual bool skip_thread_oop_barriers() const {
-    // None of the safepoint cleanup tasks read oops in the Java threads.
+class VM_EmptyOperation : public VM_Operation {
+public:
+  virtual void doit() final {}
+  virtual bool skip_thread_oop_barriers() const final {
+    // Neither the doit function nor the the safepoint
+    // cleanup tasks read oops in the Java threads.
     return true;
   }
+};
+
+class VM_Halt: public VM_EmptyOperation {
+ public:
+  VMOp_Type type() const { return VMOp_Halt; }
+};
+
+class VM_SafepointALot: public VM_EmptyOperation {
+ public:
+  VMOp_Type type() const { return VMOp_SafepointALot; }
+};
+
+class VM_Cleanup: public VM_EmptyOperation {
+ public:
+  VMOp_Type type() const { return VMOp_Cleanup; }
+};
+
+// empty vm op, evaluated just to force a safepoint
+class VM_ForceSafepoint: public VM_EmptyOperation {
+ public:
+  VMOp_Type type() const { return VMOp_ForceSafepoint; }
+};
+
+// empty vm op, when forcing a safepoint due to inline cache buffers being full
+class VM_ICBufferFull: public VM_EmptyOperation {
+ public:
+  VMOp_Type type() const { return VMOp_ICBufferFull; }
 };
 
 class VM_ClearICs: public VM_Operation {
@@ -58,32 +76,6 @@ class VM_ClearICs: public VM_Operation {
   VM_ClearICs(bool preserve_static_stubs) { _preserve_static_stubs = preserve_static_stubs; }
   void doit();
   VMOp_Type type() const { return VMOp_ClearICs; }
-};
-
-// empty vm op, evaluated just to force a safepoint
-class VM_ForceSafepoint: public VM_Operation {
- public:
-  void doit()         {}
-  VMOp_Type type() const { return VMOp_ForceSafepoint; }
-};
-
-// empty vm op, when forcing a safepoint to suspend a thread
-class VM_ThreadSuspend: public VM_ForceSafepoint {
- public:
-  VMOp_Type type() const { return VMOp_ThreadSuspend; }
-};
-
-// empty vm op, when forcing a safepoint to suspend threads from jvmti
-class VM_ThreadsSuspendJVMTI: public VM_ForceSafepoint {
- public:
-  VMOp_Type type() const { return VMOp_ThreadsSuspendJVMTI; }
-};
-
-// empty vm op, when forcing a safepoint due to inline cache buffers being full
-class VM_ICBufferFull: public VM_ForceSafepoint {
- public:
-  VMOp_Type type() const { return VMOp_ICBufferFull; }
-  virtual bool skip_thread_oop_barriers() const { return true; }
 };
 
 // Base class for invoking parts of a gtest in a safepoint.

--- a/src/hotspot/share/runtime/vmThread.cpp
+++ b/src/hotspot/share/runtime/vmThread.cpp
@@ -96,8 +96,8 @@ void VMOperationTimeoutTask::disarm() {
 //------------------------------------------------------------------------------------------------------------------
 // Implementation of VMThread stuff
 
-static VM_None    safepointALot_op("SafepointALot");
-static VM_Cleanup cleanup_op;
+static VM_SafepointALot safepointALot_op;
+static VM_Cleanup       cleanup_op;
 
 bool              VMThread::_should_terminate   = false;
 bool              VMThread::_terminated         = false;
@@ -147,7 +147,7 @@ void VMThread::destroy() {
   _vm_thread = NULL;      // VM thread is gone
 }
 
-static VM_None halt_op("Halt");
+static VM_Halt halt_op;
 
 void VMThread::run() {
   assert(this == vm_thread(), "check");

--- a/test/hotspot/gtest/threadHelper.inline.hpp
+++ b/test/hotspot/gtest/threadHelper.inline.hpp
@@ -49,13 +49,13 @@ static void startTestThread(JavaThread* thread, const char* name) {
   }
 }
 
-class VM_StopSafepoint : public VM_Operation {
+class VM_GTestStopSafepoint : public VM_Operation {
 public:
   Semaphore* _running;
   Semaphore* _test_complete;
-  VM_StopSafepoint(Semaphore* running, Semaphore* wait_for) :
+  VM_GTestStopSafepoint(Semaphore* running, Semaphore* wait_for) :
     _running(running), _test_complete(wait_for) {}
-  VMOp_Type type() const          { return VMOp_None; }
+  VMOp_Type type() const          { return VMOp_GTestStopSafepoint; }
   bool evaluate_at_safepoint() const { return false; }
   void doit()                     { _running->signal(); _test_complete->wait(); }
 };
@@ -67,7 +67,7 @@ class VMThreadBlocker : public JavaThread {
 
   static void blocker_thread_entry(JavaThread* thread, TRAPS) {
     VMThreadBlocker* t = static_cast<VMThreadBlocker*>(thread);
-    VM_StopSafepoint ss(&t->_ready, &t->_unblock);
+    VM_GTestStopSafepoint ss(&t->_ready, &t->_unblock);
     VMThread::execute(&ss);
   }
 


### PR DESCRIPTION
There are a number of VM operations that do nothing, except triggering a safepoint. I'd like to clean up and unify them a bit to:
1) Use one parent class which implements the empty doit function and turns off thread oop processing.
2) Remove unused VM_Operations
3) Don't reuse the VM_None type - there's bug/inconsistency here in that some subsystems report the name as None, while others report the name passed to the constructor
4) Remove unused enum values

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280817](https://bugs.openjdk.java.net/browse/JDK-8280817): Clean up and unify empty VM operations


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7261/head:pull/7261` \
`$ git checkout pull/7261`

Update a local copy of the PR: \
`$ git checkout pull/7261` \
`$ git pull https://git.openjdk.java.net/jdk pull/7261/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7261`

View PR using the GUI difftool: \
`$ git pr show -t 7261`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7261.diff">https://git.openjdk.java.net/jdk/pull/7261.diff</a>

</details>
