### PR TITLE
8281829: runtime/CommandLine/OptionsValidation/TestOptionsWithRanges.java fails after JDK-8281467

### DIFF
--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -226,6 +226,15 @@ JVMFlag::Error CodeEntryAlignmentConstraintFunc(intx value, bool verbose) {
                           "greater than or equal to %d\n",
                           CodeEntryAlignment, 16);
       return JVMFlag::VIOLATES_CONSTRAINT;
+  }
+
+  if ((uintx)CodeEntryAlignment > CodeCacheSegmentSize) {
+    JVMFlag::printError(verbose,
+                        "CodeEntryAlignment  (" INTX_FORMAT ") must be "
+                        "less than or equal to CodeCacheSegmentSize (" UINTX_FORMAT ") "
+                        "to align entry points\n",
+                        CodeEntryAlignment, CodeCacheSegmentSize);
+    return JVMFlag::VIOLATES_CONSTRAINT;
   }
 
   return JVMFlag::SUCCESS;

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
@@ -230,7 +230,7 @@ JVMFlag::Error CodeEntryAlignmentConstraintFunc(intx value, bool verbose) {
 
   if ((uintx)CodeEntryAlignment > CodeCacheSegmentSize) {
     JVMFlag::printError(verbose,
-                        "CodeEntryAlignment  (" INTX_FORMAT ") must be "
+                        "CodeEntryAlignment (" INTX_FORMAT ") must be "
                         "less than or equal to CodeCacheSegmentSize (" UINTX_FORMAT ") "
                         "to align entry points\n",
                         CodeEntryAlignment, CodeCacheSegmentSize);


### PR DESCRIPTION
Hi all,

runtime/CommandLine/OptionsValidation/TestOptionsWithRanges.java fails due to SIGFPE after JDK-8281467 with release VMs.
It can be reproduced by running `java -XX:+UnlockExperimentalVMOptions -XX:CodeEntryAlignment=4294967296` with release VMs.

This is because `CodeEntryAlignment` would be converted from `intx` to `int` at line 825.
```
 824   address generate_fp_mask(const char *stub_name, int64_t mask) {
 825     __ align(CodeEntryAlignment);
 826     StubCodeMark mark(this, "StubRoutines", stub_name);
 827     address start = __ pc();
 828
 829     __ emit_data64( mask, relocInfo::none );
 830     __ emit_data64( mask, relocInfo::none );
 831
 832     return start;
 833   }
```

Then at line 1187, `modulus` would become 0 after the conversion of `CodeEntryAlignment`, which leads to SIGFPE at line 1191.
```
1184 void MacroAssembler::align(int modulus) {
1185   // 8273459: Ensure alignment is possible with current segment alignment
1186   assert(modulus <= CodeEntryAlignment, "Alignment must be <= CodeEntryAlignment");
1187   align(modulus, offset());
1188 }
1189
1190 void MacroAssembler::align(int modulus, int target) {
1191   if (target % modulus != 0) {
1192     nop(modulus - (target % modulus));
1193   }
1194 }
```

The fix just adding a rule (`CodeEntryAlignment <= CodeCacheSegmentSize`) in `CodeEntryAlignmentConstraintFunc`.

This is fine because we already has that rule in `CodeCacheSegmentSizeConstraintFunc`.
And this is necessary since `CodeCacheSegmentSizeConstraintFunc` won't be called in release VMs.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281829](https://bugs.openjdk.java.net/browse/JDK-8281829): runtime/CommandLine/OptionsValidation/TestOptionsWithRanges.java fails after JDK-8281467


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to b39bc8f34c4cb2bbfad3df6f3fd98aecbd3b5c72
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to b39bc8f34c4cb2bbfad3df6f3fd98aecbd3b5c72


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7480/head:pull/7480` \
`$ git checkout pull/7480`

Update a local copy of the PR: \
`$ git checkout pull/7480` \
`$ git pull https://git.openjdk.java.net/jdk pull/7480/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7480`

View PR using the GUI difftool: \
`$ git pr show -t 7480`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7480.diff">https://git.openjdk.java.net/jdk/pull/7480.diff</a>

</details>
