### PR TITLE
JDK-8282200: ShouldNotReachHere() reached by AsyncGetCallTrace after JDK-8280422

### DIFF
--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -562,16 +562,14 @@ static void forte_fill_call_trace_given_top(JavaThread* thd,
 extern "C" {
 JNIEXPORT
 void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
-  JavaThread* thread;
-
-  if (trace->env_id == NULL ||
-    (thread = JavaThread::thread_from_jni_environment(trace->env_id)) == NULL ||
-    thread->is_exiting()) {
-
+    if (trace->env_id == NULL || JavaThread::is_thread_from_jni_environment_terminated(trace->env_id)) {
     // bad env_id, thread has exited or thread is exiting
     trace->num_frames = ticks_thread_exit; // -8
     return;
   }
+
+  JavaThread* thread = JavaThread::thread_from_jni_environment(trace->env_id);
+
 
   if (thread->in_deopt_handler()) {
     // thread is in the deoptimization handler so return no frames

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1321,6 +1321,8 @@ class JavaThread: public Thread {
   // Returns the current thread as indicated by the given JNIEnv.
   // We don't assert it is Thread::current here as that is done at the
   // external JNI entry points where the JNIEnv is passed into the VM.
+  // Does not return null, check is_thread_from_jni_environment_termminated()
+  // if you are not sure that it is not.
   static JavaThread* thread_from_jni_environment(JNIEnv* env) {
     JavaThread* current = (JavaThread*)((intptr_t)env - in_bytes(jni_environment_offset()));
     // We can't get here in a thread that has completed its execution and so
@@ -1333,6 +1335,20 @@ class JavaThread: public Thread {
       ShouldNotReachHere();
     }
     return current;
+  }
+
+  // Returns whether current thread as indicated by the given JNIEnv
+  // is terminated.
+  // We don't assert it is Thread::current here as that is done at the
+  // external JNI entry points where the JNIEnv is passed into the VM.
+  static bool is_thread_from_jni_environment_terminated(JNIEnv* env) {
+    JavaThread* current = (JavaThread*)((intptr_t)env - in_bytes(jni_environment_offset()));
+    // We can't get here in a thread that has completed its execution and so
+    // "is_terminated", but a thread is also considered terminated if the VM
+    // has exited, so we have to check this and block in case this is a daemon
+    // thread returning to the VM (the JNI DirectBuffer entry points rely on
+    // this).
+    return current->is_terminated();
   }
 
   // JNI critical regions. These can nest.


### PR DESCRIPTION
Fixes the mentioned bug by replacing the check in AsyncGetCallTrace using the newly introduced method `JavaThread::thread_from_jni_environment`.