### PR TITLE
8254574: PrintWriter handling of InterruptedIOException should be removed

### DIFF
--- a/src/java.base/share/classes/java/io/PrintStream.java
+++ b/src/java.base/share/classes/java/io/PrintStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -464,22 +464,11 @@ public class PrintStream extends FilterOutputStream
     }
 
     /**
-     * Flushes the stream and checks its error state. The internal error state
-     * is set to {@code true} when the underlying output stream throws an
-     * {@code IOException} other than {@code InterruptedIOException},
-     * and when the {@code setError} method is invoked.  If an operation
-     * on the underlying output stream throws an
-     * {@code InterruptedIOException}, then the {@code PrintStream}
-     * converts the exception back into an interrupt by doing:
-     * <pre>{@code
-     *     Thread.currentThread().interrupt();
-     * }</pre>
-     * or the equivalent.
+     * Flushes the stream if it's not closed and checks its error state.
      *
      * @return {@code true} if and only if this stream has encountered an
-     *         {@code IOException} other than
-     *         {@code InterruptedIOException}, or the
-     *         {@code setError} method has been invoked
+     *         {@code IOException}, or the {@code setError} method has been
+     *         invoked
      */
     public boolean checkError() {
         if (out != null)
@@ -504,7 +493,7 @@ public class PrintStream extends FilterOutputStream
     }
 
     /**
-     * Clears the internal error state of this stream.
+     * Clears the error state of this stream.
      *
      * <p> This method will cause subsequent invocations of {@link
      * #checkError()} to return {@code false} until another write

--- a/src/java.base/share/classes/java/io/PrintWriter.java
+++ b/src/java.base/share/classes/java/io/PrintWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -428,9 +428,9 @@ public class PrintWriter extends Writer {
     /**
      * Flushes the stream if it's not closed and checks its error state.
      *
-     * @return {@code true} if the print stream has encountered an error,
-     *          either on the underlying output stream or during a format
-     *          conversion.
+     * @return {@code true} if and only if this stream has encountered an
+     *         {@code IOException}, or the {@code setError} method has been
+     *         invoked
      */
     public boolean checkError() {
         if (out != null) {
@@ -445,7 +445,7 @@ public class PrintWriter extends Writer {
     }
 
     /**
-     * Indicates that an error has occurred.
+     * Sets the error state of the stream to {@code true}.
      *
      * <p> This method will cause subsequent invocations of {@link
      * #checkError()} to return {@code true} until {@link


### PR DESCRIPTION
Remove reference to `java.io.InterruptedIOException` from `java.io.PrintStream`, and make the specifications of `checkError()`, `setError()`, and `clearError()` consistent between `java.io.PrintStream` and `java.io.PrintWriter`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8254574](https://bugs.openjdk.java.net/browse/JDK-8254574): PrintWriter handling of InterruptedIOException should be removed
 * [JDK-8282135](https://bugs.openjdk.java.net/browse/JDK-8282135): PrintWriter handling of InterruptedIOException should be removed (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to 4015d9c06119b93a8d11df482fddb7af36baa3ed


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7507/head:pull/7507` \
`$ git checkout pull/7507`

Update a local copy of the PR: \
`$ git checkout pull/7507` \
`$ git pull https://git.openjdk.java.net/jdk pull/7507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7507`

View PR using the GUI difftool: \
`$ git pr show -t 7507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7507.diff">https://git.openjdk.java.net/jdk/pull/7507.diff</a>

</details>
