### PR TITLE
8282219: jdk/java/lang/ProcessBuilder/Basic.java fails on AIX

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -80,7 +80,9 @@ public class Basic {
     static final String libpath;
     static {
         String libpathString = System.getenv("LIBPATH");
-        if (AIX.is()) {
+        if (libpathString == null) {
+            libpathString = "";
+        } else if (AIX.is()) {
             String nativepath = System.getProperty("test.nativepath");
             if (nativepath != null) {
                 libpathString = Arrays.asList(


### PR DESCRIPTION
Run jtreg:jdk/java/lang/ProcessBuilder/Basic.java on AIX.
The test was failed by:
  Incorrect handling of envstrings containing NULs

According to my investigation, this issue was happened after following change was applied.
JDK-8272600: (test) Use native "sleep" in Basic.java

test.nativepath value was added into AIX's LIBPATH during running this testcase.
On AIX, test.nativepath value should be removed from LIBPATH value before comparing the values.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282219](https://bugs.openjdk.java.net/browse/JDK-8282219): jdk/java/lang/ProcessBuilder/Basic.java fails on AIX


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7574/head:pull/7574` \
`$ git checkout pull/7574`

Update a local copy of the PR: \
`$ git checkout pull/7574` \
`$ git pull https://git.openjdk.java.net/jdk pull/7574/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7574`

View PR using the GUI difftool: \
`$ git pr show -t 7574`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7574.diff">https://git.openjdk.java.net/jdk/pull/7574.diff</a>

</details>
