### PR TITLE
6911375: mouseWheel has no effect without vertical scrollbar

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollPaneUI.java
@@ -997,20 +997,30 @@ public class BasicScrollPaneUI
         // MouseWheelListener
         //
         public void mouseWheelMoved(MouseWheelEvent e) {
+            System.out.println("scrollpane.isWheelScrollingEnabled()" + scrollpane.isWheelScrollingEnabled());
             if (scrollpane.isWheelScrollingEnabled() &&
                 e.getWheelRotation() != 0) {
                 JScrollBar toScroll = scrollpane.getVerticalScrollBar();
                 int direction = e.getWheelRotation() < 0 ? -1 : 1;
                 int orientation = SwingConstants.VERTICAL;
 
+                System.out.println("toScroll.isVisible() " + toScroll.isVisible() + "e.isShiftDown()" + e.isShiftDown());
                 // find which scrollbar to scroll, or return if none
                 if (toScroll == null || !toScroll.isVisible()
                         || e.isShiftDown()) {
-                    toScroll = scrollpane.getHorizontalScrollBar();
-                    if (toScroll == null || !toScroll.isVisible()) {
+                    JScrollBar hScroll = scrollpane.getHorizontalScrollBar();
+                    if (hScroll != null) System.out.println("horiz.isVisible()" + hScroll.isVisible());
+                    if (hScroll == null) {
                         return;
+                    } else if (hScroll.isVisible()) {
+                        toScroll = hScroll;
+                        orientation = SwingConstants.HORIZONTAL;
+                    } else if (!hScroll.isVisible()) {
+                        if (e.isShiftDown()) {
+                            return;
+                        }
+                        orientation = SwingConstants.VERTICAL;
                     }
-                    orientation = SwingConstants.HORIZONTAL;
                 }
 
                 e.consume();

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollPaneUI.java
@@ -997,19 +997,16 @@ public class BasicScrollPaneUI
         // MouseWheelListener
         //
         public void mouseWheelMoved(MouseWheelEvent e) {
-            System.out.println("scrollpane.isWheelScrollingEnabled()" + scrollpane.isWheelScrollingEnabled());
             if (scrollpane.isWheelScrollingEnabled() &&
                 e.getWheelRotation() != 0) {
                 JScrollBar toScroll = scrollpane.getVerticalScrollBar();
                 int direction = e.getWheelRotation() < 0 ? -1 : 1;
                 int orientation = SwingConstants.VERTICAL;
 
-                System.out.println("toScroll.isVisible() " + toScroll.isVisible() + "e.isShiftDown()" + e.isShiftDown());
                 // find which scrollbar to scroll, or return if none
                 if (toScroll == null || !toScroll.isVisible()
                         || e.isShiftDown()) {
                     JScrollBar hScroll = scrollpane.getHorizontalScrollBar();
-                    if (hScroll != null) System.out.println("horiz.isVisible()" + hScroll.isVisible());
                     if (hScroll == null) {
                         return;
                     } else if (hScroll.isVisible()) {

--- a/test/jdk/javax/swing/JScrollPane/TestMouseWheelScroll.java
+++ b/test/jdk/javax/swing/JScrollPane/TestMouseWheelScroll.java
@@ -46,7 +46,8 @@ public class TestMouseWheelScroll {
     static Point p;
     static int width;
     static int height;
-    static Point viewPosition;
+    static volatile Point viewPosition;
+    static volatile Point newPosition;
 
     private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
         try {
@@ -77,7 +78,7 @@ public class TestMouseWheelScroll {
 
                     scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_NEVER);
                     frame.add(scrollPane);
-                    frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                    frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
                     frame.setSize(200,200);
                     frame.setLocationRelativeTo(null);
                     frame.setVisible(true);
@@ -97,8 +98,12 @@ public class TestMouseWheelScroll {
                 });
                 robot.delay(1000);
                 robot.mouseWheel(1);
+                robot.delay(500);
+                SwingUtilities.invokeAndWait(() -> {
+                    newPosition = scrollPane.getViewport().getViewPosition();
+                });
                 robot.delay(1000);
-                if (scrollPane.getViewport().getViewPosition().equals(viewPosition)) {
+                if (newPosition.equals(viewPosition)) {
                     throw new RuntimeException("Mouse wheel not handled");
                 }
             } finally {

--- a/test/jdk/javax/swing/JScrollPane/TestMouseWheelScroll.java
+++ b/test/jdk/javax/swing/JScrollPane/TestMouseWheelScroll.java
@@ -43,9 +43,9 @@ public class TestMouseWheelScroll {
 
     static JFrame frame;
     static JScrollPane scrollPane;
-    static Point p;
-    static int width;
-    static int height;
+    static volatile Point p;
+    static volatile int width;
+    static volatile int height;
     static volatile Point viewPosition;
     static volatile Point newPosition;
 
@@ -93,6 +93,7 @@ public class TestMouseWheelScroll {
                 robot.mouseMove(p.x + width / 2, p.y + height / 2);
                 robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
                 robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+                robot.waitForIdle();
                 SwingUtilities.invokeAndWait(() -> {
                     viewPosition = scrollPane.getViewport().getViewPosition();
                 });

--- a/test/jdk/javax/swing/JScrollPane/TestMouseWheelScroll.java
+++ b/test/jdk/javax/swing/JScrollPane/TestMouseWheelScroll.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import javax.swing.DefaultListModel;
+import javax.swing.ListModel;
+import javax.swing.JScrollPane;
+import javax.swing.JFrame;
+import javax.swing.JList;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+/*
+ * @test
+ * @key headful
+ * @requires (os.family != "mac")
+ * @bug  6911375
+ * @summary Verifies mouseWheel effect on JList without scrollBar
+ */
+public class TestMouseWheelScroll {
+
+    static JFrame frame;
+    static JScrollPane scrollPane;
+    static Point p;
+    static int width;
+    static int height;
+    static Point viewPosition;
+
+    private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
+        try {
+            UIManager.setLookAndFeel(laf.getClassName());
+        } catch (UnsupportedLookAndFeelException ignored) {
+            System.out.println("Unsupported L&F: " + laf.getClassName());
+        } catch (ClassNotFoundException | InstantiationException
+                 | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        for (UIManager.LookAndFeelInfo laf : UIManager.getInstalledLookAndFeels()) {
+            System.out.println("Testing L&F: " + laf.getClassName());
+            SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
+
+            try {
+                SwingUtilities.invokeAndWait(() -> {
+                    frame = new JFrame();
+                    JList list = new JList(createListModel());
+                    // disable list bindings
+                    list.getInputMap().getParent().clear();
+                    scrollPane = new JScrollPane(list);
+
+                    scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_NEVER);
+                    frame.add(scrollPane);
+                    frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                    frame.setSize(200,200);
+                    frame.setLocationRelativeTo(null);
+                    frame.setVisible(true);
+                });
+                robot.waitForIdle();
+                robot.delay(1000);
+                SwingUtilities.invokeAndWait(() -> {
+                    p = frame.getLocationOnScreen();
+                    width = frame.getWidth();
+                    height = frame.getHeight();
+                });
+                robot.mouseMove(p.x + width / 2, p.y + height / 2);
+                robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+                SwingUtilities.invokeAndWait(() -> {
+                    viewPosition = scrollPane.getViewport().getViewPosition();
+                });
+                robot.delay(1000);
+                robot.mouseWheel(1);
+                robot.delay(1000);
+                if (scrollPane.getViewport().getViewPosition().equals(viewPosition)) {
+                    throw new RuntimeException("Mouse wheel not handled");
+                }
+            } finally {
+                SwingUtilities.invokeAndWait(() -> {
+                    if (frame != null) {
+                        frame.dispose();
+                    }
+                });
+            }
+        }
+    }
+
+    private static ListModel createListModel() {
+        DefaultListModel model = new DefaultListModel();
+        for (int i = 0; i < 100; i++) {
+            model.addElement("element " + i);
+        }
+        return model;
+    }
+}


### PR DESCRIPTION
It is observed that mouseWheel doesn't scroll through a list if there is no scrollbar even though pressing PageUp/Down using keyboard moves up/down the list.
Issue stems from the fact that BasicScrollPaneUI.Handler.mouseWheelMoved() skips the mouse wheel events when the scrollbar is not visible. 
Fixed to handle mouseWheelEvent even though scrollbar is not visible with the assumption that if both vertical and horizontal scrollbar is not visible, then assume default orientation to be vertical.

Existing jtreg, jck tests are ok. All L&F works well with the fix and testcase works in all platforms except on mac which will be handled separately.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-6911375](https://bugs.openjdk.java.net/browse/JDK-6911375): mouseWheel has no effect without vertical scrollbar


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7585/head:pull/7585` \
`$ git checkout pull/7585`

Update a local copy of the PR: \
`$ git checkout pull/7585` \
`$ git pull https://git.openjdk.java.net/jdk pull/7585/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7585`

View PR using the GUI difftool: \
`$ git pr show -t 7585`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7585.diff">https://git.openjdk.java.net/jdk/pull/7585.diff</a>

</details>
