### PR TITLE
8280881: (fs) UnixNativeDispatcher.close0 may throw UnixException

### DIFF
--- a/src/java.base/linux/classes/sun/nio/fs/LinuxDosFileAttributeView.java
+++ b/src/java.base/linux/classes/sun/nio/fs/LinuxDosFileAttributeView.java
@@ -182,10 +182,7 @@ class LinuxDosFileAttributeView
             x.rethrowAsIOException(file);
             return null;    // keep compiler happy
         } finally {
-            try {
-                close(fd);
-            } catch (UnixException ignore) {
-            }
+            close(fd, null);
         }
     }
 
@@ -280,10 +277,7 @@ class LinuxDosFileAttributeView
         } catch (UnixException x) {
             x.rethrowAsIOException(file);
         } finally {
-            try {
-                close(fd);
-            } catch (UnixException ignore) {
-            }
+            close(fd, null);
         }
     }
 }

--- a/src/java.base/linux/classes/sun/nio/fs/LinuxDosFileAttributeView.java
+++ b/src/java.base/linux/classes/sun/nio/fs/LinuxDosFileAttributeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -182,7 +182,10 @@ class LinuxDosFileAttributeView
             x.rethrowAsIOException(file);
             return null;    // keep compiler happy
         } finally {
-            close(fd);
+            try {
+                close(fd);
+            } catch (UnixException ignore) {
+            }
         }
     }
 
@@ -277,7 +280,10 @@ class LinuxDosFileAttributeView
         } catch (UnixException x) {
             x.rethrowAsIOException(file);
         } finally {
-            close(fd);
+            try {
+                close(fd);
+            } catch (UnixException ignore) {
+            }
         }
     }
 }

--- a/src/java.base/linux/classes/sun/nio/fs/LinuxDosFileAttributeView.java
+++ b/src/java.base/linux/classes/sun/nio/fs/LinuxDosFileAttributeView.java
@@ -182,7 +182,7 @@ class LinuxDosFileAttributeView
             x.rethrowAsIOException(file);
             return null;    // keep compiler happy
         } finally {
-            close(fd, null);
+            close(fd, e -> null);
         }
     }
 
@@ -277,7 +277,7 @@ class LinuxDosFileAttributeView
         } catch (UnixException x) {
             x.rethrowAsIOException(file);
         } finally {
-            close(fd, null);
+            close(fd, e -> null);
         }
     }
 }

--- a/src/java.base/linux/classes/sun/nio/fs/LinuxWatchService.java
+++ b/src/java.base/linux/classes/sun/nio/fs/LinuxWatchService.java
@@ -71,7 +71,7 @@ class LinuxWatchService
             configureBlocking(sp[0], false);
         } catch (UnixException x) {
             throw UnixNativeDispatcher.close(ifd,
-                new IOException(x.errorString()), y -> y.asIOException(null));
+                new IOException(x.errorString()), e -> null);
         }
 
         this.poller = new Poller(fs, this, ifd, sp);

--- a/src/java.base/linux/classes/sun/nio/fs/LinuxWatchService.java
+++ b/src/java.base/linux/classes/sun/nio/fs/LinuxWatchService.java
@@ -296,9 +296,9 @@ class LinuxWatchService
 
             // free resources
             unsafe.freeMemory(address);
