### PR TITLE
JDK-8281671: Class.getCanonicalName spec should explicitly cover array classes

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -1732,8 +1732,18 @@ public final class Class<T> implements java.io.Serializable,
      * <li>an array whose component type does not have a canonical name</li>
      * </ul>
      *
+     * The canonical name for a primitive class is the keyword for the
+     * corresponding primitive type ({@code byte}, {@code short},
+     * {@code char}, {@code int}, and so on).
+     *
+     * <p>An array type has a canonical name if and only if its
+     * component type has a canonical name. When an array type has a
+     * canonical name, it is equal to the canonical name of the
+     * component type followed by "{@code []}".
+     *
      * @return the canonical name of the underlying class if it exists, and
      * {@code null} otherwise.
+     * @jls 6.7 Fully Qualified Names and Canonical Names
      * @since 1.5
      */
     public String getCanonicalName() {

--- a/test/jdk/java/lang/Class/NameTest.java
+++ b/test/jdk/java/lang/Class/NameTest.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 public class NameTest {
     public static void main(String... args) {
         testCanonicalName();
+        testSimpleName();
     }
 
     private static void testCanonicalName() {
@@ -62,6 +63,36 @@ public class NameTest {
             if (!Objects.equals(canonicalName, expectedName)) {
                 System.err.println("Unexpected canonical name '" +
                                    canonicalName + "' found for " +
+                                   key + ", expected " + expectedName);
+                throw new RuntimeException();
+            }
+        }
+    }
+
+    private static void testSimpleName() {
+        class ALocalClass {} // Local class
+        Object o = new Object() {}; // Anonymous class, empty simple name
+        Object[] objectArray = {};
+
+        Map<Class<?>, String> expectedSimpleName = new HashMap<>();
+
+        expectedSimpleName.put(ALocalClass.class,             "ALocalClass");
+        expectedSimpleName.put(o.getClass(),                  "");
+
+        expectedSimpleName.put(ALocalClass.class.arrayType(), "ALocalClass[]");
+        expectedSimpleName.put(o.getClass().arrayType(),      "[]");
+
+        expectedSimpleName.put(int.class,                     "int");
+        expectedSimpleName.put(Object.class,                  "Object");
+        expectedSimpleName.put(objectArray.getClass(),        "Object[]");
+
+        for (var entry : expectedSimpleName.entrySet()) {
+            var key = entry.getKey();
+            var expectedName = entry.getValue();
+            String simpleName = key.getSimpleName();
+            if (!Objects.equals(simpleName, expectedName)) {
+                System.err.println("Unexpected simple name '" +
+                                   simpleName + "' found for " +
                                    key + ", expected " + expectedName);
                 throw new RuntimeException();
             }

--- a/test/jdk/java/lang/Class/NameTest.java
+++ b/test/jdk/java/lang/Class/NameTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8281671
+ * @summary Checks on various "getFooName" methods of java.lang.Class
+ */
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class NameTest {
+    public static void main(String... args) {
+        testCanonicalName();
+    }
+
+    private static void testCanonicalName() {
+        class LocalClass {} // Local class; no canonical name
+        Object o = new Object() {}; // Anonymous class; no canonical name
+        Object[] objectArray = {};
+
+        Map<Class<?>, String> expectedCanonicalName = new HashMap<>();
+
+        expectedCanonicalName.put(LocalClass.class,             null);
+        expectedCanonicalName.put(o.getClass(),                 null);
+
+        // If a component type doesn't have a canonical name, neither
+        // does an array of that type.
+        expectedCanonicalName.put(LocalClass.class.arrayType(), null);
+        expectedCanonicalName.put(o.getClass().arrayType(),     null);
+
+        expectedCanonicalName.put(int.class,              "int");
+        expectedCanonicalName.put(Object.class,           "java.lang.Object");
+        expectedCanonicalName.put(objectArray.getClass(), "java.lang.Object[]");
+
+        for (var entry : expectedCanonicalName.entrySet()) {
+            var key = entry.getKey();
+            var expectedName = entry.getValue();
+            String canonicalName = key.getCanonicalName();
+            if (!Objects.equals(canonicalName, expectedName)) {
+                System.err.println("Unexpected canonical name '" +
+                                   canonicalName + "' found for " +
+                                   key + ", expected " + expectedName);
+                throw new RuntimeException();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add explicit discussion of array types to Class.getCanonicalName, no change in behavior.

I didn't see any existing regression tests for the various "getFooName" methods of Class so I created a new test file for a handful of test cases.

Please also review the corresponding CSR: https://bugs.openjdk.java.net/browse/JDK-8281922

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8281671](https://bugs.openjdk.java.net/browse/JDK-8281671): Class.getCanonicalName spec should explicitly cover array classes
 * [JDK-8281922](https://bugs.openjdk.java.net/browse/JDK-8281922): Class.getCanonicalName spec should explicitly cover array classes (**CSR**)


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to 2b0729ad163c13fc6cbee90a0f896b40b7567605


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7483/head:pull/7483` \
`$ git checkout pull/7483`

Update a local copy of the PR: \
`$ git checkout pull/7483` \
`$ git pull https://git.openjdk.java.net/jdk pull/7483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7483`

View PR using the GUI difftool: \
`$ git pr show -t 7483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7483.diff">https://git.openjdk.java.net/jdk/pull/7483.diff</a>

</details>
