### PR TITLE
8279949: JavaThread::_free_handle_block leaks native memory

### DIFF
--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012 Red Hat, Inc.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -658,10 +658,10 @@ JNI_ENTRY(jobject, jni_PopLocalFrame(JNIEnv *env, jobject result))
     // As a sanity check we only release the handle blocks if the pop_frame_link is not NULL.
     // This way code will still work if PopLocalFrame is called without a corresponding
     // PushLocalFrame call. Note that we set the pop_frame_link to NULL explicitly, otherwise
-    // the release_block call will release the blocks.
+    // the move_to_free_handle_block call will release the blocks.
     thread->set_active_handles(new_handles);
     old_handles->set_pop_frame_link(NULL);              // clear link we won't release new_handles below
-    JNIHandleBlock::release_block(old_handles, thread); // may block
+    JNIHandleBlock::move_to_free_handle_block(old_handles, thread);
     result = JNIHandles::make_local(thread, result_handle());
   }
   HOTSPOT_JNI_POPLOCALFRAME_RETURN(result);

--- a/src/hotspot/share/prims/universalUpcallHandler.cpp
+++ b/src/hotspot/share/prims/universalUpcallHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -129,7 +129,7 @@ void ProgrammableUpcallHandler::on_exit(OptimizedEntryBlob::FrameData* context) 
 
   // Release handles after we are marked as being in native code again, since this
   // operation might block
-  JNIHandleBlock::release_block(context->new_handles, thread);
+  JNIHandleBlock::move_to_free_handle_block(context->new_handles, thread);
 
   assert(!thread->has_pending_exception(), "Upcall can not throw an exception");
 

--- a/src/hotspot/share/runtime/javaCalls.cpp
+++ b/src/hotspot/share/runtime/javaCalls.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -126,7 +126,7 @@ JavaCallWrapper::~JavaCallWrapper() {
 
   // Release handles after we are marked as being inside the VM again, since this
   // operation might block
-  JNIHandleBlock::release_block(_old_handles, _thread);
+  JNIHandleBlock::move_to_free_handle_block(_old_handles, _thread);
 
   if (_thread->has_pending_exception() && _thread->has_last_Java_frame()) {
     // If we get here, the Java code threw an exception that unwound a frame.

--- a/src/hotspot/share/runtime/jniHandles.hpp
+++ b/src/hotspot/share/runtime/jniHandles.hpp
@@ -166,7 +166,8 @@ class JNIHandleBlock : public CHeapObj<mtInternal> {
 
   // Block allocation and block free list management
   static JNIHandleBlock* allocate_block(JavaThread* thread = NULL, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM);
-  static void release_block(JNIHandleBlock* block, JavaThread* thread = NULL);
+  static void move_to_free_handle_block(JNIHandleBlock* block, JavaThread* thread);
+  static void release_block(JNIHandleBlock* block);
 
   // JNI PushLocalFrame/PopLocalFrame support
   JNIHandleBlock* pop_frame_link() const          { return _pop_frame_link; }

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1925,7 +1925,7 @@ void JavaThread::pop_jni_handle_block() {
   assert(new_handles != nullptr, "should never set active handles to null");
   set_active_handles(new_handles);
   old_handles->set_pop_frame_link(NULL);
-  JNIHandleBlock::release_block(old_handles, this);
+  JNIHandleBlock::move_to_free_handle_block(old_handles, this);
 }
 
 void JavaThread::oops_do_no_frames(OopClosure* f, CodeBlobClosure* cf) {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8279949](https://bugs.openjdk.java.net/browse/JDK-8279949): JavaThread::_free_handle_block leaks native memory


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7417/head:pull/7417` \
`$ git checkout pull/7417`

Update a local copy of the PR: \
`$ git checkout pull/7417` \
`$ git pull https://git.openjdk.java.net/jdk pull/7417/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7417`

View PR using the GUI difftool: \
`$ git pr show -t 7417`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7417.diff">https://git.openjdk.java.net/jdk/pull/7417.diff</a>

</details>
