### PR TITLE
8274524: SSLSocket.close() hangs if it is called during the ssl handshake

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
@@ -110,7 +110,7 @@ public final class SSLSocketImpl
     /*
      * Default timeout to skip bytes from the open socket
      */
-    private static final int DEFAULT_SKIP_TIMEOUT = 100;
+    private static final int DEFAULT_SKIP_TIMEOUT = 1;
 
     /**
      * Package-private constructor used to instantiate an unconnected
@@ -1788,6 +1788,11 @@ public final class SSLSocketImpl
                 if (appInput.readLock.tryLock()) {
                     int soTimeout = getSoTimeout();
                     try {
+                        // deplete could hang on the skip operation
+                        // in case of infinite socket read timeout.
+                        // Change read timeout to avoid deadlock.
+                        // This workaround could be replaced later
+                        // with the right synchronization
                         if (soTimeout == 0)
                             setSoTimeout(DEFAULT_SKIP_TIMEOUT);
                         inputRecord.deplete(false);

--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketInputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketInputRecord.java
@@ -34,7 +34,6 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
-import java.util.concurrent.locks.ReentrantLock;
 import javax.crypto.BadPaddingException;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
@@ -59,9 +58,6 @@ final class SSLSocketInputRecord extends InputRecord implements SSLRecord {
 
     // Cache for incomplete handshake messages.
     private ByteBuffer handshakeBuffer = null;
-
-    // reading lock
-    private final ReentrantLock readLock = new ReentrantLock();
 
     SSLSocketInputRecord(HandshakeHash handshakeHash) {
         super(handshakeHash, SSLReadCipher.nullTlsReadCipher());
@@ -478,16 +474,8 @@ final class SSLSocketInputRecord extends InputRecord implements SSLRecord {
         return headerSize;
     }
 
-    private int read(InputStream is, byte[] buf, int off, int len)  throws IOException {
-
-        int readLen = 0;
-        readLock.lock();
-        try {
-            readLen = is.read(buf, off, len);
-        } finally {
-            readLock.unlock();
-        }
-
+    private static int read(InputStream is, byte[] buf, int off, int len)  throws IOException {
+        int readLen = is.read(buf, off, len);
         if (readLen < 0) {
             if (SSLLogger.isOn && SSLLogger.isOn("packet")) {
                 SSLLogger.fine("Raw read: EOF");
@@ -504,19 +492,14 @@ final class SSLSocketInputRecord extends InputRecord implements SSLRecord {
 
     // Try to use up the input stream without impact the performance too much.
     void deplete(boolean tryToRead) throws IOException {
-        readLock.lock();
-        try {
-            int remaining = is.available();
-            if (tryToRead && (remaining == 0)) {
-                // try to wait and read one byte if no buffered input
-                is.read();
-            }
+        int remaining = is.available();
+        if (tryToRead && (remaining == 0)) {
+            // try to wait and read one byte if no buffered input
+            is.read();
+        }
 
-            while ((remaining = is.available()) != 0) {
-                is.skip(remaining);
-            }
-        } finally {
-            readLock.unlock();
+        while ((remaining = is.available()) != 0) {
+            is.skip(remaining);
         }
     }
 }

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/ClientSocketCloseHang.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/ClientSocketCloseHang.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8274524
+ * @summary 8274524: SSLSocket.close() hangs if it is called during the ssl handshake
+ * @library /javax/net/ssl/templates
+ * @run main/othervm ClientSocketCloseHang TLSv1.2
+ * @run main/othervm ClientSocketCloseHang TLSv1.3
+ */
+
+
+import javax.net.ssl.*;
+import java.net.InetAddress;
+
+public class ClientSocketCloseHang implements SSLContextTemplate {
+
+    public static void main(String[] args) throws Exception {
+        System.setProperty("jdk.tls.client.protocols", args[0]);
+        for (int i = 0; i<= 20; i++) {
+            System.err.println("===================================");
+            System.err.println("loop " + i);
+            System.err.println("===================================");
+            new ClientSocketCloseHang().test();
+        }
+    }
+
+    private void test() throws Exception {
+        SSLServerSocket listenSocket = null;
+        SSLSocket serverSocket = null;
+        ClientSocket clientSocket = null;
+        try {
+            SSLServerSocketFactory serversocketfactory =
+                    createServerSSLContext().getServerSocketFactory();
+            listenSocket =
+                    (SSLServerSocket)serversocketfactory.createServerSocket(0);
+            listenSocket.setNeedClientAuth(false);
+            listenSocket.setEnableSessionCreation(true);
+            listenSocket.setUseClientMode(false);
+
+
+            System.err.println("Starting client");
+            clientSocket = new ClientSocket(listenSocket.getLocalPort());
+            clientSocket.start();
+
+            System.err.println("Accepting client requests");
+            serverSocket = (SSLSocket) listenSocket.accept();
+
+            serverSocket.startHandshake();
+        } finally {
+            if (clientSocket != null) {
+                clientSocket.close();
+            }
+            if (listenSocket != null) {
+                listenSocket.close();
+            }
+
+            if (serverSocket != null) {
+                serverSocket.close();
+            }
+        }
+    }
+
+    private class ClientSocket extends Thread{
+        int serverPort = 0;
+        SSLSocket clientSocket = null;
+
+        public ClientSocket(int serverPort) {
+            this.serverPort = serverPort;
+        }
+
+        @Override
+        public void run() {
+            try {
+                System.err.println(
+                        "Connecting to server at port " + serverPort);
+                SSLSocketFactory sslSocketFactory =
+                        createClientSSLContext().getSocketFactory();
+                clientSocket = (SSLSocket)sslSocketFactory.createSocket(
+                        InetAddress.getLocalHost(), serverPort);
+                clientSocket.setSoLinger(true, 3);
+                clientSocket.startHandshake();
+            } catch (Exception e) {
+            }
+        }
+
+        public void close() {
+            Thread t = new Thread() {
+                @Override
+                public void run() {
+                    try {
+                        if (clientSocket != null) {
+                            clientSocket.close();
+                        }
+                    } catch(Exception ex) {
+                    }
+                }
+            };
+            try {
+                // Close client connection
+                t.start();
+                t.join(2000); // 2 sec
+            } catch (InterruptedException ex) {
+                return;
+            }
+ 
+            if (t.isAlive()) {
+                throw new RuntimeException("SSL Client hangs on close");
+            }
+        }
+    }
+}
+

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/ClientSocketCloseHang.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/ClientSocketCloseHang.java
@@ -113,7 +113,7 @@ public class ClientSocketCloseHang implements SSLContextTemplate {
                         if (clientSocket != null) {
                             clientSocket.close();
                         }
-                    } catch(Exception ex) {
+                    } catch (Exception ex) {
                     }
                 }
             };
