### PR TITLE
8281470: tools/jar/CreateMissingParentDirectories.java fails with "Should have failed creating jar file"

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -765,7 +765,6 @@ javax/swing/JTree/4908142/bug4908142.java 8278348 macosx-all
 # core_tools
 
 tools/jlink/plugins/CompressorPluginTest.java                   8247407 generic-all
-tools/jar/CreateMissingParentDirectories.java                   8281470 generic-all
 
 ############################################################################
 

--- a/test/jdk/tools/jar/CreateMissingParentDirectories.java
+++ b/test/jdk/tools/jar/CreateMissingParentDirectories.java
@@ -32,6 +32,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.spi.ToolProvider;
 import java.util.stream.Stream;
 
@@ -66,7 +67,6 @@ public class CreateMissingParentDirectories {
             doHappyPathTest(topDir.resolve("a/test.jar"), entry);
             doHappyPathTest(topDir.resolve("a/b/test.jar"), entry);
 
-            doFailingTest(topDir.toString() + "/a/*/test.jar", entry);
             Path blocker = Files.writeString(topDir.resolve("blocker.txt"), "Blocked!");
             doFailingTest(topDir.resolve("blocker.txt/test.jar").toString(), entry);
         } finally {
@@ -77,7 +77,12 @@ public class CreateMissingParentDirectories {
     private static void doHappyPathTest(Path jar, Path entry) throws Throwable {
         String[] jarArgs = new String[]{"cf", jar.toString(), entry.toString()};
         if (JAR_TOOL.run(System.out, System.err, jarArgs) != 0) {
-            fail("Could not create jar file: " + jar);
+            fail("Could not create jar file: " + List.of(jarArgs));
+            return;
+        }
+        jarArgs = new String[]{"--create", "--file", jar.toString(), entry.toString()};
+        if (JAR_TOOL.run(System.out, System.err, jarArgs) != 0) {
+            fail("Could not create jar file: " + List.of(jarArgs));
             return;
         }
         pass();

--- a/test/jdk/tools/jar/CreateMissingParentDirectories.java
+++ b/test/jdk/tools/jar/CreateMissingParentDirectories.java
@@ -97,8 +97,6 @@ public class CreateMissingParentDirectories {
             fail("Should have failed creating jar file: " + jar);
             return;
         }
-        // non-zero exit code expected, check error message contains jar file's name
-        check(err.toString().contains(jar));
         pass();
     }
 


### PR DESCRIPTION
This PR removes the redundant and failing test-case.
It also removes the test class from the problem list.

Adds additional test-cases using long form option names of `jar`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281470](https://bugs.openjdk.java.net/browse/JDK-8281470): tools/jar/CreateMissingParentDirectories.java fails with "Should have failed creating jar file"


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7397/head:pull/7397` \
`$ git checkout pull/7397`

Update a local copy of the PR: \
`$ git checkout pull/7397` \
`$ git pull https://git.openjdk.java.net/jdk pull/7397/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7397`

View PR using the GUI difftool: \
`$ git pr show -t 7397`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7397.diff">https://git.openjdk.java.net/jdk/pull/7397.diff</a>

</details>
