### PR TITLE
8272996: JNDI DNS provider fails to resolve SRV entries when IPV6 stack is enabled

### DIFF
--- a/src/jdk.naming.dns/share/classes/com/sun/jndi/dns/DnsClient.java
+++ b/src/jdk.naming.dns/share/classes/com/sun/jndi/dns/DnsClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,10 +26,12 @@
 package com.sun.jndi.dns;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.DatagramSocket;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.PortUnreachableException;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.security.SecureRandom;
@@ -275,19 +277,22 @@ public class DnsClient {
                             } // servers
                         }
                         return new ResourceRecords(msg, msg.length, hdr, false);
-
+                    } catch (UncheckedIOException | PortUnreachableException ex) {
+                        // DatagramSocket.connect in doUdpQuery can throw UncheckedIOException
+                        // DatagramSocket.send in doUdpQuery can throw PortUnreachableException
+                        if (debug) {
+                            dprint("Caught Exception:" + ex);
+                        }
+                        if (caughtException == null) {
+                            caughtException = ex;
+                        }
+                        doNotRetry[i] = true;
                     } catch (IOException e) {
                         if (debug) {
                             dprint("Caught IOException:" + e);
                         }
                         if (caughtException == null) {
                             caughtException = e;
-                        }
-                        // Use reflection to allow pre-1.4 compilation.
-                        // This won't be needed much longer.
-                        if (e.getClass().getName().equals(
-                                "java.net.PortUnreachableException")) {
-                            doNotRetry[i] = true;
                         }
                     } catch (NameNotFoundException e) {
                         // This is authoritative, so return immediately


### PR DESCRIPTION
Hi,

JNDI's `DnsClient` can fail with `UncheckedIOException` during `connect` or `disconnect` method calls. It is a [know behavior](https://bugs.openjdk.java.net/browse/JDK-8236076) of `DatagramSocket`.

Currently, `DnsClient` method fast-fails when `UncheckedIOException` is observed during connect attempt. But it supposed to mark such server as invalid and continue checking other servers.

Testing: tier1, tier2, tier3 and existing JCK tests show no failures relevant to the proposed changed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272996](https://bugs.openjdk.java.net/browse/JDK-8272996): JNDI DNS provider fails to resolve SRV entries when IPV6 stack is enabled


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7353/head:pull/7353` \
`$ git checkout pull/7353`

Update a local copy of the PR: \
`$ git checkout pull/7353` \
`$ git pull https://git.openjdk.java.net/jdk pull/7353/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7353`

View PR using the GUI difftool: \
`$ git pr show -t 7353`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7353.diff">https://git.openjdk.java.net/jdk/pull/7353.diff</a>

</details>
