### PR TITLE
8281314: Rename Stack{Red,Yellow,Reserved,Shadow}Pages multipliers

### DIFF
--- a/src/hotspot/share/runtime/stackOverflow.cpp
+++ b/src/hotspot/share/runtime/stackOverflow.cpp
@@ -39,9 +39,10 @@ void StackOverflow::initialize_stack_zone_sizes() {
   // Stack zone sizes must be page aligned.
   size_t page_size = os::vm_page_size();
 
-  // We need to adapt the configured number of stack protection pages given
-  // in 4K pages to the actual os page size. We must do this before setting
-  // up minimal stack sizes etc. in os::init_2().
+  // We need to adapt the configured number of stack protection pages to the
+  // actual OS page size. We must do this before setting up minimal stack
+  // sizes etc. in os::init_2(). The option values are given in the 4K units,
+  // matching the smallest page size in supported platforms.
   size_t unit = 4*K;
 
   assert(_stack_red_zone_size == 0, "This should be called only once.");

--- a/src/hotspot/share/runtime/stackOverflow.cpp
+++ b/src/hotspot/share/runtime/stackOverflow.cpp
@@ -41,7 +41,7 @@ void StackOverflow::initialize_stack_zone_sizes() {
 
   // We need to adapt the configured number of stack protection pages to the
   // actual OS page size. We must do this before setting up minimal stack
-  // sizes etc. in os::init_2(). The option values are given in the 4K units,
+  // sizes etc. in os::init_2(). The option values are given in 4K units,
   // matching the smallest page size in supported platforms.
   size_t unit = 4*K;
 

--- a/src/hotspot/share/runtime/stackOverflow.cpp
+++ b/src/hotspot/share/runtime/stackOverflow.cpp
@@ -42,16 +42,16 @@ void StackOverflow::initialize_stack_zone_sizes() {
   // We need to adapt the configured number of stack protection pages given
   // in 4K pages to the actual os page size. We must do this before setting
   // up minimal stack sizes etc. in os::init_2().
-  size_t alignment = 4*K;
+  size_t unit = 4*K;
 
   assert(_stack_red_zone_size == 0, "This should be called only once.");
-  _stack_red_zone_size = align_up(StackRedPages * alignment, page_size);
+  _stack_red_zone_size = align_up(StackRedPages * unit, page_size);
 
   assert(_stack_yellow_zone_size == 0, "This should be called only once.");
-  _stack_yellow_zone_size = align_up(StackYellowPages * alignment, page_size);
+  _stack_yellow_zone_size = align_up(StackYellowPages * unit, page_size);
 
   assert(_stack_reserved_zone_size == 0, "This should be called only once.");
-  _stack_reserved_zone_size = align_up(StackReservedPages * alignment, page_size);
+  _stack_reserved_zone_size = align_up(StackReservedPages * unit, page_size);
 
   // The shadow area is not allocated or protected, so
   // it needs not be page aligned.
@@ -63,7 +63,7 @@ void StackOverflow::initialize_stack_zone_sizes() {
   // suffices to touch all pages. (Some pages are banged
   // several times, though.)
   assert(_stack_shadow_zone_size == 0, "This should be called only once.");
-  _stack_shadow_zone_size = align_up(StackShadowPages * alignment, page_size);
+  _stack_shadow_zone_size = align_up(StackShadowPages * unit, page_size);
 }
 
 bool StackOverflow::stack_guards_enabled() const {


### PR DESCRIPTION
This was a question during [JDK-8072070](https://bugs.openjdk.java.net/browse/JDK-8072070) review. The code in `StackOverflow::initialize_stack_zone_sizes()` multiplies `Stack{Red,Yellow,Reserved,Shadow}Pages` by "alignment", while that is actually just a "unit".

```
  product_pd(intx, StackYellowPages, \
          "Number of yellow zone (recoverable overflows) pages of size " \
          "4KB. If pages are bigger yellow zone is aligned up.") \
          range(MIN_STACK_YELLOW_PAGES, (DEFAULT_STACK_YELLOW_PAGES+5)) \
```

We can rename it for clarity.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281314](https://bugs.openjdk.java.net/browse/JDK-8281314): Rename Stack{Red,Yellow,Reserved,Shadow}Pages multipliers


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to 608ca21ac60fdc6d57542f146e122132af62d64e
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Xin Liu](https://openjdk.java.net/census#xliu) (@navyxliu - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7362/head:pull/7362` \
`$ git checkout pull/7362`

Update a local copy of the PR: \
`$ git checkout pull/7362` \
`$ git pull https://git.openjdk.java.net/jdk pull/7362/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7362`

View PR using the GUI difftool: \
`$ git pr show -t 7362`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7362.diff">https://git.openjdk.java.net/jdk/pull/7362.diff</a>

</details>
