### PR TITLE
8279535: C2: Dead code in PhaseIdealLoop::create_loop_nest after JDK-8276116

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -830,10 +830,7 @@ bool PhaseIdealLoop::create_loop_nest(IdealLoopTree* loop, Node_List &old_new) {
     return false;
   }
 
-
   IfNode* exit_test = head->loopexit();
-  BoolTest::mask mask = exit_test->as_BaseCountedLoopEnd()->test_trip();
-  Node* cmp = exit_test->as_BaseCountedLoopEnd()->cmp_node();
 
   assert(back_control->Opcode() == Op_IfTrue, "wrong projection for back edge");
 


### PR DESCRIPTION
Removal of a couple lines of dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279535](https://bugs.openjdk.java.net/browse/JDK-8279535): C2: Dead code in PhaseIdealLoop::create_loop_nest after JDK-8276116


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7309/head:pull/7309` \
`$ git checkout pull/7309`

Update a local copy of the PR: \
`$ git checkout pull/7309` \
`$ git pull https://git.openjdk.java.net/jdk pull/7309/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7309`

View PR using the GUI difftool: \
`$ git pr show -t 7309`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7309.diff">https://git.openjdk.java.net/jdk/pull/7309.diff</a>

</details>
