### PR TITLE
8280913: Create a regression test for JRootPane.setDefaultButton() method

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -727,7 +727,6 @@ javax/swing/dnd/8139050/NativeErrorsInTableDnD.java 8202765  macosx-all,linux-al
 javax/swing/Popup/TaskbarPositionTest.java 8065097 macosx-all,linux-all
 javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
-javax/swing/JRootPane/DefaultButtonTest.java 6718771 linux-all
 javax/swing/JButton/8151303/PressedIconTest.java 8266246 macosx-aarch64
 javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java 8273573 macosx-all
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -727,6 +727,7 @@ javax/swing/dnd/8139050/NativeErrorsInTableDnD.java 8202765  macosx-all,linux-al
 javax/swing/Popup/TaskbarPositionTest.java 8065097 macosx-all,linux-all
 javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
+javax/swing/JRootPane/DefaultButtonTest.java 6718771 linux-all
 javax/swing/JButton/8151303/PressedIconTest.java 8266246 macosx-aarch64
 javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java 8273573 macosx-all
 

--- a/test/jdk/javax/swing/JRootPane/DefaultButtonTest.java
+++ b/test/jdk/javax/swing/JRootPane/DefaultButtonTest.java
@@ -1,0 +1,122 @@
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import java.lang.reflect.InvocationTargetException;
+
+/*
+ * @test
+ * @key headful
+ * @bug 8280913
+ * @summary Check whether the default button is honoured when <Enter> key is
+ * pressed when the focus is on the frame.
+ * @run main DefaultButtonTest
+ */
+public class DefaultButtonTest {
+    static JFrame frame = new JFrame();
+    static volatile boolean buttonPressed = false;
+    boolean testFailed = false;
+    JButton button1;
+    Robot robot;
+    private JPanel panel;
+    private JButton button2;
+
+    public static void main(String[] s) throws Exception {
+        DefaultButtonTest test = new DefaultButtonTest();
+        try {
+            test.runTest();
+        } finally {
+            if (frame != null) {
+                frame.dispose();
+                frame = null;
+            }
+        }
+
+    }
+
+    private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
+        try {
+            UIManager.setLookAndFeel(laf.getClassName());
+        } catch (UnsupportedLookAndFeelException ignored) {
+            System.out.println("Unsupported L&F: " + laf.getClassName());
+        } catch (ClassNotFoundException | InstantiationException
+                | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void createUI() {
+//        frame = new JFrame();
+        panel = new JPanel();
+        panel.setLayout(new FlowLayout());
+        button1 = new JButton("butt1");
+        button1.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                synchronized (this) {
+                    buttonPressed = true;
+                    notifyAll();
+                }
+            }
+        });
+        panel.add(button1);
+
+        button2 = new JButton("butt2");
+        panel.add(button2);
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setLayout(new FlowLayout());
+
+        frame.add(panel);
+
+        frame.setSize(200, 300);
+        frame.setLocationRelativeTo(null);
+        frame.getRootPane().setDefaultButton(button1);
+        frame.setVisible(true);
+    }
+
+    public void runTest() throws InvocationTargetException, InterruptedException {
+        try {
+            robot = new Robot();
+        } catch (Exception e) {
+            System.err.print("Error creating robot");
+            e.printStackTrace();
+            System.exit(1);
+        }
+        for (UIManager.LookAndFeelInfo laf : UIManager.getInstalledLookAndFeels()) {
+            buttonPressed = false;
+            System.out.println("Testing L&F: " + laf);
+            try {
+                SwingUtilities.invokeAndWait(new Runnable() {
+                    public void run() {
+                        setLookAndFeel(laf);
+                        createUI();
+                        frame.getRootPane().requestFocus();
+                    }
+                });
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            robot.waitForIdle();
+            robot.keyPress(KeyEvent.VK_ENTER);
+            robot.delay(100);
+            robot.keyRelease(KeyEvent.VK_ENTER);
+            robot.waitForIdle();
+
+            if (buttonPressed) {
+                System.out.println("Test Passed for laf " + laf);
+            } else {
+                testFailed = true;
+                System.out.println("Test Failed, button not pressed for laf " + laf);
+            }
+            //frame.dispose();
+           // frame = null;
+        }
+        if (testFailed) {
+            throw new RuntimeException("Test Failed, button not pressed in one or more LAFs");
+        } else {
+            System.out.println("Test Passed for all supported LAFs ");
+        }
+    }
+
+}
+

