### PR TITLE
JDK-8281274: deal with ActiveProcessorCount in os::Linux::print_container_info

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2175,7 +2175,7 @@ bool os::Linux::print_container_info(outputStream* st) {
   st->print("active_processor_count: ");
   if (i > 0) {
     if (ActiveProcessorCount > 0) {
-      st->print_cr("%d, but overridden by -XX:ActiveProcessorCount", i);
+      st->print_cr("%d, but overridden by -XX:ActiveProcessorCount %d", i, ActiveProcessorCount);
     } else {
       st->print_cr("%d", i);
     }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2174,7 +2174,12 @@ bool os::Linux::print_container_info(outputStream* st) {
   int i = OSContainer::active_processor_count();
   st->print("active_processor_count: ");
   if (i > 0) {
-    st->print_cr("%d", i);
+    if (ActiveProcessorCount > 0) {
+      st->print_cr("%d, but overwritten by flag ActiveProcessorCount: %d",
+                i, ActiveProcessorCount);
+    } else {
+      st->print_cr("%d", i);
+    }
   } else {
     st->print_cr("not supported");
   }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2175,8 +2175,7 @@ bool os::Linux::print_container_info(outputStream* st) {
   st->print("active_processor_count: ");
   if (i > 0) {
     if (ActiveProcessorCount > 0) {
-      st->print_cr("%d, but overwritten by flag ActiveProcessorCount: %d",
-                i, ActiveProcessorCount);
+      st->print_cr("%d, but overridden by -XX:ActiveProcessorCount", i);
     } else {
       st->print_cr("%d", i);
     }

--- a/test/hotspot/jtreg/containers/docker/TestMisc.java
+++ b/test/hotspot/jtreg/containers/docker/TestMisc.java
@@ -56,6 +56,7 @@ public class TestMisc {
             testMinusContainerSupport();
             testIsContainerized();
             testPrintContainerInfo();
+            testPrintContainerInfoActiveProcessorCount();
         } finally {
             DockerTestUtils.removeDockerImage(imageName);
         }
@@ -86,14 +87,23 @@ public class TestMisc {
     private static void testPrintContainerInfo() throws Exception {
         Common.logNewTestCase("Test print_container_info()");
 
+        DockerRunOptions opts = Common.newOpts(imageName, "PrintContainerInfo");
+        Common.addWhiteBoxOpts(opts);
+
+        checkContainerInfo(Common.run(opts), null);
+    }
+
+    private static void testPrintContainerInfoActiveProcessorCount() throws Exception {
+        Common.logNewTestCase("Test print_container_info()");
+
         DockerRunOptions opts = Common.newOpts(imageName, "PrintContainerInfo", "-XX:ActiveProcessorCount=2");
         Common.addWhiteBoxOpts(opts);
 
-        checkContainerInfo(Common.run(opts));
+        checkContainerInfo(Common.run(opts), "but overridden by -XX:ActiveProcessorCount 2");
     }
 
 
-    private static void checkContainerInfo(OutputAnalyzer out) throws Exception {
+    private static void checkContainerInfo(OutputAnalyzer out, String additionallyExpected) throws Exception {
         String[] expectedToContain = new String[] {
             "cpuset.cpus",
             "cpuset.mems",
@@ -101,7 +111,6 @@ public class TestMisc {
             "CPU Quota",
             "CPU Period",
             "OSContainer::active_processor_count",
-            "but overridden by -XX:ActiveProcessorCount 2",
             "Memory Limit",
             "Memory Soft Limit",
             "Memory Usage",
@@ -114,6 +123,7 @@ public class TestMisc {
         for (String s : expectedToContain) {
             out.shouldContain(s);
         }
+        if (additionallyExpected != null) out.shouldContain(additionallyExpected);
     }
 
 }

--- a/test/hotspot/jtreg/containers/docker/TestMisc.java
+++ b/test/hotspot/jtreg/containers/docker/TestMisc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,7 +86,7 @@ public class TestMisc {
     private static void testPrintContainerInfo() throws Exception {
         Common.logNewTestCase("Test print_container_info()");
 
-        DockerRunOptions opts = Common.newOpts(imageName, "PrintContainerInfo");
+        DockerRunOptions opts = Common.newOpts(imageName, "PrintContainerInfo", "-XX:ActiveProcessorCount=2");
         Common.addWhiteBoxOpts(opts);
 
         checkContainerInfo(Common.run(opts));
@@ -101,6 +101,7 @@ public class TestMisc {
             "CPU Quota",
             "CPU Period",
             "OSContainer::active_processor_count",
+            "but overridden by -XX:ActiveProcessorCount 2",
             "Memory Limit",
             "Memory Soft Limit",
             "Memory Usage",

--- a/test/hotspot/jtreg/containers/docker/TestMisc.java
+++ b/test/hotspot/jtreg/containers/docker/TestMisc.java
@@ -90,20 +90,20 @@ public class TestMisc {
         DockerRunOptions opts = Common.newOpts(imageName, "PrintContainerInfo");
         Common.addWhiteBoxOpts(opts);
 
-        checkContainerInfo(Common.run(opts), null);
+        checkContainerInfo(Common.run(opts));
     }
 
     private static void testPrintContainerInfoActiveProcessorCount() throws Exception {
         Common.logNewTestCase("Test print_container_info()");
 
-        DockerRunOptions opts = Common.newOpts(imageName, "PrintContainerInfo", "-XX:ActiveProcessorCount=2");
+        DockerRunOptions opts = Common.newOpts(imageName, "PrintContainerInfo").addJavaOpts("-XX:ActiveProcessorCount=2");
         Common.addWhiteBoxOpts(opts);
 
-        checkContainerInfo(Common.run(opts), "but overridden by -XX:ActiveProcessorCount 2");
+        OutputAnalyzer out = Common.run(opts);
+        out.shouldContain("but overridden by -XX:ActiveProcessorCount 2");
     }
 
-
-    private static void checkContainerInfo(OutputAnalyzer out, String additionallyExpected) throws Exception {
+    private static void checkContainerInfo(OutputAnalyzer out) throws Exception {
         String[] expectedToContain = new String[] {
             "cpuset.cpus",
             "cpuset.mems",
@@ -123,7 +123,6 @@ public class TestMisc {
         for (String s : expectedToContain) {
             out.shouldContain(s);
         }
-        if (additionallyExpected != null) out.shouldContain(additionallyExpected);
     }
 
 }

--- a/test/lib/jdk/test/lib/containers/docker/Common.java
+++ b/test/lib/jdk/test/lib/containers/docker/Common.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,17 +64,13 @@ public class Common {
 
     // create commonly used options with class to be launched inside container
     public static DockerRunOptions newOpts(String imageNameAndTag, String testClass) {
-        return newOpts(imageNameAndTag, testClass, null);
-    }
-
-    public static DockerRunOptions newOpts(String imageNameAndTag, String testClass, String addJavaOpts) {
         DockerRunOptions opts =
             new DockerRunOptions(imageNameAndTag, "/jdk/bin/java", testClass);
         opts.addDockerOpts("--volume", Utils.TEST_CLASSES + ":/test-classes/");
         opts.addJavaOpts("-Xlog:os+container=trace", "-cp", "/test-classes/");
-        if (addJavaOpts != null) opts.addJavaOpts(addJavaOpts);
         return opts;
     }
+
 
     public static DockerRunOptions addWhiteBoxOpts(DockerRunOptions opts) {
         opts.addJavaOpts("-Xbootclasspath/a:/test-classes/whitebox.jar",

--- a/test/lib/jdk/test/lib/containers/docker/Common.java
+++ b/test/lib/jdk/test/lib/containers/docker/Common.java
@@ -64,11 +64,7 @@ public class Common {
 
     // create commonly used options with class to be launched inside container
     public static DockerRunOptions newOpts(String imageNameAndTag, String testClass) {
-        DockerRunOptions opts =
-            new DockerRunOptions(imageNameAndTag, "/jdk/bin/java", testClass);
-        opts.addDockerOpts("--volume", Utils.TEST_CLASSES + ":/test-classes/");
-        opts.addJavaOpts("-Xlog:os+container=trace", "-cp", "/test-classes/");
-        return opts;
+        return newOpts(imageNameAndTag, testClass, null);
     }
 
     public static DockerRunOptions newOpts(String imageNameAndTag, String testClass, String addJavaOpts) {
@@ -76,7 +72,7 @@ public class Common {
             new DockerRunOptions(imageNameAndTag, "/jdk/bin/java", testClass);
         opts.addDockerOpts("--volume", Utils.TEST_CLASSES + ":/test-classes/");
         opts.addJavaOpts("-Xlog:os+container=trace", "-cp", "/test-classes/");
-        opts.addJavaOpts(addJavaOpts);
+        if (addJavaOpts != null) opts.addJavaOpts(addJavaOpts);
         return opts;
     }
 

--- a/test/lib/jdk/test/lib/containers/docker/Common.java
+++ b/test/lib/jdk/test/lib/containers/docker/Common.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,6 +71,14 @@ public class Common {
         return opts;
     }
 
+    public static DockerRunOptions newOpts(String imageNameAndTag, String testClass, String addJavaOpts) {
+        DockerRunOptions opts =
+            new DockerRunOptions(imageNameAndTag, "/jdk/bin/java", testClass);
+        opts.addDockerOpts("--volume", Utils.TEST_CLASSES + ":/test-classes/");
+        opts.addJavaOpts("-Xlog:os+container=trace", "-cp", "/test-classes/");
+        opts.addJavaOpts(addJavaOpts);
+        return opts;
+    }
 
     public static DockerRunOptions addWhiteBoxOpts(DockerRunOptions opts) {
         opts.addJavaOpts("-Xbootclasspath/a:/test-classes/whitebox.jar",


### PR DESCRIPTION
The function os::Linux::print_container_info outputs memory- and cpu-related container information (when running in a containerized environment).
However in the case of active processor count , it currently just outputs the info from OSContainer::active_processor_count without  looking at  ActiveProcessorCount that can be set to overwrite the OSContainer::active_processor_count() - information. This should be improved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281274](https://bugs.openjdk.java.net/browse/JDK-8281274): deal with ActiveProcessorCount in os::Linux::print_container_info


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to 2d84545672189daadc3abf97a0d3b0c562d43ff1
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 2d84545672189daadc3abf97a0d3b0c562d43ff1
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to 293524211b130dc1187ec909828620f651fc5e68


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7354/head:pull/7354` \
`$ git checkout pull/7354`

Update a local copy of the PR: \
`$ git checkout pull/7354` \
`$ git pull https://git.openjdk.java.net/jdk pull/7354/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7354`

View PR using the GUI difftool: \
`$ git pr show -t 7354`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7354.diff">https://git.openjdk.java.net/jdk/pull/7354.diff</a>

</details>
