### PR TITLE
8282096: G1: Remove redundant checks in G1CardSet::free_mem_object

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.cpp
@@ -365,15 +365,7 @@ void G1CardSet::free_mem_object(CardSetPtr card_set) {
   assert(type == G1CardSet::CardSetArrayOfCards ||
          type == G1CardSet::CardSetBitMap ||
          type == G1CardSet::CardSetHowl, "should not free card set type %zu", type);
-
-#ifdef ASSERT
-  if (type == G1CardSet::CardSetArrayOfCards ||
-      type == G1CardSet::CardSetBitMap ||
-      type == G1CardSet::CardSetHowl) {
-    G1CardSetContainer* card_set = (G1CardSetContainer*)value;
-    assert((card_set->refcount() == 1), "must be");
-  }
-#endif
+  assert(static_cast<G1CardSetContainer*>(value)->refcount() == 1, "must be");
 
   _mm->free(card_set_type_to_mem_object_type(type), value);
 }


### PR DESCRIPTION
Simple change of removing unnecessary checks.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282096](https://bugs.openjdk.java.net/browse/JDK-8282096): G1: Remove redundant checks in G1CardSet::free_mem_object


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7532/head:pull/7532` \
`$ git checkout pull/7532`

Update a local copy of the PR: \
`$ git checkout pull/7532` \
`$ git pull https://git.openjdk.java.net/jdk pull/7532/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7532`

View PR using the GUI difftool: \
`$ git pr show -t 7532`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7532.diff">https://git.openjdk.java.net/jdk/pull/7532.diff</a>

</details>
