### PR TITLE
JDK-8281023: NMT integration into pp debug command does not work

### DIFF
--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -24,6 +24,7 @@
 #include "precompiled.hpp"
 
 #include "runtime/os.hpp"
+#include "runtime/safefetch.inline.hpp"
 #include "services/mallocSiteTable.hpp"
 #include "services/mallocTracker.hpp"
 #include "services/mallocTracker.inline.hpp"
@@ -288,4 +289,33 @@ void* MallocTracker::record_free(void* memblock) {
   MallocHeader* header = malloc_header(memblock);
   header->release();
   return (void*)header;
+}
+
+// Given a pointer, if it seems to point to the start of a valid malloced block,
+// print the block. Note that since there is very low risk of memory looking
+// accidentally like a valid malloc block header (canaries and all) this is not
+// totally failproof. Only use this during debugging or when you can afford
+// signals popping up, e.g. when writing an hs_err file.
+bool MallocTracker::print_pointer_information(const void* p, outputStream* st) {
+  assert(MemTracker::enabled(), "NMT must be enabled");
+  if (CanUseSafeFetchN() && os::is_readable_pointer(p)) {
+    const NMT_TrackingLevel tracking_level = MemTracker::tracking_level();
+    const MallocHeader* mhdr = (const MallocHeader*)MallocTracker::get_base(const_cast<void*>(p), tracking_level);
+    char msg[256];
+    address p_corrupted;
+    if (os::is_readable_pointer(mhdr) &&
+        mhdr->check_block_integrity(msg, sizeof(msg), &p_corrupted)) {
+      st->print_cr(PTR_FORMAT " malloc'd " SIZE_FORMAT " bytes by %s",
+          p2i(p), mhdr->size(), NMTUtil::flag_to_name(mhdr->flags()));
+      if (tracking_level == NMT_detail) {
+        NativeCallStack ncs;
+        if (mhdr->get_stack(ncs)) {
+          ncs.print_on(st);
+          st->cr();
+        }
+      }
+      return true;
+    }
+  }
+  return false;
 }

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -298,7 +298,7 @@ void* MallocTracker::record_free(void* memblock) {
 // signals popping up, e.g. when writing an hs_err file.
 bool MallocTracker::print_pointer_information(const void* p, outputStream* st) {
   assert(MemTracker::enabled(), "NMT must be enabled");
-  if (CanUseSafeFetchN() && os::is_readable_pointer(p)) {
+  if (CanUseSafeFetch32() && os::is_readable_pointer(p)) {
     const NMT_TrackingLevel tracking_level = MemTracker::tracking_level();
     const MallocHeader* mhdr = (const MallocHeader*)MallocTracker::get_base(const_cast<void*>(p), tracking_level);
     char msg[256];

--- a/src/hotspot/share/services/mallocTracker.hpp
+++ b/src/hotspot/share/services/mallocTracker.hpp
@@ -31,6 +31,8 @@
 #include "services/nmtCommon.hpp"
 #include "utilities/nativeCallStack.hpp"
 
+class outputStream;
+
 /*
  * This counter class counts memory allocation and deallocation,
  * records total memory allocation size and number of allocations.
@@ -438,6 +440,14 @@ class MallocTracker : AllStatic {
   static inline void record_arena_size_change(ssize_t size, MEMFLAGS flags) {
     MallocMemorySummary::record_arena_size_change(size, flags);
   }
+
+  // Given a pointer, if it seems to point to the start of a valid malloced block,
+  // print the block. Note that since there is very low risk of memory looking
+  // accidentally like a valid malloc block header (canaries and all) this is not
+  // totally failproof. Only use this during debugging or when you can afford
+  // signals popping up, e.g. when writing an hs_err file.
+  static bool print_pointer_information(const void* p, outputStream* st);
+
  private:
   static inline MallocHeader* malloc_header(void *memblock) {
     assert(memblock != NULL, "NULL pointer");

--- a/src/hotspot/share/services/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.cpp
@@ -672,28 +672,32 @@ bool VirtualMemoryTracker::walk_virtual_memory(VirtualMemoryWalker* walker) {
   return true;
 }
 
-class FindAndSnapshotRegionWalker : public VirtualMemoryWalker {
+class PrintRegionWalker : public VirtualMemoryWalker {
 private:
-  const ReservedMemoryRegion* _region;
   const address               _p;
+  outputStream*               _st;
 public:
-  FindAndSnapshotRegionWalker(const void* p) :
-    _region(NULL), _p((address)p) { }
+  PrintRegionWalker(const void* p, outputStream* st) :
+    _p((address)p), _st(st) { }
 
   bool do_allocation_site(const ReservedMemoryRegion* rgn) {
     if (rgn->contain_address(_p)) {
-      _region = rgn;
+      _st->print_cr(PTR_FORMAT " in mmap'd memory region [" PTR_FORMAT " - " PTR_FORMAT "] by %s",
+        p2i(_p), p2i(rgn->base()), p2i(rgn->base() + rgn->size()), rgn->flag_name());
+      if (MemTracker::tracking_level() == NMT_detail) {
+        rgn->call_stack()->print_on(_st);
+        _st->cr();
+      }
       return false;
     }
     return true;
   }
-  const ReservedMemoryRegion* region() const {
-    return _region;
-  }
 };
 
-const ReservedMemoryRegion* VirtualMemoryTracker::find_containing_region(const void* p) {
-  FindAndSnapshotRegionWalker walker(p);
-  walk_virtual_memory(&walker);
-  return walker.region();
+// If p is contained within a known memory region, print information about it to the
+// given stream and return true; false otherwise.
+bool VirtualMemoryTracker::print_containing_region(const void* p, outputStream* st) {
+  PrintRegionWalker walker(p, st);
+  return !walk_virtual_memory(&walker);
+
 }

--- a/src/hotspot/share/services/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.cpp
@@ -674,26 +674,26 @@ bool VirtualMemoryTracker::walk_virtual_memory(VirtualMemoryWalker* walker) {
 
 class FindAndSnapshotRegionWalker : public VirtualMemoryWalker {
 private:
-  ReservedMemoryRegion& _region;
-  const address         _p;
-  bool                  _found_region;
+  const ReservedMemoryRegion* _region;
+  const address               _p;
 public:
-  FindAndSnapshotRegionWalker(void* p, ReservedMemoryRegion& region) :
-    _region(region), _p((address)p), _found_region(false) { }
+  FindAndSnapshotRegionWalker(const void* p) :
+    _region(NULL), _p((address)p) { }
 
   bool do_allocation_site(const ReservedMemoryRegion* rgn) {
     if (rgn->contain_address(_p)) {
-      _region = *rgn;
-      _found_region = true;
+      _region = rgn;
       return false;
     }
     return true;
   }
-  bool found_region() const { return _found_region; }
+  const ReservedMemoryRegion* region() const {
+    return _region;
+  }
 };
 
-const bool VirtualMemoryTracker::snapshot_region_contains(void* p, ReservedMemoryRegion& region) {
-  FindAndSnapshotRegionWalker walker(p, region);
+const ReservedMemoryRegion* VirtualMemoryTracker::find_containing_region(const void* p) {
+  FindAndSnapshotRegionWalker walker(p);
   walk_virtual_memory(&walker);
-  return walker.found_region();
+  return walker.region();
 }

--- a/src/hotspot/share/services/virtualMemoryTracker.hpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.hpp
@@ -385,7 +385,7 @@ class VirtualMemoryTracker : AllStatic {
   // Walk virtual memory data structure for creating baseline, etc.
   static bool walk_virtual_memory(VirtualMemoryWalker* walker);
 
-  static const bool snapshot_region_contains(void* p, ReservedMemoryRegion& region);
+  static const ReservedMemoryRegion* find_containing_region(const void* p);
 
   // Snapshot current thread stacks
   static void snapshot_thread_stacks();

--- a/src/hotspot/share/services/virtualMemoryTracker.hpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.hpp
@@ -385,7 +385,9 @@ class VirtualMemoryTracker : AllStatic {
   // Walk virtual memory data structure for creating baseline, etc.
   static bool walk_virtual_memory(VirtualMemoryWalker* walker);
 
-  static const ReservedMemoryRegion* find_containing_region(const void* p);
+  // If p is contained within a known memory region, print information about it to the
+  // given stream and return true; false otherwise.
+  static bool print_containing_region(const void* p, outputStream* st);
 
   // Snapshot current thread stacks
   static void snapshot_thread_stacks();

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -44,7 +44,6 @@
 #include "runtime/handles.inline.hpp"
 #include "runtime/java.hpp"
 #include "runtime/os.hpp"
-#include "runtime/safefetch.inline.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubCodeGenerator.hpp"
 #include "runtime/stubRoutines.hpp"
@@ -483,42 +482,20 @@ extern "C" JNIEXPORT void pp(void* p) {
     oop obj = cast_to_oop(p);
     obj->print();
   } else {
+    // Ask NMT about this pointer.
+    // GDB note: We will be using SafeFetch to access the supposed malloc header. If the address is
+    // not readable, this will generate a signal. That signal will trip up the debugger: gdb will
+    // catch the signal and disable the pp() command for further use.
+    // In order to avoid that, switch off SIGSEGV handling with "handle SIGSEGV nostop" before
+    // invoking pp()
     if (MemTracker::enabled()) {
-      const NMT_TrackingLevel tracking_level = MemTracker::tracking_level();
-      // Check and snapshot a mmap'd region that contains the pointer
-      const ReservedMemoryRegion* const region =
-          VirtualMemoryTracker::find_containing_region(p);
-      if (region != NULL) {
-        tty->print_cr(PTR_FORMAT " in mmap'd memory region [" PTR_FORMAT " - " PTR_FORMAT "] by %s",
-          p2i(p), p2i(region->base()), p2i(region->base() + region->size()), region->flag_name());
-        if (tracking_level == NMT_detail) {
-          region->call_stack()->print_on(tty);
-          tty->cr();
-        }
+      // Does it point into a known mmaped region?
+      if (VirtualMemoryTracker::print_containing_region(p, tty)) {
         return;
       }
-      // Check if it is a malloc'd memory block
-      // GDB note: Before reading the malloc header from the assumed-to-be-malloced address, we do a basic
-      //  SafeFetch test to check if reading is safe. This will generate a signal if it isn't. That signal normally
-      //  is handled quietly by the VM, but it will trip up the debugger. gdb will catch the signal and disable
-      //  the pp() command for further use.
-      // In order to avoid that, before invoking pp(), switch off SIGSEGV handling with "handle SIGSEGV nostop".
-      if (CanUseSafeFetchN() && os::is_readable_pointer(p)) {
-        const MallocHeader* mhdr = (const MallocHeader*)MallocTracker::get_base(p, tracking_level);
-        char msg[256];
-        address p_corrupted;
-        if (os::is_readable_pointer(mhdr) && mhdr->check_block_integrity(msg, sizeof(msg), &p_corrupted)) {
-          tty->print_cr(PTR_FORMAT " malloc'd " SIZE_FORMAT " bytes by %s",
-            p2i(p), mhdr->size(), NMTUtil::flag_to_name(mhdr->flags()));
-          if (tracking_level == NMT_detail) {
-            NativeCallStack ncs;
-            if (mhdr->get_stack(ncs)) {
-              ncs.print_on(tty);
-              tty->cr();
-            }
-          }
-          return;
-        }
+      // Does it look like the start of a malloced block?
+      if (MallocTracker::print_pointer_information(p, tty)) {
+        return;
       }
     }
     tty->print_cr(PTR_FORMAT, p2i(p));


### PR DESCRIPTION
JDK-8280289 enhanced the debug pp() command to use NMT if enabled, and to print NMT related info. That is useful, but there are some issues.

On debug, it just asserts, since the empty reserved region we create to hold the output of the mmap-search is created with address=NULL:

```
(gdb) call pp(0x7ffff010b030)

"Executing pp"

Thread 2 "java" received signal SIGSEGV, Segmentation fault.
0x00007ffff6721a71 in VirtualMemoryRegion::VirtualMemoryRegion (this=this@entry=0x7ffff5bb2620, addr=addr@entry=0x0, size=size@entry=0) at /shared/projects/openjdk/jdk-jdk/source/src/hotspot/share/services/virtualMemoryTracker.hpp:180
180 assert(addr != NULL, "Invalid address");
```

On release we don't assert and get further, but the use of SafeFetch is slightly wrong. It will deny us any NMT data about p if *p==0:

```
if (CanUseSafeFetchN() && SafeFetchN((intptr_t*)p, 0) != 0) {
```

This patch:
- fixes uses of SafeFetch
- changes the mmap-region-search-code to not require an empty ReservedMemoryRegion in order to avoid triggering the assert in virtualMemoryTracker.hpp:180
- adds a comment about the safe use of pp() in gdb (one needs to switch off signal handling of SIGSEGV for this to work)

Tests:
- I tested manually that pp works with different levels of NMT (Linux x64)
- GHAs in process

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281023](https://bugs.openjdk.java.net/browse/JDK-8281023): NMT integration into pp debug command does not work


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7297/head:pull/7297` \
`$ git checkout pull/7297`

Update a local copy of the PR: \
`$ git checkout pull/7297` \
`$ git pull https://git.openjdk.java.net/jdk pull/7297/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7297`

View PR using the GUI difftool: \
`$ git pr show -t 7297`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7297.diff">https://git.openjdk.java.net/jdk/pull/7297.diff</a>

</details>