-            UnixNativeDispatcher.close(socketpair[0], null);
-            UnixNativeDispatcher.close(socketpair[1], null);
-            UnixNativeDispatcher.close(ifd, null);
+            UnixNativeDispatcher.close(socketpair[0], e -> null);
+            UnixNativeDispatcher.close(socketpair[1], e -> null);
+            UnixNativeDispatcher.close(ifd, e -> null);
         }
 
         /**

--- a/src/java.base/linux/classes/sun/nio/fs/LinuxWatchService.java
+++ b/src/java.base/linux/classes/sun/nio/fs/LinuxWatchService.java
@@ -70,13 +70,8 @@ class LinuxWatchService
             socketpair(sp);
             configureBlocking(sp[0], false);
         } catch (UnixException x) {
-            IOException ioe = new IOException(x.errorString());
-            try {
-                UnixNativeDispatcher.close(ifd);
-            } catch (UnixException e) {
-                ioe.addSuppressed(e);
-            }
-            throw ioe;
+            throw UnixNativeDispatcher.close(ifd,
+                new IOException(x.errorString()), y -> y.asIOException(null));
         }
 
         this.poller = new Poller(fs, this, ifd, sp);
@@ -301,12 +296,9 @@ class LinuxWatchService
 
             // free resources
             unsafe.freeMemory(address);
-            try {
-                UnixNativeDispatcher.close(socketpair[0]);
-                UnixNativeDispatcher.close(socketpair[1]);
-                UnixNativeDispatcher.close(ifd);
-            } catch (UnixException ignore) {
-            }
+            UnixNativeDispatcher.close(socketpair[0], null);
+            UnixNativeDispatcher.close(socketpair[1], null);
+            UnixNativeDispatcher.close(ifd, null);
         }
 
         /**

--- a/src/java.base/linux/classes/sun/nio/fs/LinuxWatchService.java
+++ b/src/java.base/linux/classes/sun/nio/fs/LinuxWatchService.java
@@ -70,8 +70,8 @@ class LinuxWatchService
             socketpair(sp);
             configureBlocking(sp[0], false);
         } catch (UnixException x) {
-            throw UnixNativeDispatcher.close(ifd,
-                new IOException(x.errorString()), e -> null);
+            UnixNativeDispatcher.close(ifd, e -> null);
+            throw new IOException(x.errorString());
         }
 
         this.poller = new Poller(fs, this, ifd, sp);

--- a/src/java.base/unix/classes/sun/nio/fs/UnixCopyFile.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixCopyFile.java
@@ -186,11 +186,7 @@ class UnixCopyFile {
                 }
                 if (sfd >= 0) {
                     source.getFileSystem().copyNonPosixAttributes(sfd, dfd);
-                    try {
-                        close(sfd);
-                    } catch (UnixException e) {
-                        e.rethrowAsIOException(source);
-                    }
+                    close(sfd, x -> x.asIOException(source));
                 }
             }
             // copy time stamps last
@@ -213,14 +209,8 @@ class UnixCopyFile {
             }
             done = true;
         } finally {
-            if (dfd >= 0) {
-                try {
-                    close(dfd);
-                } catch (UnixException e) {
-                    if (done)
-                        e.rethrowAsIOException(target);
-                }
-            }
+            if (dfd >= 0)
+                close(dfd, null);
             if (!done) {
                 // rollback
                 try { rmdir(target); } catch (UnixException ignore) { }
@@ -243,8 +233,6 @@ class UnixCopyFile {
             x.rethrowAsIOException(source);
         }
 
-        // set to true when file and attributes copied
-        boolean complete = false;
         try {
             // open new file
             int fo = -1;
@@ -258,6 +246,8 @@ class UnixCopyFile {
                 x.rethrowAsIOException(target);
             }
 
+            // set to true when file and attributes copied
+            boolean complete = false;
             try {
                 // transfer bytes to target file
                 try {
@@ -298,12 +288,7 @@ class UnixCopyFile {
                 }
                 complete = true;
             } finally {
-                try {
-                    close(fo);
-                } catch (UnixException e) {
-                    if (complete)
-                        e.rethrowAsIOException(target);
-                }
+                close(fo, null);
 
                 // copy of file or attributes failed so rollback
                 if (!complete) {
@@ -313,12 +298,7 @@ class UnixCopyFile {
                 }
             }
         } finally {
-            try {
-                close(fi);
-            } catch (UnixException e) {
-                if (complete)
-                    e.rethrowAsIOException(source);
-            }
+            close(fi, null);
         }
     }
 

--- a/src/java.base/unix/classes/sun/nio/fs/UnixCopyFile.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixCopyFile.java
@@ -186,7 +186,7 @@ class UnixCopyFile {
                 }
                 if (sfd >= 0) {
                     source.getFileSystem().copyNonPosixAttributes(sfd, dfd);
-                    close(sfd, null);
+                    close(sfd, e -> null);
                 }
             }
             // copy time stamps last

--- a/src/java.base/unix/classes/sun/nio/fs/UnixCopyFile.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixCopyFile.java
@@ -210,7 +210,7 @@ class UnixCopyFile {
             done = true;
         } finally {
             if (dfd >= 0)
-                close(dfd, null);
+                close(dfd, e -> null);
             if (!done) {
                 // rollback
                 try { rmdir(target); } catch (UnixException ignore) { }
@@ -288,7 +288,7 @@ class UnixCopyFile {
                 }
                 complete = true;
             } finally {
-                close(fo, null);
+                close(fo, e -> null);
 
                 // copy of file or attributes failed so rollback
                 if (!complete) {
@@ -298,7 +298,7 @@ class UnixCopyFile {
                 }
             }
         } finally {
-            close(fi, null);
+            close(fi, e -> null);
         }
     }
 

--- a/src/java.base/unix/classes/sun/nio/fs/UnixCopyFile.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixCopyFile.java
@@ -186,7 +186,7 @@ class UnixCopyFile {
                 }
                 if (sfd >= 0) {
                     source.getFileSystem().copyNonPosixAttributes(sfd, dfd);
-                    close(sfd, x -> x.asIOException(source));
+                    close(sfd, null);
                 }
             }
             // copy time stamps last

--- a/src/java.base/unix/classes/sun/nio/fs/UnixCopyFile.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixCopyFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -186,7 +186,11 @@ class UnixCopyFile {
                 }
                 if (sfd >= 0) {
                     source.getFileSystem().copyNonPosixAttributes(sfd, dfd);
-                    close(sfd);
+                    try {
+                        close(sfd);
+                    } catch (UnixException e) {
+                        e.rethrowAsIOException(source);
+                    }
                 }
             }
             // copy time stamps last
@@ -210,7 +214,11 @@ class UnixCopyFile {
             done = true;
         } finally {
             if (dfd >= 0)
-                close(dfd);
+                try {
+                    close(dfd);
+                } catch (UnixException e) {
+                    e.rethrowAsIOException(target);
+                }
             if (!done) {
                 // rollback
                 try { rmdir(target); } catch (UnixException ignore) { }
@@ -288,7 +296,11 @@ class UnixCopyFile {
                 }
                 complete = true;
             } finally {
-                close(fo);
+                try {
+                    close(fo);
+                } catch (UnixException e) {
+                    e.rethrowAsIOException(target);
+                }
 
                 // copy of file or attributes failed so rollback
                 if (!complete) {
@@ -298,7 +310,11 @@ class UnixCopyFile {
                 }
             }
         } finally {
-            close(fi);
+            try {
+                close(fi);
+            } catch (UnixException e) {
+                e.rethrowAsIOException(source);
+            }
         }
     }
 

--- a/src/java.base/unix/classes/sun/nio/fs/UnixDirectoryStream.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixDirectoryStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ class UnixDirectoryStream
         this.filter = filter;
     }
 
-    protected final UnixPath directory() {
+    final UnixPath directory() {
         return dir;
     }
 

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributeViews.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributeViews.java
@@ -160,10 +160,7 @@ class UnixFileAttributeViews {
                     }
                 }
             } finally {
-                try {
-                    close(fd);
-                } catch (UnixException ignore) {
-                }
+                close(fd, null);
             }
         }
     }

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributeViews.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributeViews.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -160,7 +160,11 @@ class UnixFileAttributeViews {
                     }
                 }
             } finally {
-                close(fd);
+                try {
+                    close(fd);
+                } catch (UnixException e) {
+                    e.rethrowAsIOException(file);
+                }
             }
         }
     }

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributeViews.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributeViews.java
@@ -162,8 +162,7 @@ class UnixFileAttributeViews {
             } finally {
                 try {
                     close(fd);
-                } catch (UnixException e) {
-                    e.rethrowAsIOException(file);
+                } catch (UnixException ignore) {
                 }
             }
         }

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributeViews.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributeViews.java
@@ -160,7 +160,7 @@ class UnixFileAttributeViews {
                     }
                 }
             } finally {
-                close(fd, null);
+                close(fd, e -> null);
             }
         }
     }

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileStore.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileStore.java
@@ -197,7 +197,7 @@ abstract class UnixFileStore
             if (e.errno() == UnixConstants.XATTR_NOT_FOUND)
                 return true;
         } finally {
-            UnixNativeDispatcher.close(fd, null);
+            UnixNativeDispatcher.close(fd, e -> null);
         }
         return false;
     }

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileStore.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileStore.java
@@ -199,7 +199,7 @@ abstract class UnixFileStore
         } finally {
             try {
                 UnixNativeDispatcher.close(fd);
-            } catch (UnixException ignored) {
+            } catch (UnixException ignore) {
             }
         }
         return false;

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileStore.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -197,7 +197,10 @@ abstract class UnixFileStore
             if (e.errno() == UnixConstants.XATTR_NOT_FOUND)
                 return true;
         } finally {
-            UnixNativeDispatcher.close(fd);
+            try {
+                UnixNativeDispatcher.close(fd);
+            } catch (UnixException ignored) {
+            }
         }
         return false;
     }

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileStore.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileStore.java
@@ -197,10 +197,7 @@ abstract class UnixFileStore
             if (e.errno() == UnixConstants.XATTR_NOT_FOUND)
                 return true;
         } finally {
-            try {
-                UnixNativeDispatcher.close(fd);
-            } catch (UnixException ignore) {
-            }
+            UnixNativeDispatcher.close(fd, null);
         }
         return false;
     }

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
@@ -434,14 +434,10 @@ public abstract class UnixFileSystemProvider
             IOException ioe = x.errno() == UnixConstants.ENOTDIR ?
                 new NotDirectoryException(dir.getPathForExceptionMessage()) :
                 x.asIOException(dir);
-            if (dfd1 != -1) {
-                ioe = UnixNativeDispatcher.close(dfd1, ioe,
-                    y -> y.asIOException(dir));
-            }
-            if (dfd2 != -1) {
-                ioe = UnixNativeDispatcher.close(dfd2, ioe,
-                    z -> z.asIOException(dir));
-            }
+            if (dfd1 != -1)
+                ioe = UnixNativeDispatcher.close(dfd1, ioe, e -> null);
+            if (dfd2 != -1)
+                ioe = UnixNativeDispatcher.close(dfd2, ioe, e -> null);
             throw ioe;
         }
         return new UnixSecureDirectoryStream(dir, dp, dfd2, filter);

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
@@ -435,9 +435,9 @@ public abstract class UnixFileSystemProvider
                 new NotDirectoryException(dir.getPathForExceptionMessage()) :
                 x.asIOException(dir);
             if (dfd1 != -1)
-                ioe = UnixNativeDispatcher.close(dfd1, ioe, e -> null);
+                UnixNativeDispatcher.close(dfd1, e -> null);
             if (dfd2 != -1)
-                ioe = UnixNativeDispatcher.close(dfd2, ioe, e -> null);
+                UnixNativeDispatcher.close(dfd2, e -> null);
             throw ioe;
         }
         return new UnixSecureDirectoryStream(dir, dp, dfd2, filter);

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
@@ -435,18 +435,12 @@ public abstract class UnixFileSystemProvider
                 new NotDirectoryException(dir.getPathForExceptionMessage()) :
                 x.asIOException(dir);
             if (dfd1 != -1) {
-                try {
-                    UnixNativeDispatcher.close(dfd1);
-                } catch (UnixException y) {
-                    ioe.addSuppressed(y);
-                }
+                ioe = UnixNativeDispatcher.close(dfd1, ioe,
+                    y -> y.asIOException(dir));
             }
             if (dfd2 != -1) {
-                try {
-                    UnixNativeDispatcher.close(dfd2);
-                } catch (UnixException z) {
-                    ioe.addSuppressed(z);
-                }
+                ioe = UnixNativeDispatcher.close(dfd2, ioe,
+                    z -> z.asIOException(dir));
             }
             throw ioe;
         }

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -431,10 +431,20 @@ public abstract class UnixFileSystemProvider
             dfd2 = dup(dfd1);
             dp = fdopendir(dfd1);
         } catch (UnixException x) {
-            if (dfd1 != -1)
-                UnixNativeDispatcher.close(dfd1);
-            if (dfd2 != -1)
-                UnixNativeDispatcher.close(dfd2);
+            if (dfd1 != -1) {
+                try {
+                    UnixNativeDispatcher.close(dfd1);
+                } catch (UnixException y) {
+                    x.addSuppressed(y);
+                }
+            }
+            if (dfd2 != -1) {
+                try {
+                    UnixNativeDispatcher.close(dfd2);
+                } catch (UnixException z) {
+                    x.addSuppressed(z);
+                }
+            }
             if (x.errno() == UnixConstants.ENOTDIR)
                 throw new NotDirectoryException(dir.getPathForExceptionMessage());
             x.rethrowAsIOException(dir);

--- a/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,12 +90,12 @@ class UnixNativeDispatcher {
     /**
      * close(int filedes). If fd is -1 this is a no-op.
      */
