### PR TITLE
8280600: C2: assert(!had_error) failed: bad dominance

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -1234,7 +1234,7 @@ Node *PhaseIdealLoop::clone_up_backedge_goo(Node *back_ctrl, Node *preheader_ctr
 }
 
 Node* PhaseIdealLoop::cast_incr_before_loop(Node* incr, Node* ctrl, Node* loop) {
-  Node* castii = new CastIINode(incr, TypeInt::INT, ConstraintCastNode::StrongDependency);
+  Node* castii = new CastIINode(incr, TypeInt::INT, ConstraintCastNode::UnconditionalDependency);
   castii->set_req(0, ctrl);
   register_new_node(castii, ctrl);
   for (DUIterator_Fast imax, i = incr->fast_outs(imax); i < imax; i++) {

--- a/test/hotspot/jtreg/compiler/loopopts/TestCastIIMakesMainLoopPhiDead.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestCastIIMakesMainLoopPhiDead.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * bug 8280600
+ * @summary C2: assert(!had_error) failed: bad dominance
+ * @run main/othervm -Xcomp -XX:CompileOnly=TestCastIIMakesMainLoopPhiDead TestCastIIMakesMainLoopPhiDead
+ */
+
+public class TestCastIIMakesMainLoopPhiDead {
+  int iArr[] = new int[0];
+
+  void test() {
+    int x = 8;
+    try {
+      for (int i = 0; i < 8; i++) {
+        iArr[1] = 9;
+        for (int j = -400; 1 > j; j++) {
+          iArr[j] = 4;
+          x -= 2;
+        }
+      }
+    } catch (ArrayIndexOutOfBoundsException e) {
+    }
+  }
+  public static void main(String[] k) {
+      TestCastIIMakesMainLoopPhiDead t = new TestCastIIMakesMainLoopPhiDead();
+      for (int i = 0; i < 3; i++) {
+        t.test();
+      }
+  }
+}

--- a/test/hotspot/jtreg/compiler/loopopts/TestCastIIMakesMainLoopPhiDead.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestCastIIMakesMainLoopPhiDead.java
@@ -29,25 +29,25 @@
  */
 
 public class TestCastIIMakesMainLoopPhiDead {
-  int iArr[] = new int[0];
+    int iArr[] = new int[0];
 
-  void test() {
-    int x = 8;
-    try {
-      for (int i = 0; i < 8; i++) {
-        iArr[1] = 9;
-        for (int j = -400; 1 > j; j++) {
-          iArr[j] = 4;
-          x -= 2;
+    void test() {
+        int x = 8;
+        try {
+            for (int i = 0; i < 8; i++) {
+                iArr[1] = 9;
+                for (int j = -400; 1 > j; j++) {
+                    iArr[j] = 4;
+                    x -= 2;
+                }
+            }
+        } catch (ArrayIndexOutOfBoundsException e) {
         }
-      }
-    } catch (ArrayIndexOutOfBoundsException e) {
     }
-  }
-  public static void main(String[] k) {
-      TestCastIIMakesMainLoopPhiDead t = new TestCastIIMakesMainLoopPhiDead();
-      for (int i = 0; i < 3; i++) {
-        t.test();
-      }
-  }
+    public static void main(String[] k) {
+        TestCastIIMakesMainLoopPhiDead t = new TestCastIIMakesMainLoopPhiDead();
+        for (int i = 0; i < 3; i++) {
+            t.test();
+        }
+    }
 }


### PR DESCRIPTION
For the inner loop of the test, c2, first, creates a counted loop and
assigns the type -400..1 to the trip count Phi. The loop body has a
range check that guards a CastII on the trip count Phi. That CastII
has type: 0..1 as a result.

Pre/main/post loops are then created. In the process,
PhaseIdealLoop::cast_incr_before_loop() inserts a CastII right before
the main loop. That CastII's input is the add node of the pre
loop. The loop is also unrolled once. The CastII on the loop entry is
pushed through the add node and replaced by the range check CastII
that has the same input and dominates. As a result, the main loop
tripcount Phi has type -400..1 but init value, 1..2. This causes the
Phi to constant fold to 1. The amount of unrolling and the main loop
bounds are inconsistent (the loop shouldn't be unrolled if it executes
for one iteration) but when the unrolling decision is made the type of
the lower bound of the main loop is not yet accurately known.

The actual crash is the result of a chain of nodes sunk out of the
inner loop and pinned out of the loop with a CastII node. The type of
the CastII and the type of its input after unrolling conflict.

The fix I propose is to change the type of the CastII that's added
before the main loop so it can't be replaced by a dominating
CastII. Given that CastII's role is to carry dependencies for nodes in
the loop body on the loop entry test, I think it's the right thing to
do. I've also been working on 8275202 (C2: optimize out more redundant
conditions) as a way to avoid type inconsistencies like this one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280600](https://bugs.openjdk.java.net/browse/JDK-8280600): C2: assert(!had_error) failed: bad dominance


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to c218381f1617c4f354ddbb5d9acf6541e5f4734e
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to c218381f1617c4f354ddbb5d9acf6541e5f4734e


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7307/head:pull/7307` \
`$ git checkout pull/7307`

Update a local copy of the PR: \
`$ git checkout pull/7307` \
`$ git pull https://git.openjdk.java.net/jdk pull/7307/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7307`

View PR using the GUI difftool: \
`$ git pr show -t 7307`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7307.diff">https://git.openjdk.java.net/jdk/pull/7307.diff</a>

</details>
