### PR TITLE
8279997: check_for_dynamic_dump should not exit vm

### DIFF
--- a/src/hotspot/share/cds/dynamicArchive.cpp
+++ b/src/hotspot/share/cds/dynamicArchive.cpp
@@ -375,9 +375,10 @@ void DynamicArchive::check_for_dynamic_dump() {
       vm_exit_during_initialization("-XX:+RecordDynamicDumpInfo" __THEMSG, NULL);
     } else {
       assert(ArchiveClassesAtExit != nullptr, "sanity");
-      vm_exit_during_initialization("-XX:ArchiveClassesAtExit" __THEMSG, NULL);
-#undef __THEMSG
+      warning("-XX:ArchiveClassesAtExit" __THEMSG);
     }
+#undef __THEMSG
+    DynamicDumpSharedSpaces = false;
   }
 }
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3576,6 +3576,10 @@ void Arguments::init_shared_archive_paths() {
             SharedArchivePath = get_default_shared_archive_path();
             SharedArchiveFile = nullptr;
           } else {
+            if (AutoCreateSharedArchive) {
+              warning("-XX:+AutoCreateSharedArchive is unsupported when base CDS archive is not loaded. Run with -Xlog:cds for more info.");
+              AutoCreateSharedArchive = false;
+            }
             no_shared_spaces("invalid archive");
           }
         } else if (base_archive_path == NULL) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchiveConsistency.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchiveConsistency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -202,5 +202,30 @@ public class ArchiveConsistency extends DynamicArchiveTestBase {
         runTwo(nonExistBase, nonExistTop,
                appJar, mainClass, isAuto ? 0 : 1,
                "Specified shared archive not found (" + nonExistBase + ")");
+
+        // following two tests:
+        //   -Xshare:auto -XX:SharedArchiveFile=top.jsa, but base does not exist.
+
+        new File(baseArchiveName).delete();
+
+        startTest("10. -XX:+AutoCreateSharedArchive -XX:SharedArchiveFile=" + topArchiveName);
+        run(topArchiveName,
+            "-Xshare:auto",
+            "-XX:+AutoCreateSharedArchive",
+            "-cp",
+            appJar, mainClass)
+            .assertNormalExit(output -> {
+                output.shouldContain("warning: -XX:+AutoCreateSharedArchive is unsupported when base CDS archive is not loaded");
+            });
+
+        startTest("10. -XX:SharedArchiveFile=" + topArchiveName + " -XX:ArchiveClassesAtExit=" + getNewArchiveName("top3"));
+        run(topArchiveName,
+            "-Xshare:auto",
+            "-XX:ArchiveClassesAtExit=" + getNewArchiveName("top3"),
+            "-cp",
+            appJar, mainClass)
+            .assertNormalExit(output -> {
+                output.shouldContain("VM warning: -XX:ArchiveClassesAtExit is unsupported when base CDS archive is not loaded");
+            });
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchiveConsistency.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchiveConsistency.java
@@ -218,7 +218,7 @@ public class ArchiveConsistency extends DynamicArchiveTestBase {
                 output.shouldContain("warning: -XX:+AutoCreateSharedArchive is unsupported when base CDS archive is not loaded");
             });
 
