### PR TITLE
8282130: (bf) Remove unused ARRAY_BASE_OFFSET, ARRAY_INDEX_SCALE from read-only Heap Buffers

### DIFF
--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,6 @@ import jdk.internal.access.foreign.MemorySegmentProxy;
  * instance of this class rather than of the superclass.
 #end[rw]
  */
-
 class Heap$Type$Buffer$RW$
     extends {#if[ro]?Heap}$Type$Buffer
 {

--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -44,6 +44,7 @@ import jdk.internal.access.foreign.MemorySegmentProxy;
 class Heap$Type$Buffer$RW$
     extends {#if[ro]?Heap}$Type$Buffer
 {
+#if[rw]
     // Cached array base offset
     private static final long ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset($type$[].class);
 
@@ -53,11 +54,10 @@ class Heap$Type$Buffer$RW$
     // For speed these fields are actually declared in X-Buffer;
     // these declarations are here as documentation
     /*
-#if[rw]
     protected final $type$[] hb;
     protected final int offset;
-#end[rw]
     */
+#end[rw]
 
     Heap$Type$Buffer$RW$(int cap, int lim, MemorySegmentProxy segment) {            // package-private
 #if[rw]


### PR DESCRIPTION
IDEA noticed unused fields in ReadOnly Heap buffer classes: `HeapByteBufferR`, `HeapCharBufferR`, `HeapDoubleBufferR`, `HeapFloatBufferR`, `HeapIntBufferR`, `HeapLongBufferR`, `HeapShortBufferR`.
![изображение](https://user-images.githubusercontent.com/741251/154662464-1bfc7860-72f9-41bc-ad2a-35ba23b49011.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282130](https://bugs.openjdk.java.net/browse/JDK-8282130): (bf) Remove unused ARRAY_BASE_OFFSET, ARRAY_INDEX_SCALE from read-only Heap Buffers


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7530/head:pull/7530` \
`$ git checkout pull/7530`

Update a local copy of the PR: \
`$ git checkout pull/7530` \
`$ git pull https://git.openjdk.java.net/jdk pull/7530/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7530`

View PR using the GUI difftool: \
`$ git pr show -t 7530`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7530.diff">https://git.openjdk.java.net/jdk/pull/7530.diff</a>

</details>
