### PR TITLE
8281243: Test java/lang/instrument/RetransformWithMethodParametersTest.java is failing

### DIFF
--- a/test/jdk/java/lang/instrument/RetransformWithMethodParametersTest.java
+++ b/test/jdk/java/lang/instrument/RetransformWithMethodParametersTest.java
@@ -35,7 +35,7 @@
 import java.io.File;
 import java.io.FileOutputStream;
 import java.lang.instrument.ClassFileTransformer;
-import java.lang.reflect.Method;
+import java.lang.reflect.Executable;
 import java.lang.reflect.Parameter;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -59,10 +59,11 @@ import jdk.test.lib.util.ClassTransformer;
 class MethodParametersTarget {
     // The class contains the only method, so we don't have issue with method sorting
     // and ClassFileReconstituter should restore the same bytes as original classbytes.
-    public void method1(
+    // This method should be ctor, otherwise default ctor will be implicitly declared.
+    public MethodParametersTarget(
             int intParam1, String stringParam1 // @1 commentout
             // @1 uncomment   int intParam2, String stringParam2
-            )
+    )
     {
         // @1 uncomment System.out.println(stringParam2);   // change CP
     }
@@ -99,8 +100,8 @@ public class RetransformWithMethodParametersTest extends ATransformerManagementT
 
     private Parameter[] getTargetMethodParameters() throws ClassNotFoundException {
         Class cls = Class.forName(targetClassName);
-        // the class contains 1 method (method1)
-        Method method = cls.getDeclaredMethods()[0];
+        // the class contains 1 method (ctor)
+        Executable method = cls.getDeclaredConstructors()[0];
         Parameter[] params = method.getParameters();
         log("Params of " + method.getName() + " method (" + params.length + "):");
         for (int i = 0; i < params.length; i++) {
@@ -174,7 +175,7 @@ public class RetransformWithMethodParametersTest extends ATransformerManagementT
         }
         log("Class bytes are different.");
         printDisassembled("expected", expected);
-        printDisassembled("expected", actual);
+        printDisassembled("actual", actual);
         fail(targetClassName + " did not match .class file");
     }
 

--- a/test/jdk/java/lang/instrument/RetransformWithMethodParametersTest.java
+++ b/test/jdk/java/lang/instrument/RetransformWithMethodParametersTest.java
@@ -63,7 +63,7 @@ class MethodParametersTarget {
     public MethodParametersTarget(
             int intParam1, String stringParam1 // @1 commentout
             // @1 uncomment   int intParam2, String stringParam2
-    )
+            )
     {
         // @1 uncomment System.out.println(stringParam2);   // change CP
     }


### PR DESCRIPTION
The test expects ClassFileReconstituter restores exactly the same bytes as original classbytes.
This can be wrong if the class has more than 1 method (due to method sorting in the VM).
MethodParametersTarget class had only 1 method (method1), but didn't have constructors. This caused declaration of implicit default constructor, so the class actually had 2 methods.
The fix converts the method to constructor to avoid default constructor declaration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281243](https://bugs.openjdk.java.net/browse/JDK-8281243): Test java/lang/instrument/RetransformWithMethodParametersTest.java is failing


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7345/head:pull/7345` \
`$ git checkout pull/7345`

Update a local copy of the PR: \
`$ git checkout pull/7345` \
`$ git pull https://git.openjdk.java.net/jdk pull/7345/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7345`

View PR using the GUI difftool: \
`$ git pr show -t 7345`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7345.diff">https://git.openjdk.java.net/jdk/pull/7345.diff</a>

</details>
