### PR TITLE
8281962: Avoid unnecessary native calls in InflaterInputStream

### DIFF
--- a/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
@@ -150,7 +150,7 @@ public class InflaterInputStream extends FilterInputStream {
         }
         try {
             int n;
-            while ((n = inf.inflate(b, off, len)) == 0) {
+            do {
                 if (inf.finished() || inf.needsDictionary()) {
                     reachEOF = true;
                     return -1;
@@ -158,7 +158,7 @@ public class InflaterInputStream extends FilterInputStream {
                 if (inf.needsInput()) {
                     fill();
                 }
-            }
+            } while ((n = inf.inflate(b, off, len)) == 0);
             return n;
         } catch (DataFormatException e) {
             String s = e.getMessage();

--- a/test/micro/org/openjdk/bench/java/util/zip/InflaterInputStreams.java
+++ b/test/micro/org/openjdk/bench/java/util/zip/InflaterInputStreams.java
@@ -51,16 +51,16 @@ import java.util.zip.DeflaterOutputStream;
  * before JDK-8281962
  * ------------------
  * Benchmark                                     (size)  Mode  Cnt  Score   Error  Units
- * InflaterInputStreams.inflaterInputStreamRead     256  avgt    5  2.571 ± 0.120  us/op
- * InflaterInputStreams.inflaterInputStreamRead     512  avgt    5  2.861 ± 0.064  us/op
- * InflaterInputStreams.inflaterInputStreamRead    4096  avgt    5  5.110 ± 0.278  us/op
+ * InflaterInputStreams.inflaterInputStreamRead     256  avgt    5  2.571   0.120  us/op
+ * InflaterInputStreams.inflaterInputStreamRead     512  avgt    5  2.861   0.064  us/op
+ * InflaterInputStreams.inflaterInputStreamRead    4096  avgt    5  5.110   0.278  us/op
  *
  * after JDK-8281962
  * -----------------
  * Benchmark                                     (size)  Mode  Cnt  Score   Error  Units
- * InflaterInputStreams.inflaterInputStreamRead     256  avgt    5  2.332 ± 0.081  us/op
- * InflaterInputStreams.inflaterInputStreamRead     512  avgt    5  2.691 ± 0.293  us/op
- * InflaterInputStreams.inflaterInputStreamRead    4096  avgt    5  4.812 ± 1.038  us/op
+ * InflaterInputStreams.inflaterInputStreamRead     256  avgt    5  2.332   0.081  us/op
+ * InflaterInputStreams.inflaterInputStreamRead     512  avgt    5  2.691   0.293  us/op
+ * InflaterInputStreams.inflaterInputStreamRead    4096  avgt    5  4.812   1.038  us/op
  *
  */
 @BenchmarkMode(Mode.AverageTime)
@@ -74,8 +74,7 @@ public class InflaterInputStreams {
     private int size;
     private byte[] chars;
     private byte[] words;
-    private static final int MAX_SIZE = 5000; // Should be bigger than the biggest size @Param
-    private static byte[] inflated = new byte[MAX_SIZE];
+    private static byte[] inflated;
     ByteArrayInputStream deflated;
 
     @Setup(Level.Trial)
@@ -89,11 +88,14 @@ public class InflaterInputStreams {
         for (int i = 0; i < words.length / wordLength; i++) {
             System.arraycopy(chars, r.nextInt(charCount - wordLength), words, i * wordLength, wordLength);
         }
-    }
+        inflated = new byte[2*size];
+   }
 
     @Setup(Level.Iteration)
     public void beforeIteration() throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream(MAX_SIZE);
+        // Maximum deflated size (see https://stackoverflow.com/a/23578269/4146053)
+        int maxDeflated = size + 5*(size/16383 + 1);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(maxDeflated);
         DeflaterOutputStream defout = new DeflaterOutputStream(baos);
         ByteArrayInputStream bais = new ByteArrayInputStream(words, 0, size);
         bais.transferTo(defout);

--- a/test/micro/org/openjdk/bench/java/util/zip/InflaterInputStreams.java
+++ b/test/micro/org/openjdk/bench/java/util/zip/InflaterInputStreams.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.java.util.zip;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.Inflater;
+import java.util.zip.InflaterInputStream;
+import java.util.zip.DeflaterOutputStream;
+
+/**
+ * A simple benchmark to measure the performance improvements achieved by avoiding
+ * unnecessary native calls in InflaterInputStream::read() (see JDK-8281962).
+ *
+ * before JDK-8281962
+ * ------------------
+ * Benchmark                                     (size)  Mode  Cnt  Score   Error  Units
+ * InflaterInputStreams.inflaterInputStreamRead     256  avgt    5  2.571 ± 0.120  us/op
+ * InflaterInputStreams.inflaterInputStreamRead     512  avgt    5  2.861 ± 0.064  us/op
+ * InflaterInputStreams.inflaterInputStreamRead    4096  avgt    5  5.110 ± 0.278  us/op
+ *
+ * after JDK-8281962
+ * -----------------
+ * Benchmark                                     (size)  Mode  Cnt  Score   Error  Units
+ * InflaterInputStreams.inflaterInputStreamRead     256  avgt    5  2.332 ± 0.081  us/op
+ * InflaterInputStreams.inflaterInputStreamRead     512  avgt    5  2.691 ± 0.293  us/op
+ * InflaterInputStreams.inflaterInputStreamRead    4096  avgt    5  4.812 ± 1.038  us/op
+ *
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+public class InflaterInputStreams {
+
+    @Param({"256", "512", "4096"})
+    private int size;
+    private byte[] chars;
+    private byte[] words;
+    private static final int MAX_SIZE = 5000; // Should be bigger than the biggest size @Param
+    private static byte[] inflated = new byte[MAX_SIZE];
+    ByteArrayInputStream deflated;
+
+    @Setup(Level.Trial)
+    public void beforeRun() throws IOException {
+        final int charCount = 64;
+        final int wordLength = 8;
+        chars = new byte[charCount];
+        Random r = new Random(123456789);
+        r.nextBytes(chars);
+        words = new byte[1024];
+        for (int i = 0; i < words.length / wordLength; i++) {
+            System.arraycopy(chars, r.nextInt(charCount - wordLength), words, i * wordLength, wordLength);
+        }
+    }
+
+    @Setup(Level.Iteration)
+    public void beforeIteration() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(MAX_SIZE);
+        DeflaterOutputStream defout = new DeflaterOutputStream(baos);
+        ByteArrayInputStream bais = new ByteArrayInputStream(words, 0, size);
+        bais.transferTo(defout);
+        // We need to close the DeflaterOutputStream in order to flush
+        // all the compressed data in the Deflater.
+        defout.close();
+        deflated = new ByteArrayInputStream(baos.toByteArray());
+    }
+
+    @Benchmark
+    public void inflaterInputStreamRead() throws IOException {
+        deflated.reset();
+        InflaterInputStream iis = new InflaterInputStream(deflated);
+        while (iis.read(inflated, 0, inflated.length) != -1);
+    }
+}


### PR DESCRIPTION
Currently, `InflaterInputStream::read()` first does a native call to the underlying zlib `inflate()` function and only afterwards checks if the inflater requires input (i.e. `Inflater::needsInput()`) or has finished inflating (`Inflater::finished()`). This leads to an unnecessary native call to `inflate()` when `InflaterInputStream::read()` is invoked for the very first time because `Inflater::fill()` hasn't been called and another unnecessary native call to detect the end of the stream. For small streams/files which completely fit into the output buffer passed to `InflaterInputStream::read()` we can therefore save two out of three native calls. The attached micro benchmark shows that this results in a 5%-10% performance improvement for zip files of sizes between 4096 to 256 bytes (notice that in common jars like Tomcat, Spring-Boot, Maven, Jackson, etc. about 60-80% of the classes are smaller than 4096 bytes).

```
before JDK-8281962
------------------
Benchmark                                     (size)  Mode  Cnt  Score   Error  Units
InflaterInputStreams.inflaterInputStreamRead     256  avgt    5  2.571 ± 0.120  us/op
InflaterInputStreams.inflaterInputStreamRead     512  avgt    5  2.861 ± 0.064  us/op
InflaterInputStreams.inflaterInputStreamRead    4096  avgt    5  5.110 ± 0.278  us/op

after JDK-8281962
-----------------
Benchmark                                     (size)  Mode  Cnt  Score   Error  Units
InflaterInputStreams.inflaterInputStreamRead     256  avgt    5  2.332 ± 0.081  us/op
InflaterInputStreams.inflaterInputStreamRead     512  avgt    5  2.691 ± 0.293  us/op
InflaterInputStreams.inflaterInputStreamRead    4096  avgt    5  4.812 ± 1.038  us/op
```

Tested with the JTreg zip/jar/zipfs and the JCK zip/jar tests.

As a side effect, this change also fixes an issue with alternative zlib implementations like zlib-Chromium or zlib-Cloudflare which pad the inflated bytes with a specif byte pattern at the end of the output for debugging purpose. This breaks code patterns like the following:

```java
int readcount = 0;
while ((bytesRead = inflaterInputStream.read(data, 0, bufferSize)) != -1) {
    outputStream.write(data, 0, bytesRead);
    readCount++;
}
if (readCount == 1) {
    return data;         //  <---- first bytes might be overwritten
}
return outputStream.toByteArray();
```

Even if the whole data fits into the `data` array during the first call to `inflaterInputStream.read()`, we still need a second call to `inflaterInputStream.read()` in order to detect the end of the inflater stream. If this second call calls into the native `inflate()` function of Cloudflare/Chromium's zlib version, this will still write some padding bytes at the beginning of the `data` array and overwrite the previously read data. This issue has been reported in Spring [1] and ASM [2] when using these libraries with Cloudflares zlib version (by setting `LD_LIBRARY_PATH` accordingly).

[1] https://github.com/spring-projects/spring-framework/issues/27429
[2] https://gitlab.ow2.org/asm/asm/-/issues/317955

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281962](https://bugs.openjdk.java.net/browse/JDK-8281962): Avoid unnecessary native calls in InflaterInputStream


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**) ⚠️ Review applies to 8314380e9ff77eefd6cb65f760d77efd3998291a
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7492/head:pull/7492` \
`$ git checkout pull/7492`

Update a local copy of the PR: \
`$ git checkout pull/7492` \
`$ git pull https://git.openjdk.java.net/jdk pull/7492/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7492`

View PR using the GUI difftool: \
`$ git pr show -t 7492`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7492.diff">https://git.openjdk.java.net/jdk/pull/7492.diff</a>

</details>
