### PR TITLE
8282307: Parallel: Incorrect discovery mode in PCReferenceProcessor

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -853,7 +853,7 @@ public:
       ReferenceProcessor(is_subject_to_discovery,
       ParallelGCThreads,   // mt processing degree
       ParallelGCThreads,   // mt discovery degree
-      true,                // atomic_discovery
+      false,               // concurrent_discovery
       is_alive_non_header) {
   }
 

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -851,11 +851,10 @@ public:
     BoolObjectClosure* is_subject_to_discovery,
     BoolObjectClosure* is_alive_non_header) :
       ReferenceProcessor(is_subject_to_discovery,
-      ParallelGCThreads,   // mt processing degree
-      ParallelGCThreads,   // mt discovery degree
-      false,               // concurrent_discovery
-      is_alive_non_header) {
-  }
+                         ParallelGCThreads,   // mt processing degree
+                         ParallelGCThreads,   // mt discovery degree
+                         false,               // concurrent_discovery
+                         is_alive_non_header) {}
 
   template<typename T> bool discover(oop obj, ReferenceType type) {
     T* referent_addr = (T*) java_lang_ref_Reference::referent_addr_raw(obj);


### PR DESCRIPTION
Simple followup of [JDK-8273185](https://bugs.openjdk.java.net/browse/JDK-8273185). This bug should not affect correctness though: treating STW discovery as concurrent discovery.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282307](https://bugs.openjdk.java.net/browse/JDK-8282307): Parallel: Incorrect discovery mode in PCReferenceProcessor


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to fdf5b5266a866a36719f04f804e4be66fff2814c
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7590/head:pull/7590` \
`$ git checkout pull/7590`

Update a local copy of the PR: \
`$ git checkout pull/7590` \
`$ git pull https://git.openjdk.java.net/jdk pull/7590/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7590`

View PR using the GUI difftool: \
`$ git pr show -t 7590`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7590.diff">https://git.openjdk.java.net/jdk/pull/7590.diff</a>

</details>
