### PR TITLE
8280825: Modules that "provide" ToolProvider should document the name that can be used

### DIFF
--- a/src/jdk.compiler/share/classes/module-info.java
+++ b/src/jdk.compiler/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,9 @@
  *
  * @toolGuide javac
  *
- * @provides java.util.spi.ToolProvider
+ * @provides java.util.spi.ToolProvider Pass {@code "javac"} as the name to
+ *           {@link java.util.spi.ToolProvider#findFirst ToolProvider.findFirst}
+ *           in order to obtain an instance of the tool.
  * @provides com.sun.tools.javac.platform.PlatformProvider
  * @provides javax.tools.JavaCompiler
  * @provides javax.tools.Tool

--- a/src/jdk.jartool/share/classes/module-info.java
+++ b/src/jdk.jartool/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,10 @@
  *
  * @toolGuide jar
  * @toolGuide jarsigner
+ *
+ * @provides java.util.spi.ToolProvider Pass {@code "jar"} as the name to
+ *           {@link java.util.spi.ToolProvider#findFirst ToolProvider.findFirst}
+ *           in order to obtain an instance of the tool.
  *
  * @moduleGraph
  * @since 9

--- a/src/jdk.javadoc/share/classes/module-info.java
+++ b/src/jdk.javadoc/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,9 @@
  *
  * @toolGuide javadoc
  *
- * @provides java.util.spi.ToolProvider
+ * @provides java.util.spi.ToolProvider Pass {@code "javadoc"} as the name to
+ *           {@link java.util.spi.ToolProvider#findFirst ToolProvider.findFirst}
+ *           in order to obtain an instance of the tool.
  * @provides javax.tools.DocumentationTool
  * @provides javax.tools.Tool
  *

--- a/src/jdk.jdeps/share/classes/module-info.java
+++ b/src/jdk.jdeps/share/classes/module-info.java
@@ -48,7 +48,9 @@
  * @toolGuide jdeprscan
  * @toolGuide jdeps
  *
- * @provides java.util.spi.ToolProvider
+ * @provides java.util.spi.ToolProvider Pass {@code "javap"} or {@code "jdeps"}
+ *           as the name to {@link java.util.spi.ToolProvider#findFirst
+ *           ToolProvider.findFirst} in order to obtain an instance of the tool.
  *
  * @moduleGraph
  * @since 9

--- a/src/jdk.jlink/share/classes/module-info.java
+++ b/src/jdk.jlink/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,9 @@
  * @toolGuide jlink
  * @toolGuide jmod
  *
- * @provides java.util.spi.ToolProvider
+ * @provides java.util.spi.ToolProvider Pass {@code "jlink"} or {@code "jmod"}
+ *           as the name to {@link java.util.spi.ToolProvider#findFirst
+ *           ToolProvider.findFirst} in order to obtain an instance of the tool.
  *
  * @moduleGraph
  * @since 9

--- a/src/jdk.jpackage/share/classes/module-info.java
+++ b/src/jdk.jpackage/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,9 @@
  * concurrently, even with separate {@code "jpackage"} {@code ToolProvider}
  * instances, or undefined behavior may result.
  *
+ * @provides java.util.spi.ToolProvider Pass {@code "jpackage"} as the name to
+ *           {@link java.util.spi.ToolProvider#findFirst ToolProvider.findFirst}
+ *           in order to obtain an instance of the tool.
  *
  * @moduleGraph
  * @since 16


### PR DESCRIPTION
A number of modules declare that the "provide" ToolProvider.

These modules now specify the "name" of the argument used by `ToolProvider.findFirst` to access an instance of the tool provider within the description part of a `@provides` API tag.