### PR TITLE
8280898: ProblemList compiler/regalloc/TestC2IntPressure.java on macosx-aarch64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -73,6 +73,7 @@ compiler/whitebox/MakeMethodNotCompilableTest.java 8265360 macosx-aarch64
 
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-generic
 compiler/codecache/TestStressCodeBuffers.java 8272094 generic-aarch64
+compiler/regalloc/TestC2IntPressure.java 8280843 macosx-aarch64
 
 
 #############################################################################


### PR DESCRIPTION
A trivial fix to ProblemList compiler/regalloc/TestC2IntPressure.java on macosx-aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280898](https://bugs.openjdk.java.net/browse/JDK-8280898): ProblemList compiler/regalloc/TestC2IntPressure.java on macosx-aarch64


### Reviewers
 * [Christian Tornqvist](https://openjdk.java.net/census#ctornqvi) (@ctornqvi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7272/head:pull/7272` \
`$ git checkout pull/7272`

Update a local copy of the PR: \
`$ git checkout pull/7272` \
`$ git pull https://git.openjdk.java.net/jdk pull/7272/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7272`

View PR using the GUI difftool: \
`$ git pr show -t 7272`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7272.diff">https://git.openjdk.java.net/jdk/pull/7272.diff</a>

</details>
