### PR TITLE
8281745: Create a regression test for JDK-4514331

### DIFF
--- a/test/jdk/javax/swing/JTextArea/4514331/TabShiftsFocusToNextComponent.java
+++ b/test/jdk/javax/swing/JTextArea/4514331/TabShiftsFocusToNextComponent.java
@@ -29,6 +29,7 @@ import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import javax.swing.JButton;
 import javax.swing.JFrame;
@@ -67,15 +68,21 @@ public class TabShiftsFocusToNextComponent {
                                   .collect(Collectors.toList());
         for (final String laf : lafs) {
             try {
+                SwingUtilities.invokeAndWait(() -> frame = new JFrame());
+                robot.waitForIdle();
+                AtomicReference<Point> editorLoc = new AtomicReference<Point>();
                 SwingUtilities.invokeAndWait(() -> {
                     setLookAndFeel(laf);
                     createUI();
+                    editorLoc.set(editor.getLocationOnScreen());
                 });
                 passed = false;
-                Point editorLoc = editor.getLocationOnScreen();
-                robot.mouseMove(editorLoc.x, editorLoc.y);
+
+                final int x = editorLoc.get().x;
+                final int y = editorLoc.get().y;
+                robot.mouseMove(x, y);
                 robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-                robot.mouseMove(editorLoc.x + 20, editorLoc.y);
+                robot.mouseMove(x + 20, y);
                 robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
                 robot.keyPress(KeyEvent.VK_TAB);
                 robot.keyRelease(KeyEvent.VK_TAB);
@@ -92,11 +99,9 @@ public class TabShiftsFocusToNextComponent {
 
 
     private static void createUI() {
-        frame = new JFrame();
         JPanel panel = new JPanel();
         editor = new JTextArea("I am a JTextArea");
         editor.setEditable(false);
-        editor.requestFocusInWindow();
         panel.add(editor);
         JButton button = new JButton("Button");
         panel.add(button);
@@ -113,6 +118,7 @@ public class TabShiftsFocusToNextComponent {
         frame.setAlwaysOnTop(true);
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
+        editor.requestFocusInWindow();
 
     }
 

--- a/test/jdk/javax/swing/JTextArea/4514331/TabShiftsFocusToNextComponent.java
+++ b/test/jdk/javax/swing/JTextArea/4514331/TabShiftsFocusToNextComponent.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+import static javax.swing.UIManager.getInstalledLookAndFeels;
+
+/*
+ * @test
+ * @key headful
+ * @bug 4514331
+ * @summary Check whether pressing <Tab> key always shift focus to next component,
+ *          even though the current focus is in JTextArea and some text is already selected.
+ * @run main TabShiftsFocusToNextComponent
+ */
+public class TabShiftsFocusToNextComponent {
+
+    private static JFrame frame;
+    private static JTextArea editor;
+    private static Robot robot;
+    private static boolean passed = false;
+
+    public static void main(String[] s) throws Exception {
+        runTest();
+    }
+
+    public static void runTest() throws Exception {
+        robot = new Robot();
+        robot.setAutoWaitForIdle(true);
+        robot.setAutoDelay(200);
+        List<String> lafs = Arrays.stream(getInstalledLookAndFeels())
+                                  .map(UIManager.LookAndFeelInfo::getClassName)
+                                  .collect(Collectors.toList());
+        for (final String laf : lafs) {
+            try {
+                SwingUtilities.invokeAndWait(() -> {
+                    setLookAndFeel(laf);
+                    createUI();
+                });
+                passed = false;
+                Point editorLoc = editor.getLocationOnScreen();
+                robot.mouseMove(editorLoc.x, editorLoc.y);
+                robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+                robot.mouseMove(editorLoc.x + 20, editorLoc.y);
+                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+                robot.keyPress(KeyEvent.VK_TAB);
+                robot.keyRelease(KeyEvent.VK_TAB);
+                if (passed) {
+                    System.out.println(" Test passed for " + laf);
+                } else {
+                    throw new RuntimeException("Test failed for " + laf);
+                }
+            } finally {
+                SwingUtilities.invokeAndWait(TabShiftsFocusToNextComponent::disposeFrame);
+            }
+        }
+    }
+
+
+    private static void createUI() {
+        frame = new JFrame();
+        JPanel panel = new JPanel();
+        editor = new JTextArea("I am a JTextArea");
+        editor.setEditable(false);
+        editor.requestFocusInWindow();
+        panel.add(editor);
+        JButton button = new JButton("Button");
+        panel.add(button);
+        button.addFocusListener(new FocusAdapter() {
+            @Override
+            public void focusGained(FocusEvent e) {
+                passed = true;
+            }
+        });
+
+        frame.add(panel);
+        frame.setUndecorated(true);
+        frame.pack();
+        frame.setAlwaysOnTop(true);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+
+    }
+
+    private static void setLookAndFeel(final String laf) {
+        try {
+            UIManager.setLookAndFeel(laf);
+            System.out.println("LookAndFeel: " + laf);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void disposeFrame() {
+        if (frame != null) {
+            frame.dispose();
+            frame = null;
+        }
+    }
+}


### PR DESCRIPTION
Create a regression test for JDK-4514331.
It checks whether pressing 'Tab' key always shift focus to next component, even though the current focus is in JTextArea and some text is already selected.

Testing:
I have verified this test with JDK 1.3.1 and JDK 1.4.1 .
The issue is reproducible with JDK 1.3.1 and the test failed there, where the bug was originally reported and the test passed in JDK 1.4.1 where the issue was fixed.
I have tested it in Linux, Mac and Windows platforms and it passed everywhere.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281745](https://bugs.openjdk.java.net/browse/JDK-8281745): Create a regression test for JDK-4514331


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7469/head:pull/7469` \
`$ git checkout pull/7469`

Update a local copy of the PR: \
`$ git checkout pull/7469` \
`$ git pull https://git.openjdk.java.net/jdk pull/7469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7469`

View PR using the GUI difftool: \
`$ git pr show -t 7469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7469.diff">https://git.openjdk.java.net/jdk/pull/7469.diff</a>

</details>
