### PR TITLE
8267796: vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t002/TestDescription.java fails with NoClassDefFoundError

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t002.java
@@ -156,8 +156,6 @@ class hs201t002Thread extends Thread {
         setName("hs201t002Thread");
     }
 
-    
-
     public void run() {
         // run method
         ready.countDown();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 package nsk.jvmti.scenarios.hotswap.HS201;
 
 import java.io.PrintStream;
+import java.util.concurrent.CountDownLatch;
 
 import nsk.share.*;
 import nsk.share.jvmti.*;
@@ -73,13 +74,21 @@ public class hs201t002 extends DebugeeClass {
         timeout = argHandler.getWaitTime() * 60 * 1000; // milliseconds
 
         log.display(">>> starting tested thread");
-        Thread thread = new hs201t002Thread();
+        hs201t002Thread thread = new hs201t002Thread();
 
         // testing sync
         status = checkStatus(status);
 
-        setThread(thread);
         thread.start();
+
+        // enable events requires live thread
+        try {
+            thread.ready.await();
+        } catch (InterruptedException e) {
+        }
+        setThread(thread);
+
+        thread.go.countDown();
 
         while (currentStep != 4) {
             try {
@@ -114,6 +123,10 @@ public class hs201t002 extends DebugeeClass {
             }
 
             log.display("Thread suspended in a wrong moment. Retrying...");
+            for (int i = 0; i < stackTrace.length; i++) {
+                log.display("\t" + i + ". " + stackTrace[i]);
+            }
+            log.display("Retrying...");
             resumeThread(thread);
             suspendTry++;
             // Test thread will be suspended at the top of the loop. Let it run for a while.
@@ -136,12 +149,22 @@ public class hs201t002 extends DebugeeClass {
 
 class hs201t002Thread extends Thread {
 
+    CountDownLatch ready = new CountDownLatch(1);
+    CountDownLatch go = new CountDownLatch(1);
+
     hs201t002Thread() {
         setName("hs201t002Thread");
     }
 
+    
+
     public void run() {
         // run method
+        ready.countDown();
+        try {
+            go.await();
+        } catch (InterruptedException e) {
+        }
         try {
             throwException();
         } catch (Exception e) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t002.java
@@ -81,7 +81,8 @@ public class hs201t002 extends DebugeeClass {
 
         thread.start();
 
-        // enable events requires live thread
+        // setThread(thread) enables JVMTI events, and that can only be done on a live thread,
+        // so wait until the thread has started.
         try {
             thread.ready.await();
         } catch (InterruptedException e) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t002/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,7 @@
  *      newclass
  *
  * @run main/othervm/native
- *      -agentlib:hs201t002=pathToNewByteCode=./bin,-waittime=5
- *      nsk.jvmti.scenarios.hotswap.HS201.hs201t002
+ *      -agentlib:hs201t002=pathToNewByteCode=./bin,-waittime=5,-verbose
+ *      nsk.jvmti.scenarios.hotswap.HS201.hs201t002 -verbose
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t002/newclass/hs201t002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t002/newclass/hs201t002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package nsk.jvmti.scenarios.hotswap.HS201;
 public class hs201t002a extends Exception {
 
     public hs201t002a () {
+        System.out.println("Current step: " + hs201t002.currentStep); // Avoid calling classloader to find hs201t002 in doInit()
         doInit();
     }
 


### PR DESCRIPTION
The fix adds workaround in hs201t001a class like we have in hs201t001 test to avoid class loading while the test do single stepping/pop frame.
Also fixed a number of issues in the test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267796](https://bugs.openjdk.java.net/browse/JDK-8267796): vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t002/TestDescription.java fails with NoClassDefFoundError


### Reviewers
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to 404d421abc60a8b777eccfda2c4097a9eef59387
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7607/head:pull/7607` \
`$ git checkout pull/7607`

Update a local copy of the PR: \
`$ git checkout pull/7607` \
`$ git pull https://git.openjdk.java.net/jdk pull/7607/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7607`

View PR using the GUI difftool: \
`$ git pr show -t 7607`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7607.diff">https://git.openjdk.java.net/jdk/pull/7607.diff</a>

</details>
