### PR TITLE
8281309: x86: Select better stack banging instruction

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -3456,6 +3456,13 @@ void Assembler::movzwl(Register dst, Register src) { // movzxw
   emit_int24(0x0F, (unsigned char)0xB7, 0xC0 | encode);
 }
 
+void Assembler::movntil(Address dst, Register src) {
+  InstructionMark im(this);
+  prefix(dst);
+  emit_int16((unsigned char)0x0F, (unsigned char)0xC3);
+  emit_operand(src, dst);
+}
+
 void Assembler::mull(Address src) {
   InstructionMark im(this);
   prefix(src);
@@ -12533,6 +12540,13 @@ void Assembler::movzwq(Register dst, Address src) {
 void Assembler::movzwq(Register dst, Register src) {
   int encode = prefixq_and_encode(dst->encoding(), src->encoding());
   emit_int24(0x0F, (unsigned char)0xB7, (0xC0 | encode));
+}
+
+void Assembler::movntiq(Address dst, Register src) {
+  InstructionMark im(this);
+  prefixq(dst);
+  emit_int16((unsigned char)0x0F, (unsigned char)0xC3);
+  emit_operand(src, dst);
 }
 
 void Assembler::mulq(Address src) {

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -1652,6 +1652,12 @@ private:
   void movzwq(Register dst, Register src);
 #endif
 
+  void movntil(Address dst, Register src);
+
+#ifdef _LP64
+  void movntiq(Address dst, Register src);
+#endif
+
   // Unsigned multiply with RAX destination register
   void mull(Address src);
   void mull(Register src);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1272,7 +1272,7 @@ void MacroAssembler::bang_stack_size(Register size, Register tmp) {
   for (int i = 1; i < ((int)StackOverflow::stack_shadow_zone_size() / os::vm_page_size()); i++) {
     // this could be any sized move but this is can be a debugging crumb
     // so the bigger the better.
-    testptr(tmp, Address(tmp, (-i*os::vm_page_size())));
+    bang_stack_with_offset(i*os::vm_page_size());
   }
 }
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1281,6 +1281,9 @@ void MacroAssembler::bang_stack_size(Register size, Register tmp) {
     case 6:
       testptr(size, Address(tmp, (-os::vm_page_size())));
       break;
+    case 7:
+      movntiptr(Address(tmp, (-os::vm_page_size())), size);
+      break;
     default:
       ShouldNotReachHere();
   }
@@ -1319,6 +1322,9 @@ void MacroAssembler::bang_stack_size(Register size, Register tmp) {
         break;
       case 6:
         testptr(size, Address(tmp, (-os::vm_page_size())));
+        break;
+      case 7:
+        movntiptr(Address(tmp, (-os::vm_page_size())), size);
         break;
       default:
         ShouldNotReachHere();
@@ -2545,6 +2551,10 @@ void MacroAssembler::movptr(Register dst, intptr_t src) {
 
 void MacroAssembler::movptr(Address dst, Register src) {
   LP64_ONLY(movq(dst, src)) NOT_LP64(movl(dst, src));
+}
+
+void MacroAssembler::movntiptr(Address dst, Register src) {
+  LP64_ONLY(movntiq(dst, src)) NOT_LP64(movntil(dst, src));
 }
 
 void MacroAssembler::movdqu(Address dst, XMMRegister src) {

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1272,7 +1272,7 @@ void MacroAssembler::bang_stack_size(Register size, Register tmp) {
   for (int i = 1; i < ((int)StackOverflow::stack_shadow_zone_size() / os::vm_page_size()); i++) {
     // this could be any sized move but this is can be a debugging crumb
     // so the bigger the better.
-    movptr(Address(tmp, (-i*os::vm_page_size())), size );
+    testptr(tmp, Address(tmp, (-i*os::vm_page_size())));
   }
 }
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1258,7 +1258,33 @@ void MacroAssembler::bang_stack_size(Register size, Register tmp) {
   // red zones.
   Label loop;
   bind(loop);
-  movl(Address(tmp, (-os::vm_page_size())), size );
+
+  switch (StackBangStyle) {
+    case 0:
+      // Dangerous.
+      break;
+    case 1:
+      movl(Address(tmp, (-os::vm_page_size())), size);
+      break;
+    case 2:
+      movb(Address(tmp, (-os::vm_page_size())), 0);
+      break;
+    case 3:
+      movptr(Address(tmp, (-os::vm_page_size())), size);
+      break;
+    case 4:
+      testl(size, Address(tmp, (-os::vm_page_size())));
+      break;
+    case 5:
+      testb(Address(tmp, (-os::vm_page_size())), 0);
+      break;
+    case 6:
+      testptr(size, Address(tmp, (-os::vm_page_size())));
+      break;
+    default:
+      ShouldNotReachHere();
+  }
+
   subptr(tmp, os::vm_page_size());
   subl(size, os::vm_page_size());
   jcc(Assembler::greater, loop);
@@ -1272,7 +1298,31 @@ void MacroAssembler::bang_stack_size(Register size, Register tmp) {
   for (int i = 1; i < ((int)StackOverflow::stack_shadow_zone_size() / os::vm_page_size()); i++) {
     // this could be any sized move but this is can be a debugging crumb
     // so the bigger the better.
-    bang_stack_with_offset(i*os::vm_page_size());
+    switch (StackBangStyle) {
+      case 0:
+        // Dangerous.
+        break;
+      case 1:
+        movl(Address(tmp, (-os::vm_page_size())), size);
+        break;
+      case 2:
+        movb(Address(tmp, (-os::vm_page_size())), 0);
+        break;
+      case 3:
+        movptr(Address(tmp, (-os::vm_page_size())), size);
+        break;
+      case 4:
+        testl(size, Address(tmp, (-os::vm_page_size())));
+        break;
+      case 5:
+        testb(Address(tmp, (-os::vm_page_size())), 0);
+        break;
+      case 6:
+        testptr(size, Address(tmp, (-os::vm_page_size())));
+        break;
+      default:
+        ShouldNotReachHere();
+    }
   }
 }
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -659,7 +659,25 @@ class MacroAssembler: public Assembler {
   void bang_stack_with_offset(int offset) {
     // stack grows down, caller passes positive offset
     assert(offset > 0, "must bang with negative offset");
-    testptr(rax, Address(rsp, (-offset)));
+    switch (StackBangStyle) {
+      case 0:
+        movptr(Address(rsp, (-offset)), rax);
+        break;
+      case 1:
+        movptr(Address(rsp, (-offset)), rsp);
+        break;
+      case 2:
+        testptr(rax, Address(rsp, (-offset)));
+        break;
+      case 3:
+        testptr(rsp, Address(rsp, (-offset)));
+        break;
+      case 4:
+        prefetchnta(Address(rsp, (-offset)));
+        break;
+      default:
+        ShouldNotReachHere();
+    }
   }
 
   // Writes to stack successive pages until offset reached to check for

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -659,7 +659,7 @@ class MacroAssembler: public Assembler {
   void bang_stack_with_offset(int offset) {
     // stack grows down, caller passes positive offset
     assert(offset > 0, "must bang with negative offset");
-    movl(Address(rsp, (-offset)), rax);
+    testptr(rax, Address(rsp, (-offset)));
   }
 
   // Writes to stack successive pages until offset reached to check for

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -681,6 +681,9 @@ class MacroAssembler: public Assembler {
       case 6:
         testptr(rax, Address(rsp, (-offset)));
         break;
+      case 7:
+        movntiptr(Address(rsp, (-offset)), rax);
+        break;
       default:
         ShouldNotReachHere();
     }
@@ -1810,6 +1813,8 @@ public:
   void movptr(Address dst, int32_t imm32);
   void movptr(Register dst, int32_t imm32);
 #endif // _LP64
+
+  void movntiptr(Address dst, Register src);
 
   // to avoid hiding movl
   void mov32(AddressLiteral dst, Register src);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -661,18 +661,21 @@ class MacroAssembler: public Assembler {
     assert(offset > 0, "must bang with negative offset");
     switch (StackBangStyle) {
       case 0:
-        movptr(Address(rsp, (-offset)), rax);
+        // Dangerous.
         break;
       case 1:
-        movptr(Address(rsp, (-offset)), rsp);
+        movptr(Address(rsp, (-offset)), rax);
         break;
       case 2:
-        testptr(rax, Address(rsp, (-offset)));
+        movptr(Address(rsp, (-offset)), rsp);
         break;
       case 3:
-        testptr(rsp, Address(rsp, (-offset)));
+        testptr(rax, Address(rsp, (-offset)));
         break;
       case 4:
+        testptr(rsp, Address(rsp, (-offset)));
+        break;
+      case 5:
         prefetchnta(Address(rsp, (-offset)));
         break;
       default:

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -664,19 +664,22 @@ class MacroAssembler: public Assembler {
         // Dangerous.
         break;
       case 1:
-        movptr(Address(rsp, (-offset)), rax);
+        movl(Address(rsp, (-offset)), rax);
         break;
       case 2:
-        movptr(Address(rsp, (-offset)), rsp);
+        movb(Address(rsp, (-offset)), 0);
         break;
       case 3:
-        testptr(rax, Address(rsp, (-offset)));
+        movptr(Address(rsp, (-offset)), rax);
         break;
       case 4:
-        testptr(rsp, Address(rsp, (-offset)));
+        testl(rax, Address(rsp, (-offset)));
         break;
       case 5:
-        prefetchnta(Address(rsp, (-offset)));
+        testb(Address(rsp, (-offset)), 0);
+        break;
+      case 6:
+        testptr(rax, Address(rsp, (-offset)));
         break;
       default:
         ShouldNotReachHere();

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2012,6 +2012,9 @@ const intx ObjectAlignmentInBytes = 8;
   JFR_ONLY(product(ccstr, StartFlightRecording, NULL,                       \
           "Start flight recording with options"))                           \
                                                                             \
+  product(int, StackBangStyle, 0, EXPERIMENTAL,                             \
+          "Use a particular stack bang style")                              \
+                                                                            \
   product(bool, UseFastUnorderedTimeStamps, false, EXPERIMENTAL,            \
           "Use platform unstable time where supported for timestamps only") \
                                                                             \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2012,7 +2012,7 @@ const intx ObjectAlignmentInBytes = 8;
   JFR_ONLY(product(ccstr, StartFlightRecording, NULL,                       \
           "Start flight recording with options"))                           \
                                                                             \
-  product(int, StackBangStyle, 0, EXPERIMENTAL,                             \
+  product(int, StackBangStyle, 1, EXPERIMENTAL,                             \
           "Use a particular stack bang style")                              \
                                                                             \
   product(bool, UseFastUnorderedTimeStamps, false, EXPERIMENTAL,            \


### PR DESCRIPTION
WIP.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8281309](https://bugs.openjdk.java.net/browse/JDK-8281309): x86: Select better stack banging instruction


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7361/head:pull/7361` \
`$ git checkout pull/7361`

Update a local copy of the PR: \
`$ git checkout pull/7361` \
`$ git pull https://git.openjdk.java.net/jdk pull/7361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7361`

View PR using the GUI difftool: \
`$ git pr show -t 7361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7361.diff">https://git.openjdk.java.net/jdk/pull/7361.diff</a>

</details>
