### PR TITLE
[PATCH] Remove unused static fields 'DEGREES_TO_RADIANS', RADIANS_TO_DEGREES in StrictMath

### DIFF
--- a/src/java.base/share/classes/java/lang/StrictMath.java
+++ b/src/java.base/share/classes/java/lang/StrictMath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,19 +100,6 @@ public final class StrictMath {
      * diameter.
      */
     public static final double PI = 3.14159265358979323846;
-
-    /**
-     * Constant by which to multiply an angular value in degrees to obtain an
-     * angular value in radians.
-     */
-    private static final double DEGREES_TO_RADIANS = 0.017453292519943295;
-
-    /**
-     * Constant by which to multiply an angular value in radians to obtain an
-     * angular value in degrees.
-     */
-
-    private static final double RADIANS_TO_DEGREES = 57.29577951308232;
 
     /**
      * Returns the trigonometric sine of an angle. Special cases:
@@ -397,7 +384,7 @@ public final class StrictMath {
      * @param a the value to be floored or ceiled
      * @param negativeBoundary result for values in (-1, 0)
      * @param positiveBoundary result for values in (0, 1)
-     * @param increment value to add when the argument is non-integral
+     * @param sign the sign of the result
      */
     private static double floorOrCeil(double a,
                                       double negativeBoundary,
@@ -408,8 +395,8 @@ public final class StrictMath {
         if (exponent < 0) {
             /*
              * Absolute value of argument is less than 1.
-             * floorOrceil(-0.0) => -0.0
-             * floorOrceil(+0.0) => +0.0
+             * floorOrCeil(-0.0) => -0.0
+             * floorOrCeil(+0.0) => +0.0
              */
             return ((a == 0.0) ? a :
                     ( (a < 0.0) ?  negativeBoundary : positiveBoundary) );


### PR DESCRIPTION
Couple of fields in StrictMath are unused since [JDK-8244146](https://bugs.openjdk.java.net/browse/JDK-8244146).
Also I fixed incorrect javadoc for private method. Looks like typo in [JDK-6282196](https://bugs.openjdk.java.net/browse/JDK-6282196)