### PR TITLE
JDK-8268866: Javascript when used in an iframe cannot display search results

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js.template
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js.template
@@ -359,11 +359,7 @@ $(function() {
                 } else if (ui.item.category === catSearchTags) {
                     url += ui.item.u;
                 }
-                if (top !== window) {
-                    parent.classFrame.location = pathtoroot + url;
-                } else {
-                    window.location.href = pathtoroot + url;
-                }
+                window.location.href = pathtoroot + url;
                 $("#search-input").focus();
             }
         }


### PR DESCRIPTION
Please review a trivial fix to make javadoc search work inside an `iframe`. The fix consists in removing old code that probably stems from back when javadoc used frames and doesn't work with generic iframes. 

With the fix applied the search result is opened within the `iframe` as expected. I tested on Firefox, Chrome and Safari. Labeled `noreg-hard` as we have no way of testing browser behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268866](https://bugs.openjdk.java.net/browse/JDK-8268866): Javascript when used in an iframe cannot display search results


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7594/head:pull/7594` \
`$ git checkout pull/7594`

Update a local copy of the PR: \
`$ git checkout pull/7594` \
`$ git pull https://git.openjdk.java.net/jdk pull/7594/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7594`

View PR using the GUI difftool: \
`$ git pr show -t 7594`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7594.diff">https://git.openjdk.java.net/jdk/pull/7594.diff</a>

</details>
