### PR TITLE
8185261: Font fallback sometimes doesn't work in Swing text components

### DIFF
--- a/src/java.desktop/share/classes/sun/font/FontAccess.java
+++ b/src/java.desktop/share/classes/sun/font/FontAccess.java
@@ -44,7 +44,7 @@ public abstract class FontAccess {
 
     public abstract Font2D getFont2D(Font f);
     public abstract void setFont2D(Font f, Font2DHandle h);
-    public abstract void setCreatedFont(Font f);
+    public abstract void setWithFallback(Font f);
     public abstract boolean isCreatedFont(Font f);
     public abstract FontPeer getFontPeer(Font f);
 }

--- a/src/java.desktop/share/classes/sun/font/FontUtilities.java
+++ b/src/java.desktop/share/classes/sun/font/FontUtilities.java
@@ -428,10 +428,10 @@ public final class FontUtilities {
             compMap.put(physicalFont, compFont);
         }
         FontAccess.getFontAccess().setFont2D(fuir, compFont.handle);
-        /* marking this as a created font is needed as only created fonts
-         * copy their creator's handles.
+        /* marking this as a font with fallback to make sure its
+         * handle is copied to derived fonts.
          */
-        FontAccess.getFontAccess().setCreatedFont(fuir);
+        FontAccess.getFontAccess().setWithFallback(fuir);
         return fuir;
     }
 

--- a/src/java.desktop/unix/classes/sun/awt/X11FontManager.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11FontManager.java
@@ -732,14 +732,13 @@ public final class X11FontManager extends FcFontManager {
         /* The name of the font will be that of the physical font in slot,
          * but by setting the handle to that of the CompositeFont it
          * renders as that CompositeFont.
-         * It also needs to be marked as a created font which is the
-         * current mechanism to signal that deriveFont etc must copy
-         * the handle from the original font.
+         * Font is marked as having fallback components to signal that
+         * deriveFont etc must copy the handle from the original font.
          */
         FontUIResource fuir =
             new FontUIResource(font2D.getFamilyName(null), style, size);
         FontAccess.getFontAccess().setFont2D(fuir, font2D.handle);
-        FontAccess.getFontAccess().setCreatedFont(fuir);
+        FontAccess.getFontAccess().setWithFallback(fuir);
         return fuir;
     }
 }

--- a/test/jdk/javax/swing/JEditorPane/JEditorPaneFontFallback.java
+++ b/test/jdk/javax/swing/JEditorPane/JEditorPaneFontFallback.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8185261
  * @summary Tests that font fallback works reliably in JEditorPane
- * @key headful
  */
 
 import javax.imageio.ImageIO;

--- a/test/jdk/javax/swing/JEditorPane/JEditorPaneFontFallback.java
+++ b/test/jdk/javax/swing/JEditorPane/JEditorPaneFontFallback.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2022 JetBrains s.r.o.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8185261
+ * @summary Tests that font fallback works reliably in JEditorPane
+ * @key headful
+ */
+
+import javax.imageio.ImageIO;
+import javax.swing.*;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.File;
+
+public class JEditorPaneFontFallback {
+    public static final char CHINESE_CHAR = '\u4e2d';
+
+    public static void main(String[] args) throws Exception {
+        String fontFamily = findSuitableFont();
+        if (fontFamily == null) {
+            System.out.println("No suitable fonts, test cannot be performed");
+            return;
+        }
+        System.out.println("Fount font: " + fontFamily);
+        BufferedImage img1 = renderJEditorPaneInSubprocess(fontFamily, false);
+        BufferedImage img2 = renderJEditorPaneInSubprocess(fontFamily, true);
+        if (!imagesAreEqual(img1, img2)) {
+            throw new RuntimeException("Unexpected rendering in JEditorPane");
+        }
+    }
+
+    private static String findSuitableFont() {
+        String[] familyNames = GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames();
+        for (String familyName : familyNames) {
+            if (!familyName.contains("'") && !familyName.contains("<") && !familyName.contains("&")) {
+                Font font = new Font(familyName, Font.PLAIN, 1);
+                if (!font.canDisplay(CHINESE_CHAR)) return familyName;
+            }
+        }
+        return null;
+    }
+
+    private static boolean imagesAreEqual(BufferedImage i1, BufferedImage i2) {
+        if (i1.getWidth() != i2.getWidth() || i1.getHeight() != i2.getHeight()) return false;
+        for (int i = 0; i < i1.getWidth(); i++) {
+            for (int j = 0; j < i1.getHeight(); j++) {
+                if (i1.getRGB(i, j) != i2.getRGB(i, j)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private static BufferedImage renderJEditorPaneInSubprocess(String fontFamilyName, boolean afterFontInfoCaching)
+            throws Exception {
+        String tmpFileName = "image.png";
+        int exitCode = Runtime.getRuntime().exec(new String[]{
+                System.getProperty("java.home") + File.separator + "bin" + File.separator + "java",
+                "-cp",
+                System.getProperty("test.classes", "."),
+                JEditorPaneRenderer.class.getName(),
+                fontFamilyName,
+                Boolean.toString(afterFontInfoCaching),
+                tmpFileName
+        }).waitFor();
+        if (exitCode != 0) {
+            throw new RuntimeException("Sub-process exited abnormally: " + exitCode);
+        }
+        return ImageIO.read(new File(tmpFileName));
+    }
+}
+
+class JEditorPaneRenderer {
+    private static final int FONT_SIZE = 12;
+    private static final int WIDTH = 20;
+    private static final int HEIGHT = 20;
+
+    public static void main(String[] args) throws Exception {
+        String fontFamily = args[0];
+        JEditorPane pane = new JEditorPane("text/html",
+                "<html><head><style>body {font-family:'" + fontFamily + "'; font-size:" + FONT_SIZE +
+                "pt;}</style></head><body>" + JEditorPaneFontFallback.CHINESE_CHAR + "</body></html>");
+        pane.setSize(WIDTH, HEIGHT);
+        if (Boolean.parseBoolean(args[1])) pane.getFontMetrics(new Font(fontFamily, Font.PLAIN, FONT_SIZE));
+        BufferedImage img = new BufferedImage(WIDTH, HEIGHT, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = img.createGraphics();
+        pane.paint(g);
+        g.dispose();
+        ImageIO.write(img, "png", new File(args[2]));
+    }
+}


### PR DESCRIPTION
The proposed fix makes fonts with and without fallback components distinguishable (in terms of `equals` method), so that
font metrics cache (and other similar code) can handle them separately. This is achieved by adding a new boolean field
to `Font` class, specifically denoting fonts with fallback components. The latter ones don't need to pretend to be
'created' fonts anymore, to preserve their `Font2D` handle.
It's not possible to use the existing `createdFont` field in `equals` implementation, as JCK requires a 'real' created
font (the one obtained using `Font.createFont` method) to be equal to the same font after serialization and
deserialization.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8185261](https://bugs.openjdk.java.net/browse/JDK-8185261): Font fallback sometimes doesn't work in Swing text components


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7313/head:pull/7313` \
`$ git checkout pull/7313`

Update a local copy of the PR: \
`$ git checkout pull/7313` \
`$ git pull https://git.openjdk.java.net/jdk pull/7313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7313`

View PR using the GUI difftool: \
`$ git pr show -t 7313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7313.diff">https://git.openjdk.java.net/jdk/pull/7313.diff</a>

</details>
