### PR TITLE
8281114: G1: Remove PreservedMarks::init_forwarded_mark

### DIFF
--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@
 #include "gc/g1/g1OopClosures.inline.hpp"
 #include "gc/g1/heapRegion.hpp"
 #include "gc/g1/heapRegionRemSet.inline.hpp"
-#include "gc/shared/preservedMarks.inline.hpp"
 #include "oops/access.inline.hpp"
 #include "oops/compressedOops.inline.hpp"
 #include "oops/oop.inline.hpp"
@@ -94,7 +93,8 @@ public:
     size_t obj_size = obj->size();
 
     _marked_words += obj_size;
-    PreservedMarks::init_forwarded_mark(obj);
+    // Reset the markWord
+    obj->init_mark();
 
     HeapWord* obj_end = obj_addr + obj_size;
     _last_forwarded_object_end = obj_end;

--- a/src/hotspot/share/gc/shared/preservedMarks.hpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,6 @@ public:
   void adjust_during_full_gc();
 
   void restore_and_increment(volatile size_t* const _total_size_addr);
-  inline static void init_forwarded_mark(oop obj);
 
   // Assert the stack is empty and has no cached segments.
   void assert_empty() PRODUCT_RETURN;

--- a/src/hotspot/share/gc/shared/preservedMarks.inline.hpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,10 +46,6 @@ inline void PreservedMarks::push_always(oop obj, markWord m) {
   assert(!m.is_marked(), "precondition");
   OopAndMarkWord elem(obj, m);
   _stack.push(elem);
-}
-
-inline void PreservedMarks::init_forwarded_mark(oop obj) {
-  obj->init_mark();
 }
 
 inline PreservedMarks::PreservedMarks()


### PR DESCRIPTION
Simple change of inlining `PreservedMarks::init_forwarded_mark` and removing it. This decouples G1 self-forwarded obj handling from preserved marks.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281114](https://bugs.openjdk.java.net/browse/JDK-8281114): G1: Remove PreservedMarks::init_forwarded_mark


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7321/head:pull/7321` \
`$ git checkout pull/7321`

Update a local copy of the PR: \
`$ git checkout pull/7321` \
`$ git pull https://git.openjdk.java.net/jdk pull/7321/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7321`

View PR using the GUI difftool: \
`$ git pr show -t 7321`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7321.diff">https://git.openjdk.java.net/jdk/pull/7321.diff</a>

</details>
