### PR TITLE
7017094: ParsedSynthStyle: parameter name "direction" should be changed to "tabIndex"

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/ParsedSynthStyle.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/ParsedSynthStyle.java
@@ -1935,9 +1935,9 @@ class ParsedSynthStyle extends DefaultSynthStyle {
         }
 
         public void paintTabbedPaneTabBackground(SynthContext context,
-                     Graphics g, int x, int y, int w, int h, int direction) {
+                     Graphics g, int x, int y, int w, int h, int tabIndex) {
             getPainter(context, "tabbedpanetabbackground", -1).
-                paintTabbedPaneTabBackground(context, g, x, y, w, h, direction);
+                paintTabbedPaneTabBackground(context, g, x, y, w, h, tabIndex);
         }
 
         public void paintTabbedPaneTabBackground(SynthContext context,


### PR DESCRIPTION
[SynthPainter](https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthPainter.java#L1759)
and 
[SynthPainterImpl](https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/javax/swing/plaf/nimbus/SynthPainterImpl.java#L2074)
expects a "tabIndex" although the parameter is not used currently.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-7017094](https://bugs.openjdk.java.net/browse/JDK-7017094): ParsedSynthStyle: parameter name "direction" should be changed to "tabIndex"


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7551/head:pull/7551` \
`$ git checkout pull/7551`

Update a local copy of the PR: \
`$ git checkout pull/7551` \
`$ git pull https://git.openjdk.java.net/jdk pull/7551/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7551`

View PR using the GUI difftool: \
`$ git pr show -t 7551`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7551.diff">https://git.openjdk.java.net/jdk/pull/7551.diff</a>

</details>
