### PR TITLE
8281637: Remove unused VerifyOption_G1UseNextMarking

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2405,7 +2405,6 @@ bool G1CollectedHeap::is_obj_dead_cond(const oop obj,
                                        const VerifyOption vo) const {
   switch (vo) {
   case VerifyOption_G1UsePrevMarking: return is_obj_dead(obj, hr);
-  case VerifyOption_G1UseNextMarking: return is_obj_ill(obj, hr);
   case VerifyOption_G1UseFullMarking: return is_obj_dead_full(obj, hr);
   default:                            ShouldNotReachHere();
   }
@@ -2416,7 +2415,6 @@ bool G1CollectedHeap::is_obj_dead_cond(const oop obj,
                                        const VerifyOption vo) const {
   switch (vo) {
   case VerifyOption_G1UsePrevMarking: return is_obj_dead(obj);
-  case VerifyOption_G1UseNextMarking: return is_obj_ill(obj);
   case VerifyOption_G1UseFullMarking: return is_obj_dead_full(obj);
   default:                            ShouldNotReachHere();
   }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1236,11 +1236,6 @@ public:
   // the region to which the object belongs.
   inline bool is_obj_dead(const oop obj, const HeapRegion* hr) const;
 
-  // This function returns true when an object has been
-  // around since the previous marking and hasn't yet
-  // been marked during this marking, and is not in a closed archive region.
-  inline bool is_obj_ill(const oop obj, const HeapRegion* hr) const;
-
   // Determine if an object is dead, given only the object itself.
   // This will find the region to which the object belongs and
   // then call the region version of the same function.
@@ -1248,8 +1243,6 @@ public:
   // Added if it is NULL it isn't dead.
 
   inline bool is_obj_dead(const oop obj) const;
-
-  inline bool is_obj_ill(const oop obj) const;
 
   inline bool is_obj_dead_full(const oop obj, const HeapRegion* hr) const;
   inline bool is_obj_dead_full(const oop obj) const;
@@ -1302,15 +1295,11 @@ public:
   // Perform verification.
 
   // vo == UsePrevMarking -> use "prev" marking information,
-  // vo == UseNextMarking -> use "next" marking information
   // vo == UseFullMarking -> use "next" marking bitmap but no TAMS
   //
   // NOTE: Only the "prev" marking information is guaranteed to be
   // consistent most of the time, so most calls to this should use
   // vo == UsePrevMarking.
-  // Currently, there is only one case where this is called with
-  // vo == UseNextMarking, which is to verify the "next" marking
-  // information at the end of remark.
   // Currently there is only one place where this is called with
   // vo == UseFullMarking, which is to verify the marking during a
   // full GC.

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -226,20 +226,6 @@ inline bool G1CollectedHeap::is_obj_dead(const oop obj) const {
   return is_obj_dead(obj, heap_region_containing(obj));
 }
 
-inline bool G1CollectedHeap::is_obj_ill(const oop obj, const HeapRegion* hr) const {
-  return
-    !hr->obj_allocated_since_next_marking(obj) &&
-    !is_marked_next(obj) &&
-    !hr->is_closed_archive();
-}
-
-inline bool G1CollectedHeap::is_obj_ill(const oop obj) const {
-  if (obj == NULL) {
-    return false;
-  }
-  return is_obj_ill(obj, heap_region_containing(obj));
-}
-
 inline bool G1CollectedHeap::is_obj_dead_full(const oop obj, const HeapRegion* hr) const {
    return !is_marked_next(obj) && !hr->is_closed_archive();
 }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
@@ -41,7 +41,20 @@
 #include "utilities/bitMap.inline.hpp"
 
 inline bool G1CMIsAliveClosure::do_object_b(oop obj) {
-  return !_g1h->is_obj_ill(obj);
+  HeapRegion* hr = _g1h->heap_region_containing(cast_from_oop<HeapWord*>(obj));
+
+  // All objects allocated since the start of marking is considered live.
+  if (hr->obj_allocated_since_next_marking(obj)) {
+    return true;
+  }
+
+  // All object in closed archive regions are live.
+  if (hr->is_closed_archive()) {
+    return true;
+  }
+
+  // All objects that are marked are live.
+  return _g1h->is_marked_next(obj);
 }
 
 inline bool G1CMSubjectToDiscoveryClosure::do_object_b(oop obj) {
@@ -110,7 +123,6 @@ inline void G1CMTask::push(G1TaskQueueEntry task_entry) {
   assert(task_entry.is_array_slice() || _g1h->is_in_reserved(task_entry.obj()), "invariant");
   assert(task_entry.is_array_slice() || !_g1h->is_on_master_free_list(
               _g1h->heap_region_containing(task_entry.obj())), "invariant");
-  assert(task_entry.is_array_slice() || !_g1h->is_obj_ill(task_entry.obj()), "invariant");  // FIXME!!!
   assert(task_entry.is_array_slice() || _next_mark_bitmap->is_marked(cast_from_oop<HeapWord*>(task_entry.obj())), "invariant");
 
   if (!_task_queue->push(task_entry)) {

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
@@ -48,7 +48,7 @@ inline bool G1CMIsAliveClosure::do_object_b(oop obj) {
     return true;
   }
 
-  // All object in closed archive regions are live.
+  // All objects in closed archive regions are live.
   if (hr->is_closed_archive()) {
     return true;
   }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
@@ -43,7 +43,7 @@
 inline bool G1CMIsAliveClosure::do_object_b(oop obj) {
   HeapRegion* hr = _g1h->heap_region_containing(cast_from_oop<HeapWord*>(obj));
 
-  // All objects allocated since the start of marking is considered live.
+  // All objects allocated since the start of marking are considered live.
   if (hr->obj_allocated_since_next_marking(obj)) {
     return true;
   }

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -53,7 +53,6 @@ private:
   bool             _failures;
 public:
   // _vo == UsePrevMarking -> use "prev" marking information,
-  // _vo == UseNextMarking -> use "next" marking information,
   // _vo == UseFullMarking -> use "next" marking bitmap but no TAMS
   VerifyRootsClosure(VerifyOption vo) :
     _g1h(G1CollectedHeap::heap()),
@@ -206,7 +205,6 @@ private:
   VerifyOption _vo;
 public:
   // _vo == UsePrevMarking -> use "prev" marking information,
-  // _vo == UseNextMarking -> use "next" marking information,
   // _vo == UseFullMarking -> use "next" marking bitmap but no TAMS.
   VerifyObjsInRegionClosure(HeapRegion *hr, VerifyOption vo)
     : _live_bytes(0), _hr(hr), _vo(vo) {
@@ -359,7 +357,6 @@ private:
   bool             _failures;
 public:
   // _vo == UsePrevMarking -> use "prev" marking information,
-  // _vo == UseNextMarking -> use "next" marking information,
   // _vo == UseFullMarking -> use "next" marking bitmap but no TAMS
   VerifyRegionClosure(bool par, VerifyOption vo)
     : _par(par),
@@ -407,16 +404,10 @@ public:
       } else if (!r->is_starts_humongous()) {
         VerifyObjsInRegionClosure not_dead_yet_cl(r, _vo);
         r->object_iterate(&not_dead_yet_cl);
-        if (_vo != VerifyOption_G1UseNextMarking) {
-          if (r->max_live_bytes() < not_dead_yet_cl.live_bytes()) {
-            log_error(gc, verify)("[" PTR_FORMAT "," PTR_FORMAT "] max_live_bytes " SIZE_FORMAT " < calculated " SIZE_FORMAT,
+        if (r->max_live_bytes() < not_dead_yet_cl.live_bytes()) {
+          log_error(gc, verify)("[" PTR_FORMAT "," PTR_FORMAT "] max_live_bytes " SIZE_FORMAT " < calculated " SIZE_FORMAT,
                                   p2i(r->bottom()), p2i(r->end()), r->max_live_bytes(), not_dead_yet_cl.live_bytes());
-            _failures = true;
-          }
-        } else {
-          // When vo == UseNextMarking we cannot currently do a sanity
-          // check on the live bytes as the calculation has not been
-          // finalized yet.
+          _failures = true;
         }
       }
     }
@@ -435,7 +426,6 @@ private:
 
 public:
   // _vo == UsePrevMarking -> use "prev" marking information,
-  // _vo == UseNextMarking -> use "next" marking information,
   // _vo == UseFullMarking -> use "next" marking bitmap but no TAMS
   G1ParVerifyTask(G1CollectedHeap* g1h, VerifyOption vo) :
       WorkerTask("Parallel verify task"),

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.hpp
@@ -61,15 +61,11 @@ public:
   // Perform verification.
 
   // vo == UsePrevMarking -> use "prev" marking information,
-  // vo == UseNextMarking -> use "next" marking information
   // vo == UseFullMarking -> use "next" marking bitmap but no TAMS
   //
   // NOTE: Only the "prev" marking information is guaranteed to be
   // consistent most of the time, so most calls to this should use
   // vo == UsePrevMarking.
-  // Currently, there is only one case where this is called with
-  // vo == UseNextMarking, which is to verify the "next" marking
-  // information at the end of remark.
   // Currently there is only one place where this is called with
   // vo == UseFullMarking, which is to verify the marking during a
   // full GC.

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -479,7 +479,6 @@ protected:
   VerifyOption _vo;
 public:
   // _vo == UsePrevMarking -> use "prev" marking information,
-  // _vo == UseNextMarking -> use "next" marking information,
   // _vo == UseFullMarking -> use "next" marking bitmap but no TAMS.
   G1VerificationClosure(G1CollectedHeap* g1h, VerifyOption vo) :
     _g1h(g1h), _ct(g1h->card_table()),

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -582,15 +582,11 @@ public:
   void print_on(outputStream* st) const;
 
   // vo == UsePrevMarking -> use "prev" marking information,
-  // vo == UseNextMarking -> use "next" marking information
   // vo == UseFullMarking -> use "next" marking bitmap but no TAMS
   //
   // NOTE: Only the "prev" marking information is guaranteed to be
   // consistent most of the time, so most calls to this should use
   // vo == UsePrevMarking.
-  // Currently, there is only one case where this is called with
-  // vo == UseNextMarking, which is to verify the "next" marking
-  // information at the end of remark.
   // Currently there is only one place where this is called with
   // vo == UseFullMarking, which is to verify the marking during a
   // full GC.

--- a/src/hotspot/share/gc/shared/verifyOption.hpp
+++ b/src/hotspot/share/gc/shared/verifyOption.hpp
@@ -30,8 +30,7 @@ enum VerifyOption {
 
       // G1
       VerifyOption_G1UsePrevMarking = VerifyOption_Default,
-      VerifyOption_G1UseNextMarking = VerifyOption_G1UsePrevMarking + 1,
-      VerifyOption_G1UseFullMarking = VerifyOption_G1UseNextMarking + 1
+      VerifyOption_G1UseFullMarking = VerifyOption_G1UsePrevMarking + 1
 };
 
 #endif // SHARE_GC_SHARED_VERIFYOPTION_HPP


### PR DESCRIPTION
Please review this change to remove an unused verification option.

**Summary**
In G1 there have been three different `VerifyOption` that can be passed to verification to signal how to determine liveness. One of these options, `VerifyOption_G1UseNextMarking`,  has been unused for quite some time and this change removes it. When removing it the `G1CollectedHeap::is_obj_ill(...)` functions are more or less unused, so I removed those as well and inlined the checks in the only place where it is really used `G1CMIsAliveClosure::do_object_b(...)`

**Testing**

- [x] Mach5
- [x] Local verification testing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281637](https://bugs.openjdk.java.net/browse/JDK-8281637): Remove unused VerifyOption_G1UseNextMarking


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 11e020179894a9857e17d7c1f21c3ed3dbc46854
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**) ⚠️ Review applies to 11e020179894a9857e17d7c1f21c3ed3dbc46854


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7440/head:pull/7440` \
`$ git checkout pull/7440`

Update a local copy of the PR: \
`$ git checkout pull/7440` \
`$ git pull https://git.openjdk.java.net/jdk pull/7440/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7440`

View PR using the GUI difftool: \
`$ git pr show -t 7440`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7440.diff">https://git.openjdk.java.net/jdk/pull/7440.diff</a>

</details>
