### PR TITLE
8281440: AWT: Conversion from string literal loses const qualifier

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/WPrinterJob.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/WPrinterJob.cpp
@@ -729,7 +729,7 @@ Java_sun_print_Win32PrintService_getPrinterPort(JNIEnv *env,
   }
 
   jstring jPort;
-  LPTSTR printerName = NULL, printerPort = TEXT("LPT1");
+  LPTSTR printerName = NULL, printerPort = (LPTSTR)TEXT("LPT1");
   LPBYTE buffer = NULL;
   DWORD cbBuf = 0;
 
@@ -745,7 +745,7 @@ Java_sun_print_Win32PrintService_getPrinterPort(JNIEnv *env,
   }
 
   if (printerPort == NULL) {
-    printerPort = TEXT("LPT1");
+    printerPort = (LPTSTR)TEXT("LPT1");
   }
   jPort = JNU_NewStringPlatform(env, printerPort);
   delete [] buffer;
@@ -1110,7 +1110,7 @@ Java_sun_print_Win32PrintJob_startPrintRawData(JNIEnv *env,
   // Fill in the structure with info about this "document."
   DocInfo.pDocName = jname;
   DocInfo.pOutputFile = NULL;
-  DocInfo.pDatatype = TEXT("RAW");
+  DocInfo.pDatatype = (LPTSTR)TEXT("RAW");
 
   // Inform the spooler the document is beginning.
   if( (::StartDocPrinter(hPrinter, 1, (LPBYTE)&DocInfo)) == 0 ) {

--- a/src/java.desktop/windows/native/libawt/windows/awt_Debug.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Debug.cpp
@@ -193,7 +193,7 @@ void AwtDebugSupport::AssertCallback(const char * expr, const char * file, int l
                   NULL);
 
     if (msgBuffer == NULL) {
-        msgBuffer = "<Could not get GetLastError() message text>";
+        msgBuffer = (LPSTR)"<Could not get GetLastError() message text>";
     }
     // format the assertion message
     _snprintf(assertMsg, ASSERT_MSG_SIZE, AssertFmt, expr, file, line, lastError, msgBuffer);

--- a/src/java.desktop/windows/native/libawt/windows/awt_DesktopProperties.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_DesktopProperties.cpp
@@ -138,7 +138,7 @@ void AwtDesktopProperties::GetSystemProperties() {
 // Note that it uses malloc() and returns the pointer to allocated
 // memory, so remember to use free() when you are done with its
 // result.
-static LPTSTR resolveShellDialogFont(LPTSTR fontName, HKEY handle) {
+static LPTSTR resolveShellDialogFont(LPCTSTR fontName, HKEY handle) {
     DWORD valueType, valueSize;
     if (RegQueryValueEx((HKEY)handle, fontName, NULL,
                         &valueType, NULL, &valueSize) != 0) {
@@ -164,7 +164,7 @@ static LPTSTR resolveShellDialogFont(LPTSTR fontName, HKEY handle) {
 // memory, so remember to use free() when you are done with its
 // result.
 static LPTSTR resolveShellDialogFont() {
-    LPTSTR subKey = TEXT("Software\\Microsoft\\Windows NT\\CurrentVersion\\FontSubstitutes");
+    LPCTSTR subKey = TEXT("Software\\Microsoft\\Windows NT\\CurrentVersion\\FontSubstitutes");
 
     HKEY handle;
     if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, subKey, 0, KEY_READ, &handle) != 0) {
@@ -183,7 +183,7 @@ static LPTSTR resolveShellDialogFont() {
 // Note that it uses malloc() and returns the pointer to allocated
 // memory, so remember to use free() when you are done with its
 // result.
-static LPTSTR getWindowsPropFromReg(LPTSTR subKey, LPTSTR valueName, DWORD *valueType) {
+static LPTSTR getWindowsPropFromReg(LPCTSTR subKey, LPCTSTR valueName, DWORD *valueType) {
     HKEY handle;
     if (RegOpenKeyEx(HKEY_CURRENT_USER, subKey, 0, KEY_READ, &handle) != 0) {
         return NULL;
@@ -221,7 +221,7 @@ static LPTSTR getWindowsPropFromReg(LPTSTR subKey, LPTSTR valueName, DWORD *valu
     }
 }
 
-static LPTSTR getXPStylePropFromReg(LPTSTR valueName) {
+static LPTSTR getXPStylePropFromReg(LPCTSTR valueName) {
     DWORD valueType;
     return getWindowsPropFromReg(TEXT("Software\\Microsoft\\Windows\\CurrentVersion\\ThemeManager"),
                                  valueName, &valueType);
@@ -651,11 +651,11 @@ void AwtDesktopProperties::GetOtherParameters() {
         throw;
     }
 
-    LPTSTR valueName = TEXT("PlaceN");
+    LPCTSTR valueName = TEXT("PlaceN");
     LPTSTR valueNameBuf = (LPTSTR)SAFE_SIZE_ARRAY_ALLOC(safe_Malloc, (lstrlen(valueName) + 1), sizeof(TCHAR));
     lstrcpy(valueNameBuf, valueName);
 
-    LPTSTR propKey = TEXT("win.comdlg.placesBarPlaceN");
+    LPCTSTR propKey = TEXT("win.comdlg.placesBarPlaceN");
 
     LPTSTR propKeyBuf;
     try {
@@ -672,7 +672,7 @@ void AwtDesktopProperties::GetOtherParameters() {
         valueNameBuf[5] = _T('0' + i++);
         propKeyBuf[25] = valueNameBuf[5];
 
-        LPTSTR key = TEXT("Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\comdlg32\\PlacesBar");
+        LPCTSTR key = TEXT("Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\comdlg32\\PlacesBar");
         try {
             value = NULL;
             if ((value = getWindowsPropFromReg(key, valueNameBuf, &valueType)) != NULL) {

--- a/src/java.desktop/windows/native/libawt/windows/awt_DrawingSurface.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_DrawingSurface.cpp
@@ -275,7 +275,7 @@ extern "C" JNIEXPORT void JNICALL DSUnlockAWT(JNIEnv* env)
 
 // EmbeddedFrame support
 
-static char *const embeddedClassName = "sun/awt/windows/WEmbeddedFrame";
+static const char *const embeddedClassName = "sun/awt/windows/WEmbeddedFrame";
 
 JNIEXPORT jobject JNICALL awt_CreateEmbeddedFrame
 (JNIEnv* env, void* platformInfo)

--- a/src/java.desktop/windows/native/libawt/windows/awt_Font.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Font.cpp
@@ -345,7 +345,7 @@ AwtFont* AwtFont::Create(JNIEnv *env, jobject font, jint angle, jfloat awScale)
                 wName = L"Arial";
             }
 
-            WCHAR* wEName;
+            LPCWSTR wEName;
             if (!wcscmp(wName, L"Helvetica") || !wcscmp(wName, L"SansSerif")) {
                 wEName = L"Arial";
             } else if (!wcscmp(wName, L"TimesRoman") ||
@@ -388,7 +388,7 @@ AwtFont* AwtFont::Create(JNIEnv *env, jobject font, jint angle, jfloat awScale)
     return awtFont;
 }
 
-static void strip_tail(wchar_t* text, wchar_t* tail) { // strips tail and any possible whitespace before it from the end of text
+static void strip_tail(wchar_t* text, const wchar_t* tail) { // strips tail and any possible whitespace before it from the end of text
     if (wcslen(text)<=wcslen(tail)) {
         return;
     }
@@ -495,7 +495,7 @@ static HFONT CreateHFont_sub(LPCWSTR name, int style, int height,
     return hFont;
 }
 
-HFONT AwtFont::CreateHFont(WCHAR* name, int style, int height,
+HFONT AwtFont::CreateHFont(LPCWSTR name, int style, int height,
                            int angle, float awScale)
 {
     WCHAR longName[80];

--- a/src/java.desktop/windows/native/libawt/windows/awt_Font.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Font.h
@@ -155,7 +155,7 @@ public:
      */
     static AwtFont* Create(JNIEnv *env, jobject font,
                            jint angle = 0, jfloat awScale=1.0f);
-    static HFONT CreateHFont(WCHAR* name, int style, int height,
+    static HFONT CreateHFont(LPCWSTR name, int style, int height,
                              int angle = 0, float awScale=1.0f);
 
     static void Cleanup();

--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintControl.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintControl.cpp
@@ -1045,7 +1045,7 @@ BOOL AwtPrintControl::UpdateAttributes(JNIEnv *env,
         DEVNAMES *devnames = (DEVNAMES*)::GlobalLock(pd.hDevNames);
         DASSERT(!IsBadReadPtr(devnames, sizeof(DEVNAMES)));
         LPTSTR lpcNames = (LPTSTR)devnames;
-        LPTSTR pbuf = (_tcslen(lpcNames + devnames->wDeviceOffset) == 0 ?
+        LPCTSTR pbuf = (_tcslen(lpcNames + devnames->wDeviceOffset) == 0 ?
                       TEXT("") : lpcNames + devnames->wDeviceOffset);
         if (pbuf != NULL) {
             jstring jstr = JNU_NewStringPlatform(env, pbuf);

--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
@@ -64,8 +64,8 @@ extern "C" {
 
 /*** Private Constants ***/
 
-static char *kJavaIntStr = "I";
-static char *kJavaLongStr = "J";
+static const char *kJavaIntStr = "I";
+static const char *kJavaLongStr = "J";
 
 /* 2D printing uses 3 byte BGR pixels in Raster printing */
 static int J2DRasterBPP = 3;
@@ -1353,7 +1353,7 @@ Java_sun_awt_windows_WPrinterJob__1startDoc(JNIEnv *env, jobject self,
     } else {
         destination = VerifyDestination(env, self);
     }
-    LPTSTR docname = NULL;
+    LPCTSTR docname = NULL;
     if (jobname != NULL) {
         LPTSTR tmp = (LPTSTR)JNU_GetStringPlatformChars(env, jobname, NULL);
         if (tmp == NULL) {

--- a/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
@@ -530,7 +530,7 @@ void ToolkitThreadProc(void *param)
     JNIEnv *env;
     JavaVMAttachArgs attachArgs;
     attachArgs.version  = JNI_VERSION_1_2;
-    attachArgs.name     = "AWT-Windows";
+    attachArgs.name     = (char*)"AWT-Windows";
     attachArgs.group    = data->threadGroup;
 
     jint res = jvm->AttachCurrentThreadAsDaemon((void **)&env, &attachArgs);

--- a/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
@@ -234,7 +234,7 @@ Java_sun_awt_Win32FontManager_getEUDCFontFile(JNIEnv *env, jclass cl) {
     unsigned long fontPathLen = MAX_PATH + 1;
     WCHAR  tmpPath[MAX_PATH + 1];
     LPWSTR fontPath = fontPathBuf;
-    LPWSTR eudcKey = NULL;
+    LPCWSTR eudcKey = NULL;
 
     LANGID langID = GetSystemDefaultLangID();
     //lookup for encoding ID, EUDC only supported in


### PR DESCRIPTION
This patch fixes AWT compilation under VisualStudio 2019 with `/Zc:strictStrings` enabled.

Strict string handling is already enabled in GCC and Clang. With some effort we should be able to enable it in MSVC as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281440](https://bugs.openjdk.java.net/browse/JDK-8281440): AWT: Conversion from string literal loses const qualifier


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7379/head:pull/7379` \
`$ git checkout pull/7379`

Update a local copy of the PR: \
`$ git checkout pull/7379` \
`$ git pull https://git.openjdk.java.net/jdk pull/7379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7379`

View PR using the GUI difftool: \
`$ git pr show -t 7379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7379.diff">https://git.openjdk.java.net/jdk/pull/7379.diff</a>

</details>
