### PR TITLE
JDK-8281238: TYPE_USE annotations not printed in correct position in toString output

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -1038,8 +1038,17 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
                 appendAnnotationsString(buf);
                 buf.append(className(tsym, false));
             } else {
-                appendAnnotationsString(buf);
-                buf.append(className(tsym, true));
+                if (isAnnotated()) {
+                    if (!tsym.packge().isUnnamed()) {
+                        buf.append(tsym.packge());
+                        buf.append(".");
+                    }
+                    appendAnnotationsString(buf);
+                    buf.append(tsym.name);
+                    
+                } else {
+                    buf.append(className(tsym, true));
+                }
             }
 
             if (getTypeArguments().nonEmpty()) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -1045,7 +1045,6 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
                     }
                     appendAnnotationsString(buf);
                     buf.append(tsym.name);
-                    
                 } else {
                     buf.append(className(tsym, true));
                 }

--- a/test/langtools/tools/javac/patterns/Annotations.java
+++ b/test/langtools/tools/javac/patterns/Annotations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8256266
+ * @bug 8256266 8281238
  * @summary Verify annotations work correctly on binding variables
  * @library /tools/javac/lib
  * @modules java.compiler

--- a/test/langtools/tools/javac/patterns/Annotations.java
+++ b/test/langtools/tools/javac/patterns/Annotations.java
@@ -114,11 +114,11 @@ public class Annotations extends JavacTestingAbstractProcessor {
                         }
                         case "dta" -> {
                             expectedDeclAnnos = "@Annotations.DTA";
-                            expectedType = "@Annotations.DTA java.lang.String";
+                            expectedType = "java.lang.@Annotations.DTA String";
                         }
                         case "ta" -> {
                             expectedDeclAnnos = "";
-                            expectedType = "@Annotations.TA java.lang.String";
+                            expectedType = "java.lang.@Annotations.TA String";
                         }
                         default -> {
                             throw new AssertionError("Unexpected variable: " + var);
@@ -133,7 +133,7 @@ public class Annotations extends JavacTestingAbstractProcessor {
                     String type = varType.toString();
                     if (!expectedType.equals(type)) {
                         throw new AssertionError("Unexpected type: " + type +
-                                                  " for: " + var.getName());
+                                                  " for: " + var.getName() + " expected " + expectedType);
                     }
                     return super.visitInstanceOf(node, p);
                 }

--- a/test/langtools/tools/javac/tree/ArrayTypeToString.java
+++ b/test/langtools/tools/javac/tree/ArrayTypeToString.java
@@ -66,7 +66,7 @@ public class ArrayTypeToString extends JavacTestingAbstractProcessor {
                 // Normalize output by removing whitespace
                 s = s.replaceAll("\\s", "");
 
-                // Expected: "@Foo(0)java.lang.String@Foo(3)[]@Foo(2)[]@Foo(1)[]"
+                // Expected: "java.lang.@Foo(0)String@Foo(1)[]@Foo(2)[]@Foo(3)[]"
                 processingEnv.getMessager().printNote(s);
             }
         }

--- a/test/langtools/tools/javac/tree/ArrayTypeToString.java
+++ b/test/langtools/tools/javac/tree/ArrayTypeToString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8068737
+ * @bug 8068737 8281238
  * @summary Tests ArrayType.toString with type annotations present
  * @modules jdk.compiler/com.sun.tools.javac.code
  * @library /tools/javac/lib

--- a/test/langtools/tools/javac/tree/ArrayTypeToString.out
+++ b/test/langtools/tools/javac/tree/ArrayTypeToString.out
@@ -1,1 +1,1 @@
-- compiler.note.proc.messager: @Foo(0)java.lang.String@Foo(1)[]@Foo(2)[]@Foo(3)[]
+- compiler.note.proc.messager: java.lang.@Foo(0)String@Foo(1)[]@Foo(2)[]@Foo(3)[]


### PR DESCRIPTION
To use a type annotation on a fully qualified type name, the annotations must appear between the package name and the type:

    java.lang. @TypeAnnotation String // good

and *not* before the fully qualified name

   @TypeAnnotation java.lang.String // bad

This required ordering is not preserved in the toString output of TypeMirrors in annotation processing. This changeset corrects that and updates a few tests that assume the older formatting.

(This listed update to the given toString method is necessary; I don't believe any of the other Type toString methods also need to be updated, but some might need updating too.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281238](https://bugs.openjdk.java.net/browse/JDK-8281238): TYPE_USE annotations not printed in correct position in toString output


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7411/head:pull/7411` \
`$ git checkout pull/7411`

Update a local copy of the PR: \
`$ git checkout pull/7411` \
`$ git pull https://git.openjdk.java.net/jdk pull/7411/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7411`

View PR using the GUI difftool: \
`$ git pr show -t 7411`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7411.diff">https://git.openjdk.java.net/jdk/pull/7411.diff</a>

</details>
