### PR TITLE
8277369: Strange behavior of JMenuBar with RIGHT_TO_LEFT orientation, arrow keys behaves opposite traversing through keyboard

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicPopupMenuUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicPopupMenuUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import javax.swing.plaf.*;
 import java.applet.Applet;
 
 import java.awt.Component;
+import java.awt.ComponentOrientation;
 import java.awt.KeyboardFocusManager;
 import java.awt.Window;
 import java.awt.event.*;
@@ -536,6 +537,11 @@ public class BasicPopupMenuUI extends PopupMenuUI {
             // If this is the case, we select another toplevel menu
             if (len > 1 && path[0] instanceof JMenuBar) {
                 MenuElement currentMenu = path[1];
+                // direction traversal to be reversed for RTL orientation
+                if (path[0].getComponent().getComponentOrientation().
+                        equals(ComponentOrientation.RIGHT_TO_LEFT)) {
+                    direction = !direction;
+                }
                 MenuElement nextMenu = findEnabledChild(
                     path[0].getSubElements(), currentMenu, direction);
 

--- a/test/jdk/javax/swing/JMenuBar/MenuBarRTLBug.java
+++ b/test/jdk/javax/swing/JMenuBar/MenuBarRTLBug.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+import java.awt.BorderLayout;
+import java.awt.ComponentOrientation;
+import java.awt.Point;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.Robot;
+
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.event.MenuEvent;
+import javax.swing.event.MenuListener;
+import javax.swing.SwingUtilities;
+
+/*
+ * @test
+ * @key headful
+ * @bug  8277369
+ * @summary Verifies arrow traversal in RTL orientation in JMenuBar
+ */
+public class MenuBarRTLBug {
+
+    static JFrame frame;
+    static JMenuBar menuBar;
+    static JMenu firstMenu;
+    static JMenuItem a;
+    static JMenuItem b;
+    static JMenu secondMenu;
+    static JMenuItem c;
+    static JMenuItem d;
+    static JMenu thirdMenu;
+    static JMenuItem e;
+    static JMenuItem f;
+	static JMenu forthMenu;
+	static JMenu fifthMenu;
+
+	static Point p;
+	static int width;
+	static int height;
+
+    static volatile boolean passed = false;
+
+    public static void main(String[] args) throws  Exception {
+
+	    try {
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame();
+                frame.setLayout(new BorderLayout());
+
+                firstMenu = new JMenu("first");
+                a = new JMenuItem("a");
+                b = new JMenuItem("b");
+                firstMenu.add(a);
+                firstMenu.add(b);
+
+                secondMenu = new JMenu("second");
+                c = new JMenuItem("c");
+                d = new JMenuItem("d");
+                secondMenu.add(c);
+                secondMenu.add(d);
+                secondMenu.addMenuListener(new MenuListener() {
+                    @Override
+                    public void menuSelected(MenuEvent e) {
+                        passed = true;
+                    }
+                    @Override
+                    public void menuDeselected(MenuEvent e) {
+                    }
+
+                    @Override
+                    public void menuCanceled(MenuEvent e) {
+                    }
+                });
+
+
+                thirdMenu = new JMenu("third");
+                e = new JMenuItem("e");
+                f = new JMenuItem("f");
+                thirdMenu.add(e);
+                thirdMenu.add(f);
+
+                forthMenu = new JMenu("fourth");
+                e = new JMenuItem("e");
+                f = new JMenuItem("f");
+                forthMenu.add(e);
+                forthMenu.add(f);
+
+                fifthMenu = new JMenu("fifth");
+                e = new JMenuItem("e");
+                f = new JMenuItem("f");
+                fifthMenu.add(e);
+                fifthMenu.add(f);
+
+                menuBar = new JMenuBar();
+                menuBar.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+                menuBar.add(firstMenu);
+                menuBar.add(secondMenu);
+                menuBar.add(thirdMenu);
+                menuBar.add(forthMenu);
+                menuBar.add(fifthMenu);
+                frame.setJMenuBar(menuBar);
+
+                frame.setLocationRelativeTo(null);
+                frame.pack();
+                frame.setVisible(true);
+            });
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                p = thirdMenu.getLocationOnScreen();
+                width = thirdMenu.getWidth();
+                height = thirdMenu.getHeight();
+            });
+            robot.mouseMove(p.x + width / 2, p.y + height / 2);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(1000);
+            robot.keyPress(KeyEvent.VK_RIGHT);
+            robot.keyRelease(KeyEvent.VK_RIGHT);
+            robot.delay(1000);
+            if (!passed) {
+                throw new RuntimeException("Arrow traversal order not correct in RTL orientation");
+            }
+        } finally {
+	        SwingUtilities.invokeAndWait(() -> {
+	            if (frame != null) {
+	                frame.dispose();
+                }
+            });
+        }
+    }
+} 