-    static void close(int fd) {
+    static void close(int fd) throws UnixException {
         if (fd != -1) {
             close0(fd);
         }
     }
-    private static native void close0(int fd);
+    private static native void close0(int fd) throws UnixException;
 
     /**
      * void rewind(FILE* stream);

--- a/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
@@ -118,28 +118,6 @@ class UnixNativeDispatcher {
     }
 
     /**
-     * close(fd). If close is successful then {@code ex} is returned. If
-     * close fails then the given exception supplier function is invoked
-     * to produce an exception. If {@code ex} is null then the produced
-     * exception is returned, otherwise it is added to {@code ex} as a
-     * suppressed exception and {@code ex} is returned.
-     */
-    static <X extends Throwable>
-    X close(int fd, X ex, Function<UnixException, X>  mapper) {
-        try {
-            close(fd);
-        } catch (UnixException ue) {
-            X closeEx = mapper.apply(ue);
-            if (ex != null) {
-                ex.addSuppressed(closeEx);
-            } else {
-                ex = closeEx;
-            }
-        }
-        return ex;
-    }
-
-    /**
      * void rewind(FILE* stream);
      */
     static native void rewind(long stream) throws UnixException;

--- a/src/java.base/unix/classes/sun/nio/fs/UnixSecureDirectoryStream.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixSecureDirectoryStream.java
@@ -121,9 +121,9 @@ class UnixSecureDirectoryStream
                     new NotDirectoryException(file.toString()) :
                     x.asIOException(file);
                 if (newdfd1 != -1)
-                    ioe = UnixNativeDispatcher.close(newdfd1, ioe, e -> null);
+                    UnixNativeDispatcher.close(newdfd1, e -> null);
                 if (newdfd2 != -1)
-                    ioe = UnixNativeDispatcher.close(newdfd1, ioe, e -> null);
+                    UnixNativeDispatcher.close(newdfd1, e -> null);
                 throw ioe;
             }
             return new UnixSecureDirectoryStream(child, ptr, newdfd2, null);

