### PR TITLE
8282239 [testbug, AIX] ProcessBuilder/Basic.java fails with incorrect LIBPATH

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -1865,17 +1865,16 @@ public class Basic {
             List<String> childArgs = new ArrayList<String>(javaChildArgs);
             childArgs.add("System.getenv()");
             String[] cmdp = childArgs.toArray(new String[childArgs.size()]);
-            String[] envp;
-            String[] envpWin = {"=C:=\\", "=ExitValue=3", "SystemRoot="+systemRoot};
-            String[] envpOth = {"=ExitValue=3", "=C:=\\"};
-            if (Windows.is()) {
-                envp = envpWin;
-            } else {
-                envp = envpOth;
-            }
+            String[] envp = {
+                "=ExitValue=3",
+                "=C:=\\",
+                (AIX.is() ? "LIBPATH="+libpath : ""),
+                (Windows.is() ? "SystemRoot="+systemRoot : "")
+            };
             Process p = Runtime.getRuntime().exec(cmdp, envp);
-            String expected = Windows.is() ? "=C:=\\,=ExitValue=3,SystemRoot="+systemRoot+"," : "=C:=\\,";
-            expected = AIX.is() ? expected + "LIBPATH="+libpath+",": expected;
+            String expected = "=C:=\\," +
+                (AIX.is() ? "LIBPATH="+libpath+"," : "") +
+                (Windows.is() ? "=ExitValue=3,SystemRoot="+systemRoot+"," : "");
             String commandOutput = commandOutput(p);
             if (MacOSX.is()) {
                 commandOutput = removeMacExpectedVars(commandOutput);
@@ -1911,16 +1910,12 @@ public class Basic {
             List<String> childArgs = new ArrayList<String>(javaChildArgs);
             childArgs.add("System.getenv()");
             String[] cmdp = childArgs.toArray(new String[childArgs.size()]);
-            String[] envpWin = {"SystemRoot="+systemRoot, "LC_ALL=C\u0000\u0000", // Yuck!
-                             "FO\u0000=B\u0000R"};
-            String[] envpOth = {"LC_ALL=C\u0000\u0000", // Yuck!
-                             "FO\u0000=B\u0000R"};
-            String[] envp;
-            if (Windows.is()) {
-                envp = envpWin;
-            } else {
-                envp = envpOth;
-            }
+            String[] envp = {
+                "LC_ALL=C\u0000\u0000", // Yuck!
+                "FO\u0000=B\u0000R",
+                (AIX.is() ? "LIBPATH="+libpath : ""),
+                (Windows.is() ? "SystemRoot="+systemRoot : "")
+            };
             System.out.println ("cmdp");
             for (int i=0; i<cmdp.length; i++) {
                 System.out.printf ("cmdp %d: %s\n", i, cmdp[i]);
@@ -1937,12 +1932,10 @@ public class Basic {
             if (AIX.is()) {
                 commandOutput = removeAixExpectedVars(commandOutput);
             }
-            check(commandOutput.equals(Windows.is()
-                    ? "LC_ALL=C,SystemRoot="+systemRoot+","
-                    : AIX.is()
-                            ? "LC_ALL=C,LIBPATH="+libpath+","
-                            : "LC_ALL=C,"),
-                  "Incorrect handling of envstrings containing NULs");
+            String expected = "LC_ALL=C," +
+                (AIX.is() ? "LIBPATH="+libpath+"," : "") +
+                (Windows.is() ? "SystemRoot="+systemRoot+"," : "");
+            check(commandOutput.equals(expected), "Incorrect handling of envstrings containing NULs");
         } catch (Throwable t) { unexpected(t); }
 
         //----------------------------------------------------------------


### PR DESCRIPTION
This test had two failing sections on AIX related to an incorrect expected value for LIBPATH. The two (previously failing) test sections are below. 

- Test Runtime.exec(...envp...) with envstrings with initial `='
- Test Runtime.exec(...envp...) with envstrings containing NULs

This PR modifies the environment passed to the process at ...exec(cmdp, **envp**) to include the LIBPATH of the parent. With this change, the expected libpath matches the libpath returned by the process.

### Alternatives

An equivalent change would be to modify the libpath variable used to set the expected value for the test without explicitly setting the LIBPATH in process invocation. This would involve removing the libpath for .../jtreg/native that is added by the test runner by command-line option `-J-Dtest.nativepath=...images/test/jdk/jtreg/native \`. This change would be reasonable, but I prefer the approach taken in this PR.

### Testing

This test now passes on my test machine running AIX 7.1.