### PR TITLE
8282220: contentType should not be a PKCS7's member

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs/PKCS7.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,8 +52,6 @@ import sun.security.x509.*;
  * @author Benjamin Renaud
  */
 public class PKCS7 {
-
-    private ObjectIdentifier contentType;
 
     // the ASN.1 members for a signedData (and other) contentTypes
     private BigInteger version = null;
@@ -167,7 +165,7 @@ public class PKCS7 {
         throws IOException
     {
         ContentInfo block = new ContentInfo(derin, oldStyle);
-        contentType = block.contentType;
+        ObjectIdentifier contentType = block.contentType;
         DerValue content = block.getContent();
 
         if (contentType.equals(ContentInfo.SIGNED_DATA_OID)) {
@@ -240,13 +238,9 @@ public class PKCS7 {
                     bais.close();
                     bais = null;
                 }
-            } catch (CertificateException ce) {
+            } catch (CertificateException | IOException ce) {
                 ParsingException pe = new ParsingException(ce.getMessage());
                 pe.initCause(ce);
-                throw pe;
-            } catch (IOException ioe) {
-                ParsingException pe = new ParsingException(ioe.getMessage());
-                pe.initCause(ioe);
                 throw pe;
             } finally {
                 if (bais != null)
@@ -330,13 +324,9 @@ public class PKCS7 {
                         }
                         count++;
                     }
-                } catch (CertificateException ce) {
+                } catch (CertificateException | IOException ce) {
                     ParsingException pe = new ParsingException(ce.getMessage());
                     pe.initCause(ce);
-                    throw pe;
-                } catch (IOException ioe) {
-                    ParsingException pe = new ParsingException(ioe.getMessage());
-                    pe.initCause(ioe);
                     throw pe;
                 } finally {
                     if (bais != null)
@@ -444,13 +434,9 @@ public class PKCS7 {
                     bais.close();
                     bais = null;
                 }
-            } catch (CertificateException ce) {
+            } catch (CertificateException | IOException ce) {
                 ParsingException pe = new ParsingException(ce.getMessage());
                 pe.initCause(ce);
-                throw pe;
-            } catch (IOException ioe) {
-                ParsingException pe = new ParsingException(ioe.getMessage());
-                pe.initCause(ioe);
                 throw pe;
             } finally {
                 if (bais != null)


### PR DESCRIPTION
`contentType` should be a local variable because it is only used in method `parse(DerInputStream derin, boolean oldStyle)`.
This change also improves some exception catch blocks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282220](https://bugs.openjdk.java.net/browse/JDK-8282220): contentType should not be a PKCS7's member


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7568/head:pull/7568` \
`$ git checkout pull/7568`

Update a local copy of the PR: \
`$ git checkout pull/7568` \
`$ git pull https://git.openjdk.java.net/jdk pull/7568/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7568`

View PR using the GUI difftool: \
`$ git pr show -t 7568`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7568.diff">https://git.openjdk.java.net/jdk/pull/7568.diff</a>

</details>