--- a/src/java.base/unix/classes/sun/nio/fs/UnixSecureDirectoryStream.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixSecureDirectoryStream.java
@@ -427,7 +427,7 @@ class UnixSecureDirectoryStream
                     }
                 } finally {
                     if (file != null)
-                        UnixNativeDispatcher.close(fd, null);
+                        UnixNativeDispatcher.close(fd, e-> null);
                 }
             } finally {
                 ds.readLock().unlock();
@@ -509,7 +509,7 @@ class UnixSecureDirectoryStream
                     x.rethrowAsIOException(file);
                 } finally {
                     if (file != null && fd >= 0)
-                        UnixNativeDispatcher.close(fd, null);
+                        UnixNativeDispatcher.close(fd, e-> null);
                 }
             } finally {
                 ds.readLock().unlock();
@@ -532,7 +532,7 @@ class UnixSecureDirectoryStream
                     x.rethrowAsIOException(file);
                 } finally {
                     if (file != null && fd >= 0)
-                        UnixNativeDispatcher.close(fd, null);
+                        UnixNativeDispatcher.close(fd, e-> null);
                 }
             } finally {
                 ds.readLock().unlock();

--- a/src/java.base/unix/classes/sun/nio/fs/UnixSecureDirectoryStream.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixSecureDirectoryStream.java
@@ -61,11 +61,7 @@ class UnixSecureDirectoryStream
         ds.writeLock().lock();
         try {
             if (ds.closeImpl()) {
-                try {
-                    UnixNativeDispatcher.close(dfd);
-                } catch (UnixException e) {
-                    e.rethrowAsIOException(ds.directory());
-                }
+                UnixNativeDispatcher.close(dfd, e -> e.asIOException(ds.directory()));
             }
         } finally {
             ds.writeLock().unlock();
@@ -125,18 +121,12 @@ class UnixSecureDirectoryStream
                     new NotDirectoryException(file.toString()) :
                     x.asIOException(file);
                 if (newdfd1 != -1) {
-                    try {
-                        UnixNativeDispatcher.close(newdfd1);
-                    } catch (UnixException e) {
-                        ioe.addSuppressed(e);
-                    }
+                    ioe = UnixNativeDispatcher.close(newdfd1, ioe,
+                        y -> y.asIOException(file));
                 }
                 if (newdfd2 != -1) {
-                    try {
-                        UnixNativeDispatcher.close(newdfd2);
-                    } catch (UnixException e) {
-                        ioe.addSuppressed(e);
-                    }
+                    ioe = UnixNativeDispatcher.close(newdfd1, ioe,
+                        z -> z.asIOException(file));
                 }
                 throw ioe;
             }
@@ -436,12 +426,8 @@ class UnixSecureDirectoryStream
                         x.rethrowAsIOException(file);
                     }
                 } finally {
-                    if (file != null) {
-                        try {
-                            UnixNativeDispatcher.close(fd);
-                        } catch (UnixException ignore) {
-                        }
-                    }
+                    if (file != null)
+                        UnixNativeDispatcher.close(fd, null);
                 }
             } finally {
                 ds.readLock().unlock();
@@ -522,12 +508,8 @@ class UnixSecureDirectoryStream
                 } catch (UnixException x) {
                     x.rethrowAsIOException(file);
                 } finally {
-                    if (file != null && fd >= 0) {
-                        try {
-                            UnixNativeDispatcher.close(fd);
-                        } catch (UnixException ignore) {
-                        }
-                    }
+                    if (file != null && fd >= 0)
+                        UnixNativeDispatcher.close(fd, null);
                 }
             } finally {
                 ds.readLock().unlock();
@@ -549,12 +531,8 @@ class UnixSecureDirectoryStream
                 } catch (UnixException x) {
                     x.rethrowAsIOException(file);
                 } finally {
-                    if (file != null && fd >= 0) {
-                        try {
-                            UnixNativeDispatcher.close(fd);
-                        } catch (UnixException ignore) {
-                        }
-                    }
+                    if (file != null && fd >= 0)
+                        UnixNativeDispatcher.close(fd, null);
                 }
             } finally {
                 ds.readLock().unlock();

--- a/src/java.base/unix/classes/sun/nio/fs/UnixSecureDirectoryStream.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixSecureDirectoryStream.java
@@ -120,14 +120,10 @@ class UnixSecureDirectoryStream
                 IOException ioe = x.errno() == UnixConstants.ENOTDIR ?
                     new NotDirectoryException(file.toString()) :
                     x.asIOException(file);
-                if (newdfd1 != -1) {
-                    ioe = UnixNativeDispatcher.close(newdfd1, ioe,
-                        y -> y.asIOException(file));
-                }
-                if (newdfd2 != -1) {
-                    ioe = UnixNativeDispatcher.close(newdfd1, ioe,
-                        z -> z.asIOException(file));
-                }
+                if (newdfd1 != -1)
+                    ioe = UnixNativeDispatcher.close(newdfd1, ioe, e -> null);
+                if (newdfd2 != -1)
+                    ioe = UnixNativeDispatcher.close(newdfd1, ioe, e -> null);
                 throw ioe;
             }
             return new UnixSecureDirectoryStream(child, ptr, newdfd2, null);

