### PR TITLE
8281771: Crash in java_lang_invoke_MethodType::print_signature

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -4087,11 +4087,20 @@ void java_lang_invoke_MethodType::serialize_offsets(SerializeClosure* f) {
 void java_lang_invoke_MethodType::print_signature(oop mt, outputStream* st) {
   st->print("(");
   objArrayOop pts = ptypes(mt);
-  for (int i = 0, limit = pts->length(); i < limit; i++) {
-    java_lang_Class::print_signature(pts->obj_at(i), st);
+  if (pts != NULL) {
+    for (int i = 0, limit = pts->length(); i < limit; i++) {
+      java_lang_Class::print_signature(pts->obj_at(i), st);
+    }
+  } else {
+    st->print("NULL");
   }
   st->print(")");
-  java_lang_Class::print_signature(rtype(mt), st);
+  oop rt = rtype(mt);
+  if (rt != NULL) {
+    java_lang_Class::print_signature(rtype(mt), st);
+  } else {
+    st->print("NULL");
+  }
 }
 
 Symbol* java_lang_invoke_MethodType::as_signature(oop mt, bool intern_if_not_found) {

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -4097,7 +4097,7 @@ void java_lang_invoke_MethodType::print_signature(oop mt, outputStream* st) {
   st->print(")");
   oop rt = rtype(mt);
   if (rt != NULL) {
-    java_lang_Class::print_signature(rtype(mt), st);
+    java_lang_Class::print_signature(rt, st);
   } else {
     st->print("NULL");
   }


### PR DESCRIPTION
The crash happens in java.lang.invoke.MethodType.<init> when VM tries to print this objec while rtype and ptypes are not initialized yet. So the fix is just to check if they are not NULL.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281771](https://bugs.openjdk.java.net/browse/JDK-8281771): Crash in java_lang_invoke_MethodType::print_signature


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7470/head:pull/7470` \
`$ git checkout pull/7470`

Update a local copy of the PR: \
`$ git checkout pull/7470` \
`$ git pull https://git.openjdk.java.net/jdk pull/7470/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7470`

View PR using the GUI difftool: \
`$ git pr show -t 7470`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7470.diff">https://git.openjdk.java.net/jdk/pull/7470.diff</a>

</details>
