### PR TITLE
8280896: java/nio/file/Files/probeContentType/Basic.java fails on Windows 11

### DIFF
--- a/test/jdk/java/nio/file/Files/probeContentType/Basic.java
+++ b/test/jdk/java/nio/file/Files/probeContentType/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -161,7 +161,7 @@ public class Basic {
                 new ExType("doc", List.of("application/msword")),
                 new ExType("docx", List.of("application/vnd.openxmlformats-officedocument.wordprocessingml.document")),
                 new ExType("gz", List.of("application/gzip", "application/x-gzip")),
-                new ExType("jar", List.of("application/java-archive", "application/x-java-archive")),
+                new ExType("jar", List.of("application/java-archive", "application/x-java-archive", "application/jar")),
                 new ExType("jpg", List.of("image/jpeg")),
                 new ExType("js", List.of("text/javascript", "application/javascript")),
                 new ExType("json", List.of("application/json")),


### PR DESCRIPTION
Test fails because actual content type `application/jar` is not in allowed list of types: `application/java-archive`, `application/x-java-archive`.
But Amazon Corretto installer set this content type to Windows registry.
![изображение](https://user-images.githubusercontent.com/741251/152308738-58d790ea-167a-45c7-9e08-8d619c4f316d.png)
I propose to add this value to expected list.
Test always fails for me. After fix, test passes.  Windows 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280896](https://bugs.openjdk.java.net/browse/JDK-8280896): java/nio/file/Files/probeContentType/Basic.java fails on Windows 11


### Reviewers
 * [Jaikiran Pai](https://openjdk.java.net/census#jpai) (@jaikiran - Committer)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7334/head:pull/7334` \
`$ git checkout pull/7334`

Update a local copy of the PR: \
`$ git checkout pull/7334` \
`$ git pull https://git.openjdk.java.net/jdk pull/7334/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7334`

View PR using the GUI difftool: \
`$ git pr show -t 7334`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7334.diff">https://git.openjdk.java.net/jdk/pull/7334.diff</a>

</details>
