### PR TITLE
8227369: pd_disjoint_words_atomic() needs to be atomic

### DIFF
--- a/src/hotspot/cpu/ppc/copy_ppc.hpp
+++ b/src/hotspot/cpu/ppc/copy_ppc.hpp
@@ -53,7 +53,7 @@ static void pd_disjoint_words(const HeapWord* from, HeapWord* to, size_t count) 
 }
 
 static void pd_disjoint_words_atomic(const HeapWord* from, HeapWord* to, size_t count) {
-  _shared_disjoint_words_atomic(from, to, count);
+  shared_disjoint_words_atomic(from, to, count);
 }
 
 static void pd_aligned_conjoint_words(const HeapWord* from, HeapWord* to, size_t count) {

--- a/src/hotspot/cpu/ppc/copy_ppc.hpp
+++ b/src/hotspot/cpu/ppc/copy_ppc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2013 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -53,21 +53,7 @@ static void pd_disjoint_words(const HeapWord* from, HeapWord* to, size_t count) 
 }
 
 static void pd_disjoint_words_atomic(const HeapWord* from, HeapWord* to, size_t count) {
-  switch (count) {
-  case 8:  to[7] = from[7];
-  case 7:  to[6] = from[6];
-  case 6:  to[5] = from[5];
-  case 5:  to[4] = from[4];
-  case 4:  to[3] = from[3];
-  case 3:  to[2] = from[2];
-  case 2:  to[1] = from[1];
-  case 1:  to[0] = from[0];
-  case 0:  break;
-  default: while (count-- > 0) {
-             *to++ = *from++;
-           }
-           break;
-  }
+  _shared_disjoint_words_atomic(from, to, count);
 }
 
 static void pd_aligned_conjoint_words(const HeapWord* from, HeapWord* to, size_t count) {

--- a/src/hotspot/cpu/x86/copy_x86.hpp
+++ b/src/hotspot/cpu/x86/copy_x86.hpp
@@ -148,7 +148,7 @@ static void pd_disjoint_words(const HeapWord* from, HeapWord* to, size_t count) 
 
 static void pd_disjoint_words_atomic(const HeapWord* from, HeapWord* to, size_t count) {
 #ifdef AMD64
-  _shared_disjoint_words_atomic(from, to, count);
+  shared_disjoint_words_atomic(from, to, count);
 #else
   // pd_disjoint_words is word-atomic in this implementation.
   pd_disjoint_words(from, to, count);

--- a/src/hotspot/cpu/x86/copy_x86.hpp
+++ b/src/hotspot/cpu/x86/copy_x86.hpp
@@ -148,22 +148,7 @@ static void pd_disjoint_words(const HeapWord* from, HeapWord* to, size_t count) 
 
 static void pd_disjoint_words_atomic(const HeapWord* from, HeapWord* to, size_t count) {
 #ifdef AMD64
-  switch (count) {
-  case 8:  to[7] = from[7];
-  case 7:  to[6] = from[6];
-  case 6:  to[5] = from[5];
-  case 5:  to[4] = from[4];
-  case 4:  to[3] = from[3];
-  case 3:  to[2] = from[2];
-  case 2:  to[1] = from[1];
-  case 1:  to[0] = from[0];
-  case 0:  break;
-  default:
-    while (count-- > 0) {
-      *to++ = *from++;
-    }
-    break;
-  }
+  _shared_disjoint_words_atomic(from, to, count);
 #else
   // pd_disjoint_words is word-atomic in this implementation.
   pd_disjoint_words(from, to, count);

--- a/src/hotspot/cpu/zero/copy_zero.hpp
+++ b/src/hotspot/cpu/zero/copy_zero.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2007 Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -52,22 +52,7 @@ static void pd_disjoint_words(const HeapWord* from, HeapWord* to, size_t count) 
 static void pd_disjoint_words_atomic(const HeapWord* from,
                                      HeapWord* to,
                                      size_t count) {
-  switch (count) {
-  case 8:  to[7] = from[7];
-  case 7:  to[6] = from[6];
-  case 6:  to[5] = from[5];
-  case 5:  to[4] = from[4];
-  case 4:  to[3] = from[3];
-  case 3:  to[2] = from[2];
-  case 2:  to[1] = from[1];
-  case 1:  to[0] = from[0];
-  case 0:  break;
-  default:
-    while (count-- > 0) {
-      *to++ = *from++;
-    }
-    break;
-  }
+  _shared_disjoint_words_atomic(from, to, count);
 }
 
 static void pd_aligned_conjoint_words(const HeapWord* from,

--- a/src/hotspot/cpu/zero/copy_zero.hpp
+++ b/src/hotspot/cpu/zero/copy_zero.hpp
@@ -52,7 +52,7 @@ static void pd_disjoint_words(const HeapWord* from, HeapWord* to, size_t count) 
 static void pd_disjoint_words_atomic(const HeapWord* from,
                                      HeapWord* to,
                                      size_t count) {
-  _shared_disjoint_words_atomic(from, to, count);
+  shared_disjoint_words_atomic(from, to, count);
 }
 
 static void pd_aligned_conjoint_words(const HeapWord* from,

--- a/src/hotspot/os_cpu/windows_aarch64/copy_windows_aarch64.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/copy_windows_aarch64.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,21 +50,7 @@ static void pd_disjoint_words(const HeapWord* from, HeapWord* to, size_t count) 
 }
 
 static void pd_disjoint_words_atomic(const HeapWord* from, HeapWord* to, size_t count) {
-  switch (count) {
-  case 8:  to[7] = from[7];
-  case 7:  to[6] = from[6];
-  case 6:  to[5] = from[5];
-  case 5:  to[4] = from[4];
-  case 4:  to[3] = from[3];
-  case 3:  to[2] = from[2];
-  case 2:  to[1] = from[1];
-  case 1:  to[0] = from[0];
-  case 0:  break;
-  default: while (count-- > 0) {
-             *to++ = *from++;
-           }
-           break;
-  }
+  _shared_disjoint_words_atomic(from, to, count);
 }
 
 static void pd_aligned_conjoint_words(const HeapWord* from, HeapWord* to, size_t count) {

--- a/src/hotspot/os_cpu/windows_aarch64/copy_windows_aarch64.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/copy_windows_aarch64.hpp
@@ -50,7 +50,7 @@ static void pd_disjoint_words(const HeapWord* from, HeapWord* to, size_t count) 
 }
 
 static void pd_disjoint_words_atomic(const HeapWord* from, HeapWord* to, size_t count) {
-  _shared_disjoint_words_atomic(from, to, count);
+  shared_disjoint_words_atomic(from, to, count);
 }
 
 static void pd_aligned_conjoint_words(const HeapWord* from, HeapWord* to, size_t count) {

--- a/src/hotspot/share/utilities/copy.hpp
+++ b/src/hotspot/share/utilities/copy.hpp
@@ -299,8 +299,8 @@ class Copy : AllStatic {
   }
 
  protected:
-  inline static void _shared_disjoint_words_atomic(const HeapWord* from,
-                                                   HeapWord* to, size_t count) {
+  inline static void shared_disjoint_words_atomic(const HeapWord* from,
+                                                  HeapWord* to, size_t count) {
 
     switch (count) {
     case 8:  Atomic::store(&to[7], Atomic::load(&from[7]));

--- a/src/hotspot/share/utilities/copy.hpp
+++ b/src/hotspot/share/utilities/copy.hpp
@@ -26,6 +26,7 @@
 #define SHARE_UTILITIES_COPY_HPP
 
 #include "oops/oopsHierarchy.hpp"
+#include "runtime/atomic.hpp"
 #include "runtime/globals.hpp"
 #include "utilities/align.hpp"
 #include "utilities/bytes.hpp"
@@ -295,6 +296,28 @@ class Copy : AllStatic {
   // Zero bytes
   static void zero_to_bytes(void* to, size_t count) {
     pd_zero_to_bytes(to, count);
+  }
+
+ protected:
+  inline static void _shared_disjoint_words_atomic(const HeapWord* from,
+                                                   HeapWord* to, size_t count) {
+
+    switch (count) {
+    case 8:  Atomic::store(&to[7], Atomic::load(&from[7]));
+    case 7:  Atomic::store(&to[6], Atomic::load(&from[6]));
+    case 6:  Atomic::store(&to[5], Atomic::load(&from[5]));
+    case 5:  Atomic::store(&to[4], Atomic::load(&from[4]));
+    case 4:  Atomic::store(&to[3], Atomic::load(&from[3]));
+    case 3:  Atomic::store(&to[2], Atomic::load(&from[2]));
+    case 2:  Atomic::store(&to[1], Atomic::load(&from[1]));
+    case 1:  Atomic::store(&to[0], Atomic::load(&from[0]));
+    case 0:  break;
+    default:
+      while (count-- > 0) {
+        Atomic::store(to++, Atomic::load(from++));
+      }
+      break;
+    }
   }
 
  private:


### PR DESCRIPTION
Replace the common "atomic" switch+loop code chunks in the pd code with a shared version that uses Atomic::load/store.

See details in the bug report that show how current code is actually replaced by `memcpy` (in some places at least) whereas the new code is not.

Platforms affected:
 - all x86
 - Zero
 - Windows Aarch64
 - PPC

Testing: tiers 1-3
Additional builds: tiers 4 and 5
 - builds covered: x86 and Zero

GHA
- builds covered:  Windows-Aarch64

The only build affected and not tested is PPC. It would be great if someone could take this for a spin on PPC.

For platforms not affected by this change, i.e. those that already specialise the code, I make not claims regarding the atomicity or otherwise of those specialized versions. That would be for someone interested in those specific platforms to check out.

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8227369](https://bugs.openjdk.java.net/browse/JDK-8227369): pd_disjoint_words_atomic() needs to be atomic


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to a34aee31e979fc369dd0a7949917a4b317d468ae
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7567/head:pull/7567` \
`$ git checkout pull/7567`

Update a local copy of the PR: \
`$ git checkout pull/7567` \
`$ git pull https://git.openjdk.java.net/jdk pull/7567/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7567`

View PR using the GUI difftool: \
`$ git pr show -t 7567`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7567.diff">https://git.openjdk.java.net/jdk/pull/7567.diff</a>

</details>
