### PR TITLE
8279969: NULL return from map_bitmap_region() needs to be checked

### DIFF
--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -1679,6 +1679,10 @@ void HeapShared::sort_loaded_regions(LoadedArchiveHeapRegion* loaded_regions, in
 bool HeapShared::load_regions(FileMapInfo* mapinfo, LoadedArchiveHeapRegion* loaded_regions,
                               int num_loaded_regions, uintptr_t buffer) {
   uintptr_t bitmap_base = (uintptr_t)mapinfo->map_bitmap_region();
+  if (bitmap_base == 0) {
+    _loading_failed = true;
+    return false; // OOM or CRC error
+  }
   uintptr_t load_address = buffer;
   for (int i = 0; i < num_loaded_regions; i++) {
     LoadedArchiveHeapRegion* ri = &loaded_regions[i];

--- a/test/hotspot/jtreg/runtime/cds/appcds/SharedArchiveConsistency.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/SharedArchiveConsistency.java
@@ -80,6 +80,14 @@ public class SharedArchiveConsistency {
         OutputAnalyzer output = shareAuto ? TestCommon.execAuto(execArgs) : TestCommon.execCommon(execArgs);
         String stdtxt = output.getOutput();
         System.out.println("Note: this test may fail in very rare occasions due to CRC32 checksum collision");
+        for (String opt : execArgs) {
+          if (opt.equals("-XX:+VerifySharedSpaces")) {
+            // If VerifySharedSpaces is enabled, the VM should never crash even if the archive
+            // is corrupted (unless if we are so lucky that the corrupted archive ends up
+            // have the same checksum as recoreded in the header)
+            output.shouldNotContain("A fatal error has been detected by the Java Runtime Environment");
+          }
+        }
         for (String message : matchMessages) {
             if (stdtxt.contains(message)) {
                 // match any to return


### PR DESCRIPTION
The CDS-related function `FileMapInfo::map_bitmap_region()` could return `NULL` if CRC check fails, or if we run out of memory. There are two call sites of map_bitmap_region() that did not check for `NULL` , and the VM subsequently would crash. However, there was a bug in the test case that ignored such crashes, and we only found out by chance because jtreg timed out while trying to copy the core file.

The fix is to add the missing NULL checks. Also, since `FileMapInfo::patch_heap_embedded_pointers()` cannot handle the mapping failure, I moved the mapping to an earlier stage (`FileMapInfo::map_heap_regions_impl()`) where the error can be handled.

I also added a VM crash check in the test case.

Note: there's a single bitmap region in the CDS archive. It will be mapped on the first call to `FileMapInfo::map_bitmap_region()`, and will remain mapped until after the loading of the CDS archive is completed.

Passed tiers 1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279969](https://bugs.openjdk.java.net/browse/JDK-8279969): NULL return from map_bitmap_region() needs to be checked


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7487/head:pull/7487` \
`$ git checkout pull/7487`

Update a local copy of the PR: \
`$ git checkout pull/7487` \
`$ git pull https://git.openjdk.java.net/jdk pull/7487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7487`

View PR using the GUI difftool: \
`$ git pr show -t 7487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7487.diff">https://git.openjdk.java.net/jdk/pull/7487.diff</a>

</details>
