### PR TITLE
8281400: Remove unused wcslen() function

### DIFF
--- a/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -125,11 +125,6 @@ inline int g_isnan(double f) { return isnan(f); }
 
 inline int g_isfinite(jfloat  f)                 { return isfinite(f); }
 inline int g_isfinite(jdouble f)                 { return isfinite(f); }
-
-
-// Wide characters
-
-inline int wcslen(const jchar* x) { return wcslen((const wchar_t*)x); }
 
 
 // Formatting.

--- a/src/hotspot/share/utilities/globalDefinitions_xlc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_xlc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -108,10 +108,6 @@ inline int g_isnan(double f) { return isnan(f); }
 // Checking for finiteness
 inline int g_isfinite(jfloat  f)                 { return finite(f); }
 inline int g_isfinite(jdouble f)                 { return finite(f); }
-
-// Wide characters
-inline int wcslen(const jchar* x) { return wcslen((const wchar_t*)x); }
-
 
 // Formatting.
 #ifdef _LP64


### PR DESCRIPTION
Please review this small change to remove the unused wcslen() function.  This change was tested by running Mach5 tiers 1-2 on Linux, Mac OS, and Windows.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281400](https://bugs.openjdk.java.net/browse/JDK-8281400): Remove unused wcslen() function


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to 820152687853e8179f6f22b2690abb5db318cd43
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7374/head:pull/7374` \
`$ git checkout pull/7374`

Update a local copy of the PR: \
`$ git checkout pull/7374` \
`$ git pull https://git.openjdk.java.net/jdk pull/7374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7374`

View PR using the GUI difftool: \
`$ git pr show -t 7374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7374.diff">https://git.openjdk.java.net/jdk/pull/7374.diff</a>

</details>
