### PR TITLE
8281315: Unicode, (?i) flag and backreference throwing IndexOutOfBounds Exception

### DIFF
--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -5076,12 +5076,12 @@ loop:   for(int x=0, offset=0; x<nCodePoints; x++, offset+=len) {
             // referenced matched last time around
             int x = i;
 
-            //We set groupSize to the number of chars in the given subsequence
-            //but this is an upper bound we can reduce if we spot 2-char
-            //codepoints.
-            int groupSize = groupSizeChars;
+            // We set groupCodepoints to the number of chars
+            // in the given subsequence but this is an upper bound estimate
+            // we reduce by one if we spot 2-char codepoints.
+            int groupCodepoints = groupSizeChars;
 
-            for (int index=0; index<groupSize; index++) {
+            for (int index=0; index<groupCodepoints; index++) {
                 int c1 = Character.codePointAt(seq, x);
                 int c2 = Character.codePointAt(seq, j);
                 if (c1 != c2) {
@@ -5097,14 +5097,13 @@ loop:   for(int x=0, offset=0; x<nCodePoints; x++, offset+=len) {
                             return false;
                     }
                 }
-                int xIncr = Character.charCount(c1);
-                x += xIncr;
+                x += Character.charCount(c1);
                 j += Character.charCount(c2);
 
-                if(xIncr > 1) {
+                if(c1 >= Character.MIN_SUPPLEMENTARY_CODE_POINT) {
                     //Group size is guessed in terms of chars, but we need to
                     //adjust if we spot a 2-char codePoint.
-                    groupSize--;
+                    groupCodepoints--;
                 }
             }
 

--- a/test/jdk/java/util/regex/RegExTest.java
+++ b/test/jdk/java/util/regex/RegExTest.java
@@ -4556,4 +4556,13 @@ public class RegExTest {
                 Pattern.compile(pattern));
         assertTrue(e.getMessage().contains("Bad intersection syntax"));
     }
+
+    //This test is for 8281315
+    @Test
+    public static void iOOBForCIBackrefs(){
+        String line = "\ud83d\udc95\ud83d\udc95\ud83d\udc95";
+        var pattern2 = Pattern.compile("(?i)(.)\\1{2,}");
+        assertTrue(pattern2.matcher(line).find());
+
+    }
 }


### PR DESCRIPTION
This is a fix in the buggy way CIBackRef traverses unicode characters that could be variable-length. Originally it followed the approach that BackRef does, but failed to account for unicode characters that could be 2 chars-long. The upper bound (groupSize) for the traversing loop is set by the difference between group start and stop indexes. This works for single char characters and it also works for case-sensitive comparisons because byte-by-byte comparisons are acceptable, but it doesn't work for a comparison where some kind of normalization (i.e. case) is required. This fix adjusts the upper bound for the loop that traverses the character when a two-char character is encountered.

An alternative was to check the length of the group size by scanning the group in advance and converting to code points, but this could potentially result in multiple scans and codepoint conversions of the same matcher group which could be long. The solution that adjusts the loop bounds on the fly avoids this case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281315](https://bugs.openjdk.java.net/browse/JDK-8281315): Unicode, (?i) flag and backreference throwing IndexOutOfBounds Exception


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7501/head:pull/7501` \
`$ git checkout pull/7501`

Update a local copy of the PR: \
`$ git checkout pull/7501` \
`$ git pull https://git.openjdk.java.net/jdk pull/7501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7501`

View PR using the GUI difftool: \
`$ git pr show -t 7501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7501.diff">https://git.openjdk.java.net/jdk/pull/7501.diff</a>

</details>
