### PR TITLE
8280965: Tests com/sun/net/httpserver/simpleserver fail with FileSystemException on Windows 11

### DIFF
--- a/test/jdk/com/sun/net/httpserver/simpleserver/CustomFileSystemTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/CustomFileSystemTest.java
@@ -71,10 +71,10 @@ import com.sun.net.httpserver.SimpleFileServer;
 import com.sun.net.httpserver.SimpleFileServer.OutputLevel;
 import jdk.test.lib.Platform;
 import jdk.test.lib.net.URIBuilder;
-import jtreg.SkippedException;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.testng.SkipException;
 import static java.net.http.HttpClient.Builder.NO_PROXY;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardOpenOption.CREATE;
@@ -446,9 +446,9 @@ public class CustomFileSystemTest {
             Files.createSymbolicLink(symlink, target);
             return true;
         } catch (UnsupportedOperationException uoe) {
-            throw new SkippedException("sym link creation not supported", uoe);
+            throw new SkipException("sym link creation not supported", uoe);
         } catch (IOException ioe) {
-            throw new SkippedException("probably insufficient privileges to create sym links (Windows)", ioe);
+            throw new SkipException("probably insufficient privileges to create sym links (Windows)", ioe);
         }
     }
 

--- a/test/jdk/com/sun/net/httpserver/simpleserver/CustomFileSystemTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/CustomFileSystemTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,6 +71,7 @@ import com.sun.net.httpserver.SimpleFileServer;
 import com.sun.net.httpserver.SimpleFileServer.OutputLevel;
 import jdk.test.lib.Platform;
 import jdk.test.lib.net.URIBuilder;
