### PR TITLE
8276990: Memory leak in invoker.c fillInvokeRequest() during JDI operations

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/invoker.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/invoker.c
@@ -232,10 +232,7 @@ fillInvokeRequest(JNIEnv *env, InvokeRequest *request,
     /*
      * Squirrel away the method signature
      */
-    char* oldSignature = request->methodSignature;
-    if (oldSignature != NULL) {
-      jvmtiDeallocate(oldSignature);
-    }
+    JDI_ASSERT_MSG(request->methodSignature == NULL, "Request methodSignature not null");
     error = methodSignature(method, NULL, &request->methodSignature,  NULL);
     if (error != JVMTI_ERROR_NONE) {
         return error;
@@ -766,6 +763,10 @@ invoker_completeInvokeRequest(jthread thread)
         mustReleaseReturnValue = request->invokeType == INVOKE_CONSTRUCTOR ||
            isReferenceTag(returnType);
     }
+
+    JDI_ASSERT_MSG(request->methodSignature != NULL, "methodSignature must be != NULL");
+    jvmtiDeallocate(request->methodSignature);
+    request->methodSignature = NULL;
 
     /*
      * At this time, there's no need to retain global references on

--- a/src/jdk.jdwp.agent/share/native/libjdwp/invoker.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/invoker.c
@@ -173,7 +173,6 @@ deleteGlobalArgumentRefs(JNIEnv *env, InvokeRequest *request)
     jint argIndex = 0;
     jbyte argumentTag = 0;
     jvalue *argument = request->arguments;
-    methodSignature_init(request->methodSignature, &cursor);
 
     if (request->clazz != NULL) {
         tossGlobalRef(env, &(request->clazz));
@@ -192,6 +191,10 @@ deleteGlobalArgumentRefs(JNIEnv *env, InvokeRequest *request)
         argument++;
         argIndex++;
     }
+
+    JDI_ASSERT_MSG(request->methodSignature != NULL, "methodSignature is NULL");
+    jvmtiDeallocate(request->methodSignature);
+    request->methodSignature = NULL;
 }
 
 static jvmtiError
@@ -763,10 +766,6 @@ invoker_completeInvokeRequest(jthread thread)
         mustReleaseReturnValue = request->invokeType == INVOKE_CONSTRUCTOR ||
            isReferenceTag(returnType);
     }
-
-    JDI_ASSERT_MSG(request->methodSignature != NULL, "methodSignature must be != NULL");
-    jvmtiDeallocate(request->methodSignature);
-    request->methodSignature = NULL;
 
     /*
      * At this time, there's no need to retain global references on

--- a/src/jdk.jdwp.agent/share/native/libjdwp/invoker.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/invoker.c
@@ -232,6 +232,10 @@ fillInvokeRequest(JNIEnv *env, InvokeRequest *request,
     /*
      * Squirrel away the method signature
      */
+    char* oldSignature = request->methodSignature;
+    if (oldSignature != NULL) {
+      jvmtiDeallocate(oldSignature);
+    }
     error = methodSignature(method, NULL, &request->methodSignature,  NULL);
     if (error != JVMTI_ERROR_NONE) {
         return error;

--- a/src/jdk.jdwp.agent/share/native/libjdwp/invoker.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/invoker.c
@@ -192,10 +192,6 @@ deleteGlobalArgumentRefs(JNIEnv *env, InvokeRequest *request)
         argument++;
         argIndex++;
     }
-
-    JDI_ASSERT_MSG(request->methodSignature != NULL, "methodSignature is NULL");
-    jvmtiDeallocate(request->methodSignature);
-    request->methodSignature = NULL;
 }
 
 static jvmtiError
@@ -779,6 +775,10 @@ invoker_completeInvokeRequest(jthread thread)
      * after writing the respone.
      */
     deleteGlobalArgumentRefs(env, request);
+
+    JDI_ASSERT_MSG(request->methodSignature != NULL, "methodSignature is NULL");
+    jvmtiDeallocate(request->methodSignature);
+    request->methodSignature = NULL;
 
     /* From now on, do not access the request structure anymore
      * for this request id, because once we give up the invokerLock it may

--- a/src/jdk.jdwp.agent/share/native/libjdwp/invoker.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/invoker.c
@@ -173,6 +173,7 @@ deleteGlobalArgumentRefs(JNIEnv *env, InvokeRequest *request)
     jint argIndex = 0;
     jbyte argumentTag = 0;
     jvalue *argument = request->arguments;
+    methodSignature_init(request->methodSignature, &cursor);
 
     if (request->clazz != NULL) {
         tossGlobalRef(env, &(request->clazz));


### PR DESCRIPTION
We observe a native memory leak when repeating JDI operations from Eclipse in a debuggee JVM. See bug report for details.

AFAICT, this happens because we override methodSignature of a possible pre-existing request object. I am not sure if there is a better place to deallocate the signature.

Also, I am not sure how to make an automated test for this. We (that is, the customer that reported the problem) verified that the memory leak disappears with the fix.

Testing:
 - [x] tier1
 - [x] tier2
 - [ ] tier3
 - [x] Customer confirming fix of memory leak

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276990](https://bugs.openjdk.java.net/browse/JDK-8276990): Memory leak in invoker.c fillInvokeRequest() during JDI operations


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7306/head:pull/7306` \
`$ git checkout pull/7306`

Update a local copy of the PR: \
`$ git checkout pull/7306` \
`$ git pull https://git.openjdk.java.net/jdk pull/7306/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7306`

View PR using the GUI difftool: \
`$ git pr show -t 7306`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7306.diff">https://git.openjdk.java.net/jdk/pull/7306.diff</a>

</details>
