### PR TITLE
8280932: G1: Rename HeapRegionRemSet::_code_roots accessors

### DIFF
--- a/src/hotspot/share/gc/g1/g1CodeBlobClosure.cpp
+++ b/src/hotspot/share/gc/g1/g1CodeBlobClosure.cpp
@@ -40,8 +40,8 @@ void G1CodeBlobClosure::HeapRegionGatheringOopClosure::do_oop_work(T* p) {
   if (!CompressedOops::is_null(oop_or_narrowoop)) {
     oop o = CompressedOops::decode_not_null(oop_or_narrowoop);
     HeapRegion* hr = _g1h->heap_region_containing(o);
-    assert(!_g1h->is_in_cset(o) || hr->rem_set()->strong_code_roots_list_contains(_nm), "if o still in collection set then evacuation failed and nm must already be in the remset");
-    hr->add_strong_code_root(_nm);
+    assert(!_g1h->is_in_cset(o) || hr->rem_set()->code_roots_list_contains(_nm), "if o still in collection set then evacuation failed and nm must already be in the remset");
+    hr->add_code_root(_nm);
   }
 }
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1042,8 +1042,8 @@ void G1CollectedHeap::prepare_heap_for_mutators() {
   resize_heap_if_necessary();
   uncommit_regions_if_necessary();
 
-  // Rebuild the strong code root lists for each region
-  rebuild_strong_code_roots();
+  // Rebuild the code root lists for each region
+  rebuild_code_roots();
 
   // Purge code root memory
   purge_code_root_memory();
@@ -3411,11 +3411,11 @@ void G1CollectedHeap::purge_code_root_memory() {
   G1CodeRootSet::purge();
 }
 
-class RebuildStrongCodeRootClosure: public CodeBlobClosure {
+class RebuildCodeRootClosure: public CodeBlobClosure {
   G1CollectedHeap* _g1h;
 
 public:
-  RebuildStrongCodeRootClosure(G1CollectedHeap* g1h) :
+  RebuildCodeRootClosure(G1CollectedHeap* g1h) :
     _g1h(g1h) {}
 
   void do_code_blob(CodeBlob* cb) {
@@ -3428,8 +3428,8 @@ public:
   }
 };
 
-void G1CollectedHeap::rebuild_strong_code_roots() {
-  RebuildStrongCodeRootClosure blob_cl(this);
+void G1CollectedHeap::rebuild_code_roots() {
+  RebuildCodeRootClosure blob_cl(this);
   CodeCache::blobs_do(&blob_cl);
 }
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3342,8 +3342,8 @@ public:
              " starting at " HR_FORMAT,
              p2i(_nm), HR_FORMAT_PARAMS(hr), HR_FORMAT_PARAMS(hr->humongous_start_region()));
 
-      // HeapRegion::add_strong_code_root_locked() avoids adding duplicate entries.
-      hr->add_strong_code_root_locked(_nm);
+      // HeapRegion::add_code_root_locked() avoids adding duplicate entries.
+      hr->add_code_root_locked(_nm);
     }
   }
 
@@ -3368,7 +3368,7 @@ public:
              " starting at " HR_FORMAT,
              p2i(_nm), HR_FORMAT_PARAMS(hr), HR_FORMAT_PARAMS(hr->humongous_start_region()));
 
-      hr->remove_strong_code_root(_nm);
+      hr->remove_code_root(_nm);
     }
   }
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1287,9 +1287,9 @@ public:
   // Free up superfluous code root memory.
   void purge_code_root_memory();
 
-  // Rebuild the strong code root lists for each region
+  // Rebuild the code root lists for each region
   // after a full GC.
