### PR TITLE
8281042: G1: Remove unused init_threshold in G1FullGCCompactionPoint

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -353,7 +353,7 @@ void G1FullCollector::phase2c_prepare_serial_compaction() {
     if (!cp->is_initialized()) {
       // Initialize the compaction point. Nothing more is needed for the first heap region
       // since it is already prepared for compaction.
-      cp->initialize(current, false);
+      cp->initialize(current);
     } else {
       assert(!current->is_humongous(), "Should be no humongous regions in compaction queue");
       G1SerialRePrepareClosure re_prepare(cp, current);

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
@@ -45,7 +45,7 @@ void G1FullGCCompactionPoint::update() {
   }
 }
 
-void G1FullGCCompactionPoint::initialize_values(bool init_threshold) {
+void G1FullGCCompactionPoint::initialize_values() {
   _compaction_top = _current_region->compaction_top();
 }
 
@@ -57,9 +57,9 @@ bool G1FullGCCompactionPoint::is_initialized() {
   return _current_region != NULL;
 }
 
-void G1FullGCCompactionPoint::initialize(HeapRegion* hr, bool init_threshold) {
+void G1FullGCCompactionPoint::initialize(HeapRegion* hr) {
   _current_region = hr;
-  initialize_values(init_threshold);
+  initialize_values();
 }
 
 HeapRegion* G1FullGCCompactionPoint::current_region() {
@@ -86,7 +86,7 @@ void G1FullGCCompactionPoint::switch_region() {
   _current_region->set_compaction_top(_compaction_top);
   // Get the next region and re-initialize the values.
   _current_region = next_region();
-  initialize_values(true);
+  initialize_values();
 }
 
 void G1FullGCCompactionPoint::forward(oop object, size_t size) {

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.hpp
@@ -38,7 +38,7 @@ class G1FullGCCompactionPoint : public CHeapObj<mtGC> {
   GrowableArrayIterator<HeapRegion*> _compaction_region_iterator;
 
   bool object_will_fit(size_t size);
-  void initialize_values(bool init_threshold);
+  void initialize_values();
   void switch_region();
   HeapRegion* next_region();
 
@@ -48,7 +48,7 @@ public:
 
   bool has_regions();
   bool is_initialized();
-  void initialize(HeapRegion* hr, bool init_threshold);
+  void initialize(HeapRegion* hr);
   void update();
   void forward(oop object, size_t size);
   void add(HeapRegion* hr);

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.inline.hpp
@@ -70,7 +70,7 @@ inline void G1DetermineCompactionQueueClosure::add_to_compaction_queue(HeapRegio
   hr->set_compaction_top(hr->bottom());
   G1FullGCCompactionPoint* cp = next_compaction_point();
   if (!cp->is_initialized()) {
-    cp->initialize(hr, true);
+    cp->initialize(hr);
   }
   // Add region to the compaction queue.
   cp->add(hr);


### PR DESCRIPTION
Simple change of removing unused method arg.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281042](https://bugs.openjdk.java.net/browse/JDK-8281042): G1: Remove unused init_threshold in G1FullGCCompactionPoint


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7304/head:pull/7304` \
`$ git checkout pull/7304`

Update a local copy of the PR: \
`$ git checkout pull/7304` \
`$ git pull https://git.openjdk.java.net/jdk pull/7304/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7304`

View PR using the GUI difftool: \
`$ git pr show -t 7304`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7304.diff">https://git.openjdk.java.net/jdk/pull/7304.diff</a>

</details>
