### PR TITLE
8282017: sun/net/www/protocol/https/HttpsURLConnection/B6216082.java fails with "SocketException: Unexpected end of file from server"

### DIFF
--- a/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/TunnelProxy.java
+++ b/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/TunnelProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,8 +45,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Set;
 
-import jdk.test.lib.net.HttpHeaderParser;
-
+import sun.net.www.MessageHeader;
 
 public class TunnelProxy {
 
@@ -262,7 +261,7 @@ public class TunnelProxy {
             try {
                 InputStream is = new BufferedInputStream (new NioInputStream (chan));
                 String requestline = readLine (is);
-                HttpHeaderParser mhead = new HttpHeaderParser (is);
+                MessageHeader mhead = new MessageHeader (is);
                 String[] req = requestline.split (" ");
                 if (req.length < 2) {
                     /* invalid request line */


### PR DESCRIPTION
A seemingly innocuous change from [JDK-8061729](https://bugs.openjdk.java.net/browse/JDK-8061729) is causing a test failure.  The fix is to simply revert that small change.