### PR TITLE
JDK-8281007: Test jdk/javadoc/doclet/checkStylesheetClasses/CheckStylesheetClasses.java fails after JDK-8280738

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/checkStylesheetClasses/CheckStylesheetClasses.java
+++ b/test/langtools/jdk/javadoc/doclet/checkStylesheetClasses/CheckStylesheetClasses.java
@@ -139,9 +139,6 @@ public class CheckStylesheetClasses {
                 "search-tag-desc-result", "search-tag-holder-result",
                 "ui-autocomplete", "ui-autocomplete-category", "expanded");
 
-        // snippet-related
-        removeAll(styleSheetNames, "bold", "highlighted", "italic");
-
         // very JDK specific
         styleSheetNames.remove("module-graph");
 


### PR DESCRIPTION
Remove review a trivial fix to remove a workaround for the absence of some CSS classes in HtmlStyle.java. Those snippet-related classes have now been added, and the workaround needs to be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281007](https://bugs.openjdk.java.net/browse/JDK-8281007): Test jdk/javadoc/doclet/checkStylesheetClasses/CheckStylesheetClasses.java fails after JDK-8280738


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7293/head:pull/7293` \
`$ git checkout pull/7293`

Update a local copy of the PR: \
`$ git checkout pull/7293` \
`$ git pull https://git.openjdk.java.net/jdk pull/7293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7293`

View PR using the GUI difftool: \
`$ git pr show -t 7293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7293.diff">https://git.openjdk.java.net/jdk/pull/7293.diff</a>

</details>
