### PR TITLE
8280642: ObjectInputStream.readObject should throw InvalidClassException instead of IllegalAccessError

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -1995,9 +1995,9 @@ public class ObjectInputStream
             }
         } catch (ClassNotFoundException ex) {
             resolveEx = ex;
-        } catch (IllegalAccessError err) {
-            IOException ice = new InvalidObjectException(err.getMessage());
-            ice.initCause(err);
+        } catch (IllegalAccessError aie) {
+            IOException ice = new InvalidClassException(aie.getMessage());
+            ice.initCause(aie);
             throw ice;
         } catch (OutOfMemoryError memerr) {
             IOException ex = new InvalidObjectException("Proxy interface limit exceeded: " +

--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -1995,6 +1995,10 @@ public class ObjectInputStream
             }
         } catch (ClassNotFoundException ex) {
             resolveEx = ex;
+        } catch (IllegalAccessError err) {
+            IOException ice = new InvalidObjectException(err.getMessage());
+            ice.initCause(err);
+            throw ice;
         } catch (OutOfMemoryError memerr) {
             IOException ex = new InvalidObjectException("Proxy interface limit exceeded: " +
                     Arrays.toString(ifaces));

--- a/test/jdk/java/rmi/server/RMIClassLoader/loadProxyClasses/LoadProxyClasses.java
+++ b/test/jdk/java/rmi/server/RMIClassLoader/loadProxyClasses/LoadProxyClasses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- *
+ * @bug 8280642
  * @summary functional test for RMIClassLoader.loadProxyClass; test
  * ensures that the default RMI class loader provider implements
  * RMIClassLoader.loadProxyClass correctly.
@@ -49,6 +49,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.io.Serializable;
 import java.io.IOException;
+import java.io.InvalidObjectException;
 
 import java.util.Arrays;
 import java.util.zip.Checksum;
@@ -205,20 +206,20 @@ public class LoadProxyClasses {
                 currentThread.getContextClassLoader();
             currentThread.setContextClassLoader(nonpublicLoaderB);
 
-            IllegalAccessError illegal = null;
+            InvalidObjectException invalid = null;
             try {
                 unmarshalProxyClass(proxy4, fnnLoader2, nonpublicLoaderB,
                                     4, null);
-            } catch (IllegalAccessError e) {
-                illegal = e;
+            } catch (InvalidObjectException e) {
+                invalid = e;
             }
 
-            if (illegal == null) {
-                TestLibrary.bomb("case4: IllegalAccessError not thrown " +
+            if (invalid == null) {
+                TestLibrary.bomb("case4: InvalidObjectException not thrown " +
                                  "when multiple nonpublic interfaces have \n" +
                                  "different class loaders");
             } else {
-                System.err.println("\ncase4: IllegalAccessError correctly " +
+                System.err.println("\ncase4: InvalidObjectException correctly " +
                                    "thrown \n when trying to load proxy " +
                                    "with multiple nonpublic interfaces in \n" +
                                    "  different class loaders");

--- a/test/jdk/java/rmi/server/RMIClassLoader/loadProxyClasses/LoadProxyClasses.java
+++ b/test/jdk/java/rmi/server/RMIClassLoader/loadProxyClasses/LoadProxyClasses.java
@@ -48,8 +48,8 @@ import java.rmi.MarshalledObject;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.io.Serializable;
+import java.io.InvalidClassException;
 import java.io.IOException;
-import java.io.InvalidObjectException;
 
 import java.util.Arrays;
 import java.util.zip.Checksum;
@@ -206,20 +206,20 @@ public class LoadProxyClasses {
                 currentThread.getContextClassLoader();
             currentThread.setContextClassLoader(nonpublicLoaderB);
 
-            InvalidObjectException invalid = null;
+            InvalidClassException invalid = null;
             try {
                 unmarshalProxyClass(proxy4, fnnLoader2, nonpublicLoaderB,
                                     4, null);
-            } catch (InvalidObjectException e) {
+            } catch (InvalidClassException e) {
                 invalid = e;
             }
 
             if (invalid == null) {
-                TestLibrary.bomb("case4: InvalidObjectException not thrown " +
+                TestLibrary.bomb("case4: InvalidClassException not thrown " +
                                  "when multiple nonpublic interfaces have \n" +
                                  "different class loaders");
             } else {
-                System.err.println("\ncase4: InvalidObjectException correctly " +
+                System.err.println("\ncase4: InvalidClassException correctly " +
                                    "thrown \n when trying to load proxy " +
                                    "with multiple nonpublic interfaces in \n" +
                                    "  different class loaders");


### PR DESCRIPTION
During deserialization of a serialized data stream that contains a proxy descriptor with non-public interfaces
`java.io.ObjectInputStream` checks that the interfaces can be loaded from a single classloader in `ObjectInputStream.resolveProxyClass`.
If the interfaces cannot be loaded from a single classloader, an `IllegalAccessError` is thrown.
When `ObjectInputStream.readObject` encounters this case, it reflects an incompatibility
between the classloaders of the source of the serialized stream and the classloader being used for deserialization.
When a proxy object cannot be created from the interfaces, `ObjectInputStream.readObject` should catch
the `InvalidAccessError` and throw `InvalidObjectException` with the `InvalidAccessError` as the cause.
This allows the application to handle the exception consistently with other errors during deserialization.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8280642](https://bugs.openjdk.java.net/browse/JDK-8280642): ObjectInputStream.readObject should throw InvalidClassException instead of IllegalAccessError
 * [JDK-8280906](https://bugs.openjdk.java.net/browse/JDK-8280906): ObjectInputStream.readObject should throw InvalidClassException instead of IllegalAccessError (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7274/head:pull/7274` \
`$ git checkout pull/7274`

Update a local copy of the PR: \
`$ git checkout pull/7274` \
`$ git pull https://git.openjdk.java.net/jdk pull/7274/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7274`

View PR using the GUI difftool: \
`$ git pr show -t 7274`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7274.diff">https://git.openjdk.java.net/jdk/pull/7274.diff</a>

</details>
