### PR TITLE
8280944: Enable Unix domain sockets in Windows Selector notification mechanism

### DIFF
--- a/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
@@ -185,7 +185,7 @@ class PipeImpl
 
     /**
      * Creates Pipe implementation that supports optionally buffering
-     * and is TCP by default, but if Unix domain is supported and 
+     * and is TCP by default, but if Unix domain is supported and
      * preferAfUnix is true, then Unix domain sockets are used.
      *
      * @param buffering if false set TCP_NODELAY on TCP sockets

--- a/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
@@ -34,7 +34,6 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.StandardSocketOptions;
 import java.net.UnixDomainSocketAddress;
-
 import java.nio.*;
 import java.nio.channels.*;
 import java.nio.file.Files;
@@ -188,12 +187,12 @@ class PipeImpl
      * and is TCP by default, but if Unix domain is supported and
      * preferAfUnix is true, then Unix domain sockets are used.
      *
-     * @param buffering if false set TCP_NODELAY on TCP sockets
-     *
      * @param preferAfUnix use Unix domain sockets if supported
+     *
+     * @param buffering if false set TCP_NODELAY on TCP sockets
      */
     @SuppressWarnings("removal")
-    PipeImpl(SelectorProvider sp, boolean buffering, boolean preferAfUnix) throws IOException {
+    PipeImpl(SelectorProvider sp, boolean preferAfUnix, boolean buffering) throws IOException {
         Initializer initializer = new Initializer(sp, preferAfUnix);
         try {
             AccessController.doPrivileged(initializer);
@@ -223,7 +222,7 @@ class PipeImpl
                 listener = ServerSocketChannel.open(UNIX);
                 listener.bind(null);
                 return listener;
-            } catch (IOException | UnsupportedOperationException e) {}
+            } catch (IOException e) {}
         }
         listener = ServerSocketChannel.open();
         InetAddress lb = InetAddress.getLoopbackAddress();

--- a/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
@@ -159,11 +159,6 @@ class PipeImpl
                     try {
                         if (sc1 != null)
                             sc1.close();
-
-                        if (sa instanceof UnixDomainSocketAddress uaddr) {
-                            Files.deleteIfExists(uaddr.getPath());
-                        }
-
                         if (sc2 != null)
                             sc2.close();
                     } catch (IOException e2) {}
@@ -172,6 +167,9 @@ class PipeImpl
                     try {
                         if (ssc != null)
                             ssc.close();
+                        if (sa instanceof UnixDomainSocketAddress uaddr) {
+                            Files.deleteIfExists(uaddr.getPath());
+                        }
                     } catch (IOException e2) {}
                 }
             }

--- a/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
@@ -33,6 +33,8 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.StandardSocketOptions;
+import java.net.UnixDomainSocketAddress;
+
 import java.nio.*;
 import java.nio.channels.*;
 import java.nio.file.Files;
@@ -44,6 +46,7 @@ import java.security.PrivilegedActionException;
 import java.security.SecureRandom;
 import java.util.Random;
 
+import static java.net.StandardProtocolFamily.UNIX;
 
 /**
  * A simple Pipe implementation based on a socket connection.
@@ -156,6 +159,11 @@ class PipeImpl
                     try {
                         if (sc1 != null)
                             sc1.close();
+
+                        if (sa instanceof UnixDomainSocketAddress uaddr) {
+                            Files.deleteIfExists(uaddr.getPath());
+                        }
+
                         if (sc2 != null)
                             sc2.close();
                     } catch (IOException e2) {}

--- a/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
@@ -177,23 +177,24 @@ class PipeImpl
     }
 
     /**
-     * Creates a Pipe implementation that supports buffering.
+     * Creates a (TCP) Pipe implementation that supports buffering.
      */
     PipeImpl(SelectorProvider sp) throws IOException {
         this(sp, true, false);
     }
 
     /**
-     * Creates Pipe implementation that supports optionally buffering.
+     * Creates Pipe implementation that supports optionally buffering
+     * and is TCP by default, but if Unix domain is supported and 
+     * preferAfUnix is true, then Unix domain sockets are used.
      *
-     * @param useAfUnix use Unix domain sockets if supported
+     * @param buffering if false set TCP_NODELAY on TCP sockets
      *
-     * @implNote Uses a loopback connection. When buffering is
-     * disabled then it sets TCP_NODELAY on the sink channel.
+     * @param preferAfUnix use Unix domain sockets if supported
      */
     @SuppressWarnings("removal")
