### PR TITLE
8281223: Improve the API documentation of HttpRequest.Builder::build to state that the default implementation provided by the JDK returns immutable objects.

### DIFF
--- a/src/java.net.http/share/classes/java/net/http/HttpRequest.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpRequest.java
@@ -292,8 +292,8 @@ public abstract class HttpRequest {
         /**
          * Builds and returns an {@link HttpRequest}.
          *
-         * @implSpec Returns a new {@code HttpRequest} each time it is
-         * invoked. Once built, the HttpRequest is immutable and can be
+         * @implSpec This method returns a new {@code HttpRequest} each time it is
+         * invoked. Once built, the {@code HttpRequest} is immutable and can be
          * sent multiple times.
          *
          * @return a new {@code HttpRequest}

--- a/src/java.net.http/share/classes/java/net/http/HttpRequest.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpRequest.java
@@ -292,6 +292,10 @@ public abstract class HttpRequest {
         /**
          * Builds and returns an {@link HttpRequest}.
          *
+         * @implSpec Returns a new {@code HttpRequest} each time it is
+         * invoked. Once built, the HttpRequest is immutable and can be
+         * sent multiple times.
+         *
          * @return a new {@code HttpRequest}
          * @throws IllegalStateException if a URI has not been set
          */


### PR DESCRIPTION
As described in the title, this is a simple change to the `HttpRequest.Builder::build` method to highlight that an immutable and reusable instance of an `HttpRequest` is created when this method is invoked. This is done by adding an `@implSpec` Javadoc Tag (details on `@implSpec` given [here](https://openjdk.java.net/jeps/8068562)). 

The detail added under the `@implSpec` Tag is similar to that provided at the interface-level Javadoc for Builder.

Please also review the CSR for this change: https://bugs.openjdk.java.net/browse/JDK-8281833

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8281223](https://bugs.openjdk.java.net/browse/JDK-8281223): Improve the API documentation of HttpRequest.Builder::build to state that the default implementation provided by the JDK returns immutable objects.
 * [JDK-8281833](https://bugs.openjdk.java.net/browse/JDK-8281833): Improve the API documentation of HttpRequest.Builder::build to state that the default implementation provided by the JDK returns immutable objects. (**CSR**)


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.java.net/census#jpai) (@jaikiran - Committer)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7479/head:pull/7479` \
`$ git checkout pull/7479`

Update a local copy of the PR: \
`$ git checkout pull/7479` \
`$ git pull https://git.openjdk.java.net/jdk pull/7479/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7479`

View PR using the GUI difftool: \
`$ git pr show -t 7479`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7479.diff">https://git.openjdk.java.net/jdk/pull/7479.diff</a>

</details>
