### PR TITLE
8282075: ProblemList 3 compiler/whitebox tests on macosx-x64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -67,9 +67,9 @@ compiler/rtm/print/TestPrintPreciseRTMLockingStatistics.java 8183263 generic-x64
 
 compiler/c2/Test8004741.java 8235801 generic-all
 
-compiler/whitebox/ClearMethodStateTest.java 8265360 macosx-aarch64
-compiler/whitebox/EnqueueMethodForCompilationTest.java 8265360 macosx-aarch64
-compiler/whitebox/MakeMethodNotCompilableTest.java 8265360 macosx-aarch64
+compiler/whitebox/ClearMethodStateTest.java 8265360 macosx-generic
+compiler/whitebox/EnqueueMethodForCompilationTest.java 8265360 macosx-generic
+compiler/whitebox/MakeMethodNotCompilableTest.java 8265360 macosx-generic
 
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-generic
 compiler/codecache/TestStressCodeBuffers.java 8272094 generic-aarch64


### PR DESCRIPTION
A trivial fix to ProblemList 3 compiler/whitebox tests on macosx-x64.