### PR TITLE
8281035: Serial: Move RemoveForwardedPointerClosure to local scope

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -680,8 +680,7 @@ void DefNewGeneration::remove_forwarding_pointers() {
         obj->init_mark();
       }
     }
-  };
-  ResetForwardedMarkWord cl;
+  } cl;
   eden()->object_iterate(&cl);
   from()->object_iterate(&cl);
 

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -669,9 +669,22 @@ void DefNewGeneration::init_assuming_no_promotion_failure() {
 }
 
 void DefNewGeneration::remove_forwarding_pointers() {
-  RemoveForwardedPointerClosure rspc;
-  eden()->object_iterate(&rspc);
-  from()->object_iterate(&rspc);
+  assert(_promotion_failed, "precondition");
+
+  // Will enter Full GC soon due to failed promotion. Must reset the mark word
+  // of objs in young-gen so that no objs are marked (forwarded) when Full GC
+  // starts. (The mark word is overloaded: `is_marked()` == `is_forwarded()`.)
+  struct ResetForwardedMarkWord : ObjectClosure {
+    void do_object(oop obj) override {
+      if (obj->is_forwarded()) {
+        obj->init_mark();
+      }
+    }
+  };
+  ResetForwardedMarkWord cl;
+  eden()->object_iterate(&cl);
+  from()->object_iterate(&cl);
+
   restore_preserved_marks();
 }
 

--- a/src/hotspot/share/gc/shared/preservedMarks.cpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.cpp
@@ -71,12 +71,6 @@ void PreservedMarks::assert_empty() {
 }
 #endif // ndef PRODUCT
 
-void RemoveForwardedPointerClosure::do_object(oop obj) {
-  if (obj->is_forwarded()) {
-    PreservedMarks::init_forwarded_mark(obj);
-  }
-}
-
 void PreservedMarksSet::init(uint num) {
   assert(_stacks == nullptr && _num == 0, "do not re-initialize");
   assert(num > 0, "pre-condition");

--- a/src/hotspot/share/gc/shared/preservedMarks.hpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.hpp
@@ -75,11 +75,6 @@ public:
   ~PreservedMarks() { assert_empty(); }
 };
 
-class RemoveForwardedPointerClosure: public ObjectClosure {
-public:
-  virtual void do_object(oop obj);
-};
-
 class PreservedMarksSet : public CHeapObj<mtGC> {
 private:
   // true -> _stacks will be allocated in the C heap


### PR DESCRIPTION
Simple change of moving `RemoveForwardedPointerClosure` from shared code to Serial code.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281035](https://bugs.openjdk.java.net/browse/JDK-8281035): Serial: Move RemoveForwardedPointerClosure to local scope


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to 9297a6fc9d917b6be440da84f3b858d2d2cd4b73
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7301/head:pull/7301` \
`$ git checkout pull/7301`

Update a local copy of the PR: \
`$ git checkout pull/7301` \
`$ git pull https://git.openjdk.java.net/jdk pull/7301/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7301`

View PR using the GUI difftool: \
`$ git pr show -t 7301`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7301.diff">https://git.openjdk.java.net/jdk/pull/7301.diff</a>

</details>
