### PR TITLE
JDK-8281944: JavaDoc throws java.lang.IllegalStateException: ERRONEOUS

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -1010,6 +1010,10 @@ public class HtmlDocletWriter {
                         // @see reference label...
                         label = ref.subList(1, ref.size());
                     }
+                    case ERRONEOUS -> {
+                        return invalidTagOutput(resources.getText("doclet.tag.invalid_input", seeText),
+                                Optional.empty());
+                    }
                     default ->
                         throw new IllegalStateException(ref.get(0).getKind().toString());
                 }

--- a/test/langtools/jdk/javadoc/doclet/testSeeTag/TestSeeTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSeeTag/TestSeeTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testSeeTag/TestSeeTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSeeTag/TestSeeTag.java
@@ -23,15 +23,19 @@
 
 /*
  * @test
- * @bug      8017191 8182765 8200432 8239804 8250766 8262992
+ * @bug      8017191 8182765 8200432 8239804 8250766 8262992 8281944
  * @summary  Javadoc is confused by at-link to imported classes outside of the set of generated packages
- * @library  ../../lib
+ * @library  /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
- * @build    javadoc.tester.*
+ * @build    toolbox.ToolBox javadoc.tester.*
  * @run main TestSeeTag
  */
 
 import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+import java.io.IOException;
+import java.nio.file.Path;
 
 public class TestSeeTag extends JavadocTester {
 
@@ -109,5 +113,41 @@ public class TestSeeTag extends JavadocTester {
                     </ul>
                     </dd>
                     </dl>""");
+    }
+
+    ToolBox tb = new ToolBox();
+
+    @Test
+    public void testErroneous() throws IOException {
+        Path src = Path.of("erroneous", "src");
+        tb.writeJavaFiles(src, """
+                package erroneous;
+                /**
+                 * Comment.
+                 * @see <a href="
+                 */
+                public class C {
+                    private C() { }
+                }
+                """);
+
+        javadoc("-d", Path.of("erroneous", "api").toString(),
+                "-sourcepath", src.toString(),
+                "--no-platform-links",
+                "erroneous");
+        checkExit(Exit.ERROR);
+
+        checkOutput("erroneous/C.html", true,
+                """
+                    <dl class="notes">
+                    <dt>See Also:</dt>
+                    <dd>
+                    <ul class="see-list">
+                    <li><span class="invalid-tag">invalid input: '&lt;a href="'</span></li>
+                    </ul>
+                    </dd>
+                    </dl>
+                    """);
+
     }
 }


### PR DESCRIPTION
Please review a simple change to handle erroneous content in an `@see` tag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281944](https://bugs.openjdk.java.net/browse/JDK-8281944): JavaDoc throws java.lang.IllegalStateException: ERRONEOUS


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.java.net/census#hannesw) (@hns - **Reviewer**) ⚠️ Review applies to 3592da9bae5c1090950b2977ac68392be8feb1da


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7603/head:pull/7603` \
`$ git checkout pull/7603`

Update a local copy of the PR: \
`$ git checkout pull/7603` \
`$ git pull https://git.openjdk.java.net/jdk pull/7603/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7603`

View PR using the GUI difftool: \
`$ git pr show -t 7603`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7603.diff">https://git.openjdk.java.net/jdk/pull/7603.diff</a>

</details>
