### PR TITLE
8281634: jdeps: java.lang.InternalError: Missing message: err.invalid.filters

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/resources/jdeps.properties
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/resources/jdeps.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -241,6 +241,7 @@ err.module.not.found=module not found: {0}
 err.root.module.not.set=root module set empty
 err.option.already.specified={0} option specified more than once.
 err.filter.not.specified=--package (-p), --regex (-e), --require option must be specified
+err.invalid.filters=Only one of --package (-p), --regex (-e), --require option can be specified
 err.multirelease.option.exists={0} is not a multi-release jar file but --multi-release option is set
 err.multirelease.option.notfound={0} is a multi-release jar file but --multi-release option is not set
 err.multirelease.version.associated=class {0} already associated with version {1}, trying to add version {2}

--- a/test/langtools/tools/jdeps/Options.java
+++ b/test/langtools/tools/jdeps/Options.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8168386 8205116
+ * @bug 8168386 8205116 8281634
  * @summary Test option validation
  * @modules jdk.jdeps
  * @library lib
@@ -48,11 +48,11 @@ public class Options {
                 "-v, -verbose cannot be used with -s, -summary option"
             },
             {
-                new String[] { "-jdkinternal", "-summary", TEST_CLASSES },
+                new String[] { "-jdkinternals", "-summary", TEST_CLASSES },
                 "-summary or -verbose cannot be used with -jdkinternals option"
             },
             {
-                new String[] { "-jdkinternal", "-p", "java.lang", TEST_CLASSES },
+                new String[] { "-jdkinternals", "-p", "java.lang", TEST_CLASSES },
                 "--package, --regex, --require cannot be used with -jdkinternals option"
             },
             {
@@ -69,7 +69,7 @@ public class Options {
             },
             {
                 new String[] { "--inverse", "-R", TEST_CLASSES },
-                "-R cannot be used with --inverse option"
+                "--recursive and --no-recursive cannot be used with --inverse option"
             },
             {
                 new String[] { "--generate-module-info", "dots", "-cp", TEST_CLASSES },
@@ -77,18 +77,22 @@ public class Options {
             },
             {
                 new String[] { "--list-deps", "-summary", TEST_CLASSES },
-                "--list-deps and --list-reduced-deps options are specified"
+                "-summary or -verbose cannot be used with --list-deps option"
             },
             {
                 new String[] { "--list-deps", "--list-reduced-deps", TEST_CLASSES },
                 "--list-deps and --list-reduced-deps options are specified"
             },
+            {
+                new String[] { "--package", "sun.misc", "--require", "java.net.http" },
+                "Only one of --package (-p), --regex (-e), --require option can be specified"
+            }
         };
     }
 
     @Test(dataProvider = "errors")
     public void test(String[] options, String expected) {
-        jdepsError(options).outputContains(expected);
+        assertTrue(jdepsError(options).outputContains(expected));
     }
 
 
@@ -109,6 +113,6 @@ public class Options {
         // invalid path
         jdeps = new JdepsRunner("--check", "java.base", "--system", "bad");
         assertTrue(jdeps.run(true) != 0);
-        jdeps.outputContains("invalid path: bad");
+        assertTrue(jdeps.outputContains("invalid path: bad"));
     }
 }


### PR DESCRIPTION
Can I please get a review for this change which proposes to fix the issue noted in https://bugs.openjdk.java.net/browse/JDK-8281634?

The commit introduces the missing `err.invalid.filters` key in the jdeps resource bundle. I have run a simple check to make sure this resource bundle doesn't miss any other `err.` keys. From a simple search, following are the  unique `err.` keys used in the code of jdeps (under `src/jdk.jdeps/share/classes/com/sun/tools/jdeps` directory):
```
err.exception.message
err.invalid.options
err.multirelease.version.associated
err.missing.arg
err.multirelease.jar.malformed
err.option.already.specified
err.missing.dependences
err.module.not.found
err.invalid.path
err.genmoduleinfo.not.jarfile
err.invalid.arg.for.option
err.multirelease.option.notfound
err.filter.not.specified
err.unknown.option
err.command.set
err.invalid.filters
err.genmoduleinfo.unnamed.package
err.option.after.class
```
Apart from the `err.invalid.filters` key which this PR is fixing, none of the other keys are missing from the resource bundle. I haven't updated the resource bundles for Japanese and Chinese languages because I don't know their equivalent values and looking at the commit history of those files, it appears that those changes are done as separate tasks (should a JBS issue be raised for this?)

The existing `test/langtools/tools/jdeps/Options.java` jtreg test has been updated to reproduce the issue and verify this fix.

An important detail about the update to the test is that while working on the update to this test, I realized that the current implementation in the test isn't fully functional. As a result, this test is currently, incorrectly considered as passing. Specifically, the test was missing a `assertTrue` call against the ouput/error content generated by the run of the `jdeps` tool.  This PR adds that assertion.
Once that assertion is added, it started showing up 3 genuine failures. These failures are within that test code:
- The test uses `-jdkinternal` instead of `-jdkinternals`. This appears to be a typo when this section in the test was added. The commit history of the source of jdeps tool shows that this option was always `-jdkinternals`. This PR fixes that part in the test.
- The test expects an error message "-R cannot be used with --inverse option" when `-R` and `--inverse` are used together. However, at some point the source of jdeps tool was changed (as part of https://bugs.openjdk.java.net/browse/JDK-8213909) to return a different error message. That changes appears to have missed changing this test case error message and since this test has been falsely passing, it never got caught. This PR now fixes that issue by expecting the correct error message.
- The test was expecting an error message "--list-deps and --list-reduced-deps options are specified" when "--list-deps" was used along with "--summary". This appears to be a copy/paste error in the test case and wasn't caught because the test was falsely passing. This too has been fixed in this PR.

With the fixes in this test, the test now reproduces the original issue and verifies the fix. I realize that this PR has changes in the test that aren't directly related to the issue raised in https://bugs.openjdk.java.net/browse/JDK-8281634, but those changes are necessary to get the test functional. However if a separate JBS issue needs to be opened to track those changes, please do let me know and I'll address these test changes in a separate PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281634](https://bugs.openjdk.java.net/browse/JDK-8281634): jdeps:  java.lang.InternalError: Missing message: err.invalid.filters


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7455/head:pull/7455` \
`$ git checkout pull/7455`

Update a local copy of the PR: \
`$ git checkout pull/7455` \
`$ git pull https://git.openjdk.java.net/jdk pull/7455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7455`

View PR using the GUI difftool: \
`$ git pr show -t 7455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7455.diff">https://git.openjdk.java.net/jdk/pull/7455.diff</a>

</details>
