### PR TITLE
JDK-8281183: RandomGenerator:NextDouble() default behavior partially fixed by JDK-8280950

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
@@ -677,7 +677,7 @@ public class RandomSupport {
         double r = rng.nextDouble();
         r = r * bound;
         if (r >= bound)  // may need to correct a rounding problem
-            r = Math.nextDown(r);
+            r = Math.nextDown(bound);
         return r;
     }
 

--- a/test/jdk/java/util/Random/RandomNextDoubleBoundary.java
+++ b/test/jdk/java/util/Random/RandomNextDoubleBoundary.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @summary Verify nextDouble stays within range
- * @bug 8280550 8280950
+ * @bug 8280550 8280950 8281183
  */
 
 import java.util.SplittableRandom;
@@ -79,8 +79,11 @@ public class RandomNextDoubleBoundary {
         };
         double value = rg.nextDouble(origin, bound);
 
-        assertTrue(value >= origin);
-        assertTrue(value < bound);
+        if (bound > 0) {
+            value = rg.nextDouble(bound); // Equivalent to nextDouble(0.0, bound)
+            assertTrue(value >= 0.0);
+            assertTrue(value < bound);
+        }
     }
 
     public static void assertTrue(boolean condition) {


### PR DESCRIPTION
Third time should be the charm to get this issue of out-of-bounds random numbers fully fixed; sorry for the noise.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281183](https://bugs.openjdk.java.net/browse/JDK-8281183): RandomGenerator:NextDouble() default behavior partially fixed by JDK-8280950


### Reviewers
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7360/head:pull/7360` \
`$ git checkout pull/7360`

Update a local copy of the PR: \
`$ git checkout pull/7360` \
`$ git pull https://git.openjdk.java.net/jdk pull/7360/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7360`

View PR using the GUI difftool: \
`$ git pr show -t 7360`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7360.diff">https://git.openjdk.java.net/jdk/pull/7360.diff</a>

</details>
