### PR TITLE
8277922: Unable to click JCheckBox in JTable through Java Access Bridge

### DIFF
--- a/test/jdk/javax/accessibility/JTable/JCheckBoxInJTableCannotBeClickedTest.java
+++ b/test/jdk/javax/accessibility/JTable/JCheckBoxInJTableCannotBeClickedTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 8277922
+   @key headful
+   @summary Execution of AccessibleAction of AccessibleContext of JTable cell
+            with JCheckBox does not lead to change of the cell value and view.
+ */
+
+import java.awt.AWTException;
+import java.awt.BorderLayout;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Robot;
+import java.lang.reflect.InvocationTargetException;
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleAction;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleTable;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+import javax.swing.plaf.metal.MetalLookAndFeel;
+import javax.swing.table.DefaultTableModel;
+
+public class JCheckBoxInJTableCannotBeClickedTest {
+    private volatile JFrame frame;
+    private volatile JTable table;
+
+    public static void main(String[] args) {
+        final JCheckBoxInJTableCannotBeClickedTest test =
+            new JCheckBoxInJTableCannotBeClickedTest();
+
+        try {
+            SwingUtilities.invokeAndWait(new Runnable() {
+                @Override
+                public void run() {
+                    test.createGUI();
+                }
+            });
+            Robot robot = new Robot();
+            robot.waitForIdle();
+
+            SwingUtilities.invokeAndWait(new Runnable() {
+                @Override
+                public void run() {
+                    test.runTest();
+                }
+            });
+        } catch (InterruptedException | InvocationTargetException |
+            AWTException e) {
+            throw new RuntimeException(e);
+        } finally {
+            try {
+                SwingUtilities.invokeAndWait(new Runnable() {
+                    @Override
+                    public void run() {
+                        test.dispose();
+                    }
+                });
+            } catch (InterruptedException | InvocationTargetException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private void createGUI() {
+        if (!(UIManager.getLookAndFeel() instanceof MetalLookAndFeel)) {
+            try {
+                UIManager.setLookAndFeel(new MetalLookAndFeel());
+            } catch (UnsupportedLookAndFeelException ulafe) {
+                throw new RuntimeException(ulafe);
+            }
+        }
+
+        frame = new JFrame("JCheckBoxInJTableCannotBeClickedTest");
+        frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+        Container content = frame.getContentPane();
+        content.setLayout(new BorderLayout());
+
+        String[] tblColNames = {"Column 1", "Column 2", "Column 3"};
+        Object[][] tblData = {
+            {Boolean.TRUE, "Text 1", Boolean.FALSE},
+            {Boolean.FALSE, "Text 2", Boolean.TRUE},
+            {Boolean.TRUE, "Text 3", Boolean.FALSE}
+        };
+        final DefaultTableModel tblModel = new DefaultTableModel(
+                tblData, tblColNames) {
+            @Override
+            public Class<?> getColumnClass(int column) {
+                return getValueAt(0, column).getClass();
+            }
+
+            @Override
+            public boolean isCellEditable(int row, int column) {
+                if (column == 0) {
+                    return false;
+                }
+                return true;
+            }
+        };
+        table = new JTable(tblModel);
+        table.setPreferredScrollableViewportSize(new Dimension(400, 100));
+
+        JScrollPane tblScroller = new JScrollPane(table);
+        tblScroller.setHorizontalScrollBarPolicy(
+            JScrollPane.HORIZONTAL_SCROLLBAR_ALWAYS);
+        tblScroller.setVerticalScrollBarPolicy(
+            JScrollPane.VERTICAL_SCROLLBAR_ALWAYS
+        );
+        content.add(tblScroller, BorderLayout.CENTER);
+
+        frame.pack();
+        frame.setVisible(true);
+    }
+
+    private void dispose() {
+        if (frame != null) {
+            frame.dispose();
+            frame = null;
+        }
+    }
+
+    private void runTest() {
+        if (table == null) {
+            throw new RuntimeException("'table' should not be null");
+        }
+
+        testDoAccessibleActionInCell(0, 2, 0, true);
+        testDoAccessibleActionInCell(0, 2, 0, true);
+        testDoAccessibleActionInCell(1, 2, 0, true);
+        testDoAccessibleActionInCell(1, 2, 0, true);
+        testDoAccessibleActionInCell(0, 0, 0, false);
+        testDoAccessibleActionInCell(1, 0, 0, false);
+        testDoAccessibleActionInCell(2, 0, 0, false);
+
+        System.out.println("Disabling the table...");
+        table.setEnabled(false);
+        testDoAccessibleActionInCell(0, 2, 0, false);
+        testDoAccessibleActionInCell(1, 2, 0, false);
+        testDoAccessibleActionInCell(2, 2, 0, false);
+
+        System.out.println("Enabling the table...");
+        table.setEnabled(true);
+        testDoAccessibleActionInCell(0, 2, 0, true);
+        testDoAccessibleActionInCell(1, 2, 0, true);
+        testDoAccessibleActionInCell(2, 2, 0, true);
+
+        System.out.println("Test passed.");
+    }
+
+    private void testDoAccessibleActionInCell(int row, int column,
+            int actionIndex, boolean expectCellValChange) {
+        System.out.println(String.format("testDoAccessibleActionInCell():" +
+                    " row='%d', column='%d', actionIndex='%d'" +
+                    ", expectCellValChange='%b'",
+                row, column, actionIndex, expectCellValChange));
+
+        if (table == null) {
+            throw new RuntimeException("'table' should not be null");
+        }
+
+        AccessibleContext tblAc = table.getAccessibleContext();
+        AccessibleTable accessibleTbl = tblAc.getAccessibleTable();
+        if (accessibleTbl == null) {
+            throw new RuntimeException("'accessibleTbl' should not be null");
+        }
+
+        Accessible cellAccessible = accessibleTbl.getAccessibleAt(row, column);
+        AccessibleContext cellAc = cellAccessible.getAccessibleContext();
+        if (cellAc == null) {
+            throw new RuntimeException("'cellAc' should not be null");
+        }
+
+        AccessibleAction cellAa = cellAc.getAccessibleAction();
+        if (cellAa == null) {
+            throw new RuntimeException("'cellAa' should not be null");
+        }
+        if (cellAa.getAccessibleActionCount() <= actionIndex) {
+            throw new RuntimeException(
+                "cellAa.getAccessibleActionCount() <= actionIndex");
+        }
+
+        Object oldCellVal = table.getValueAt(row, column);
+        cellAa.doAccessibleAction(actionIndex);
+        Object newCellVal = table.getValueAt(row, column);
+
+        boolean cellValChanged = oldCellVal != newCellVal;
+        if ((expectCellValChange && !cellValChanged) ||
+            (!expectCellValChange && cellValChanged)) {
+            throw new RuntimeException(String.format(
+                    "Test failed. cellValChanged='%b'", cellValChanged));
+        }
+    }
+}


### PR DESCRIPTION
Hello,

Could you please review the following fix for the bug. The bug consists in the fact that When an assistive technology software by means of Java Access Bridge API executes "AccessibleAction" "click" on "AccessibleContext" which corresponds to "javax.swing.JTable" cell containing "javax.swing.JCheckBox", then the cell's value and cell's view represented by "JCheckBox" stay unchanged. The issue is a bug in JDK and should be fixed in JDK, because JDK informs the assistive technology software through Java Access Bridge API in particular through the function

"BOOL getAccessibleActions(long vmID, AccessibleContext accessibleContext, AccessibleActions *actions)"

that "AccessibleContext" of the table cell with "JCheckBox" supports one action "click", while real execution of this action on this accessible context does not lead to any result.

THE ROOT CAUSE OF THE BUG:

The reason of the issue is the fact that when the assistive technology software tries to do "AccessibleAction" on "AccessibleContext" associated with a cell with boolean data type in "JTable" component through Java Access Bridge (JAB), the JDK executes this "AccessibleAction" on "AccessibleContext" of a renderer, which is an instance of the class "javax.swing.JTable.BooleanRenderer" which is a derivative of "JCheckBox" class, and the instance of this renderer is single and common for all cells of boolean data type. Therefore execution of "click" "AccessibleAction" on this renderer component which is not permanently bound to any particular cell in the table does not lead to update of the table cell value.

THE FIX:

The fix implements an approach which guarantees setting of new values to the table's cells with boolean data type on each execution of "AccessibleAction" of "javax.swing.JTable.BooleanRenderer" instance, when execution of this action changes the "selected" state of this "BooleanRenderer" JCheckBox component.

Please take into account that the created automatic regression test simulates the issue only with Java Accessibility API what is not fully equal to the original test scenario which requires the assistive technology software and usage of Java Access Bridge API and which can be tested using the manual test case attached to the issue in JBS. However the regression test still allows to reproduce the issue and verify that the fix resolves it.

Thank you,
Anton