### PR TITLE
8281525: Enable Zc:strictStrings flag in Visual Studio build

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -133,7 +133,7 @@ AC_DEFUN([FLAGS_SETUP_WARNINGS],
       BUILD_CC_DISABLE_WARNING_PREFIX="-wd"
       CFLAGS_WARNINGS_ARE_ERRORS="-WX"
 
-      WARNINGS_ENABLE_ALL="-W3"
+      WARNINGS_ENABLE_ALL="-W3 -Zc:strictStrings"
       DISABLED_WARNINGS="4800"
       if test "x$TOOLCHAIN_VERSION" = x2017; then
         # VS2017 incorrectly triggers this warning for constexpr

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4458,7 +4458,7 @@ static errno_t get_full_path(LPCWSTR unicode_path, LPWSTR* full_path) {
   return ERROR_SUCCESS;
 }
 
-static void set_path_prefix(char* buf, LPWSTR* prefix, int* prefix_off, bool* needs_fullpath) {
+static void set_path_prefix(char* buf, LPCWSTR* prefix, int* prefix_off, bool* needs_fullpath) {
   *prefix_off = 0;
   *needs_fullpath = true;
 
@@ -4494,7 +4494,7 @@ static wchar_t* wide_abs_unc_path(char const* path, errno_t & err, int additiona
   strncpy(buf, path, buf_len);
   os::native_path(buf);
 
-  LPWSTR prefix = NULL;
+  LPCWSTR prefix = NULL;
   int prefix_off = 0;
   bool needs_fullpath = true;
   set_path_prefix(buf, &prefix, &prefix_off, &needs_fullpath);

--- a/src/java.security.jgss/windows/native/libsspi_bridge/sspi.cpp
+++ b/src/java.security.jgss/windows/native/libsspi_bridge/sspi.cpp
@@ -139,7 +139,7 @@ seconds_until(int inputIsUTC, TimeStamp *time)
 }
 
 static void
-show_time(char* label, TimeStamp* ts)
+show_time(const char* label, TimeStamp* ts)
 {
     if (trace) {
         SYSTEMTIME stLocal;
@@ -286,7 +286,7 @@ get_full_name(WCHAR* input)
     }
 
     // Always use the default domain
-    WCHAR* realm = _wgetenv(L"USERDNSDOMAIN");
+    const WCHAR* realm = _wgetenv(L"USERDNSDOMAIN");
     if (realm == NULL) {
         realm = L"";
     }
@@ -653,7 +653,7 @@ gss_acquire_cred(OM_uint32 *minor_status,
         }
         ss = AcquireCredentialsHandle(
                 NULL,
-                L"Kerberos",
+                (LPWSTR)L"Kerberos",
                 cred_usage == 0 ? SECPKG_CRED_BOTH :
                     (cred_usage == 1 ? SECPKG_CRED_OUTBOUND : SECPKG_CRED_INBOUND),
                 NULL,
@@ -683,7 +683,7 @@ gss_acquire_cred(OM_uint32 *minor_status,
         auth.PackageListLength = 8;
         ss = AcquireCredentialsHandle(
                 NULL,
-                L"Negotiate",
+                (LPWSTR)L"Negotiate",
                 cred_usage == 0 ? SECPKG_CRED_BOTH :
                     (cred_usage == 1 ? SECPKG_CRED_OUTBOUND : SECPKG_CRED_INBOUND),
                 NULL,
@@ -945,7 +945,7 @@ gss_init_sec_context(OM_uint32 *minor_status,
             auth.PackageListLength = 8;
             ss = AcquireCredentialsHandle(
                     NULL,
-                    isSPNEGO ? L"Negotiate" : L"Kerberos",
+                    (LPWSTR)(isSPNEGO ? L"Negotiate" : L"Kerberos"),
                     SECPKG_CRED_OUTBOUND,
                     NULL,
                     isSPNEGO ? &auth : NULL,

--- a/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
+++ b/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
@@ -84,7 +84,7 @@ DEF_STATIC_JNI_OnLoad
 
 void showProperty(NCRYPT_HANDLE hKey);
 
-void dump(LPSTR title, PBYTE data, DWORD len)
+void dump(LPCSTR title, PBYTE data, DWORD len)
 {
     if (trace) {
         printf("==== %s ====\n", title);
@@ -533,7 +533,7 @@ JNIEXPORT void JNICALL Java_sun_security_mscapi_CKeyStore_loadKeysOrCertificateC
             // Build certificate chain by using system certificate store.
             // Add cert chain into collection for any key usage.
             //
-            if (GetCertificateChain(OID_EKU_ANY, pCertContext, &pCertChainContext))
+            if (GetCertificateChain((LPSTR)OID_EKU_ANY, pCertContext, &pCertChainContext))
             {
                 for (DWORD i = 0; i < pCertChainContext->cChain; i++)
                 {
@@ -1267,7 +1267,7 @@ void showProperty(NCRYPT_HANDLE hKey) {
     BCryptBuffer bb;
     bb.BufferType = NCRYPTBUFFER_PKCS_SECRET;
     bb.cbBuffer = 18;
-    bb.pvBuffer = L"changeit";
+    bb.pvBuffer = (LPWSTR)L"changeit";
     BCryptBufferDesc bbd;
     bbd.ulVersion = 0;
     bbd.cBuffers = 1;

--- a/src/jdk.jpackage/windows/native/libwixhelper/libwixhelper.cpp
+++ b/src/jdk.jpackage/windows/native/libwixhelper/libwixhelper.cpp
@@ -59,7 +59,7 @@ extern "C" {
         DWORD cchSize = 0;
 
         UINT result = MsiGetProperty(hInstall, TEXT("INSTALLDIR"),
-                TEXT(""), &cchSize);
+                (LPTSTR)TEXT(""), &cchSize);
         if (result == ERROR_MORE_DATA) {
             cchSize = cchSize + 1; // NULL termination
             szValue = new TCHAR[cchSize];

--- a/test/hotspot/gtest/runtime/test_os_windows.cpp
+++ b/test/hotspot/gtest/runtime/test_os_windows.cpp
@@ -177,7 +177,7 @@ static void delete_rel_file_w(const wchar_t* path) {
   EXPECT_TRUE(result) << "Failed to delete file \"" << path << "\": " << GetLastError();
 }
 
-static bool convert_to_cstring(char* c_str, size_t size, wchar_t* w_str) {
+static bool convert_to_cstring(char* c_str, size_t size, const wchar_t* w_str) {
   size_t converted;
   errno_t err = wcstombs_s(&converted, c_str, size, w_str, size - 1);
   EXPECT_EQ(err, ERROR_SUCCESS) << "Could not convert \"" << w_str << "\" to c-string";
@@ -307,7 +307,7 @@ static void check_file_impl(wchar_t* path) {
   }
 }
 
-static void check_file_not_present_impl(wchar_t* path) {
+static void check_file_not_present_impl(const wchar_t* path) {
   char buf[JVM_MAXPATHLEN];
 
   if (convert_to_cstring(buf, JVM_MAXPATHLEN, path)) {
@@ -361,7 +361,7 @@ static void check_file(wchar_t* path) {
   }
 }
 
-static void check_file_not_present(wchar_t* path) {
+static void check_file_not_present(const wchar_t* path) {
   check_file_not_present_impl(path);
 
   for (int i = 0; mods_filter != Allow_None && i < mods_per_path; ++i) {
@@ -455,7 +455,7 @@ static void bench_path(wchar_t* path) {
   }
 }
 
-static void print_attr_result_for_path(wchar_t* path) {
+static void print_attr_result_for_path(const wchar_t* path) {
   WIN32_FILE_ATTRIBUTE_DATA file_data;
   struct stat st;
   char buf[JVM_MAXPATHLEN];
@@ -476,7 +476,7 @@ static void print_attr_result_for_path(wchar_t* path) {
   }
 }
 
-static void print_attr_result(wchar_t* format, ...) {
+static void print_attr_result(const wchar_t* format, ...) {
   va_list argptr;
   wchar_t buf[JVM_MAXPATHLEN];
 
@@ -513,10 +513,10 @@ TEST_VM(os_windows, handle_long_paths) {
   static wchar_t root_dir_path[JVM_MAXPATHLEN];
   static wchar_t root_rel_dir_path[JVM_MAXPATHLEN];
 
-  wchar_t* dir_prefix = L"os_windows_long_paths_dir_";
-  wchar_t* empty_dir_name = L"empty_directory_with_long_path";
-  wchar_t* not_empty_dir_name = L"not_empty_directory_with_long_path";
-  wchar_t* file_name = L"file";
+  const wchar_t* dir_prefix = L"os_windows_long_paths_dir_";
+  const wchar_t* empty_dir_name = L"empty_directory_with_long_path";
+  const wchar_t* not_empty_dir_name = L"not_empty_directory_with_long_path";
+  const wchar_t* file_name = L"file";
   wchar_t dir_letter;
   WIN32_FILE_ATTRIBUTE_DATA file_data;
   bool can_test_unc = false;
@@ -683,7 +683,7 @@ TEST_VM(os_windows, handle_long_paths) {
     // The other drive letter should not overwrite the original one.
     if (dir_letter) {
       static wchar_t tmp[JVM_MAXPATHLEN];
-      wchar_t* other_letter = dir_letter == L'D' ? L"C" : L"D";
+      const wchar_t* other_letter = dir_letter == L'D' ? L"C" : L"D";
       wsprintfW(tmp, L"%2ls\\..\\%ls:%ls", nearly_long_file_path, other_letter, nearly_long_file_path + 2);
       check_file_not_present(tmp);
       wsprintfW(tmp, L"%2ls\\..\\%ls:%ls", file_path, other_letter, file_path + 2);


### PR DESCRIPTION
Please review this PR that enables [Zc:strictStrings](https://docs.microsoft.com/en-us/cpp/build/reference/zc-strictstrings-disable-string-literal-type-conversion?view=msvc-170) compiler flag, which makes assigning a string literal to a non-const pointer a compile-time error.

This type of assignment produces a warning in gcc and clang.

The included code changes are trivial; I added `const` keyword to variable and parameter declarations where needed, and added casts to non-const pointers where adding `const` was not feasible.

I verified that the build passes both with and without `--enable-debug`, both with VS2017 and VS2019.