### PR TITLE
8280866: SuppressWarnings does not work properly in package-info and module-info

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -73,7 +73,7 @@ public class Lint
      */
     public Lint augment(Symbol sym) {
         Lint l = augmentor.augment(this, sym.getDeclarationAttributes());
-        if (sym.isDeprecated()) {
+        if (sym.isDeprecated() && sym.isDeprecatableViaAnnotation()) {
             if (l == this)
                 l = new Lint(this);
             l.values.remove(LintCategory.DEPRECATION);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -27,6 +27,7 @@ package com.sun.tools.javac.comp;
 
 import java.util.*;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import javax.lang.model.element.ElementKind;
 import javax.tools.JavaFileObject;
@@ -78,7 +79,6 @@ import static com.sun.tools.javac.code.TypeTag.*;
 import static com.sun.tools.javac.code.TypeTag.WILDCARD;
 import static com.sun.tools.javac.tree.JCTree.Tag.*;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticFlag;
-import java.util.function.Consumer;
 
 /** This is the main context-dependent analysis phase in GJC. It
  *  encompasses name resolution, type checking and constant folding as

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,6 +78,7 @@ import static com.sun.tools.javac.code.TypeTag.*;
 import static com.sun.tools.javac.code.TypeTag.WILDCARD;
 import static com.sun.tools.javac.tree.JCTree.Tag.*;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticFlag;
+import java.util.function.Consumer;
 
 /** This is the main context-dependent analysis phase in GJC. It
  *  encompasses name resolution, type checking and constant folding as
@@ -5188,8 +5189,8 @@ public class Attr extends JCTree.Visitor {
     }
 
     void attribPackage(PackageSymbol p) {
-        Env<AttrContext> env = typeEnvs.get(p);
-        chk.checkDeprecatedAnnotation(((JCPackageDecl) env.tree).pid.pos(), p);
+        attribWithLint(p,
+                       env -> chk.checkDeprecatedAnnotation(((JCPackageDecl) env.tree).pid.pos(), p));
     }
 
     public void attribModule(DiagnosticPosition pos, ModuleSymbol m) {
@@ -5202,9 +5203,28 @@ public class Attr extends JCTree.Visitor {
     }
 
     void attribModule(ModuleSymbol m) {
-        // Get environment current at the point of module definition.
-        Env<AttrContext> env = enter.typeEnvs.get(m);
-        attribStat(env.tree, env);
+        attribWithLint(m, env -> attribStat(env.tree, env));
+    }
+
+    private void attribWithLint(TypeSymbol sym, Consumer<Env<AttrContext>> attrib) {
+        Env<AttrContext> env = typeEnvs.get(sym);
+
+        Env<AttrContext> lintEnv = env;
+        while (lintEnv.info.lint == null)
+            lintEnv = lintEnv.next;
+
+        Lint lint = lintEnv.info.lint.augment(sym);
+
+        Lint prevLint = chk.setLint(lint);
+        JavaFileObject prev = log.useSource(env.toplevel.sourcefile);
+
+        try {
+            deferredLintHandler.flush(env.tree.pos());
+            attrib.accept(env);
+        } finally {
+            log.useSource(prev);
+            chk.setLint(prevLint);
+        }
     }
 
     /** Main method: attribute class definition associated with given class symbol.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -371,10 +371,15 @@ public class TypeEnter implements Completer {
                 }
 
                 if (decl != null) {
-                    //check @Deprecated:
-                    markDeprecated(decl.sym, decl.mods.annotations, env);
+                    DiagnosticPosition prevCheckDeprecatedLintPos = deferredLintHandler.setPos(decl.pos());
+                    try {
+                        //check @Deprecated:
+                        markDeprecated(decl.sym, decl.mods.annotations, env);
+                    } finally {
+                        deferredLintHandler.setPos(prevCheckDeprecatedLintPos);
+                    }
                     // process module annotations
-                    annotate.annotateLater(decl.mods.annotations, env, env.toplevel.modle, null);
+                    annotate.annotateLater(decl.mods.annotations, env, env.toplevel.modle, decl.pos());
                 }
             } finally {
                 this.env = prevEnv;
@@ -402,7 +407,7 @@ public class TypeEnter implements Completer {
                 }
             }
             // process package annotations
-            annotate.annotateLater(tree.annotations, env, env.toplevel.packge, null);
+            annotate.annotateLater(tree.annotations, env, env.toplevel.packge, tree.pos());
         }
 
         private void doImport(JCImport tree) {

--- a/test/langtools/tools/javac/warnings/suppress/SuppressWarningsPackage.java
+++ b/test/langtools/tools/javac/warnings/suppress/SuppressWarningsPackage.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8280866
+ * @summary Verify SuppressWarnings works on package clauses and modules.
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ * @modules jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.JavacTask toolbox.TestRunner toolbox.ToolBox
+ * @run main SuppressWarningsPackage
+ */
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import toolbox.JavacTask;
+import toolbox.Task.Expect;
+import toolbox.Task.OutputKind;
+import toolbox.TestRunner;
+import toolbox.ToolBox;
+
+public class SuppressWarningsPackage extends TestRunner {
+    public static void main(String... args) throws Exception {
+        SuppressWarningsPackage t = new SuppressWarningsPackage();
+        t.runTests(m -> new Object[] { Paths.get(m.getName()) });
+    }
+
+    private final ToolBox tb = new ToolBox();
+
+    public SuppressWarningsPackage() throws IOException {
+        super(System.err);
+    }
+
+    @Test
+    public void testSuppressWarningsOnPackageInfo(Path base) throws IOException {
+        Path src = base.resolve("src");
+        Path classes = Files.createDirectories(base.resolve("classes"));
+        TestCase[] testCases = new TestCase[] {
+            new TestCase("",
+                         "package-info.java:1:2: compiler.warn.has.been.deprecated: test.DeprecatedAnn, test",
+                         "package-info.java:1:16: compiler.warn.has.been.deprecated: test.DeprecatedClass, test",
+                         "Use.java:2:2: compiler.warn.has.been.deprecated: test.DeprecatedAnn, test",
+                         "Use.java:2:16: compiler.warn.has.been.deprecated: test.DeprecatedClass, test",
+                         "4 warnings"),
+            new TestCase("@SuppressWarnings(\"deprecation\")",
+                         "Use.java:2:2: compiler.warn.has.been.deprecated: test.DeprecatedAnn, test",
+                         "Use.java:2:16: compiler.warn.has.been.deprecated: test.DeprecatedClass, test",
+                         "2 warnings")
+        };
+        for (TestCase tc : testCases) {
+            tb.writeJavaFiles(src,
+                              """
+                              @DeprecatedAnn(DeprecatedClass.class)
+                              #
+                              package test;
+                              """.replace("#", tc.sw),
+                              """
+                              package test;
+                              @Deprecated
+                              public @interface DeprecatedAnn {
+                                  public Class<?> value();
+                              }
+                              """,
+                              """
+                              package test;
+                              @Deprecated
+                              public class DeprecatedClass {
+                                  public static class Nested {}
+                              }
+                              """,
+                              """
+                              package test;
+                              @DeprecatedAnn(DeprecatedClass.class)
+                              public class Use {}
+                              """);
+
+            List<String> log = new JavacTask(tb)
+                    .outdir(classes)
+                    .files(tb.findJavaFiles(src))
+                    .options("-XDrawDiagnostics",
+                             "-Xlint:deprecation")
+                    .run(Expect.SUCCESS)
+                    .writeAll()
+                    .getOutputLines(OutputKind.DIRECT);
+
+            if (!Objects.equals(log, List.of(tc.expectedOutput))) {
+                error("Unexpected output, expected:\n" + Arrays.toString(tc.expectedOutput) +
+                                         "\nactual:\n" + log);
+            }
+        }
+    }
+
+    @Test
+    public void testSuppressWarningsOnModuleInfo(Path base) throws IOException {
+        Path src = base.resolve("src");
+        Path classes = Files.createDirectories(base.resolve("classes"));
+        TestCase[] testCases = new TestCase[] {
+            new TestCase("",
+                         "module-info.java:3:12: compiler.warn.has.been.deprecated: test.DeprecatedClass, test",
+                         "module-info.java:4:2: compiler.warn.has.been.deprecated: test.DeprecatedAnn, test",
+                         "module-info.java:4:16: compiler.warn.has.been.deprecated: test.DeprecatedClass, test",
+                         "module-info.java:7:14: compiler.warn.has.been.deprecated: test.Service, test",
+                         "module-info.java:8:18: compiler.warn.has.been.deprecated: test.Service, test",
+                         "module-info.java:8:36: compiler.warn.has.been.deprecated: test.ServiceImpl, test",
+                         "package-info.java:1:2: compiler.warn.has.been.deprecated: test.DeprecatedAnn, test",
+                         "package-info.java:1:16: compiler.warn.has.been.deprecated: test.DeprecatedClass, test",
+                         "Use.java:2:2: compiler.warn.has.been.deprecated: test.DeprecatedAnn, test",
+                         "Use.java:2:16: compiler.warn.has.been.deprecated: test.DeprecatedClass, test",
+                         "10 warnings"),
+            new TestCase("@SuppressWarnings(\"deprecation\")",
+                         "module-info.java:3:12: compiler.warn.has.been.deprecated: test.DeprecatedClass, test",
+                         "package-info.java:1:2: compiler.warn.has.been.deprecated: test.DeprecatedAnn, test",
+                         "package-info.java:1:16: compiler.warn.has.been.deprecated: test.DeprecatedClass, test",
+                         "Use.java:2:2: compiler.warn.has.been.deprecated: test.DeprecatedAnn, test",
+                         "Use.java:2:16: compiler.warn.has.been.deprecated: test.DeprecatedClass, test",
+                         "5 warnings")
+        };
+        for (TestCase tc : testCases) {
+            tb.writeJavaFiles(src,
+                              """
+                              import test.DeprecatedAnn;
+                              import test.DeprecatedClass;
+                              import test.DeprecatedClass.Nested;
+                              @DeprecatedAnn(DeprecatedClass.class)
+                              #
+                              module m {
+                                  uses test.Service;
+                                  provides test.Service with test.ServiceImpl;
+                              }
+                              """.replace("#", tc.sw),
+                              """
+                              @DeprecatedAnn(DeprecatedClass.class)
+                              package test;
+                              """,
+                              """
+                              package test;
+                              @Deprecated
+                              public @interface DeprecatedAnn {
+                                  public Class<?> value();
+                              }
+                              """,
+                              """
+                              package test;
+                              @Deprecated
+                              public class DeprecatedClass {
+                                  public static class Nested {}
+                              }
+                              """,
+                              """
+                              package test;
+                              @Deprecated
+                              public interface Service {}
+                              """,
+                              """
+                              package test;
+                              @Deprecated
+                              public class ServiceImpl implements Service {}
+                              """,
+                              """
+                              package test;
+                              @DeprecatedAnn(DeprecatedClass.class)
+                              public class Use {}
+                              """);
+
+            List<String> log = new JavacTask(tb)
+                    .outdir(classes)
+                    .files(tb.findJavaFiles(src))
+                    .options("-XDrawDiagnostics",
+                             "-Xlint:deprecation")
+                    .run(Expect.SUCCESS)
+                    .writeAll()
+                    .getOutputLines(OutputKind.DIRECT);
+
+            if (!Objects.equals(log, List.of(tc.expectedOutput))) {
+                error("Unexpected output, expected:\n" + Arrays.toString(tc.expectedOutput) +
+                                         "\nactual:\n" + log);
+            }
+        }
+    }
+
+    record TestCase(String sw, String... expectedOutput) {}
+}


### PR DESCRIPTION
`@SuppressWarnings` is not handled properly in `module-info` and, after https://bugs.openjdk.java.net/browse/JDK-8280744, also not in `package-info`. This patch attempts to fix that, by correctly deferring the warnings, and the printing them at an appropriate point.