### PR TITLE
8282224: Correct TIG::bang_stack_shadow_pages comments

### DIFF
--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -755,8 +755,8 @@ void TemplateInterpreterGenerator::bang_stack_shadow_pages(bool native_call) {
     __ bang_stack_with_offset(p*page_size);
   }
 
-  // Record a new watermark, unless the update is above the safe limit.
-  // Otherwise, the next time around a check above would pass the safe limit.
+  // Record the new watermark, but only if update is above the safe limit.
+  // Otherwise, the next time around the check above would pass the safe limit.
   __ cmpptr(rsp, Address(thread, JavaThread::shadow_zone_safe_limit()));
   __ jccb(Assembler::belowEqual, L_done);
   __ movptr(Address(thread, JavaThread::shadow_zone_growth_watermark()), rsp);


### PR DESCRIPTION
When reviewing the RISC-V port of the change, I noticed the comment in the x86 code is worded incorrectly:

```
  // Record a new watermark, unless the update is above the safe limit.
  __ cmpptr(rsp, Address(thread, JavaThread::shadow_zone_safe_limit()));
  __ jccb(Assembler::belowEqual, L_done);
```

Stacks grow downwards, so we are recording a new watermark *when* update is above the safe limit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282224](https://bugs.openjdk.java.net/browse/JDK-8282224): Correct TIG::bang_stack_shadow_pages comments


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7569/head:pull/7569` \
`$ git checkout pull/7569`

Update a local copy of the PR: \
`$ git checkout pull/7569` \
`$ git pull https://git.openjdk.java.net/jdk pull/7569/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7569`

View PR using the GUI difftool: \
`$ git pr show -t 7569`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7569.diff">https://git.openjdk.java.net/jdk/pull/7569.diff</a>

</details>
