### PR TITLE
8281335: Allow a library already loaded via System::loadLibrary to be loaded as a raw library

### DIFF
--- a/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -2385,7 +2385,7 @@ public abstract class ClassLoader {
         return null;
     }
 
-    private final NativeLibraries libraries = NativeLibraries.jniNativeLibraries(this);
+    private final NativeLibraries libraries = NativeLibraries.newInstance(this);
 
     // Invoked in the java.lang.Runtime class to implement load and loadLibrary.
     static NativeLibrary loadLibrary(Class<?> fromClass, File file) {

--- a/src/java.base/share/classes/jdk/internal/loader/BootLoader.java
+++ b/src/java.base/share/classes/jdk/internal/loader/BootLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,7 +74,7 @@ public class BootLoader {
 
     // native libraries loaded by the boot class loader
     private static final NativeLibraries NATIVE_LIBS
-        = NativeLibraries.jniNativeLibraries(null);
+        = NativeLibraries.newInstance(null);
 
     /**
      * Returns the unnamed module for the boot loader.

--- a/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
+++ b/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
@@ -317,7 +317,11 @@ public final class NativeLibraries {
             return findEntry0(this, name);
         }
 
-        Runnable unloader() {
+        /*
+         * Unloader::run method is invoked to unload the native library
+         * when this class loader becomes phantom reachable.
+         */
+        private Runnable unloader() {
             return new Unloader(name, handle, isBuiltin, isJNI);
         }
 
@@ -330,6 +334,13 @@ public final class NativeLibraries {
             }
 
             return load(this, name, isBuiltin, isJNI, loadLibraryOnlyIfPresent);
+        }
+
+        /*
+         * Close this native library.
+         */
+        void close() {
+            unload(name, isBuiltin, isJNI, handle);
         }
     }
 
