### PR TITLE
JDK-8281766: Update java.lang.reflect.Parameter to implement Member

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/Parameter.java
+++ b/src/java.base/share/classes/java/lang/reflect/Parameter.java
@@ -27,6 +27,7 @@ package java.lang.reflect;
 import java.lang.annotation.*;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.Objects;
 import sun.reflect.annotation.AnnotationSupport;
 
@@ -39,7 +40,7 @@ import sun.reflect.annotation.AnnotationSupport;
  *
  * @since 1.8
  */
-public final class Parameter implements AnnotatedElement {
+public final class Parameter implements AnnotatedElement, Member {
 
     private final String name;
     private final int modifiers;
@@ -146,6 +147,19 @@ public final class Parameter implements AnnotatedElement {
      */
     public Executable getDeclaringExecutable() {
         return executable;
+    }
+
+    /**
+     * {@return the class object of the {@code Executable} declaring
+     * this parameter}
+     * @implSpec
+     * The returned value is equal to {@code
+     * getDeclaringExecutable().getDeclaringClass()}.
+     * @since 19
+     */
+    @Override
+    public Class<?> getDeclaringClass() {
+        return executable.getDeclaringClass();
     }
 
     /**


### PR DESCRIPTION
Retrofitting of Parameter to implement Member, an interface already implemented by similar reflective modeling classes.

Since Parameter is final, there is little compatibility impact from adding a new method.

Please also review the corresponding CSR:

https://bugs.openjdk.java.net/browse/JDK-8281767

I'll update the copyright year before pushing; I judged this as trivial enough to not require a regression test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed
- [ ] Change requires a CSR request to be approved

### Issues
 * [JDK-8281766](https://bugs.openjdk.java.net/browse/JDK-8281766): Update java.lang.reflect.Parameter to implement Member
 * [JDK-8281767](https://bugs.openjdk.java.net/browse/JDK-8281767): Update java.lang.reflect.Parameter to implement Member (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7468/head:pull/7468` \
`$ git checkout pull/7468`

Update a local copy of the PR: \
`$ git checkout pull/7468` \
`$ git pull https://git.openjdk.java.net/jdk pull/7468/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7468`

View PR using the GUI difftool: \
`$ git pr show -t 7468`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7468.diff">https://git.openjdk.java.net/jdk/pull/7468.diff</a>

</details>