--- a/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,7 +133,11 @@ abstract class UnixUserDefinedFileAttributeView
                 null, "Unable to get list of extended attributes: " +
                 x.getMessage());
         } finally {
-            close(fd);
+            try {
+                close(fd);
+            } catch (UnixException y) {
+                y.rethrowAsIOException(file);
+            }
         }
     }
 
@@ -157,7 +161,11 @@ abstract class UnixUserDefinedFileAttributeView
                 null, "Unable to get size of extended attribute '" + name +
                 "': " + x.getMessage());
         } finally {
-            close(fd);
+            try {
+                close(fd);
+            } catch (UnixException y) {
+                y.rethrowAsIOException(file);
+            }
         }
     }
 
@@ -221,7 +229,11 @@ abstract class UnixUserDefinedFileAttributeView
             throw new FileSystemException(file.getPathForExceptionMessage(),
                     null, "Error reading extended attribute '" + name + "': " + msg);
         } finally {
-            close(fd);
+            try {
+                close(fd);
+            } catch (UnixException y) {
+                y.rethrowAsIOException(file);
+            }
         }
     }
 
@@ -283,7 +295,11 @@ abstract class UnixUserDefinedFileAttributeView
                     null, "Error writing extended attribute '" + name + "': " +
                     x.getMessage());
         } finally {
-            close(fd);
+            try {
+                close(fd);
+            } catch (UnixException y) {
+                y.rethrowAsIOException(file);
+            }
         }
     }
 