+import jtreg.SkippedException;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -395,19 +396,20 @@ public class CustomFileSystemTest {
         var root = createDirectoryInCustomFs("testSymlinkGET");
         var symlink = root.resolve("symlink");
         var target = Files.writeString(root.resolve("target.txt"), "some text", CREATE);
-        Files.createSymbolicLink(symlink, target);
+        if (createSymLink(symlink, target)) {  // sym link creation succeeded
 
-        var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
-        server.start();
-        try {
-            var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
-            var request = HttpRequest.newBuilder(uri(server, "symlink")).build();
-            var response = client.send(request, BodyHandlers.ofString());
-            assertEquals(response.statusCode(), 404);
-            assertEquals(response.headers().firstValue("content-length").get(), expectedLength);
-            assertEquals(response.body(), expectedBody);
-        } finally {
-            server.stop(0);
+            var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
+            server.start();
+            try {
+                var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
+                var request = HttpRequest.newBuilder(uri(server, "symlink")).build();
+                var response = client.send(request, BodyHandlers.ofString());
+                assertEquals(response.statusCode(), 404);
+                assertEquals(response.headers().firstValue("content-length").get(), expectedLength);
+                assertEquals(response.body(), expectedBody);
+            } finally {
+                server.stop(0);
+            }
         }
     }
 
@@ -422,19 +424,31 @@ public class CustomFileSystemTest {
         var symlink = root.resolve("symlink");
         var target = Files.createDirectory(root.resolve("target"));
         Files.writeString(target.resolve("aFile.txt"), "some text", CREATE);
-        Files.createSymbolicLink(symlink, target);
+        if (createSymLink(symlink, target)) {  // sym link creation succeeded
 
-        var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
-        server.start();
+            var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
+            server.start();
+            try {
+                var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
+                var request = HttpRequest.newBuilder(uri(server, "symlink/aFile.txt")).build();
+                var response = client.send(request, BodyHandlers.ofString());
+                assertEquals(response.statusCode(), 404);
+                assertEquals(response.headers().firstValue("content-length").get(), expectedLength);
+                assertEquals(response.body(), expectedBody);
+            } finally {
+                server.stop(0);
+            }
+        }
+    }
+
+    private boolean createSymLink(Path symlink, Path target) {
         try {
-            var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
-            var request = HttpRequest.newBuilder(uri(server, "symlink/aFile.txt")).build();
-            var response = client.send(request, BodyHandlers.ofString());
-            assertEquals(response.statusCode(), 404);
-            assertEquals(response.headers().firstValue("content-length").get(), expectedLength);
-            assertEquals(response.body(), expectedBody);
-        } finally {
-            server.stop(0);
+            Files.createSymbolicLink(symlink, target);
+            return true;
+        } catch (UnsupportedOperationException uoe) {
+            throw new SkippedException("sym link creation not supported", uoe);
+        } catch (IOException ioe) {
+            throw new SkippedException("probably insufficient privileges to create sym links (Windows)", ioe);
         }
     }
 

--- a/test/jdk/com/sun/net/httpserver/simpleserver/CustomFileSystemTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/CustomFileSystemTest.java
@@ -396,20 +396,19 @@ public class CustomFileSystemTest {
         var root = createDirectoryInCustomFs("testSymlinkGET");
         var symlink = root.resolve("symlink");
         var target = Files.writeString(root.resolve("target.txt"), "some text", CREATE);
-        if (createSymLink(symlink, target)) {  // sym link creation succeeded
+        createSymLink(symlink, target);
 
-            var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
-            server.start();
-            try {
-                var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
-                var request = HttpRequest.newBuilder(uri(server, "symlink")).build();
-                var response = client.send(request, BodyHandlers.ofString());
-                assertEquals(response.statusCode(), 404);
-                assertEquals(response.headers().firstValue("content-length").get(), expectedLength);
-                assertEquals(response.body(), expectedBody);
-            } finally {
-                server.stop(0);
-            }
+        var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
+        server.start();
+        try {
+            var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
+            var request = HttpRequest.newBuilder(uri(server, "symlink")).build();
+            var response = client.send(request, BodyHandlers.ofString());
+            assertEquals(response.statusCode(), 404);
+            assertEquals(response.headers().firstValue("content-length").get(), expectedLength);
+            assertEquals(response.body(), expectedBody);
+        } finally {
+            server.stop(0);
         }
     }
 
@@ -424,27 +423,25 @@ public class CustomFileSystemTest {
         var symlink = root.resolve("symlink");
         var target = Files.createDirectory(root.resolve("target"));
         Files.writeString(target.resolve("aFile.txt"), "some text", CREATE);
-        if (createSymLink(symlink, target)) {  // sym link creation succeeded
+        createSymLink(symlink, target);
 
-            var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
-            server.start();
-            try {
-                var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
-                var request = HttpRequest.newBuilder(uri(server, "symlink/aFile.txt")).build();
-                var response = client.send(request, BodyHandlers.ofString());
-                assertEquals(response.statusCode(), 404);
-                assertEquals(response.headers().firstValue("content-length").get(), expectedLength);
-                assertEquals(response.body(), expectedBody);
-            } finally {
-                server.stop(0);
-            }
+        var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
+        server.start();
+        try {
+            var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
+            var request = HttpRequest.newBuilder(uri(server, "symlink/aFile.txt")).build();
+            var response = client.send(request, BodyHandlers.ofString());
+            assertEquals(response.statusCode(), 404);
+            assertEquals(response.headers().firstValue("content-length").get(), expectedLength);
+            assertEquals(response.body(), expectedBody);
+        } finally {
+            server.stop(0);
         }
     }
 
-    private boolean createSymLink(Path symlink, Path target) {
+    private void createSymLink(Path symlink, Path target) {
         try {
             Files.createSymbolicLink(symlink, target);
-            return true;
         } catch (UnsupportedOperationException uoe) {
             throw new SkipException("sym link creation not supported", uoe);
         } catch (IOException ioe) {

--- a/test/jdk/com/sun/net/httpserver/simpleserver/SimpleFileServerTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/SimpleFileServerTest.java
@@ -52,11 +52,11 @@ import com.sun.net.httpserver.SimpleFileServer.OutputLevel;
 import jdk.test.lib.Platform;
 import jdk.test.lib.net.URIBuilder;
 import jdk.test.lib.util.FileUtils;
-import jtreg.SkippedException;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.testng.SkipException;
 import static java.net.http.HttpClient.Builder.NO_PROXY;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardOpenOption.CREATE;
@@ -438,9 +438,9 @@ public class SimpleFileServerTest {
             Files.createSymbolicLink(symlink, target);
             return true;
         } catch (UnsupportedOperationException uoe) {
-            throw new SkippedException("sym link creation not supported", uoe);
+            throw new SkipException("sym link creation not supported", uoe);
         } catch (IOException ioe) {
-            throw new SkippedException("probably insufficient privileges to create sym links (Windows)", ioe);
+            throw new SkipException("probably insufficient privileges to create sym links (Windows)", ioe);
         }
     }
 

--- a/test/jdk/com/sun/net/httpserver/simpleserver/SimpleFileServerTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/SimpleFileServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,7 @@ import com.sun.net.httpserver.SimpleFileServer.OutputLevel;
 import jdk.test.lib.Platform;
 import jdk.test.lib.net.URIBuilder;
 import jdk.test.lib.util.FileUtils;
+import jtreg.SkippedException;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
@@ -387,19 +388,20 @@ public class SimpleFileServerTest {
         var root = Files.createDirectory(TEST_DIR.resolve("testSymlinkGET"));
         var symlink = root.resolve("symlink");
         var target = Files.writeString(root.resolve("target.txt"), "some text", CREATE);
-        Files.createSymbolicLink(symlink, target);
+        if (createSymLink(symlink, target)) {  // sym link creation succeeded
 
-        var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
-        server.start();
-        try {
-            var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
-            var request = HttpRequest.newBuilder(uri(server, "symlink")).build();
-            var response = client.send(request, BodyHandlers.ofString());
-            assertEquals(response.statusCode(), 404);
-            assertEquals(response.headers().firstValue("content-length").get(), expectedLength);
-            assertEquals(response.body(), expectedBody);
-        } finally {
-            server.stop(0);
+            var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
+            server.start();
+            try {
+                var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
+                var request = HttpRequest.newBuilder(uri(server, "symlink")).build();
+                var response = client.send(request, BodyHandlers.ofString());
+                assertEquals(response.statusCode(), 404);
+                assertEquals(response.headers().firstValue("content-length").get(), expectedLength);
+                assertEquals(response.body(), expectedBody);
+            } finally {
+                server.stop(0);
+            }
         }
     }
 
@@ -414,19 +416,31 @@ public class SimpleFileServerTest {
         var symlink = root.resolve("symlink");
         var target = Files.createDirectory(root.resolve("target"));
         Files.writeString(target.resolve("aFile.txt"), "some text", CREATE);
-        Files.createSymbolicLink(symlink, target);
+        if (createSymLink(symlink, target)) {  // sym link creation succeeded
 
-        var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
-        server.start();
+            var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
+            server.start();
+            try {
+                var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
+                var request = HttpRequest.newBuilder(uri(server, "symlink/aFile.txt")).build();
+                var response = client.send(request, BodyHandlers.ofString());
+                assertEquals(response.statusCode(), 404);
+                assertEquals(response.headers().firstValue("content-length").get(), expectedLength);
+                assertEquals(response.body(), expectedBody);
+            } finally {
+                server.stop(0);
+            }
+        }
+    }
+
+    private boolean createSymLink(Path symlink, Path target) {
         try {
-            var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
-            var request = HttpRequest.newBuilder(uri(server, "symlink/aFile.txt")).build();
-            var response = client.send(request, BodyHandlers.ofString());
-            assertEquals(response.statusCode(), 404);
-            assertEquals(response.headers().firstValue("content-length").get(), expectedLength);
-            assertEquals(response.body(), expectedBody);
-        } finally {
-            server.stop(0);
+            Files.createSymbolicLink(symlink, target);
+            return true;
+        } catch (UnsupportedOperationException uoe) {
+            throw new SkippedException("sym link creation not supported", uoe);
+        } catch (IOException ioe) {
+            throw new SkippedException("probably insufficient privileges to create sym links (Windows)", ioe);
         }
     }
 

--- a/test/jdk/com/sun/net/httpserver/simpleserver/SimpleFileServerTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/SimpleFileServerTest.java
@@ -388,20 +388,19 @@ public class SimpleFileServerTest {
         var root = Files.createDirectory(TEST_DIR.resolve("testSymlinkGET"));
         var symlink = root.resolve("symlink");
         var target = Files.writeString(root.resolve("target.txt"), "some text", CREATE);
-        if (createSymLink(symlink, target)) {  // sym link creation succeeded
+        createSymLink(symlink, target);
 
-            var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
-            server.start();
-            try {
-                var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
-                var request = HttpRequest.newBuilder(uri(server, "symlink")).build();
-                var response = client.send(request, BodyHandlers.ofString());
-                assertEquals(response.statusCode(), 404);
-                assertEquals(response.headers().firstValue("content-length").get(), expectedLength);
-                assertEquals(response.body(), expectedBody);
-            } finally {
-                server.stop(0);
-            }
+        var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
+        server.start();
+        try {
+            var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
+            var request = HttpRequest.newBuilder(uri(server, "symlink")).build();
+            var response = client.send(request, BodyHandlers.ofString());
+            assertEquals(response.statusCode(), 404);
+            assertEquals(response.headers().firstValue("content-length").get(), expectedLength);
+            assertEquals(response.body(), expectedBody);
+        } finally {
+            server.stop(0);
         }
     }
 
@@ -416,27 +415,25 @@ public class SimpleFileServerTest {
         var symlink = root.resolve("symlink");
         var target = Files.createDirectory(root.resolve("target"));
         Files.writeString(target.resolve("aFile.txt"), "some text", CREATE);
-        if (createSymLink(symlink, target)) {  // sym link creation succeeded
+        createSymLink(symlink, target);
 
-            var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
-            server.start();
-            try {
-                var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
-                var request = HttpRequest.newBuilder(uri(server, "symlink/aFile.txt")).build();
-                var response = client.send(request, BodyHandlers.ofString());
-                assertEquals(response.statusCode(), 404);
-                assertEquals(response.headers().firstValue("content-length").get(), expectedLength);
-                assertEquals(response.body(), expectedBody);
-            } finally {
-                server.stop(0);
-            }
+        var server = SimpleFileServer.createFileServer(LOOPBACK_ADDR, root, OutputLevel.VERBOSE);
+        server.start();
+        try {
+            var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
+            var request = HttpRequest.newBuilder(uri(server, "symlink/aFile.txt")).build();
+            var response = client.send(request, BodyHandlers.ofString());
+            assertEquals(response.statusCode(), 404);
+            assertEquals(response.headers().firstValue("content-length").get(), expectedLength);
+            assertEquals(response.body(), expectedBody);
+        } finally {
+            server.stop(0);
         }
     }
 
-    private boolean createSymLink(Path symlink, Path target) {
+    private void createSymLink(Path symlink, Path target) {
         try {
             Files.createSymbolicLink(symlink, target);
-            return true;
         } catch (UnsupportedOperationException uoe) {
             throw new SkipException("sym link creation not supported", uoe);
         } catch (IOException ioe) {


### PR DESCRIPTION
This change updates the tests in question to handle the case where sym link creation is not supported, as observed on Windows 11 where additional privileges are required to create sym links.

Testing: tier 1-3 across platforms, plus tests in question on Windows 11 specifically

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280965](https://bugs.openjdk.java.net/browse/JDK-8280965): Tests com/sun/net/httpserver/simpleserver fail with FileSystemException on Windows 11


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7335/head:pull/7335` \
`$ git checkout pull/7335`

Update a local copy of the PR: \
`$ git checkout pull/7335` \
`$ git pull https://git.openjdk.java.net/jdk pull/7335/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7335`

View PR using the GUI difftool: \
`$ git pr show -t 7335`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7335.diff">https://git.openjdk.java.net/jdk/pull/7335.diff</a>

</details>
