### PR TITLE
6218162: DefaultTableColumnModel.getColumn() method should mention ArrayIndexOutOfBoundsException

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/table/DefaultTableColumnModel.java
+++ b/src/java.desktop/share/classes/javax/swing/table/DefaultTableColumnModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/table/DefaultTableColumnModel.java
+++ b/src/java.desktop/share/classes/javax/swing/table/DefaultTableColumnModel.java
@@ -258,7 +258,7 @@ public class DefaultTableColumnModel implements TableColumnModel,
      * @return          the index of the first column in the
      *                  <code>tableColumns</code> array whose identifier
      *                  is equal to <code>identifier</code>
-     * @throws          IllegalArgumentException  if <code>identifier</code>
+     * @exception       IllegalArgumentException  if <code>identifier</code>
      *                          is <code>null</code>, or if no
      *                          <code>TableColumn</code> has this
      *                          <code>identifier</code>
@@ -290,7 +290,7 @@ public class DefaultTableColumnModel implements TableColumnModel,
      * @param   columnIndex     the index of the column desired
      * @return  the <code>TableColumn</code> object for the column
      *                          at <code>columnIndex</code>
-     * @exception  ArrayIndexOutOfBoundsException if <code>columnIndex</code>
+     * @throws  ArrayIndexOutOfBoundsException if <code>columnIndex</code>
      *             is out of range:
      *             (<code>columnIndex &lt; 0 || columnIndex &gt;= getColumnCount()</code>)
      */

--- a/src/java.desktop/share/classes/javax/swing/table/DefaultTableColumnModel.java
+++ b/src/java.desktop/share/classes/javax/swing/table/DefaultTableColumnModel.java
@@ -258,7 +258,7 @@ public class DefaultTableColumnModel implements TableColumnModel,
      * @return          the index of the first column in the
      *                  <code>tableColumns</code> array whose identifier
      *                  is equal to <code>identifier</code>
-     * @exception       IllegalArgumentException  if <code>identifier</code>
+     * @throws          IllegalArgumentException  if <code>identifier</code>
      *                          is <code>null</code>, or if no
      *                          <code>TableColumn</code> has this
      *                          <code>identifier</code>

--- a/src/java.desktop/share/classes/javax/swing/table/DefaultTableColumnModel.java
+++ b/src/java.desktop/share/classes/javax/swing/table/DefaultTableColumnModel.java
@@ -291,7 +291,8 @@ public class DefaultTableColumnModel implements TableColumnModel,
      * @return  the <code>TableColumn</code> object for the column
      *                          at <code>columnIndex</code>
      * @exception  ArrayIndexOutOfBoundsException if <code>columnIndex</code>
-     *             is not in valid range (< 0 or >= getColumnCount())
+     *             is out of range:
+     *             (<code>columnIndex &lt; 0 || columnIndex &gt;= getColumnCount()</code>)
      */
     public TableColumn getColumn(int columnIndex) {
         return tableColumns.elementAt(columnIndex);

--- a/src/java.desktop/share/classes/javax/swing/table/DefaultTableColumnModel.java
+++ b/src/java.desktop/share/classes/javax/swing/table/DefaultTableColumnModel.java
@@ -290,6 +290,8 @@ public class DefaultTableColumnModel implements TableColumnModel,
      * @param   columnIndex     the index of the column desired
      * @return  the <code>TableColumn</code> object for the column
      *                          at <code>columnIndex</code>
+     * @exception  ArrayIndexOutOfBoundsException if <code>columnIndex</code>
+     *             is not in valid range (< 0 or >= getColumnCount())
      */
     public TableColumn getColumn(int columnIndex) {
         return tableColumns.elementAt(columnIndex);


### PR DESCRIPTION
If invalid ie 0 or > getColumnCount() index is passed to DefaultTableColumnModel.getColumn() then it returns AIOBE in current implementation which should be documented in the spec. Fixed the spec to mention the exception.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-6218162](https://bugs.openjdk.java.net/browse/JDK-6218162): DefaultTableColumnModel.getColumn() method should mention ArrayIndexOutOfBoundsException
 * [JDK-8282378](https://bugs.openjdk.java.net/browse/JDK-8282378): DefaultTableColumnModel.getColumn() method should mention ArrayIndexOutOfBoundsException (**CSR**)


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7587/head:pull/7587` \
`$ git checkout pull/7587`

Update a local copy of the PR: \
`$ git checkout pull/7587` \
`$ git pull https://git.openjdk.java.net/jdk pull/7587/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7587`

View PR using the GUI difftool: \
`$ git pr show -t 7587`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7587.diff">https://git.openjdk.java.net/jdk/pull/7587.diff</a>

</details>
