### PR TITLE
8281553: Ensure we only require liveness from mach-nodes with barriers

### DIFF
--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -135,7 +135,9 @@ address ZLoadBarrierStubC2::slow_path() const {
 }
 
 RegMask& ZLoadBarrierStubC2::live() const {
-  return *barrier_set_state()->live(_node);
+  RegMask* mask = barrier_set_state()->live(_node);
+  assert(mask!=NULL, "must be mach-node with barrier");
+  return *mask;
 }
 
 Label* ZLoadBarrierStubC2::entry() {

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -136,7 +136,7 @@ address ZLoadBarrierStubC2::slow_path() const {
 
 RegMask& ZLoadBarrierStubC2::live() const {
   RegMask* mask = barrier_set_state()->live(_node);
-  assert(mask!=NULL, "must be mach-node with barrier");
+  assert(mask != NULL, "must be mach-node with barrier");
   return *mask;
 }
 


### PR DESCRIPTION
Adding NULL check. This also ensures we are not returning a NULL reference.

Ran tests to ensure assert is never triggered.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281553](https://bugs.openjdk.java.net/browse/JDK-8281553): Ensure we only require liveness from mach-nodes with barriers


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7407/head:pull/7407` \
`$ git checkout pull/7407`

Update a local copy of the PR: \
`$ git checkout pull/7407` \
`$ git pull https://git.openjdk.java.net/jdk pull/7407/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7407`

View PR using the GUI difftool: \
`$ git pr show -t 7407`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7407.diff">https://git.openjdk.java.net/jdk/pull/7407.diff</a>

</details>
