### PR TITLE
8281544: assert(VM_Version::supports_avx512bw()) failed for Tests jdk/incubator/vector/

### DIFF
--- a/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
@@ -452,7 +452,7 @@ private:
 
   void opmask_register_save(KRegister reg) {
     _spill_offset -= 8;
-    __ kmovql(Address(rsp, _spill_offset), reg);
+    __ kmov(Address(rsp, _spill_offset), reg);
   }
 
   void gp_register_restore(Register reg) {
@@ -461,7 +461,7 @@ private:
   }
 
   void opmask_register_restore(KRegister reg) {
-    __ kmovql(reg, Address(rsp, _spill_offset));
+    __ kmov(reg, Address(rsp, _spill_offset));
     _spill_offset += 8;
   }
 

--- a/test/jdk/jdk/incubator/vector/VectorMaxConversionTests.java
+++ b/test/jdk/jdk/incubator/vector/VectorMaxConversionTests.java
@@ -48,8 +48,8 @@ import java.util.List;
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.vm.annotation
  * @run testng/othervm  -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
- * -XX:+UnlockDiagnosticVMOptions -XX:+UseKNLSetting -XX:+UseZGC -XX:+IgnoreUnrecognizedVMOptions
- * VectorMaxConversionTests
+ *                      -XX:+UnlockDiagnosticVMOptions -XX:+UseKNLSetting -XX:+UseZGC -XX:+IgnoreUnrecognizedVMOptions
+ *                      VectorMaxConversionTests
  */
 
 @Test

--- a/test/jdk/jdk/incubator/vector/VectorMaxConversionTests.java
+++ b/test/jdk/jdk/incubator/vector/VectorMaxConversionTests.java
@@ -40,6 +40,18 @@ import java.util.List;
  * VectorMaxConversionTests
  */
 
+/*
+ * @test
+ * @bug 8281544
+ * @summary Test that ZGC and vectorapi with KNL work together.
+ * @requires vm.gc.Z
+ * @modules jdk.incubator.vector
+ * @modules java.base/jdk.internal.vm.annotation
+ * @run testng/othervm  -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
+ * -XX:+UnlockDiagnosticVMOptions -XX:+UseKNLSetting -XX:+UseZGC -XX:+IgnoreUnrecognizedVMOptions
+ * VectorMaxConversionTests
+ */
+
 @Test
 public class VectorMaxConversionTests extends AbstractVectorConversionTest {
 


### PR DESCRIPTION
`ZSaveLiveRegisters::ZSaveLiveRegisters` stores live registers, and later they are loaded again.
This includes opmask registers, which are part of AVX512. However, not all platforms have all of the AVX512 instructions.
For example Knights Landing has general AVX512 support and makes use of optmask registers, but does not support the AVX512 BW subset of instructions, specifically it does not support the `kmovql` instruction. Platforms like Cannon Landing have support for AVX512 BW.

Solution: in analogy to `RegisterSaver::save_live_registers`, which seems to perform a very similar task, use `MacroAssembler::kmov` instead of `kmovql` directly. Internally, `kmov` choses either `kmovql` if avx512bw is available, else it takes `kmovwl`.

As a regression test, I took one of the tests that failed with `-XX:+UnlockExperimentalVMOptions -XX:+UseZGC`, and added an additional `@run` statement with those flags. I simulated this test locally with Intel Software Development Emulator:
`sde -knl`: Knights Landing, AVX512 but not BW, fails without change to `kmov`, passes with it.
`sde -cnl`: Cannon Landing, has AVX512 BW, passes before and after code change.

Ran additional tests to verify that the test triggers before code change, and that with the code change nothing broke.

@neliasso Thanks for the help!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281544](https://bugs.openjdk.java.net/browse/JDK-8281544): assert(VM_Version::supports_avx512bw()) failed for Tests jdk/incubator/vector/


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7510/head:pull/7510` \
`$ git checkout pull/7510`

Update a local copy of the PR: \
`$ git checkout pull/7510` \
`$ git pull https://git.openjdk.java.net/jdk pull/7510/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7510`

View PR using the GUI difftool: \
`$ git pr show -t 7510`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7510.diff">https://git.openjdk.java.net/jdk/pull/7510.diff</a>

</details>