-        startTest("10. -XX:SharedArchiveFile=" + topArchiveName + " -XX:ArchiveClassesAtExit=" + getNewArchiveName("top3"));
+        startTest("11. -XX:SharedArchiveFile=" + topArchiveName + " -XX:ArchiveClassesAtExit=" + getNewArchiveName("top3"));
         run(topArchiveName,
             "-Xshare:auto",
             "-XX:ArchiveClassesAtExit=" + getNewArchiveName("top3"),

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/SharedArchiveFileOption.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/SharedArchiveFileOption.java
@@ -187,36 +187,37 @@ public class SharedArchiveFileOption extends DynamicArchiveTestBase {
 
         testcase("Specifying -XX:+RecordDynamicDumpInfo should not cause dynamic dump");
         run2(baseArchiveName, null,
-            "-XX:+RecordDynamicDumpInfo",
-            "-Xlog:cds+dynamic=debug",
-            "-cp", appJar, mainClass)
+             "-XX:+RecordDynamicDumpInfo",
+             "-Xlog:cds+dynamic=debug",
+             "-cp", appJar, mainClass)
             .assertNormalExit(output -> {
-                output.shouldNotMatch("\\[cds,dynamic");
-            });
+                    output.shouldNotMatch("\\[cds,dynamic");
+                });
 
          {
-            testcase("-XX:ArchiveClassesAtExit with CDS disabled (-Xshare:off)");
             String ERROR = "-XX:ArchiveClassesAtExit is unsupported when base CDS archive is not loaded";
+
+            testcase("-XX:ArchiveClassesAtExit with CDS disabled (-Xshare:off)");
             dump2(baseArchiveName,
                   topArchiveName,
                   "-Xshare:off",
                   "-Xlog:cds",
                   "-cp", appJar, mainClass)
-            .assertNormalExit(output -> {
-                output.shouldNotMatch("\\[cds,dynamic");
-                output.shouldContain("-XX:ArchiveClassesAtExit is unsupported when base CDS archive is not loaded");
-            });
+                 .assertNormalExit(output -> {
+                         output.shouldNotMatch("\\[cds,dynamic");
+                         output.shouldContain(ERROR);
+                     });
 
             testcase("-XX:ArchiveClassesAtExit with CDS disabled (Base archive cannot be mapped -- doesn't exist");
             dump2(baseArchiveName + ".notExist",
                   topArchiveName,
                   "-Xlog:cds",
                   "-Xshare:auto",
-                 "-cp", appJar, mainClass)
-            .assertNormalExit(output -> {
-                output.shouldNotMatch("\\[cds,dynamic");
-                output.shouldContain("-XX:ArchiveClassesAtExit is unsupported when base CDS archive is not loaded");
-            });
+                  "-cp", appJar, mainClass)
+                 .assertNormalExit(output -> {
+                         output.shouldNotMatch("\\[cds,dynamic");
+                         output.shouldContain(ERROR);
+                     });
 
             testcase("-XX:ArchiveClassesAtExit with CDS disabled (incompatible VM options)");
             dump2(baseArchiveName,
@@ -226,7 +227,7 @@ public class SharedArchiveFileOption extends DynamicArchiveTestBase {
                   "-Xshare:auto",
                   "-Xlog:cds",
                   "-cp", appJar, mainClass)
-            .assertAbnormalExit("Cannot use the following option when dumping the shared archive: --patch-module");
+                 .assertAbnormalExit("Cannot use the following option when dumping the shared archive: --patch-module");
         }
 
         {

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/SharedArchiveFileOption.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/SharedArchiveFileOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,17 +62,6 @@ public class SharedArchiveFileOption extends DynamicArchiveTestBase {
 
     private interface MyRunnable {
         public void run() throws Exception;
-    }
-
-    private static void mustSkipWith(String expectedMsg, MyRunnable r) throws Exception {
-        try {
-            r.run();
-        } catch (SkippedException e) {
-            System.out.println("Got SkippedException: " + e);
-            Asserts.assertTrue(e.getMessage().contains(expectedMsg), "SkippedException must have message " + expectedMsg);
-            return;
-        }
-        Asserts.fail("SkippedException should have been thrown");
     }
 
     private static void doTest(String baseArchiveName, String topArchiveName) throws Exception {
@@ -198,32 +187,36 @@ public class SharedArchiveFileOption extends DynamicArchiveTestBase {
 
         testcase("Specifying -XX:+RecordDynamicDumpInfo should not cause dynamic dump");
         run2(baseArchiveName, null,
-             "-XX:+RecordDynamicDumpInfo",
-             "-Xlog:cds+dynamic=debug",
-             "-cp", appJar, mainClass)
+            "-XX:+RecordDynamicDumpInfo",
+            "-Xlog:cds+dynamic=debug",
+            "-cp", appJar, mainClass)
             .assertNormalExit(output -> {
-                    output.shouldNotMatch("\\[cds,dynamic");
-                });
+                output.shouldNotMatch("\\[cds,dynamic");
+            });
 
-        {
-            String ERROR = "-XX:ArchiveClassesAtExit is unsupported when base CDS archive is not loaded";
-
+         {
             testcase("-XX:ArchiveClassesAtExit with CDS disabled (-Xshare:off)");
-            mustSkipWith(ERROR, () -> {
-                    dump2(baseArchiveName,
-                          topArchiveName,
-                          "-Xshare:off",
-                          "-cp", appJar, mainClass);
-                });
+            String ERROR = "-XX:ArchiveClassesAtExit is unsupported when base CDS archive is not loaded";
+            dump2(baseArchiveName,
+                  topArchiveName,
+                  "-Xshare:off",
+                  "-Xlog:cds",
+                  "-cp", appJar, mainClass)
+            .assertNormalExit(output -> {
+                output.shouldNotMatch("\\[cds,dynamic");
+                output.shouldContain("-XX:ArchiveClassesAtExit is unsupported when base CDS archive is not loaded");
+            });
 
             testcase("-XX:ArchiveClassesAtExit with CDS disabled (Base archive cannot be mapped -- doesn't exist");
-            mustSkipWith(ERROR, () -> {
-                    dump2(baseArchiveName + ".notExist",
-                          topArchiveName,
-                          "-Xlog:cds",
-                          "-Xshare:auto",
-                          "-cp", appJar, mainClass);
-                });
+            dump2(baseArchiveName + ".notExist",
+                  topArchiveName,
+                  "-Xlog:cds",
+                  "-Xshare:auto",
+                 "-cp", appJar, mainClass)
+            .assertNormalExit(output -> {
+                output.shouldNotMatch("\\[cds,dynamic");
+                output.shouldContain("-XX:ArchiveClassesAtExit is unsupported when base CDS archive is not loaded");
+            });
 
             testcase("-XX:ArchiveClassesAtExit with CDS disabled (incompatible VM options)");
             dump2(baseArchiveName,
@@ -233,7 +226,7 @@ public class SharedArchiveFileOption extends DynamicArchiveTestBase {
                   "-Xshare:auto",
                   "-Xlog:cds",
                   "-cp", appJar, mainClass)
-                .assertAbnormalExit("Cannot use the following option when dumping the shared archive: --patch-module");
+            .assertAbnormalExit("Cannot use the following option when dumping the shared archive: --patch-module");
         }
 
         {


### PR DESCRIPTION
Hi, please review
  When run with -Xshare:auto and the base archive could not be loaded, vm should not exit in DynamicArchive::check_for_dynamic_dump, instead, it should continue without sharing.
  The fix is the run will continue but print out warning to remind user of using -Xlog:cds for more information.

Tests: tier1,tier4

Thanks
Yumin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279997](https://bugs.openjdk.java.net/browse/JDK-8279997): check_for_dynamic_dump should not exit vm


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7433/head:pull/7433` \
`$ git checkout pull/7433`

Update a local copy of the PR: \
`$ git checkout pull/7433` \
`$ git pull https://git.openjdk.java.net/jdk pull/7433/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7433`

View PR using the GUI difftool: \
`$ git pr show -t 7433`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7433.diff">https://git.openjdk.java.net/jdk/pull/7433.diff</a>

</details>
