### PR TITLE
8281948 JFR: Parser skips too many bytes for fractional types

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ParserFactory.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ParserFactory.java
@@ -270,7 +270,7 @@ final class ParserFactory {
 
         @Override
         public void skip(RecordingInput input) throws IOException {
-            input.skipBytes(Float.SIZE);
+            input.skipBytes(Float.BYTES);
         }
     }
 
@@ -282,7 +282,7 @@ final class ParserFactory {
 
         @Override
         public void skip(RecordingInput input) throws IOException {
-            input.skipBytes(Double.SIZE);
+            input.skipBytes(Double.BYTES);
         }
     }
 


### PR DESCRIPTION
Hi,

Could I have review of this bug fix. For details, see bug description.

Testing: test/jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281948](https://bugs.openjdk.java.net/browse/JDK-8281948): JFR: Parser skips too many bytes for fractional types


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7488/head:pull/7488` \
`$ git checkout pull/7488`

Update a local copy of the PR: \
`$ git checkout pull/7488` \
`$ git pull https://git.openjdk.java.net/jdk pull/7488/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7488`

View PR using the GUI difftool: \
`$ git pr show -t 7488`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7488.diff">https://git.openjdk.java.net/jdk/pull/7488.diff</a>

</details>
