### PR TITLE
8281988: Create a regression test for JDK-4618767

### DIFF
--- a/test/jdk/javax/swing/JList/4618767/JListSelectedElementTest.java
+++ b/test/jdk/javax/swing/JList/4618767/JListSelectedElementTest.java
@@ -50,8 +50,9 @@ import static javax.swing.UIManager.getInstalledLookAndFeels;
  * @test
  * @key headful
  * @bug 4618767
- * @summary Typing a letter while a JList has focus now makes the selection jump to the item whose text
- *          starts with that letter even though that letter is accompanied by modifier keys such as ALT or CTRL.
+ * @summary This test confirms that typing a letter while a JList has focus now makes the selection
+ *          not jump to the item whose text starts with that letter if that typed letter is accompanied
+ *          by modifier keys such as ALT or CTRL(eg: ALT+F).
  * @run main JListSelectedElementTest
  */
 public class JListSelectedElementTest {
@@ -97,7 +98,7 @@ public class JListSelectedElementTest {
 
                 // Wait until the list gains focus.
                 if (!listGainedFocusLatch.await(3, TimeUnit.SECONDS)) {
-                    throw new RuntimeException("Waited for long, but can't gain focus for list");
+                    throw new RuntimeException("Waited too long, but can't gain focus for list");
                 }
 
                 // Select element named as 'bill'
@@ -114,8 +115,8 @@ public class JListSelectedElementTest {
                     );
                 }
 
-                // Now operate Menu using Mnemonics, different key combinations for different OS.
-                // For most of the OS its ALT+F, except for non Nimbus LnFs in Mac where it is ALT+CNTRL+F.
+                // Now operate Menu using Mnemonics, different key combinations for different OSes.
+                // For most OSes it's ALT+F; on macOS it's ALT+CNTRL+F except for Nimbus LaF.
                 if (isMac && !laf.contains("Nimbus")) {
                     hitKeys(KeyEvent.VK_ALT, KeyEvent.VK_CONTROL, FILE_MENU);
                 } else {
@@ -124,7 +125,7 @@ public class JListSelectedElementTest {
 
                 // Wait until the menu got selected.
                 if (!menuSelectedEventLatch.await(3, TimeUnit.SECONDS)) {
-                    throw new RuntimeException("Waited for long, but can't select menu using mnemonics for " + laf);
+                    throw new RuntimeException("Waited too long, but can't select menu using mnemonics for " + laf);
                 }
 
                 hitKeys(KeyEvent.VK_ENTER);

--- a/test/jdk/javax/swing/JList/4618767/JListSelectedElementTest.java
+++ b/test/jdk/javax/swing/JList/4618767/JListSelectedElementTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.swing.JFrame;
+import javax.swing.JList;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+
+import static javax.swing.UIManager.getInstalledLookAndFeels;
+
+/*
+ * @test
+ * @key headful
+ * @bug 4618767
+ * @summary Typing a letter while a JList has focus now makes the selection jump to the item whose text
+ *          starts with that letter even though that letter is accompanied by modifier keys such as ALT or CTRL.
+ * @run main JListSelectedElementTest
+ */
+public class JListSelectedElementTest {
+
+    private static final int MENU = KeyEvent.VK_F;
+
+    private static JFrame frame;
+    private static JList<String> list;
+    private static Robot robot;
+
+    public static void main(String[] args) throws Exception {
+        runTest();
+    }
+
+    public static void runTest() throws Exception {
+        robot = new Robot();
+        robot.setAutoWaitForIdle(true);
+        robot.setAutoDelay(200);
+
+        final boolean isAMac = System.getProperty("os.name").toLowerCase().contains("os x");
+
+        List<String> lafs = Arrays.stream(getInstalledLookAndFeels())
+                                  .map(UIManager.LookAndFeelInfo::getClassName)
+                                  .collect(Collectors.toList());
+        for (final String laf : lafs) {
+            try {
+                SwingUtilities.invokeAndWait(() -> frame = new JFrame());
+                robot.waitForIdle();
+
+                SwingUtilities.invokeAndWait(() -> {
+                    setLookAndFeel(laf);
+                    createUI();
+                });
+
+                // Select element named as bill
+                robot.keyPress(KeyEvent.VK_B);
+                robot.keyRelease(KeyEvent.VK_B);
+
+                // Assertion check to verify that selected node is 'bill'
+                String elementSel = list.getSelectedValue();
+                if (!"bill".equals(elementSel)) {
+                    throw new RuntimeException("Test failed for " + laf
+                            + " as the list element selected: " + elementSel
+                            + " is not the expected value 'bill'"
+                    );
+                }
+
+                //Now operate Menu using Mnemonics ALT+M
+                if (isAMac && laf.contains("Nimbus")) {
+                    robot.keyPress(KeyEvent.VK_ALT);
+                    robot.keyPress(MENU);
+                    robot.keyRelease(KeyEvent.VK_ALT);
+                    robot.keyRelease(MENU);
+                } else {
+                    robot.keyPress(KeyEvent.VK_ALT);
+                    robot.keyPress(KeyEvent.VK_CONTROL);
+                    robot.keyPress(MENU);
+                    robot.keyRelease(KeyEvent.VK_ALT);
+                    robot.keyRelease(KeyEvent.VK_CONTROL);
+                    robot.keyRelease(MENU);
+                }
+
+                robot.delay(500);
+                robot.keyPress(KeyEvent.VK_ENTER);
+                robot.keyRelease(KeyEvent.VK_ENTER);
+
+                String elementSelAfter = list.getSelectedValue();
+
+                // As per the fix of BugID 4618767, the list element selection should not change
+                if (!elementSel.equals(elementSelAfter)) {
+                    throw new RuntimeException("Test failed for " + laf
+                            + " as list.getSelectedValue() before = " + elementSel
+                            + " not equal to list.getSelectedValue() after pressing Enter = " + elementSelAfter
+                    );
+                }
+                System.out.println("Test passed for laf: " + laf);
+
+            } finally {
+                SwingUtilities.invokeAndWait(JListSelectedElementTest::disposeFrame);
+            }
+        }
+    }
+
+    private static void createUI() {
+        list = new JList(new String[]{"anaheim", "bill", "chicago", "dingo", "ernie", "freak"});
+
+        JMenu menu = new JMenu("File");
+        menu.setMnemonic(MENU);
+
+        JMenuItem menuItem = new JMenuItem("Dummy");
+        menu.add(menuItem);
+
+        JMenuBar menuBar = new JMenuBar();
+        menuBar.add(menu);
+
+        frame.setJMenuBar(menuBar);
+        frame.setContentPane(list);
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.pack();
+        frame.setAlwaysOnTop(true);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    private static void setLookAndFeel(final String laf) {
+        try {
+            UIManager.setLookAndFeel(laf);
+            System.out.println("LookAndFeel: " + laf);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void disposeFrame() {
+        if (frame != null) {
+            frame.dispose();
+            frame = null;
+        }
+    }
+
+}

--- a/test/jdk/javax/swing/JList/4618767/JListSelectedElementTest.java
+++ b/test/jdk/javax/swing/JList/4618767/JListSelectedElementTest.java
@@ -44,6 +44,7 @@ import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
 
 
+import static javax.swing.UIManager.LookAndFeelInfo;
 import static javax.swing.UIManager.getInstalledLookAndFeels;
 
 /*
@@ -78,7 +79,7 @@ public class JListSelectedElementTest {
                                     .contains("os x");
 
         List<String> lafs = Arrays.stream(getInstalledLookAndFeels())
-                                  .map(UIManager.LookAndFeelInfo::getClassName)
+                                  .map(LookAndFeelInfo::getClassName)
                                   .collect(Collectors.toList());
         for (final String laf : lafs) {
             listGainedFocusLatch = new CountDownLatch(1);

--- a/test/jdk/javax/swing/JList/4618767/JListSelectedElementTest.java
+++ b/test/jdk/javax/swing/JList/4618767/JListSelectedElementTest.java
@@ -39,12 +39,12 @@ import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
+import javax.swing.UIManager.LookAndFeelInfo;
 import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
 
 
-import static javax.swing.UIManager.LookAndFeelInfo;
 import static javax.swing.UIManager.getInstalledLookAndFeels;
 
 /*


### PR DESCRIPTION
Create a regression test for [JDK-4618767](https://bugs.openjdk.java.net/browse/JDK-4618767)

Issue identified in [JDK-4618767](https://bugs.openjdk.java.net/browse/JDK-4618767):
Typing a letter while a JList has focus now makes the selection jump to the first/next node/item whose text starts with that letter even though that letter is accompanied by modifier keys such as ALT or CTRL.

Fix:
Only enable JList letter navigation when the user
doesn't press any modifier keys such as ALT or CTRL.

Testing:
I have verified this test with JDK 1.4.0 and JDK 1.4.1 .
The issue is reproducible using the test with JDK 1.4.0 , where the bug was originally reported and the test passed in JDK 1.4.1 where the issue was fixed.
I have tested it in Mac and Windows platforms multiple times and it passed everywhere.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281988](https://bugs.openjdk.java.net/browse/JDK-8281988): Create a regression test for JDK-4618767


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7496/head:pull/7496` \
`$ git checkout pull/7496`

Update a local copy of the PR: \
`$ git checkout pull/7496` \
`$ git pull https://git.openjdk.java.net/jdk pull/7496/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7496`

View PR using the GUI difftool: \
`$ git pr show -t 7496`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7496.diff">https://git.openjdk.java.net/jdk/pull/7496.diff</a>

</details>
