### PR TITLE
8280903: javadoc build fails after JDK-4774868

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -567,9 +567,10 @@ public abstract class FileChannel
      *
      * <p> This method is only guaranteed to force changes that were made to
      * this channel's file via the methods defined in this class, or the methods
-     * defined by {@link FileOutputStream} or {@link RandomAccessFile} when the
-     * channel was obtained with the {@code getChannel} method. It may or
-     * may not force changes that were made by modifying the content of a
+     * defined by {@link java.io.FileOutputStream} or
+     * {@link java.io.RandomAccessFile} when the channel was obtained with the
+     * {@code getChannel} method. It may or may not force changes that were made
+     * by modifying the content of a
      * {@link MappedByteBuffer <i>mapped byte buffer</i>} obtained by
      * invoking the {@link #map map} method.  Invoking the {@link
      * MappedByteBuffer#force force} method of the mapped byte buffer will


### PR DESCRIPTION
Prefix `java.io` to FOS and RAF links.
[(Redo of 7273](https://github.com/openjdk/jdk/pull/7273) whose branch was deleted before integrating).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280903](https://bugs.openjdk.java.net/browse/JDK-8280903): javadoc build fails after JDK-4774868


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7277/head:pull/7277` \
`$ git checkout pull/7277`

Update a local copy of the PR: \
`$ git checkout pull/7277` \
`$ git pull https://git.openjdk.java.net/jdk pull/7277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7277`

View PR using the GUI difftool: \
`$ git pr show -t 7277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7277.diff">https://git.openjdk.java.net/jdk/pull/7277.diff</a>

</details>
