### PR TITLE
8281175: Add a -providerPath option to jarsigner

### DIFF
--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package sun.security.tools.jarsigner;
 
 import java.io.*;
 import java.net.UnknownHostException;
+import java.net.URLClassLoader;
 import java.security.cert.CertPathValidatorException;
 import java.security.cert.PKIXBuilderParameters;
 import java.util.*;
@@ -59,6 +60,7 @@ import sun.security.pkcs.SignerInfo;
 import sun.security.provider.certpath.CertPathConstraintsParameters;
 import sun.security.timestamp.TimestampToken;
 import sun.security.tools.KeyStoreUtil;
+import sun.security.tools.PathList;
 import sun.security.validator.Validator;
 import sun.security.validator.ValidatorException;
 import sun.security.x509.*;
@@ -152,6 +154,7 @@ public class Main {
     List<String> providerClasses = null; // list of provider classes
     // arguments for provider constructors
     HashMap<String,String> providerArgs = new HashMap<>();
+    String pathlist = null;
     char[] keypass; // private key password
     String sigfile; // name of .SF file
     String sigalg; // name of signature algorithm
@@ -246,7 +249,20 @@ public class Main {
             }
 
             if (providerClasses != null) {
-                ClassLoader cl = ClassLoader.getSystemClassLoader();
+                ClassLoader cl;
+                if (pathlist != null) {
+                    String path = null;
+                    path = PathList.appendPath(
+                            path, System.getProperty("java.class.path"));
+                    path = PathList.appendPath(
+                            path, System.getProperty("env.class.path"));
+                    path = PathList.appendPath(path, pathlist);
+
+                    URL[] urls = PathList.pathToURLs(path);
+                    cl = new URLClassLoader(urls);
+                } else {
+                    cl = ClassLoader.getSystemClassLoader();
+                }
                 for (String provClass: providerClasses) {
                     try {
                         KeyStoreUtil.loadProviderByClass(provClass,
@@ -434,6 +450,9 @@ public class Main {
                         n += 2;
                     }
                 }
+            } else if (collator.compare(flags, "-providerpath") == 0) {
+                if (++n == args.length) usageNoArg();
+                pathlist = args[n];
             } else if (collator.compare(flags, "-protected") ==0) {
                 protectedPath = true;
             } else if (collator.compare(flags, "-certchain") ==0) {
@@ -704,6 +723,9 @@ public class Main {
                 (".providerClass.option"));
         System.out.println(rb.getString
                 (".providerArg.option.2"));
+        System.out.println();
+        System.out.println(rb.getString
+                (".providerPath.option"));
         System.out.println();
         System.out.println(rb.getString
                 (".strict.treat.warnings.as.errors"));

--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Resources.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Resources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,6 +119,8 @@ public class Resources extends java.util.ListResourceBundle {
                 "[-providerClass <class>     add security provider by fully-qualified class name"},
         {".providerArg.option.2",
                 "  [-providerArg <arg>]] ... configure argument for -providerClass"},
+        {".providerPath.option",
+                "[-providerPath <list>]      provider classpath"},
         {".strict.treat.warnings.as.errors",
                 "[-strict]                   treat warnings as errors"},
         {".conf.url.specify.a.pre.configured.options.file",

--- a/test/jdk/sun/security/tools/jarsigner/AltProvider.java
+++ b/test/jdk/sun/security/tools/jarsigner/AltProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4906940 8130302 8194152
+ * @bug 4906940 8130302 8194152 8281175
  * @summary -providerPath, -providerClass, -addprovider, and -providerArg
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
@@ -81,33 +81,28 @@ public class AltProvider {
         // Without new provider
         testBoth("", 1, "DUMMYKS not found");
 
-        // legacy use (-providerPath only supported by keytool)
-        testKeytool("-providerPath mods/test.dummy " +
-                "-providerClass org.test.dummy.DummyProvider -providerArg full",
-                0, "loadProviderByClass: org.test.dummy.DummyProvider");
-
         // legacy, on classpath
-        testBoth("-J-cp -Jmods/test.dummy " +
+        testBoth("-providerpath mods/test.dummy " +
                 "-providerClass org.test.dummy.DummyProvider -providerArg full",
                 0, "loadProviderByClass: org.test.dummy.DummyProvider");
 
         // Wrong name
-        testBoth("-J-cp -Jmods/test.dummy " +
+        testBoth("-providerpath mods/test.dummy " +
                 "-providerClass org.test.dummy.Dummy -providerArg full",
                 1, "Provider \"org.test.dummy.Dummy\" not found");
 
         // Not a provider name
-        testBoth("-J-cp -Jmods/test.dummy " +
+        testBoth("-providerpath mods/test.dummy " +
                 "-providerClass java.lang.Object -providerArg full",
                 1, "java.lang.Object not a provider");
 
         // without arg
-        testBoth("-J-cp -Jmods/test.dummy " +
+        testBoth("-providerpath mods/test.dummy " +
                 "-providerClass org.test.dummy.DummyProvider",
                 1, "DUMMYKS not found");
 
         // old -provider still works
-        testBoth("-J-cp -Jmods/test.dummy " +
+        testBoth("-providerpath mods/test.dummy " +
                 "-provider org.test.dummy.DummyProvider -providerArg full",
                 0, "loadProviderByClass: org.test.dummy.DummyProvider");
 


### PR DESCRIPTION
Add the `-providerPath` option to jarsigner to be consistent with keytool.