### PR TITLE
[TBD]: New optimization: convert "(x|y)-(x^y)" into "x&y"

### DIFF
--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -322,6 +322,14 @@ Node *SubINode::Ideal(PhaseGVN *phase, bool can_reshape){
     }
   }
 
+  // Convert "(x|y)-(x^y)" into "x&y"
+  if (in(1)->Opcode() == Op_OrI
+      && in(2)->Opcode() == Op_XorI
+      && in(1)->in(1) == in(2)->in(1)
+      && in(1)->in(2) == in(2)->in(2)) {
+    return new AndINode(in(1)->in(1), in(1)->in(2));
+  }
+
   return NULL;
 }
 
@@ -493,6 +501,14 @@ Node *SubLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     if ( t21 && t22 && zero == TypeLong::ZERO && t22->is_con(63) ) {
       return new URShiftLNode(in21, in22);
     }
+  }
+
+  // Convert "(x|y)-(x^y)" into "x&y"
+  if (in(1)->Opcode() == Op_OrL
+      && in(2)->Opcode() == Op_XorL
+      && in(1)->in(1) == in(2)->in(1)
+      && in(1)->in(2) == in(2)->in(2)) {
+    return new AndLNode(in(1)->in(1), in(1)->in(2));
   }
 
   return NULL;

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestIRSubIdeal_XOrY_Minus_XXorY_.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestIRSubIdeal_XOrY_Minus_XXorY_.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import jdk.test.lib.Asserts;
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @summary Test that transformation from "(x|y)-(x^y)" to "x&y" works
+ *          as intended.
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.TestIRSubIdeal_XOrY_Minus_XXorY_
+ */
+public class TestIRSubIdeal_XOrY_Minus_XXorY_ {
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    @Test
+    @IR(failOn = {IRNode.OR_I, IRNode.XOR_I, IRNode.SUB_I})
+    @IR(counts = {IRNode.AND_I, "1"})
+    public int testInt(int x, int y) {
+        return (x | y) - (x ^ y); // transformed to x & y
+    }
+
+    @Run(test = "testInt")
+    public void checkTestInt(RunInfo info) {
+        assertC2Compiled(info);
+        Asserts.assertEquals(0x5050_A0A0, testInt(0x5A5A_A5A5, 0x5555_AAAA));
+        Asserts.assertEquals(0x0000_0000, testInt(0x0000_0000, 0x0000_0000));
+        Asserts.assertEquals(0xFFFF_FFFF, testInt(0xFFFF_FFFF, 0xFFFF_FFFF));
+        Asserts.assertEquals(0x0000_0000, testInt(0xFFFF_FFFF, 0x0000_0000));
+        Asserts.assertEquals(0x0000_0000, testInt(0x0000_0000, 0xFFFF_FFFF));
+        Asserts.assertEquals(0x8000_0000, testInt(0x8000_0000, 0xFFFF_0000));
+        Asserts.assertEquals(0x7FFF_FFFF, testInt(0x7FFF_FFFF, 0x7FFF_FFFF));
+    }
+
+    @Test
+    @IR(failOn = {IRNode.OR_L, IRNode.XOR_L, IRNode.SUB_L})
+    @IR(counts = {IRNode.AND_L, "1"})
+    public long testLong(long x, long y) {
+        return (x | y) - (x ^ y); // transformed to x & y
+    }
+
+    @Run(test = "testLong")
+    public void checkTestLong(RunInfo info) {
+        assertC2Compiled(info);
+        Asserts.assertEquals(0x5050_A0A0_0000_50A0L, testLong(0x5A5A_A5A5_5AA5_55AAL, 0x5555_AAAA_A55A_5AA5L));
+        Asserts.assertEquals(0x0000_0000_0000_0000L, testLong(0x0000_0000_0000_0000L, 0x0000_0000_0000_0000L));
+        Asserts.assertEquals(0xFFFF_FFFF_FFFF_FFFFL, testLong(0xFFFF_FFFF_FFFF_FFFFL, 0xFFFF_FFFF_FFFF_FFFFL));
+        Asserts.assertEquals(0x0000_0000_0000_0000L, testLong(0xFFFF_FFFF_FFFF_FFFFL, 0x0000_0000_0000_0000L));
+        Asserts.assertEquals(0x0000_0000_0000_0000L, testLong(0x0000_0000_0000_0000L, 0xFFFF_FFFF_FFFF_FFFFL));
+        Asserts.assertEquals(0x8000_0000_0000_0000L, testLong(0x8000_0000_0000_0000L, 0xFFFF_0000_0000_0000L));
+        Asserts.assertEquals(0x7FFF_FFFF_FFFF_FFFFL, testLong(0x7FFF_FFFF_FFFF_FFFFL, 0x7FFF_FFFF_FFFF_FFFFL));
+    }
+
+    private void assertC2Compiled(RunInfo info) {
+        // Test VM allows C2 to work
+        Asserts.assertTrue(info.isC2CompilationEnabled());
+        if (!info.isWarmUp()) {
+            // C2 compilation happens
+            Asserts.assertTrue(info.isTestC2Compiled());
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -142,6 +142,8 @@ public class IRNode {
     public static final String ABS_D = START + "AbsD" + MID + END;
     public static final String AND_I = START + "AndI" + MID + END;
     public static final String AND_L = START + "AndL" + MID + END;
+    public static final String OR_I = START + "OrI" + MID + END;
+    public static final String OR_L = START + "OrL" + MID + END;
     public static final String XOR_I = START + "XorI" + MID + END;
     public static final String XOR_L = START + "XorL" + MID + END;
     public static final String LSHIFT_I = START + "LShiftI" + MID + END;

--- a/test/micro/org/openjdk/bench/vm/compiler/SubIdeal_XOrY_Minus_XXorY_.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/SubIdeal_XOrY_Minus_XXorY_.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests transformation that converts "(x|y)-(x^y)" into "x&y" in
+ * SubINode:Ideal and SubLNode::Ideal.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
+public class SubIdeal_XOrY_Minus_XXorY_ {
+
+    private int iX = 4711;
+
+    private int iY = 1174;
+
+    private long lX = 4711 * 4711 * 4711;
+
+    private long lY = 1174 * 1174 * 1174;
+
+    @Benchmark
+    public void baselineInt(Blackhole bh) {
+        bh.consume(iX);
+    }
+
+    @Benchmark
+    public void baselineLong(Blackhole bh) {
+        bh.consume(lX);
+    }
+
+    // Convert "(x|y)-(x^y)" into "x&y" for int.
+    @Benchmark
+    public void testInt(Blackhole bh) {
+        bh.consume((iX | iY) - (iX ^ iY));
+    }
+
+    // Convert "(x|y)-(x^y)" into "x&y" for long.
+    @Benchmark
+    public void testLong(Blackhole bh) {
+        bh.consume((lX | lY) - (lX ^ lY));
+    }
+}


### PR DESCRIPTION
Convert `(x|y)-(x^y)` into `x&y`, in `SubINode::Ideal` and `SubLNode::Ideal`.

The results of the microbenchmark are as follows:
```
Baseline:                                                                                                                                         
Benchmark                                Mode  Cnt  Score   Error  Units
SubIdeal_XOrY_Minus_XXorY_.baselineInt   avgt   60  0.481 ± 0.003  ns/op
SubIdeal_XOrY_Minus_XXorY_.baselineLong  avgt   60  0.482 ± 0.004  ns/op
SubIdeal_XOrY_Minus_XXorY_.testInt       avgt   60  0.901 ± 0.007  ns/op
SubIdeal_XOrY_Minus_XXorY_.testLong      avgt   60  0.894 ± 0.004  ns/op

Patch:
Benchmark                                Mode  Cnt  Score   Error  Units
SubIdeal_XOrY_Minus_XXorY_.baselineInt   avgt   60  0.480 ± 0.003  ns/op
SubIdeal_XOrY_Minus_XXorY_.baselineLong  avgt   60  0.483 ± 0.005  ns/op
SubIdeal_XOrY_Minus_XXorY_.testInt       avgt   60  0.600 ± 0.004  ns/op
SubIdeal_XOrY_Minus_XXorY_.testLong      avgt   60  0.602 ± 0.004  ns/op
```