### PR TITLE
8280476: [macOS] : hotspot arm64 bug exposed by latest clang

### DIFF
--- a/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
@@ -129,8 +129,14 @@ static inline uint32_t uimm(uint32_t val, int hi, int lo)
 
 uint64_t replicate(uint64_t bits, int nbits, int count)
 {
+  // Special case nbits == 64 since the shift below with that nbits value
+  // would result in undefined behavior.
+  if (nbits == 64) {
+    assert(count <= 1, "must be");
+    return bits;
+  }
+
   uint64_t result = 0;
-  // nbits may be 64 in which case we want mask to be -1
   uint64_t mask = ones(nbits);
   for (int i = 0; i < count ; i++) {
     result <<= nbits;

--- a/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
@@ -129,10 +129,13 @@ static inline uint32_t uimm(uint32_t val, int hi, int lo)
 
 uint64_t replicate(uint64_t bits, int nbits, int count)
 {
+  assert(count > 0, "must be");
+  assert(nbits > 0, "must be");
+  assert(count * nbits <= 64, "must be");
+
   // Special case nbits == 64 since the shift below with that nbits value
   // would result in undefined behavior.
   if (nbits == 64) {
-    assert(count <= 1, "must be");
     return bits;
   }
 


### PR DESCRIPTION
A trivial fix to solve undefined behavior in src/hotspot/cpu/aarch64/immediate_aarch64.cpp:
replicate().

I was not able to reproduce the reported failure using:

  Xcode: Version 13.2.1 (13C100) which includes clang Apple LLVM 13.0.0 (clang-1300.0.29.30)

so I'm moving forward with the proposed fix from a code inspection
point of view.

I've tested this fix with Mach5 Tier[1-6]. Tier1 and Tier2 have completed with
no failures. Tier[3-6] are still running.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280476](https://bugs.openjdk.java.net/browse/JDK-8280476): [macOS] : hotspot arm64 bug exposed by latest clang


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7270/head:pull/7270` \
`$ git checkout pull/7270`

Update a local copy of the PR: \
`$ git checkout pull/7270` \
`$ git pull https://git.openjdk.java.net/jdk pull/7270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7270`

View PR using the GUI difftool: \
`$ git pr show -t 7270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7270.diff">https://git.openjdk.java.net/jdk/pull/7270.diff</a>

</details>
