### PR TITLE
8276687: Remove support for JDK 1.4.1 PerfData shared memory files

### DIFF
--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/LocalVmManager.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/LocalVmManager.java
@@ -67,15 +67,6 @@ public class LocalVmManager {
                 return userDirFilePattern.matcher(name).matches();
             }
         };
-
-        // 1.4.1 (or earlier?): the files are stored directly under {tmpdir}/ with
-        // the following pattern.
-        Pattern oldtmpFilePattern = Pattern.compile(PerfDataFile.tmpFileNamePattern);
-        oldtmpFileFilter = new FilenameFilter() {
-            public boolean accept(File dir, String name) {
-                return oldtmpFilePattern.matcher(name).matches();
-            }
-        };
     }
 
     /**

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/LocalVmManager.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/LocalVmManager.java
@@ -67,6 +67,15 @@ public class LocalVmManager {
                 return userDirFilePattern.matcher(name).matches();
             }
         };
+
+        // 1.4.1 (or earlier?): the files are stored directly under {tmpdir}/ with
+        // the following pattern.
+        Pattern oldtmpFilePattern = Pattern.compile(PerfDataFile.tmpFileNamePattern);
+        oldtmpFileFilter = new FilenameFilter() {
+            public boolean accept(File dir, String name) {
+                return oldtmpFilePattern.matcher(name).matches();
+            }
+        };
     }
 
     /**

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/PerfDataFile.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/monitor/protocol/local/PerfDataFile.java
@@ -69,16 +69,6 @@ public class PerfDataFile {
     public static final String fileNamePattern = "^[0-9]+$";
 
     /**
-     * The file name pattern for 1.4.1 PerfData shared memory files.
-     * <p>
-     * This pattern must be kept in synch with the file name pattern
-     * used by the 1.4.1 HotSpot JVM.
-     */
-    public static final String tmpFileNamePattern =
-            "^hsperfdata_[0-9]+(_[1-2]+)?$";
-
-
-    /**
      * Platform Specific methods for looking up temporary directories
      * and process IDs.
      */


### PR DESCRIPTION
Removed the file name pattern for 1.4.1 PerfData since the Hotspot JVM 1.4.1 is no longer supported.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8276687](https://bugs.openjdk.java.net/browse/JDK-8276687): Remove support for JDK 1.4.1 PerfData shared memory files


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7602/head:pull/7602` \
`$ git checkout pull/7602`

Update a local copy of the PR: \
`$ git checkout pull/7602` \
`$ git pull https://git.openjdk.java.net/jdk pull/7602/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7602`

View PR using the GUI difftool: \
`$ git pr show -t 7602`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7602.diff">https://git.openjdk.java.net/jdk/pull/7602.diff</a>

</details>
