### PR TITLE
8282086: Update jib profile to not set build to 0

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1424,7 +1424,10 @@ var getVersion = function (feature, interim, update, patch, extra1, extra2, extr
  * other version inputs
  */
 var versionArgs = function(input, common) {
-    var args = ["--with-version-build=" + common.build_number];
+    var args = [];
+    if (common.build_number != 0) {
+        args = concat(args, "--with-version-build=" + common.build_number);
+    }
     if (input.build_type == "promoted") {
         args = concat(args,
                       "--with-version-pre=" + version_numbers.get("DEFAULT_PROMOTED_VERSION_PRE"),


### PR DESCRIPTION
The jib profile definition does not play well with [JDK-8274980](https://bugs.openjdk.java.net/browse/JDK-8274980). When using 0 as a marker for "no build number", we should not pass that on to configure, since it will trigger a warning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282086](https://bugs.openjdk.java.net/browse/JDK-8282086): Update jib profile to not set build to 0


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7527/head:pull/7527` \
`$ git checkout pull/7527`

Update a local copy of the PR: \
`$ git checkout pull/7527` \
`$ git pull https://git.openjdk.java.net/jdk pull/7527/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7527`

View PR using the GUI difftool: \
`$ git pr show -t 7527`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7527.diff">https://git.openjdk.java.net/jdk/pull/7527.diff</a>

</details>
