### PR TITLE
8282103: fix macosx-generic typo in ProblemList

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -67,11 +67,11 @@ compiler/rtm/print/TestPrintPreciseRTMLockingStatistics.java 8183263 generic-x64
 
 compiler/c2/Test8004741.java 8235801 generic-all
 
-compiler/whitebox/ClearMethodStateTest.java 8265360 macosx-generic
-compiler/whitebox/EnqueueMethodForCompilationTest.java 8265360 macosx-generic
-compiler/whitebox/MakeMethodNotCompilableTest.java 8265360 macosx-generic
+compiler/whitebox/ClearMethodStateTest.java 8265360 macosx-all
+compiler/whitebox/EnqueueMethodForCompilationTest.java 8265360 macosx-all
+compiler/whitebox/MakeMethodNotCompilableTest.java 8265360 macosx-all
 
-compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-generic
+compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-all
 compiler/codecache/TestStressCodeBuffers.java 8272094 generic-aarch64
 
 


### PR DESCRIPTION
A trivial change to fix macosx-generic typo in ProblemList.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282103](https://bugs.openjdk.java.net/browse/JDK-8282103): fix macosx-generic typo in ProblemList


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7535/head:pull/7535` \
`$ git checkout pull/7535`

Update a local copy of the PR: \
`$ git checkout pull/7535` \
`$ git pull https://git.openjdk.java.net/jdk pull/7535/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7535`

View PR using the GUI difftool: \
`$ git pr show -t 7535`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7535.diff">https://git.openjdk.java.net/jdk/pull/7535.diff</a>

</details>
