### PR TITLE
8281750: export java.base/jdk.internal.misc to jdk.internal.vm.compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,17 @@ NashornProfile.txt
 /src/utils/LogCompilation/target/
 /.project/
 /.settings/
+# -- BEGIN mx_jdk GENERATED
+/mxbuild/
+**/.checkstyle
+**/.classpath
+**/.externalToolBuilders
+**/.factorypath
+**/.idea
+**/.project
+**/.pydevproject
+**/.settings/
+**/*.pyc
+**/eclipse-launches/
+/.metadata/
+# -- END mx_jdk GENERATED

--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -207,6 +207,7 @@ module java.base {
         jdk.nio.mapmode,
         jdk.unsupported,
         jdk.internal.vm.ci,
+        jdk.internal.vm.compiler,
         jdk.incubator.foreign;
     exports jdk.internal.module to
         java.instrument,


### PR DESCRIPTION
JVMCI and JVMCI-based compilers need direct access to memory using Unsafe. Instead of using `sun.misc.Unsafe`, they should use `jdk.internal.misc.Unsafe`, because:
* that's what JDK-internal code is supposed to use
* `sun.misc.Unsafe` has additional artificial restrictions around records (e.g. https://github.com/oracle/graal/issues/4261).

This PR adds the required qualified export of `jdk.internal.misc` to the `jdk.internal.vm.compiler` module. Note that such as export already exists to the  `jdk.internal.vm.ci` module.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8281750](https://bugs.openjdk.java.net/browse/JDK-8281750): export java.base/jdk.internal.misc to jdk.internal.vm.compiler


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7472/head:pull/7472` \
`$ git checkout pull/7472`

Update a local copy of the PR: \
`$ git checkout pull/7472` \
`$ git pull https://git.openjdk.java.net/jdk pull/7472/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7472`

View PR using the GUI difftool: \
`$ git pr show -t 7472`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7472.diff">https://git.openjdk.java.net/jdk/pull/7472.diff</a>

</details>
