### PR TITLE
8281467: Allow larger OptoLoopAlignment and CodeEntryAlignment

### DIFF
--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
@@ -250,6 +250,14 @@ JVMFlag::Error OptoLoopAlignmentConstraintFunc(intx value, bool verbose) {
     return JVMFlag::VIOLATES_CONSTRAINT;
   }
 
+  if (OptoLoopAlignment > CodeEntryAlignment) {
+    JVMFlag::printError(verbose,
+                        "OptoLoopAlignment (" INTX_FORMAT ") must be "
+                        "less or equal to CodeEntryAlignment (" INTX_FORMAT ")\n",
+                        value, CodeEntryAlignment);
+    return JVMFlag::VIOLATES_CONSTRAINT;
+  }
+
   return JVMFlag::SUCCESS;
 }
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1528,13 +1528,13 @@ const intx ObjectAlignmentInBytes = 8;
           range(1, 1024)                                                    \
           constraint(CodeCacheSegmentSizeConstraintFunc, AfterErgo)         \
                                                                             \
-  develop_pd(intx, CodeEntryAlignment,                                      \
+  product_pd(intx, CodeEntryAlignment, EXPERIMENTAL,                        \
           "Code entry alignment for generated code (in bytes)")             \
           constraint(CodeEntryAlignmentConstraintFunc, AfterErgo)           \
                                                                             \
   product_pd(intx, OptoLoopAlignment,                                       \
           "Align inner loops to zero relative to this modulus")             \
-          range(1, 16)                                                      \
+          range(1, 128)                                                     \
           constraint(OptoLoopAlignmentConstraintFunc, AfterErgo)            \
                                                                             \
   product_pd(uintx, InitialCodeCacheSize,                                   \

--- a/test/hotspot/jtreg/compiler/arguments/TestCodeEntryAlignment.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestCodeEntryAlignment.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @library /test/lib /
+ * @bug 8281467
+ * @requires vm.flagless
+ * @requires os.arch=="amd64" | os.arch=="x86_64"
+ *
+ * @summary Test large CodeEntryAlignments are accepted
+ * @run driver compiler.arguments.TestCodeEntryAlignment
+ */
+
+package compiler.arguments;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Arrays;
+import java.util.ArrayList;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class TestCodeEntryAlignment {
+
+    public static void main(String[] args) throws IOException {
+        if (args.length == 0) {
+            driver();
+        } else {
+            System.out.println("Pass");
+        }
+    }
+
+    private static List<String> cmdline(String[] args) {
+        List<String> r = new ArrayList();
+        r.addAll(Arrays.asList(args));
+        r.add("compiler.arguments.TestCodeEntryAlignment");
+        r.add("run");
+        return r;
+    }
+
+    public static void shouldPass(String... args) throws IOException {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(cmdline(args));
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldHaveExitValue(0);
+    }
+
+    public static void driver() throws IOException {
+        for (int align = 16; align < 256; align *= 2) {
+            shouldPass(
+                "-XX:+UnlockExperimentalVMOptions",
+                "-XX:CodeEntryAlignment=" + align
+            );
+        }
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/arguments/TestOptoLoopAlignment.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestOptoLoopAlignment.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @library /test/lib /
+ * @bug 8281467
+ * @requires vm.flagless
+ * @requires os.arch=="amd64" | os.arch=="x86_64"
+ *
+ * @summary Test large OptoLoopAlignments are accepted
+ * @run driver compiler.arguments.TestOptoLoopAlignment
+ */
+
+package compiler.arguments;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Arrays;
+import java.util.ArrayList;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class TestOptoLoopAlignment {
+
+    public static void main(String[] args) throws IOException {
+        if (args.length == 0) {
+            driver();
+        } else {
+            System.out.println("Pass");
+        }
+    }
+
+    private static final String MSG = "must be less or equal to CodeEntryAlignment";
+
+    private static List<String> cmdline(String[] args) {
+        List<String> r = new ArrayList();
+        r.addAll(Arrays.asList(args));
+        r.add("compiler.arguments.TestOptoLoopAlignment");
+        r.add("run");
+        return r;
+    }
+
+    public static void shouldFail(String... args) throws IOException {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(cmdline(args));
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldNotHaveExitValue(0);
+        output.shouldContain(MSG);
+    }
+
+    public static void shouldPass(String... args) throws IOException {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(cmdline(args));
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldHaveExitValue(0);
+        output.shouldNotContain(MSG);
+    }
+
+    public static void driver() throws IOException {
+        for (int align = 1; align < 64; align *= 2) {
+            shouldPass(
+                "-XX:OptoLoopAlignment=" + align
+            );
+        }
+        for (int align = 64; align <= 128; align *= 2) {
+            shouldFail(
+                "-XX:OptoLoopAlignment=" + align
+            );
+        }
+    }
+
+}


### PR DESCRIPTION
I am following up on the performance issue where the culprit seems to be the too low `OptoLoopAlignment`. To perform better experiments, I suggest allowing larger alignments.

Note that we cannot make `OptoLoopAlignment` larger than `CodeEntryAlignment`, because nmethod copy would break it, see assert in `MacroAssembler::align`. See [JDK-8273459](https://bugs.openjdk.java.net/browse/JDK-8273459) for latest discussion about it. So `CodeEntryAlignment` needs to be configurable as well.

The default values for options are different per platform, so tests are x86_64 specific.

No default value is changed, this only unblocks experiments.

Additional testing:
 - [x] New tests on Linux x86_64 fastdebug
 - [x] New tests on Linux x86_64 release

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281467](https://bugs.openjdk.java.net/browse/JDK-8281467): Allow larger OptoLoopAlignment and CodeEntryAlignment


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7388/head:pull/7388` \
`$ git checkout pull/7388`

Update a local copy of the PR: \
`$ git checkout pull/7388` \
`$ git pull https://git.openjdk.java.net/jdk pull/7388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7388`

View PR using the GUI difftool: \
`$ git pr show -t 7388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7388.diff">https://git.openjdk.java.net/jdk/pull/7388.diff</a>

</details>
