### PR TITLE
8282299: Remove unused PartialArrayScanTask default constructor

### DIFF
--- a/src/hotspot/share/gc/shared/taskqueue.hpp
+++ b/src/hotspot/share/gc/shared/taskqueue.hpp
@@ -580,7 +580,6 @@ class PartialArrayScanTask {
   oop _src;
 
 public:
-  PartialArrayScanTask() : _src() {}
   explicit PartialArrayScanTask(oop src_array) : _src(src_array) {}
   // Trivially copyable.
 


### PR DESCRIPTION
Trivial change of removing dead code.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282299](https://bugs.openjdk.java.net/browse/JDK-8282299): Remove unused PartialArrayScanTask default constructor


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7588/head:pull/7588` \
`$ git checkout pull/7588`

Update a local copy of the PR: \
`$ git checkout pull/7588` \
`$ git pull https://git.openjdk.java.net/jdk pull/7588/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7588`

View PR using the GUI difftool: \
`$ git pr show -t 7588`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7588.diff">https://git.openjdk.java.net/jdk/pull/7588.diff</a>

</details>
