### PR TITLE
8279949: JavaThread::_free_handle_block leaks native memory

### DIFF
--- a/src/hotspot/share/runtime/jniHandles.cpp
+++ b/src/hotspot/share/runtime/jniHandles.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -384,10 +384,15 @@ void JNIHandleBlock::release_block(JNIHandleBlock* block, JavaThread* thread) {
       block->_next = freelist;
     }
     block = NULL;
-  }
-  if (block != NULL) {
-    Atomic::dec(&_blocks_allocated);
-    delete block;
+  } else {
+    DEBUG_ONLY(block->set_pop_frame_link(NULL));
+    while (block != NULL) {
+      JNIHandleBlock* next = block->_next;
+      Atomic::dec(&_blocks_allocated);
+      assert(block->pop_frame_link() == NULL, "pop_frame_link should be NULL");
+      delete block;
+      block = next;
+    }
   }
   if (pop_frame_link != NULL) {
     // As a sanity check we release blocks pointed to by the pop_frame_link.


### PR DESCRIPTION
Please review following fix which delete whole list of JNIHandle blocks in JNIHandleBlock::release_block(...).
Also, I added sanity verification of _pop_frame_link to ensure that there are no leaks there.

Fix verified with tier1-6. Also, verified that memory leak is not reproduced anymore.

Thanks to Vladimir I.  for finding exact root cause of problem.