### PR TITLE
8280885: Shenandoah: Some tests failed with "EA: missing allocation reference path"

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
@@ -718,7 +718,7 @@ Node* ShenandoahBarrierSetC2::atomic_xchg_at_resolved(C2AtomicParseAccess& acces
 
 // Support for GC barriers emitted during parsing
 bool ShenandoahBarrierSetC2::is_gc_barrier_node(Node* node) const {
-  if (node->Opcode() == Op_ShenandoahLoadReferenceBarrier) return true;
+  if (node->Opcode() == Op_ShenandoahLoadReferenceBarrier || node->Opcode() == Op_ShenandoahIUBarrier) return true;
   if (node->Opcode() != Op_CallLeaf && node->Opcode() != Op_CallLeafNoFP) {
     return false;
   }

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestUnexpectedIUBarrierEA.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestUnexpectedIUBarrierEA.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * bug 8280885
+ * @summary Shenandoah: Some tests failed with "EA: missing allocation reference path"
+ * @requires vm.gc.Shenandoah
+ *
+ * @run main/othervm -XX:-BackgroundCompilation -XX:+UseShenandoahGC -XX:+UnlockExperimentalVMOptions -XX:ShenandoahGCMode=iu
+ *                   -XX:CompileCommand=dontinline,TestUnexpectedIUBarrierEA::notInlined TestUnexpectedIUBarrierEA
+ */
+
+public class TestUnexpectedIUBarrierEA {
+
+    private static Object field;
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            test(false);
+        }
+    }
+
+    private static void test(boolean flag) {
+        A a = new A();
+        B b = new B();
+        b.field = a;
+        notInlined();
+        Object o = b.field;
+        if (!(o instanceof A)) {
+
+        }
+        C c = new C();
+        c.field = o;
+        if (flag) {
+            field = c.field;
+        }
+    }
+
+    private static void notInlined() {
+
+    }
+
+    private static class A {
+    }
+
+    private static class B {
+        public Object field;
+    }
+
+    private static class C {
+        public Object field;
+    }
+}


### PR DESCRIPTION
EA encounters an unexpected IU barrier. I think it's good enough to
change ShenandoahBarrierSetC2::is_gc_barrier_node() so it returns true
for IU barriers.

/cc hotspot-compiler

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280885](https://bugs.openjdk.java.net/browse/JDK-8280885): Shenandoah: Some tests failed with "EA: missing allocation reference path"


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7299/head:pull/7299` \
`$ git checkout pull/7299`

Update a local copy of the PR: \
`$ git checkout pull/7299` \
`$ git pull https://git.openjdk.java.net/jdk pull/7299/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7299`

View PR using the GUI difftool: \
`$ git pr show -t 7299`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7299.diff">https://git.openjdk.java.net/jdk/pull/7299.diff</a>

</details>
