### PR TITLE
8202836 : [macosx] test java/awt/Graphics/TextAAHintsTest.java fails

### DIFF
--- a/test/jdk/java/awt/Graphics/TextAAHintsTest.java
+++ b/test/jdk/java/awt/Graphics/TextAAHintsTest.java
@@ -1,3 +1,5 @@
+package awt;
+
 /*
  * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -44,6 +46,8 @@ import java.awt.RenderingHints;
 import java.awt.TextArea;
 import java.awt.image.BufferedImage;
 import java.awt.image.VolatileImage;
+import java.lang.reflect.InvocationTargetException;
+import javax.swing.SwingUtilities;
 
 public class TextAAHintsTest  extends Component {
 
@@ -165,7 +169,6 @@ public class TextAAHintsTest  extends Component {
         frame.add(textAAHintsTestObject, BorderLayout.NORTH);
 
         String instructions = """
-
                 Note: Texts are rendered with different TEXT_ANTIALIASING &
                    VALUE_TEXT_ANTIALIAS. Text should be B&W, grayscale, and LCD.
                    Note: The results may be visually the same.
@@ -218,7 +221,7 @@ public class TextAAHintsTest  extends Component {
         frame.setVisible(true);
     }
 
-    public static void main(String[] args) throws InterruptedException {
+    public static void main(String[] args) throws InterruptedException, InvocationTargetException {
         createTestUI();
         mainThread = Thread.currentThread();
         try {
@@ -228,7 +231,11 @@ public class TextAAHintsTest  extends Component {
                 throw new RuntimeException("Test failed : Reason : " + failureReason);
             }
         } finally {
-            frame.dispose();
+            SwingUtilities.invokeAndWait(()->{
+                if ( frame != null) {
+                    frame.dispose();
+                }
+            });
         }
 
         if (!isInterrupted) {

--- a/test/jdk/java/awt/Graphics/TextAAHintsTest.java
+++ b/test/jdk/java/awt/Graphics/TextAAHintsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dialog;
 import java.awt.Dimension;
+import java.awt.EventQueue;
 import java.awt.Frame;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -54,10 +55,10 @@ public class TextAAHintsTest extends Component {
     private static final String black = "This text should be solid black";
     private static final String gray  = "This text should be gray scale anti-aliased";
     private static final String lcd   = "This text should be LCD sub-pixel text (coloured).";
-    public static final CountDownLatch countDownLatch = new CountDownLatch(1);
+    private static final CountDownLatch countDownLatch = new CountDownLatch(1);
+    private static volatile String failureReason;
+    private static volatile boolean testPassed = false;
     private static Frame frame;
-    public static String failureReason;
-    public static volatile boolean testPassed = false;
 
     public void paint(Graphics g) {
 
@@ -183,7 +184,7 @@ public class TextAAHintsTest extends Component {
         });
         Button failButton = new Button("Fail");
         failButton.addActionListener(e -> {
-            readFailedReason();
+            getFailureReason();
             testPassed = false;
             countDownLatch.countDown();
             frame.dispose();
@@ -196,7 +197,7 @@ public class TextAAHintsTest extends Component {
         frame.setVisible(true);
     }
 
-    public static void readFailedReason() {
+    public static void getFailureReason() {
         // Show dialog to read why the testcase was failed and append the
         // testcase failure reason to the output
         final Dialog dialog = new Dialog(frame, "TestCase" +
@@ -218,9 +219,9 @@ public class TextAAHintsTest extends Component {
     }
 
     public static void main(String[] args) throws InterruptedException, InvocationTargetException {
-        java.awt.EventQueue.invokeAndWait(TextAAHintsTest::createTestUI);
+        EventQueue.invokeAndWait(TextAAHintsTest::createTestUI);
         if (!countDownLatch.await(2, TimeUnit.MINUTES)) {
-            java.awt.EventQueue.invokeAndWait(() -> {
+            EventQueue.invokeAndWait(() -> {
                 if (frame != null) {
                     frame.dispose();
                 }

--- a/test/jdk/java/awt/Graphics/TextAAHintsTest.java
+++ b/test/jdk/java/awt/Graphics/TextAAHintsTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 6263951
  * @summary Text should be B&W, grayscale, and LCD.
+ * @requires (os.family != "mac")
  * @run main/manual TextAAHintsTest
  */
 import java.awt.AWTException;


### PR DESCRIPTION
1) Removed =yesno that was causing the test to fail with following exception
test result: Error. Parse Exception: Arguments to `manual' option not supported: yesno
After removing =yesno, test was just passing without user interaction so fixed the following

Add the following so that user can user interact with the test
a) Added pass/fail button and instruction for the user to know what he/she is going to test and what is expected.
b) Added Dialog with textarea to enter the reason for the testcase failure. This will help the user to understanding the reason why the test was failed while analyzing the results. 

@shurymury

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8202836](https://bugs.openjdk.java.net/browse/JDK-8202836): [macosx] test java/awt/Graphics/TextAAHintsTest.java fails


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to 63a661975687c68f65ef5c15077e7823097bb125
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7275/head:pull/7275` \
`$ git checkout pull/7275`

Update a local copy of the PR: \
`$ git checkout pull/7275` \
`$ git pull https://git.openjdk.java.net/jdk pull/7275/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7275`

View PR using the GUI difftool: \
`$ git pr show -t 7275`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7275.diff">https://git.openjdk.java.net/jdk/pull/7275.diff</a>

</details>
