### PR TITLE
8282225: GHA: Allow one concurrent run per PR only

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -12,6 +12,10 @@ on:
         required: true
         default: "Linux additional (hotspot only), Linux x64, Linux x86, Windows aarch64, Windows x64, macOS x64"
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   prerequisites:
     name: Prerequisites

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -13,7 +13,7 @@ on:
         default: "Linux additional (hotspot only), Linux x64, Linux x86, Windows aarch64, Windows x64, macOS x64"
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Since last year, GHA allows concurrency control over GHA runs:
 https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/
 https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency

Our GHA workflows trigger on every PR update, sometimes doing multiple runs per PR. This is seldom useful and wastes resources with our very large jobs. For example, one can push a commit, quickly realize there is a mistake, push another commit, and this would do *two* GHA runs, both taking many hours.

I think we can say that only one run per branch is good, and all running/pending runs should be cancelled when a new run starts.

Additional testing:
 - [x] Verified queued run gets cancelled on new commit
 - [x] Verified in-progress run gets cancelled on new commit
 - [x] Verified in-progress run gets cancelled on merge
 - [x] Verified in-progress run gets cancelled on rebase + force-push

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282225](https://bugs.openjdk.java.net/browse/JDK-8282225): GHA: Allow one concurrent run per PR only


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7570/head:pull/7570` \
`$ git checkout pull/7570`

Update a local copy of the PR: \
`$ git checkout pull/7570` \
`$ git pull https://git.openjdk.java.net/jdk pull/7570/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7570`

View PR using the GUI difftool: \
`$ git pr show -t 7570`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7570.diff">https://git.openjdk.java.net/jdk/pull/7570.diff</a>

</details>
