### PR TITLE
8012675: Javadoc for javax.swing.text.html.parser.Parser.handleComment() needs to be updated

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/parser/Parser.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/parser/Parser.java
@@ -68,6 +68,10 @@ import java.net.URL;
  * encountered, all whitespace will be ignored until a non whitespace
  * character is encountered. This appears to give behavior closer to
  * the popular browsers.
+ * <p>
+ * The tag parser does not support script tags. If a tag is encountered,
+ * an error will be logged. The script tags are removed, and contents inside
+ * the script tag will be handled by <code>handleComment</code>.
  *
  * @see DTD
  * @see TagElement


### PR DESCRIPTION
Updated Parser class doc by appending to the doc regarding lack of support for HTML script tags. Adding this information to the "parse" function did not seem as consistent for formatting as adding it to the Parser class doc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed
- [ ] Change requires a CSR request to be approved

### Issues
 * [JDK-8012675](https://bugs.openjdk.java.net/browse/JDK-8012675): Javadoc for javax.swing.text.html.parser.Parser.handleComment() needs to be updated
 * [JDK-8281670](https://bugs.openjdk.java.net/browse/JDK-8281670): Javadoc for javax.swing.text.html.parser.Parser.handleComment() needs to be updated (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7446/head:pull/7446` \
`$ git checkout pull/7446`

Update a local copy of the PR: \
`$ git checkout pull/7446` \
`$ git pull https://git.openjdk.java.net/jdk pull/7446/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7446`

View PR using the GUI difftool: \
`$ git pr show -t 7446`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7446.diff">https://git.openjdk.java.net/jdk/pull/7446.diff</a>

</details>
