### PR TITLE
8282190: Typo in javadoc of java.time.format.DateTimeFormatter#getDecimalStyle

### DIFF
--- a/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
@@ -1573,7 +1573,7 @@ public final class DateTimeFormatter {
     /**
      * Gets the DecimalStyle to be used during formatting.
      *
-     * @return the locale of this formatter, not null
+     * @return the DecimalStyle of this formatter, not null
      */
     public DecimalStyle getDecimalStyle() {
         return decimalStyle;


### PR DESCRIPTION
Can I please get a review of this trivial change to the javadoc of `DateTimeFormatter.getDecimalStyle()` method which fixes the typo noted in https://bugs.openjdk.java.net/browse/JDK-8282190?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282190](https://bugs.openjdk.java.net/browse/JDK-8282190): Typo in javadoc of java.time.format.DateTimeFormatter#getDecimalStyle


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7556/head:pull/7556` \
`$ git checkout pull/7556`

Update a local copy of the PR: \
`$ git checkout pull/7556` \
`$ git pull https://git.openjdk.java.net/jdk pull/7556/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7556`

View PR using the GUI difftool: \
`$ git pr show -t 7556`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7556.diff">https://git.openjdk.java.net/jdk/pull/7556.diff</a>

</details>
