### PR TITLE
8280007: Enable Neoverse N1 optimizations for Arm Neoverse V1 & N2

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -197,8 +197,10 @@ void VM_Version::initialize() {
     }
   }
 
-  // Neoverse N1
-  if (_cpu == CPU_ARM && (_model == 0xd0c || _model2 == 0xd0c)) {
+  // Neoverse N1, N2 and V1
+  if (_cpu == CPU_ARM && ((_model == 0xd0c || _model2 == 0xd0c)
+                          || (_model == 0xd49 || _model2 == 0xd49)
+                          || (_model == 0xd40 || _model2 == 0xd40))) {
     if (FLAG_IS_DEFAULT(UseSIMDForMemoryOps)) {
       FLAG_SET_DEFAULT(UseSIMDForMemoryOps, true);
     }


### PR DESCRIPTION
As Arm Neoverse V1 and N2s will benefit from the same optimizations as Neoverse N1 does, it should have OnSpinWaitInst/OnSpinWaitInstCount defaults set to "isb"/1 and UseSIMDForMemoryOps default set to true.
This patch sets these flags accordingly for both V1 and N2 architectures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280007](https://bugs.openjdk.java.net/browse/JDK-8280007): Enable Neoverse N1 optimizations for Arm Neoverse V1 & N2


### Reviewers
 * @eastig (no known github.com user name / role)
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7383/head:pull/7383` \
`$ git checkout pull/7383`

Update a local copy of the PR: \
`$ git checkout pull/7383` \
`$ git pull https://git.openjdk.java.net/jdk pull/7383/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7383`

View PR using the GUI difftool: \
`$ git pr show -t 7383`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7383.diff">https://git.openjdk.java.net/jdk/pull/7383.diff</a>

</details>