@@ -305,7 +321,11 @@ abstract class UnixUserDefinedFileAttributeView
             throw new FileSystemException(file.getPathForExceptionMessage(),
                 null, "Unable to delete extended attribute '" + name + "': " + x.getMessage());
         } finally {
-            close(fd);
+            try {
+                close(fd);
+            } catch (UnixException y) {
+                y.rethrowAsIOException(file);
+            }
         }
     }
 

--- a/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
@@ -133,10 +133,7 @@ abstract class UnixUserDefinedFileAttributeView
                 null, "Unable to get list of extended attributes: " +
                 x.getMessage());
         } finally {
-            try {
-                close(fd);
-            } catch (UnixException ignore) {
-            }
+            close(fd, null);
         }
     }
 
@@ -160,10 +157,7 @@ abstract class UnixUserDefinedFileAttributeView
                 null, "Unable to get size of extended attribute '" + name +
                 "': " + x.getMessage());
         } finally {
-            try {
-                close(fd);
-            } catch (UnixException ignore) {
-            }
+            close(fd, null);
         }
     }
 
@@ -227,10 +221,7 @@ abstract class UnixUserDefinedFileAttributeView
             throw new FileSystemException(file.getPathForExceptionMessage(),
                     null, "Error reading extended attribute '" + name + "': " + msg);
         } finally {
-            try {
-                close(fd);
-            } catch (UnixException ignore) {
-            }
+            close(fd, null);
         }
     }
 
