### PR TITLE
8281741: [testbug] PrintIdealPhaseTest fails with -Xcomp

### DIFF
--- a/test/hotspot/jtreg/compiler/oracle/PrintIdealPhaseTest.java
+++ b/test/hotspot/jtreg/compiler/oracle/PrintIdealPhaseTest.java
@@ -27,7 +27,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @requires vm.debug == true & vm.compiler2.enabled
+ * @requires vm.debug == true & vm.compiler2.enabled & vm.compMode != "Xcomp"
  * @run driver compiler.oracle.PrintIdealPhaseTest
  */
 
@@ -77,6 +77,7 @@ public class PrintIdealPhaseTest {
         options.add("-XX:+PrintCompilation");
         options.add("-XX:LogFile="+logFile);
         options.add("-XX:+IgnoreUnrecognizedVMOptions");
+        options.add("-XX:CompileCommand=dontinline," + getTestClass() + "::test");
         options.add("-XX:CompileCommand=PrintIdealPhase," + getTestClass() + "::test," + cmdPhases);
         options.add(getTestClass());
 


### PR DESCRIPTION
Hi,

The PrintIdealPhaseTest fails with Xcomp - the test method is inlined, and not compiled. Adding a DontInline command to fix this. 

Also excluding this test from Xcomp - the flag it's propagated to the sub tests which spends a lot of time wasting energy compiling nothing of interest.

Please review,
Nils Eliasson

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281741](https://bugs.openjdk.java.net/browse/JDK-8281741): [testbug] PrintIdealPhaseTest fails with -Xcomp


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7465/head:pull/7465` \
`$ git checkout pull/7465`

Update a local copy of the PR: \
`$ git checkout pull/7465` \
`$ git pull https://git.openjdk.java.net/jdk pull/7465/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7465`

View PR using the GUI difftool: \
`$ git pr show -t 7465`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7465.diff">https://git.openjdk.java.net/jdk/pull/7465.diff</a>

</details>
