### PR TITLE
8282042: [testbug] FileEncodingTest.java depends on default encoding

### DIFF
--- a/test/jdk/java/lang/System/FileEncodingTest.java
+++ b/test/jdk/java/lang/System/FileEncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/System/FileEncodingTest.java
+++ b/test/jdk/java/lang/System/FileEncodingTest.java
@@ -40,7 +40,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class FileEncodingTest {
-    private static final boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
+    private static final String OS_NAME = System.getProperty("os.name");
 
     @DataProvider
     public Object[][] fileEncodingToDefault() {
@@ -56,7 +56,7 @@ public class FileEncodingTest {
     @Test(dataProvider = "fileEncodingToDefault")
     public void testFileEncodingToDefault(String fileEncoding, String expected) throws Exception {
         if (fileEncoding.equals("COMPAT")) {
-            if (IS_WINDOWS) {
+            if (OS_NAME.startsWith("Windows")) {
                 // Only tests on English locales
                 if (Locale.getDefault().getLanguage().equals("en")) {
                     expected = "windows-1252";
@@ -64,6 +64,8 @@ public class FileEncodingTest {
                     System.out.println("Tests only run on Windows with English locales");
                     return;
                 }
+            } else if (OS_NAME.startsWith("AIX")) {
+                expected = "ISO-8859-1";
             } else {
                 expected = "US-ASCII";
             }

--- a/test/jdk/java/lang/System/FileEncodingTest.java
+++ b/test/jdk/java/lang/System/FileEncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8260265
+ * @bug 8260265 8282042
  * @summary Test file.encoding system property
  * @library /test/lib
  * @build jdk.test.lib.process.*


### PR DESCRIPTION
FileEncodingTest expects all non-Windows platforms will have `Charset.defaultCharset().name()` set to US-ASCII when file.encoding is set to COMPAT. This assumption does not hold for AIX where it is ISO-8859-1.

According to [JEP-400](https://openjdk.java.net/jeps/400), we should expect  `Charset.defaultCharset().name()` to equal `System.getProperty("native.encoding")` whenever the COMPAT flag is set. From JEP-400: "... if file.encoding is set to COMPAT on the command line, then the run-time value of file.encoding will be the same as the run-time value of native.encoding...". So one way to resolve this is to choose the value for each system from the native.encoding property.

With these changes however, my test systems continue to fail. 

- AIX reports: Default Charset: ISO-8859-1, expected: ISO8859-1
- Linux/Z reports: Default Charset: US-ASCII, expected: ANSI_X3.4-1968
- Linux/PowerLE reports: Default Charset: US-ASCII, expected: ANSI_X3.4-1968

Note that the expected value is populated from native.encoding.

This implies more work to be done. It looks to me that some modification to java_props_md.c may be needed to ensure that the System properties for native.encoding return [canonical names](http://www.iana.org/assignments/character-sets). 

---

A tempting alternative is to set the expected value for AIX to "ISO-8859-1" in the test explicitly, as was done for the Windows expected encoding prior to this proposed change. The main advantage to this alternative is that it is quick and easy, but the disadvantages are that it fails to test that COMPAT behaves as specified in JEP-400, and the approach does not scale well if it happens that other systems require other cases. I wonder if this is the reason non-English locals are excluded by the test.

Proceeding with this change and the work implied by the new failures it highlights goes beyond the scope of what I thought was a simple testbug. So I'm opening this up for some comments before proceeding down the rabbit hole of further changes. If there is generally positive support for this direction I'm happy to make the modifications necessary to populate native.encoding with canonical names. As I am new to OpenJDK, I am especially looking to ensure that changing the value returned by native.encoding will not have unintended consequences elsewhere in the project.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282042](https://bugs.openjdk.java.net/browse/JDK-8282042): [testbug] FileEncodingTest.java depends on default encoding


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7525/head:pull/7525` \
`$ git checkout pull/7525`

Update a local copy of the PR: \
`$ git checkout pull/7525` \
`$ git pull https://git.openjdk.java.net/jdk pull/7525/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7525`

View PR using the GUI difftool: \
`$ git pr show -t 7525`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7525.diff">https://git.openjdk.java.net/jdk/pull/7525.diff</a>

</details>
