### PR TITLE
8281744: x86: Use short jumps in TIG::set_vtos_entry_points

### DIFF
--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -1738,21 +1738,21 @@ void TemplateInterpreterGenerator::set_vtos_entry_points(Template* t,
 #ifndef _LP64
   fep = __ pc();     // ftos entry point
       __ push(ftos);
-      __ jmp(L);
+      __ jmpb(L);
   dep = __ pc();     // dtos entry point
       __ push(dtos);
-      __ jmp(L);
+      __ jmpb(L);
 #else
   fep = __ pc();     // ftos entry point
       __ push_f(xmm0);
-      __ jmp(L);
+      __ jmpb(L);
   dep = __ pc();     // dtos entry point
       __ push_d(xmm0);
-      __ jmp(L);
+      __ jmpb(L);
 #endif // _LP64
   lep = __ pc();     // ltos entry point
       __ push_l();
-      __ jmp(L);
+      __ jmpb(L);
   aep = bep = cep = sep = iep = __ pc();      // [abcsi]tos entry point
       __ push_i_or_ptr();
   vep = __ pc();    // vtos entry point


### PR DESCRIPTION
Performance in `-Xint` mode seems to be bottlenecked on number of instructions executed, rather than particular instruction hotspots, which means code density is important.

There are forward branches in `TemplateInterpreterGenerator::set_vtos_entry_points`, which cannot be shortened by macro-assembler, unless we tell it specifically that the upcoming branch target would be within the 8-bit offset. Which it apparently is in this particular case, because there are just a handful of `push`-es between the jump and its target. If we break that invariant, the interpreter would catch fire just about everywhere, since `set_vtos_entry_points` is always used.

Current patch improves specjvm2008:serial performance in `-Xint` for about 7% on R7 5700G. (More perf runs pending).

Additional testing:
 - [ ] Linux x86_64 fastdebug, `tier1`
 - [ ] Linux x86_32 fastdebug, `tier1`