### PR TITLE
8281259: MutableBigInteger subtraction could be simplified

### DIFF
--- a/src/java.base/share/classes/java/math/MutableBigInteger.java
+++ b/src/java.base/share/classes/java/math/MutableBigInteger.java
@@ -945,13 +945,13 @@ class MutableBigInteger {
             x--; y--;
 
             diff = (a.value[x+a.offset] & LONG_MASK) -
-                   (b.value[y+b.offset] & LONG_MASK) - ((int)-(diff>>32));
+                   (b.value[y+b.offset] & LONG_MASK) + (diff >> 32);
             result[rstart--] = (int)diff;
         }
         // Subtract remainder of longer number
         while (x > 0) {
             x--;
-            diff = (a.value[x+a.offset] & LONG_MASK) - ((int)-(diff>>32));
+            diff = (a.value[x+a.offset] & LONG_MASK) + (diff >> 32);
             result[rstart--] = (int)diff;
         }
 
@@ -986,13 +986,13 @@ class MutableBigInteger {
         while (y > 0) {
             x--; y--;
             diff = (a.value[a.offset+ x] & LONG_MASK) -
-                (b.value[b.offset+ y] & LONG_MASK) - ((int)-(diff>>32));
+                (b.value[b.offset+ y] & LONG_MASK) + (diff >> 32);
             a.value[a.offset+x] = (int)diff;
         }
         // Subtract remainder of longer number
         while (x > 0) {
             x--;
-            diff = (a.value[a.offset+ x] & LONG_MASK) - ((int)-(diff>>32));
+            diff = (a.value[a.offset+ x] & LONG_MASK) + (diff >> 32);
             a.value[a.offset+x] = (int)diff;
         }
 

--- a/src/java.base/share/classes/java/math/MutableBigInteger.java
+++ b/src/java.base/share/classes/java/math/MutableBigInteger.java
@@ -990,7 +990,7 @@ class MutableBigInteger {
             a.value[a.offset+x] = (int)diff;
         }
         // Subtract remainder of longer number
-        while (x > 0) {
+        while (diff < 0 && x > 0) {
             x--;
             diff = (a.value[a.offset+ x] & LONG_MASK) + (diff >> 32);
             a.value[a.offset+x] = (int)diff;

--- a/test/micro/org/openjdk/bench/java/math/BigIntegers.java
+++ b/test/micro/org/openjdk/bench/java/math/BigIntegers.java
@@ -207,4 +207,15 @@ public class BigIntegers {
             bh.consume(tmp);
         }
     }
+
+    /** Invokes the gcd method of BigInteger with different values. */
+    @Benchmark
+    @OperationsPerInvocation(TESTSIZE)
+    public void testGcd(Blackhole bh) {
+        for (int i = 0; i < TESTSIZE; i++) {
+            BigInteger i1 = shiftArray[TESTSIZE - i - 1];
+            BigInteger i2 = shiftArray[i];
+            bh.consume(i2.gcd(i1));
+        }
+    }
 }


### PR DESCRIPTION
The proposed form of borrow bit handling is [already used in BigInteger class](https://github.com/djelinski/jdk/blob/ce26a19be5e907c11164b46f1bcb370b534d5bf6/src/java.base/share/classes/java/math/BigInteger.java#L1558).

JMH results without the patch:
```
Benchmark            (maxNumbits)  Mode  Cnt        Score        Error  Units
BigIntegers.testGcd           256  avgt   25  3181205,367 ± 155272,427  ns/op
```
JMH results with the patch applied:
```
Benchmark            (maxNumbits)  Mode  Cnt        Score       Error  Units
BigIntegers.testGcd           256  avgt   25  2696030,849 ± 14141,940  ns/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281259](https://bugs.openjdk.java.net/browse/JDK-8281259): MutableBigInteger subtraction could be simplified


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7342/head:pull/7342` \
`$ git checkout pull/7342`

Update a local copy of the PR: \
`$ git checkout pull/7342` \
`$ git pull https://git.openjdk.java.net/jdk pull/7342/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7342`

View PR using the GUI difftool: \
`$ git pr show -t 7342`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7342.diff">https://git.openjdk.java.net/jdk/pull/7342.diff</a>

</details>
