### PR TITLE
8282077: PKCS11 provider C_sign() impl should handle CKR_BUFFER_TOO_SMALL error

### DIFF
--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sign.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sign.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -143,6 +143,16 @@ JNIEXPORT jbyteArray JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1Sign
         bufP, &ckSignatureLength);
 
     TRACE1("DEBUG C_Sign: ret rv=0x%lX\n", rv);
+
+    if (rv == CKR_BUFFER_TOO_SMALL) {
+        bufP = (CK_BYTE_PTR) malloc(ckSignatureLength);
+        if (bufP == NULL) {
+            throwOutOfMemoryError(env, 0);
+            return NULL;
+        }
+        rv = (*ckpFunctions->C_Sign)(ckSessionHandle, ckpData, ckDataLength,
+            bufP, &ckSignatureLength);
+    }
 
     if (ckAssertReturnValueOK(env, rv) == CK_ASSERT_OK) {
         jSignature = ckByteArrayToJByteArray(env, bufP, ckSignatureLength);

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sign.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sign.c
@@ -148,7 +148,7 @@ JNIEXPORT jbyteArray JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1Sign
         bufP = (CK_BYTE_PTR) malloc(ckSignatureLength);
         if (bufP == NULL) {
             throwOutOfMemoryError(env, 0);
-            return NULL;
+            goto cleanup;
         }
         rv = (*ckpFunctions->C_Sign)(ckSessionHandle, ckpData, ckDataLength,
             bufP, &ckSignatureLength);
@@ -159,6 +159,7 @@ JNIEXPORT jbyteArray JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1Sign
         TRACE1("DEBUG C_Sign: signature length = %lu\n", ckSignatureLength);
     }
 
+cleanup:
     free(ckpData);
     if (bufP != BUF) { free(bufP); }
 


### PR DESCRIPTION
Could someone please help review this trivial change? This is to add an error handling for the potential CKR_BUFFER_TOO_SMALL error when calling C_Sign(). Since none of the supported signature algorithms trigger this error as the default buffer size is large enough, this is more for consistency sake. No new regression test for this and thus the @noreg-hard label.

Thanks,
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282077](https://bugs.openjdk.java.net/browse/JDK-8282077): PKCS11 provider C_sign() impl should handle CKR_BUFFER_TOO_SMALL error


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7540/head:pull/7540` \
`$ git checkout pull/7540`

Update a local copy of the PR: \
`$ git checkout pull/7540` \
`$ git pull https://git.openjdk.java.net/jdk pull/7540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7540`

View PR using the GUI difftool: \
`$ git pr show -t 7540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7540.diff">https://git.openjdk.java.net/jdk/pull/7540.diff</a>

</details>