-    PipeImpl(SelectorProvider sp, boolean buffering, boolean useAfUnix) throws IOException {
-        Initializer initializer = new Initializer(sp, useAfUnix);
+    PipeImpl(SelectorProvider sp, boolean buffering, boolean preferAfUnix) throws IOException {
+        Initializer initializer = new Initializer(sp, preferAfUnix);
         try {
             AccessController.doPrivileged(initializer);
             SinkChannelImpl sink = initializer.sink;

--- a/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
@@ -70,14 +70,14 @@ class PipeImpl
     {
 
         private final SelectorProvider sp;
-        private final boolean useUnixDomain;
+        private final boolean preferUnixDomain;
         private IOException ioe;
         SourceChannelImpl source;
         SinkChannelImpl sink;
 
-        private Initializer(SelectorProvider sp, boolean useUnixDomain) {
+        private Initializer(SelectorProvider sp, boolean preferUnixDomain) {
             this.sp = sp;
-            this.useUnixDomain = useUnixDomain;
+            this.preferUnixDomain = preferUnixDomain;
         }
 
         @Override
@@ -125,7 +125,7 @@ class PipeImpl
                         // Bind ServerSocketChannel to a port on the loopback
                         // address
                         if (ssc == null || !ssc.isOpen()) {
-                            ssc = createListener(useUnixDomain);
+                            ssc = createListener(preferUnixDomain);
                             sa = ssc.getLocalAddress();
                         }
 
@@ -215,9 +215,9 @@ class PipeImpl
         return sink;
     }
 
-    private static ServerSocketChannel createListener(boolean unixDomain) throws IOException {
+    private static ServerSocketChannel createListener(boolean preferUnixDomain) throws IOException {
         ServerSocketChannel listener;
-        if (unixDomain && UnixDomainSockets.isSupported()) {
+        if (preferUnixDomain && UnixDomainSockets.isSupported()) {
             try {
                 listener = ServerSocketChannel.open(UNIX);
                 listener.bind(null);

--- a/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
@@ -216,13 +216,16 @@ class PipeImpl
     }
 
     private static ServerSocketChannel createListener(boolean preferUnixDomain) throws IOException {
-        ServerSocketChannel listener;
+        ServerSocketChannel listener = null;
         if (preferUnixDomain && UnixDomainSockets.isSupported()) {
             try {
                 listener = ServerSocketChannel.open(UNIX);
                 listener.bind(null);
                 return listener;
-            } catch (IOException e) {}
+            } catch (IOException | UnsupportedOperationException e) {
+                if (listener != null)
+                    listener.close();
+            }
         }
         listener = ServerSocketChannel.open();
         InetAddress lb = InetAddress.getLoopbackAddress();

--- a/src/java.base/windows/classes/sun/nio/ch/WEPollSelectorImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/WEPollSelectorImpl.java
@@ -75,7 +75,7 @@ class WEPollSelectorImpl extends SelectorImpl {
 
         // wakeup support
         try {
-            this.pipe = new PipeImpl(sp, /*buffering*/ false);
+            this.pipe = new PipeImpl(sp, /*buffering*/ false, /* AF_UNIX */ true);
         } catch (IOException ioe) {
             WEPoll.freePollArray(pollArrayAddress);
             WEPoll.close(eph);

--- a/src/java.base/windows/classes/sun/nio/ch/WEPollSelectorImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/WEPollSelectorImpl.java
@@ -75,7 +75,7 @@ class WEPollSelectorImpl extends SelectorImpl {
 
         // wakeup support
         try {
-            this.pipe = new PipeImpl(sp, /*buffering*/ false, /* AF_UNIX */ true);
+            this.pipe = new PipeImpl(sp, /* AF_UNIX */ true, /*buffering*/ false);
         } catch (IOException ioe) {
             WEPoll.freePollArray(pollArrayAddress);
             WEPoll.close(eph);

--- a/src/java.base/windows/classes/sun/nio/ch/WindowsSelectorImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/WindowsSelectorImpl.java
@@ -139,7 +139,7 @@ class WindowsSelectorImpl extends SelectorImpl {
     WindowsSelectorImpl(SelectorProvider sp) throws IOException {
         super(sp);
         pollWrapper = new PollArrayWrapper(INIT_CAP);
-        wakeupPipe = new PipeImpl(sp, false);
+        wakeupPipe = new PipeImpl(sp, false, /* AF_UNIX */ true);
         wakeupSourceFd = ((SelChImpl)wakeupPipe.source()).getFDVal();
         wakeupSinkFd = ((SelChImpl)wakeupPipe.sink()).getFDVal();
         pollWrapper.addWakeupSocket(wakeupSourceFd, 0);

--- a/src/java.base/windows/classes/sun/nio/ch/WindowsSelectorImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/WindowsSelectorImpl.java
@@ -139,7 +139,7 @@ class WindowsSelectorImpl extends SelectorImpl {
     WindowsSelectorImpl(SelectorProvider sp) throws IOException {
         super(sp);
         pollWrapper = new PollArrayWrapper(INIT_CAP);
-        wakeupPipe = new PipeImpl(sp, false, /* AF_UNIX */ true);
+        wakeupPipe = new PipeImpl(sp, /* AF_UNIX */ true, /*buffering*/ false);
         wakeupSourceFd = ((SelChImpl)wakeupPipe.source()).getFDVal();
         wakeupSinkFd = ((SelChImpl)wakeupPipe.sink()).getFDVal();
         pollWrapper.addWakeupSocket(wakeupSourceFd, 0);


### PR DESCRIPTION
Hi,

Could I get the following change reviewed please?

8280233 temporarily disabled AF_UNIX sockets in the windows pipe implementation due to a Windows bug. We would like to re-enable one internal usage of AF_UNIX pipes in the JDK, for the windows NIO selector notification mechanism since this use case does not involve closing the socket and should therefore not encounter the bug.

I haven't included a regression test as this change will exercise tests that are currently running into TCP resource limitations on windows 10 client systems.

Thanks,
Michael

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280944](https://bugs.openjdk.java.net/browse/JDK-8280944): Enable Unix domain sockets in Windows Selector notification mechanism


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7302/head:pull/7302` \
`$ git checkout pull/7302`

Update a local copy of the PR: \
`$ git checkout pull/7302` \
`$ git pull https://git.openjdk.java.net/jdk pull/7302/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7302`

View PR using the GUI difftool: \
`$ git pr show -t 7302`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7302.diff">https://git.openjdk.java.net/jdk/pull/7302.diff</a>

</details>
