### PR TITLE
8281262: Windows builds in different directories are not fully reproducible

### DIFF
--- a/make/TestImage.gmk
+++ b/make/TestImage.gmk
@@ -35,8 +35,8 @@ BUILD_INFO_PROPERTIES := $(TEST_IMAGE_DIR)/build-info.properties
 $(BUILD_INFO_PROPERTIES):
 	$(call MakeTargetDir)
 	$(ECHO) "# Build info properties for JDK tests" > $@
-	$(ECHO) "build.workspace.root=$(call FixPath, $(WORKSPACE_ROOT))" >> $@
-	$(ECHO) "build.output.root=$(call FixPath, $(OUTPUTDIR))" >> $@
+	$(ECHO) 'build.workspace.root=$(call FixPath, $(WORKSPACE_ROOT))' >> $@
+	$(ECHO) 'build.output.root=$(call FixPath, $(OUTPUTDIR))' >> $@
 
 README := $(TEST_IMAGE_DIR)/Readme.txt
 

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -782,10 +782,8 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
         test "x$ENABLE_REPRODUCIBLE_BUILD" = xtrue; then
       # There is a known issue with the pathmap if the mapping is made to the
       # empty string. Add a minimal string "s" as prefix to work around this.
-      workspace_root_win=`$FIXPATH_BASE print "${WORKSPACE_ROOT%/}"`
       # PATHMAP_FLAGS is also added to LDFLAGS in flags-ldflags.m4.
-      PATHMAP_FLAGS="-pathmap:${workspace_root_win//\//\\\\}=s \
-          -pathmap:${workspace_root_win}=s"
+      PATHMAP_FLAGS="-pathmap:${WORKSPACE_ROOT}=s"
       FILE_MACRO_CFLAGS="$PATHMAP_FLAGS"
       FLAGS_COMPILER_CHECK_ARGUMENTS(ARGUMENT: [${FILE_MACRO_CFLAGS}],
           PREFIX: $3,

--- a/test/jdk/build/AbsPathsInImage.java
+++ b/test/jdk/build/AbsPathsInImage.java
@@ -96,6 +96,13 @@ public class AbsPathsInImage {
         if (buildOutputRoot == null) {
             throw new Error("Could not find build output root, test cannot run");
         }
+        // Validate the root paths
+        if (!Paths.get(buildWorkspaceRoot).isAbsolute()) {
+            throw new Error("Workspace root is not an absolute path: " + buildWorkspaceRoot);
+        }
+        if (!Paths.get(buildOutputRoot).isAbsolute()) {
+            throw new Error("Output root is not an absolute path: " + buildOutputRoot);
+        }
 
         List<byte[]> searchPatterns = new ArrayList<>();
         expandPatterns(searchPatterns, buildWorkspaceRoot);


### PR DESCRIPTION
Some dll/exe files end up having absolute path names embedded in them despite the use of `--disable-absolute-paths-in-output` build option. This option effectively translates into adding `-pathmap` to compilation lines, but doesn't (always) achieve the desired effects. The reason for that is in the use of Windows-style path for the argument provided to `pathmap`. The slash characters in the path passed as an argument get removed by the `fixpath` script that pre-processes all commands on Windows prior to running them and is supposed to convert Unix-style paths to what is understood by Windows.

For example:
```
$ build/windows-x86_64-server-release/fixpath print -pathmap:C:\cygwin64\home\maxim\work\repr.build.1=s
-pathmap:C:cygwin64homemaximworkrepr.build.1=s
```
However, if a "normal" Unix-style path is provided, it gets converted correctly:
```
$ build/windows-x86_64-server-release/fixpath print -pathmap:/home/maxim/work/repr.build.1=s
-pathmap:C:\cygwin64\home\maxim\work\repr.build.1=s 
```

This commit changes the `-pathmap` compiler option to use "normal", Unix-style paths on Windows. Those will be changed to Windows style by the `fixpath` script. 

Verified by running two builds (details below) in different directories on the same machine; with this commit, all the exe/dll files under `.../images/jdk/...` are the same.


Builds were produced by running the following commands on Windows 10 x64 with Visual Studio 2019 installed:
```
 ./configure --with-debug-level=release --with-jvm-features=shenandoahgc --with-version-pre= --with-version-build=1 --with-version-opt=b42 --with-toolchain-version=2019 --disable-ccache --enable-cds=yes --enable-reproducible-build --with-source-date=1643953637 --with-hotspot-build-time=2022-02-04 --with-copyright-year=2022 --disable-absolute-paths-in-output --with-boot-jdk=/home/maxim/work/zulu17.0.81-ea-jdk17.0.0-ea.35-win_x64
make reconfigure clean
make images
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281262](https://bugs.openjdk.java.net/browse/JDK-8281262): Windows builds in different directories are not fully reproducible


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to c66ea187f4cfbb8ae554e180b620e1437e08b2c6
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to c66ea187f4cfbb8ae554e180b620e1437e08b2c6


### Contributors
 * Erik Joelsson `<erikj@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7344/head:pull/7344` \
`$ git checkout pull/7344`

Update a local copy of the PR: \
`$ git checkout pull/7344` \
`$ git pull https://git.openjdk.java.net/jdk pull/7344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7344`

View PR using the GUI difftool: \
`$ git pr show -t 7344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7344.diff">https://git.openjdk.java.net/jdk/pull/7344.diff</a>

</details>