--- a/test/jdk/javax/swing/JRootPane/DefaultButtonTest.java
+++ b/test/jdk/javax/swing/JRootPane/DefaultButtonTest.java
@@ -35,7 +35,7 @@ import javax.swing.UnsupportedLookAndFeelException;
  * @test
  * @key headful
  * @bug 8280913
- * @summary Check whether the default button is honored when <Enter> key is typed.
+ * @summary Check whether the default button is honored when <Enter> key is pressed.
  * @run main DefaultButtonTest
  */
 public class DefaultButtonTest {

--- a/test/jdk/javax/swing/JRootPane/DefaultButtonTest.java
+++ b/test/jdk/javax/swing/JRootPane/DefaultButtonTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
@@ -47,7 +70,6 @@ public class DefaultButtonTest {
     }
 
     private void createUI() {
-//        frame = new JFrame();
         panel = new JPanel();
         panel.setLayout(new FlowLayout());
         button1 = new JButton("butt1");
@@ -108,8 +130,6 @@ public class DefaultButtonTest {
                 testFailed = true;
                 System.out.println("Test Failed, button not pressed for laf " + laf);
             }
-            //frame.dispose();
-           // frame = null;
         }
         if (testFailed) {
             throw new RuntimeException("Test Failed, button not pressed in one or more LAFs");

--- a/test/jdk/javax/swing/JRootPane/DefaultButtonTest.java
+++ b/test/jdk/javax/swing/JRootPane/DefaultButtonTest.java
@@ -21,103 +21,88 @@
  * questions.
  */
 
-import javax.swing.*;
-import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
+import java.awt.FlowLayout;
+import java.awt.Robot;
 import java.awt.event.KeyEvent;
-import java.lang.reflect.InvocationTargetException;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
 
 /*
  * @test
  * @key headful
  * @bug 8280913
- * @summary Check whether the default button is honoured when <Enter> key is
- * pressed when the focus is on the frame.
+ * @summary Check whether the default button is honored when <Enter> key is
+ * pressed while the focus is on the frame.
  * @run main DefaultButtonTest
  */
 public class DefaultButtonTest {
-    static JFrame frame = new JFrame();
-    static volatile boolean buttonPressed = false;
-    boolean testFailed = false;
-    JButton button1;
-    Robot robot;
-    private JPanel panel;
-    private JButton button2;
+    volatile boolean buttonPressed = false;
+    JFrame frame;
 
     public static void main(String[] s) throws Exception {
         DefaultButtonTest test = new DefaultButtonTest();
         try {
             test.runTest();
         } finally {
-            if (frame != null) {
-                frame.dispose();
-                frame = null;
-            }
+            test.disposeFrame();
         }
 
     }
 
-    private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
+    private static void setLookAndFeel(String lafName) {
         try {
-            UIManager.setLookAndFeel(laf.getClassName());
+            UIManager.setLookAndFeel(lafName);
         } catch (UnsupportedLookAndFeelException ignored) {
-            System.out.println("Unsupported L&F: " + laf.getClassName());
+            System.out.println("Ignoring Unsupported L&F: " + lafName);
         } catch (ClassNotFoundException | InstantiationException
                 | IllegalAccessException e) {
             throw new RuntimeException(e);
         }
     }
 
+    private void disposeFrame() {
+        if (frame != null) {
+            frame.dispose();
+            frame = null;
+        }
+    }
+
     private void createUI() {
-        panel = new JPanel();
+        frame = new JFrame();
+        JPanel panel = new JPanel();
         panel.setLayout(new FlowLayout());
-        button1 = new JButton("butt1");
-        button1.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                synchronized (this) {
-                    buttonPressed = true;
-                    notifyAll();
-                }
-            }
-        });
+        JButton button1 = new JButton("button1");
+        button1.addActionListener(e -> buttonPressed = true);
         panel.add(button1);
 
-        button2 = new JButton("butt2");
+        JButton button2 = new JButton("button2");
         panel.add(button2);
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.setLayout(new FlowLayout());
 
         frame.add(panel);
 
-        frame.setSize(200, 300);
+        frame.setSize(200, 200);
         frame.setLocationRelativeTo(null);
         frame.getRootPane().setDefaultButton(button1);
         frame.setVisible(true);
     }
 
