### PR TITLE
8282094: [REDO] Parallel: Refactor PSCardTable::scavenge_contents_parallel

### DIFF
--- a/src/hotspot/share/gc/parallel/psCardTable.hpp
+++ b/src/hotspot/share/gc/parallel/psCardTable.hpp
@@ -42,6 +42,19 @@ class PSCardTable: public CardTable {
     verify_card       = CT_MR_BS_last_reserved + 5
   };
 
+  CardValue* find_first_dirty_card(CardValue* const start_card,
+                                   CardValue* const end_card);
+
+  CardValue* find_first_clean_card(ObjectStartArray* start_array,
+                                   CardValue* const start_card,
+                                   CardValue* const end_card);
+
+  void clear_cards(CardValue* const start, CardValue* const end);
+
+  void scan_objects_in_range(PSPromotionManager* pm,
+                             HeapWord* start,
+                             HeapWord* end);
+
  public:
   PSCardTable(MemRegion whole_heap) : CardTable(whole_heap) {}
 
@@ -53,8 +66,8 @@ class PSCardTable: public CardTable {
                                   MutableSpace* sp,
                                   HeapWord* space_top,
                                   PSPromotionManager* pm,
-                                  uint stripe_number,
-                                  uint stripe_total);
+                                  uint stripe_index,
+                                  uint n_stripes);
 
   bool addr_is_marked_imprecise(void *addr);
   bool addr_is_marked_precise(void *addr);


### PR DESCRIPTION
Mostly the same as [JDK-8280783](https://bugs.openjdk.java.net/browse/JDK-8280783), except one assertion is weakened.

```cpp
assert(*dirty_r == clean_card || dirty_r >= clear_limit_r);
```

Test: tier1-6
I also tried to reproduce the failures in https://bugs.openjdk.java.net/browse/JDK-8282062, but to no avail.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282094](https://bugs.openjdk.java.net/browse/JDK-8282094): [REDO] Parallel: Refactor PSCardTable::scavenge_contents_parallel


### Reviewers
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7573/head:pull/7573` \
`$ git checkout pull/7573`

Update a local copy of the PR: \
`$ git checkout pull/7573` \
`$ git pull https://git.openjdk.java.net/jdk pull/7573/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7573`

View PR using the GUI difftool: \
`$ git pr show -t 7573`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7573.diff">https://git.openjdk.java.net/jdk/pull/7573.diff</a>

</details>
