### PR TITLE
8281815: x86: Use short jumps in TIG::generate_slow_signature_handler

### DIFF
--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86_64.cpp
@@ -69,7 +69,7 @@ address TemplateInterpreterGenerator::generate_slow_signature_handler() {
     Label isfloatordouble, isdouble, next;
 
     __ testl(c_rarg3, 1 << (i*2));      // Float or Double?
-    __ jcc(Assembler::notZero, isfloatordouble);
+    __ jccb(Assembler::notZero, isfloatordouble);
 
     // Do Int register here
     switch ( i ) {
@@ -88,15 +88,15 @@ address TemplateInterpreterGenerator::generate_slow_signature_handler() {
         break;
     }
 
-    __ jmp (next);
+    __ jmpb(next);
 
     __ bind(isfloatordouble);
     __ testl(c_rarg3, 1 << ((i*2)+1));     // Double?
-    __ jcc(Assembler::notZero, isdouble);
+    __ jccb(Assembler::notZero, isdouble);
 
 // Do Float Here
     __ movflt(floatreg, Address(rsp, i * wordSize));
-    __ jmp(next);
+    __ jmpb(next);
 
 // Do Double here
     __ bind(isdouble);
@@ -150,9 +150,9 @@ address TemplateInterpreterGenerator::generate_slow_signature_handler() {
     Label d, done;
 
     __ testl(c_rarg3, 1 << i);
-    __ jcc(Assembler::notZero, d);
+    __ jccb(Assembler::notZero, d);
     __ movflt(r, Address(rsp, (6 + i) * wordSize));
-    __ jmp(done);
+    __ jmpb(done);
     __ bind(d);
     __ movdbl(r, Address(rsp, (6 + i) * wordSize));
     __ bind(done);


### PR DESCRIPTION
Similar to [JDK-8281744](https://bugs.openjdk.java.net/browse/JDK-8281744), this change improves `TemplateInterpreterGenerator::generate_slow_signature_handler`: there are only a few moves between the jumps, and we can tell `MacroAssembler` those can be short. This code is used to process arguments after the slow call to VM, so the performance improvement is drowned by the call itself. This makes interpreter code a bit more compact, though.

Additional testing:
 - [x] Linux x86_64 fastdebug `hotspot:tier1`
 - [x] Linux x86_32 fastdebug `hotspot:tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281815](https://bugs.openjdk.java.net/browse/JDK-8281815): x86: Use short jumps in TIG::generate_slow_signature_handler


### Reviewers
 * [Richard Reingruber](https://openjdk.java.net/census#rrich) (@reinrich - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7475/head:pull/7475` \
`$ git checkout pull/7475`

Update a local copy of the PR: \
`$ git checkout pull/7475` \
`$ git pull https://git.openjdk.java.net/jdk pull/7475/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7475`

View PR using the GUI difftool: \
`$ git pr show -t 7475`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7475.diff">https://git.openjdk.java.net/jdk/pull/7475.diff</a>

</details>
