### PR TITLE
8281100: Spurious "variable might not have been initialized" with sealed class switch

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -664,10 +664,7 @@ public class Flow {
             ListBuffer<PendingExit> prevPendingExits = pendingExits;
             pendingExits = new ListBuffer<>();
             scan(tree.selector);
-            boolean exhaustiveSwitch = tree.patternSwitch ||
-                                       tree.cases.stream()
-                                                 .flatMap(c -> c.labels.stream())
-                                                 .anyMatch(l -> TreeInfo.isNull(l));
+            boolean exhaustiveSwitch = TreeInfo.expectedExhaustive(tree);
             Set<Symbol> constants = exhaustiveSwitch ? new HashSet<>() : null;
             for (List<JCCase> l = tree.cases; l.nonEmpty(); l = l.tail) {
                 alive = Liveness.ALIVE;
@@ -689,10 +686,13 @@ public class Flow {
                                 l.tail.head.pos(),
                                 Warnings.PossibleFallThroughIntoCase);
             }
-            if (!tree.hasTotalPattern && exhaustiveSwitch &&
-                !TreeInfo.isErrorEnumSwitch(tree.selector, tree.cases) &&
-                (constants == null || !isExhaustive(tree.selector.pos(), tree.selector.type, constants))) {
-                log.error(tree, Errors.NotExhaustiveStatement);
+            tree.isExhaustive = tree.hasTotalPattern ||
+                                TreeInfo.isErrorEnumSwitch(tree.selector, tree.cases);
+            if (exhaustiveSwitch) {
+                tree.isExhaustive |= isExhaustive(tree.selector.pos(), tree.selector.type, constants);
+                if (!tree.isExhaustive) {
+                    log.error(tree, Errors.NotExhaustiveStatement);
+                }
             }
             if (!tree.hasTotalPattern) {
                 alive = Liveness.ALIVE;
@@ -725,8 +725,10 @@ public class Flow {
                     }
                 }
             }
-            if (!tree.hasTotalPattern && !TreeInfo.isErrorEnumSwitch(tree.selector, tree.cases) &&
-                !isExhaustive(tree.selector.pos(), tree.selector.type, constants)) {
+            tree.isExhaustive = tree.hasTotalPattern ||
+                                TreeInfo.isErrorEnumSwitch(tree.selector, tree.cases) ||
+                                isExhaustive(tree.selector.pos(), tree.selector.type, constants);
+            if (!tree.isExhaustive) {
                 log.error(tree, Errors.NotExhaustive);
             }
             alive = prevAlive;
@@ -2432,15 +2434,15 @@ public class Flow {
         }
 
         public void visitSwitch(JCSwitch tree) {
-            handleSwitch(tree, tree.selector, tree.cases, tree.hasTotalPattern);
+            handleSwitch(tree, tree.selector, tree.cases, tree.isExhaustive);
         }
 
         public void visitSwitchExpression(JCSwitchExpression tree) {
-            handleSwitch(tree, tree.selector, tree.cases, tree.hasTotalPattern);
+            handleSwitch(tree, tree.selector, tree.cases, tree.isExhaustive);
         }
 
         private void handleSwitch(JCTree tree, JCExpression selector,
-                                  List<JCCase> cases, boolean hasTotalPattern) {
+                                  List<JCCase> cases, boolean isExhaustive) {
             ListBuffer<PendingExit> prevPendingExits = pendingExits;
             pendingExits = new ListBuffer<>();
             int nextadrPrev = nextadr;
@@ -2478,10 +2480,10 @@ public class Flow {
                 addVars(c.stats, initsSwitch, uninitsSwitch);
                 // Warn about fall-through if lint switch fallthrough enabled.
             }
-            if (!hasTotalPattern) {
+            if (!isExhaustive) {
                 if (tree.hasTag(SWITCH_EXPRESSION)) {
                     markDead();
-                } else {
+                } else if (tree.hasTag(SWITCH) && !TreeInfo.expectedExhaustive((JCSwitch) tree)) {
                     inits.assign(initsSwitch);
                     uninits.assign(uninits.andSet(uninitsSwitch));
                 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
@@ -1285,6 +1285,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         /** Position of closing brace, optional. */
         public int endpos = Position.NOPOS;
         public boolean hasTotalPattern;
+        public boolean isExhaustive;
         public boolean patternSwitch;
         protected JCSwitch(JCExpression selector, List<JCCase> cases) {
             this.selector = selector;
@@ -1371,6 +1372,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         /** Position of closing brace, optional. */
         public int endpos = Position.NOPOS;
         public boolean hasTotalPattern;
+        public boolean isExhaustive;
         public boolean patternSwitch;
         protected JCSwitchExpression(JCExpression selector, List<JCCase> cases) {
             this.selector = selector;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
@@ -1384,4 +1384,10 @@ public class TreeInfo {
 
     public record PatternPrimaryType(Type type, boolean unconditional) {}
 
+    public static boolean expectedExhaustive(JCSwitch tree) {
+        return tree.patternSwitch ||
+               tree.cases.stream()
+                         .flatMap(c -> c.labels.stream())
+                         .anyMatch(l -> TreeInfo.isNull(l));
+    }
 }


### PR DESCRIPTION
Consider:
```
interface I permits A, B {}

String data;
I i = ...;
switch (i) {
    case A a -> data = 0;
    case B b -> data = 0;
}
System.err.println(data); //incorrect error here
```

The specification says that `data` is definitely assigned as the `System.err.println`, as the switch covers `I`, but javac will report an error that the variable may not be assigned.

This patch fixes that - the only tricky part is that if there's an error in the switch (like when the switch is expected to be exhaustive, but is not), the current patch will try to suppress the follow-up "variable may not be assigned" errors. As an example:
```
interface I permits A, B {}

String data;
I i = ...;
switch (i) { //error here, not exhaustive
    case A a -> data = 0;
}
System.err.println(data); //no error here, due to the preceding exhaustiveness error
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281100](https://bugs.openjdk.java.net/browse/JDK-8281100): Spurious "variable might not have been initialized" with sealed class switch


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7402/head:pull/7402` \
`$ git checkout pull/7402`

Update a local copy of the PR: \
`$ git checkout pull/7402` \
`$ git pull https://git.openjdk.java.net/jdk pull/7402/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7402`

View PR using the GUI difftool: \
`$ git pr show -t 7402`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7402.diff">https://git.openjdk.java.net/jdk/pull/7402.diff</a>

</details>
