### PR TITLE
8037965: NullPointerException in TextLayout.getBaselineFromGraphic() for JTextComponents

### DIFF
--- a/src/java.desktop/share/classes/java/awt/font/TextLayout.java
+++ b/src/java.desktop/share/classes/java/awt/font/TextLayout.java
@@ -2638,6 +2638,9 @@ public final class TextLayout implements Cloneable {
 
     static byte getBaselineFromGraphic(GraphicAttribute graphic) {
 
+        if (graphic == null) {
+            return (byte)GraphicAttribute.ROMAN_BASELINE;
+        }
         byte alignment = (byte) graphic.getAlignment();
 
         if (alignment == GraphicAttribute.BOTTOM_ALIGNMENT ||

--- a/test/jdk/javax/swing/JTextField/SwingUnicodeTest.java
+++ b/test/jdk/javax/swing/JTextField/SwingUnicodeTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+import javax.swing.SwingUtilities;
+import javax.swing.JTextField;
+
+/*
+ * @test
+ * @bug 8037965
+ * @summary Verifies NPE in TextLayout.getBaselineFromGraphic() for invalid
+ *          Unicode characters
+ */
+public class SwingUnicodeTest {
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(() -> 
+            new JTextField(new StringBuilder().appendCodePoint(0xFFFF).
+		            appendCodePoint(0x10000).toString()));
+    }
+} 

--- a/test/jdk/javax/swing/JTextField/SwingUnicodeTest.java
+++ b/test/jdk/javax/swing/JTextField/SwingUnicodeTest.java
@@ -31,8 +31,8 @@ import javax.swing.JTextField;
  */
 public class SwingUnicodeTest {
     public static void main(String[] args) throws Exception {
-        SwingUtilities.invokeAndWait(() -> 
+        SwingUtilities.invokeAndWait(() ->
             new JTextField(new StringBuilder().appendCodePoint(0xFFFF).
-		            appendCodePoint(0x10000).toString()));
+                            appendCodePoint(0x10000).toString()));
     }
-} 
+}


### PR DESCRIPTION
When invalid unicode codepoints 0xFFFF and 0x10000 are added to an empty javax.swing.JTextComponent (JTextArea or JTextField), the view cannot be updated due to a NullPointerException in TextLayout.getBaselineFromGraphic() 
owing to the fact GraphicAttribute is null for these invalid codepoints. 

TextLayout.getBaselineFromGraphic() is called from [TextLayout.standardInit](https://github.com/openjdk/jdk/blame/master/src/java.desktop/share/classes/java/awt/font/TextLayout.java#L647) and [TextMeasurer.initAll](https://github.com/openjdk/jdk/blame/master/src/java.desktop/share/classes/java/awt/font/TextMeasurer.java#L249) where it relies on CHAR_REPLACEMENT TextAttribute 
and its spec says "The default value is null, indicating that the standard glyphs provided by the font should be used. " so if invalid codepoints is used, the default value is not changed so we need to be ready for null value too.

Since TextAttribute_CHAR_REPLACEMENT says "It is required for correct positioning of 'inline' components within a line when bidirectional reordering is performed. Each character (Unicode code point) will be rendered using the provided GraphicAttribute." so 
Fixed by checking if GraphicAttribute is null, then keep the baseline to default value (which is 0) by returning default baseline (which is ROMAN_BASELINE)

Existing jtreg,jck tests are green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8037965](https://bugs.openjdk.java.net/browse/JDK-8037965): NullPointerException in TextLayout.getBaselineFromGraphic() for JTextComponents


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7490/head:pull/7490` \
`$ git checkout pull/7490`

Update a local copy of the PR: \
`$ git checkout pull/7490` \
`$ git pull https://git.openjdk.java.net/jdk pull/7490/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7490`

View PR using the GUI difftool: \
`$ git pr show -t 7490`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7490.diff">https://git.openjdk.java.net/jdk/pull/7490.diff</a>

</details>
