### PR TITLE
8281626: NonblockingQueue should use nullptr

### DIFF
--- a/src/hotspot/share/utilities/nonblockingQueue.hpp
+++ b/src/hotspot/share/utilities/nonblockingQueue.hpp
@@ -45,7 +45,7 @@
 //
 // A queue may temporarily appear to be empty even though elements have been
 // added and not removed.  For example, after running the following program,
-// the value of r may be NULL.
+// the value of r may be nullptr.
 //
 // thread1: q.push(a); r = q.pop();
 // thread2: q.push(b);
@@ -105,15 +105,15 @@ public:
 
   // Thread-safe attempt to remove and return the first object in the queue.
   // Returns true if successful.  If successful then *node_ptr is the former
-  // first object, or NULL if the queue was empty.  If unsuccessful, because
+  // first object, or nullptr if the queue was empty.  If unsuccessful, because
   // of contention with a concurrent modification, then returns false with
   // the value of *node_ptr unspecified.  Subject to ABA behavior; callers
   // must ensure usage is safe.
   inline bool try_pop(T** node_ptr);
 
-  // Thread-safe remove and return the first object in the queue, or NULL if
-  // the queue was empty.  This just iterates on try_pop() until it
-  // succeeds, returning the (possibly NULL) element obtained from that.
+  // Thread-safe remove and return the first object in the queue, or nullptr
+  // if the queue was empty.  This just iterates on try_pop() until it
+  // succeeds, returning the (possibly nullptr) element obtained from that.
   // Subject to ABA behavior; callers must ensure usage is safe.
   inline T* pop();
 


### PR DESCRIPTION
Please review this change to use nullptr instead of NULL throughout the NonblockingQueue class.

Testing:
mach5 tier1
