### PR TITLE
8281705: SourceLauncherTest.testSystemProperty isn't being run

### DIFF
--- a/test/langtools/tools/javac/launcher/SourceLauncherTest.java
+++ b/test/langtools/tools/javac/launcher/SourceLauncherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ import toolbox.JavaTask;
 import toolbox.JavacTask;
 import toolbox.Task;
 import toolbox.TestRunner;
-import toolbox.TestRunner;
+import toolbox.TestRunner.Test;
 import toolbox.ToolBox;
 
 public class SourceLauncherTest extends TestRunner {
@@ -257,6 +257,7 @@ public class SourceLauncherTest extends TestRunner {
                     "access denied (\"java.util.PropertyPermission\" \"user.dir\" \"write\")");
     }
 
+    @Test
     public void testSystemProperty(Path base) throws IOException {
         tb.writeJavaFiles(base,
             "class ShowProperty {\n" +


### PR DESCRIPTION
Can I please get a review of this test-only change which fixes the issue noted in https://bugs.openjdk.java.net/browse/JDK-8281705? 

The change in this commit adds the `@Test` annotation on the test method to make sure it gets run. Before this change, the test run logs showed that `28 tests` were being run and now after this change, the logs report `29 tests` and I can see `testSystemProperty` in the test run logs.