### PR TITLE
8280357: user.home = "?" when running with systemd DynamicUser=true

### DIFF
--- a/src/java.base/unix/native/libjava/java_props_md.c
+++ b/src/java.base/unix/native/libjava/java_props_md.c
@@ -488,8 +488,13 @@ GetJavaProperties(JNIEnv *env)
 #else
         sprops.user_home = pwent ? strdup(pwent->pw_dir) : NULL;
 #endif
-        if (sprops.user_home == NULL) {
-            sprops.user_home = "?";
+        if (sprops.user_home == NULL || *sprops.user_home == '\0') {
+            // If the OS supplied home directory is not valid
+            // $HOME is the backup source for the home directory
+            sprops.user_home = getenv("HOME");
+            if ((sprops.user_home == NULL) && (*sprops.user_home == '\0')) {
+                sprops.user_home = "NO_HOME_DIR";
+            }
         }
     }
 

--- a/src/java.base/unix/native/libjava/java_props_md.c
+++ b/src/java.base/unix/native/libjava/java_props_md.c
@@ -488,7 +488,8 @@ GetJavaProperties(JNIEnv *env)
 #else
         sprops.user_home = pwent ? strdup(pwent->pw_dir) : NULL;
 #endif
-        if (sprops.user_home == NULL || *sprops.user_home == '\0') {
+        if (sprops.user_home == NULL || *sprops.user_home == '\0' ||
+            strcmp(sprops.user_home, "/") == 0) {
             // If the OS supplied home directory is not valid
             // $HOME is the backup source for the home directory
             sprops.user_home = getenv("HOME");

--- a/src/java.base/unix/native/libjava/java_props_md.c
+++ b/src/java.base/unix/native/libjava/java_props_md.c
@@ -495,6 +495,8 @@ GetJavaProperties(JNIEnv *env)
             char* user_home = getenv("HOME");
             if ((user_home != NULL) && (user_home[0] != '\0')) {
                 sprops.user_home = user_home;
+            } else {
+                sprops.user_home = "?";
             }
         }
     }

--- a/src/java.base/unix/native/libjava/java_props_md.c
+++ b/src/java.base/unix/native/libjava/java_props_md.c
@@ -488,13 +488,13 @@ GetJavaProperties(JNIEnv *env)
 #else
         sprops.user_home = pwent ? strdup(pwent->pw_dir) : NULL;
 #endif
-        if (sprops.user_home == NULL || *sprops.user_home == '\0' ||
-            strcmp(sprops.user_home, "/") == 0) {
-            // If the OS supplied home directory is not valid
-            // $HOME is the backup source for the home directory
-            sprops.user_home = getenv("HOME");
-            if ((sprops.user_home == NULL) && (*sprops.user_home == '\0')) {
-                sprops.user_home = "NO_HOME_DIR";
+        if (sprops.user_home == NULL || sprops.user_home[0] == '\0' ||
+            sprops.user_home[1] == '\0') {
+            // If the OS supplied home directory is not defined or less than two characters long
+            // $HOME is the backup source for the home directory, if defined
+            char* user_home = getenv("HOME");
+            if ((user_home != NULL) && (user_home[0] != '\0')) {
+                sprops.user_home = user_home;
             }
         }
     }


### PR DESCRIPTION
In some Linux configurations, the Linux home directory provided by getpwent is not usable.
The value of the system property `user.home` should fallback to the value of $HOME 
if getpwent.user_home is null or less that 2 characters long. "/" is not a valid home directory name.

If $HOME is undefined or empty, the value of the getpwent.user_home is retained.

There are more details in the Jira issue: https://bugs.openjdk.java.net/browse/JDK-8280357

The fix has been tested manually on Ubuntu 20.0.4 using the suggested systemd command line and variations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8280357](https://bugs.openjdk.java.net/browse/JDK-8280357): user.home = "?" when running with systemd DynamicUser=true
 * [JDK-8282102](https://bugs.openjdk.java.net/browse/JDK-8282102): If the users home directory is invalid, system property user.home is set to $HOME (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7534/head:pull/7534` \
`$ git checkout pull/7534`

Update a local copy of the PR: \
`$ git checkout pull/7534` \
`$ git pull https://git.openjdk.java.net/jdk pull/7534/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7534`

View PR using the GUI difftool: \
`$ git pr show -t 7534`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7534.diff">https://git.openjdk.java.net/jdk/pull/7534.diff</a>

</details>
