### PR TITLE
8282188: Unused static field MathContext.DEFAULT_DIGITS

### DIFF
--- a/src/java.base/share/classes/java/math/MathContext.java
+++ b/src/java.base/share/classes/java/math/MathContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,6 @@ public final class MathContext implements Serializable {
     /* ----- Constants ----- */
 
     // defaults for constructors
-    private static final int DEFAULT_DIGITS = 9;
     private static final RoundingMode DEFAULT_ROUNDINGMODE = RoundingMode.HALF_UP;
     // Smallest values for digits (Maximum is Integer.MAX_VALUE)
     private static final int MIN_DIGITS = 0;
@@ -140,7 +139,6 @@ public final class MathContext implements Serializable {
      */
     public MathContext(int setPrecision) {
         this(setPrecision, DEFAULT_ROUNDINGMODE);
-        return;
     }
 
     /**
@@ -162,7 +160,6 @@ public final class MathContext implements Serializable {
 
         precision = setPrecision;
         roundingMode = setRoundingMode;
-        return;
     }
 
     /**
@@ -181,7 +178,6 @@ public final class MathContext implements Serializable {
      * @throws NullPointerException if the argument is {@code null}
      */
     public MathContext(String val) {
-        boolean bad = false;
         int setPrecision;
         if (val == null)
             throw new NullPointerException("null String");
@@ -232,7 +228,6 @@ public final class MathContext implements Serializable {
      * @return a {@code RoundingMode} object which is the value of the
      *         {@code roundingMode} setting
      */
-
     public RoundingMode getRoundingMode() {
         return roundingMode;
     }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282188](https://bugs.openjdk.java.net/browse/JDK-8282188): Unused static field MathContext.DEFAULT_DIGITS


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7538/head:pull/7538` \
`$ git checkout pull/7538`

Update a local copy of the PR: \
`$ git checkout pull/7538` \
`$ git pull https://git.openjdk.java.net/jdk pull/7538/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7538`

View PR using the GUI difftool: \
`$ git pr show -t 7538`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7538.diff">https://git.openjdk.java.net/jdk/pull/7538.diff</a>

</details>
