### PR TITLE
8282316: Operation before String case conversion

### DIFF
--- a/src/java.base/share/classes/sun/security/util/SignatureUtil.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureUtil.java
@@ -47,8 +47,8 @@ import sun.security.x509.AlgorithmId;
 public class SignatureUtil {
 
     /**
-     * Convert OID.1.2.3.4 or 1.2.3.4 to its matching stdName, and literal
-     * name to upper case.
+     * Convert OID.1.2.3.4 or 1.2.3.4 to its matching stdName, and return
+     * upper case algorithm name.
      *
      * @param algName input, could be in any form
      * @return the matching algorithm name or the OID string in upper case.

--- a/src/java.base/share/classes/sun/security/util/SignatureUtil.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureUtil.java
@@ -51,8 +51,7 @@ public class SignatureUtil {
      * name to upper case.
      *
      * @param algName input, could be in any form
-     * @return the matching stdName, or {@code algName} if it is not in the
-     *      form of an OID, or the OID value if no match is found.
+     * @return the matching algorithm name or the OID string in upper case.
      */
     private static String checkName(String algName) {
         algName = algName.toUpperCase(Locale.ENGLISH);

--- a/src/java.base/share/classes/sun/security/util/SignatureUtil.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,32 +47,40 @@ import sun.security.x509.AlgorithmId;
 public class SignatureUtil {
 
     /**
-     * Convert OID.1.2.3.4 or 1.2.3.4 to its matching stdName.
+     * Convert OID.1.2.3.4 or 1.2.3.4 to its matching stdName, and literal
+     * name to upper case.
      *
      * @param algName input, could be in any form
      * @return the matching stdName, or {@code algName} if it is not in the
      *      form of an OID, or the OID value if no match is found.
      */
     private static String checkName(String algName) {
-        if (!algName.contains(".")) {
-            return algName;
-        } else {
+        algName = algName.toUpperCase(Locale.ENGLISH);
+        if (algName.contains(".")) {
             // convert oid to String
             if (algName.startsWith("OID.")) {
                 algName = algName.substring(4);
             }
+
             KnownOIDs ko = KnownOIDs.findMatch(algName);
-            return ko != null ? ko.stdName() : algName;
+            if (ko != null) {
+                return ko.stdName().toUpperCase(Locale.ENGLISH);
+            }
         }
+
+        return algName;
     }
 
     // Utility method of creating an AlgorithmParameters object with
     // the specified algorithm name and encoding
+    //
+    // Note this method can be called only after converting OID.1.2.3.4 or
+    // 1.2.3.4 to its matching stdName, which is implemented in the
+    // checkName(String) method.
     private static AlgorithmParameters createAlgorithmParameters(String algName,
             byte[] paramBytes) throws ProviderException {
 
         try {
-            algName = checkName(algName);
             AlgorithmParameters result =
                 AlgorithmParameters.getInstance(algName);
             result.init(paramBytes);
@@ -96,7 +104,7 @@ public class SignatureUtil {
 
         AlgorithmParameterSpec paramSpec = null;
         if (params != null) {
-            sigName = checkName(sigName).toUpperCase(Locale.ENGLISH);
+            sigName = checkName(sigName);
             // AlgorithmParameters.getAlgorithm() may returns oid if it's
             // created during DER decoding. Convert to use the standard name
             // before passing it to RSAUtil
@@ -140,7 +148,7 @@ public class SignatureUtil {
         AlgorithmParameterSpec paramSpec = null;
 
         if (paramBytes != null) {
-            sigName = checkName(sigName).toUpperCase(Locale.ENGLISH);
+            sigName = checkName(sigName);
             if (sigName.contains("RSA")) {
                 AlgorithmParameters params =
                     createAlgorithmParameters(sigName, paramBytes);
@@ -313,7 +321,7 @@ public class SignatureUtil {
     public static AlgorithmParameterSpec getDefaultParamSpec(
             String sigAlg, Key k) {
         sigAlg = checkName(sigAlg);
-        if (sigAlg.equalsIgnoreCase("RSASSA-PSS")) {
+        if (sigAlg.equals("RSASSA-PSS")) {
             if (k instanceof RSAKey) {
                 AlgorithmParameterSpec spec = ((RSAKey) k).getParams();
                 if (spec instanceof PSSParameterSpec) {
@@ -428,7 +436,7 @@ public class SignatureUtil {
      */
     public static void checkKeyAndSigAlgMatch(PrivateKey key, String sAlg) {
         String kAlg = key.getAlgorithm().toUpperCase(Locale.ENGLISH);
-        sAlg = checkName(sAlg).toUpperCase(Locale.ENGLISH);
+        sAlg = checkName(sAlg);
         switch (sAlg) {
             case "RSASSA-PSS" -> {
                 if (!kAlg.equals("RSASSA-PSS")


### PR DESCRIPTION
In the SignatureUtil implementation, the checkName() requires case-insensitive input for "OID".  However, the method is called before the case conversion, for example: 

            sigName = checkName(sigName).toUpperCase(Locale.ENGLISH); 

This update also clean up redundant calls to the checkName() method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282316](https://bugs.openjdk.java.net/browse/JDK-8282316): Operation before String case conversion


### Reviewers
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**) ⚠️ Review applies to e90b730521b5bd4c07bbb1dbd76e4c8eb38c826e


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7598/head:pull/7598` \
`$ git checkout pull/7598`

Update a local copy of the PR: \
`$ git checkout pull/7598` \
`$ git pull https://git.openjdk.java.net/jdk pull/7598/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7598`

View PR using the GUI difftool: \
`$ git pr show -t 7598`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7598.diff">https://git.openjdk.java.net/jdk/pull/7598.diff</a>

</details>