--- a/test/jdk/javax/swing/JMenuBar/MenuBarRTLBug.java
+++ b/test/jdk/javax/swing/JMenuBar/MenuBarRTLBug.java
@@ -158,4 +158,4 @@ public class MenuBarRTLBug {
             });
         }
     }
-} 
+}

--- a/test/jdk/javax/swing/JMenuBar/MenuBarRTLBug.java
+++ b/test/jdk/javax/swing/JMenuBar/MenuBarRTLBug.java
@@ -38,6 +38,8 @@ import javax.swing.event.ChangeListener;
 import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
 import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
 
 /*
  * @test
@@ -67,95 +69,110 @@ public class MenuBarRTLBug {
 
     static volatile boolean passed = false;
 
+    private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
+        try {
+            UIManager.setLookAndFeel(laf.getClassName());
+        } catch (UnsupportedLookAndFeelException ignored) {
+            System.out.println("Unsupported L&F: " + laf.getClassName());
+        } catch (ClassNotFoundException | InstantiationException
+                 | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public static void main(String[] args) throws  Exception {
 
-        try {
-            SwingUtilities.invokeAndWait(() -> {
-                frame = new JFrame();
-                frame.setLayout(new BorderLayout());
+        for (UIManager.LookAndFeelInfo laf : UIManager.getInstalledLookAndFeels()) {
+            System.out.println("Testing L&F: " + laf.getClassName());
+            passed = false;
+            SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
+            try {
+                SwingUtilities.invokeAndWait(() -> {
+                    frame = new JFrame();
+                    frame.setLayout(new BorderLayout());
 
-                firstMenu = new JMenu("first");
-                a = new JMenuItem("a");
-                b = new JMenuItem("b");
-                firstMenu.add(a);
-                firstMenu.add(b);
+                    firstMenu = new JMenu("first");
+                    a = new JMenuItem("a");
+                    b = new JMenuItem("b");
+                    firstMenu.add(a);
+                    firstMenu.add(b);
 
-                secondMenu = new JMenu("second");
-                c = new JMenuItem("c");
-                d = new JMenuItem("d");
-                secondMenu.add(c);
-                secondMenu.add(d);
-                secondMenu.addMenuListener(new MenuListener() {
-                    @Override
-                    public void menuSelected(MenuEvent e) {
-                        passed = true;
-                    }
-                    @Override
-                    public void menuDeselected(MenuEvent e) {
-                    }
+                    secondMenu = new JMenu("second");
+                    c = new JMenuItem("c");
+                    d = new JMenuItem("d");
+                    secondMenu.add(c);
+                    secondMenu.add(d);
+                    secondMenu.addMenuListener(new MenuListener() {
+                        @Override
+                        public void menuSelected(MenuEvent e) {
+                            passed = true;
+                        }
+                        @Override
+                        public void menuDeselected(MenuEvent e) {
+                        }
 
-                    @Override
-                    public void menuCanceled(MenuEvent e) {
+                        @Override
+                        public void menuCanceled(MenuEvent e) {
+                        }
+                    });
+
+                    thirdMenu = new JMenu("third");
+                    e = new JMenuItem("e");
+                    f = new JMenuItem("f");
+                    thirdMenu.add(e);
+                    thirdMenu.add(f);
+
+                    forthMenu = new JMenu("fourth");
+                    e = new JMenuItem("e");
+                    f = new JMenuItem("f");
+                    forthMenu.add(e);
+                    forthMenu.add(f);
+
+                    fifthMenu = new JMenu("fifth");
+                    e = new JMenuItem("e");
+                    f = new JMenuItem("f");
+                    fifthMenu.add(e);
+                    fifthMenu.add(f);
+
+                    menuBar = new JMenuBar();
+                    menuBar.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+                    menuBar.add(firstMenu);
+                    menuBar.add(secondMenu);
+                    menuBar.add(thirdMenu);
+                    menuBar.add(forthMenu);
+                    menuBar.add(fifthMenu);
+                    frame.setJMenuBar(menuBar);
+
+                    frame.setLocationRelativeTo(null);
+                    frame.pack();
+                    frame.setVisible(true);
+                });
+                Robot robot = new Robot();
+                robot.setAutoDelay(100);
+                robot.waitForIdle();
+                robot.delay(1000);
+                SwingUtilities.invokeAndWait(() -> {
+                    p = thirdMenu.getLocationOnScreen();
+                    width = thirdMenu.getWidth();
+                    height = thirdMenu.getHeight();
+                });
+                robot.mouseMove(p.x + width / 2, p.y + height / 2);
+                robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+                robot.delay(1000);
+                robot.keyPress(KeyEvent.VK_RIGHT);
+                robot.keyRelease(KeyEvent.VK_RIGHT);
+                robot.delay(1000);
+                if (!passed) {
+                    throw new RuntimeException("Arrow traversal order not correct in RTL orientation");
+                }
+            } finally {
+                SwingUtilities.invokeAndWait(() -> {
+                    if (frame != null) {
+                        frame.dispose();
                     }
                 });
-
-
-                thirdMenu = new JMenu("third");
-                e = new JMenuItem("e");
-                f = new JMenuItem("f");
-                thirdMenu.add(e);
-                thirdMenu.add(f);
-
-                forthMenu = new JMenu("fourth");
-                e = new JMenuItem("e");
-                f = new JMenuItem("f");
-                forthMenu.add(e);
-                forthMenu.add(f);
-
-                fifthMenu = new JMenu("fifth");
-                e = new JMenuItem("e");
-                f = new JMenuItem("f");
-                fifthMenu.add(e);
-                fifthMenu.add(f);
-
-                menuBar = new JMenuBar();
-                menuBar.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
-                menuBar.add(firstMenu);
-                menuBar.add(secondMenu);
-                menuBar.add(thirdMenu);
-                menuBar.add(forthMenu);
-                menuBar.add(fifthMenu);
-                frame.setJMenuBar(menuBar);
-
-                frame.setLocationRelativeTo(null);
-                frame.pack();
-                frame.setVisible(true);
-            });
-            Robot robot = new Robot();
-            robot.setAutoDelay(100);
-            robot.waitForIdle();
-            robot.delay(1000);
-            SwingUtilities.invokeAndWait(() -> {
-                p = thirdMenu.getLocationOnScreen();
-                width = thirdMenu.getWidth();
-                height = thirdMenu.getHeight();
-            });
-            robot.mouseMove(p.x + width / 2, p.y + height / 2);
-            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-            robot.delay(1000);
-            robot.keyPress(KeyEvent.VK_RIGHT);
-            robot.keyRelease(KeyEvent.VK_RIGHT);
-            robot.delay(1000);
-            if (!passed) {
-                throw new RuntimeException("Arrow traversal order not correct in RTL orientation");
             }
-        } finally {
-            SwingUtilities.invokeAndWait(() -> {
-                if (frame != null) {
-                    frame.dispose();
-                }
-            });
-        }
+	}
     }
 }

--- a/test/jdk/javax/swing/JMenuBar/MenuBarRTLBug.java
+++ b/test/jdk/javax/swing/JMenuBar/MenuBarRTLBug.java
@@ -173,6 +173,6 @@ public class MenuBarRTLBug {
                     }
                 });
             }
-	}
+        }
     }
 }

--- a/test/jdk/javax/swing/JMenuBar/MenuBarRTLBug.java
+++ b/test/jdk/javax/swing/JMenuBar/MenuBarRTLBug.java
@@ -58,18 +58,18 @@ public class MenuBarRTLBug {
     static JMenu thirdMenu;
     static JMenuItem e;
     static JMenuItem f;
-	static JMenu forthMenu;
-	static JMenu fifthMenu;
+    static JMenu forthMenu;
+    static JMenu fifthMenu;
 
-	static Point p;
-	static int width;
-	static int height;
+    static Point p;
+    static int width;
+    static int height;
 
     static volatile boolean passed = false;
 
     public static void main(String[] args) throws  Exception {
 
-	    try {
+        try {
             SwingUtilities.invokeAndWait(() -> {
                 frame = new JFrame();
                 frame.setLayout(new BorderLayout());
@@ -151,9 +151,9 @@ public class MenuBarRTLBug {
                 throw new RuntimeException("Arrow traversal order not correct in RTL orientation");
             }
         } finally {
-	        SwingUtilities.invokeAndWait(() -> {
-	            if (frame != null) {
-	                frame.dispose();
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
                 }
             });
         }


### PR DESCRIPTION
After applying setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT) to the JMenuBar the arrow keys started to behave the opposite of what expected. Right arrow goes left and Left arrow goes right when trying to traverse through keyboard.

Fixed to reverse the direction traversal for RTL orientation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277369](https://bugs.openjdk.java.net/browse/JDK-8277369): Strange behavior of JMenuBar with RIGHT_TO_LEFT orientation, arrow keys behaves opposite traversing through keyboard


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7396/head:pull/7396` \
`$ git checkout pull/7396`

Update a local copy of the PR: \
`$ git checkout pull/7396` \
`$ git pull https://git.openjdk.java.net/jdk pull/7396/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7396`

View PR using the GUI difftool: \
`$ git pr show -t 7396`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7396.diff">https://git.openjdk.java.net/jdk/pull/7396.diff</a>

</details>
