### PR TITLE
8269091: javax/sound/sampled/Clip/SetPositionHang.java failed with ArrayIndexOutOfBoundsException: Array index out of range: -4

### DIFF
--- a/src/java.desktop/share/classes/com/sun/media/sound/DirectAudioDevice.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/DirectAudioDevice.java
@@ -1297,9 +1297,11 @@ final class DirectAudioDevice extends AbstractMixer {
                     }
                 }
                 while (doIO && thread == curThread) {
-                    if (newFramePosition >= 0) {
-                        clipBytePosition = newFramePosition * frameSize;
-                        newFramePosition = -1;
+                    synchronized (this) {
+                        if (newFramePosition >= 0) {
+                            clipBytePosition = newFramePosition * frameSize;
+                            newFramePosition = -1;
+                        }
                     }
                     int endFrame = getFrameLength() - 1;
                     if (loopCount > 0 || loopCount == LOOP_CONTINUOUSLY) {

--- a/src/java.desktop/share/classes/com/sun/media/sound/DirectAudioDevice.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/DirectAudioDevice.java
@@ -1297,11 +1297,10 @@ final class DirectAudioDevice extends AbstractMixer {
                     }
                 }
                 while (doIO && thread == curThread) {
-                    synchronized (this) {
-                        if (newFramePosition >= 0) {
-                            clipBytePosition = newFramePosition * frameSize;
-                            newFramePosition = -1;
-                        }
+                    int npf = newFramePosition; // copy into local variable
+                    if (npf >= 0) {
+                        clipBytePosition = npf * frameSize;
+                        newFramePosition = -1;
                     }
                     int endFrame = getFrameLength() - 1;
                     if (loopCount > 0 || loopCount == LOOP_CONTINUOUSLY) {

--- a/test/jdk/javax/sound/sampled/Clip/SetPositionHang.java
+++ b/test/jdk/javax/sound/sampled/Clip/SetPositionHang.java
@@ -28,7 +28,7 @@ import javax.sound.sampled.LineUnavailableException;
 
 /**
  * @test
- * @bug 8266421
+ * @bug 8266421 8269091
  * @summary Tests that Clip.setFramePosition/setMicrosecondPosition do not hang.
  */
 public final class SetPositionHang implements Runnable {


### PR DESCRIPTION
This test has started failing since we got M1 macs to test on. I don't think we've ever seen this failure elsewhere.
I don't know what it is about that architecture that makes it more likely but I can see how it can happen when multiple threads are using the same instance. 

                    if (newFramePosition >= 0) { 
                        clipBytePosition = newFramePosition * frameSize; 
                        newFramePosition = -1; 
                    } 

newFramePosition is declared volatile which does make it quite possible that after the read and before the use it will have changed.

The fix just synchronizes this block to prevent it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269091](https://bugs.openjdk.java.net/browse/JDK-8269091): javax/sound/sampled/Clip/SetPositionHang.java failed with ArrayIndexOutOfBoundsException: Array index out of range: -4


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7436/head:pull/7436` \
`$ git checkout pull/7436`

Update a local copy of the PR: \
`$ git checkout pull/7436` \
`$ git pull https://git.openjdk.java.net/jdk pull/7436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7436`

View PR using the GUI difftool: \
`$ git pr show -t 7436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7436.diff">https://git.openjdk.java.net/jdk/pull/7436.diff</a>

</details>
