### PR TITLE
8279662: serviceability/sa/ClhsdbScanOops.java can fail do to unexpected GC

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbScanOops.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbScanOops.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,7 @@ import java.util.Map;
 import java.util.ArrayList;
 import jdk.test.lib.Utils;
 import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.process.OutputAnalyzer;
 import jtreg.SkippedException;
 
 public class ClhsdbScanOops {
@@ -71,35 +72,54 @@ public class ClhsdbScanOops {
             Map<String, List<String>> expStrMap = new HashMap<>();
             Map<String, List<String>> unExpStrMap = new HashMap<>();
 
-            String startAddress = null;
-            String endAddress = null;
-            String[] snippets = null;
+            String startAddress;
+            String endAddress;
+            String[] snippets;
+            String[] words;
+            String cmd;
 
+            // Run scanoops on the old gen
+            if (gc.contains("UseParallelGC")) {
+                snippets = universeOutput.split("PSOldGen \\[  ");
+            } else {
+                snippets = universeOutput.split("old  \\[");
+            }
+            words = snippets[1].split(",");
+            // Get the addresses from Old
+            startAddress = words[0].replace("[", "");
+            endAddress = words[1];
+            cmd = "scanoops " + startAddress + " " + endAddress;
+            String output1 = test.run(theApp.getPid(), List.of(cmd), null, null);
+
+            // Run scanoops on the eden gen
             if (gc.contains("UseParallelGC")) {
                 snippets = universeOutput.split("eden =  ");
             } else {
                 snippets = universeOutput.split("eden \\[");
             }
-            String[] words = snippets[1].split(",");
+            words = snippets[1].split(",");
             // Get the addresses from Eden
             startAddress = words[0].replace("[", "");
             endAddress = words[1];
-            String cmd = "scanoops " + startAddress + " " + endAddress;
-            cmds.add(cmd);
+            cmd = "scanoops " + startAddress + " " + endAddress;
+            String output2 = test.run(theApp.getPid(), List.of(cmd), null, null);
 
-            expStrMap.put(cmd, List.of
-                ("java/lang/Object", "java/lang/Class", "java/lang/Thread",
-                 "java/lang/String", "\\[B", "\\[I"));
+            // Look for expected types in the combined eden and old gens
+            OutputAnalyzer out = new OutputAnalyzer(output1 + output2);
+            List<String> expectStrs = List.of(
+                    "java/lang/Object", "java/lang/Class", "java/lang/Thread",
+                    "java/lang/String", "\\[B", "\\[I");
+            for (String expectStr : expectStrs) {
+                out.shouldMatch(expectStr);
+            }
 
-            // Test the 'type' option also
-            // scanoops <start addr> <end addr> java/lang/String
+            // Test the 'type' option also:
+            //   scanoops <start addr> <end addr> java/lang/String
             // Ensure that only the java/lang/String oops are printed.
             cmd = cmd + " java/lang/String";
-            cmds.add(cmd);
             expStrMap.put(cmd, List.of("java/lang/String"));
-            unExpStrMap.put(cmd, List.of("java/lang/Thread"));
-
-            test.run(theApp.getPid(), cmds, expStrMap, unExpStrMap);
+            unExpStrMap.put(cmd, List.of("java/lang/Thread", "java/lang/Class", "java/lang/Object"));
+            test.run(theApp.getPid(), List.of(cmd), expStrMap, unExpStrMap);
         } catch (SkippedException e) {
             throw e;
         } catch (Exception ex) {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbScanOops.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbScanOops.java
@@ -85,7 +85,7 @@ public class ClhsdbScanOops {
                 snippets = universeOutput.split("old  \\[");
             }
             words = snippets[1].split(",");
-            // Get the addresses from Old
+            // Get the addresses for Old gen
             startAddress = words[0].replace("[", "");
             endAddress = words[1];
             cmd = "scanoops " + startAddress + " " + endAddress;
@@ -98,7 +98,7 @@ public class ClhsdbScanOops {
                 snippets = universeOutput.split("eden \\[");
             }
             words = snippets[1].split(",");
-            // Get the addresses from Eden
+            // Get the addresses for Eden gen
             startAddress = words[0].replace("[", "");
             endAddress = words[1];
             cmd = "scanoops " + startAddress + " " + endAddress;


### PR DESCRIPTION
The test is failing to find certain types in the scanoops output when run with -Xcomp. This is happening in the loom repo. The reason it is happening there is because loom introduced a full GC during codecache sweeping. The test only runs scanoops on the eden gen, and the full GC is causing objects of certain expected types to no longer be present in the eden gen. The fix is to also check the old gen.

The logic of the test had to be reworked a bit to accomplish checking the output of two scanoops commands together. It was relying on the ClhsdbLauncher class to check the output for expected strings, but in this case we need to accumulate the output of the two scanoops commands and check the combined output for the expected strings, so now the checking is done directly by the test and not by ClhsdbLauncher.

I'm choosing to fix this in the jdk repo rather than the loom repo since it is a latent bug that theoretically could occur even without the loom changes, and also to help reduce the amount of changes to be reviewed when loom is integrated into jdk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279662](https://bugs.openjdk.java.net/browse/JDK-8279662): serviceability/sa/ClhsdbScanOops.java can fail do to unexpected GC


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7295/head:pull/7295` \
`$ git checkout pull/7295`

Update a local copy of the PR: \
`$ git checkout pull/7295` \
`$ git pull https://git.openjdk.java.net/jdk pull/7295/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7295`

View PR using the GUI difftool: \
`$ git pr show -t 7295`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7295.diff">https://git.openjdk.java.net/jdk/pull/7295.diff</a>

</details>