@@ -292,10 +283,7 @@ abstract class UnixUserDefinedFileAttributeView
                     null, "Error writing extended attribute '" + name + "': " +
                     x.getMessage());
         } finally {
-            try {
-                close(fd);
-            } catch (UnixException ignore) {
-            }
+            close(fd, null);
         }
     }
 
@@ -317,10 +305,7 @@ abstract class UnixUserDefinedFileAttributeView
             throw new FileSystemException(file.getPathForExceptionMessage(),
                 null, "Unable to delete extended attribute '" + name + "': " + x.getMessage());
         } finally {
-            try {
-                close(fd);
-            } catch (UnixException ignore) {
-            }
+            close(fd, null);
         }
     }
 

--- a/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
@@ -133,7 +133,7 @@ abstract class UnixUserDefinedFileAttributeView
                 null, "Unable to get list of extended attributes: " +
                 x.getMessage());
         } finally {
-            close(fd, null);
+            close(fd, e -> null);
         }
     }
 
@@ -157,7 +157,7 @@ abstract class UnixUserDefinedFileAttributeView
                 null, "Unable to get size of extended attribute '" + name +
                 "': " + x.getMessage());
         } finally {
-            close(fd, null);
+            close(fd, e -> null);
         }
     }
 
@@ -221,7 +221,7 @@ abstract class UnixUserDefinedFileAttributeView
             throw new FileSystemException(file.getPathForExceptionMessage(),
                     null, "Error reading extended attribute '" + name + "': " + msg);
         } finally {
-            close(fd, null);
+            close(fd, e -> null);
         }
     }
 
