### PR TITLE
8280820: Clean up bug8033699 and bug8075609.java tests: regtesthelpers aren't used

### DIFF
--- a/test/jdk/javax/swing/JRadioButton/8033699/bug8033699.java
+++ b/test/jdk/javax/swing/JRadioButton/8033699/bug8033699.java
@@ -245,9 +245,9 @@ public class bug8033699 {
         });
     }
 
-    private static Boolean actRB1 = false;
-    private static Boolean actRB2 = false;
-    private static Boolean actRB3 = false;
+    private static boolean actRB1 = false;
+    private static boolean actRB2 = false;
+    private static boolean actRB3 = false;
 
     // JDK-8226892: Verify that ActionListener is called when a RadioButton is selected using arrow key.
     private static void runTest9() throws Exception {

--- a/test/jdk/javax/swing/JRadioButton/8033699/bug8033699.java
+++ b/test/jdk/javax/swing/JRadioButton/8033699/bug8033699.java
@@ -63,6 +63,7 @@ public class bug8033699 {
 
         robot = new Robot();
         Thread.sleep(100);
+        robot.waitForIdle();
 
         robot.setAutoDelay(100);
 

--- a/test/jdk/javax/swing/JRadioButton/8033699/bug8033699.java
+++ b/test/jdk/javax/swing/JRadioButton/8033699/bug8033699.java
@@ -72,7 +72,7 @@ public class bug8033699 {
         // tab key test non-grouped radio button
         runTest2();
 
-        // shift tab key test grouped and non grouped radio button
+        // shift tab key test grouped and non-grouped radio button
         runTest3();
 
         // left/up key test in grouped radio button

--- a/test/jdk/javax/swing/JRadioButton/8033699/bug8033699.java
+++ b/test/jdk/javax/swing/JRadioButton/8033699/bug8033699.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,11 +21,9 @@
  * questions.
  */
 
- /*
+/*
  * @test
  * @key headful
- * @library ../../regtesthelpers
- * @build Util
  * @bug 8033699 8154043 8167160 8208640 8226892
  * @summary  Incorrect radio button behavior when pressing tab key
  * @run main bug8033699
@@ -34,8 +32,7 @@ import java.awt.KeyboardFocusManager;
 import java.awt.Robot;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.ButtonGroup;
@@ -45,7 +42,6 @@ import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
-import javax.swing.UnsupportedLookAndFeelException;
 
 public class bug8033699 {
 
@@ -59,7 +55,7 @@ public class bug8033699 {
     private static JRadioButton radioBtn3;
     private static JRadioButton radioBtnSingle;
 
-    public static void main(String args[]) throws Throwable {
+    public static void main(String[] args) throws Throwable {
         SwingUtilities.invokeAndWait(() -> {
                 changeLAF();
                 createAndShowGUI();

--- a/test/jdk/javax/swing/JRadioButton/8033699/bug8033699.java
+++ b/test/jdk/javax/swing/JRadioButton/8033699/bug8033699.java
@@ -155,9 +155,9 @@ public class bug8033699 {
 
     // Radio button Group as a single component when traversing through tab key
     private static void runTest1() throws Exception {
-        hitKey(robot, KeyEvent.VK_TAB);
-        hitKey(robot, KeyEvent.VK_TAB);
-        hitKey(robot, KeyEvent.VK_TAB);
+        hitKey(KeyEvent.VK_TAB);
+        hitKey(KeyEvent.VK_TAB);
+        hitKey(KeyEvent.VK_TAB);
 
         SwingUtilities.invokeAndWait(() -> {
             if (KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner() != radioBtnSingle) {
@@ -169,7 +169,7 @@ public class bug8033699 {
 
     // Non-Grouped Radio button as a single component when traversing through tab key
     private static void runTest2() throws Exception {
-        hitKey(robot, KeyEvent.VK_TAB);
+        hitKey(KeyEvent.VK_TAB);
         SwingUtilities.invokeAndWait(() -> {
             if (KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner() != btnEnd) {
                 System.out.println("Non Grouped Radio Button Go To Next Component through Tab Key failed");
@@ -180,9 +180,9 @@ public class bug8033699 {
 
     // Non-Grouped Radio button and Group Radio button as a single component when traversing through shift-tab key
     private static void runTest3() throws Exception {
-        hitKey(robot, KeyEvent.VK_SHIFT, KeyEvent.VK_TAB);
-        hitKey(robot, KeyEvent.VK_SHIFT, KeyEvent.VK_TAB);
-        hitKey(robot, KeyEvent.VK_SHIFT, KeyEvent.VK_TAB);
+        hitKey(KeyEvent.VK_SHIFT, KeyEvent.VK_TAB);
+        hitKey(KeyEvent.VK_SHIFT, KeyEvent.VK_TAB);
+        hitKey(KeyEvent.VK_SHIFT, KeyEvent.VK_TAB);
         SwingUtilities.invokeAndWait(() -> {
             if (KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner() != radioBtn1) {
                 System.out.println("Radio button Group/Non Grouped Radio Button SHIFT-Tab Key Test failed");
@@ -193,8 +193,8 @@ public class bug8033699 {
 
     // Using arrow key to move focus in radio button group
     private static void runTest4() throws Exception {
-        hitKey(robot, KeyEvent.VK_DOWN);
-        hitKey(robot, KeyEvent.VK_RIGHT);
+        hitKey(KeyEvent.VK_DOWN);
+        hitKey(KeyEvent.VK_RIGHT);
         SwingUtilities.invokeAndWait(() -> {
             if (KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner() != radioBtn3) {
                 System.out.println("Radio button Group UP/LEFT Arrow Key Move Focus Failed");
@@ -204,8 +204,8 @@ public class bug8033699 {
     }
 
     private static void runTest5() throws Exception {
-        hitKey(robot, KeyEvent.VK_UP);
-        hitKey(robot, KeyEvent.VK_LEFT);
+        hitKey(KeyEvent.VK_UP);
+        hitKey(KeyEvent.VK_LEFT);
         SwingUtilities.invokeAndWait(() -> {
             if (KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner() != radioBtn1) {
                 System.out.println("Radio button Group Left/Up Arrow Key Move Focus Failed");
@@ -215,8 +215,8 @@ public class bug8033699 {
     }
 
     private static void runTest6() throws Exception {
-        hitKey(robot, KeyEvent.VK_UP);
-        hitKey(robot, KeyEvent.VK_UP);
+        hitKey(KeyEvent.VK_UP);
+        hitKey(KeyEvent.VK_UP);
         SwingUtilities.invokeAndWait(() -> {
             if (KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner() != radioBtn2) {
                 System.out.println("Radio button Group Circle Back To First Button Test");
@@ -226,7 +226,7 @@ public class bug8033699 {
     }
 
     private static void runTest7() throws Exception {
-        hitKey(robot, KeyEvent.VK_TAB);
+        hitKey(KeyEvent.VK_TAB);
         SwingUtilities.invokeAndWait(() -> {
             if (KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner() != btnMiddle) {
                 System.out.println("Separate Component added in button group layout");
@@ -236,7 +236,7 @@ public class bug8033699 {
     }
 
     private static void runTest8() throws Exception {
-        hitKey(robot, KeyEvent.VK_TAB);
+        hitKey(KeyEvent.VK_TAB);
         SwingUtilities.invokeAndWait(() -> {
             if (KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner() != radioBtnSingle) {
                 System.out.println("Separate Component added in button group layout");
@@ -264,9 +264,9 @@ public class bug8033699 {
         radioBtn2.addActionListener(actLrRB2);
         radioBtn3.addActionListener(actLrRB3);
 
-        hitKey(robot, KeyEvent.VK_DOWN);
-        hitKey(robot, KeyEvent.VK_DOWN);
-        hitKey(robot, KeyEvent.VK_DOWN);
+        hitKey(KeyEvent.VK_DOWN);
+        hitKey(KeyEvent.VK_DOWN);
+        hitKey(KeyEvent.VK_DOWN);
 
         String failMessage = "ActionListener not invoked when selected using arrow key.";
         if (!actRB2) {
@@ -284,13 +284,13 @@ public class bug8033699 {
         radioBtn3.removeActionListener(actLrRB3);
     }
 
-    private static void hitKey(Robot robot, int keycode) {
+    private static void hitKey(int keycode) {
         robot.keyPress(keycode);
         robot.keyRelease(keycode);
         robot.waitForIdle();
     }
 
-    private static void hitKey(Robot robot, int mode, int keycode) {
+    private static void hitKey(int mode, int keycode) {
         robot.keyPress(mode);
         robot.keyPress(keycode);
         robot.keyRelease(keycode);

--- a/test/jdk/javax/swing/JRadioButton/8033699/bug8033699.java
+++ b/test/jdk/javax/swing/JRadioButton/8033699/bug8033699.java
@@ -149,7 +149,7 @@ public class bug8033699 {
         mainFrame.setLayout(new BoxLayout(mainFrame.getContentPane(), BoxLayout.Y_AXIS));
 
         mainFrame.setSize(300, 300);
-        mainFrame.setLocation(200, 200);
+        mainFrame.setLocationRelativeTo(null);
         mainFrame.setVisible(true);
         mainFrame.toFront();
     }

--- a/test/jdk/javax/swing/JRadioButton/8075609/bug8075609.java
+++ b/test/jdk/javax/swing/JRadioButton/8075609/bug8075609.java
@@ -48,11 +48,7 @@ public class bug8075609 {
 
     public static void main(String[] args) throws Throwable {
         try {
-            SwingUtilities.invokeAndWait(new Runnable() {
-                public void run() {
-                    createAndShowGUI();
-                }
-            });
+            SwingUtilities.invokeAndWait(bug8075609::createAndShowGUI);
 
             robot = new Robot();
             Thread.sleep(100);
@@ -108,12 +104,10 @@ public class bug8075609 {
         hitKey(KeyEvent.VK_TAB);
 
         robot.delay(1000);
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                if (!textField.hasFocus()) {
-                    System.out.println("Radio Button Group Go To Next Component through Tab Key failed");
-                    throw new RuntimeException("Focus is not on textField as Expected");
-                }
+        SwingUtilities.invokeAndWait(() -> {
+            if (!textField.hasFocus()) {
+                System.out.println("Radio Button Group Go To Next Component through Tab Key failed");
+                throw new RuntimeException("Focus is not on textField as Expected");
             }
         });
     }

--- a/test/jdk/javax/swing/JRadioButton/8075609/bug8075609.java
+++ b/test/jdk/javax/swing/JRadioButton/8075609/bug8075609.java
@@ -96,6 +96,7 @@ public class bug8075609 {
 
         mainFrame.add(rootPanel);
         mainFrame.pack();
+        mainFrame.setLocationRelativeTo(null);
         mainFrame.setVisible(true);
         mainFrame.toFront();
     }

--- a/test/jdk/javax/swing/JRadioButton/8075609/bug8075609.java
+++ b/test/jdk/javax/swing/JRadioButton/8075609/bug8075609.java
@@ -105,7 +105,7 @@ public class bug8075609 {
 
     // Radio button Group as a single component when traversing through tab key
     private static void runTest1() throws Exception {
-        hitKey(robot, KeyEvent.VK_TAB);
+        hitKey(KeyEvent.VK_TAB);
 
         robot.delay(1000);
         SwingUtilities.invokeAndWait(new Runnable() {
@@ -118,7 +118,7 @@ public class bug8075609 {
         });
     }
 
-    private static void hitKey(Robot robot, int keycode) {
+    private static void hitKey(int keycode) {
         robot.keyPress(keycode);
         robot.keyRelease(keycode);
         robot.waitForIdle();

--- a/test/jdk/javax/swing/JRadioButton/8075609/bug8075609.java
+++ b/test/jdk/javax/swing/JRadioButton/8075609/bug8075609.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,28 +21,32 @@
  * questions.
  */
 
- /*
+/*
  * @test
  * @key headful
- * @library ../../regtesthelpers
- * @build Util
  * @bug 8075609
  * @summary  IllegalArgumentException when transferring focus from JRadioButton using tab
- * @author Vivi An
  * @run main bug8075609
  */
+import java.awt.BorderLayout;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
 
-import javax.swing.*;
-import javax.swing.event.*;
-import java.awt.event.*;
-import java.awt.*;
+import javax.swing.ButtonGroup;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
+import javax.swing.JTextField;
+import javax.swing.LayoutFocusTraversalPolicy;
+import javax.swing.SwingUtilities;
 
 public class bug8075609 {
     private static Robot robot;
     private static JTextField textField;
     private static JFrame mainFrame;
 
-    public static void main(String args[]) throws Throwable {
+    public static void main(String[] args) throws Throwable {
         try {
             SwingUtilities.invokeAndWait(new Runnable() {
                 public void run() {
@@ -96,10 +100,10 @@ public class bug8075609 {
     }
 
     // Radio button Group as a single component when traversing through tab key
-    private static void runTest1() throws Exception{
+    private static void runTest1() throws Exception {
         hitKey(robot, KeyEvent.VK_TAB);
 
-        robot.delay(1000 );
+        robot.delay(1000);
         SwingUtilities.invokeAndWait(new Runnable() {
             public void run() {
                 if (!textField.hasFocus()) {

--- a/test/jdk/javax/swing/JRadioButton/8075609/bug8075609.java
+++ b/test/jdk/javax/swing/JRadioButton/8075609/bug8075609.java
@@ -52,6 +52,7 @@ public class bug8075609 {
 
             robot = new Robot();
             Thread.sleep(100);
+            robot.waitForIdle();
 
             robot.setAutoDelay(100);
 

--- a/test/jdk/javax/swing/JRadioButton/8075609/bug8075609.java
+++ b/test/jdk/javax/swing/JRadioButton/8075609/bug8075609.java
@@ -62,7 +62,11 @@ public class bug8075609 {
             // Radio button group tab key test
             runTest1();
         } finally {
-            if (mainFrame != null) SwingUtilities.invokeAndWait(() -> mainFrame.dispose());
+            SwingUtilities.invokeAndWait(() -> {
+                if (mainFrame != null) {
+                    mainFrame.dispose();
+                }
+            });
         }
     }
 


### PR DESCRIPTION
Removed references to `regtesthelpers` libarary which isn't used.
Organised imports and replaced anonymous classes with lambda expressions.

Put `waitForIdle` before the test execution starts and moved the frame to the centre of the screen.

The CI with the updated tests is green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280820](https://bugs.openjdk.java.net/browse/JDK-8280820): Clean up bug8033699 and bug8075609.java tests: regtesthelpers aren't used


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7322/head:pull/7322` \
`$ git checkout pull/7322`

Update a local copy of the PR: \
`$ git checkout pull/7322` \
`$ git pull https://git.openjdk.java.net/jdk pull/7322/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7322`

View PR using the GUI difftool: \
`$ git pr show -t 7322`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7322.diff">https://git.openjdk.java.net/jdk/pull/7322.diff</a>

</details>
