### PR TITLE
8216358: [accessibility] [macos] The focus is invisible when tab to "Image Radio Buttons" and "Image CheckBoxes"

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaButtonLabeledUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaButtonLabeledUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,7 +170,7 @@ public abstract class AquaButtonLabeledUI extends AquaButtonToggleUI implements 
             }
 
             int offset = 0;
-            if (b.isFocusOwner()) {
+            if (b.isFocusOwner() && b.isFocusPainted()) {
                 offset = 2;
                 altIcon = AquaFocus.createFocusedIcon(altIcon, c, 2);
             }

--- a/test/jdk/javax/swing/JCheckBox/ImageCheckboxFocus/ImageCheckboxTest.java
+++ b/test/jdk/javax/swing/JCheckBox/ImageCheckboxFocus/ImageCheckboxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import javax.swing.JCheckBox;
 /*
  * @test
  * @key headful
- * @bug 8216358
+ * @bug 8216358 8279586
  * @summary [macos] The focus is invisible when tab to "Image Radio Buttons" and "Image CheckBoxes"
  * @library ../../regtesthelpers/
  * @build Util
@@ -51,8 +51,12 @@ public class ImageCheckboxTest {
                 BufferedImage.TYPE_INT_ARGB);
         BufferedImage imageFocus = new BufferedImage(100, 50,
                 BufferedImage.TYPE_INT_ARGB);
+        BufferedImage imageFocusNotPainted = new BufferedImage(100, 50,
+                BufferedImage.TYPE_INT_ARGB);
+
 
         CustomCheckBox checkbox = new CustomCheckBox("Test", new MyIcon(Color.GREEN));
+        checkbox.setFocusPainted(true);
         checkbox.setSize(100, 50);
         checkbox.setFocused(false);
         checkbox.paint(imageNoFocus.createGraphics());
@@ -63,6 +67,17 @@ public class ImageCheckboxTest {
             ImageIO.write(imageFocus, "png", new File("imageFocus.png"));
             ImageIO.write(imageNoFocus, "png", new File("imageNoFocus.png"));
             throw new Exception("Changing focus is not visualized");
+        }
+
+        checkbox.setFocusPainted(false);
+        checkbox.paint(imageFocusNotPainted.createGraphics());
+
+        if (!Util.compareBufferedImages(imageFocusNotPainted, imageNoFocus)) {
+            ImageIO.write(imageFocusNotPainted, "png",
+                    new File("imageFocusNotPainted.png"));
+            ImageIO.write(imageFocus, "png", new File("imageFocus.png"));
+            ImageIO.write(imageNoFocus, "png", new File("imageNoFocus.png"));
+            throw new Exception("setFocusPainted(false) is ignored");
         }
     }
 


### PR DESCRIPTION
Focus painting for combo box and radio button with custom icon should honour the corresponding property.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8216358](https://bugs.openjdk.java.net/browse/JDK-8216358): [accessibility] [macos] The focus is invisible when tab to "Image Radio Buttons" and "Image CheckBoxes" ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7284/head:pull/7284` \
`$ git checkout pull/7284`

Update a local copy of the PR: \
`$ git checkout pull/7284` \
`$ git pull https://git.openjdk.java.net/jdk pull/7284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7284`

View PR using the GUI difftool: \
`$ git pr show -t 7284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7284.diff">https://git.openjdk.java.net/jdk/pull/7284.diff</a>

</details>
