### PR TITLE
8281263: virtual space leakage if large page commit fails.

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4028,18 +4028,16 @@ char* os::Linux::reserve_memory_special_huge_tlbfs(size_t bytes,
   char* small_start = aligned_start + large_bytes;
   size_t small_size = bytes - large_bytes;
   if (!large_committed) {
-    // Failed to commit large pages, so we need to unmap the
-    // reminder of the orinal reservation.
-    ::munmap(small_start, small_size);
+    // Failed to commit large pages, so we need to unmap the whole reservation.
+    ::munmap(aligned_start, bytes);
     return NULL;
   }
 
   // Commit the remaining bytes using small pages.
   bool small_committed = commit_memory_special(small_size, os::vm_page_size(), small_start, exec);
   if (!small_committed) {
-    // Failed to commit the remaining size, need to unmap
-    // the large pages part of the reservation.
-    ::munmap(aligned_start, large_bytes);
+    // Failed to commit the remaining size, need to unmap the whole reservation.
+    ::munmap(aligned_start, bytes);
     return NULL;
   }
   return aligned_start;


### PR DESCRIPTION
Hi Team,

In this patch I have fixed the virtual space leakage issue. While attempting commit over larger pages we first try to reserve requested bytes over the virtual address space, in case commit to large page fails we should be un reserving entire reservation to avoid leaving any leaks in virtual address space.

Please review and provide your valuable comments.


Thanks,
Swati Sharma
Runtime Software Development Engineer 
Intel

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8281263](https://bugs.openjdk.java.net/browse/JDK-8281263): virtual space leakage if large page commit fails.


### Contributors
 * Jatin Bhateja `<jbhateja@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7350/head:pull/7350` \
`$ git checkout pull/7350`

Update a local copy of the PR: \
`$ git checkout pull/7350` \
`$ git pull https://git.openjdk.java.net/jdk pull/7350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7350`

View PR using the GUI difftool: \
`$ git pr show -t 7350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7350.diff">https://git.openjdk.java.net/jdk/pull/7350.diff</a>

</details>
