### PR TITLE
8282320: Remove case conversion for debugging log in SSLCipher

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
@@ -1867,10 +1867,10 @@ enum SSLCipher {
                 this.random = random;
 
                 keyLimitCountdown = cipherLimits.getOrDefault(
-                        algorithm.toUpperCase(Locale.ENGLISH) + ":" + tag[0], 0L);
+                    algorithm.toUpperCase(Locale.ENGLISH) + ":" + tag[0], 0L);
                 if (SSLLogger.isOn && SSLLogger.isOn("ssl")) {
                     SSLLogger.fine("KeyLimit read side: algorithm = " +
-                            algorithm.toUpperCase(Locale.ENGLISH) + ":" + tag[0] +
+                            algorithm + ":" + tag[0] +
                             "\ncountdown value = " + keyLimitCountdown);
                 }
                 if (keyLimitCountdown > 0) {
@@ -2021,10 +2021,10 @@ enum SSLCipher {
                 this.random = random;
 
                 keyLimitCountdown = cipherLimits.getOrDefault(
-                        algorithm.toUpperCase(Locale.ENGLISH) + ":" + tag[0], 0L);
+                    algorithm.toUpperCase(Locale.ENGLISH) + ":" + tag[0], 0L);
                 if (SSLLogger.isOn && SSLLogger.isOn("ssl")) {
                     SSLLogger.fine("KeyLimit write side: algorithm = "
-                            + algorithm.toUpperCase(Locale.ENGLISH) + ":" + tag[0] +
+                            + algorithm + ":" + tag[0] +
                             "\ncountdown value = " + keyLimitCountdown);
                 }
                 if (keyLimitCountdown > 0) {
@@ -2281,9 +2281,9 @@ enum SSLCipher {
                 this.random = random;
 
                 keyLimitCountdown = cipherLimits.getOrDefault(
-                        algorithm.toUpperCase(Locale.ENGLISH) + ":" + tag[0], 0L);
+                    algorithm.toUpperCase(Locale.ENGLISH) + ":" + tag[0], 0L);
                 if (SSLLogger.isOn && SSLLogger.isOn("ssl")) {
-                    SSLLogger.fine("algorithm = " + algorithm.toUpperCase(Locale.ENGLISH) +
+                    SSLLogger.fine("algorithm = " + algorithm +
                             ":" + tag[0] + "\ncountdown value = " +
                             keyLimitCountdown);
                 }
@@ -2563,9 +2563,9 @@ enum SSLCipher {
                 this.random = random;
 
                 keyLimitCountdown = cipherLimits.getOrDefault(
-                        algorithm.toUpperCase(Locale.ENGLISH) + ":" + tag[0], 0L);
+                    algorithm.toUpperCase(Locale.ENGLISH) + ":" + tag[0], 0L);
                 if (SSLLogger.isOn && SSLLogger.isOn("ssl")) {
-                    SSLLogger.fine("algorithm = " + algorithm.toUpperCase(Locale.ENGLISH) +
+                    SSLLogger.fine("algorithm = " + algorithm +
                             ":" + tag[0] + "\ncountdown value = " +
                             keyLimitCountdown);
                 }


### PR DESCRIPTION
String.toUpperCase() is used in SSLCipher.java for debugging logging, which is not necessary. See also comment in [this PR](https://github.com/openjdk/jdk/pull/7583).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282320](https://bugs.openjdk.java.net/browse/JDK-8282320): Remove case conversion for debugging log in SSLCipher


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7600/head:pull/7600` \
`$ git checkout pull/7600`

Update a local copy of the PR: \
`$ git checkout pull/7600` \
`$ git pull https://git.openjdk.java.net/jdk pull/7600/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7600`

View PR using the GUI difftool: \
`$ git pr show -t 7600`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7600.diff">https://git.openjdk.java.net/jdk/pull/7600.diff</a>

</details>
