### PR TITLE
8282194: C1: Missing side effects of dynamic constant linkage

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -953,7 +953,8 @@ void GraphBuilder::load_constant() {
     }
     Value x;
     if (patch_state != NULL) {
-      x = new Constant(t, patch_state);
+      bool kills_memory = stream()->is_dynamic_constant(); // arbitrary memory effects from running BSM during linkage
+      x = new Constant(t, patch_state, kills_memory);
     } else {
       x = new Constant(t);
     }

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -363,6 +363,7 @@ class Instruction: public CompilationResourceObj {
     NeedsRangeCheckFlag,
     InWorkListFlag,
     DeoptimizeOnException,
+    KillsMemoryFlag,
     InstructionLastFlag
   };
 
@@ -718,13 +719,13 @@ LEAF(Constant, Instruction)
     assert(type->is_constant(), "must be a constant");
   }
 
-  Constant(ValueType* type, ValueStack* state_before):
+  Constant(ValueType* type, ValueStack* state_before, bool kills_memory = false):
     Instruction(type, state_before, /*type_is_constant*/ true)
   {
     assert(state_before != NULL, "only used for constants which need patching");
     assert(type->is_constant(), "must be a constant");
-    // since it's patching it needs to be pinned
-    pin();
+    set_flag(KillsMemoryFlag, kills_memory);
+    pin(); // since it's patching it needs to be pinned
   }
 
   // generic
@@ -735,6 +736,8 @@ LEAF(Constant, Instruction)
   virtual bool is_equal(Value v) const;
 
   virtual ciType* exact_type() const;
+
+  bool kills_memory() const { return check_flag(KillsMemoryFlag); }
 
   enum CompareResult { not_comparable = -1, cond_false, cond_true };
 

--- a/src/hotspot/share/c1/c1_ValueMap.hpp
+++ b/src/hotspot/share/c1/c1_ValueMap.hpp
@@ -164,7 +164,12 @@ class ValueNumberingVisitor: public InstructionVisitor {
 
   void do_Phi            (Phi*             x) { /* nothing to do */ }
   void do_Local          (Local*           x) { /* nothing to do */ }
-  void do_Constant       (Constant*        x) { /* nothing to do */ }
+  void do_Constant       (Constant*        x) {
+    if (x->kills_memory()) {
+      assert(x->can_trap(), "already linked");
+      kill_memory();
+    }
+  }
   void do_LoadField      (LoadField*       x) {
     if (x->is_init_point() ||         // getstatic is an initialization point so treat it as a wide kill
         x->field()->is_volatile()) {  // the JMM requires this

--- a/src/hotspot/share/ci/ciStreams.cpp
+++ b/src/hotspot/share/ci/ciStreams.cpp
@@ -257,6 +257,14 @@ constantTag ciBytecodeStream::get_constant_pool_tag(int index) const {
 }
 
 // ------------------------------------------------------------------
+// ciBytecodeStream::get_raw_pool_tag
+//
+constantTag ciBytecodeStream::get_raw_pool_tag(int index) const {
+  VM_ENTRY_MARK;
+  return _method->get_Method()->constants()->tag_at(index);
+}
+
+// ------------------------------------------------------------------
 // ciBytecodeStream::get_basic_type_for_constant_at
 //
 BasicType ciBytecodeStream::get_basic_type_for_constant_at(int index) const {

--- a/src/hotspot/share/ci/ciStreams.hpp
+++ b/src/hotspot/share/ci/ciStreams.hpp
@@ -230,10 +230,23 @@ public:
   constantTag get_constant_pool_tag(int index) const;
   BasicType   get_basic_type_for_constant_at(int index) const;
 
+  constantTag get_raw_pool_tag(int index) const;
+
   // True if the klass-using bytecode points to an unresolved klass
   bool is_unresolved_klass() const {
     constantTag tag = get_constant_pool_tag(get_klass_index());
     return tag.is_unresolved_klass();
+  }
+
+  bool is_dynamic_constant() const {
+    assert(cur_bc() == Bytecodes::_ldc    ||
+           cur_bc() == Bytecodes::_ldc_w  ||
+           cur_bc() == Bytecodes::_ldc2_w, "not supported: %s", Bytecodes::name(cur_bc()));
+
+    int index = get_constant_pool_index();
+    constantTag tag = get_raw_pool_tag(index);
+    return tag.is_dynamic_constant() ||
+           tag.is_dynamic_constant_in_error();
   }
 
   bool is_in_error() const {


### PR DESCRIPTION
After [JDK-8280473](https://bugs.openjdk.java.net/browse/JDK-8280473), C1 handles unresolved dynamic constants by performing
constant resolution at runtime and then putting the constant value into the
generated code by patching it. But it treats the not-yet-resolved constant as a
pure value, dynamic constants are produced by user-defined bootstrap methods
and there are no guarantees that they don't have any side effects.

Proposed fix conservatively kills the whole memory state after any unresolved
dynamic constant.

Testing:
- [x] jck:vm/constantpool/resolveDynamicConstant w/ -Xcomp
- [x] hs-tier1 - hs-tier4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282194](https://bugs.openjdk.java.net/browse/JDK-8282194): C1: Missing side effects of dynamic constant linkage


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7557/head:pull/7557` \
`$ git checkout pull/7557`

Update a local copy of the PR: \
`$ git checkout pull/7557` \
`$ git pull https://git.openjdk.java.net/jdk pull/7557/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7557`

View PR using the GUI difftool: \
`$ git pr show -t 7557`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7557.diff">https://git.openjdk.java.net/jdk/pull/7557.diff</a>

</details>
