### PR TITLE
6742362: JComponent.setFont() font comparison is not correct

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -2822,7 +2822,7 @@ public abstract class JComponent extends Container implements Serializable,
         Font oldFont = getFont();
         super.setFont(font);
         // font already bound in AWT1.2
-        if (font != oldFont) {
+        if (font != null && !font.equals(oldFont)) {
             revalidate();
             repaint();
         }


### PR DESCRIPTION
Font comparison in JComponent.setFont() uses `font != oldFont` check which is not correct as per Object equality essence. The correct way of checking font equality is to use "equals" as is done in [GlyphLayout](https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/sun/font/GlyphLayout.java#L144) , [StandardGlyphVector](https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/sun/font/StandardGlyphVector.java#L657) etc

Existing jtreg, jck test are green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-6742362](https://bugs.openjdk.java.net/browse/JDK-6742362): JComponent.setFont() font comparison is not correct


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7571/head:pull/7571` \
`$ git checkout pull/7571`

Update a local copy of the PR: \
`$ git checkout pull/7571` \
`$ git pull https://git.openjdk.java.net/jdk pull/7571/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7571`

View PR using the GUI difftool: \
`$ git pr show -t 7571`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7571.diff">https://git.openjdk.java.net/jdk/pull/7571.diff</a>

</details>
