### PR TITLE
8279329: Remove hardcoded IPv4 available policy on Windows

### DIFF
--- a/src/java.base/windows/native/libnet/net_util_md.c
+++ b/src/java.base/windows/native/libnet/net_util_md.c
@@ -215,7 +215,12 @@ NET_GetFileDescriptorID(JNIEnv *env)
 
 jint  IPv4_supported()
 {
-    /* TODO: properly check for IPv4 support on Windows */
+    SOCKET s = socket(AF_INET, SOCK_STREAM, 0);
+    if (s == INVALID_SOCKET) {
+        return JNI_FALSE;
+    }
+    closesocket(s);
+
     return JNI_TRUE;
 }
 


### PR DESCRIPTION
I added socket connection check same as IPv6_supported().
Before this fix, when IPv4 is uninstalled (called `netsh interface ipv4 uninstall`), and set property `-Djava.net.preferIPv4Stack=true`, java.net.InetAddress.PLATFORM_LOOKUP_POLICY.characteristics is always set to 1(IPv4), because IPv4_supported() always returns TRUE. After applied this fix, java.net.InetAddress.PLATFORM_LOOKUP_POLICY.characteristics is set to 2(IPv6). 
It looks fine that IPv4_supported() returns FALSE.
Would you review this fix?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279329](https://bugs.openjdk.java.net/browse/JDK-8279329): Remove hardcoded IPv4 available policy on Windows


### Reviewers
 * [Daniel Jeliński](https://openjdk.java.net/census#djelinski) (@djelinski - Author)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Aleksei Efimov](https://openjdk.java.net/census#aefimov) (@AlekseiEfimov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7317/head:pull/7317` \
`$ git checkout pull/7317`

Update a local copy of the PR: \
`$ git checkout pull/7317` \
`$ git pull https://git.openjdk.java.net/jdk pull/7317/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7317`

View PR using the GUI difftool: \
`$ git pr show -t 7317`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7317.diff">https://git.openjdk.java.net/jdk/pull/7317.diff</a>

</details>
