### PR TITLE
JDK-8281217: Source file launch with security manager enabled fails

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/Main.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/Main.java
@@ -64,8 +64,6 @@ import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.NoSuchElementException;
 import java.util.ResourceBundle;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.NestingKind;
@@ -129,7 +127,9 @@ public class Main {
      */
     public static void main(String... args) throws Throwable {
         try {
-            new Main(System.err).run(VM.getRuntimeArguments(), args);
+            new Main(System.err)
+                    .checkSecurityManager()
+                    .run(VM.getRuntimeArguments(), args);
         } catch (Fault f) {
             System.err.println(f.getMessage());
             System.exit(1);
@@ -160,6 +160,19 @@ public class Main {
      */
     public Main(PrintWriter out) {
         this.out = out;
+    }
+
+    /**
+     * Checks if a security manager is present and throws an exception if so.
+     * @return this object
+     * @throws Fault if a security manager is present
+     */
+    @SuppressWarnings("removal")
+    private Main checkSecurityManager() throws Fault {
+        if (System.getSecurityManager() != null) {
+            throw new Fault(Errors.SecurityManager);
+        }
+        return this;
     }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/launcher.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/launcher.properties
@@ -84,6 +84,9 @@ launcher.error=\
 launcher.err.no.args=\
     no path for source file
 
+launcher.err.security.manager=\
+    cannot use source-code launcher with a security manager enabled
+
 # 0: string
 launcher.err.invalid.filename=\
     invalid path for source file: {0}


### PR DESCRIPTION
Please review a small change to the source-code launcher to formally reject the use of a security manager in programs launched by the source-code launcher.  This changes the previous behavior where it was tacitly allowed but would trigger an `IllegalAccessException` unless extra (effectively, all) privileges were granted to the `jdk.compiler` module.

The test is modified too reflect the new behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281217](https://bugs.openjdk.java.net/browse/JDK-8281217): Source file launch with security manager enabled fails


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7518/head:pull/7518` \
`$ git checkout pull/7518`

Update a local copy of the PR: \
`$ git checkout pull/7518` \
`$ git pull https://git.openjdk.java.net/jdk pull/7518/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7518`

View PR using the GUI difftool: \
`$ git pr show -t 7518`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7518.diff">https://git.openjdk.java.net/jdk/pull/7518.diff</a>

</details>