-    public void runTest() throws InvocationTargetException, InterruptedException {
-        try {
-            robot = new Robot();
-        } catch (Exception e) {
-            System.err.print("Error creating robot");
-            e.printStackTrace();
-            System.exit(1);
-        }
+    public void runTest() throws Exception {
+        Robot robot = new Robot();
         for (UIManager.LookAndFeelInfo laf : UIManager.getInstalledLookAndFeels()) {
             buttonPressed = false;
-            System.out.println("Testing L&F: " + laf);
-            try {
-                SwingUtilities.invokeAndWait(new Runnable() {
-                    public void run() {
-                        setLookAndFeel(laf);
-                        createUI();
-                        frame.getRootPane().requestFocus();
-                    }
-                });
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            String lafName = laf.getClassName();
+            System.out.println("Testing L&F: " + lafName);
+            SwingUtilities.invokeAndWait(() -> {
+                setLookAndFeel(lafName);
+                createUI();
+                frame.getRootPane().requestFocus();
+            });
             robot.waitForIdle();
             robot.keyPress(KeyEvent.VK_ENTER);
             robot.delay(100);
@@ -125,18 +110,12 @@ public class DefaultButtonTest {
             robot.waitForIdle();
 
             if (buttonPressed) {
-                System.out.println("Test Passed for laf " + laf);
+                System.out.println("Test Passed for L&F: " + lafName);
             } else {
-                testFailed = true;
-                System.out.println("Test Failed, button not pressed for laf " + laf);
+                throw new RuntimeException("Test Failed, button not pressed for L&F: " + lafName);
             }
-        }
-        if (testFailed) {
-            throw new RuntimeException("Test Failed, button not pressed in one or more LAFs");
-        } else {
-            System.out.println("Test Passed for all supported LAFs ");
+            disposeFrame();
         }
     }
 
 }
-


### PR DESCRIPTION
This tests the behaviour of the method JRootPane.setDefaultButton() in different platforms with different LAFs.
As per the spec https://docs.oracle.com/en/java/javase/17/docs/api/java.desktop/javax/swing/JRootPane.html#setDefaultButton(javax.swing.JButton), "The default button is the button which will be activated when a UI-defined activation event (typically the Enter key) occurs in the root pane regardless of whether or not the button has keyboard focus (unless there is another component within the root pane which consumes the activation event, such as a JTextPane). ".

This test is run multiple times in different platforms and got 100% success in mac and windows, linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280913](https://bugs.openjdk.java.net/browse/JDK-8280913): Create a regression test for JRootPane.setDefaultButton() method


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7278/head:pull/7278` \
`$ git checkout pull/7278`

Update a local copy of the PR: \
`$ git checkout pull/7278` \
`$ git pull https://git.openjdk.java.net/jdk pull/7278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7278`

View PR using the GUI difftool: \
`$ git pr show -t 7278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7278.diff">https://git.openjdk.java.net/jdk/pull/7278.diff</a>

</details>
