### PR TITLE
8281419: The source data for the color conversion can be discarded

### DIFF
--- a/src/java.desktop/share/native/liblcms/LCMS.c
+++ b/src/java.desktop/share/native/liblcms/LCMS.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -496,19 +496,20 @@ static void *getILData(JNIEnv *env, jobject data, jint type) {
     }
 }
 
-static void releaseILData(JNIEnv *env, void *pData, jint type, jobject data) {
+static void releaseILData(JNIEnv *env, void *pData, jint type, jobject data,
+                          jint mode) {
     switch (type) {
         case DT_BYTE:
-            (*env)->ReleaseByteArrayElements(env, data, (jbyte *) pData, 0);
+            (*env)->ReleaseByteArrayElements(env, data, (jbyte *) pData, mode);
             break;
         case DT_SHORT:
-            (*env)->ReleaseShortArrayElements(env, data, (jshort *) pData, 0);
+            (*env)->ReleaseShortArrayElements(env, data, (jshort *) pData, mode);
             break;
         case DT_INT:
-            (*env)->ReleaseIntArrayElements(env, data, (jint *) pData, 0);
+            (*env)->ReleaseIntArrayElements(env, data, (jint *) pData, mode);
             break;
         case DT_DOUBLE:
-            (*env)->ReleaseDoubleArrayElements(env, data, (jdouble *) pData, 0);
+            (*env)->ReleaseDoubleArrayElements(env, data, (jdouble *) pData, mode);
             break;
     }
 }
@@ -542,7 +543,7 @@ JNIEXPORT void JNICALL Java_sun_java2d_cmm_lcms_LCMS_colorConvert
 
     void *outputBuffer = getILData(env, dstData, dstDType);
     if (outputBuffer == NULL) {
-        releaseILData(env, inputBuffer, srcDType, srcData);
+        releaseILData(env, inputBuffer, srcDType, srcData, JNI_ABORT);
         // An exception should have already been thrown.
         return;
     }
@@ -560,8 +561,8 @@ JNIEXPORT void JNICALL Java_sun_java2d_cmm_lcms_LCMS_colorConvert
         }
     }
 
-    releaseILData(env, inputBuffer, srcDType, srcData);
-    releaseILData(env, outputBuffer, dstDType, dstData);
+    releaseILData(env, inputBuffer, srcDType, srcData, JNI_ABORT);
+    releaseILData(env, outputBuffer, dstDType, dstData, 0);
 }
 
 /*


### PR DESCRIPTION
When we convert the image from one color profile to another one we copy data to the temp array, and after conversion, we commit both(src and dst). But the source array could be discarded since we do not(should not) change it. 

Tested on windows (fastest result after a few runs). ThreadsMAX is 32 threads. The test is just a "ColorConvertOp.filter()" for the opaque buffered image.

![images](https://user-images.githubusercontent.com/14138494/152925400-cf248f88-e2ba-47ec-8d58-71784026ff8a.png)

https://jmh.morethan.io/?gists=541569ac2fe6173d471455d282680fa2,d3b91e1fba067c71fc73a6df8d47773f

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281419](https://bugs.openjdk.java.net/browse/JDK-8281419): The source data for the color conversion can be discarded


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7375/head:pull/7375` \
`$ git checkout pull/7375`

Update a local copy of the PR: \
`$ git checkout pull/7375` \
`$ git pull https://git.openjdk.java.net/jdk pull/7375/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7375`

View PR using the GUI difftool: \
`$ git pr show -t 7375`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7375.diff">https://git.openjdk.java.net/jdk/pull/7375.diff</a>

</details>
