### PR TITLE
8280832: Update usage docs for NonblockingQueue

### DIFF
--- a/src/hotspot/share/utilities/nonblockingQueue.hpp
+++ b/src/hotspot/share/utilities/nonblockingQueue.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,9 +96,11 @@ public:
   inline size_t length() const;
 
   // Thread-safe add the object to the end of the queue.
+  // Subject to ABA behavior; callers must ensure usage is safe.
   inline void push(T& node) { append(node, node); }
 
   // Thread-safe add the objects from first to last to the end of the queue.
+  // Subject to ABA behavior; callers must ensure usage is safe.
   inline void append(T& first, T& last);
 
   // Thread-safe attempt to remove and return the first object in the queue.

--- a/src/hotspot/share/utilities/nonblockingQueue.inline.hpp
+++ b/src/hotspot/share/utilities/nonblockingQueue.inline.hpp
@@ -116,7 +116,10 @@ void NonblockingQueue<T, next_ptr>::append(T& first, T& last) {
     // Successfully extended the queue list from old_tail to first.  No
     // other push/append could have competed with us, because we claimed
     // old_tail for extension.  We won any races with try_pop by changing
-    // away from end-marker.  So we're done.
+    // away from end-marker.  So we're done.  Note that ABA is possible;
+    // try_pop could take old_tail before our update, it gets recycled and
+    // re-added to the end, and then we successfully cmpxchg, rendering the
+    // list in _tail circular.
     return;
   } else {
     // A concurrent try_pop has claimed old_tail, so it is no longer in the

--- a/src/hotspot/share/utilities/nonblockingQueue.inline.hpp
+++ b/src/hotspot/share/utilities/nonblockingQueue.inline.hpp
@@ -116,10 +116,10 @@ void NonblockingQueue<T, next_ptr>::append(T& first, T& last) {
     // Successfully extended the queue list from old_tail to first.  No
     // other push/append could have competed with us, because we claimed
     // old_tail for extension.  We won any races with try_pop by changing
-    // away from end-marker.  So we're done.  Note that ABA is possible;
-    // try_pop could take old_tail before our update, it gets recycled and
-    // re-added to the end, and then we successfully cmpxchg, rendering the
-    // list in _tail circular.
+    // away from end-marker.  So we're done.  Note that ABA is possible; a
+    // concurrent try_pop could take old_tail before our update, it gets
+    // recycled and re-added to the end, and then we successfully cmpxchg,
+    // rendering the list in _tail circular.
     return;
   } else {
     // A concurrent try_pop has claimed old_tail, so it is no longer in the

--- a/src/hotspot/share/utilities/nonblockingQueue.inline.hpp
+++ b/src/hotspot/share/utilities/nonblockingQueue.inline.hpp
@@ -116,10 +116,13 @@ void NonblockingQueue<T, next_ptr>::append(T& first, T& last) {
     // Successfully extended the queue list from old_tail to first.  No
     // other push/append could have competed with us, because we claimed
     // old_tail for extension.  We won any races with try_pop by changing
-    // away from end-marker.  So we're done.  Note that ABA is possible; a
-    // concurrent try_pop could take old_tail before our update, it gets
-    // recycled and re-added to the end, and then we successfully cmpxchg,
-    // rendering the list in _tail circular.
+    // away from end-marker.  So we're done.
+    //
+    // Note that ABA is possible here.  A concurrent try_pop could take
+    // old_tail before our update of old_tail's next_ptr, old_tail gets
+    // recycled and re-added to the end of this queue, and then we
+    // successfully cmpxchg, making the list in _tail circular.  Callers
+    // must ensure this can't happen.
     return;
   } else {
     // A concurrent try_pop has claimed old_tail, so it is no longer in the


### PR DESCRIPTION
Please review this update of the usage and implementation comments for
NonblockingQueue to discuss the ABA issue in push/append operations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280832](https://bugs.openjdk.java.net/browse/JDK-8280832): Update usage docs for NonblockingQueue


### Reviewers
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**) ⚠️ Review applies to 8c6593dc4961826c3dfdf6759080352990965a6b
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 7aacc083366cfd09387b2b66b5ba3999e1eace3f


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7393/head:pull/7393` \
`$ git checkout pull/7393`

Update a local copy of the PR: \
`$ git checkout pull/7393` \
`$ git pull https://git.openjdk.java.net/jdk pull/7393/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7393`

View PR using the GUI difftool: \
`$ git pr show -t 7393`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7393.diff">https://git.openjdk.java.net/jdk/pull/7393.diff</a>

</details>
