### PR TITLE
8282158: ECParameters InvalidParameterSpecException messages missed ECKeySizeParameterSpec

### DIFF
--- a/src/java.base/share/classes/sun/security/util/ECParameters.java
+++ b/src/java.base/share/classes/sun/security/util/ECParameters.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-package sun.security.util;
+package java.security;
 
 import java.io.IOException;
 
@@ -122,9 +122,9 @@ public final class ECParameters extends AlgorithmParametersSpi {
             int keySize = ((ECKeySizeParameterSpec)paramSpec).getKeySize();
             namedCurve = CurveDB.lookup(keySize);
         } else {
-            throw new InvalidParameterSpecException
-                ("Only ECParameterSpec, ECGenParameterSpec " +
-                        "and ECKeySizeParameterSpec supported");
+            throw new InvalidParameterSpecException(
+                "Only ECParameterSpec, ECGenParameterSpec " +
+                "and ECKeySizeParameterSpec supported");
         }
 
         if (namedCurve == null) {
@@ -215,7 +215,7 @@ public final class ECParameters extends AlgorithmParametersSpi {
 
         throw new InvalidParameterSpecException(
             "Only ECParameterSpec, ECGenParameterSpec " +
-                    "and ECKeySizeParameterSpec supported");
+            "and ECKeySizeParameterSpec supported");
     }
 
     protected byte[] engineGetEncoded() throws IOException {

--- a/src/java.base/share/classes/sun/security/util/ECParameters.java
+++ b/src/java.base/share/classes/sun/security/util/ECParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,7 +123,8 @@ public final class ECParameters extends AlgorithmParametersSpi {
             namedCurve = CurveDB.lookup(keySize);
         } else {
             throw new InvalidParameterSpecException
-                ("Only ECParameterSpec and ECGenParameterSpec supported");
+                ("Only ECParameterSpec, ECGenParameterSpec " +
+                        "and ECKeySizeParameterSpec supported");
         }
 
         if (namedCurve == null) {
@@ -213,7 +214,8 @@ public final class ECParameters extends AlgorithmParametersSpi {
         }
 
         throw new InvalidParameterSpecException(
-            "Only ECParameterSpec and ECGenParameterSpec supported");
+            "Only ECParameterSpec, ECGenParameterSpec " +
+                    "and ECKeySizeParameterSpec supported");
     }
 
     protected byte[] engineGetEncoded() throws IOException {
@@ -233,4 +235,3 @@ public final class ECParameters extends AlgorithmParametersSpi {
         return namedCurve.toString();
     }
 }
-


### PR DESCRIPTION
sun.security.util.ECParameters class supports three AlgorithmParameterSpec types, exactly ECParameterSpec, ECGenParameterSpec and ECKeySizeParameterSpec, however the InvalidParameterSpecException messages missed ECKeySizeParameterSpec.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282158](https://bugs.openjdk.java.net/browse/JDK-8282158): ECParameters InvalidParameterSpecException messages missed ECKeySizeParameterSpec


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**) ⚠️ Review applies to f661203ab16925ac752c0ba8001c6865645ad530


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7550/head:pull/7550` \
`$ git checkout pull/7550`

Update a local copy of the PR: \
`$ git checkout pull/7550` \
`$ git pull https://git.openjdk.java.net/jdk pull/7550/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7550`

View PR using the GUI difftool: \
`$ git pr show -t 7550`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7550.diff">https://git.openjdk.java.net/jdk/pull/7550.diff</a>

</details>