@@ -124,7 +124,7 @@ public class ClientSocketCloseHang implements SSLContextTemplate {
             } catch (InterruptedException ex) {
                 return;
             }
- 
+
             if (t.isAlive()) {
                 throw new RuntimeException("SSL Client hangs on close");
             }


### PR DESCRIPTION
Please review the patch for the JDK-8274524

SSLSocket.close() could cause an intermittent hang of the socket read operation. It happens in case of SO_TIMEOUT is set to 0 (infinite timeout).
SSLSocket.close() reads from the socket as part of the skip() operation to prevent TCP Connection reset (see JDK-8268965). Socket reads are performed in a loop for small chunks. These read operations could cause a deadlock, in case of SO_TIMEOUT = 0
I suggest to force non-zero SO_TIMEOUT during the skip() operation to prevent such deadlock

This is a second iteration of review. Previous PR was closed without integration: https://github.com/openjdk/jdk/pull/5760

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274524](https://bugs.openjdk.java.net/browse/JDK-8274524): SSLSocket.close() hangs if it is called during the ssl handshake


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7432/head:pull/7432` \
`$ git checkout pull/7432`

Update a local copy of the PR: \
`$ git checkout pull/7432` \
`$ git pull https://git.openjdk.java.net/jdk pull/7432/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7432`

View PR using the GUI difftool: \
`$ git pr show -t 7432`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7432.diff">https://git.openjdk.java.net/jdk/pull/7432.diff</a>

</details>
