### PR TITLE
8281638: jfr/event/allocation tests fail with release VMs after JDK-8281318 due to lack of -XX:+UnlockDiagnosticVMOptions

### DIFF
--- a/test/jdk/jdk/jfr/event/allocation/TestObjectAllocationInNewTLABEvent.java
+++ b/test/jdk/jdk/jfr/event/allocation/TestObjectAllocationInNewTLABEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,10 +42,10 @@ import sun.hotspot.WhiteBox;
  * @build sun.hotspot.WhiteBox
  *
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  *                   -XX:+UseTLAB -XX:TLABSize=100k -XX:-ResizeTLAB -XX:TLABRefillWasteFraction=1
  *                   jdk.jfr.event.allocation.TestObjectAllocationInNewTLABEvent
- * @run main/othervm -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  *                   -XX:+UseTLAB -XX:TLABSize=100k -XX:-ResizeTLAB -XX:TLABRefillWasteFraction=1
  *                   -Xint
  *                   jdk.jfr.event.allocation.TestObjectAllocationInNewTLABEvent

--- a/test/jdk/jdk/jfr/event/allocation/TestObjectAllocationOutsideTLABEvent.java
+++ b/test/jdk/jdk/jfr/event/allocation/TestObjectAllocationOutsideTLABEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,10 +42,10 @@ import sun.hotspot.WhiteBox;
  * @build sun.hotspot.WhiteBox
  *
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  *                   -XX:+UseTLAB -XX:TLABSize=90k -XX:-ResizeTLAB -XX:TLABRefillWasteFraction=256
  *                   jdk.jfr.event.allocation.TestObjectAllocationOutsideTLABEvent
- * @run main/othervm -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  *                   -XX:+UseTLAB -XX:TLABSize=90k -XX:-ResizeTLAB -XX:TLABRefillWasteFraction=256
  *                   -Xint
  *                   jdk.jfr.event.allocation.TestObjectAllocationOutsideTLABEvent

--- a/test/jdk/jdk/jfr/event/allocation/TestObjectAllocationSampleEventThrottling.java
+++ b/test/jdk/jdk/jfr/event/allocation/TestObjectAllocationSampleEventThrottling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ import sun.hotspot.WhiteBox;
  * @build sun.hotspot.WhiteBox
  *
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  *                   -XX:+UseTLAB -XX:TLABSize=2k -XX:-ResizeTLAB
  *                   jdk.jfr.event.allocation.TestObjectAllocationSampleEventThrottling
  */


### PR DESCRIPTION
Hi all,

The following three tests fail with release VMs.

```
jdk/jfr/event/allocation/TestObjectAllocationInNewTLABEvent.java
jdk/jfr/event/allocation/TestObjectAllocationOutsideTLABEvent.java
jdk/jfr/event/allocation/TestObjectAllocationSampleEventThrottling.java
```

The failing reason is
```
STDERR:
Error: VM option 'WhiteBoxAPI' is diagnostic and must be enabled via -XX:+UnlockDiagnosticVMOptions.
Error: The unlock option must precede 'WhiteBoxAPI'.
```

Fix:
 1) Add -XX:+UnlockDiagnosticVMOptions
 2) Update the copyright year

Testing:
 - Affected tests on Linux/x64 with {release, fastdebug}

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281638](https://bugs.openjdk.java.net/browse/JDK-8281638): jfr/event/allocation tests fail with release VMs after JDK-8281318 due to lack of -XX:+UnlockDiagnosticVMOptions


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7441/head:pull/7441` \
`$ git checkout pull/7441`

Update a local copy of the PR: \
`$ git checkout pull/7441` \
`$ git pull https://git.openjdk.java.net/jdk pull/7441/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7441`

View PR using the GUI difftool: \
`$ git pr show -t 7441`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7441.diff">https://git.openjdk.java.net/jdk/pull/7441.diff</a>

</details>
