### PR TITLE
8047749: javadoc for getPathBounds() in TreeUI and BasicTreeUI is incorrect

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/TreeUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/TreeUI.java
@@ -45,7 +45,7 @@ public abstract class TreeUI extends ComponentUI
     /**
      * Returns the Rectangle enclosing the label portion that the
      * last item in path will be drawn into.  Will return null if
-     * any component in path is currently valid.
+     * any component in path is currently invalid.
      *
      * @param tree the {@code JTree} for {@code path}
      * @param path the {@code TreePath} identifying the node

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTreeUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTreeUI.java
@@ -665,7 +665,7 @@ public class BasicTreeUI extends TreeUI
     /**
       * Returns the Rectangle enclosing the label portion that the
       * last item in path will be drawn into.  Will return null if
-      * any component in path is currently valid.
+      * any component in path is currently invalid.
       */
     public Rectangle getPathBounds(JTree tree, TreePath path) {
         if(tree != null && treeState != null) {


### PR DESCRIPTION
The javadoc descriptions for javax.swing.plaf.TreeUI.getPathBounds() and javax.swing.plaf.basic.BasicTreeUI.getPathBounds() have stated it returns null if any component in path is currently "valid", which is wrong.
The getPathBounds() in BasicTreeUI returns null if tree or treeState is null. 
Fixed the javadoc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8047749](https://bugs.openjdk.java.net/browse/JDK-8047749): javadoc for getPathBounds() in TreeUI and BasicTreeUI is incorrect


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7421/head:pull/7421` \
`$ git checkout pull/7421`

Update a local copy of the PR: \
`$ git checkout pull/7421` \
`$ git pull https://git.openjdk.java.net/jdk pull/7421/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7421`

View PR using the GUI difftool: \
`$ git pr show -t 7421`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7421.diff">https://git.openjdk.java.net/jdk/pull/7421.diff</a>

</details>
