### PR TITLE
8280949: Correct the references for the Java Security Standard Algorithm Names specification

### DIFF
--- a/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
@@ -920,9 +920,9 @@ public abstract class SSLEngine {
      * The returned array includes cipher suites from the list of standard
      * cipher suite names in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
-     * JSSE Cipher Suite Names</a> section of the Java Cryptography
-     * Architecture Standard Algorithm Name Documentation, and may also
-     * include other cipher suites that the provider supports.
+     * JSSE Cipher Suite Names</a> section of the Java Security Standard
+     * Algorithm Names specification, and may also include other cipher
+     * suites that the provider supports.
      *
      * @return  an array of cipher suite names
      * @see     #getEnabledCipherSuites()
@@ -946,9 +946,9 @@ public abstract class SSLEngine {
      * The returned array includes cipher suites from the list of standard
      * cipher suite names in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
-     * JSSE Cipher Suite Names</a> section of the Java Cryptography
-     * Architecture Standard Algorithm Name Documentation, and may also
-     * include other cipher suites that the provider supports.
+     * JSSE Cipher Suite Names</a> section of the Java Security Standard
+     * Algorithm Names specification, and may also include other cipher
+     * suites that the provider supports.
      *
      * @return  an array of cipher suite names
      * @see     #getSupportedCipherSuites()
@@ -968,10 +968,10 @@ public abstract class SSLEngine {
      * Note that the standard list of cipher suite names may be found in the
      * <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
-     * JSSE Cipher Suite Names</a> section of the Java Cryptography
-     * Architecture Standard Algorithm Name Documentation.  Providers
-     * may support cipher suite names not found in this list or might not
-     * use the recommended name for a certain cipher suite.
+     * JSSE Cipher Suite Names</a> section of the Java Security Standard
+     * Algorithm Names specification. Providers may support cipher suite
+     * names not found in this list or might not use the recommended name
+     * for a certain cipher suite.
      * <P>
      * See {@link #getEnabledCipherSuites()} for more information
      * on why a specific cipher suite may never be used on a engine.

--- a/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
@@ -921,7 +921,7 @@ public abstract class SSLEngine {
      * cipher suite names in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
      * JSSE Cipher Suite Names</a> section of the Java Security Standard
-     * Algorithm Names specification, and may also include other cipher
+     * Algorithm Names Specification, and may also include other cipher
      * suites that the provider supports.
      *
      * @return  an array of cipher suite names
@@ -947,7 +947,7 @@ public abstract class SSLEngine {
      * cipher suite names in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
      * JSSE Cipher Suite Names</a> section of the Java Security Standard
-     * Algorithm Names specification, and may also include other cipher
+     * Algorithm Names Specification, and may also include other cipher
      * suites that the provider supports.
      *
      * @return  an array of cipher suite names
@@ -969,7 +969,7 @@ public abstract class SSLEngine {
      * <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
      * JSSE Cipher Suite Names</a> section of the Java Security Standard
-     * Algorithm Names specification. Providers may support cipher suite
+     * Algorithm Names Specification. Providers may support cipher suite
      * names not found in this list or might not use the recommended name
      * for a certain cipher suite.
      * <P>

--- a/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
@@ -111,9 +111,9 @@ public class SSLParameters {
      * {@code setCipherSuites(cipherSuites);}.  Note that the
      * standard list of cipher suite names may be found in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
-     * JSSE Cipher Suite Names</a> section of the Java Cryptography
-     * Architecture Standard Algorithm Name Documentation.  Providers
-     * may support cipher suite names not found in this list.
+     * JSSE Cipher Suite Names</a> section of the Java Security Standard
+     * Algorithm Names specification.  Providers may support cipher suite
+     * names not found in this list.
      *
      * @param cipherSuites the array of ciphersuites (or null)
      */
@@ -131,9 +131,9 @@ public class SSLParameters {
      * Note that the standard list of cipher suite names may be found in the
      * <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
-     * JSSE Cipher Suite Names</a> section of the Java Cryptography
-     * Architecture Standard Algorithm Name Documentation.  Providers
-     * may support cipher suite names not found in this list.
+     * JSSE Cipher Suite Names</a> section of the Java Security Standard
+     * Algorithm Names specification.  Providers may support cipher suite
+     * names not found in this list.
      *
      * @param cipherSuites the array of ciphersuites (or null)
      * @param protocols the array of protocols (or null)
@@ -154,9 +154,9 @@ public class SSLParameters {
      * The returned array includes cipher suites from the list of standard
      * cipher suite names in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
-     * JSSE Cipher Suite Names</a> section of the Java Cryptography
-     * Architecture Standard Algorithm Name Documentation, and may also
-     * include other cipher suites that the provider supports.
+     * JSSE Cipher Suite Names</a> section of the Java Security Standard
+     * Algorithm Names specification, and may also include other cipher suites
+     * that the provider supports.
      *
      * @return a copy of the array of ciphersuites or null if none
      * have been set.
@@ -171,10 +171,10 @@ public class SSLParameters {
      * @param cipherSuites the array of ciphersuites (or null).  Note that the
      * standard list of cipher suite names may be found in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
-     * JSSE Cipher Suite Names</a> section of the Java Cryptography
-     * Architecture Standard Algorithm Name Documentation.  Providers
-     * may support cipher suite names not found in this list or might not
-     * use the recommended name for a certain cipher suite.
+     * JSSE Cipher Suite Names</a> section of the Java Security Standard
+     * Algorithm Names specification.  Providers may support cipher suite
+     * names not found in this list or might not use the recommended name
+     * for a certain cipher suite.
      */
     public void setCipherSuites(String[] cipherSuites) {
         this.cipherSuites = clone(cipherSuites);

--- a/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLParameters.java
@@ -112,7 +112,7 @@ public class SSLParameters {
      * standard list of cipher suite names may be found in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
      * JSSE Cipher Suite Names</a> section of the Java Security Standard
-     * Algorithm Names specification.  Providers may support cipher suite
+     * Algorithm Names Specification.  Providers may support cipher suite
      * names not found in this list.
      *
      * @param cipherSuites the array of ciphersuites (or null)
@@ -132,7 +132,7 @@ public class SSLParameters {
      * <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
      * JSSE Cipher Suite Names</a> section of the Java Security Standard
-     * Algorithm Names specification.  Providers may support cipher suite
+     * Algorithm Names Specification.  Providers may support cipher suite
      * names not found in this list.
      *
      * @param cipherSuites the array of ciphersuites (or null)
@@ -155,7 +155,7 @@ public class SSLParameters {
      * cipher suite names in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
      * JSSE Cipher Suite Names</a> section of the Java Security Standard
-     * Algorithm Names specification, and may also include other cipher suites
+     * Algorithm Names Specification, and may also include other cipher suites
      * that the provider supports.
      *
      * @return a copy of the array of ciphersuites or null if none
@@ -172,7 +172,7 @@ public class SSLParameters {
      * standard list of cipher suite names may be found in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
      * JSSE Cipher Suite Names</a> section of the Java Security Standard
-     * Algorithm Names specification.  Providers may support cipher suite
+     * Algorithm Names Specification.  Providers may support cipher suite
      * names not found in this list or might not use the recommended name
      * for a certain cipher suite.
      */

--- a/src/java.base/share/classes/javax/net/ssl/SSLServerSocket.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLServerSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/javax/net/ssl/SSLServerSocket.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLServerSocket.java
@@ -197,9 +197,9 @@ public abstract class SSLServerSocket extends ServerSocket {
      * The returned array includes cipher suites from the list of standard
      * cipher suite names in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
-     * JSSE Cipher Suite Names</a> section of the Java Cryptography
-     * Architecture Standard Algorithm Name Documentation, and may also
-     * include other cipher suites that the provider supports.
+     * JSSE Cipher Suite Names</a> section of the Java Security Standard
+     * Algorithm Names specification, and may also include other cipher
+     * suites that the provider supports.
      *
      * @return an array of cipher suites enabled
      * @see #getSupportedCipherSuites()
@@ -223,10 +223,10 @@ public abstract class SSLServerSocket extends ServerSocket {
      * Note that the standard list of cipher suite names may be found in the
      * <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
-     * JSSE Cipher Suite Names</a> section of the Java Cryptography
-     * Architecture Standard Algorithm Name Documentation.  Providers
-     * may support cipher suite names not found in this list or might not
-     * use the recommended name for a certain cipher suite.
+     * JSSE Cipher Suite Names</a> section of the Java Security Standard
+     * Algorithm Names specification.  Providers  may support cipher suite
+     * names not found in this list or might not use the recommended name
+     * for a certain cipher suite.
      * <P>
      * <code>SSLSocket</code>s returned from <code>accept()</code>
      * inherit this setting.
@@ -253,9 +253,9 @@ public abstract class SSLServerSocket extends ServerSocket {
      * The returned array includes cipher suites from the list of standard
      * cipher suite names in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
-     * JSSE Cipher Suite Names</a> section of the Java Cryptography
-     * Architecture Standard Algorithm Name Documentation, and may also
-     * include other cipher suites that the provider supports.
+     * JSSE Cipher Suite Names</a> section of the Java Security Standard
+     * Algorithm Names specification, and may also include other cipher
+     * suites that the provider supports.
      *
      * @return an array of cipher suite names
      * @see #getEnabledCipherSuites()

--- a/src/java.base/share/classes/javax/net/ssl/SSLServerSocket.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLServerSocket.java
@@ -198,7 +198,7 @@ public abstract class SSLServerSocket extends ServerSocket {
      * cipher suite names in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
      * JSSE Cipher Suite Names</a> section of the Java Security Standard
-     * Algorithm Names specification, and may also include other cipher
+     * Algorithm Names Specification, and may also include other cipher
      * suites that the provider supports.
      *
      * @return an array of cipher suites enabled
@@ -224,7 +224,7 @@ public abstract class SSLServerSocket extends ServerSocket {
      * <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
      * JSSE Cipher Suite Names</a> section of the Java Security Standard
-     * Algorithm Names specification.  Providers  may support cipher suite
+     * Algorithm Names Specification.  Providers  may support cipher suite
      * names not found in this list or might not use the recommended name
      * for a certain cipher suite.
      * <P>
@@ -254,7 +254,7 @@ public abstract class SSLServerSocket extends ServerSocket {
      * cipher suite names in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
      * JSSE Cipher Suite Names</a> section of the Java Security Standard
-     * Algorithm Names specification, and may also include other cipher
+     * Algorithm Names Specification, and may also include other cipher
      * suites that the provider supports.
      *
      * @return an array of cipher suite names

--- a/src/java.base/share/classes/javax/net/ssl/SSLServerSocketFactory.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLServerSocketFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/javax/net/ssl/SSLServerSocketFactory.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLServerSocketFactory.java
@@ -87,9 +87,9 @@ public abstract class SSLServerSocketFactory extends ServerSocketFactory {
      * The returned array includes cipher suites from the list of standard
      * cipher suite names in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
-     * JSSE Cipher Suite Names</a> section of the Java Cryptography
-     * Architecture Standard Algorithm Name Documentation, and may also
-     * include other cipher suites that the provider supports.
+     * JSSE Cipher Suite Names</a> section of the Java Security Standard
+     * Algorithm Names specification, and may also include other cipher
+     * suites that the provider supports.
      *
      * @see #getSupportedCipherSuites()
      * @return array of the cipher suites enabled by default
@@ -108,9 +108,9 @@ public abstract class SSLServerSocketFactory extends ServerSocketFactory {
      * The returned array includes cipher suites from the list of standard
      * cipher suite names in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
-     * JSSE Cipher Suite Names</a> section of the Java Cryptography
-     * Architecture Standard Algorithm Name Documentation, and may also
-     * include other cipher suites that the provider supports.
+     * JSSE Cipher Suite Names</a> section of the Java Security Standard
+     * Algorithm Names specification, and may also include other cipher
+     * suites that the provider supports.
      *
      * @return an array of cipher suite names
      * @see #getDefaultCipherSuites()

--- a/src/java.base/share/classes/javax/net/ssl/SSLServerSocketFactory.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLServerSocketFactory.java
@@ -88,7 +88,7 @@ public abstract class SSLServerSocketFactory extends ServerSocketFactory {
      * cipher suite names in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
      * JSSE Cipher Suite Names</a> section of the Java Security Standard
-     * Algorithm Names specification, and may also include other cipher
+     * Algorithm Names Specification, and may also include other cipher
      * suites that the provider supports.
      *
      * @see #getSupportedCipherSuites()
@@ -109,7 +109,7 @@ public abstract class SSLServerSocketFactory extends ServerSocketFactory {
      * cipher suite names in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
      * JSSE Cipher Suite Names</a> section of the Java Security Standard
-     * Algorithm Names specification, and may also include other cipher
+     * Algorithm Names Specification, and may also include other cipher
      * suites that the provider supports.
      *
      * @return an array of cipher suite names

--- a/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
@@ -328,7 +328,7 @@ public abstract class SSLSocket extends Socket
      * cipher suite names in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
      * JSSE Cipher Suite Names</a> section of the Java Security Standard
-     * Algorithm Names specification, and may also include other cipher
+     * Algorithm Names Specification, and may also include other cipher
      * suites that the provider supports.
      *
      * @return an array of cipher suite names
@@ -354,7 +354,7 @@ public abstract class SSLSocket extends Socket
      * cipher suite names in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
      * JSSE Cipher Suite Names</a> section of the Java Security Standard
-     * Algorithm Names specification, and may also include other cipher
+     * Algorithm Names Specification, and may also include other cipher
      * suites that the provider supports.
      *
      * @return an array of cipher suite names
@@ -376,7 +376,7 @@ public abstract class SSLSocket extends Socket
      * <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
      * JSSE Cipher Suite Names</a> section of the Java Security Standard
-     * Algorithm Names specification. Providers may support cipher suite
+     * Algorithm Names Specification. Providers may support cipher suite
      * names not found in this list or might not use the recommended name
      * for a certain cipher suite.
      * <P>

--- a/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
@@ -327,9 +327,9 @@ public abstract class SSLSocket extends Socket
      * The returned array includes cipher suites from the list of standard
      * cipher suite names in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
-     * JSSE Cipher Suite Names</a> section of the Java Cryptography
-     * Architecture Standard Algorithm Name Documentation, and may also
-     * include other cipher suites that the provider supports.
+     * JSSE Cipher Suite Names</a> section of the Java Security Standard
+     * Algorithm Names specification, and may also include other cipher
+     * suites that the provider supports.
      *
      * @return an array of cipher suite names
      * @see #getEnabledCipherSuites()
@@ -353,9 +353,9 @@ public abstract class SSLSocket extends Socket
      * The returned array includes cipher suites from the list of standard
      * cipher suite names in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
-     * JSSE Cipher Suite Names</a> section of the Java Cryptography
-     * Architecture Standard Algorithm Name Documentation, and may also
-     * include other cipher suites that the provider supports.
+     * JSSE Cipher Suite Names</a> section of the Java Security Standard
+     * Algorithm Names specification, and may also include other cipher
+     * suites that the provider supports.
      *
      * @return an array of cipher suite names
      * @see #getSupportedCipherSuites()
@@ -375,10 +375,10 @@ public abstract class SSLSocket extends Socket
      * Note that the standard list of cipher suite names may be found in the
      * <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
-     * JSSE Cipher Suite Names</a> section of the Java Cryptography
-     * Architecture Standard Algorithm Name Documentation.  Providers
-     * may support cipher suite names not found in this list or might not
-     * use the recommended name for a certain cipher suite.
+     * JSSE Cipher Suite Names</a> section of the Java Security Standard
+     * Algorithm Names specification. Providers may support cipher suite
+     * names not found in this list or might not use the recommended name
+     * for a certain cipher suite.
      * <P>
      * See {@link #getEnabledCipherSuites()} for more information
      * on why a specific ciphersuite may never be used on a connection.

--- a/src/java.base/share/classes/javax/net/ssl/SSLSocketFactory.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLSocketFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/javax/net/ssl/SSLSocketFactory.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLSocketFactory.java
@@ -114,7 +114,7 @@ public abstract class SSLSocketFactory extends SocketFactory {
      * cipher suite names in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
      * JSSE Cipher Suite Names</a> section of the Java Security Standard
-     * Algorithm Names specification, and may also include other cipher suites
+     * Algorithm Names Specification, and may also include other cipher suites
      * that the provider supports.
      *
      * @see #getSupportedCipherSuites()
@@ -133,7 +133,7 @@ public abstract class SSLSocketFactory extends SocketFactory {
      * cipher suite names in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
      * JSSE Cipher Suite Names</a> section of the Java Security Standard
-     * Algorithm Names specification, and may also include other cipher suites
+     * Algorithm Names Specification, and may also include other cipher suites
      * that the provider supports.
      *
      * @see #getDefaultCipherSuites()

--- a/src/java.base/share/classes/javax/net/ssl/SSLSocketFactory.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLSocketFactory.java
@@ -113,9 +113,9 @@ public abstract class SSLSocketFactory extends SocketFactory {
      * The returned array includes cipher suites from the list of standard
      * cipher suite names in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
-     * JSSE Cipher Suite Names</a> section of the Java Cryptography
-     * Architecture Standard Algorithm Name Documentation, and may also
-     * include other cipher suites that the provider supports.
+     * JSSE Cipher Suite Names</a> section of the Java Security Standard
+     * Algorithm Names specification, and may also include other cipher suites
+     * that the provider supports.
      *
      * @see #getSupportedCipherSuites()
      * @return array of the cipher suites enabled by default
@@ -132,9 +132,9 @@ public abstract class SSLSocketFactory extends SocketFactory {
      * The returned array includes cipher suites from the list of standard
      * cipher suite names in the <a href=
      * "{@docRoot}/../specs/security/standard-names.html#jsse-cipher-suite-names">
-     * JSSE Cipher Suite Names</a> section of the Java Cryptography
-     * Architecture Standard Algorithm Name Documentation, and may also
-     * include other cipher suites that the provider supports.
+     * JSSE Cipher Suite Names</a> section of the Java Security Standard
+     * Algorithm Names specification, and may also include other cipher suites
+     * that the provider supports.
      *
      * @see #getDefaultCipherSuites()
      * @return an array of cipher suite names


### PR DESCRIPTION
In the JSSE specification, the reference to "Java Security Standard Algorithm Names" specification is documented as "Java Cryptography Architecture Standard Algorithm Name Documentation".  As should be corrected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280949](https://bugs.openjdk.java.net/browse/JDK-8280949): Correct the references for the Java Security Standard Algorithm Names specification


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**) ⚠️ Review applies to 9f75163bdb9605ef86d5c0a6db1567fa02f09ad4


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7290/head:pull/7290` \
`$ git checkout pull/7290`

Update a local copy of the PR: \
`$ git checkout pull/7290` \
`$ git pull https://git.openjdk.java.net/jdk pull/7290/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7290`

View PR using the GUI difftool: \
`$ git pr show -t 7290`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7290.diff">https://git.openjdk.java.net/jdk/pull/7290.diff</a>

</details>
