### PR TITLE
8282025: assert(ctrl != __null) failed: control out is assumed to be unique after JDK-8281732

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015, 2021, Red Hat, Inc. All rights reserved.
+ * Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -706,7 +707,7 @@ Node* ShenandoahBarrierC2Support::no_branches(Node* c, Node* dom, bool allow_one
   Node* iffproj = NULL;
   while (c != dom) {
     Node* next = phase->idom(c);
-    assert(next->unique_ctrl_out() == c || c->is_Proj() || c->is_Region(), "multiple control flow out but no proj or region?");
+    assert(next->unique_ctrl_out_or_null() == c || c->is_Proj() || c->is_Region(), "multiple control flow out but no proj or region?");
     if (c->is_Region()) {
       ResourceMark rm;
       Unique_Node_List wq;


### PR DESCRIPTION
Hi all,

The following tests fail after JDK-8281732.
```
compiler/gcbarriers/UnsafeIntrinsicsTest.java
gc/metaspace/TestMetaspacePerfCounters.java
gc/shenandoah/TestEvilSyncBug.java
gc/stringdedup/TestStringDeduplicationFullGC.java
gc/stringdedup/TestStringDeduplicationTableResize.java
gc/stringdedup/TestStringDeduplicationYoungGC.java
serviceability/dcmd/gc/HeapDumpCompressedTest.java
jdk/jfr/event/gc/detailed/TestGCPhaseConcurrent.java
jdk/jfr/event/gc/detailed/TestShenandoahHeapRegionStateChangeEvent.java
jdk/jfr/event/gc/detailed/TestShenandoahHeapRegionInformationEvent.java
jdk/jfr/event/oldobject/TestShenandoah.java
sun/net/www/protocol/https/HttpsURLConnection/B6216082.java
sun/tools/jmap/BasicJMapTest.java
``` 

The fix just replaces `unique_ctrl_out()` with `unique_ctrl_out_or_null()`.

Testing:
 - All failing tests passed after this patch

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282025](https://bugs.openjdk.java.net/browse/JDK-8282025): assert(ctrl != __null) failed: control out is assumed to be unique after JDK-8281732


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7508/head:pull/7508` \
`$ git checkout pull/7508`

Update a local copy of the PR: \
`$ git checkout pull/7508` \
`$ git pull https://git.openjdk.java.net/jdk pull/7508/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7508`

View PR using the GUI difftool: \
`$ git pr show -t 7508`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7508.diff">https://git.openjdk.java.net/jdk/pull/7508.diff</a>

</details>
