### PR TITLE
8276680: Malformed Javadoc inline tags in JDK source in javax/management

### DIFF
--- a/src/java.management/share/classes/javax/management/NumericValueExp.java
+++ b/src/java.management/share/classes/javax/management/NumericValueExp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,7 +113,7 @@ class NumericValueExp extends QueryEval implements ValueExp {
     public NumericValueExp() {
     }
 
-    /** Creates a new NumericValue representing the numeric literal @{code val}.*/
+    /** Creates a new NumericValue representing the numeric literal {@code val}. */
     NumericValueExp(Number val)
     {
       this.val = val;


### PR DESCRIPTION
Trivial doc  typo.
Now I realise this javadoc for a package-private constructor isn't even in the standard generated docs.  But  you could choose to use different javadoc options.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8276680](https://bugs.openjdk.java.net/browse/JDK-8276680): Malformed Javadoc inline tags in JDK source in javax/management


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7366/head:pull/7366` \
`$ git checkout pull/7366`

Update a local copy of the PR: \
`$ git checkout pull/7366` \
`$ git pull https://git.openjdk.java.net/jdk pull/7366/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7366`

View PR using the GUI difftool: \
`$ git pr show -t 7366`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7366.diff">https://git.openjdk.java.net/jdk/pull/7366.diff</a>

</details>
