### PR TITLE
8274238: Inconsistent type for young_list_target_length()

### DIFF
--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -382,7 +382,7 @@ public:
   // This must be called at the very beginning of an evacuation pause.
   void decide_on_concurrent_start_pause();
 
-  size_t young_list_target_length() const { return _young_list_target_length; }
+  uint young_list_target_length() const { return _young_list_target_length; }
 
   bool should_allocate_mutator_region() const;
 


### PR DESCRIPTION
This is a cleanup PR that changes the return type for G1Policy::young_list_target_length() to uint in order to be consistent with the underlying variable and all related variables and functions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274238](https://bugs.openjdk.java.net/browse/JDK-8274238): Inconsistent type for young_list_target_length()


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7357/head:pull/7357` \
`$ git checkout pull/7357`

Update a local copy of the PR: \
`$ git checkout pull/7357` \
`$ git pull https://git.openjdk.java.net/jdk pull/7357/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7357`

View PR using the GUI difftool: \
`$ git pr show -t 7357`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7357.diff">https://git.openjdk.java.net/jdk/pull/7357.diff</a>

</details>
