### PR TITLE
8282023: PropertiesStoreTest and StoreReproducibilityTest jtreg failures due to en_CA locale

### DIFF
--- a/test/jdk/java/util/Properties/PropertiesStoreTest.java
+++ b/test/jdk/java/util/Properties/PropertiesStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/Properties/PropertiesStoreTest.java
+++ b/test/jdk/java/util/Properties/PropertiesStoreTest.java
@@ -107,7 +107,7 @@ public class PropertiesStoreTest {
         Set<Locale> locales = Arrays.stream(Locale.getAvailableLocales())
                 .filter(l -> !l.getLanguage().isEmpty() && !l.getLanguage().equals("en"))
                 .limit(1)
-                .collect(Collectors.toCollection(() -> new HashSet<>()));
+                .collect(Collectors.toCollection(HashSet::new));
         locales.add(Locale.getDefault()); // always test the default locale
         locales.add(Locale.US); // guaranteed to be present
         locales.add(Locale.ROOT); // guaranteed to be present

--- a/test/jdk/java/util/Properties/PropertiesStoreTest.java
+++ b/test/jdk/java/util/Properties/PropertiesStoreTest.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 /*
  * @test
@@ -102,27 +103,18 @@ public class PropertiesStoreTest {
     @DataProvider(name = "localeProvider")
     private Object[][] provideLocales() {
         // pick a non-english locale for testing
-        Locale nonEnglishLocale = null;
-        for (Locale locale : Locale.getAvailableLocales()) {
-            // skip ROOT locale and ENGLISH language ones
-            if (!locale.getLanguage().isEmpty() && !locale.getLanguage().equals("en")) {
-                nonEnglishLocale = locale;
-                break;
-            }
-        }
-        if (nonEnglishLocale == null) {
-            return new Object[][] {
-                {Locale.getDefault()},
-                {Locale.US}, // guaranteed to be present
-                {Locale.ROOT}, // guaranteed to be present
-            };
-        }
-        return new Object[][]{
-                {Locale.getDefault()},
-                {Locale.US}, // guaranteed to be present
-                {Locale.ROOT}, // guaranteed to be present
-                {nonEnglishLocale}
-        };
+        Set<Locale> locales = Arrays.stream(Locale.getAvailableLocales())
+                .filter(l -> !l.getLanguage().isEmpty() && !l.getLanguage().equals("en"))
+                .limit(1)
+                .collect(Collectors.toSet());
+        locales.add(Locale.getDefault()); // always test the default locale
+        locales.add(Locale.US); // guaranteed to be present
+        locales.add(Locale.ROOT); // guaranteed to be present
+
+        // return the chosen locales
+        return locales.stream()
+                .map(m -> new Locale[] {m})
+                .toArray(n -> new Object[n][0]);
     }
 
     /**

--- a/test/jdk/java/util/Properties/PropertiesStoreTest.java
+++ b/test/jdk/java/util/Properties/PropertiesStoreTest.java
@@ -107,7 +107,6 @@ public class PropertiesStoreTest {
             // skip ROOT locale and ENGLISH language ones
             if (!locale.getLanguage().isEmpty() && !locale.getLanguage().equals("en")) {
                 nonEnglishLocale = locale;
-                System.out.println("Selected non-english locale: " + nonEnglishLocale + " for tests");
                 break;
             }
         }

--- a/test/jdk/java/util/Properties/PropertiesStoreTest.java
+++ b/test/jdk/java/util/Properties/PropertiesStoreTest.java
@@ -55,9 +55,8 @@ public class PropertiesStoreTest {
     private static final String DATE_FORMAT_PATTERN = "EEE MMM dd HH:mm:ss zzz uuuu";
     // use a neutral locale, since when the date comment was written by Properties.store(...),
     // it internally calls the Date.toString() which always writes in a locale insensitive manner
-    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN)
-            .withLocale(Locale.ROOT);
-    private static final Locale prevLocale = Locale.getDefault();
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN, Locale.ROOT);
+    private static final Locale PREV_LOCALE = Locale.getDefault();
 
     @DataProvider(name = "propsProvider")
     private Object[][] createProps() {
@@ -204,7 +203,7 @@ public class PropertiesStoreTest {
             testDateComment(tmpFile);
         } finally {
             // reset to the previous one
-            Locale.setDefault(prevLocale);
+            Locale.setDefault(PREV_LOCALE);
         }
     }
 
@@ -226,7 +225,7 @@ public class PropertiesStoreTest {
             testDateComment(tmpFile);
         } finally {
             // reset to the previous one
-            Locale.setDefault(prevLocale);
+            Locale.setDefault(PREV_LOCALE);
         }
     }
 
@@ -251,7 +250,7 @@ public class PropertiesStoreTest {
             Assert.fail("No comment line found in the stored properties file " + file);
         }
         try {
-            formatter.parse(comment);
+            FORMATTER.parse(comment);
         } catch (DateTimeParseException pe) {
             Assert.fail("Unexpected date comment: " + comment, pe);
         }

--- a/test/jdk/java/util/Properties/PropertiesStoreTest.java
+++ b/test/jdk/java/util/Properties/PropertiesStoreTest.java
@@ -37,6 +37,7 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -106,7 +107,7 @@ public class PropertiesStoreTest {
         Set<Locale> locales = Arrays.stream(Locale.getAvailableLocales())
                 .filter(l -> !l.getLanguage().isEmpty() && !l.getLanguage().equals("en"))
                 .limit(1)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(() -> new HashSet<>()));
         locales.add(Locale.getDefault()); // always test the default locale
         locales.add(Locale.US); // guaranteed to be present
         locales.add(Locale.ROOT); // guaranteed to be present

--- a/test/jdk/java/util/Properties/PropertiesStoreTest.java
+++ b/test/jdk/java/util/Properties/PropertiesStoreTest.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -47,7 +48,7 @@ import java.util.TreeSet;
  * @test
  * @summary tests the order in which the Properties.store() method writes out the properties
  * @bug 8231640
- * @run testng PropertiesStoreTest
+ * @run testng/othervm PropertiesStoreTest
  */
 public class PropertiesStoreTest {
 
@@ -88,6 +89,36 @@ public class PropertiesStoreTest {
                 {overrideCallsSuper, naturalOrder(overrideCallsSuper)},
                 {overridesEntrySet, overridesEntrySet.expectedKeyOrder()},
                 {doesNotOverrideEntrySet, naturalOrder(doesNotOverrideEntrySet)}
+        };
+    }
+
+    /**
+     * Returns a {@link Locale} to use for testing
+     */
+    @DataProvider(name = "localeProvider")
+    private Object[][] provideLocales() {
+        // pick a non-english locale for testing
+        Locale nonEnglishLocale = null;
+        for (Locale locale : Locale.getAvailableLocales()) {
+            // skip ROOT locale and ENGLISH language ones
+            if (!locale.getLanguage().isEmpty() && !locale.getLanguage().equals(Locale.ENGLISH.getLanguage())) {
+                nonEnglishLocale = locale;
+                System.out.println("Selected non-english locale: " + nonEnglishLocale + " for tests");
+                break;
+            }
+        }
+        if (nonEnglishLocale == null) {
+            return new Object[][] {
+                {Locale.getDefault()},
+                {Locale.US}, // guaranteed to be present
+                {Locale.ROOT}, // guaranteed to be present
+            };
+        }
+        return new Object[][]{
+                {Locale.getDefault()},
+                {Locale.US}, // guaranteed to be present
+                {Locale.ROOT}, // guaranteed to be present
+                {nonEnglishLocale}
         };
     }
 
@@ -153,29 +184,47 @@ public class PropertiesStoreTest {
     /**
      * Tests that {@link Properties#store(Writer, String)} writes out a proper date comment
      */
-    @Test
-    public void testStoreWriterDateComment() throws Exception {
-        final Properties props = new Properties();
-        props.setProperty("a", "b");
-        final Path tmpFile = Files.createTempFile("8231640", "props");
-        try (final Writer writer = Files.newBufferedWriter(tmpFile)) {
-            props.store(writer, null);
+    @Test(dataProvider = "localeProvider")
+    public void testStoreWriterDateComment(final Locale testLocale) throws Exception {
+        var prevLocale = Locale.getDefault();
+        // switch the default locale to the one being tested
+        Locale.setDefault(testLocale);
+        System.out.println("Using locale: " + testLocale + " for Properties#store(Writer) test");
+        try {
+            final Properties props = new Properties();
+            props.setProperty("a", "b");
+            final Path tmpFile = Files.createTempFile("8231640", "props");
+            try (final Writer writer = Files.newBufferedWriter(tmpFile)) {
+                props.store(writer, null);
+            }
+            testDateComment(tmpFile);
+        } finally {
+            // reset to the previous one
+            Locale.setDefault(prevLocale);
         }
-        testDateComment(tmpFile);
     }
 
     /**
      * Tests that {@link Properties#store(OutputStream, String)} writes out a proper date comment
      */
-    @Test
-    public void testStoreOutputStreamDateComment() throws Exception {
-        final Properties props = new Properties();
-        props.setProperty("a", "b");
-        final Path tmpFile = Files.createTempFile("8231640", "props");
-        try (final Writer writer = Files.newBufferedWriter(tmpFile)) {
-            props.store(writer, null);
+    @Test(dataProvider = "localeProvider")
+    public void testStoreOutputStreamDateComment(final Locale testLocale) throws Exception {
+        var prevLocale = Locale.getDefault();
+        // switch the default locale to the one being tested
+        Locale.setDefault(testLocale);
+        System.out.println("Using locale: " + testLocale + " for Properties#store(OutputStream) test");
+        try {
+            final Properties props = new Properties();
+            props.setProperty("a", "b");
+            final Path tmpFile = Files.createTempFile("8231640", "props");
+            try (final Writer writer = Files.newBufferedWriter(tmpFile)) {
+                props.store(writer, null);
+            }
+            testDateComment(tmpFile);
+        } finally {
+            // reset to the previous one
+            Locale.setDefault(prevLocale);
         }
-        testDateComment(tmpFile);
     }
 
     /**
@@ -199,7 +248,9 @@ public class PropertiesStoreTest {
             Assert.fail("No comment line found in the stored properties file " + file);
         }
         try {
-            DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN).parse(comment);
+            // use a neutral locale for parsing, since when the date comment was written by Properties.store(...),
+            // it internally calls the Date.toString() which always writes in a locale insensitive manner
+            DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN).withLocale(Locale.ROOT).parse(comment);
         } catch (DateTimeParseException pe) {
             Assert.fail("Unexpected date comment: " + comment, pe);
         }

--- a/test/jdk/java/util/Properties/PropertiesStoreTest.java
+++ b/test/jdk/java/util/Properties/PropertiesStoreTest.java
@@ -48,7 +48,6 @@ import java.util.TreeSet;
  * @test
  * @summary tests the order in which the Properties.store() method writes out the properties
  * @bug 8231640 8282023
- * @modules jdk.localedata
  * @run testng/othervm PropertiesStoreTest
  */
 public class PropertiesStoreTest {

--- a/test/jdk/java/util/Properties/StoreReproducibilityTest.java
+++ b/test/jdk/java/util/Properties/StoreReproducibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/Properties/StoreReproducibilityTest.java
+++ b/test/jdk/java/util/Properties/StoreReproducibilityTest.java
@@ -425,10 +425,13 @@ public class StoreReproducibilityTest {
         System.out.println("Found date comment " + dateComment + " in file " + destFile);
         final Date parsedDate;
         try {
-            Instant instant = Instant.from(DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN).parse(dateComment));
+            // use a neutral locale for parsing, since when the date comment was written by Properties.store(...),
+            // it internally calls the Date.toString() which always writes in a locale insensitive manner
+            var df = DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN).withLocale(Locale.ROOT);
+            Instant instant = Instant.from(df.parse(dateComment));
             parsedDate = new Date(instant.toEpochMilli());
         } catch (DateTimeParseException pe) {
-            throw new RuntimeException("Unexpected date " + dateComment + " in stored properties " + destFile);
+            throw new RuntimeException("Unexpected date " + dateComment + " in stored properties " + destFile, pe);
         }
         if (!parsedDate.after(date)) {
             throw new RuntimeException("Expected date comment " + dateComment + " to be after " + date

--- a/test/jdk/java/util/Properties/StoreReproducibilityTest.java
+++ b/test/jdk/java/util/Properties/StoreReproducibilityTest.java
@@ -52,8 +52,8 @@ public class StoreReproducibilityTest {
 
     private static final String DATE_FORMAT_PATTERN = "EEE MMM dd HH:mm:ss zzz uuuu";
     private static final String SYS_PROP_JAVA_PROPERTIES_DATE = "java.properties.date";
-    private static final DateTimeFormatter reproducibleDateTimeFormatter = DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN)
-            .withLocale(Locale.ROOT).withZone(ZoneOffset.UTC);
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN, Locale.ROOT)
+            .withZone(ZoneOffset.UTC);
 
     public static void main(final String[] args) throws Exception {
         // no security manager enabled
@@ -88,7 +88,7 @@ public class StoreReproducibilityTest {
      */
     private static void testWithoutSecurityManager() throws Exception {
         final List<Path> storedFiles = new ArrayList<>();
-        final String sysPropVal = reproducibleDateTimeFormatter.format(Instant.ofEpochSecond(243535322));
+        final String sysPropVal = FORMATTER.format(Instant.ofEpochSecond(243535322));
         for (int i = 0; i < 5; i++) {
             final Path tmpFile = Files.createTempFile("8231640", ".props");
             storedFiles.add(tmpFile);
@@ -130,7 +130,7 @@ public class StoreReproducibilityTest {
                 };
                 """));
         final List<Path> storedFiles = new ArrayList<>();
-        final String sysPropVal = reproducibleDateTimeFormatter.format(Instant.ofEpochSecond(1234342423));
+        final String sysPropVal = FORMATTER.format(Instant.ofEpochSecond(1234342423));
         for (int i = 0; i < 5; i++) {
             final Path tmpFile = Files.createTempFile("8231640", ".props");
             storedFiles.add(tmpFile);
@@ -174,7 +174,7 @@ public class StoreReproducibilityTest {
                 };
                 """));
         final List<Path> storedFiles = new ArrayList<>();
-        final String sysPropVal = reproducibleDateTimeFormatter.format(Instant.ofEpochSecond(1234342423));
+        final String sysPropVal = FORMATTER.format(Instant.ofEpochSecond(1234342423));
         for (int i = 0; i < 5; i++) {
             final Path tmpFile = Files.createTempFile("8231640", ".props");
             storedFiles.add(tmpFile);
@@ -425,7 +425,7 @@ public class StoreReproducibilityTest {
         System.out.println("Found date comment " + dateComment + " in file " + destFile);
         final Date parsedDate;
         try {
-            Instant instant = Instant.from(reproducibleDateTimeFormatter.parse(dateComment));
+            Instant instant = Instant.from(FORMATTER.parse(dateComment));
             parsedDate = new Date(instant.toEpochMilli());
         } catch (DateTimeParseException pe) {
             throw new RuntimeException("Unexpected date " + dateComment + " in stored properties " + destFile, pe);

--- a/test/jdk/java/util/Properties/StoreReproducibilityTest.java
+++ b/test/jdk/java/util/Properties/StoreReproducibilityTest.java
@@ -44,7 +44,7 @@ import java.util.TimeZone;
 /*
  * @test
  * @summary Tests that the Properties.store() APIs generate output that is reproducible
- * @bug 8231640
+ * @bug 8231640 8282023
  * @library /test/lib
  * @run driver StoreReproducibilityTest
  */
@@ -425,10 +425,7 @@ public class StoreReproducibilityTest {
         System.out.println("Found date comment " + dateComment + " in file " + destFile);
         final Date parsedDate;
         try {
-            // use a neutral locale for parsing, since when the date comment was written by Properties.store(...),
-            // it internally calls the Date.toString() which always writes in a locale insensitive manner
-            var df = DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN).withLocale(Locale.ROOT);
-            Instant instant = Instant.from(df.parse(dateComment));
+            Instant instant = Instant.from(reproducibleDateTimeFormatter.parse(dateComment));
             parsedDate = new Date(instant.toEpochMilli());
         } catch (DateTimeParseException pe) {
             throw new RuntimeException("Unexpected date " + dateComment + " in stored properties " + destFile, pe);


### PR DESCRIPTION
Can I please get a review of this test only change which fixes the issue noted in https://bugs.openjdk.java.net/browse/JDK-8282023?

As noted in that JBS issue these tests fail when the default locale under which those tests are run isn't `en_US`. Both these tests were introduced as part of https://bugs.openjdk.java.net/browse/JDK-8231640. At a high level, these test do the following:
- Use Properties.store(...) APIs to write out a properties file. This internally ends up writing a date comment via a call to `java.util.Date.toString()` method.
- The test then runs a few checks to make sure that the written out `Date` is an expected one. To run these checks it uses the `java.time.format.DateTimeFormatter` to parse the date comment out of the properties file.

All this works fine when the default locale is (for example) `en_US`. However, when the default locale is (for example `en_CA` or even `hi_IN`) the tests fail with an exception in the latter step above while parsing the date comment using the `DateTimeFormatter` instance. The exception looks like:

```
Using locale: he for Properties#store(OutputStream) test
test PropertiesStoreTest.testStoreOutputStreamDateComment(he): failure
java.lang.AssertionError: Unexpected date comment: Mon Feb 21 19:10:31 IST 2022
	at org.testng.Assert.fail(Assert.java:87)
	at PropertiesStoreTest.testDateComment(PropertiesStoreTest.java:255)
	at PropertiesStoreTest.testStoreOutputStreamDateComment(PropertiesStoreTest.java:223)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:577)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132)
	at org.testng.internal.TestInvoker.invokeMethod(TestInvoker.java:599)
	at org.testng.internal.TestInvoker.invokeTestMethod(TestInvoker.java:174)
	at org.testng.internal.MethodRunner.runInSequence(MethodRunner.java:46)
	at org.testng.internal.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:822)
	at org.testng.internal.TestInvoker.invokeTestMethods(TestInvoker.java:147)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:146)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:128)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.testng.TestRunner.privateRun(TestRunner.java:764)
	at org.testng.TestRunner.run(TestRunner.java:585)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:384)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:378)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:337)
	at org.testng.SuiteRunner.run(SuiteRunner.java:286)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:53)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:96)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1218)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1140)
	at org.testng.TestNG.runSuites(TestNG.java:1069)
	at org.testng.TestNG.run(TestNG.java:1037)
	at com.sun.javatest.regtest.agent.TestNGRunner.main(TestNGRunner.java:94)
	at com.sun.javatest.regtest.agent.TestNGRunner.main(TestNGRunner.java:54)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:577)
	at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
	at java.base/java.lang.Thread.run(Thread.java:828)
Caused by: java.time.format.DateTimeParseException: Text 'Mon Feb 21 19:10:31 IST 2022' could not be parsed at index 0
	at java.base/java.time.format.DateTimeFormatter.parseResolved0(DateTimeFormatter.java:2106)
	at java.base/java.time.format.DateTimeFormatter.parse(DateTimeFormatter.java:1934)
	at PropertiesStoreTest.testDateComment(PropertiesStoreTest.java:253)
	... 30 more
```
(in the exception above a locale with language `he` is being used)

The root cause of this failure lies (only) within the tests - the `DateTimeFormatter` used in the tests is locale sensitive and uses the current (`Locale.getDefault()`) locale by default for parsing the date text. This parsing fails because, although `Date.toString()` javadoc states nothing about locales, it does mention the exact characters that will be used to write out the date comment. In other words, this date comment written out is locale insensitive and as such when parsing using `DateTimeFormatter` a neutral locale is appropriate on the `DateTimeFormatter` instance. This PR thus changes the tests to use `Locale.ROOT` while parsing this date comment.  Additionally, while I was at it, I updated the `PropertiesStoreTest` to automate the use of multiple different locales to reproduce this issue (automatically) and verify the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282023](https://bugs.openjdk.java.net/browse/JDK-8282023): PropertiesStoreTest and StoreReproducibilityTest jtreg failures due to en_CA locale


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to 1d14f1c7b00bd7ad4ecea052e632fadbf888aa97
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7558/head:pull/7558` \
`$ git checkout pull/7558`

Update a local copy of the PR: \
`$ git checkout pull/7558` \
`$ git pull https://git.openjdk.java.net/jdk pull/7558/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7558`

View PR using the GUI difftool: \
`$ git pr show -t 7558`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7558.diff">https://git.openjdk.java.net/jdk/pull/7558.diff</a>

</details>
