### PR TITLE
8282056: Clean up com.sun.tools.javac.util.GraphUtils

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Dependencies.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Dependencies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -189,7 +189,7 @@ public abstract class Dependencies {
                 super(value);
                 this.depsByKind = new EnumMap<>(CompletionCause.class);
                 for (CompletionCause depKind : CompletionCause.values()) {
-                    depsByKind.put(depKind, new ArrayList<Node>());
+                    depsByKind.put(depKind, new ArrayList<>());
                 }
             }
 
@@ -216,7 +216,7 @@ public abstract class Dependencies {
             }
 
             @Override
-            public java.util.Collection<? extends Node> getDependenciesByKind(DependencyKind dk) {
+            public Collection<? extends Node> getDependenciesByKind(DependencyKind dk) {
                 return depsByKind.get(dk);
             }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/GraphUtils.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/GraphUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ public class GraphUtils {
      */
     public interface Node<D, N extends Node<D, N>> {
         /**
-         * visitor method.
+         * Visitor method.
          */
         <A> void accept(NodeVisitor<D, N, A> visitor, A arg);
     }
@@ -105,7 +105,7 @@ public class GraphUtils {
         public abstract DependencyKind[] getSupportedDependencyKinds();
 
         /**
-         * Get all dependencies of a given kind
+         * Get all dependencies of a given kind.
          */
         public abstract Collection<? extends N> getDependenciesByKind(DependencyKind dk);
 
@@ -126,7 +126,7 @@ public class GraphUtils {
     }
 
     /**
-     * This class specialized Node, by adding elements that are required in order
+     * This class specializes Node, by adding elements that are required in order
      * to perform Tarjan computation of strongly connected components.
      */
     public abstract static class TarjanNode<D, N extends TarjanNode<D, N>> extends AbstractNode<D, N>
@@ -147,7 +147,7 @@ public class GraphUtils {
     }
 
     /**
-     * Tarjan's algorithm to determine strongly connected components of a
+     * Tarjan's algorithm to determine strongly connected components (SCCs) of a
      * directed graph in linear time. Works on TarjanNode.
      */
     public static <D, N extends TarjanNode<D, N>> List<? extends List<? extends N>> tarjan(Iterable<? extends N> nodes) {
@@ -160,10 +160,10 @@ public class GraphUtils {
         /** Unique node identifier. */
         int index = 0;
 
-        /** List of SCCs found fso far. */
+        /** List of SCCs found so far. */
         ListBuffer<List<N>> sccs = new ListBuffer<>();
 
-        /** Stack of all reacheable nodes from given root. */
+        /** Stack of all reachable nodes from given root. */
         ListBuffer<N> stack = new ListBuffer<>();
 
         private List<? extends List<? extends N>> findSCC(Iterable<? extends N> nodes) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/GraphUtils.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/GraphUtils.java
@@ -141,8 +141,9 @@ public class GraphUtils {
 
         public abstract Iterable<? extends N> getAllDependencies();
 
+        @Override
         public int compareTo(N o) {
-            return (index < o.index) ? -1 : (index == o.index) ? 0 : 1;
+            return Integer.compare(index, o.index);
         }
     }
 


### PR DESCRIPTION
Please review this trivial cleanup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282056](https://bugs.openjdk.java.net/browse/JDK-8282056): Clean up com.sun.tools.javac.util.GraphUtils


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7520/head:pull/7520` \
`$ git checkout pull/7520`

Update a local copy of the PR: \
`$ git checkout pull/7520` \
`$ git pull https://git.openjdk.java.net/jdk pull/7520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7520`

View PR using the GUI difftool: \
`$ git pr show -t 7520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7520.diff">https://git.openjdk.java.net/jdk/pull/7520.diff</a>

</details>
