### PR TITLE
8280842: Access violation in ciTypeFlow::profiled_count

### DIFF
--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -2462,9 +2462,8 @@ int ciTypeFlow::profiled_count(ciTypeFlow::Loop* loop) {
   }
 
   ciProfileData* data = methodData->bci_to_data(tail->control());
-  assert(data != NULL, "some profile data expected at branch");
 
-  if (!data->is_JumpData()) {
+  if (data == NULL || !data->is_JumpData()) {
     return 0;
   }
 

--- a/test/hotspot/jtreg/compiler/profiling/TestSharedHeadExceptionBackedges.java
+++ b/test/hotspot/jtreg/compiler/profiling/TestSharedHeadExceptionBackedges.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * bug 8280842
+ * @summary Access violation in ciTypeFlow::profiled_count
+ * @run main/othervm TestSharedHeadExceptionBackedges
+ */
+
+public class TestSharedHeadExceptionBackedges {
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            test();
+        }
+    }
+
+    static class MyException extends Exception {
+    }
+
+    private static void test() {
+        int i = 0;
+        while (i < 10) {
+            try {
+                int j = 0;
+                i++;
+                if (i % 2 == 0) {
+                    throw new MyException();
+                }
+                do {
+                    j++;
+                } while (j < 100);
+
+                throw new MyException();
+
+            } catch (MyException me) {
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/profiling/TestSharedHeadExceptionBackedges.java
+++ b/test/hotspot/jtreg/compiler/profiling/TestSharedHeadExceptionBackedges.java
@@ -25,7 +25,7 @@
  * @test
  * bug 8280842
  * @summary Access violation in ciTypeFlow::profiled_count
- * @run main/othervm TestSharedHeadExceptionBackedges
+ * @run main/othervm -XX:-BackgroundCompilation TestSharedHeadExceptionBackedges
  */
 
 public class TestSharedHeadExceptionBackedges {


### PR DESCRIPTION
When the test() method is osr compiled, the exception handler is
marked as a loop head. It has 2 backedges at the 2 throw statements in
the method. ciTypeFlow expects to find some profile data at the
backedges but hotspot doesn't collect counters for athrow. The fix is
to turn the assert into an actual check.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280842](https://bugs.openjdk.java.net/browse/JDK-8280842): Access violation in ciTypeFlow::profiled_count


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7298/head:pull/7298` \
`$ git checkout pull/7298`

Update a local copy of the PR: \
`$ git checkout pull/7298` \
`$ git pull https://git.openjdk.java.net/jdk pull/7298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7298`

View PR using the GUI difftool: \
`$ git pr show -t 7298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7298.diff">https://git.openjdk.java.net/jdk/pull/7298.diff</a>

</details>
