### PR TITLE
8281195: Mistakenly used logging causes significant overhead in interpreter

### DIFF
--- a/src/hotspot/share/interpreter/oopMapCache.cpp
+++ b/src/hotspot/share/interpreter/oopMapCache.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/interpreter/oopMapCache.cpp
+++ b/src/hotspot/share/interpreter/oopMapCache.cpp
@@ -278,6 +278,7 @@ bool OopMapCacheEntry::verify_mask(CellTypeState* vars, CellTypeState* stack, in
   // (Use ?: operator to make sure all 'true' & 'false' are represented exactly the same so we can use == afterwards)
   if (log_is_enabled(Trace, interpreter, oopmap)) {
     LogStream st(Log(interpreter, oopmap)::trace());
+
     st.print("Locals (%d): ", max_locals);
     for(int i = 0; i < max_locals; i++) {
       bool v1 = is_oop(i)               ? true : false;
@@ -286,8 +287,23 @@ bool OopMapCacheEntry::verify_mask(CellTypeState* vars, CellTypeState* stack, in
       st.print("%d", v1 ? 1 : 0);
     }
     st.cr();
+
+    st.print("Stack (%d): ", stack_top);
+    for(int j = 0; j < stack_top; j++) {
+      bool v1 = is_oop(max_locals + j)  ? true : false;
+      bool v2 = stack[j].is_reference() ? true : false;
+      assert(v1 == v2, "stack oop mask generation error");
+      st.print("%d", v1 ? 1 : 0);
+    }
+    st.cr();
   }
   else {
+    for(int i = 0; i < max_locals; i++) {
+      bool v1 = is_oop(i)               ? true : false;
+      bool v2 = vars[i].is_reference()  ? true : false;
+      assert(v1 == v2, "locals oop mask generation error");
+    }
+
     for(int j = 0; j < stack_top; j++) {
       bool v1 = is_oop(max_locals + j)  ? true : false;
       bool v2 = stack[j].is_reference() ? true : false;

--- a/src/hotspot/share/interpreter/oopMapCache.cpp
+++ b/src/hotspot/share/interpreter/oopMapCache.cpp
@@ -276,40 +276,26 @@ bool OopMapCacheEntry::verify_mask(CellTypeState* vars, CellTypeState* stack, in
 
   // Check if map is generated correctly
   // (Use ?: operator to make sure all 'true' & 'false' are represented exactly the same so we can use == afterwards)
-  if (log_is_enabled(Trace, interpreter, oopmap)) {
-    LogStream st(Log(interpreter, oopmap)::trace());
+  const bool log = log_is_enabled(Trace, interpreter, oopmap);
+  LogStream st(Log(interpreter, oopmap)::trace());
 
-    st.print("Locals (%d): ", max_locals);
-    for(int i = 0; i < max_locals; i++) {
-      bool v1 = is_oop(i)               ? true : false;
-      bool v2 = vars[i].is_reference()  ? true : false;
-      assert(v1 == v2, "locals oop mask generation error");
-      st.print("%d", v1 ? 1 : 0);
-    }
-    st.cr();
-
-    st.print("Stack (%d): ", stack_top);
-    for(int j = 0; j < stack_top; j++) {
-      bool v1 = is_oop(max_locals + j)  ? true : false;
-      bool v2 = stack[j].is_reference() ? true : false;
-      assert(v1 == v2, "stack oop mask generation error");
-      st.print("%d", v1 ? 1 : 0);
-    }
-    st.cr();
+  if (log) st.print("Locals (%d): ", max_locals);
+  for(int i = 0; i < max_locals; i++) {
+    bool v1 = is_oop(i)               ? true : false;
+    bool v2 = vars[i].is_reference()  ? true : false;
+    assert(v1 == v2, "locals oop mask generation error");
+    if (log) st.print("%d", v1 ? 1 : 0);
   }
-  else {
-    for(int i = 0; i < max_locals; i++) {
-      bool v1 = is_oop(i)               ? true : false;
-      bool v2 = vars[i].is_reference()  ? true : false;
-      assert(v1 == v2, "locals oop mask generation error");
-    }
+  if (log) st.cr();
 
-    for(int j = 0; j < stack_top; j++) {
-      bool v1 = is_oop(max_locals + j)  ? true : false;
-      bool v2 = stack[j].is_reference() ? true : false;
-      assert(v1 == v2, "stack oop mask generation error");
-    }
+  if (log) st.print("Stack (%d): ", stack_top);
+  for(int j = 0; j < stack_top; j++) {
+    bool v1 = is_oop(max_locals + j)  ? true : false;
+    bool v2 = stack[j].is_reference() ? true : false;
+    assert(v1 == v2, "stack oop mask generation error");
+    if (log) st.print("%d", v1 ? 1 : 0);
   }
+  if (log) st.cr();
   return true;
 }
 

--- a/src/hotspot/share/interpreter/oopMapCache.cpp
+++ b/src/hotspot/share/interpreter/oopMapCache.cpp
@@ -276,26 +276,28 @@ bool OopMapCacheEntry::verify_mask(CellTypeState* vars, CellTypeState* stack, in
 
   // Check if map is generated correctly
   // (Use ?: operator to make sure all 'true' & 'false' are represented exactly the same so we can use == afterwards)
-  Log(interpreter, oopmap) logv;
-  LogStream st(logv.trace());
+  typedef LogTargetImpl<LogLevel::Trace, LOG_TAGS(interpreter, oopmap) > log_type;
+  bool const is_log_enabled = log_type::is_enabled();
+  static const log_type log;
+  LogStream st(log);
 
-  st.print("Locals (%d): ", max_locals);
+  if (is_log_enabled) st.print("Locals (%d): ", max_locals);
   for(int i = 0; i < max_locals; i++) {
     bool v1 = is_oop(i)               ? true : false;
     bool v2 = vars[i].is_reference()  ? true : false;
     assert(v1 == v2, "locals oop mask generation error");
-    st.print("%d", v1 ? 1 : 0);
+    if (is_log_enabled) st.print("%d", v1 ? 1 : 0);
   }
-  st.cr();
+  if (is_log_enabled) st.cr();
 
-  st.print("Stack (%d): ", stack_top);
+  if (is_log_enabled) st.print("Stack (%d): ", stack_top);
   for(int j = 0; j < stack_top; j++) {
     bool v1 = is_oop(max_locals + j)  ? true : false;
     bool v2 = stack[j].is_reference() ? true : false;
     assert(v1 == v2, "stack oop mask generation error");
-    st.print("%d", v1 ? 1 : 0);
+    if (is_log_enabled) st.print("%d", v1 ? 1 : 0);
   }
-  st.cr();
+  if (is_log_enabled) st.cr();
   return true;
 }
 

--- a/src/hotspot/share/interpreter/oopMapCache.cpp
+++ b/src/hotspot/share/interpreter/oopMapCache.cpp
@@ -276,28 +276,26 @@ bool OopMapCacheEntry::verify_mask(CellTypeState* vars, CellTypeState* stack, in
 
   // Check if map is generated correctly
   // (Use ?: operator to make sure all 'true' & 'false' are represented exactly the same so we can use == afterwards)
-  typedef LogTargetImpl<LogLevel::Trace, LOG_TAGS(interpreter, oopmap) > log_type;
-  bool const is_log_enabled = log_type::is_enabled();
-  static const log_type log;
-  LogStream st(log);
+  const bool log = log_is_enabled(Trace, interpreter, oopmap);
+  LogStream st(Log(interpreter, oopmap)::trace());
 
-  if (is_log_enabled) st.print("Locals (%d): ", max_locals);
+  if (log) st.print("Locals (%d): ", max_locals);
   for(int i = 0; i < max_locals; i++) {
     bool v1 = is_oop(i)               ? true : false;
     bool v2 = vars[i].is_reference()  ? true : false;
     assert(v1 == v2, "locals oop mask generation error");
-    if (is_log_enabled) st.print("%d", v1 ? 1 : 0);
+    if (log) st.print("%d", v1 ? 1 : 0);
   }
-  if (is_log_enabled) st.cr();
+  if (log) st.cr();
 
-  if (is_log_enabled) st.print("Stack (%d): ", stack_top);
+  if (log) st.print("Stack (%d): ", stack_top);
   for(int j = 0; j < stack_top; j++) {
     bool v1 = is_oop(max_locals + j)  ? true : false;
     bool v2 = stack[j].is_reference() ? true : false;
     assert(v1 == v2, "stack oop mask generation error");
-    if (is_log_enabled) st.print("%d", v1 ? 1 : 0);
+    if (log) st.print("%d", v1 ? 1 : 0);
   }
-  if (is_log_enabled) st.cr();
+  if (log) st.cr();
   return true;
 }
 

--- a/src/hotspot/share/interpreter/oopMapCache.cpp
+++ b/src/hotspot/share/interpreter/oopMapCache.cpp
@@ -276,26 +276,24 @@ bool OopMapCacheEntry::verify_mask(CellTypeState* vars, CellTypeState* stack, in
 
   // Check if map is generated correctly
   // (Use ?: operator to make sure all 'true' & 'false' are represented exactly the same so we can use == afterwards)
-  const bool log = log_is_enabled(Trace, interpreter, oopmap);
-  LogStream st(Log(interpreter, oopmap)::trace());
-
-  if (log) st.print("Locals (%d): ", max_locals);
-  for(int i = 0; i < max_locals; i++) {
-    bool v1 = is_oop(i)               ? true : false;
-    bool v2 = vars[i].is_reference()  ? true : false;
-    assert(v1 == v2, "locals oop mask generation error");
-    if (log) st.print("%d", v1 ? 1 : 0);
+  if (log_is_enabled(Trace, interpreter, oopmap)) {
+    LogStream st(Log(interpreter, oopmap)::trace());
+    st.print("Locals (%d): ", max_locals);
+    for(int i = 0; i < max_locals; i++) {
+      bool v1 = is_oop(i)               ? true : false;
+      bool v2 = vars[i].is_reference()  ? true : false;
+      assert(v1 == v2, "locals oop mask generation error");
+      st.print("%d", v1 ? 1 : 0);
+    }
+    st.cr();
   }
-  if (log) st.cr();
-
-  if (log) st.print("Stack (%d): ", stack_top);
-  for(int j = 0; j < stack_top; j++) {
-    bool v1 = is_oop(max_locals + j)  ? true : false;
-    bool v2 = stack[j].is_reference() ? true : false;
-    assert(v1 == v2, "stack oop mask generation error");
-    if (log) st.print("%d", v1 ? 1 : 0);
+  else {
+    for(int j = 0; j < stack_top; j++) {
+      bool v1 = is_oop(max_locals + j)  ? true : false;
+      bool v2 = stack[j].is_reference() ? true : false;
+      assert(v1 == v2, "stack oop mask generation error");
+    }
   }
-  if (log) st.cr();
   return true;
 }
 


### PR DESCRIPTION
Fixes

`bool OopMapCacheEntry::verify_mask(CellTypeState* vars, CellTypeState* stack, int max_locals, int stack_top)`

eliminating frequent generation of log messages with no respect of logging configuration

Verification: N/A (the issue does not have an observable effect)

Regression: hotspot_compiler (20.04 on amd64 )

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281195](https://bugs.openjdk.java.net/browse/JDK-8281195): Mistakenly used logging causes significant overhead in interpreter


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to 684ee0dd50617a72acc29f1ae43d7249e92bd69f
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 684ee0dd50617a72acc29f1ae43d7249e92bd69f


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7367/head:pull/7367` \
`$ git checkout pull/7367`

Update a local copy of the PR: \
`$ git checkout pull/7367` \
`$ git pull https://git.openjdk.java.net/jdk pull/7367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7367`

View PR using the GUI difftool: \
`$ git pr show -t 7367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7367.diff">https://git.openjdk.java.net/jdk/pull/7367.diff</a>

</details>
