### PR TITLE
8281728: Redundant null check in LineNumberInputStream.read

### DIFF
--- a/src/java.base/share/classes/java/io/LineNumberInputStream.java
+++ b/src/java.base/share/classes/java/io/LineNumberInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -149,9 +149,7 @@ public class LineNumberInputStream extends FilterInputStream {
                 if (c == -1) {
                     break;
                 }
-                if (b != null) {
-                    b[off + i] = (byte)c;
-                }
+                b[off + i] = (byte)c;
             }
         } catch (IOException ee) {
         }


### PR DESCRIPTION
At start of method `b` is already checked for null.

https://github.com/openjdk/jdk/blob/178b962e01cc6c150442bf41dc6bd199caff0042/src/java.base/share/classes/java/io/LineNumberInputStream.java#L129-L131

Found by IntelliJ IDEA
![IDEA warning](https://user-images.githubusercontent.com/741251/153844753-a36c7d4f-6fc1-4618-9d22-04541af155b2.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281728](https://bugs.openjdk.java.net/browse/JDK-8281728): Redundant null check in LineNumberInputStream.read


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7409/head:pull/7409` \
`$ git checkout pull/7409`

Update a local copy of the PR: \
`$ git checkout pull/7409` \
`$ git pull https://git.openjdk.java.net/jdk pull/7409/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7409`

View PR using the GUI difftool: \
`$ git pr show -t 7409`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7409.diff">https://git.openjdk.java.net/jdk/pull/7409.diff</a>

</details>
