### PR TITLE
8281043: Intrinsify recursive ObjectMonitor locking for PPC64

### DIFF
--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -2739,10 +2739,10 @@ void MacroAssembler::compiler_fast_lock_object(ConditionRegister flag, Register 
   bne(flag, cont);
 
   // Current thread already owns the lock. Just increment recursions.
-  addi(R0, displaced_header, ObjectMonitor::recursions_offset_in_bytes()-markWord::monitor_value);
-  ldx(temp, R0);
-  addi(temp, temp, 1);
-  stdx(temp, R0);
+  Register recursions = displaced_header;
+  ld(recursions, ObjectMonitor::recursions_offset_in_bytes()-ObjectMonitor::owner_offset_in_bytes(), temp);
+  addi(recursions, recursions, 1);
+  std(recursions, ObjectMonitor::recursions_offset_in_bytes()-ObjectMonitor::owner_offset_in_bytes(), temp);
 
 #if INCLUDE_RTM_OPT
   } // use_rtm()

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -2732,16 +2732,17 @@ void MacroAssembler::compiler_fast_lock_object(ConditionRegister flag, Register 
 
   // Store a non-null value into the box.
   std(box, BasicLock::displaced_header_offset_in_bytes(), box);
+  beq(flag, cont);
 
-# ifdef ASSERT
+  // Check for recursive locking.
+  cmpd(flag, current_header, R16_thread);
   bne(flag, cont);
-  // We have acquired the monitor, check some invariants.
-  addi(/*monitor=*/temp, temp, -ObjectMonitor::owner_offset_in_bytes());
-  // Invariant 1: _recursions should be 0.
-  //assert(ObjectMonitor::recursions_size_in_bytes() == 8, "unexpected size");
-  asm_assert_mem8_is_zero(ObjectMonitor::recursions_offset_in_bytes(), temp,
-                            "monitor->_recursions should be 0");
-# endif
+
+  // Current thread already owns the lock. Just increment recursions.
+  addi(R0, displaced_header, ObjectMonitor::recursions_offset_in_bytes()-markWord::monitor_value);
+  ldx(temp, R0);
+  addi(temp, temp, 1);
+  stdx(temp, R0);
 
 #if INCLUDE_RTM_OPT
   } // use_rtm()
@@ -2757,8 +2758,7 @@ void MacroAssembler::compiler_fast_unlock_object(ConditionRegister flag, Registe
                                                  bool use_rtm) {
   assert_different_registers(oop, box, temp, displaced_header, current_header);
   assert(flag != CCR0, "bad condition register");
-  Label cont;
-  Label object_has_monitor;
+  Label cont, object_has_monitor, notRecursive;
 
 #if INCLUDE_RTM_OPT
   if (UseRTMForStackLocks && use_rtm) {
@@ -2830,11 +2830,16 @@ void MacroAssembler::compiler_fast_unlock_object(ConditionRegister flag, Registe
 #endif
 
   ld(displaced_header, ObjectMonitor::recursions_offset_in_bytes(), current_header);
-  xorr(temp, R16_thread, temp);      // Will be 0 if we are the owner.
-  orr(temp, temp, displaced_header); // Will be 0 if there are 0 recursions.
-  cmpdi(flag, temp, 0);
+
+  cmpd(flag, temp, R16_thread);
   bne(flag, cont);
 
+  addic_(displaced_header, displaced_header, -1);
+  blt(CCR0, notRecursive); // Not recursive if negative after decrement.
+  std(displaced_header, ObjectMonitor::recursions_offset_in_bytes(), current_header);
+  b(cont); // flag is already EQ here.
+
+  bind(notRecursive);
   ld(temp,             ObjectMonitor::EntryList_offset_in_bytes(), current_header);
   ld(displaced_header, ObjectMonitor::cxq_offset_in_bytes(), current_header);
   orr(temp, temp, displaced_header); // Will be 0 if both are 0.


### PR DESCRIPTION
PPC64 implementation of JDK-8277180.

`java -Xms4g -Xmx4g -jar dacapo-9.12-bach.jar h2 -s huge -t 1 -n 1 --max-iterations=35 --variance=5 --verbose --converge`

Before this patch (2 runs):
`===== DaCapo 9.12 h2 PASSED in 309753 msec =====`
`===== DaCapo 9.12 h2 PASSED in 300755 msec =====`

After:
`===== DaCapo 9.12 h2 PASSED in 285144 msec =====`
`===== DaCapo 9.12 h2 PASSED in 288255 msec =====`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281043](https://bugs.openjdk.java.net/browse/JDK-8281043): Intrinsify recursive ObjectMonitor locking for PPC64


### Reviewers
 * [Richard Reingruber](https://openjdk.java.net/census#rrich) (@reinrich - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.java.net/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7305/head:pull/7305` \
`$ git checkout pull/7305`

Update a local copy of the PR: \
`$ git checkout pull/7305` \
`$ git pull https://git.openjdk.java.net/jdk pull/7305/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7305`

View PR using the GUI difftool: \
`$ git pr show -t 7305`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7305.diff">https://git.openjdk.java.net/jdk/pull/7305.diff</a>

</details>
