### PR TITLE
8280450: Add task queue printing to STW Full GCs

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -294,6 +294,10 @@ void G1FullCollector::phase1_mark_live_objects() {
   }
 
   scope()->tracer()->report_object_count_after_gc(&_is_alive);
+#if TASKQUEUE_STATS
+  oop_queue_set()->print_and_reset_taskqueue_stats("Oop Queue");
+  array_queue_set()->print_and_reset_taskqueue_stats("ObjArrayOop Queue");
+#endif
 }
 
 void G1FullCollector::phase2_prepare_compaction() {

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -2118,6 +2118,10 @@ void PSParallelCompact::marking_phase(ParallelOldTracer *gc_tracer) {
   }
 
   _gc_tracer.report_object_count_after_gc(is_alive_closure());
+#if TASKQUEUE_STATS
+  ParCompactionManager::oop_task_queues()->print_and_reset_taskqueue_stats("Oop Queue");
+  ParCompactionManager::_objarray_task_queues->print_and_reset_taskqueue_stats("ObjArrayOop Queue");
+#endif
 }
 
 class PSAdjustTask final : public WorkerTask {


### PR DESCRIPTION
Hi all,

  please review this change that adds task queue statistics printing after full gc marking. This helps diagnosing performance issues there.

Testing: compilation, gha, local testing (all new code is guarded by `TASKQUEUE_STATS` so not compiled in by default)

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280450](https://bugs.openjdk.java.net/browse/JDK-8280450): Add task queue printing to STW Full GCs


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7264/head:pull/7264` \
`$ git checkout pull/7264`

Update a local copy of the PR: \
`$ git checkout pull/7264` \
`$ git pull https://git.openjdk.java.net/jdk pull/7264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7264`

View PR using the GUI difftool: \
`$ git pr show -t 7264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7264.diff">https://git.openjdk.java.net/jdk/pull/7264.diff</a>

</details>
