### PR TITLE
8241192: [macosx] Wrong letter typed after ´ symbol when using Finnish layout

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -50,7 +50,7 @@ static NSString *kbdLayout;
 @end
 
 // Uncomment this line to see fprintfs of each InputMethod API being called on this View
-#define IM_DEBUG TRUE
+//#define IM_DEBUG TRUE
 //#define EXTRA_DEBUG
 
 static BOOL shouldUsePressAndHold() {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -50,7 +50,7 @@ static NSString *kbdLayout;
 @end
 
 // Uncomment this line to see fprintfs of each InputMethod API being called on this View
-//#define IM_DEBUG TRUE
+#define IM_DEBUG TRUE
 //#define EXTRA_DEBUG
 
 static BOOL shouldUsePressAndHold() {
@@ -965,6 +965,7 @@ static jclass jc_CInputMethod = NULL;
 
     if ((utf16Length > 2) ||
         ((utf8Length > 1) && [self isCodePointInUnicodeBlockNeedingIMEvent:codePoint]) ||
+        ((codePoint == 0x73) && ([(NSString *)kbdLayout containsString:@"Finnish"])) ||
         ((codePoint == 0x5c) && ([(NSString *)kbdLayout containsString:@"Kotoeri"]))) {
 #ifdef IM_DEBUG
         NSLog(@"string complex ");


### PR DESCRIPTION
If we press " ´ " (on U.S. keyboard layout it is the [+] button just before the [delete] button), and then press "s" , 2 "´" characters are entered in a text field instead of "´s" with "Finish" keyboard layout.
This is because, although " ´ " is construed as "complex" char and inserted properly the next "s" character is treated as non-complex character as it's utf8Length is 1 and utf16Length is 2, so we need to explicitly make it a "complex" char sequence if the code point is 0x73 ie "s" in Finnish layout for it to be inserted properly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8241192](https://bugs.openjdk.java.net/browse/JDK-8241192): [macosx] Wrong letter typed after ´ symbol when using Finnish layout


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7262/head:pull/7262` \
`$ git checkout pull/7262`

Update a local copy of the PR: \
`$ git checkout pull/7262` \
`$ git pull https://git.openjdk.java.net/jdk pull/7262/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7262`

View PR using the GUI difftool: \
`$ git pr show -t 7262`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7262.diff">https://git.openjdk.java.net/jdk/pull/7262.diff</a>

</details>
