### PR TITLE
8280958: G1/Parallel: Unify marking code structure

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.cpp
@@ -55,7 +55,7 @@ void G1FullGCMarker::complete_marking(OopQueueSet* oop_stacks,
                                       ObjArrayTaskQueueSet* array_stacks,
                                       TaskTerminator* terminator) {
   do {
-    drain_stack();
+    follow_marking_stacks();
     ObjArrayTask steal_array;
     if (array_stacks->steal(_worker_id, steal_array)) {
       follow_array_chunk(objArrayOop(steal_array.obj()), steal_array.index());

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.hpp
@@ -79,12 +79,12 @@ class G1FullGCMarker : public CHeapObj<mtGC> {
   inline void follow_array(objArrayOop array);
   inline void follow_array_chunk(objArrayOop array, int index);
 
-  inline void drain_oop_stack();
-  // Transfer contents from the objArray task queue overflow stack to the shared
-  // objArray stack.
+  inline void publish_and_drain_oop_tasks();
+  // Try to publish all contents from the objArray task queue overflow stack to
+  // the shared objArray stack.
   // Returns true and a valid task if there has not been enough space in the shared
-  // objArray stack, otherwise the task is invalid.
-  inline bool transfer_objArray_overflow_stack(ObjArrayTask& task);
+  // objArray stack, otherwise returns false and the task is invalid.
+  inline bool publish_or_pop_objarray_tasks(ObjArrayTask& task);
 
 public:
   G1FullGCMarker(G1FullCollector* collector,
@@ -103,7 +103,7 @@ public:
   inline void follow_klass(Klass* k);
   inline void follow_cld(ClassLoaderData* cld);
 
-  inline void drain_stack();
+  inline void follow_marking_stacks();
   void complete_marking(OopQueueSet* oop_stacks,
                         ObjArrayTaskQueueSet* array_stacks,
                         TaskTerminator* terminator);

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
@@ -184,7 +184,7 @@ void G1FullGCMarker::follow_marking_stacks() {
     // Then process ObjArrays one at a time to avoid marking stack bloat.
     ObjArrayTask task;
     if (publish_or_pop_objarray_tasks(task) ||
-      _objarray_stack.pop_local(task)) {
+        _objarray_stack.pop_local(task)) {
       follow_array_chunk(objArrayOop(task.obj()), task.index());
     }
   } while (!is_empty());

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
@@ -151,7 +151,7 @@ inline void G1FullGCMarker::follow_object(oop obj) {
   }
 }
 
-inline void G1FullGCMarker::drain_oop_stack() {
+inline void G1FullGCMarker::publish_and_drain_oop_tasks() {
   oop obj;
   while (_oop_stack.pop_overflow(obj)) {
     if (!_oop_stack.try_push_to_taskqueue(obj)) {
@@ -165,7 +165,7 @@ inline void G1FullGCMarker::drain_oop_stack() {
   }
 }
 
-inline bool G1FullGCMarker::transfer_objArray_overflow_stack(ObjArrayTask& task) {
+inline bool G1FullGCMarker::publish_or_pop_objarray_tasks(ObjArrayTask& task) {
   // It is desirable to move as much as possible work from the overflow queue to
   // the shared queue as quickly as possible.
   while (_objarray_stack.pop_overflow(task)) {
@@ -176,14 +176,14 @@ inline bool G1FullGCMarker::transfer_objArray_overflow_stack(ObjArrayTask& task)
   return false;
 }
 
-void G1FullGCMarker::drain_stack() {
+void G1FullGCMarker::follow_marking_stacks() {
   do {
     // First, drain regular oop stack.
-    drain_oop_stack();
+    publish_and_drain_oop_tasks();
 
     // Then process ObjArrays one at a time to avoid marking stack bloat.
     ObjArrayTask task;
-    if (transfer_objArray_overflow_stack(task) ||
+    if (publish_or_pop_objarray_tasks(task) ||
       _objarray_stack.pop_local(task)) {
       follow_array_chunk(objArrayOop(task.obj()), task.index());
     }

--- a/src/hotspot/share/gc/g1/g1FullGCOopClosures.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCOopClosures.cpp
@@ -36,7 +36,7 @@
 G1IsAliveClosure::G1IsAliveClosure(G1FullCollector* collector) :
   G1IsAliveClosure(collector, collector->mark_bitmap()) { }
 
-void G1FollowStackClosure::do_void() { _marker->drain_stack(); }
+void G1FollowStackClosure::do_void() { _marker->follow_marking_stacks(); }
 
 void G1FullKeepAliveClosure::do_oop(oop* p) { do_oop_work(p); }
 void G1FullKeepAliveClosure::do_oop(narrowOop* p) { do_oop_work(p); }

--- a/src/hotspot/share/gc/parallel/psCompactionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.cpp
@@ -143,7 +143,7 @@ void ParCompactionManager::follow_marking_stacks() {
     // Process ObjArrays one at a time to avoid marking stack bloat.
     ObjArrayTask task;
     if (publish_or_pop_objarray_tasks(task) ||
-      _objarray_stack.pop_local(task)) {
+        _objarray_stack.pop_local(task)) {
       follow_array((objArrayOop)task.obj(), task.index());
     }
   } while (!marking_stacks_empty());

--- a/src/hotspot/share/gc/parallel/psCompactionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.cpp
@@ -113,7 +113,19 @@ ParCompactionManager::gc_thread_compaction_manager(uint index) {
   return _manager_array[index];
 }
 
-bool ParCompactionManager::transfer_from_overflow_stack(ObjArrayTask& task) {
+inline void ParCompactionManager::publish_and_drain_oop_tasks() {
+  oop obj;
+  while (marking_stack()->pop_overflow(obj)) {
+    if (!marking_stack()->try_push_to_taskqueue(obj)) {
+      follow_contents(obj);
+    }
+  }
+  while (marking_stack()->pop_local(obj)) {
+    follow_contents(obj);
+  }
+}
+
+bool ParCompactionManager::publish_or_pop_objarray_tasks(ObjArrayTask& task) {
   while (_objarray_stack.pop_overflow(task)) {
     if (!_objarray_stack.try_push_to_taskqueue(task)) {
       return true;
@@ -126,19 +138,12 @@ void ParCompactionManager::follow_marking_stacks() {
   do {
     // First, try to move tasks from the overflow stack into the shared buffer, so
     // that other threads can steal. Otherwise process the overflow stack first.
-    oop obj;
-    while (marking_stack()->pop_overflow(obj)) {
-      if (!marking_stack()->try_push_to_taskqueue(obj)) {
-        follow_contents(obj);
-      }
-    }
-    while (marking_stack()->pop_local(obj)) {
-      follow_contents(obj);
-    }
+    publish_and_drain_oop_tasks();
 
     // Process ObjArrays one at a time to avoid marking stack bloat.
     ObjArrayTask task;
-    if (transfer_from_overflow_stack(task) || _objarray_stack.pop_local(task)) {
+    if (publish_or_pop_objarray_tasks(task) ||
+      _objarray_stack.pop_local(task)) {
       follow_array((objArrayOop)task.obj(), task.index());
     }
   } while (!marking_stacks_empty());

--- a/src/hotspot/share/gc/parallel/psCompactionManager.hpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.hpp
@@ -97,7 +97,12 @@ class ParCompactionManager : public CHeapObj<mtGC> {
 
   static void initialize(ParMarkBitMap* mbm);
 
-  bool transfer_from_overflow_stack(ObjArrayTask& task);
+  void publish_and_drain_oop_tasks();
+  // Try to publish all contents from the objArray task queue overflow stack to
+  // the shared objArray stack.
+  // Returns true and a valid task if there has not been enough space in the shared
+  // objArray stack, otherwise returns false and the task is invalid.
+  bool publish_or_pop_objarray_tasks(ObjArrayTask& task);
  protected:
   // Array of task queues.  Needed by the task terminator.
   static RegionTaskQueueSet* region_task_queues()      { return _region_task_queues; }


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that makes G1 and Parallel Full GC marking code structure a bit more similar both terms of structure as well as naming?

This allows easier comparison and unless we are going to really merge them easier to do changes. They are still a bit different for several reasons:
  * G1 Full GC can disable class unloading while Parallel Full GC always unloads classes
  * different code structure in calls: Parallel GC drains the task queues after every kind of root, G1 only does at the end of all roots
  * root processing between the two collectors is very different

All these are potential follow-ups.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280958](https://bugs.openjdk.java.net/browse/JDK-8280958): G1/Parallel: Unify marking code structure


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to 4708cc6b006a3c44bda6d7d568b8f103558117aa
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to 4708cc6b006a3c44bda6d7d568b8f103558117aa


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7561/head:pull/7561` \
`$ git checkout pull/7561`

Update a local copy of the PR: \
`$ git checkout pull/7561` \
`$ git pull https://git.openjdk.java.net/jdk pull/7561/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7561`

View PR using the GUI difftool: \
`$ git pr show -t 7561`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7561.diff">https://git.openjdk.java.net/jdk/pull/7561.diff</a>

</details>
