### PR TITLE
8282309: Operation before upper case conversion

### DIFF
--- a/src/java.base/share/classes/sun/security/util/TlsChannelBinding.java
+++ b/src/java.base/share/classes/sun/security/util/TlsChannelBinding.java
@@ -102,7 +102,7 @@ public class TlsChannelBinding {
             final byte[] prefix =
                 TlsChannelBindingType.TLS_SERVER_END_POINT.getName().concat(":").getBytes();
             String hashAlg = serverCertificate.getSigAlgName().
-                    replace("SHA", "SHA-").toUpperCase(Locale.ENGLISH);
+                    toUpperCase(Locale.ENGLISH).replace("SHA", "SHA-");
             int ind = hashAlg.indexOf("WITH");
             if (ind > 0) {
                 hashAlg = hashAlg.substring(0, ind);


### PR DESCRIPTION
In the TlsChannelBinding.java implementation, the string operation is placed before the case conversion. The behavior may be not expected.

```
        String hashAlg = serverCertificate.getSigAlgName().
-          replace("SHA", "SHA-").toUpperCase(Locale.ENGLISH);
+         toUpperCase(Locale.ENGLISH).replace("SHA", "SHA-");
```

See also [Bernd Eckenfels](mailto:ecki@zusammenkunft.net) comment in [PR 7583](https://github.com/openjdk/jdk/pull/7583)