### PR TITLE
8272777: Clean up remaining AccessController warnings in test library

### DIFF
--- a/test/lib/jdk/test/lib/SA/SATestUtils.java
+++ b/test/lib/jdk/test/lib/SA/SATestUtils.java
@@ -159,6 +159,7 @@ public class SATestUtils {
      * if we are root, so return true.  Then return false for an expected denial
      * if "ptrace_scope" is 1, and true otherwise.
      */
+    @SuppressWarnings("removal")
     private static boolean canPtraceAttachLinux() throws IOException {
         // SELinux deny_ptrace:
         var deny_ptrace = Paths.get("/sys/fs/selinux/booleans/deny_ptrace");

--- a/test/lib/jdk/test/lib/net/IPSupport.java
+++ b/test/lib/jdk/test/lib/net/IPSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,6 +71,7 @@ public class IPSupport {
         }
     }
 
+    @SuppressWarnings("removal")
     private static <T> T runPrivilegedAction(Callable<T> callable) {
         try {
             PrivilegedExceptionAction<T> pa = () -> callable.call();

--- a/test/lib/jdk/test/lib/net/SimpleSSLContext.java
+++ b/test/lib/jdk/test/lib/net/SimpleSSLContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,6 +54,7 @@ public class SimpleSSLContext {
         this(() -> "TLS");
     }
 
+    @SuppressWarnings("removal")
     private SimpleSSLContext(Supplier<String> protocols) throws IOException {
         try {
             final String proto = protocols.get();


### PR DESCRIPTION
Reduce noise in test output by adding the @SuppressWarnings("removal") annotation (which has already been widely applied).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272777](https://bugs.openjdk.java.net/browse/JDK-8272777): Clean up remaining AccessController warnings in test library


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7328/head:pull/7328` \
`$ git checkout pull/7328`

Update a local copy of the PR: \
`$ git checkout pull/7328` \
`$ git pull https://git.openjdk.java.net/jdk pull/7328/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7328`

View PR using the GUI difftool: \
`$ git pr show -t 7328`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7328.diff">https://git.openjdk.java.net/jdk/pull/7328.diff</a>

</details>
