### PR TITLE
8280901: MethodHandle::linkToNative stub is missing w/ -Xint 

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -2014,8 +2014,9 @@ Method* SystemDictionary::find_method_handle_intrinsic(vmIntrinsicID iid,
     spe = NULL;
     // Must create lots of stuff here, but outside of the SystemDictionary lock.
     m = Method::make_method_handle_intrinsic(iid, signature, CHECK_NULL);
-    if (!Arguments::is_interpreter_only()) {
+    if (!Arguments::is_interpreter_only() || iid == vmIntrinsics::_linkToNative) {
       // Generate a compiled form of the MH intrinsic.
+      // linkToNative doesn't have interpreter-specific implementation, so always has to go through compiled version.
       AdapterHandlerLibrary::create_native_wrapper(m);
       // Check if have the compiled code.
       if (!m->has_compiled_code()) {

--- a/test/jdk/java/foreign/TestDowncall.java
+++ b/test/jdk/java/foreign/TestDowncall.java
@@ -31,6 +31,10 @@
  * @run testng/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
  *   --enable-native-access=ALL-UNNAMED -Dgenerator.sample.factor=17
  *   TestDowncall
+ *
+ * @run testng/othervm -Xint -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
+ *   --enable-native-access=ALL-UNNAMED -Dgenerator.sample.factor=100000
+ *   TestDowncall
  */
 
 import jdk.incubator.foreign.Addressable;


### PR DESCRIPTION
MethodHandle::linkToNative linker doesn't have a dedicated stub for interpreter. A stub for compiled code is shared and it is invoked through i2c stub when accessed from interpreter. In interpreter-only mode, stubs for compiled code are not generated and linkToNative ends up in a broken state where `Method::_from_interpreted_entry` points to `i2c` stub while `Method::_from_compiled_entry` points to `c2i` stub.

Proposed fix unconditionally generates a stub for `MethodHandle::linkToNative` case irrespective whether it is a interpreter-only mode or not. 

Testing: test/jdk/java/foreign/ w/ -Xint

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280901](https://bugs.openjdk.java.net/browse/JDK-8280901): MethodHandle::linkToNative stub is missing w/ -Xint


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to 50f689604bccb6c120a972a966e007966722f5b3
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 50f689604bccb6c120a972a966e007966722f5b3


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7459/head:pull/7459` \
`$ git checkout pull/7459`

Update a local copy of the PR: \
`$ git checkout pull/7459` \
`$ git pull https://git.openjdk.java.net/jdk pull/7459/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7459`

View PR using the GUI difftool: \
`$ git pr show -t 7459`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7459.diff">https://git.openjdk.java.net/jdk/pull/7459.diff</a>

</details>
