### PR TITLE
8282523: Fix 'hierachy' typo

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1559,8 +1559,8 @@ InstanceKlass* SystemDictionary::find_or_define_instance_class(Symbol* class_nam
 
 
 // ----------------------------------------------------------------------------
-// Update hierachy. This is done before the new klass has been added to the SystemDictionary. The Compile_lock
-// is held, to ensure that the compiler is not using the class hierachy, and that deoptimization will kick in
+// Update hierarchy. This is done before the new klass has been added to the SystemDictionary. The Compile_lock
+// is held, to ensure that the compiler is not using the class hierarchy, and that deoptimization will kick in
 // before a new class is used.
 
 void SystemDictionary::add_to_hierarchy(InstanceKlass* k) {
@@ -1574,7 +1574,7 @@ void SystemDictionary::add_to_hierarchy(InstanceKlass* k) {
   // The compiler reads the hierarchy outside of the Compile_lock.
   // Access ordering is used to add to hierarchy.
 
-  // Link into hierachy.
+  // Link into hierarchy.
   k->append_to_sibling_list();                    // add to superklass/sibling list
   k->process_interfaces();                        // handle all "implements" declarations
 
@@ -1724,7 +1724,7 @@ void SystemDictionary::check_constraints(unsigned int name_hash,
   }
 }
 
-// Update class loader data dictionary - done after check_constraint and add_to_hierachy
+// Update class loader data dictionary - done after check_constraint and add_to_hierarchy
 // have been called.
 void SystemDictionary::update_dictionary(unsigned int hash,
                                          InstanceKlass* k,

--- a/src/hotspot/share/utilities/exceptions.hpp
+++ b/src/hotspot/share/utilities/exceptions.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ class methodHandle;
 
 // The ThreadShadow class is a helper class to access the _pending_exception
 // field of the Thread class w/o having access to the Thread's interface (for
-// include hierachy reasons).
+// include hierarchy reasons).
 
 class ThreadShadow: public CHeapObj<mtThread> {
   friend class VMStructs;

--- a/test/hotspot/jtreg/runtime/exceptionMsgs/AbstractMethodError/AbstractMethodErrorTest.java
+++ b/test/hotspot/jtreg/runtime/exceptionMsgs/AbstractMethodError/AbstractMethodErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -502,7 +502,7 @@ public class AbstractMethodErrorTest {
 // -------------------------------------------------------------------------
 // This error should be detected interpreted.
 //
-// Class hierachy:
+// Class hierarchy:
 //
 //            C     // interface, defines aFunctionOfMyInterface()
 //            |
@@ -618,7 +618,7 @@ class AME1_E extends AME1_B implements AME1_C {
 // -------------------------------------------------------------------------
 // This error should be detected interpreted.
 //
-// Class hierachy:
+// Class hierarchy:
 //
 //      A   // an interface declaring aFunctionOfMyInterface()
 //      |
@@ -664,7 +664,7 @@ class AME2_C extends AME2_B {
 // -----------------------------------------------------------------------
 // Test AbstractMethod error shadowing existing implementation.
 //
-// Class hierachy:
+// Class hierarchy:
 //
 //           A           // a class implementing m()
 //           |
@@ -693,7 +693,7 @@ class AME3_C extends AME3_B {
 // Test AbstractMethod error shadowing existing implementation. In
 // this test there are several subclasses of the abstract class.
 //
-// Class hierachy:
+// Class hierarchy:
 //
 //           A           // A: a class implementing ma()
 //           |
@@ -733,7 +733,7 @@ class AME4_E extends AME4_B {
 // -------------------------------------------------------------------------
 // This error should be detected while processing the vtable stub.
 //
-// Class hierachy:
+// Class hierarchy:
 //
 //              A__     // abstract
 //             /|\ \
@@ -811,7 +811,7 @@ class AME5_E extends AME5_A {
 // Test AbstractMethod error detected while processing
 // the itable stub.
 //
-// Class hierachy:
+// Class hierarchy:
 //
 //           A__   (interface)
 //          /|\ \

--- a/test/hotspot/jtreg/runtime/exceptionMsgs/IncompatibleClassChangeError/IncompatibleClassChangeErrorTest.java
+++ b/test/hotspot/jtreg/runtime/exceptionMsgs/IncompatibleClassChangeError/IncompatibleClassChangeErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -345,7 +345,7 @@ class ImplementsSomeInterfaces extends
 
 // Helper classes to test incompatible class change in itable stub.
 //
-// Class hierachy:
+// Class hierarchy:
 //
 //          iA,iB   (interfaces)
 //          /|\ \
@@ -407,7 +407,7 @@ class ICC2_E implements ICC2_iA, ICC2_iB {
 
 // Helper classes to test error where class appears in implements statement.
 //
-// Class hierachy:
+// Class hierarchy:
 //
 //       A  Some Class.
 //       |
@@ -421,7 +421,7 @@ class ICC3_B extends ICC3_A {
 
 // Helper classes to test error where interface appears in extends statement.
 //
-// Class hierachy:
+// Class hierarchy:
 //
 //       A  Some Interface.
 //       |

--- a/test/hotspot/jtreg/runtime/exceptionMsgs/methodPrinting/TestPrintingMethods.java
+++ b/test/hotspot/jtreg/runtime/exceptionMsgs/methodPrinting/TestPrintingMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -101,7 +101,7 @@ public class TestPrintingMethods {
 // -----------------------------------------------------------------------
 // Test AbstractMethod error shadowing existing implementation.
 //
-// Class hierachy:
+// Class hierarchy:
 //
 //           A           // A class implementing m() and similar.
 //           |


### PR DESCRIPTION
Fix multiple 'hierachy' -> 'hierarchy' typos

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282523](https://bugs.openjdk.java.net/browse/JDK-8282523): Fix 'hierachy' typo


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7474/head:pull/7474` \
`$ git checkout pull/7474`

Update a local copy of the PR: \
`$ git checkout pull/7474` \
`$ git pull https://git.openjdk.java.net/jdk pull/7474/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7474`

View PR using the GUI difftool: \
`$ git pr show -t 7474`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7474.diff">https://git.openjdk.java.net/jdk/pull/7474.diff</a>

</details>
