### PR TITLE
8282534: Remove redundant null check in ChaCha20Cipher.engineInit

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/ChaCha20Cipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/ChaCha20Cipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -159,7 +159,7 @@ abstract class ChaCha20Cipher extends CipherSpi {
      * ciphers, but allow {@code NoPadding}.  See JCE spec.
      *
      * @param padding The padding type.  The only allowed value is
-     *      {@code NoPadding} case insensitive).
+     *      {@code NoPadding} case insensitive.
      *
      * @throws NoSuchPaddingException if a padding scheme besides
      *      {@code NoPadding} is provided.
@@ -393,7 +393,7 @@ abstract class ChaCha20Cipher extends CipherSpi {
             return;
         }
 
-        byte[] newNonce = null;
+        byte[] newNonce;
         switch (mode) {
             case MODE_NONE:
                 throw new InvalidAlgorithmParameterException(
@@ -418,12 +418,6 @@ abstract class ChaCha20Cipher extends CipherSpi {
                 break;
             default:
                 throw new RuntimeException("Invalid mode: " + mode);
-        }
-
-        // If after all the above processing we still don't have a nonce value
-        // then supply a random one provided a random source has been given.
-        if (newNonce == null) {
-            newNonce = createRandomNonce(random);
         }
 
         // Continue with initialization


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282534](https://bugs.openjdk.java.net/browse/JDK-8282534): Remove redundant null check in ChaCha20Cipher.engineInit


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7424/head:pull/7424` \
`$ git checkout pull/7424`

Update a local copy of the PR: \
`$ git checkout pull/7424` \
`$ git pull https://git.openjdk.java.net/jdk pull/7424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7424`

View PR using the GUI difftool: \
`$ git pr show -t 7424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7424.diff">https://git.openjdk.java.net/jdk/pull/7424.diff</a>

</details>
