### PR TITLE
8281732: add assert for non-NULL assumption for return of unique_ctrl…

### DIFF
--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -906,7 +906,7 @@ void CallNode::extract_projections(CallProjections* projs, bool separate_io_proj
       {
         // For Control (fallthrough) and I_O (catch_all_index) we have CatchProj -> Catch -> Proj
         projs->fallthrough_proj = pn;
-        const Node *cn = pn->unique_ctrl_out();
+        const Node *cn = pn->unique_ctrl_out_or_null();
         if (cn != NULL && cn->is_Catch()) {
           ProjNode *cpn = NULL;
           for (DUIterator_Fast kmax, k = cn->fast_outs(kmax); k < kmax; k++) {
@@ -1414,7 +1414,7 @@ Node* SafePointNode::Identity(PhaseGVN* phase) {
 
   // If you have back to back safepoints, remove one
   if (in(TypeFunc::Control)->is_SafePoint()) {
-    Node* out_c = unique_ctrl_out();
+    Node* out_c = unique_ctrl_out_or_null();
     // This can be the safepoint of an outer strip mined loop if the inner loop's backedge was removed. Replacing the
     // outer loop's safepoint could confuse removal of the outer loop.
     if (out_c != NULL && !out_c->is_OuterStripMinedLoopEnd()) {

--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -865,10 +865,10 @@ bool RegionNode::optimize_trichotomy(PhaseIterGVN* igvn) {
   }
   proj1 = proj1->other_if_proj();
   proj2 = proj2->other_if_proj();
-  if (!((proj1->unique_ctrl_out() == iff2 &&
-         proj2->unique_ctrl_out() == this) ||
-        (proj2->unique_ctrl_out() == iff1 &&
-         proj1->unique_ctrl_out() == this))) {
+  if (!((proj1->unique_ctrl_out_or_null() == iff2 &&
+         proj2->unique_ctrl_out_or_null() == this) ||
+        (proj2->unique_ctrl_out_or_null() == iff1 &&
+         proj1->unique_ctrl_out_or_null() == this))) {
     return false; // Ifs are not connected through other projs
   }
   // Found 'iff -> proj -> iff -> proj -> this' shape where all other projs are merged

--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -739,7 +739,7 @@ bool IfNode::is_ctrl_folds(Node* ctrl, PhaseIterGVN* igvn) {
 // Do this If and the dominating If share a region?
 bool IfNode::has_shared_region(ProjNode* proj, ProjNode*& success, ProjNode*& fail) {
   ProjNode* otherproj = proj->other_if_proj();
-  Node* otherproj_ctrl_use = otherproj->unique_ctrl_out();
+  Node* otherproj_ctrl_use = otherproj->unique_ctrl_out_or_null();
   RegionNode* region = (otherproj_ctrl_use != NULL && otherproj_ctrl_use->is_Region()) ? otherproj_ctrl_use->as_Region() : NULL;
   success = NULL;
   fail = NULL;
@@ -1724,7 +1724,7 @@ Node* IfProjNode::Identity(PhaseGVN* phase) {
     if (in(0)->is_BaseCountedLoopEnd()) {
       // CountedLoopEndNode may be eliminated by if subsuming, replace CountedLoopNode with LoopNode to
       // avoid mismatching between CountedLoopNode and CountedLoopEndNode in the following optimization.
-      Node* head = unique_ctrl_out();
+      Node* head = unique_ctrl_out_or_null();
       if (head != NULL && head->is_BaseCountedLoop() && head->in(LoopNode::LoopBackControl) == this) {
         Node* new_head = new LoopNode(head->in(LoopNode::EntryControl), this);
         phase->is_IterGVN()->register_new_node_with_optimizer(new_head);

--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -378,7 +378,7 @@ void PhaseIdealLoop::get_skeleton_predicates(Node* predicate, Unique_Node_List& 
   while (predicate != NULL && predicate->is_Proj() && predicate->in(0)->is_If()) {
     iff = predicate->in(0)->as_If();
     uncommon_proj = iff->proj_out(1 - predicate->as_Proj()->_con);
-    if (uncommon_proj->unique_ctrl_out() != rgn) {
+    if (uncommon_proj->unique_ctrl_out_or_null() != rgn) {
       break;
     }
     if (iff->in(1)->Opcode() == Op_Opaque4 && skeleton_predicate_has_opaque(iff)) {
@@ -483,7 +483,7 @@ Node* PhaseIdealLoop::skip_loop_predicates(Node* entry) {
   entry = entry->in(0)->in(0);
   while (entry != NULL && entry->is_Proj() && entry->in(0)->is_If()) {
     uncommon_proj = entry->in(0)->as_If()->proj_out(1 - entry->as_Proj()->_con);
-    if (uncommon_proj->unique_ctrl_out() != rgn)
+    if (uncommon_proj->unique_ctrl_out_or_null() != rgn)
       break;
     entry = entry->in(0)->in(0);
   }
@@ -1189,7 +1189,7 @@ public:
             assert(con >= CatchProjNode::catch_all_index, "what else?");
             _freqs.at_put_grow(c->_idx, 0, -1);
           }
-        } else if (c->unique_ctrl_out() == NULL && !c->is_If() && !c->is_Jump()) {
+        } else if (c->unique_ctrl_out_or_null() == NULL && !c->is_If() && !c->is_Jump()) {
           ShouldNotReachHere();
         } else {
           c = c->in(0);

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -1294,7 +1294,7 @@ void PhaseIdealLoop::copy_skeleton_predicates_to_main_loop_helper(Node* predicat
     while (predicate != NULL && predicate->is_Proj() && predicate->in(0)->is_If()) {
       iff = predicate->in(0)->as_If();
       uncommon_proj = iff->proj_out(1 - predicate->as_Proj()->_con);
-      if (uncommon_proj->unique_ctrl_out() != rgn)
+      if (uncommon_proj->unique_ctrl_out_or_null() != rgn)
         break;
       if (iff->in(1)->Opcode() == Op_Opaque4) {
         assert(skeleton_predicate_has_opaque(iff), "unexpected");

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -2846,7 +2846,7 @@ bool OuterStripMinedLoopEndNode::is_expanded(PhaseGVN *phase) const {
   if (phase->is_IterGVN()) {
     Node* backedge = proj_out_or_null(true);
     if (backedge != NULL) {
-      Node* head = backedge->unique_ctrl_out();
+      Node* head = backedge->unique_ctrl_out_or_null();
       if (head != NULL && head->is_OuterStripMinedLoop()) {
         if (head->find_out_with(Op_Phi) != NULL) {
           return true;
@@ -5756,7 +5756,7 @@ void PhaseIdealLoop::build_loop_late_post_work(Node *n, bool pinned) {
   // Try not to place code on a loop entry projection
   // which can inhibit range check elimination.
   if (least != early) {
-    Node* ctrl_out = least->unique_ctrl_out();
+    Node* ctrl_out = least->unique_ctrl_out_or_null();
     if (ctrl_out && ctrl_out->is_Loop() &&
         least == ctrl_out->in(LoopNode::EntryControl) &&
         (ctrl_out->is_CountedLoop() || ctrl_out->is_OuterStripMinedLoop())) {

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -1465,7 +1465,7 @@ void PhaseMacroExpand::expand_allocate_common(
     if (result_phi_i_o->outcnt() > 1) {
       call->set_req(TypeFunc::I_O, top());
     } else {
-      assert(result_phi_i_o->unique_ctrl_out() == call, "sanity");
+      assert(result_phi_i_o->unique_ctrl_out_or_null() == call, "sanity");
       // Case of new array with negative size known during compilation.
       // AllocateArrayNode::Ideal() optimization disconnect unreachable
       // following code since call to runtime will throw exception.

--- a/src/hotspot/share/opto/multnode.cpp
+++ b/src/hotspot/share/opto/multnode.cpp
@@ -188,7 +188,7 @@ CallStaticJavaNode* ProjNode::is_uncommon_trap_proj(Deoptimization::DeoptReason 
   int path_limit = 10;
   Node* out = this;
   for (int ct = 0; ct < path_limit; ct++) {
-    out = out->unique_ctrl_out();
+    out = out->unique_ctrl_out_or_null();
     if (out == NULL)
       return NULL;
     if (out->is_CallStaticJava()) {

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -2387,9 +2387,9 @@ Node* Node::find_similar(int opc) {
 }
 
 
-//--------------------------unique_ctrl_out------------------------------
+//--------------------------unique_ctrl_out_or_null-------------------------
 // Return the unique control out if only one. Null if none or more than one.
-Node* Node::unique_ctrl_out() const {
+Node* Node::unique_ctrl_out_or_null() const {
   Node* found = NULL;
   for (uint i = 0; i < outcnt(); i++) {
     Node* use = raw_out(i);
@@ -2401,6 +2401,14 @@ Node* Node::unique_ctrl_out() const {
     }
   }
   return found;
+}
+
+//--------------------------unique_ctrl_out------------------------------
+// Return the unique control out. Asserts if none or more than one control out.
+Node* Node::unique_ctrl_out() const {
+    Node* ctrl = unique_ctrl_out_or_null();
+    assert(ctrl != NULL, "control out is assumed to be unique");
+    return ctrl;
 }
 
 void Node::ensure_control_or_add_prec(Node* c) {

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1084,6 +1084,8 @@ public:
   Node* find_similar(int opc);
 
   // Return the unique control out if only one. Null if none or more than one.
+  Node* unique_ctrl_out_or_null() const;
+  // Return the unique control out. Asserts if none or more than one control out.
   Node* unique_ctrl_out() const;
 
   // Set control or add control as precedence edge


### PR DESCRIPTION
…_out

unique_ctrl_out was used in contexts where NULL may be a valid return, and is also used in contexts where NULL is not expected.

I improved the code by having two functions instead:
unique_ctrl_out_or_null: return the unique control out, or NULL if there is no or more than one control out.
unique_ctrl_out: return the unique control out, assert if there is no or more than one control out.

This makes implicit assumptions explicit and also validates them in the future.

I changed the usage to unique_ctrl_out_or_null where NULL is among the expected return values.