### PR TITLE
8281567: Remove @throws IOException from X509CRLImpl::getExtension docs

### DIFF
--- a/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1047,7 +1047,6 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
      *
      * @param oid ObjectIdentifier of extension desired
      * @return Object of type {@code <extension>} or null, if not found
-     * @throws IOException on error
      */
     public Object getExtension(ObjectIdentifier oid) {
         if (extensions == null)


### PR DESCRIPTION
In class sun.security.x509.X509CRLImpl, method getExtension(ObjectIdentifier) doesn't declare that IOException would be thrown, so the @throws IOException doc should be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281567](https://bugs.openjdk.java.net/browse/JDK-8281567): Remove @throws IOException from X509CRLImpl::getExtension docs


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7419/head:pull/7419` \
`$ git checkout pull/7419`

Update a local copy of the PR: \
`$ git checkout pull/7419` \
`$ git pull https://git.openjdk.java.net/jdk pull/7419/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7419`

View PR using the GUI difftool: \
`$ git pr show -t 7419`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7419.diff">https://git.openjdk.java.net/jdk/pull/7419.diff</a>

</details>
