### PR TITLE
8281120: G1: Rename G1BlockOffsetTablePart::alloc_block to update_for_block

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
@@ -87,7 +87,7 @@ void G1BlockOffsetTablePart::update() {
   while (next_addr < limit) {
     prev_addr = next_addr;
     next_addr  = prev_addr + block_size(prev_addr);
-    alloc_block(prev_addr, next_addr);
+    update_for_block(prev_addr, next_addr);
   }
   assert(next_addr == limit, "Should stop the scan at the limit.");
 }
@@ -212,8 +212,8 @@ void G1BlockOffsetTablePart::check_all_cards(size_t start_card, size_t end_card)
 //       ( ^    ]
 //         blk_start
 //
-void G1BlockOffsetTablePart::alloc_block_work(HeapWord* blk_start,
-                                              HeapWord* blk_end) {
+void G1BlockOffsetTablePart::update_for_block_work(HeapWord* blk_start,
+                                                   HeapWord* blk_end) {
   HeapWord* const cur_card_boundary = align_up_by_card_size(blk_start);
   size_t const index =  _bot->index_for_raw(cur_card_boundary);
 
@@ -335,8 +335,8 @@ void G1BlockOffsetTablePart::print_on(outputStream* out) {
 #endif // !PRODUCT
 
 void G1BlockOffsetTablePart::set_for_starts_humongous(HeapWord* obj_top, size_t fill_size) {
-  alloc_block(_hr->bottom(), obj_top);
+  update_for_block(_hr->bottom(), obj_top);
   if (fill_size > 0) {
-    alloc_block(obj_top, fill_size);
+    update_for_block(obj_top, fill_size);
   }
 }

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -138,7 +138,7 @@ private:
                                                     const void* addr) const;
 
   // Update BOT entries corresponding to the mem range [blk_start, blk_end).
-  void alloc_block_work(HeapWord* blk_start, HeapWord* blk_end);
+  void update_for_block_work(HeapWord* blk_start, HeapWord* blk_end);
 
   void check_all_cards(size_t left_card, size_t right_card) const;
 
@@ -168,14 +168,14 @@ public:
   // in a space covered by the table.)
   inline HeapWord* block_start(const void* addr);
 
-  void alloc_block(HeapWord* blk_start, HeapWord* blk_end) {
+  void update_for_block(HeapWord* blk_start, HeapWord* blk_end) {
     if (is_crossing_card_boundary(blk_start, blk_end)) {
-      alloc_block_work(blk_start, blk_end);
+      update_for_block_work(blk_start, blk_end);
     }
   }
 
-  void alloc_block(HeapWord* blk_start, size_t size) {
-    alloc_block(blk_start, blk_start + size);
+  void update_for_block(HeapWord* blk_start, size_t size) {
+    update_for_block(blk_start, blk_start + size);
   }
 
   void set_for_starts_humongous(HeapWord* obj_top, size_t fill_size);

--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -98,7 +98,7 @@ public:
 
     HeapWord* obj_end = obj_addr + obj_size;
     _last_forwarded_object_end = obj_end;
-    _hr->alloc_block_in_bot(obj_addr, obj_end);
+    _hr->update_bot_for_block(obj_addr, obj_end);
     return obj_size;
   }
 
@@ -116,13 +116,13 @@ public:
       CollectedHeap::fill_with_objects(start, gap_size);
 
       HeapWord* end_first_obj = start + cast_to_oop(start)->size();
-      _hr->alloc_block_in_bot(start, end_first_obj);
+      _hr->update_bot_for_block(start, end_first_obj);
       // Fill_with_objects() may have created multiple (i.e. two)
       // objects, as the max_fill_size() is half a region.
       // After updating the BOT for the first object, also update the
       // BOT for the second object to make the BOT complete.
       if (end_first_obj != end) {
-        _hr->alloc_block_in_bot(end_first_obj, end);
+        _hr->update_bot_for_block(end_first_obj, end);
 #ifdef ASSERT
         size_t size_second_obj = cast_to_oop(end_first_obj)->size();
         HeapWord* end_of_second_obj = end_first_obj + size_second_obj;

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
@@ -107,7 +107,7 @@ void G1FullGCCompactionPoint::forward(oop object, size_t size) {
 
   // Update compaction values.
   _compaction_top += size;
-  _current_region->alloc_block_in_bot(_compaction_top - size, _compaction_top);
+  _current_region->update_bot_for_block(_compaction_top - size, _compaction_top);
 }
 
 void G1FullGCCompactionPoint::add(HeapRegion* hr) {

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -787,8 +787,8 @@ void HeapRegion::mangle_unused_area() {
 }
 #endif
 
-void HeapRegion::alloc_block_in_bot(HeapWord* start, HeapWord* end) {
-  _bot_part.alloc_block(start, end);
+void HeapRegion::update_bot_for_block(HeapWord* start, HeapWord* end) {
+  _bot_part.update_for_block(start, end);
 }
 
 void HeapRegion::object_iterate(ObjectClosure* blk) {

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -167,7 +167,7 @@ public:
 
   // Full GC support methods.
 
-  void alloc_block_in_bot(HeapWord* start, HeapWord* end);
+  void update_bot_for_block(HeapWord* start, HeapWord* end);
 
   // Update heap region that has been compacted to be consistent after Full GC.
   void reset_compacted_after_full_gc();

--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -237,7 +237,7 @@ inline void HeapRegion::update_bot_for_obj(HeapWord* obj_start, size_t obj_size)
          HR_FORMAT_PARAMS(this),
          p2i(obj_start), p2i(obj_end));
 
-  _bot_part.alloc_block(obj_start, obj_end);
+  _bot_part.update_for_block(obj_start, obj_end);
 }
 
 inline void HeapRegion::note_start_of_marking() {


### PR DESCRIPTION
Simple change of renaming certain methods.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281120](https://bugs.openjdk.java.net/browse/JDK-8281120): G1: Rename G1BlockOffsetTablePart::alloc_block to update_for_block


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7325/head:pull/7325` \
`$ git checkout pull/7325`

Update a local copy of the PR: \
`$ git checkout pull/7325` \
`$ git pull https://git.openjdk.java.net/jdk pull/7325/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7325`

View PR using the GUI difftool: \
`$ git pr show -t 7325`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7325.diff">https://git.openjdk.java.net/jdk/pull/7325.diff</a>

</details>
