### PR TITLE
8054449: Incompatible type in example code in TreePath

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/tree/TreePath.java
+++ b/src/java.desktop/share/classes/javax/swing/tree/TreePath.java
@@ -51,8 +51,8 @@ import java.beans.ConstructorProperties;
  *   ...
  *   TreePath selectedPath = tree.getSelectionPath();
  *   DefaultMutableTreeNode selectedNode =
- *       ((DefaultMutableTreeNode)selectedPath.getLastPathComponent()).
- *       getUserObject();
+ *       ((DefaultMutableTreeNode)selectedPath.getLastPathComponent());
+ *   Object myObject= selectedNode.getUserObject();
  * </pre>
  * Subclasses typically need override only {@code
  * getLastPathComponent}, and {@code getParentPath}. As {@code JTree}


### PR DESCRIPTION
The example code in TreePath throws
error: incompatible types: Object cannot be converted to DefaultMutableTreeNode
           getUserObject();
Fixed the example code

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8054449](https://bugs.openjdk.java.net/browse/JDK-8054449): Incompatible type in example code in TreePath


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Dmitry Markov](https://openjdk.java.net/census#dmarkov) (@dmarkov20 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7414/head:pull/7414` \
`$ git checkout pull/7414`

Update a local copy of the PR: \
`$ git checkout pull/7414` \
`$ git pull https://git.openjdk.java.net/jdk pull/7414/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7414`

View PR using the GUI difftool: \
`$ git pr show -t 7414`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7414.diff">https://git.openjdk.java.net/jdk/pull/7414.diff</a>

</details>
