### PR TITLE
8281117: Add regression test for JDK-8280587

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/TestCastIIMakesMainLoopPhiDead2.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestCastIIMakesMainLoopPhiDead2.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * bug 8280600
+ * @summary C2: assert(!had_error) failed: bad dominance
+ * @run main/othervm -Xcomp -XX:CompileOnly=TestCastIIMakesMainLoopPhiDead2 TestCastIIMakesMainLoopPhiDead2
+ */
+
+public class TestCastIIMakesMainLoopPhiDead2 {
+    static int zero = 0;
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 100000; i++) {
+            test();
+        }
+    }
+
+    static void test() {
+        int h[] = new int[zero];
+        for (int m = 0; m < 5; m++) {
+            try {
+                for (int f = -400; f < 1; f++) {
+                    h[f] = 1; // Out of bounds store.
+                }
+            } catch (ArrayIndexOutOfBoundsException i) {
+                // Expected
+            }
+        }
+    }
+}
+
+

--- a/test/hotspot/jtreg/compiler/loopopts/TestCastIIMakesMainLoopPhiDead2.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestCastIIMakesMainLoopPhiDead2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Recently, bug [JDK-8280600](https://bugs.openjdk.java.net/browse/JDK-8280600) was fixed, see [PR](https://github.com/openjdk/jdk/pull/7307).
[JDK-8280587](https://bugs.openjdk.java.net/browse/JDK-8280587) has been detected as a duplicate bug.
However, [JDK-8280587](https://bugs.openjdk.java.net/browse/JDK-8280587) came with a differen reported test which failed with a different assert.
Therefore, I added this additional test as a second regression test.

I ran this test to check that it passes successfully.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281117](https://bugs.openjdk.java.net/browse/JDK-8281117): Add regression test for JDK-8280587


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Xin Liu](https://openjdk.java.net/census#xliu) (@navyxliu - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7323/head:pull/7323` \
`$ git checkout pull/7323`

Update a local copy of the PR: \
`$ git checkout pull/7323` \
`$ git pull https://git.openjdk.java.net/jdk pull/7323/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7323`

View PR using the GUI difftool: \
`$ git pr show -t 7323`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7323.diff">https://git.openjdk.java.net/jdk/pull/7323.diff</a>

</details>
