### PR TITLE
8281061: [s390] JFR runs into assertions while validating interpreter frames

### DIFF
--- a/src/hotspot/cpu/s390/frame_s390.cpp
+++ b/src/hotspot/cpu/s390/frame_s390.cpp
@@ -117,8 +117,8 @@ bool frame::safe_for_sender(JavaThread *thread) {
       return false;
     }
 
-    z_abi_160* sender_abi = (z_abi_160*) fp;
-    intptr_t* sender_sp = (intptr_t*) sender_abi->callers_sp;
+    z_abi_16* sender_abi = (z_abi_16*)fp;
+    intptr_t* sender_sp = (intptr_t*) fp;
     address   sender_pc = (address)   sender_abi->return_pc;
 
     // We must always be able to find a recognizable pc.
@@ -142,7 +142,7 @@ bool frame::safe_for_sender(JavaThread *thread) {
     // sender_fp must be within the stack and above (but not
     // equal) current frame's fp.
     if (!thread->is_in_stack_range_excl(sender_fp, fp)) {
-        return false;
+      return false;
     }
 
     // If the potential sender is the interpreter then we can do some more checking.

--- a/src/hotspot/cpu/s390/frame_s390.cpp
+++ b/src/hotspot/cpu/s390/frame_s390.cpp
@@ -319,8 +319,8 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
   // do some validation of frame elements
 
   // first the method
-
-  Method* m = *interpreter_frame_method_addr();
+  // Need to use "unchecked" versions to avoid "z_istate_magic_number" assertion.
+  Method* m = (Method*)(ijava_state_unchecked()->method);
 
   // validate the method we'd find in this potential sender
   if (!Method::is_valid_method(m)) return false;
@@ -335,19 +335,17 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
   }
 
   // validate bci/bcx
-
-  address  bcp    = interpreter_frame_bcp();
+  address bcp = (address)(ijava_state_unchecked()->bcp);
   if (m->validate_bci_from_bcp(bcp) < 0) {
     return false;
   }
 
   // validate constantPoolCache*
-  ConstantPoolCache* cp = *interpreter_frame_cache_addr();
+  ConstantPoolCache* cp = (ConstantPoolCache*)(ijava_state_unchecked()->cpoolCache);
   if (MetaspaceObj::is_valid(cp) == false) return false;
 
   // validate locals
-
-  address locals =  (address) *interpreter_frame_locals_addr();
+  address locals = (address)(ijava_state_unchecked()->locals);
   return thread->is_in_stack_range_incl(locals, (address)fp());
 }
 

--- a/src/hotspot/os_cpu/linux_s390/thread_linux_s390.cpp
+++ b/src/hotspot/os_cpu/linux_s390/thread_linux_s390.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016, 2019 SAP SE. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/os_cpu/linux_s390/thread_linux_s390.cpp
+++ b/src/hotspot/os_cpu/linux_s390/thread_linux_s390.cpp
@@ -58,13 +58,14 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
   // if we were running Java code when SIGPROF came in.
   if (isInJava) {
     ucontext_t* uc = (ucontext_t*) ucontext;
-    frame ret_frame((intptr_t*)uc->uc_mcontext.gregs[15/*Z_SP*/],
-                   (address)uc->uc_mcontext.psw.addr);
+    address pc = (address)uc->uc_mcontext.psw.addr;
 
-    if (ret_frame.pc() == NULL) {
+    if (pc == NULL) {
       // ucontext wasn't useful
       return false;
     }
+
+    frame ret_frame((intptr_t*)uc->uc_mcontext.gregs[15/*Z_SP*/], pc);
 
     if (ret_frame.fp() == NULL) {
       // The found frame does not have a valid frame pointer.

--- a/src/hotspot/os_cpu/linux_s390/thread_linux_s390.cpp
+++ b/src/hotspot/os_cpu/linux_s390/thread_linux_s390.cpp
@@ -101,7 +101,7 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
 
     if (ret_frame.is_interpreted_frame()) {
       frame::z_ijava_state* istate = ret_frame.ijava_state_unchecked();
-      if (is_in_full_stack((address)istate)) {
+      if (!is_in_full_stack((address)istate)) {
         return false;
       }
       const Method *m = (const Method*)(istate->method);


### PR DESCRIPTION
s390 implementation requires small changes to avoid running into assertions in debug builds. See JBS for details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281061](https://bugs.openjdk.java.net/browse/JDK-8281061): [s390] JFR runs into assertions while validating interpreter frames


### Reviewers
 * [Lutz Schmidt](https://openjdk.java.net/census#lucy) (@RealLucy - **Reviewer**) ⚠️ Review applies to 6d9446a819a470389a4d9ce84f91f9d88ffcb558
 * [Richard Reingruber](https://openjdk.java.net/census#rrich) (@reinrich - **Reviewer**) ⚠️ Review applies to 6d9446a819a470389a4d9ce84f91f9d88ffcb558


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7312/head:pull/7312` \
`$ git checkout pull/7312`

Update a local copy of the PR: \
`$ git checkout pull/7312` \
`$ git pull https://git.openjdk.java.net/jdk pull/7312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7312`

View PR using the GUI difftool: \
`$ git pr show -t 7312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7312.diff">https://git.openjdk.java.net/jdk/pull/7312.diff</a>

</details>
