### PR TITLE
8282004: x86_32.ad rules that call SharedRuntime helpers should have CALL effects

### DIFF
--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -7827,7 +7827,7 @@ instruct divI_eReg(eAXRegI rax, eDXRegI rdx, eCXRegI div, eFlagsReg cr) %{
 // Divide Register Long
 instruct divL_eReg( eADXRegL dst, eRegL src1, eRegL src2, eFlagsReg cr, eCXRegI cx, eBXRegI bx ) %{
   match(Set dst (DivL src1 src2));
-  effect( KILL cr, KILL cx, KILL bx );
+  effect( CALL, KILL cr, KILL cx, KILL bx );
   ins_cost(10000);
   format %{ "PUSH   $src1.hi\n\t"
             "PUSH   $src1.lo\n\t"
@@ -7875,7 +7875,7 @@ instruct modI_eReg(eDXRegI rdx, eAXRegI rax, eCXRegI div, eFlagsReg cr) %{
 // Remainder Register Long
 instruct modL_eReg( eADXRegL dst, eRegL src1, eRegL src2, eFlagsReg cr, eCXRegI cx, eBXRegI bx ) %{
   match(Set dst (ModL src1 src2));
-  effect( KILL cr, KILL cx, KILL bx );
+  effect( CALL, KILL cr, KILL cx, KILL bx );
   ins_cost(10000);
   format %{ "PUSH   $src1.hi\n\t"
             "PUSH   $src1.lo\n\t"

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -7825,9 +7825,9 @@ instruct divI_eReg(eAXRegI rax, eDXRegI rdx, eCXRegI div, eFlagsReg cr) %{
 %}
 
 // Divide Register Long
-instruct divL_eReg( eADXRegL dst, eRegL src1, eRegL src2, eFlagsReg cr, eCXRegI cx, eBXRegI bx ) %{
+instruct divL_eReg(eADXRegL dst, eRegL src1, eRegL src2) %{
   match(Set dst (DivL src1 src2));
-  effect( CALL, KILL cr, KILL cx, KILL bx );
+  effect(CALL);
   ins_cost(10000);
   format %{ "PUSH   $src1.hi\n\t"
             "PUSH   $src1.lo\n\t"
@@ -7873,9 +7873,9 @@ instruct modI_eReg(eDXRegI rdx, eAXRegI rax, eCXRegI div, eFlagsReg cr) %{
 %}
 
 // Remainder Register Long
-instruct modL_eReg( eADXRegL dst, eRegL src1, eRegL src2, eFlagsReg cr, eCXRegI cx, eBXRegI bx ) %{
+instruct modL_eReg(eADXRegL dst, eRegL src1, eRegL src2) %{
   match(Set dst (ModL src1 src2));
-  effect( CALL, KILL cr, KILL cx, KILL bx );
+  effect(CALL);
   ins_cost(10000);
   format %{ "PUSH   $src1.hi\n\t"
             "PUSH   $src1.lo\n\t"


### PR DESCRIPTION
Currently missing in `divL_eReg`, `modL_eReg` rules. These rules perform the calls to `SharedRuntime`, and as such should handle register saves properly. The effect was introduced by JDK-7077312. arm.ad already has a similar effect on similar nodes: https://github.com/openjdk/jdk/blob/9b74c3f2e74a4efdec1c1488e96ab5939a408df0/src/hotspot/cpu/arm/arm.ad#L6132

I believe we see a crash where XMM-spilled register is corrupted by `divL` call because of this missing effect.

Additional testing:
 - [x] Linux x86_32 fastdebug, `tier1`
 - [x] Linux x86_32 fastdebug, `tier2`
 - [x] Linux x86_32 fastdebug, `tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8282004](https://bugs.openjdk.java.net/browse/JDK-8282004): x86_32.ad rules that call SharedRuntime helpers should have CALL effects


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7498/head:pull/7498` \
`$ git checkout pull/7498`

Update a local copy of the PR: \
`$ git checkout pull/7498` \
`$ git pull https://git.openjdk.java.net/jdk pull/7498/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7498`

View PR using the GUI difftool: \
`$ git pr show -t 7498`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7498.diff">https://git.openjdk.java.net/jdk/pull/7498.diff</a>

</details>
