### PR TITLE
8281936: compiler/arguments/TestCodeEntryAlignment.java fails on AVX512 machines

### DIFF
--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -3002,7 +3002,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(address destination, const cha
   // allocate space for the code
   ResourceMark rm;
 
-  CodeBuffer buffer(name, (UseAVX > 2) ? 1200 : 1000, 512);
+  CodeBuffer buffer(name, 1200, 512);
   MacroAssembler* masm                = new MacroAssembler(&buffer);
 
   int frame_size_in_words;

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -3002,7 +3002,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(address destination, const cha
   // allocate space for the code
   ResourceMark rm;
 
-  CodeBuffer buffer(name, 1000, 512);
+  CodeBuffer buffer(name, (UseAVX > 2) ? 1200 : 1000, 512);
   MacroAssembler* masm                = new MacroAssembler(&buffer);
 
   int frame_size_in_words;


### PR DESCRIPTION
Hi all, 

compiler/arguments/TestCodeEntryAlignment.java fails on AVX512 machines due to stub size is not big enough.
The fix just increasing the stub size for AVX512 platforms.

Testing:
  - tier1~3 on Linux/x64 with AVX512, no regression

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281936](https://bugs.openjdk.java.net/browse/JDK-8281936): compiler/arguments/TestCodeEntryAlignment.java fails on AVX512 machines


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7485/head:pull/7485` \
`$ git checkout pull/7485`

Update a local copy of the PR: \
`$ git checkout pull/7485` \
`$ git pull https://git.openjdk.java.net/jdk pull/7485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7485`

View PR using the GUI difftool: \
`$ git pr show -t 7485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7485.diff">https://git.openjdk.java.net/jdk/pull/7485.diff</a>

</details>
