### PR TITLE
8282279: Interpret case-insensitive string locale independently

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
@@ -39,6 +39,7 @@ import java.security.spec.AlgorithmParameterSpec;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
@@ -430,7 +431,8 @@ enum SSLCipher {
             for (String entry : propvalue) {
                 int index;
                 // If this is not a UsageLimit, goto to next entry.
-                String[] values = entry.trim().toUpperCase().split(" ");
+                String[] values =
+                        entry.trim().toUpperCase(Locale.ENGLISH).split(" ");
 
                 if (values[1].contains(tag[0])) {
                     index = 0;
@@ -1865,10 +1867,10 @@ enum SSLCipher {
                 this.random = random;
 
                 keyLimitCountdown = cipherLimits.getOrDefault(
-                        algorithm.toUpperCase() + ":" + tag[0], 0L);
+                        algorithm.toUpperCase(Locale.ENGLISH) + ":" + tag[0], 0L);
                 if (SSLLogger.isOn && SSLLogger.isOn("ssl")) {
                     SSLLogger.fine("KeyLimit read side: algorithm = " +
-                            algorithm.toUpperCase() + ":" + tag[0] +
+                            algorithm.toUpperCase(Locale.ENGLISH) + ":" + tag[0] +
                             "\ncountdown value = " + keyLimitCountdown);
                 }
                 if (keyLimitCountdown > 0) {
@@ -2019,10 +2021,10 @@ enum SSLCipher {
                 this.random = random;
 
                 keyLimitCountdown = cipherLimits.getOrDefault(
-                        algorithm.toUpperCase() + ":" + tag[0], 0L);
+                        algorithm.toUpperCase(Locale.ENGLISH) + ":" + tag[0], 0L);
                 if (SSLLogger.isOn && SSLLogger.isOn("ssl")) {
                     SSLLogger.fine("KeyLimit write side: algorithm = "
-                            + algorithm.toUpperCase() + ":" + tag[0] +
+                            + algorithm.toUpperCase(Locale.ENGLISH) + ":" + tag[0] +
                             "\ncountdown value = " + keyLimitCountdown);
                 }
                 if (keyLimitCountdown > 0) {
@@ -2279,9 +2281,9 @@ enum SSLCipher {
                 this.random = random;
 
                 keyLimitCountdown = cipherLimits.getOrDefault(
-                        algorithm.toUpperCase() + ":" + tag[0], 0L);
+                        algorithm.toUpperCase(Locale.ENGLISH) + ":" + tag[0], 0L);
                 if (SSLLogger.isOn && SSLLogger.isOn("ssl")) {
-                    SSLLogger.fine("algorithm = " + algorithm.toUpperCase() +
+                    SSLLogger.fine("algorithm = " + algorithm.toUpperCase(Locale.ENGLISH) +
                             ":" + tag[0] + "\ncountdown value = " +
                             keyLimitCountdown);
                 }
@@ -2561,9 +2563,9 @@ enum SSLCipher {
                 this.random = random;
 
                 keyLimitCountdown = cipherLimits.getOrDefault(
-                        algorithm.toUpperCase() + ":" + tag[0], 0L);
+                        algorithm.toUpperCase(Locale.ENGLISH) + ":" + tag[0], 0L);
                 if (SSLLogger.isOn && SSLLogger.isOn("ssl")) {
-                    SSLLogger.fine("algorithm = " + algorithm.toUpperCase() +
+                    SSLLogger.fine("algorithm = " + algorithm.toUpperCase(Locale.ENGLISH) +
                             ":" + tag[0] + "\ncountdown value = " +
                             keyLimitCountdown);
                 }

--- a/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
@@ -783,7 +783,7 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
             for (String usage : usages) {
 
                 boolean match = false;
-                switch (usage.toLowerCase()) {
+                switch (usage.toLowerCase(Locale.ENGLISH)) {
                     case "tlsserver":
                         match = variant.equals(Validator.VAR_TLS_SERVER);
                         break;

--- a/src/java.base/share/classes/sun/security/util/SecurityProviderConstants.java
+++ b/src/java.base/share/classes/sun/security/util/SecurityProviderConstants.java
@@ -140,7 +140,8 @@ public final class SecurityProviderConstants {
                         }
                         continue;
                     }
-                    String algoName = algoAndValue[0].trim().toUpperCase();
+                    String algoName =
+                            algoAndValue[0].trim().toUpperCase(Locale.ENGLISH);
                     int value = -1;
                     try {
                         value = Integer.parseInt(algoAndValue[1].trim());

--- a/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
@@ -386,7 +386,8 @@ public class SignatureFileVerifier {
                     .jarConstraints().permits(algorithm, params, false);
             } catch (GeneralSecurityException e) {
                 permittedAlgs.put(algorithm, Boolean.FALSE);
-                permittedAlgs.put(key.toUpperCase(), Boolean.FALSE);
+                permittedAlgs.put(key.toUpperCase(Locale.ENGLISH),
+                        Boolean.FALSE);
                 if (debug != null) {
                     if (e.getMessage() != null) {
                         debug.println(key + ":  " + e.getMessage());

--- a/src/java.base/share/classes/sun/security/util/TlsChannelBinding.java
+++ b/src/java.base/share/classes/sun/security/util/TlsChannelBinding.java
@@ -31,6 +31,7 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Hashtable;
+import java.util.Locale;
 
 /**
  * This class implements the Channel Binding for TLS as defined in
@@ -101,7 +102,7 @@ public class TlsChannelBinding {
             final byte[] prefix =
                 TlsChannelBindingType.TLS_SERVER_END_POINT.getName().concat(":").getBytes();
             String hashAlg = serverCertificate.getSigAlgName().
-                    replace("SHA", "SHA-").toUpperCase();
+                    replace("SHA", "SHA-").toUpperCase(Locale.ENGLISH);
             int ind = hashAlg.indexOf("WITH");
             if (ind > 0) {
                 hashAlg = hashAlg.substring(0, ind);


### PR DESCRIPTION
The String.toUpperCase() or String.toLowerCase() method is locale sensitive, and may produce unexpected results if used for strings that are intended to be interpreted locale independently.  The use of the two methods had been cleaned before, but there are a few new introduced laterly.

See https://www.ivi.co/java/2011/07/07/4878.html for examples.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282279](https://bugs.openjdk.java.net/browse/JDK-8282279): Interpret case-insensitive string locale independently


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7583/head:pull/7583` \
`$ git checkout pull/7583`

Update a local copy of the PR: \
`$ git checkout pull/7583` \
`$ git pull https://git.openjdk.java.net/jdk pull/7583/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7583`

View PR using the GUI difftool: \
`$ git pr show -t 7583`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7583.diff">https://git.openjdk.java.net/jdk/pull/7583.diff</a>

</details>
