### PR TITLE
8282142: [TestCase] compiler/inlining/ResolvedClassTest.java will fail when --with-jvm-features=-compiler1

### DIFF
--- a/test/hotspot/jtreg/compiler/inlining/ResolvedClassTest.java
+++ b/test/hotspot/jtreg/compiler/inlining/ResolvedClassTest.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8279515
  *
- * @requires vm.flagless
+ * @requires vm.flagless & vm.compiler1.enabled
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
  *

--- a/test/hotspot/jtreg/compiler/inlining/ResolvedClassTest.java
+++ b/test/hotspot/jtreg/compiler/inlining/ResolvedClassTest.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8279515
  *
- * @requires vm.flagless & vm.compMode != "Xint" & vm.compiler1.enabled & vm.compiler2.enabled
+ * @requires vm.flagless & vm.compiler1.enabled & vm.compiler2.enabled
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
  *

--- a/test/hotspot/jtreg/compiler/inlining/ResolvedClassTest.java
+++ b/test/hotspot/jtreg/compiler/inlining/ResolvedClassTest.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8279515
  *
- * @requires vm.flagless & vm.compiler1.enabled
+ * @requires vm.flagless & vm.compMode != "Xint" & vm.compiler1.enabled & vm.compiler2.enabled
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
  *


### PR DESCRIPTION
…l when --with-jvm-features=-compiler1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282142](https://bugs.openjdk.java.net/browse/JDK-8282142): [TestCase] compiler/inlining/ResolvedClassTest.java will fail when --with-jvm-features=-compiler1


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7541/head:pull/7541` \
`$ git checkout pull/7541`

Update a local copy of the PR: \
`$ git checkout pull/7541` \
`$ git pull https://git.openjdk.java.net/jdk pull/7541/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7541`

View PR using the GUI difftool: \
`$ git pr show -t 7541`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7541.diff">https://git.openjdk.java.net/jdk/pull/7541.diff</a>

</details>
