### PR TITLE
JDK-8282017 : sun/net/www/protocol/https/HttpsURLConnection/B6216082.java fails with "SocketException: Unexpected end of file from server"

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -597,8 +597,6 @@ java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8219083 windows-
 
 java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
 
-sun/net/www/protocol/https/HttpsURLConnection/B6216082.java     8282017 generic-all
-
 ############################################################################
 
 # jdk_nio

--- a/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/TunnelProxy.java
+++ b/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/TunnelProxy.java
@@ -261,9 +261,9 @@ public class TunnelProxy {
             boolean res;
             try {
                 InputStream is = new BufferedInputStream (new NioInputStream (chan));
-                String requestline = readLine (is);
-                HttpHeaderParser mhead = new HttpHeaderParser (is);
-                String[] req = requestline.split (" ");
+                HttpHeaderParser mHead = new HttpHeaderParser (is);
+                String requestLine = mHead.getRequestDetails();
+                String[] req = requestLine.split (" ");
                 if (req.length < 2) {
                     /* invalid request line */
                     return false;


### PR DESCRIPTION
Updated TunnelProxy to avoid twice read of Request line.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282017](https://bugs.openjdk.java.net/browse/JDK-8282017): sun/net/www/protocol/https/HttpsURLConnection/B6216082.java fails with "SocketException: Unexpected end of file from server"


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7519/head:pull/7519` \
`$ git checkout pull/7519`

Update a local copy of the PR: \
`$ git checkout pull/7519` \
`$ git pull https://git.openjdk.java.net/jdk pull/7519/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7519`

View PR using the GUI difftool: \
`$ git pr show -t 7519`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7519.diff">https://git.openjdk.java.net/jdk/pull/7519.diff</a>

</details>
