### PR TITLE
JDK-8281674: tools/javac/annotations/typeAnnotations/classfile/AnonymousExtendsTest.java fails with AssertionError

### DIFF
--- a/test/langtools/tools/javac/annotations/typeAnnotations/classfile/AnonymousExtendsTest.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/classfile/AnonymousExtendsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8146167
+ * @bug 8146167 8281674
  * @summary Anonymous type declarations drop supertype type parameter annotations
  * @run main AnonymousExtendsTest
  */
@@ -52,10 +52,10 @@ public class AnonymousExtendsTest {
 
     public void testIt() {
         checkAnnotations(TestClass.class.getAnnotatedSuperclass(),
-              "[@AnonymousExtendsTest$TA(1)],[@AnonymousExtendsTest$TA(2)]");
+              "[@AnonymousExtendsTest.TA(1)],[@AnonymousExtendsTest.TA(2)]");
         checkAnnotations(new @TA(3) ArrayList<@TA(4) List<Number>>() {
                          }.getClass().getAnnotatedSuperclass(),
-              "[@AnonymousExtendsTest$TA(3)],[@AnonymousExtendsTest$TA(4)]");
+              "[@AnonymousExtendsTest.TA(3)],[@AnonymousExtendsTest.TA(4)]");
     }
 
     public void checkAnnotations(AnnotatedType type, String expected) {


### PR DESCRIPTION
Update javac test for revised runtime toString output.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281674](https://bugs.openjdk.java.net/browse/JDK-8281674): tools/javac/annotations/typeAnnotations/classfile/AnonymousExtendsTest.java fails with AssertionError


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7450/head:pull/7450` \
`$ git checkout pull/7450`

Update a local copy of the PR: \
`$ git checkout pull/7450` \
`$ git pull https://git.openjdk.java.net/jdk pull/7450/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7450`

View PR using the GUI difftool: \
`$ git pr show -t 7450`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7450.diff">https://git.openjdk.java.net/jdk/pull/7450.diff</a>

</details>
