### PR TITLE
8281748: runtime/logging/RedefineClasses.java failed "assert(addr != __null) failed: invariant"

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
@@ -41,8 +41,14 @@
 #include "utilities/bitMap.inline.hpp"
 
 inline bool G1CMIsAliveClosure::do_object_b(oop obj) {
-  HeapRegion* hr = _g1h->heap_region_containing(cast_from_oop<HeapWord*>(obj));
+  // Check whether the passed in object is null. During discovery the referent
+  // may be cleared between the initial check and being passed in here.
+  if (obj == NULL) {
+    // Return true to avoid discovery when the referent is NULL.
+    return true;
+  }
 
+  HeapRegion* hr = _g1h->heap_region_containing(cast_from_oop<HeapWord*>(obj));
   // All objects allocated since the start of marking are considered live.
   if (hr->obj_allocated_since_next_marking(obj)) {
     return true;


### PR DESCRIPTION
Please review this fix for [JDK-8281748](https://bugs.openjdk.java.net/browse/JDK-8281748).

**Summary**
In a recent [cleanup](https://bugs.openjdk.java.net/browse/JDK-8281637) a NULL-check in `G1CMIsAliveClosure::do_object_b(oop obj)` was forgotten. This was not caught by the initial testing because the only time the check is needed is when a referent is cleared **during** reference discovery, which is quite hard to trigger. 

The fix is fairly simple, but returning `true` when a `NULL` is passed in feels a bit counter-intuitive. This behavior is the same as prior to the cleanup causing the error and reading the code this will lead to not discovering references where the referent is `NULL`. 

**Testing**

- [ ] Re-running mach5 tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281748](https://bugs.openjdk.java.net/browse/JDK-8281748): runtime/logging/RedefineClasses.java failed "assert(addr != __null) failed: invariant"


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7476/head:pull/7476` \
`$ git checkout pull/7476`

Update a local copy of the PR: \
`$ git checkout pull/7476` \
`$ git pull https://git.openjdk.java.net/jdk pull/7476/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7476`

View PR using the GUI difftool: \
`$ git pr show -t 7476`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7476.diff">https://git.openjdk.java.net/jdk/pull/7476.diff</a>

</details>
