### PR TITLE
8265765: DomainKeyStore may stop enumerating aliases if a constituting KeyStore is empty

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/DomainKeyStore.java
+++ b/src/java.base/share/classes/sun/security/provider/DomainKeyStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -419,20 +419,22 @@ abstract class DomainKeyStore extends KeyStoreSpi {
                     if (aliases.hasMoreElements()) {
                         return true;
                     } else {
-                        if (iterator.hasNext()) {
+                        while (iterator.hasNext()) {
                             keystoresEntry = iterator.next();
                             prefix = keystoresEntry.getKey() +
-                                entryNameSeparator;
+                                    entryNameSeparator;
                             aliases = keystoresEntry.getValue().aliases();
-                        } else {
-                            return false;
+                            if (aliases.hasMoreElements()) {
+                                return true;
+                            } else {
+                                continue;
+                            }
                         }
+                        return false;
                     }
                 } catch (KeyStoreException e) {
                     return false;
                 }
-
-                return aliases.hasMoreElements();
             }
 
             public String nextElement() {

--- a/test/jdk/sun/security/provider/KeyStore/DksWithEmptyKeystore.java
+++ b/test/jdk/sun/security/provider/KeyStore/DksWithEmptyKeystore.java
@@ -66,8 +66,12 @@ public class DksWithEmptyKeystore {
 
         // Create a domain keystore with two non-empty keystores
         Path dksWithTwoPartsPath = Path.of("two-parts.dks");
-        var twoPartsConfiguration = "domain Combo { keystore a keystoreURI=\"%s\";" +
-                "keystore b keystoreURI=\"%s\"; };";
+        var twoPartsConfiguration = """
+                domain Combo {
+                    keystore a keystoreURI="%s";
+                    keystore b keystoreURI="%s";
+                };
+                """;
         Files.writeString(dksWithTwoPartsPath, String.format(twoPartsConfiguration,
                 nonEmptyPath.toUri(), nonEmptyPath.toUri()));
         Map<String,KeyStore.ProtectionParameter> protectionParameters = new LinkedHashMap<>();
@@ -90,9 +94,13 @@ public class DksWithEmptyKeystore {
 
         // Create a domain keystore with two non-empty keystores and an empty one in between
         Path dksWithThreePartsPath = Path.of("three-parts.dks");
-        var threePartsConfiguration = "domain Combo { keystore a keystoreURI=\"%s\";" +
-                "keystore b keystoreURI=\"%s\";" +
-                "keystore c keystoreURI=\"%s\"; };";
+        var threePartsConfiguration = """
+                domain Combo {
+                    keystore a keystoreURI="%s";
+                    keystore b keystoreURI="%s";
+                    keystore c keystoreURI="%s";
+                };
+                """;
         Files.writeString(dksWithThreePartsPath, String.format(threePartsConfiguration,
                 nonEmptyPath.toUri(), emptyPath.toUri(), nonEmptyPath.toUri()));
 

--- a/test/jdk/sun/security/provider/KeyStore/DksWithEmptyKeystore.java
+++ b/test/jdk/sun/security/provider/KeyStore/DksWithEmptyKeystore.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8265765
+ * @summary Test DomainKeyStore with a collection of keystores that has an empty one in between
+ *          based on the test in the bug report
+ */
+
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.DomainLoadStoreParameter;
+import java.security.KeyStore;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.crypto.KeyGenerator;
+
+public class DksWithEmptyKeystore {
+    private static void write(Path p, KeyStore keystore) throws Exception {
+        try (OutputStream outputStream = Files.newOutputStream(p)) {
+            keystore.store(outputStream, new char[] { 'x' });
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        KeyGenerator kg = KeyGenerator.getInstance("AES");
+        kg.init(256);
+
+        // Create a keystore with one key
+        KeyStore nonEmptyKeystore = KeyStore.getInstance("PKCS12");
+        nonEmptyKeystore.load(null, null);
+
+        Path nonEmptyPath = Path.of("non_empty.p12");
+        nonEmptyKeystore.setKeyEntry("aeskey", kg.generateKey(), new char[] { 'a' }, null);
+        write(nonEmptyPath, nonEmptyKeystore);
+
+        // Create an empty keystore
+        KeyStore emptyKeystore = KeyStore.getInstance("PKCS12");
+        emptyKeystore.load(null, null);
+
+        Path emptyPath = Path.of("empty.p12");
+        write(emptyPath, emptyKeystore);
+
+        // Create a domain keystore with two non-empty keystores
+        Path dksWithTwoPartsPath = Path.of("two-parts.dks");
+        var twoPartsConfiguration = "domain Combo { keystore a keystoreURI=\"%s\";" +
+                "keystore b keystoreURI=\"%s\"; };";
+        Files.writeString(dksWithTwoPartsPath, String.format(twoPartsConfiguration,
+                nonEmptyPath.toUri(), nonEmptyPath.toUri()));
+        Map<String,KeyStore.ProtectionParameter> protectionParameters = new LinkedHashMap<>();
+
+        KeyStore dksKeystore = KeyStore.getInstance("DKS");
+        dksKeystore.load(new DomainLoadStoreParameter(dksWithTwoPartsPath.toUri(), protectionParameters));
+        System.out.printf("%s size: %d%n", dksWithTwoPartsPath, dksKeystore.size());
+
+        int index = 0;
+        for (Enumeration<String> enumeration = dksKeystore.aliases(); enumeration.hasMoreElements(); ) {
+            System.out.printf("%d: %s%n", index, enumeration.nextElement());
+            index++;
+        }
+
+        System.out.printf("enumerated aliases from %s: %d%n", dksWithTwoPartsPath, index);
+        if (index != dksKeystore.size()) {
+            throw new Exception("Failed to get the number of aliases in the domain keystore " +
+                    "that has two keystores.");
+        }
+
+        // Create a domain keystore with two non-empty keystores and an empty one in between
+        Path dksWithThreePartsPath = Path.of("three-parts.dks");
+        var threePartsConfiguration = "domain Combo { keystore a keystoreURI=\"%s\";" +
+                "keystore b keystoreURI=\"%s\";" +
+                "keystore c keystoreURI=\"%s\"; };";
+        Files.writeString(dksWithThreePartsPath, String.format(threePartsConfiguration,
+                nonEmptyPath.toUri(), emptyPath.toUri(), nonEmptyPath.toUri()));
+
+        KeyStore dksKeystore1 = KeyStore.getInstance("DKS");
+        dksKeystore1.load(new DomainLoadStoreParameter(dksWithThreePartsPath.toUri(), protectionParameters));
+        System.out.printf("%s size: %d%n", dksWithThreePartsPath, dksKeystore1.size());
+
+        index = 0;
+        for (Enumeration<String> enumeration = dksKeystore1.aliases(); enumeration.hasMoreElements(); ) {
+            System.out.printf("%d: %s%n", index, enumeration.nextElement());
+            index++;
+        }
+
+        System.out.printf("enumerated aliases from %s: %d%n", dksWithThreePartsPath, index);
+        if (index != dksKeystore1.size()) {
+            throw new Exception("Failed to get the number of aliases in the domain keystore " +
+                    "that has three keystores with an empty one in between.");
+        } else {
+            System.out.printf("Test completed successfully");
+        }
+    }
+}


### PR DESCRIPTION
This is to fix `DomainKeyStore::engineAliases` to take into account that there may be empty keystore(s) within the collection of keystores of a domain keystore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265765](https://bugs.openjdk.java.net/browse/JDK-8265765): DomainKeyStore may stop enumerating aliases if a constituting KeyStore is empty


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7386/head:pull/7386` \
`$ git checkout pull/7386`

Update a local copy of the PR: \
`$ git checkout pull/7386` \
`$ git pull https://git.openjdk.java.net/jdk pull/7386/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7386`

View PR using the GUI difftool: \
`$ git pr show -t 7386`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7386.diff">https://git.openjdk.java.net/jdk/pull/7386.diff</a>

</details>