@@ -283,7 +283,7 @@ abstract class UnixUserDefinedFileAttributeView
                     null, "Error writing extended attribute '" + name + "': " +
                     x.getMessage());
         } finally {
-            close(fd, null);
+            close(fd, e -> null);
         }
     }
 
@@ -305,7 +305,7 @@ abstract class UnixUserDefinedFileAttributeView
             throw new FileSystemException(file.getPathForExceptionMessage(),
                 null, "Unable to delete extended attribute '" + name + "': " + x.getMessage());
         } finally {
-            close(fd, null);
+            close(fd, e -> null);
         }
     }
 

--- a/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
@@ -135,8 +135,7 @@ abstract class UnixUserDefinedFileAttributeView
         } finally {
             try {
                 close(fd);
-            } catch (UnixException y) {
-                y.rethrowAsIOException(file);
+            } catch (UnixException ignore) {
             }
         }
     }
@@ -163,8 +162,7 @@ abstract class UnixUserDefinedFileAttributeView
         } finally {
             try {
                 close(fd);
-            } catch (UnixException y) {
-                y.rethrowAsIOException(file);
+            } catch (UnixException ignore) {
             }
         }
     }
@@ -231,8 +229,7 @@ abstract class UnixUserDefinedFileAttributeView
         } finally {
             try {
                 close(fd);
-            } catch (UnixException y) {
-                y.rethrowAsIOException(file);
+            } catch (UnixException ignore) {
             }
         }
     }
@@ -297,8 +294,7 @@ abstract class UnixUserDefinedFileAttributeView
         } finally {
             try {
                 close(fd);
-            } catch (UnixException y) {
-                y.rethrowAsIOException(file);
+            } catch (UnixException ignore) {
             }
         }
     }
@@ -323,8 +319,7 @@ abstract class UnixUserDefinedFileAttributeView
         } finally {
             try {
                 close(fd);
-            } catch (UnixException y) {
-                y.rethrowAsIOException(file);
+            } catch (UnixException ignore) {
             }
         }
     }


### PR DESCRIPTION
Re-specify `sun.nio.fs.UnixNativeDispatcher.close0()` to throw `sun.nio.fs.UnixException` and modify callers either to ignore it or to rethrow it as an `IOException`, as appropriate.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280881](https://bugs.openjdk.java.net/browse/JDK-8280881): (fs) UnixNativeDispatcher.close0 may throw UnixException


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7467/head:pull/7467` \
`$ git checkout pull/7467`

Update a local copy of the PR: \
`$ git checkout pull/7467` \
`$ git pull https://git.openjdk.java.net/jdk pull/7467/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7467`

View PR using the GUI difftool: \
`$ git pr show -t 7467`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7467.diff">https://git.openjdk.java.net/jdk/pull/7467.diff</a>

</details>
