### PR TITLE
8037573: Typo in DefaultTreeModel docs: askAllowsChildren instead of asksAllowsChildren

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/tree/DefaultTreeModel.java
+++ b/src/java.desktop/share/classes/javax/swing/tree/DefaultTreeModel.java
@@ -204,7 +204,7 @@ public class DefaultTreeModel implements Serializable, TreeModel {
     /**
      * Returns whether the specified node is a leaf node.
      * The way the test is performed depends on the
-     * <code>askAllowsChildren</code> setting.
+     * <code>asksAllowsChildren</code> setting.
      *
      * @param node the node to check
      * @return true if the node is a leaf node


### PR DESCRIPTION
[DefaultTreeModel.html#isLeaf](https://docs.oracle.com/en/java/javase/17/docs/api/java.desktop/javax/swing/tree/DefaultTreeModel.html#isLeaf(java.lang.Object)) to an "askAllowsChildren" attribute that doesn't exist. The real attribute is "asksAllowsChildren".
Fixed the typo

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8037573](https://bugs.openjdk.java.net/browse/JDK-8037573): Typo in DefaultTreeModel docs: askAllowsChildren instead of asksAllowsChildren
 * [JDK-8281952](https://bugs.openjdk.java.net/browse/JDK-8281952): Typo in DefaultTreeModel docs: askAllowsChildren instead of asksAllowsChildren (**CSR**)


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7489/head:pull/7489` \
`$ git checkout pull/7489`

Update a local copy of the PR: \
`$ git checkout pull/7489` \
`$ git pull https://git.openjdk.java.net/jdk pull/7489/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7489`

View PR using the GUI difftool: \
`$ git pr show -t 7489`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7489.diff">https://git.openjdk.java.net/jdk/pull/7489.diff</a>

</details>