-  void rebuild_strong_code_roots();
+  void rebuild_code_roots();
 
   // Performs cleaning of data structures after class unloading.
   void complete_cleaning(BoolObjectClosure* is_alive, bool class_unloading_occurred);

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -2954,7 +2954,7 @@ G1CMTask::G1CMTask(uint worker_id,
 G1PrintRegionLivenessInfoClosure::G1PrintRegionLivenessInfoClosure(const char* phase_name) :
   _total_used_bytes(0), _total_capacity_bytes(0),
   _total_prev_live_bytes(0), _total_next_live_bytes(0),
-  _total_remset_bytes(0), _total_strong_code_roots_bytes(0)
+  _total_remset_bytes(0), _total_code_roots_bytes(0)
 {
   if (!log_is_enabled(Trace, gc, liveness)) {
     return;
@@ -3014,7 +3014,7 @@ bool G1PrintRegionLivenessInfoClosure::do_heap_region(HeapRegion* r) {
   size_t next_live_bytes = r->next_live_bytes();
   double gc_eff          = r->gc_efficiency();
   size_t remset_bytes    = r->rem_set()->mem_size();
-  size_t strong_code_roots_bytes = r->rem_set()->strong_code_roots_mem_size();
+  size_t code_roots_bytes = r->rem_set()->code_roots_mem_size();
   const char* remset_type = r->rem_set()->get_short_state_str();
   FormatBuffer<16> gc_efficiency("");
 
@@ -3023,7 +3023,7 @@ bool G1PrintRegionLivenessInfoClosure::do_heap_region(HeapRegion* r) {
   _total_prev_live_bytes += prev_live_bytes;
   _total_next_live_bytes += next_live_bytes;
   _total_remset_bytes    += remset_bytes;
-  _total_strong_code_roots_bytes += strong_code_roots_bytes;
+  _total_code_roots_bytes += code_roots_bytes;
 
   if(gc_eff < 0) {
     gc_efficiency.append("-");
@@ -3044,7 +3044,7 @@ bool G1PrintRegionLivenessInfoClosure::do_heap_region(HeapRegion* r) {
                         G1PPRL_BYTE_FORMAT,
                         type, p2i(bottom), p2i(end),
                         used_bytes, prev_live_bytes, next_live_bytes, gc_efficiency.buffer(),
-                        remset_bytes, remset_type, strong_code_roots_bytes);
+                        remset_bytes, remset_type, code_roots_bytes);
 
   return false;
 }
@@ -3074,5 +3074,5 @@ G1PrintRegionLivenessInfoClosure::~G1PrintRegionLivenessInfoClosure() {
                          bytes_to_mb(_total_next_live_bytes),
                          percent_of(_total_next_live_bytes, _total_capacity_bytes),
                          bytes_to_mb(_total_remset_bytes),
-                         bytes_to_mb(_total_strong_code_roots_bytes));
+                         bytes_to_mb(_total_code_roots_bytes));
 }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -847,8 +847,8 @@ class G1PrintRegionLivenessInfoClosure : public HeapRegionClosure {
   // Accumulator for the remembered set size
   size_t _total_remset_bytes;
 
-  // Accumulator for strong code roots memory size
-  size_t _total_strong_code_roots_bytes;
+  // Accumulator for code roots memory size
+  size_t _total_code_roots_bytes;
 
   static double bytes_to_mb(size_t val) {
     return (double) val / (double) M;

--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -196,7 +196,7 @@ public:
 
     size_t live_bytes = remove_self_forward_ptr_by_walking_hr(hr, during_concurrent_start);
 
-    hr->rem_set()->clean_strong_code_roots(hr);
+    hr->rem_set()->clean_code_roots(hr);
     hr->rem_set()->clear_locked(true);
 
     hr->note_self_forwarding_removal_end(live_bytes);

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -116,7 +116,7 @@ class G1VerifyCodeRootOopClosure: public OopClosure {
       HeapRegionRemSet* hrrs = hr->rem_set();
       // Verify that the strong code root list for this region
       // contains the nmethod
-      if (!hrrs->strong_code_roots_list_contains(_nm)) {
+      if (!hrrs->code_roots_list_contains(_nm)) {
         log_error(gc, verify)("Code root location " PTR_FORMAT " "
                               "from nmethod " PTR_FORMAT " not in strong "
                               "code roots for region [" PTR_FORMAT "," PTR_FORMAT ")",

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -114,7 +114,7 @@ class G1VerifyCodeRootOopClosure: public OopClosure {
       // Now fetch the region containing the object
       HeapRegion* hr = _g1h->heap_region_containing(obj);
       HeapRegionRemSet* hrrs = hr->rem_set();
-      // Verify that the strong code root list for this region
+      // Verify that the code root list for this region
       // contains the nmethod
       if (!hrrs->code_roots_list_contains(_nm)) {
         log_error(gc, verify)("Code root location " PTR_FORMAT " "

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -946,8 +946,8 @@ class G1ScanCollectionSetRegionClosure : public HeapRegionClosure {
   size_t _opt_refs_scanned;
   size_t _opt_refs_memory_used;
 
-  Tickspan _strong_code_root_scan_time;
-  Tickspan _strong_code_trim_partially_time;
+  Tickspan _code_root_scan_time;
+  Tickspan _code_trim_partially_time;
 
   Tickspan _rem_set_opt_root_scan_time;
   Tickspan _rem_set_opt_trim_partially_time;
@@ -979,8 +979,8 @@ public:
     _opt_roots_scanned(0),
     _opt_refs_scanned(0),
     _opt_refs_memory_used(0),
-    _strong_code_root_scan_time(),
-    _strong_code_trim_partially_time(),
+    _code_root_scan_time(),
+    _code_trim_partially_time(),
     _rem_set_opt_root_scan_time(),
     _rem_set_opt_trim_partially_time() { }
 
@@ -997,9 +997,9 @@ public:
     if (_scan_state->claim_collection_set_region(region_idx)) {
       EventGCPhaseParallel event;
 
-      G1EvacPhaseWithTrimTimeTracker timer(_pss, _strong_code_root_scan_time, _strong_code_trim_partially_time);
-      // Scan the strong code root list attached to the current region
-      r->strong_code_roots_do(_pss->closures()->weak_codeblobs());
+      G1EvacPhaseWithTrimTimeTracker timer(_pss, _code_root_scan_time, _code_trim_partially_time);
+      // Scan the code root list attached to the current region
+      r->code_roots_do(_pss->closures()->weak_codeblobs());
 
       event.commit(GCId::current(), _worker_id, G1GCPhaseTimes::phase_name(_code_roots_phase));
     }
@@ -1007,8 +1007,8 @@ public:
     return false;
   }
 
-  Tickspan strong_code_root_scan_time() const { return _strong_code_root_scan_time;  }
-  Tickspan strong_code_root_trim_partially_time() const { return _strong_code_trim_partially_time; }
+  Tickspan code_root_scan_time() const { return _code_root_scan_time;  }
+  Tickspan code_root_trim_partially_time() const { return _code_trim_partially_time; }
 
   Tickspan rem_set_opt_root_scan_time() const { return _rem_set_opt_root_scan_time; }
   Tickspan rem_set_opt_trim_partially_time() const { return _rem_set_opt_trim_partially_time; }
@@ -1031,8 +1031,8 @@ void G1RemSet::scan_collection_set_regions(G1ParScanThreadState* pss,
   p->record_or_add_time_secs(scan_phase, worker_id, cl.rem_set_opt_root_scan_time().seconds());
   p->record_or_add_time_secs(scan_phase, worker_id, cl.rem_set_opt_trim_partially_time().seconds());
 
-  p->record_or_add_time_secs(coderoots_phase, worker_id, cl.strong_code_root_scan_time().seconds());
-  p->add_time_secs(objcopy_phase, worker_id, cl.strong_code_root_trim_partially_time().seconds());
+  p->record_or_add_time_secs(coderoots_phase, worker_id, cl.code_root_scan_time().seconds());
+  p->add_time_secs(objcopy_phase, worker_id, cl.code_root_trim_partially_time().seconds());
 
   // At this time we record some metrics only for the evacuations after the initial one.
   if (scan_phase == G1GCPhaseTimes::OptScanHR) {

--- a/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
@@ -241,12 +241,12 @@ public:
       _max_rs_mem_sz_region = r;
     }
     size_t occupied_cards = hrrs->occupied();
-    size_t code_root_mem_sz = hrrs->strong_code_roots_mem_size();
+    size_t code_root_mem_sz = hrrs->code_roots_mem_size();
     if (code_root_mem_sz > max_code_root_mem_sz()) {
       _max_code_root_mem_sz = code_root_mem_sz;
       _max_code_root_mem_sz_region = r;
     }
-    size_t code_root_elems = hrrs->strong_code_roots_list_length();
+    size_t code_root_elems = hrrs->code_roots_list_length();
 
     RegionTypeCounter* current = NULL;
     if (r->is_free()) {
@@ -306,8 +306,8 @@ public:
                   "  Max = " SIZE_FORMAT "%s.",
                   byte_size_in_proper_unit(total_code_root_mem_sz()),
                   proper_unit_for_byte_size(total_code_root_mem_sz()),
-                  byte_size_in_proper_unit(max_code_root_rem_set->strong_code_roots_mem_size()),
-                  proper_unit_for_byte_size(max_code_root_rem_set->strong_code_roots_mem_size()));
+                  byte_size_in_proper_unit(max_code_root_rem_set->code_roots_mem_size()),
+                  proper_unit_for_byte_size(max_code_root_rem_set->code_roots_mem_size()));
     for (RegionTypeCounter** current = &counters[0]; *current != NULL; current++) {
       (*current)->print_code_root_mem_info_on(out, total_code_root_mem_sz());
     }
@@ -321,9 +321,9 @@ public:
     out->print_cr("    Region with largest amount of code roots = " HR_FORMAT ", "
                   "size = " SIZE_FORMAT "%s, num_slots = " SIZE_FORMAT ".",
                   HR_FORMAT_PARAMS(max_code_root_mem_sz_region()),
-                  byte_size_in_proper_unit(max_code_root_rem_set->strong_code_roots_mem_size()),
-                  proper_unit_for_byte_size(max_code_root_rem_set->strong_code_roots_mem_size()),
-                  max_code_root_rem_set->strong_code_roots_list_length());
+                  byte_size_in_proper_unit(max_code_root_rem_set->code_roots_mem_size()),
+                  proper_unit_for_byte_size(max_code_root_rem_set->code_roots_mem_size()),
+                  max_code_root_rem_set->code_roots_list_length());
   }
 };
 

--- a/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
@@ -233,7 +233,7 @@ public:
     HeapRegionRemSet* hrrs = r->rem_set();
 
     // HeapRegionRemSet::mem_size() includes the
-    // size of the strong code roots
+    // size of the code roots
     size_t rs_wasted_mem_sz = hrrs->wasted_mem_size();
     size_t rs_mem_sz = hrrs->mem_size();
     if (rs_mem_sz > _max_rs_mem_sz) {
@@ -300,7 +300,7 @@ public:
     HeapRegionRemSet::print_static_mem_size(out);
     G1CardSetFreePool::free_list_pool()->print_on(out);
 
-    // Strong code root statistics
+    // Code root statistics
     HeapRegionRemSet* max_code_root_rem_set = max_code_root_mem_sz_region()->rem_set();
     out->print_cr("  Total heap region code root sets sizes = " SIZE_FORMAT "%s."
                   "  Max = " SIZE_FORMAT "%s.",

--- a/src/hotspot/share/gc/g1/g1SharedClosures.hpp
+++ b/src/hotspot/share/gc/g1/g1SharedClosures.hpp
@@ -37,7 +37,7 @@ public:
   G1ParCopyClosure<G1BarrierCLD,  should_mark> _oops_in_cld;
   // We do not need (and actually should not) collect oops from nmethods into the
   // optional collection set as we already automatically collect the corresponding
-  // nmethods in the region's strong code roots set. So set G1BarrierNoOptRoots in
+  // nmethods in the region's code roots set. So set G1BarrierNoOptRoots in
   // this closure.
   // If these were present there would be opportunity for multiple threads to try
   // to change this oop* at the same time. Since embedded oops are not necessarily

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -395,7 +395,7 @@ class G1PrepareEvacuationTask : public WorkerTask {
                                cast_to_oop(hr->bottom())->size() * HeapWordSize,
                                p2i(hr->bottom()),
                                hr->rem_set()->occupied(),
-                               hr->rem_set()->strong_code_roots_list_length(),
+                               hr->rem_set()->code_roots_list_length(),
                                _g1h->concurrent_mark()->next_mark_bitmap()->is_marked(hr->bottom()),
                                _g1h->is_humongous_reclaim_candidate(index),
                                cast_to_oop(hr->bottom())->is_typeArray()

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -572,20 +572,20 @@ public:
 
   // Routines for managing a list of code roots (attached to the
   // this region's RSet) that point into this heap region.
-  void add_strong_code_root(nmethod* nm);
-  void add_strong_code_root_locked(nmethod* nm);
-  void remove_strong_code_root(nmethod* nm);
+  void add_code_root(nmethod* nm);
+  void add_code_root_locked(nmethod* nm);
+  void remove_code_root(nmethod* nm);
 
   // Applies blk->do_code_blob() to each of the entries in
-  // the strong code roots list for this region
-  void strong_code_roots_do(CodeBlobClosure* blk) const;
+  // the code roots list for this region
+  void code_roots_do(CodeBlobClosure* blk) const;
 
   uint node_index() const { return _node_index; }
   void set_node_index(uint node_index) { _node_index = node_index; }
 
-  // Verify that the entries on the strong code root list for this
+  // Verify that the entries on the code root list for this
   // region are live and include at least one pointer into this region.
-  void verify_strong_code_roots(VerifyOption vo, bool* failures) const;
+  void verify_code_roots(VerifyOption vo, bool* failures) const;
 
   void print() const;
   void print_on(outputStream* st) const;

--- a/src/hotspot/share/gc/g1/heapRegionRemSet.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.cpp
@@ -122,19 +122,19 @@ void HeapRegionRemSet::print_static_mem_size(outputStream* out) {
 // When concurrent readers access the contains() function
 // (during the evacuation phase) no removals are allowed.
 
-void HeapRegionRemSet::add_strong_code_root(nmethod* nm) {
+void HeapRegionRemSet::add_code_root(nmethod* nm) {
   assert(nm != NULL, "sanity");
   assert((!CodeCache_lock->owned_by_self() || SafepointSynchronize::is_at_safepoint()),
-          "should call add_strong_code_root_locked instead. CodeCache_lock->owned_by_self(): %s, is_at_safepoint(): %s",
+          "should call add_code_root_locked instead. CodeCache_lock->owned_by_self(): %s, is_at_safepoint(): %s",
           BOOL_TO_STR(CodeCache_lock->owned_by_self()), BOOL_TO_STR(SafepointSynchronize::is_at_safepoint()));
   // Optimistic unlocked contains-check
   if (!_code_roots.contains(nm)) {
     MutexLocker ml(&_m, Mutex::_no_safepoint_check_flag);
-    add_strong_code_root_locked(nm);
+    add_code_root_locked(nm);
   }
 }
 
-void HeapRegionRemSet::add_strong_code_root_locked(nmethod* nm) {
+void HeapRegionRemSet::add_code_root_locked(nmethod* nm) {
   assert(nm != NULL, "sanity");
   assert((CodeCache_lock->owned_by_self() ||
          (SafepointSynchronize::is_at_safepoint() &&
@@ -145,7 +145,7 @@ void HeapRegionRemSet::add_strong_code_root_locked(nmethod* nm) {
   _code_roots.add(nm);
 }
 
-void HeapRegionRemSet::remove_strong_code_root(nmethod* nm) {
+void HeapRegionRemSet::remove_code_root(nmethod* nm) {
   assert(nm != NULL, "sanity");
   assert_locked_or_safepoint(CodeCache_lock);
 
@@ -156,14 +156,14 @@ void HeapRegionRemSet::remove_strong_code_root(nmethod* nm) {
   guarantee(!_code_roots.contains(nm), "duplicate entry found");
 }
 
-void HeapRegionRemSet::strong_code_roots_do(CodeBlobClosure* blk) const {
+void HeapRegionRemSet::code_roots_do(CodeBlobClosure* blk) const {
   _code_roots.nmethods_do(blk);
 }
 
-void HeapRegionRemSet::clean_strong_code_roots(HeapRegion* hr) {
+void HeapRegionRemSet::clean_code_roots(HeapRegion* hr) {
   _code_roots.clean(hr);
 }
 
-size_t HeapRegionRemSet::strong_code_roots_mem_size() {
+size_t HeapRegionRemSet::code_roots_mem_size() {
   return _code_roots.mem_size();
 }

--- a/src/hotspot/share/gc/g1/heapRegionRemSet.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.hpp
@@ -73,11 +73,11 @@ public:
   }
 
   bool is_empty() const {
-    return (strong_code_roots_list_length() == 0) && cardset_is_empty();
+    return (code_roots_list_length() == 0) && cardset_is_empty();
   }
 
   bool occupancy_less_or_equal_than(size_t occ) const {
-    return (strong_code_roots_list_length() == 0) && _card_set.occupancy_less_or_equal_to(occ);
+    return (code_roots_list_length() == 0) && _card_set.occupancy_less_or_equal_to(occ);
   }
 
   // Iterate the card based remembered set for merging them into the card table.
@@ -132,8 +132,8 @@ public:
   // root set.
   size_t mem_size() {
     return _card_set.mem_size()
-      + (sizeof(HeapRegionRemSet) - sizeof(G1CardSet)) // Avoid double-counting G1CardSet.
-      + strong_code_roots_mem_size();
+           + (sizeof(HeapRegionRemSet) - sizeof(G1CardSet)) // Avoid double-counting G1CardSet.
+           + code_roots_mem_size();
   }
 
   size_t wasted_mem_size() {
@@ -154,30 +154,29 @@ public:
 
   // Routines for managing the list of code roots that point into
   // the heap region that owns this RSet.
-  void add_strong_code_root(nmethod* nm);
-  void add_strong_code_root_locked(nmethod* nm);
-  void remove_strong_code_root(nmethod* nm);
+  void add_code_root(nmethod* nm);
+  void add_code_root_locked(nmethod* nm);
+  void remove_code_root(nmethod* nm);
 
-  // Applies blk->do_code_blob() to each of the entries in
-  // the strong code roots list
-  void strong_code_roots_do(CodeBlobClosure* blk) const;
+  // Applies blk->do_code_blob() to each of the entries in _code_roots
+  void code_roots_do(CodeBlobClosure* blk) const;
 
-  void clean_strong_code_roots(HeapRegion* hr);
+  void clean_code_roots(HeapRegion* hr);
 
-  // Returns the number of elements in the strong code roots list
-  size_t strong_code_roots_list_length() const {
+  // Returns the number of elements in _code_roots
+  size_t code_roots_list_length() const {
     return _code_roots.length();
   }
 
-  // Returns true if the strong code roots contains the given
+  // Returns true if the code roots contains the given
   // nmethod.
-  bool strong_code_roots_list_contains(nmethod* nm) {
+  bool code_roots_list_contains(nmethod* nm) {
     return _code_roots.contains(nm);
   }
 
   // Returns the amount of memory, in bytes, currently
-  // consumed by the strong code roots.
-  size_t strong_code_roots_mem_size();
+  // consumed by the code roots.
+  size_t code_roots_mem_size();
 
   static void invalidate_from_card_cache(uint start_idx, size_t num_regions) {
     G1FromCardCache::invalidate(start_idx, num_regions);

--- a/src/hotspot/share/gc/g1/heapRegionRemSet.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.hpp
@@ -128,7 +128,7 @@ public:
 
   G1SegmentedArrayMemoryStats card_set_memory_stats() const;
 
-  // The actual # of bytes this hr_remset takes up. Also includes the strong code
+  // The actual # of bytes this hr_remset takes up. Also includes the code
   // root set.
   size_t mem_size() {
     return _card_set.mem_size()


### PR DESCRIPTION
Mostly mechanical changes of renaming some methods/comments.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280932](https://bugs.openjdk.java.net/browse/JDK-8280932): G1: Rename HeapRegionRemSet::_code_roots accessors


### Reviewers
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**) ⚠️ Review applies to 6a226cdaf9588c17380eac907a25bdf523a7f345


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7285/head:pull/7285` \
`$ git checkout pull/7285`

Update a local copy of the PR: \
`$ git checkout pull/7285` \
`$ git pull https://git.openjdk.java.net/jdk pull/7285/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7285`

View PR using the GUI difftool: \
`$ git pr show -t 7285`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7285.diff">https://git.openjdk.java.net/jdk/pull/7285.diff</a>

</details>
