### PR TITLE
8280976: Incorrect encoding of avx512 vpsraq instruction with mask and constant shift.

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -9301,7 +9301,7 @@ void Assembler::evpsraq(XMMRegister dst, KRegister mask, XMMRegister src, int sh
     attributes.reset_is_clear_context();
   }
   int encode = vex_prefix_and_encode(xmm4->encoding(), dst->encoding(), src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
-  emit_int24(0x73, (0xC0 | encode), shift & 0xFF);
+  emit_int24(0x72, (0xC0 | encode), shift & 0xFF);
 }
 
 void Assembler::evpsllw(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len) {


### PR DESCRIPTION
-  Incorrect encoding fixed.

EVEX.512.66.0F.W1 72 /4 ib VPSRAQ zmm1 {k1}{z}, zmm2/m512/m64bcst, imm8 | F | V/V | AVX512F | Shift quadwords in zmm2/m512/m64bcst right by imm8 while shifting in sign bits using writemask k1.
-- | -- | -- | -- | --

Thanks,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280976](https://bugs.openjdk.java.net/browse/JDK-8280976): Incorrect encoding of avx512 vpsraq instruction with mask and constant shift.


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7291/head:pull/7291` \
`$ git checkout pull/7291`

Update a local copy of the PR: \
`$ git checkout pull/7291` \
`$ git pull https://git.openjdk.java.net/jdk pull/7291/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7291`

View PR using the GUI difftool: \
`$ git pr show -t 7291`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7291.diff">https://git.openjdk.java.net/jdk/pull/7291.diff</a>

</details>