@@ -424,7 +435,7 @@ public final class NativeLibraries {
     private static final Map<String, CountedLock> nativeLibraryLockMap =
             new ConcurrentHashMap<>();
 
-    static void acquireNativeLibraryLock(String libraryName) {
+    private static void acquireNativeLibraryLock(String libraryName) {
         nativeLibraryLockMap.compute(libraryName,
             new BiFunction<>() {
                 public CountedLock apply(String name, CountedLock currentLock) {
@@ -439,7 +450,7 @@ public final class NativeLibraries {
         ).lock();
     }
 
-    static void releaseNativeLibraryLock(String libraryName) {
+    private static void releaseNativeLibraryLock(String libraryName) {
         CountedLock lock = nativeLibraryLockMap.computeIfPresent(libraryName,
             new BiFunction<>() {
                 public CountedLock apply(String name, CountedLock currentLock) {

--- a/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
+++ b/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
@@ -247,8 +247,7 @@ public abstract class NativeLibraries {
         private JniNativeLibraries(ClassLoader loader) {
             // for null loader, default the caller to this class and
             // do not search java.library.path
-            super(loader, loader != null ? null : NativeLibraries.class,
-                    loader != null ? true : false);
+            super(loader, loader != null ? null : NativeLibraries.class, loader != null);
         }
 
         /**

--- a/src/java.base/share/classes/jdk/internal/loader/RawNativeLibraries.java
+++ b/src/java.base/share/classes/jdk/internal/loader/RawNativeLibraries.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.internal.loader;
+
+import jdk.internal.misc.VM;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.nio.file.Path;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static jdk.internal.loader.NativeLibraries.*;
+
+
+/**
+ * RawNativeLibraries has the following properties:
+ * 1. Native libraries loaded in this RawNativeLibraries instance are
+ *    not JNI native libraries.  Hence JNI_OnLoad and JNI_OnUnload will
+ *    be ignored.  No support for linking of native method.
+ * 2. Native libraries not auto-unloaded.  They may be explicitly unloaded
+ *    via NativeLibraries::unload.
+ * 3. No relationship with class loaders.
+ */
+public final class RawNativeLibraries {
+    final Map<String, NativeLibraryImpl> libraries = new ConcurrentHashMap<>();
+    final Class<?> caller;
+
+    private RawNativeLibraries(MethodHandles.Lookup trustedCaller) {
+        this.caller = trustedCaller.lookupClass();
+    }
+
+    /**
+     * Creates a RawNativeLibraries instance that has no relationship with
+     * any class loaders and disabled auto unloading.
+     *
+     * This static factory method is restricted for JDK trusted class use.
+     */
+    public static RawNativeLibraries newInstance(MethodHandles.Lookup trustedCaller) {
+        if (!trustedCaller.hasFullPrivilegeAccess() ||
+                !VM.isSystemDomainLoader(trustedCaller.lookupClass().getClassLoader())) {
+            throw new InternalError(trustedCaller + " does not have access to raw native library loading");
+        }
+        return new RawNativeLibraries(trustedCaller);
+    }
+
+    /*
+     * Load a native library from the given path.  Returns null if the given
+     * library is determined to be non-loadable, which is system-dependent.
+     *
+     * @param path the path of the native library
+     */
+    @SuppressWarnings("removal")
+    public NativeLibrary load(Path path) {
+        String name = AccessController.doPrivileged(new PrivilegedAction<>() {
+            public String run() {
+                try {
+                    return path.toRealPath().toString();
+                } catch (IOException e) {
+                    return null;
+                }
+            }
+        });
+        if (name == null) {
+            return null;
+        }
+        return load(name);
+    }
+
+    /**
+     * Load a native library of the given pathname, which is platform-specific.
+     * Returns null if it fails to load the given pathname.
+     *
+     * If the given pathname does not contain a name-separator character,
+     * for example on Unix a slash character, the library search strategy
+     * is system-dependent for example on Unix, see dlopen.
+     *
+     * @apiNote
+     * The {@code pathname} argument is platform-specific.
+     * {@link System#mapLibraryName} can be used to convert a name to
+     * a platform-specific pathname:
+     * {@snipplet
+     *     RawNativeLibraries libs = RawNativeLibraries.newInstance(MethodHandles.lookup());
+     *     NativeLibrary lib = libs.load(System.mapLibraryName("blas"));
+     * }
+     *
+     * @param pathname the pathname of the native library
+     * @see System#mapLibraryName(String)
+     */
+    public NativeLibrary load(String pathname) {
+        acquireNativeLibraryLock(pathname);
+        try {
+            // find if this library has already been loaded and registered
+            NativeLibrary cached = libraries.get(pathname);
+            if (cached != null) {
+                return cached;
+            }
+
+            NativeLibraryImpl lib = new NativeLibraryImpl(caller, pathname, false, false);
+            if (!lib.open()) {
+                return null;    // fail to open the native library
+            }
+
+            libraries.put(pathname, lib);
+            return lib;
+        } finally {
+            releaseNativeLibraryLock(pathname);
+        }
+    }
+
+    /*
+     * Unloads the given native library
+     */
+    public void unload(NativeLibrary lib) {
+        Objects.requireNonNull(lib);
+        acquireNativeLibraryLock(lib.name());
+        try {
+            NativeLibraryImpl nl = libraries.remove(lib.name());
+            if (nl != lib) {
+                throw new IllegalArgumentException(lib.name() + " not loaded by this RawNativeLibraries instance");
+            }
+            // unload the native library and also remove from the global name registry
+            nl.unloader().run();
+        } finally {
+            releaseNativeLibraryLock(lib.name());
+        }
+    }
+}
+

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/SystemLookup.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/SystemLookup.java
@@ -33,6 +33,7 @@ import jdk.incubator.foreign.MemoryAddress;
 import jdk.internal.loader.NativeLibraries;
 import jdk.internal.loader.NativeLibrary;
 
+import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
@@ -63,7 +64,7 @@ public class SystemLookup implements SymbolLookup {
 
         boolean useUCRT = Files.exists(ucrtbase);
         Path stdLib = useUCRT ? ucrtbase : msvcrt;
-        SymbolLookup lookup = libLookup(libs -> libs.loadLibrary(null, stdLib.toFile()));
+        SymbolLookup lookup = libLookup(libs -> libs.loadLibrary(stdLib.toFile()));
 
         if (useUCRT) {
             // use a fallback lookup to look up inline functions from fallback lib
@@ -85,7 +86,7 @@ public class SystemLookup implements SymbolLookup {
     }
 
     private static SymbolLookup libLookup(Function<NativeLibraries, NativeLibrary> loader) {
-        NativeLibrary lib = loader.apply(NativeLibraries.rawNativeLibraries(SystemLookup.class, false));
+        NativeLibrary lib = loader.apply(NativeLibraries.rawNativeLibraries(MethodHandles.lookup(), false));
         return name -> {
             Objects.requireNonNull(name);
             try {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/SystemLookup.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/SystemLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,8 @@ import jdk.incubator.foreign.NativeSymbol;
 import jdk.incubator.foreign.ResourceScope;
 import jdk.incubator.foreign.SymbolLookup;
 import jdk.incubator.foreign.MemoryAddress;
-import jdk.internal.loader.NativeLibraries;
 import jdk.internal.loader.NativeLibrary;
+import jdk.internal.loader.RawNativeLibraries;
 
 import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;
@@ -39,6 +39,8 @@ import java.nio.file.Path;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
+
+import sun.security.action.GetPropertyAction;
 
 import static jdk.incubator.foreign.ValueLayout.ADDRESS;
 
@@ -53,7 +55,7 @@ public class SystemLookup implements SymbolLookup {
      * on Windows. For this reason, on Windows we do not generate any side-library, and load msvcrt.dll directly instead.
      */
     private static final SymbolLookup syslookup = switch (CABI.current()) {
-        case SysV, LinuxAArch64, MacOsAArch64 -> libLookup(libs -> libs.loadLibrary("syslookup"));
+        case SysV, LinuxAArch64, MacOsAArch64 -> libLookup(libs -> libs.load(jdkLibraryPath("syslookup")));
         case Win64 -> makeWindowsLookup(); // out of line to workaround javac crash
     };
 
@@ -64,12 +66,11 @@ public class SystemLookup implements SymbolLookup {
 
         boolean useUCRT = Files.exists(ucrtbase);
         Path stdLib = useUCRT ? ucrtbase : msvcrt;
-        SymbolLookup lookup = libLookup(libs -> libs.loadLibrary(stdLib.toFile()));
+        SymbolLookup lookup = libLookup(libs -> libs.load(stdLib));
 
         if (useUCRT) {
             // use a fallback lookup to look up inline functions from fallback lib
-
-            SymbolLookup fallbackLibLookup = libLookup(libs -> libs.loadLibrary("WinFallbackLookup"));
+            SymbolLookup fallbackLibLookup = libLookup(libs -> libs.load(jdkLibraryPath("WinFallbackLookup")));
 
             int numSymbols = WindowsFallbackSymbols.values().length;
             MemorySegment funcs = MemorySegment.ofAddress(fallbackLibLookup.lookup("funcs").orElseThrow().address(),
@@ -85,8 +86,8 @@ public class SystemLookup implements SymbolLookup {
         return lookup;
     }
 
-    private static SymbolLookup libLookup(Function<NativeLibraries, NativeLibrary> loader) {
-        NativeLibrary lib = loader.apply(NativeLibraries.rawNativeLibraries(MethodHandles.lookup(), false));
+    private static SymbolLookup libLookup(Function<RawNativeLibraries, NativeLibrary> loader) {
+        NativeLibrary lib = loader.apply(RawNativeLibraries.newInstance(MethodHandles.lookup()));
         return name -> {
             Objects.requireNonNull(name);
             try {
@@ -98,6 +99,19 @@ public class SystemLookup implements SymbolLookup {
                 return Optional.empty();
             }
         };
+    }
+
+    /*
+     * Returns the path of the given library name from JDK
+     */
+    private static Path jdkLibraryPath(String name) {
+        Path javahome = Path.of(GetPropertyAction.privilegedGetProperty("java.home"));
+        String lib = switch (CABI.current()) {
+            case SysV, LinuxAArch64, MacOsAArch64 -> "lib";
+            case Win64 -> "bin";
+        };
+        String libname = System.mapLibraryName(name);
+        return javahome.resolve(lib).resolve(libname);
     }
 
     @Override

--- a/test/jdk/jdk/internal/loader/NativeLibraries/Main.java
+++ b/test/jdk/jdk/internal/loader/NativeLibraries/Main.java
@@ -30,7 +30,6 @@
  * @summary Test loading and unloading of native libraries
  */
 
-import jdk.internal.loader.*;
 import jdk.internal.loader.NativeLibrariesTest;
 
 import java.io.IOException;
@@ -53,10 +52,11 @@ public class Main {
         test.unload();
         System.loadLibrary(NativeLibrariesTest.LIB_NAME);
 
-        // expect NativeLibraries to fail since the library has been loaded by System::loadLibrary
-        try {
-            test.load(false);
-        } catch (UnsatisfiedLinkError e) { e.printStackTrace(); }
+        // expect NativeLibraries to succeed even the library has been loaded by System::loadLibrary
+        test.load(true);
+
+        // unload the native library
+        test.unload();
     }
     /*
      * move p/Test.class out from classpath to the scratch directory

--- a/test/jdk/jdk/internal/loader/NativeLibraries/Main.java
+++ b/test/jdk/jdk/internal/loader/NativeLibraries/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8240975
+ * @bug 8240975 8281335
  * @modules java.base/jdk.internal.loader
  * @build java.base/* p.Test Main
  * @run main/othervm/native -Xcheck:jni Main
@@ -41,6 +41,7 @@ public class Main {
     public static void main(String... args) throws Exception {
         setup();
 
+        // Verify a native library from test.nativepath
         NativeLibrariesTest test = new NativeLibrariesTest();
         test.runTest();
 
@@ -55,8 +56,8 @@ public class Main {
         // expect NativeLibraries to succeed even the library has been loaded by System::loadLibrary
         test.load(true);
 
-        // unload the native library
-        test.unload();
+        // load zip library from JDK
+        test.load(System.mapLibraryName("zip"));
     }
     /*
      * move p/Test.class out from classpath to the scratch directory

--- a/test/jdk/jdk/internal/loader/NativeLibraries/java.base/jdk/internal/loader/NativeLibrariesTest.java
+++ b/test/jdk/jdk/internal/loader/NativeLibraries/java.base/jdk/internal/loader/NativeLibrariesTest.java
@@ -23,6 +23,7 @@
 
 package jdk.internal.loader;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -51,7 +52,7 @@ public class NativeLibrariesTest implements Runnable {
 
     private final NativeLibraries nativeLibraries;
     public NativeLibrariesTest() {
-        this.nativeLibraries = NativeLibraries.rawNativeLibraries(NativeLibraries.class, true);
+        this.nativeLibraries = NativeLibraries.rawNativeLibraries(MethodHandles.lookup(), true);
     }
 
     /*

--- a/test/jdk/jdk/internal/loader/NativeLibraries/java.base/jdk/internal/loader/NativeLibrariesTest.java
+++ b/test/jdk/jdk/internal/loader/NativeLibraries/java.base/jdk/internal/loader/NativeLibrariesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ import java.lang.reflect.Constructor;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public class NativeLibrariesTest implements Runnable {
@@ -50,9 +51,10 @@ public class NativeLibrariesTest implements Runnable {
         unloadedCount++;
     }
 
-    private final NativeLibraries nativeLibraries;
+    private final RawNativeLibraries nativeLibraries;
+
     public NativeLibrariesTest() {
-        this.nativeLibraries = NativeLibraries.rawNativeLibraries(MethodHandles.lookup(), true);
+        this.nativeLibraries = RawNativeLibraries.newInstance(MethodHandles.lookup());
     }
 
     /*
@@ -62,9 +64,15 @@ public class NativeLibrariesTest implements Runnable {
         load(true); // expect loading of native library succeed
     }
 
+    static Path libraryPath() {
+        Path lib = Path.of(System.getProperty("test.nativepath"));
+        return lib.resolve(System.mapLibraryName(LIB_NAME));
+    }
+
     public void runTest() throws Exception {
-        NativeLibrary nl1 = nativeLibraries.loadLibrary(LIB_NAME);
-        NativeLibrary nl2 = nativeLibraries.loadLibrary(LIB_NAME);
+        Path lib = libraryPath();
+        NativeLibrary nl1 = nativeLibraries.load(lib);
+        NativeLibrary nl2 = nativeLibraries.load(lib);
         assertTrue(nl1 != null && nl2 != null, "fail to load library");
         assertTrue(nl1 == nl2, nl1 + " != " + nl2);
         assertTrue(loadedCount == 0, "Native library loaded.  Expected: JNI_OnUnload not invoked");
@@ -78,7 +86,7 @@ public class NativeLibrariesTest implements Runnable {
         assertTrue(unloadedCount == 0, "Native library unloaded.  Expected: JNI_OnUnload not invoked");
 
         // reload the native library and expect new NativeLibrary instance
-        NativeLibrary nl3 = nativeLibraries.loadLibrary(LIB_NAME);
+        NativeLibrary nl3 = nativeLibraries.load(lib);
         assertTrue(nl1 != nl3, nl1 + " == " + nl3);
         assertTrue(loadedCount == 0, "Native library loaded.  Expected: JNI_OnUnload not invoked");
 
@@ -87,19 +95,24 @@ public class NativeLibrariesTest implements Runnable {
     }
 
     public void unload() {
-        NativeLibrary nl = nativeLibraries.loadLibrary(LIB_NAME);
+        NativeLibrary nl = nativeLibraries.load(libraryPath());
         // unload the native library
         nativeLibraries.unload(nl);
         assertTrue(unloadedCount == 0, "Native library unloaded.  Expected: JNI_OnUnload not invoked");
     }
 
     public void load(boolean succeed) {
-        NativeLibrary nl = nativeLibraries.loadLibrary(LIB_NAME);
+        NativeLibrary nl = nativeLibraries.load(libraryPath());
         if (succeed) {
             assertTrue(nl != null, "fail to load library");
         } else {
             assertTrue(nl == null, "load library should fail");
         }
+    }
+
+    public void load(String pathname) {
+        NativeLibrary nl = nativeLibraries.load(pathname);
+        assertTrue(nl != null, "fail to load zip library");
     }
 
     /*


### PR DESCRIPTION
This patch removes the restriction in the raw library loading mechanism that does not allow mix-n-match of loading a library as a JNI library and as a raw library.

The raw library loading mechanism is designed for panama to load native library essentially equivalent to dlopen/dlclose calls independent of JNI library loading. If a native library is loaded as a JNI library and a raw library, it will get different NativeLibrary instances. When a class loader is being unloaded, JNI_Unload will be invoked but the native library may not be unloaded until NativeLibrary::unload is explicitly called for the raw library.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281335](https://bugs.openjdk.java.net/browse/JDK-8281335): Allow a library already loaded via System::loadLibrary to be loaded as a raw library


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - **Reviewer**) ⚠️ Review applies to 6e492d2b6851a093df57ba253657b11e9173cc29
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7435/head:pull/7435` \
`$ git checkout pull/7435`

Update a local copy of the PR: \
`$ git checkout pull/7435` \
`$ git pull https://git.openjdk.java.net/jdk pull/7435/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7435`

View PR using the GUI difftool: \
`$ git pr show -t 7435`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7435.diff">https://git.openjdk.java.net/jdk/pull/7435.diff</a>

</details>
