### PR TITLE
8282166: JDK-8282158 changed ECParameters' package by accident

### DIFF
--- a/src/java.base/share/classes/sun/security/util/ECParameters.java
+++ b/src/java.base/share/classes/sun/security/util/ECParameters.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-package java.security;
+package sun.security.util;
 
 import java.io.IOException;
 


### PR DESCRIPTION
JDK-8282158 changed ECParameters' package from sun.security.util to java.security by accident.

So sorry for this trouble!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282166](https://bugs.openjdk.java.net/browse/JDK-8282166): JDK-8282158 changed ECParameters' package by accident


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7552/head:pull/7552` \
`$ git checkout pull/7552`

Update a local copy of the PR: \
`$ git checkout pull/7552` \
`$ git pull https://git.openjdk.java.net/jdk pull/7552/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7552`

View PR using the GUI difftool: \
`$ git pr show -t 7552`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7552.diff">https://git.openjdk.java.net/jdk/pull/7552.diff</a>

</details>
