### PR TITLE
8223077: module path support for dynamic CDS archive

### DIFF
--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -491,6 +491,7 @@ public:
   static void clone_shared_path_table(TRAPS);
   static int add_shared_classpaths(int i, const char* which, ClassPathEntry *cpe, TRAPS);
   static void check_nonempty_dir_in_shared_path_table();
+  bool check_module_paths();
   bool validate_shared_path_table();
   void validate_non_existent_class_paths();
   static void set_shared_path_table(FileMapInfo* info) {

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -470,12 +470,12 @@ class Arguments : AllStatic {
   static char*  SharedArchivePath;
   static char*  SharedDynamicArchivePath;
   static size_t _default_SharedBaseAddress; // The default value specified in globals.hpp
-  static int num_archives(const char* archive_path) NOT_CDS_RETURN_(0);
   static void extract_shared_archive_paths(const char* archive_path,
                                          char** base_archive_path,
                                          char** top_archive_path) NOT_CDS_RETURN;
 
  public:
+  static int num_archives(const char* archive_path) NOT_CDS_RETURN_(0);
   // Parses the arguments, first phase
   static jint parse(const JavaVMInitArgs* args);
   // Parse a string for a unsigned integer.  Returns true if value

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
@@ -153,6 +153,19 @@ public class TestCommon extends CDSTestUtils {
         return out;
     }
 
+    public static OutputAnalyzer dumpBaseArchive(String baseArchiveName, String classList[], String ... cmdLineSuffix)
+        throws Exception
+    {
+        CDSOptions opts = new CDSOptions();
+        opts.setArchiveName(baseArchiveName);
+        opts.setClassList(classList);
+        opts.addSuffix(cmdLineSuffix);
+        opts.addSuffix("-Djava.class.path=");
+        OutputAnalyzer out = CDSTestUtils.createArchive(opts);
+        CDSTestUtils.checkBaseDump(out);
+        return out;
+    }
+
     // Create AppCDS archive using most common args - convenience method
     public static OutputAnalyzer createArchive(String appJar, String classList[],
                                                String... suffix) throws Exception {

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ModulePath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ModulePath.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import jdk.test.lib.cds.CDSTestUtils;
+
+/*
+ * @test
+ * @summary Dyanmic archive with module path
+ * @requires vm.cds
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
+ * @compile ../test-classes/Hello.java
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:./WhiteBox.jar ModulePath
+ */
+
+public class ModulePath extends DynamicArchiveTestBase {
+    private static final Path USER_DIR = Paths.get(CDSTestUtils.getOutputDir());
+
+    private static final String FS = File.separator;
+    private static final String TEST_SRC = System.getProperty("test.src") +
+        FS + ".." + FS + "jigsaw" + FS + "modulepath";
+
+    private static final Path SRC_DIR = Paths.get(TEST_SRC, "src");
+    private static final Path MODS_DIR = Paths.get("mods");
+
+    // the module name of the test module
+    private static final String TEST_MODULE = "com.simple";
+
+    // the module main class
+    private static final String MAIN_CLASS = "com.simple.Main";
+
+    private static Path moduleDir = null;
+    private static Path srcJar = null;
+
+    public static void buildTestModule() throws Exception {
+
+        // javac -d mods/$TESTMODULE --module-path MOD_DIR src/$TESTMODULE/**
+        JarBuilder.compileModule(SRC_DIR.resolve(TEST_MODULE),
+                                 MODS_DIR.resolve(TEST_MODULE),
+                                 MODS_DIR.toString());
+
+
+        moduleDir = Files.createTempDirectory(USER_DIR, "mlib");
+        srcJar = moduleDir.resolve(TEST_MODULE + ".jar");
+        String classes = MODS_DIR.resolve(TEST_MODULE).toString();
+        JarBuilder.createModularJar(srcJar.toString(), classes, MAIN_CLASS);
+    }
+
+    public static void main(String[] args) throws Exception {
+        runTest(ModulePath::test);
+    }
+
+    static void test(String args[]) throws Exception {
+        String topArchiveName = getNewArchiveName("top");
+        String baseArchiveName = getNewArchiveName("base");
+
+        String appJar    = JarBuilder.getOrCreateHelloJar();
+        String mainClass = "Hello";
+
+        // create a base archive with the --module-path option
+        buildTestModule();
+        baseArchiveName = getNewArchiveName("base-with-module");
+        String appClasses[] = {mainClass};
+        TestCommon.dumpBaseArchive(baseArchiveName,
+                        appClasses,
+                        "-Xlog:class+load",
+                        "-cp", appJar,
+                        "--module-path", moduleDir.toString(),
+                        "-m", TEST_MODULE);
+
+        // Dumping of dynamic archive should be successful if the specified
+        // --module-path is the same as for the base archive.
+        topArchiveName = getNewArchiveName("top-with-module");
+        dump2(baseArchiveName, topArchiveName,
+              "-Xlog:cds*",
+              "-Xlog:cds+dynamic=debug",
+              "-Xlog:class+path=info,class+load",
+              "-cp", appJar,
+              "--module-path", moduleDir.toString(),
+              "-m", TEST_MODULE, MAIN_CLASS)
+            .assertNormalExit();
+
+        // Load the Hello class from the base archive.
+        run2(baseArchiveName, topArchiveName,
+            "-Xlog:class+load",
+            "-Xlog:cds+dynamic=debug,cds=debug",
+            "-cp", appJar, mainClass)
+            .assertNormalExit(output -> {
+                    output.shouldContain("Hello source: shared objects file")
+                          .shouldHaveExitValue(0);
+                });
+
+        // Load the com.simple.Main class from the dynamic archive.
+        run2(baseArchiveName, topArchiveName,
+            "-Xlog:class+load",
+            "-Xlog:cds+dynamic=debug,cds=debug",
+            "-cp", appJar,
+            "--module-path", moduleDir.toString(),
+            "-m", TEST_MODULE, MAIN_CLASS)
+            .assertNormalExit(output -> {
+                    output.shouldContain("com.simple.Main source: shared objects file (top)")
+                          .shouldHaveExitValue(0);
+                });
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/UnsupportedBaseArchive.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/UnsupportedBaseArchive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/UnsupportedBaseArchive.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/UnsupportedBaseArchive.java
@@ -62,7 +62,7 @@ public class UnsupportedBaseArchive extends DynamicArchiveTestBase {
         "Dynamic archiving is disabled because base layer archive has appended boot classpath";
 
     private static final String warningModulePath =
-        "Dynamic archiving is disabled because base layer archive has module path";
+        "Dynamic archiving is disabled because base layer archive has a different module path";
 
     public static void buildTestModule() throws Exception {
 
@@ -104,22 +104,23 @@ public class UnsupportedBaseArchive extends DynamicArchiveTestBase {
         // create a base archive with the --module-path option
         buildTestModule();
         baseArchiveName = getNewArchiveName("base-with-module");
+        String appClasses[] = {mainClass};
         TestCommon.dumpBaseArchive(baseArchiveName,
-                        "-cp", srcJar.toString(),
+                        appClasses,
+                        "-Xlog:class+load",
+                        "-cp", appJar,
                         "--module-path", moduleDir.toString(),
                         "-m", TEST_MODULE);
 
-        // dumping of dynamic archive should be disabled with a warning message
-        // if the base archive contains --module-path entries.
-        topArchiveName = getNewArchiveName("top-with-module");
+        // Try to create a dynamic archive without specifying module path,
+        // dumping should fail.
+        topArchiveName = getNewArchiveName("top-with-module-failed");
         dump2(baseArchiveName, topArchiveName,
               "-Xlog:cds*",
               "-Xlog:cds+dynamic=debug",
-              "-Xlog:class+path=info",
-              "-cp", srcJar.toString(),
-              "--module-path", moduleDir.toString(),
-              "-m", TEST_MODULE)
+              "-Xlog:class+path=info,class+load",
+              "-cp", appJar,
+              mainClass)
             .assertNormalExit(warningModulePath);
-
     }
 }


### PR DESCRIPTION
Please review this patch for adding module path support for CDS dynamic archive.
Before this patch, if a module path was specified when creating a base archive, the user
won't be able to create a dynamic archive based on the base archive.
VM will issue the following warning:
"Dynamic archiving is disabled because base layer archive has module path"

This patch adds checking of the module patsh in the base archive and the ones specified
for dynamic dumping. If the module paths are the same, dynamic archive will be created.

Testing: tiers 1, 2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8223077](https://bugs.openjdk.java.net/browse/JDK-8223077): module path support for dynamic CDS archive


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to fe11eb6daa6e861f75ed3f0ea13f2758bef6e018
 * [Yumin Qi](https://openjdk.java.net/census#minqi) (@yminqi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7437/head:pull/7437` \
`$ git checkout pull/7437`

Update a local copy of the PR: \
`$ git checkout pull/7437` \
`$ git pull https://git.openjdk.java.net/jdk pull/7437/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7437`

View PR using the GUI difftool: \
`$ git pr show -t 7437`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7437.diff">https://git.openjdk.java.net/jdk/pull/7437.diff</a>

</details>
