### PR TITLE
8281678: appcds/dynamicArchive/ArchiveConsistency.java fails after JDK-8279997

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchiveConsistency.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ArchiveConsistency.java
@@ -206,6 +206,7 @@ public class ArchiveConsistency extends DynamicArchiveTestBase {
         // following two tests:
         //   -Xshare:auto -XX:SharedArchiveFile=top.jsa, but base does not exist.
 
+      if (!isUseSharedSpacesDisabled()) {
         new File(baseArchiveName).delete();
 
         startTest("10. -XX:+AutoCreateSharedArchive -XX:SharedArchiveFile=" + topArchiveName);
@@ -227,5 +228,6 @@ public class ArchiveConsistency extends DynamicArchiveTestBase {
             .assertNormalExit(output -> {
                 output.shouldContain("VM warning: -XX:ArchiveClassesAtExit is unsupported when base CDS archive is not loaded");
             });
+      }
     }
 }


### PR DESCRIPTION
Please review this trivial change - the two new test cases added in JDK-8279997 do not work when the tests are executed with `jtreg -vmoptions:-Xshare:off`. This patch disable the two test cases under such condition to avoid causing CI failures

A proper fix will be done in https://bugs.openjdk.java.net/browse/JDK-8281715