### PR TITLE
8276686: Malformed Javadoc inline tags in JDK source in /java/util/regex/Pattern.java

### DIFF
--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -396,7 +396,7 @@ import jdk.internal.util.ArraysSupport;
  * <p> Backslashes within string literals in Java source code are interpreted
  * as required by
  * <cite>The Java Language Specification</cite>
- * as either Unicode escapes (section {@jls 3.3}) or other character escapes (section {@jls 3.10.6})
+ * as either Unicode escapes (section {@jls 3.3}) or other character escapes (section {@jls 3.10.6}).
  * It is therefore necessary to double backslashes in string
  * literals that represent regular expressions to protect them from
  * interpretation by the Java bytecode compiler.  The string literal


### PR DESCRIPTION
Adding a missing period per this doc bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276686](https://bugs.openjdk.java.net/browse/JDK-8276686): Malformed Javadoc inline tags in JDK source in /java/util/regex/Pattern.java


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7521/head:pull/7521` \
`$ git checkout pull/7521`

Update a local copy of the PR: \
`$ git checkout pull/7521` \
`$ git pull https://git.openjdk.java.net/jdk pull/7521/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7521`

View PR using the GUI difftool: \
`$ git pr show -t 7521`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7521.diff">https://git.openjdk.java.net/jdk/pull/7521.diff</a>

</details>
