### PR TITLE
8281722: Removal of PrintIdealLevel

### DIFF
--- a/src/hotspot/share/compiler/compilerDirectives.hpp
+++ b/src/hotspot/share/compiler/compilerDirectives.hpp
@@ -68,7 +68,6 @@ NOT_PRODUCT(cflags(TraceOptoPipelining, bool, TraceOptoPipelining, TraceOptoPipe
 NOT_PRODUCT(cflags(TraceOptoOutput,     bool, TraceOptoOutput, TraceOptoOutput)) \
 NOT_PRODUCT(cflags(PrintIdeal,          bool, PrintIdeal, PrintIdeal)) \
 NOT_PRODUCT(cflags(PrintIdealPhase,     ccstrlist, "", PrintIdealPhase)) \
-NOT_PRODUCT(cflags(PrintIdealLevel,     uintx, PrintIdealLevel, PrintIdealLevel)) \
     cflags(TraceSpilling,           bool, TraceSpilling, TraceSpilling) \
     cflags(Vectorize,               bool, false, Vectorize) \
     cflags(CloneMapDebug,           bool, false, CloneMapDebug) \

--- a/src/hotspot/share/compiler/compilerOracle.hpp
+++ b/src/hotspot/share/compiler/compilerOracle.hpp
@@ -80,7 +80,6 @@ class methodHandle;
   option(TraceOptoOutput, "TraceOptoOutput", Bool) \
   option(TraceSpilling, "TraceSpilling", Bool) \
 NOT_PRODUCT(option(PrintIdeal, "PrintIdeal", Bool))  \
-NOT_PRODUCT(option(PrintIdealLevel, "PrintIdealLevel", Uintx)) \
 NOT_PRODUCT(option(PrintIdealPhase, "PrintIdealPhase", Ccstrlist)) \
 NOT_PRODUCT(option(IGVPrintLevel, "IGVPrintLevel", Intx)) \
   option(Vectorize, "Vectorize", Bool) \

--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -112,11 +112,6 @@
   notproduct(bool, PrintIdeal, false,                                       \
           "Print ideal graph before code generation")                       \
                                                                             \
-  notproduct(uintx, PrintIdealLevel, 0,                                     \
-          "Print ideal IR on stdout. "                                      \
-          "Same levels as PrintIdealGraphLevel")                            \
-          range(0, 4)                                                       \
-                                                                            \
   notproduct(uintx, PrintIdealIndentThreshold, 0,                           \
           "A depth threshold of ideal graph. Indentation is disabled "      \
           "when users attempt to dump an ideal graph deeper than it.")      \

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4842,7 +4842,7 @@ void Compile::print_method(CompilerPhaseType cpt, int level, Node* n) {
   if (should_print_igv(level)) {
     _igv_printer->print_method(name, level);
   }
-  if (should_print_ideal(level) || should_print_phase(cpt)) {
+  if (should_print_phase(cpt)) {
     print_ideal_ir(CompilerPhaseTypeHelper::to_name(cpt));
   }
 #endif

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -637,7 +637,6 @@ class Compile : public Phase {
   bool          trace_opto_output() const       { return _trace_opto_output; }
   void          print_ideal_ir(const char* phase_name);
   bool          should_print_ideal() const      { return _directive->PrintIdealOption; }
-  bool          should_print_ideal(uint level) const { return _directive->PrintIdealLevelOption >= level; }
   bool              parsed_irreducible_loop() const { return _parsed_irreducible_loop; }
   void          set_parsed_irreducible_loop(bool z) { _parsed_irreducible_loop = z; }
   int _in_dump_cnt;  // Required for dumping ir nodes.


### PR DESCRIPTION
The PrintIdealLevel flag was recently introduced to support testing of different phase in the IR-test framework. In practice the fit was bad and lot of excess data was printed. The PrintIdealPhase, that gives exact control of ideal printing, was added as a substitution.

This patch removes the PrintIdealLevel flag since it's no longer needed.

Best regards,
Nils Eliasson

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281722](https://bugs.openjdk.java.net/browse/JDK-8281722): Removal of PrintIdealLevel


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7458/head:pull/7458` \
`$ git checkout pull/7458`

Update a local copy of the PR: \
`$ git checkout pull/7458` \
`$ git pull https://git.openjdk.java.net/jdk pull/7458/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7458`

View PR using the GUI difftool: \
`$ git pr show -t 7458`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7458.diff">https://git.openjdk.java.net/jdk/pull/7458.diff</a>

</details>
