### PR TITLE
8282143: Objects.requireNonNull should be ForceInline

### DIFF
--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -227,6 +227,7 @@ public final class Objects {
      * @return {@code obj} if not {@code null}
      * @throws NullPointerException if {@code obj} is {@code null}
      */
+    @ForceInline
     public static <T> T requireNonNull(T obj) {
         if (obj == null)
             throw new NullPointerException();

--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -253,6 +253,7 @@ public final class Objects {
      * @return {@code obj} if not {@code null}
      * @throws NullPointerException if {@code obj} is {@code null}
      */
+    @ForceInline
     public static <T> T requireNonNull(T obj, String message) {
         if (obj == null)
             throw new NullPointerException(message);


### PR DESCRIPTION
Hi,

`Objects.requireNonNull` may fail to be inlined. The call is expensive and may lead to objects escaping to the heap while the null check is cheap and is often elided. I have observed this when using the vector API when a call to `Objects.requireNonNull` leads to vectors being materialised in a hot loop.

Should the other `requireNonNull` be `ForceInline` as well?

Thank you very much.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282143](https://bugs.openjdk.java.net/browse/JDK-8282143): Objects.requireNonNull should be ForceInline


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7543/head:pull/7543` \
`$ git checkout pull/7543`

Update a local copy of the PR: \
`$ git checkout pull/7543` \
`$ git pull https://git.openjdk.java.net/jdk pull/7543/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7543`

View PR using the GUI difftool: \
`$ git pr show -t 7543`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7543.diff">https://git.openjdk.java.net/jdk/pull/7543.diff</a>

</details>
