### PR TITLE
8281615: Deadlock caused by jdwp agent

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/classTrack.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/classTrack.c
@@ -81,7 +81,7 @@ cbTrackingObjectFree(jvmtiEnv* jvmti_env, jlong tag)
 struct bag *
 classTrack_processUnloads(JNIEnv *env)
 {
-    if (deletedSignatures == NULL || bagSize(deletedSignatures) == 0) {
+    if (deletedSignatures == NULL) {
       return NULL;
     }
 
@@ -224,15 +224,11 @@ cleanDeleted(void *signatureVoid, void *arg)
 void
 classTrack_reset(void)
 {
-    struct bag* to_delete = NULL;
     debugMonitorEnter(classTrackLock);
-
-    if (deletedSignatures != NULL) {
-        to_delete = deletedSignatures;
-        deletedSignatures = NULL;
-    }
-
+    struct bag* to_delete = deletedSignatures;
+    deletedSignatures = NULL;
     debugMonitorExit(classTrackLock);
+
     // Deallocate bag outside classTrackLock to avoid deadlock.
     // See comments in classTrack_processUnloads() for details.
     if (to_delete != NULL) {

--- a/src/jdk.jdwp.agent/share/native/libjdwp/classTrack.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/classTrack.c
@@ -88,7 +88,7 @@ classTrack_processUnloads(JNIEnv *env)
     /* Allocate new bag outside classTrackLock lock to avoid deadlock.
      *
      * Note: jvmtiAllocate/jvmtiDeallocate() may be blocked by ongoing safepoints.
-     * It is dangerous to call them (via bagCreateBag/bagDestroyBag())while holding monitor(s),
+     * It is dangerous to call them (via bagCreateBag/bagDestroyBag()) while holding monitor(s),
      * because jvmti may post events, e.g. JVMTI_EVENT_OBJECT_FREE at safepoints and event processing
      * code may acquire the same monitor(s), e.g. classTrackLock in cbTrackingObjectFree(),
      * which can lead to deadlock.


### PR DESCRIPTION
There are scenarios that JDWP agent can deadlock on `classTrackLock` monitor. Following is the scenario in bug report.

**Java Thread** 
-   loads a class and post `JVMTI_EVENT_CLASS_PREPARE` event
- JDWP event callback handler calls `classTrack_processUnloads()` to handle the event.
- `classTrack_processUnloads()` takes `classTrackLock` lock, then tries to allocate a new bag under the lock.
- bag allocation code calls` jvmtiAllocate()`, which may be blocked by ongoing safepoint due to state transition.

If the safepoint is GC safepoint (prior to JDK16) or `VM_JvmtiPostObjectFree`  safepoint (JDK16 or later)

**VM Thread**
- post `JVMTI_EVENT_OBJECT_FREE`
- JDWP event callback handler calls `cbTrackingObjectFree()` to handle the event
- `cbTrackingObjectFree()` tries to acquire `classTrackLock` lock, leads to deadlock

From my research, there are three events that may be posted at safepoints, `JVMTI_EVENT_GARBAGE_COLLECTION_START`, `JVMTI_EVENT_GARBAGE_COLLECTION_FINISH` and  `JVMTI_EVENT_OBJECT_FREE`, but only  `JVMTI_EVENT_OBJECT_FREE` is relevant to JDWP agent.

The solution I purpose here, is simply move allocation/deallocation code outside of `classTrackLock` lock.


Test:
- [x] tier1 
- [x] vmTestbase_nsk_jdi
- [x] vmTestbase_nsk_jdwp
- [x] vmTestbase_nsk_jvmti

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281615](https://bugs.openjdk.java.net/browse/JDK-8281615): Deadlock caused by jdwp agent


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to f93bf8d6b577e78f47f14267dd3347da431a15e5
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to f93bf8d6b577e78f47f14267dd3347da431a15e5


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7461/head:pull/7461` \
`$ git checkout pull/7461`

Update a local copy of the PR: \
`$ git checkout pull/7461` \
`$ git pull https://git.openjdk.java.net/jdk pull/7461/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7461`

View PR using the GUI difftool: \
`$ git pr show -t 7461`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7461.diff">https://git.openjdk.java.net/jdk/pull/7461.diff</a>

</details>
