### PR TITLE
JDK-8282046: Create a regression test for CCC8000326

### DIFF
--- a/test/jdk/java/awt/Focus/CCC8000326/CCC8000326.java
+++ b/test/jdk/java/awt/Focus/CCC8000326/CCC8000326.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key headful
+ * @summary Focus unable to traverse within the menubar
+ * @run main CCC8000326
+ */
+import java.awt.AWTException;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.ContainerOrderFocusTraversalPolicy;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+
+public class CCC8000326 {
+
+    private static JFrame jFrame;
+    private static Component currentFocusOwner;
+    private static Robot robot;
+
+    private static void doTest()
+        throws InvocationTargetException, InterruptedException, AWTException {
+        try {
+            SwingUtilities.invokeAndWait(() -> createGUI());
+            Robot robot = new Robot();
+            robot.setAutoDelay(500);
+            robot.waitForIdle();
+            Component lastFocusOwner = null;
+            do {
+                SwingUtilities.invokeAndWait(() -> {
+                    currentFocusOwner = jFrame.getFocusOwner();
+                });
+                robot.waitForIdle();
+                System.out.println("Focus owner is : " + currentFocusOwner.getClass().getName());
+                if (currentFocusOwner == lastFocusOwner) {
+                    throw new RuntimeException(
+                        "Problem moving focus from " + currentFocusOwner.getClass().getName());
+                }
+                lastFocusOwner = currentFocusOwner;
+                robot.keyPress(KeyEvent.VK_TAB);
+                robot.keyRelease(KeyEvent.VK_TAB);
+            } while (currentFocusOwner != jFrame);
+        } finally {
+            jFrame.dispose();
+        }
+    }
+
+    private static void createGUI() {
+        jFrame = new JFrame("Focus Traversal Test");
+        jFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+
+        JMenuBar jMenuBar = new JMenuBar();
+        jMenuBar.setFocusTraversalKeysEnabled(true);
+        jMenuBar.add(new JMenu("First Menu").add(new JMenuItem("First MenuItem")));
+
+        JButton northButton = new JButton("North Button");
+        JButton southButton = new JButton("South Button");
+
+        JPanel jPanel = new JPanel(new BorderLayout());
+        jPanel.add(northButton);
+        jPanel.add(jMenuBar, BorderLayout.NORTH);
+        jPanel.add(southButton, BorderLayout.SOUTH);
+
+        jFrame.getContentPane().add(jPanel);
+        jFrame.setFocusTraversalPolicy(new ContainerOrderFocusTraversalPolicy());
+        jFrame.pack();
+        northButton.requestFocusInWindow();
+        jFrame.setVisible(true);
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        CCC8000326.doTest();
+
+    }
+}


### PR DESCRIPTION
Create a regression test for CCC8000326

Issue is identified by [JDK-8000326](https://bugs.openjdk.java.net/browse/JDK-8000326), which identifies that after focus moves into JMenuBar, whose focus traversal key is disabled by default, it never moves to other focusable component.
 
By default, pressing the Tab key does not transfer focus from a JMenuBar which is added to a container together with other Swing components, because the focusTraversalKeysEnabled property of JMenuBar is set to false. To resolve this, you should call the JMenuBar.setFocusTraversalKeysEnabled(true) method.
 
The test verifies focus traversal for the above described scenario.