### PR TITLE
8281523: Accessibility: Conversion from string literal loses const qualifier

### DIFF
--- a/src/jdk.accessibility/windows/native/common/AccessBridgeDebug.cpp
+++ b/src/jdk.accessibility/windows/native/common/AccessBridgeDebug.cpp
@@ -40,7 +40,7 @@ extern "C" {
 
 static FILE* logFP = nullptr;
 
-void initializeFileLogger(char * fileName) {
+void initializeFileLogger(const char * fileName) {
     auto var = "JAVA_ACCESSBRIDGE_LOGDIR";
     const auto envfilePath = getenv(var);
     if (envfilePath != nullptr && fileName != nullptr) {
@@ -83,7 +83,7 @@ unsigned long long getTimeStamp() {
 /**
  * print a GetLastError message
  */
-char *printError(char *msg) {
+char *printError(const char *msg) {
     LPVOID lpMsgBuf = nullptr;
     static char retbuf[256] = {0};
 
@@ -119,7 +119,7 @@ char *printError(char *msg) {
     /**
      * Send debugging info to the appropriate place
      */
-    void PrintDebugString(char *msg, ...) {
+    void PrintDebugString(const char *msg, ...) {
 #ifdef DEBUGGING_ON
         char buf[1024] = {0};
         va_list argprt;
@@ -147,7 +147,7 @@ char *printError(char *msg) {
     /**
      * Send Java debugging info to the appropriate place
      */
-    void PrintJavaDebugString2(char *msg, ...) {
+    void PrintJavaDebugString2(const char *msg, ...) {
 #ifdef JAVA_DEBUGGING_ON
         char buf[1024] = {0};
         va_list argprt;
@@ -174,7 +174,7 @@ char *printError(char *msg) {
     /**
      * Wide version of the method to send debugging info to the appropriate place
      */
-    void wPrintDebugString(wchar_t *msg, ...) {
+    void wPrintDebugString(const wchar_t *msg, ...) {
 #ifdef DEBUGGING_ON
         char buf[1024] = {0};
         char charmsg[256];
@@ -204,7 +204,7 @@ char *printError(char *msg) {
     /**
      * Wide version of the method to send Java debugging info to the appropriate place
      */
-    void wPrintJavaDebugString(wchar_t *msg, ...) {
+    void wPrintJavaDebugString(const wchar_t *msg, ...) {
 #ifdef JAVA_DEBUGGING_ON
         char buf[1024] = {0};
         char charmsg[256] = {0};

--- a/src/jdk.accessibility/windows/native/common/AccessBridgeDebug.cpp
+++ b/src/jdk.accessibility/windows/native/common/AccessBridgeDebug.cpp
@@ -145,33 +145,6 @@ char *printError(const char *msg) {
     }
 
     /**
-     * Send Java debugging info to the appropriate place
-     */
-    void PrintJavaDebugString2(const char *msg, ...) {
-#ifdef JAVA_DEBUGGING_ON
-        char buf[1024] = {0};
-        va_list argprt;
-
-        va_start(argprt, msg);     // set up argptr
-        vsprintf(buf, msg, argprt);
-#ifdef SEND_TO_OUTPUT_DEBUG_STRING
-        OutputDebugString(buf);
-#endif
-#ifdef SEND_TO_CONSOLE
-        printf(buf);
-        printf("\r\n");
-#endif
-#endif
-        if (logFP) {
-            fprintf(logFP, "[%llu] ", getTimeStamp());
-            va_list args;
-            va_start(args, msg);
-            vfprintf(logFP, msg, args);
-            va_end(args);
-            fprintf(logFP, "\r\n");
-        }
-    }
-    /**
      * Wide version of the method to send debugging info to the appropriate place
      */
     void wPrintDebugString(const wchar_t *msg, ...) {

--- a/src/jdk.accessibility/windows/native/common/AccessBridgeDebug.cpp
+++ b/src/jdk.accessibility/windows/native/common/AccessBridgeDebug.cpp
@@ -145,6 +145,33 @@ char *printError(const char *msg) {
     }
 
     /**
+     * Send Java debugging info to the appropriate place
+     */
+    void PrintJavaDebugString2(const char *msg, ...) {
+#ifdef JAVA_DEBUGGING_ON
+        char buf[1024] = {0};
+        va_list argprt;
+
+        va_start(argprt, msg);     // set up argptr
+        vsprintf(buf, msg, argprt);
+#ifdef SEND_TO_OUTPUT_DEBUG_STRING
+        OutputDebugString(buf);
+#endif
+#ifdef SEND_TO_CONSOLE
+        printf(buf);
+        printf("\r\n");
+#endif
+#endif
+        if (logFP) {
+            fprintf(logFP, "[%llu] ", getTimeStamp());
+            va_list args;
+            va_start(args, msg);
+            vfprintf(logFP, msg, args);
+            va_end(args);
+            fprintf(logFP, "\r\n");
+        }
+    }
+    /**
      * Wide version of the method to send debugging info to the appropriate place
      */
     void wPrintDebugString(const wchar_t *msg, ...) {

--- a/src/jdk.accessibility/windows/native/common/AccessBridgeDebug.h
+++ b/src/jdk.accessibility/windows/native/common/AccessBridgeDebug.h
@@ -49,12 +49,12 @@
 extern "C" {
 #endif
 
-    char *printError(char *msg);
-    void PrintDebugString(char *msg, ...);
-    void PrintJavaDebugString(char *msg, ...);
-    void wPrintJavaDebugString(wchar_t *msg, ...);
-    void wPrintDebugString(wchar_t *msg, ...);
-    void initializeFileLogger(char * fileName);
+    char *printError(const char *msg);
+    void PrintDebugString(const char *msg, ...);
+    void PrintJavaDebugString(const char *msg, ...);
+    void wPrintJavaDebugString(const wchar_t *msg, ...);
+    void wPrintDebugString(const wchar_t *msg, ...);
+    void initializeFileLogger(const char * fileName);
     void finalizeFileLogger();
 
 #ifdef __cplusplus

--- a/src/jdk.accessibility/windows/native/common/AccessBridgeDebug.h
+++ b/src/jdk.accessibility/windows/native/common/AccessBridgeDebug.h
@@ -51,7 +51,6 @@ extern "C" {
 
     char *printError(const char *msg);
     void PrintDebugString(const char *msg, ...);
-    void PrintJavaDebugString(const char *msg, ...);
     void wPrintJavaDebugString(const wchar_t *msg, ...);
     void wPrintDebugString(const wchar_t *msg, ...);
     void initializeFileLogger(const char * fileName);

--- a/src/jdk.accessibility/windows/native/common/AccessBridgeDebug.h
+++ b/src/jdk.accessibility/windows/native/common/AccessBridgeDebug.h
@@ -51,6 +51,7 @@ extern "C" {
 
     char *printError(const char *msg);
     void PrintDebugString(const char *msg, ...);
+    void PrintJavaDebugString(const char *msg, ...);
     void wPrintJavaDebugString(const wchar_t *msg, ...);
     void wPrintDebugString(const wchar_t *msg, ...);
     void initializeFileLogger(const char * fileName);

--- a/src/jdk.accessibility/windows/native/jaccessinspector/jaccessinspector.cpp
+++ b/src/jdk.accessibility/windows/native/jaccessinspector/jaccessinspector.cpp
@@ -205,7 +205,7 @@ void displayJavaEvent(long vmID, AccessibleContext ac, char *announcement) {
  * Display Accessible propertyChange event info
  */
 void displayAccessiblePropertyChange(long vmID, AccessibleContext ac,
-                                     char *announcement) {
+                                     const char *announcement) {
     char buffer[HUGE_BUFSIZE];
     char *bufOffset;
 

--- a/src/jdk.accessibility/windows/native/libwindowsaccessbridge/AccessBridgeEventHandler.cpp
+++ b/src/jdk.accessibility/windows/native/libwindowsaccessbridge/AccessBridgeEventHandler.cpp
@@ -34,7 +34,7 @@
 
 DEBUG_CODE(extern HWND theDialogWindow);
 extern "C" {
-DEBUG_CODE(void AppendToCallInfo(char *s));
+DEBUG_CODE(void AppendToCallInfo(const char *s));
 }
 
 

--- a/src/jdk.accessibility/windows/native/libwindowsaccessbridge/AccessBridgeJavaVMInstance.cpp
+++ b/src/jdk.accessibility/windows/native/libwindowsaccessbridge/AccessBridgeJavaVMInstance.cpp
@@ -47,7 +47,7 @@ extern bool isVMInstanceChainInUse;
 
 DEBUG_CODE(extern HWND theDialogWindow);
 extern "C" {
-    DEBUG_CODE(void AppendToCallInfo(char *s));
+    DEBUG_CODE(void AppendToCallInfo(const char *s));
 }
 
 

--- a/src/jdk.accessibility/windows/native/libwindowsaccessbridge/AccessBridgeMessageQueue.cpp
+++ b/src/jdk.accessibility/windows/native/libwindowsaccessbridge/AccessBridgeMessageQueue.cpp
@@ -36,7 +36,7 @@
 
 DEBUG_CODE(extern HWND theDialogWindow);
 extern "C" {
-    DEBUG_CODE(void AppendToCallInfo(char *s));
+    DEBUG_CODE(void AppendToCallInfo(const char *s));
 }
 
 // -------------------

--- a/src/jdk.accessibility/windows/native/libwindowsaccessbridge/WinAccessBridge.cpp
+++ b/src/jdk.accessibility/windows/native/libwindowsaccessbridge/WinAccessBridge.cpp
@@ -152,7 +152,7 @@ extern "C" {
      * replaced with code to send output to debug file
      *
      */
-    void AppendToCallInfo(char *s) {
+    void AppendToCallInfo(const char *s) {
 
         /*
           _CrtDbgReport(_CRT_WARN, (const char *) NULL, NULL, (const char *) NULL,

--- a/src/jdk.accessibility/windows/native/toolscommon/AccessInfo.cpp
+++ b/src/jdk.accessibility/windows/native/toolscommon/AccessInfo.cpp
@@ -85,7 +85,7 @@ void displayAndLog(HWND hDlg, int nIDDlgItem, FILE *logfile, char *msg, ...) {
 /*
  * writes a text string to a logfile
  */
-void logString(FILE *logfile, char *msg, ...) {
+void logString(FILE *logfile, const char *msg, ...) {
 
     if (logfile == NULL || msg == NULL) {
         return;
@@ -105,7 +105,7 @@ void logString(FILE *logfile, char *msg, ...) {
 /*
  * safely appends a message to a buffer
  */
-BOOL appendToBuffer(char *buf, size_t buflen, char *msg, ...) {
+BOOL appendToBuffer(char *buf, size_t buflen, const char *msg, ...) {
 
     static char warning[] =
         "\nNot enough buffer space; remaining information truncated.\n";

--- a/src/jdk.accessibility/windows/native/toolscommon/AccessInfo.h
+++ b/src/jdk.accessibility/windows/native/toolscommon/AccessInfo.h
@@ -43,7 +43,7 @@ void displayAndLog(HWND hDlg, int nIDDlgItem, FILE *logfile, char *msg, ...);
 /*
  * writes a text string to a logfile
  */
-void logString(FILE *logfile, char *msg, ...);
+void logString(FILE *logfile, const char *msg, ...);
 
 /**
  * returns accessibility information for an AccessibleContext


### PR DESCRIPTION
This patch fixes jdk.accessibility compilation under VisualStudio 2019 with /Zc:strictStrings enabled.

Strict string handling is already enabled in GCC and Clang. With some effort we should be able to enable it in MSVC as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281523](https://bugs.openjdk.java.net/browse/JDK-8281523): Accessibility: Conversion from string literal loses const qualifier


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7380/head:pull/7380` \
`$ git checkout pull/7380`

Update a local copy of the PR: \
`$ git checkout pull/7380` \
`$ git pull https://git.openjdk.java.net/jdk pull/7380/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7380`

View PR using the GUI difftool: \
`$ git pr show -t 7380`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7380.diff">https://git.openjdk.java.net/jdk/pull/7380.diff</a>

</details>
