### PR TITLE
8280889: java/lang/instrument/GetObjectSizeIntrinsicsTest.java fails with -XX:-UseCompressedOops

### DIFF
--- a/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
+++ b/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
@@ -280,19 +280,16 @@
  *
  * @run main/othervm -Xmx8g
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure -XX:+WhiteBoxAPI -Xbootclasspath/a:.
- *                   -XX:ObjectAlignmentInBytes=32
  *                   -Xint
  *                   -javaagent:basicAgent.jar GetObjectSizeIntrinsicsTest GetObjectSizeIntrinsicsTest large
  *
  * @run main/othervm -Xmx8g
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure -XX:+WhiteBoxAPI -Xbootclasspath/a:.
- *                   -XX:ObjectAlignmentInBytes=32
  *                   -Xbatch -XX:TieredStopAtLevel=1
  *                   -javaagent:basicAgent.jar GetObjectSizeIntrinsicsTest GetObjectSizeIntrinsicsTest large
  *
  * @run main/othervm -Xmx8g
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure -XX:+WhiteBoxAPI -Xbootclasspath/a:.
- *                   -XX:ObjectAlignmentInBytes=32
  *                   -Xbatch -XX:-TieredCompilation
  *                   -javaagent:basicAgent.jar GetObjectSizeIntrinsicsTest GetObjectSizeIntrinsicsTest large
  */
@@ -312,8 +309,9 @@ public class GetObjectSizeIntrinsicsTest extends ASimpleInstrumentationTestCase 
 
     static final int SMALL_ARRAY_SIZE = 1024;
 
-    // With int[] arrays, this overflows 4G boundary
-    static final int LARGE_ARRAY_SIZE = 1024*1024*1024 + 1024;
+    // These should overflow 4G size boundary
+    static final int LARGE_INT_ARRAY_SIZE = 1024*1024*1024 + 1024;
+    static final int LARGE_OBJ_ARRAY_SIZE = (4096/(int)REF_SIZE)*1024*1024 + 1024;
 
     final String mode;
 
@@ -446,16 +444,16 @@ public class GetObjectSizeIntrinsicsTest extends ASimpleInstrumentationTestCase 
     }
 
     private void testSize_localLargeIntArray() {
-        int[] arr = new int[LARGE_ARRAY_SIZE];
-        long expected = roundUp(4L*LARGE_ARRAY_SIZE + 16, OBJ_ALIGN);
+        int[] arr = new int[LARGE_INT_ARRAY_SIZE];
+        long expected = roundUp(4L*LARGE_INT_ARRAY_SIZE + 16, OBJ_ALIGN);
         for (int c = 0; c < ITERS; c++) {
             assertEquals(expected, fInst.getObjectSize(arr));
         }
     }
 
     private void testSize_localLargeObjArray() {
-        Object[] arr = new Object[LARGE_ARRAY_SIZE];
-        long expected = roundUp(REF_SIZE*LARGE_ARRAY_SIZE + 16, OBJ_ALIGN);
+        Object[] arr = new Object[LARGE_OBJ_ARRAY_SIZE];
+        long expected = roundUp(REF_SIZE*LARGE_OBJ_ARRAY_SIZE + 16, OBJ_ALIGN);
         for (int c = 0; c < ITERS; c++) {
             assertEquals(expected, fInst.getObjectSize(arr));
         }


### PR DESCRIPTION
Recent test regression after adding new cases in the test. Without compressed oops, ~1G elements `Object[]` array takes >8G of memory, which fails the test. The fix cuts it down to 512M when reference size is 8 bytes. Additionally, `ObjectAlignmentInBytes=32` is excessive for new test configs.

Additional testing: 
 - [x] Linux x86_64 fastdebug, default, affected test still passes
 - [x] Linux x86_32 fastdebug, default, affected test still passes
 - [x] Linux x86_64 fastdebug, `-XX:-UseCompressedOops`, affected test now passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280889](https://bugs.openjdk.java.net/browse/JDK-8280889): java/lang/instrument/GetObjectSizeIntrinsicsTest.java fails with -XX:-UseCompressedOops


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7269/head:pull/7269` \
`$ git checkout pull/7269`

Update a local copy of the PR: \
`$ git checkout pull/7269` \
`$ git pull https://git.openjdk.java.net/jdk pull/7269/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7269`

View PR using the GUI difftool: \
`$ git pr show -t 7269`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7269.diff">https://git.openjdk.java.net/jdk/pull/7269.diff</a>

</details>
