### PR TITLE
8282147: [TESTBUG] waitForIdle after creating frame in JSpinnerMouseAndKeyPressTest.java

### DIFF
--- a/test/jdk/javax/swing/JSpinner/4515999/JSpinnerMouseAndKeyPressTest.java
+++ b/test/jdk/javax/swing/JSpinner/4515999/JSpinnerMouseAndKeyPressTest.java
@@ -83,6 +83,7 @@ public class JSpinnerMouseAndKeyPressTest {
         panel.add(spinner);
         frame.add(panel);
         frame.setUndecorated(true);
+        frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
         frame.pack();
         frame.setAlwaysOnTop(true);
         frame.setLocationRelativeTo(null);
@@ -103,6 +104,7 @@ public class JSpinnerMouseAndKeyPressTest {
                     setLookAndFeel(laf);
                     createUI();
                 });
+                robot.waitForIdle();
 
                 SwingUtilities.invokeAndWait(() -> {
                     Point loc = spinner.getLocationOnScreen();


### PR DESCRIPTION
Call Robot.waitForIdle() after createUI and before getting the location of the JSpinner component in the test: javax/swing/JSpinner/4515999/JSpinnerMouseAndKeyPressTest.java.

This is needed to ensure all the events for creating and displaying the frame are processed before interacting with the components on the screen.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282147](https://bugs.openjdk.java.net/browse/JDK-8282147): [TESTBUG] waitForIdle after creating frame in JSpinnerMouseAndKeyPressTest.java


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7545/head:pull/7545` \
`$ git checkout pull/7545`

Update a local copy of the PR: \
`$ git checkout pull/7545` \
`$ git pull https://git.openjdk.java.net/jdk pull/7545/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7545`

View PR using the GUI difftool: \
`$ git pr show -t 7545`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7545.diff">https://git.openjdk.java.net/jdk/pull/7545.diff</a>

</details>
