### PR TITLE
8281476: ProblemList tools/jar/CreateMissingParentDirectories.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -765,6 +765,7 @@ javax/swing/JTree/4908142/bug4908142.java 8278348 macosx-all
 # core_tools
 
 tools/jlink/plugins/CompressorPluginTest.java                   8247407 generic-all
+tools/jar/CreateMissingParentDirectories.java                   8281470 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList tools/jar/CreateMissingParentDirectories.java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281476](https://bugs.openjdk.java.net/browse/JDK-8281476): ProblemList tools/jar/CreateMissingParentDirectories.java


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7390/head:pull/7390` \
`$ git checkout pull/7390`

Update a local copy of the PR: \
`$ git checkout pull/7390` \
`$ git pull https://git.openjdk.java.net/jdk pull/7390/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7390`

View PR using the GUI difftool: \
`$ git pr show -t 7390`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7390.diff">https://git.openjdk.java.net/jdk/pull/7390.diff</a>

</details>
