### PR TITLE
8282240: Add _name field to Method for NOT_PRODUCT only

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -2741,6 +2741,7 @@ Method* ClassFileParser::parse_method(const ClassFileStream* const cfs,
                                      access_flags,
                                      &sizes,
                                      ConstMethod::NORMAL,
+                                     _cp->symbol_at(name_index),
                                      CHECK_NULL);
 
   ClassLoadingService::add_class_method_size(m->size()*wordSize);
@@ -2748,7 +2749,6 @@ Method* ClassFileParser::parse_method(const ClassFileStream* const cfs,
   // Fill in information from fixed part (access_flags already set)
   m->set_constants(_cp);
   m->set_name_index(name_index);
-  m->set_name();
   m->set_signature_index(signature_index);
   m->compute_from_signature(cp->symbol_at(signature_index));
   assert(args_size < 0 || args_size == m->size_of_parameters(), "");

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2748,6 +2748,7 @@ Method* ClassFileParser::parse_method(const ClassFileStream* const cfs,
   // Fill in information from fixed part (access_flags already set)
   m->set_constants(_cp);
   m->set_name_index(name_index);
+  m->set_name();
   m->set_signature_index(signature_index);
   m->compute_from_signature(cp->symbol_at(signature_index));
   assert(args_size < 0 || args_size == m->size_of_parameters(), "");

--- a/src/hotspot/share/classfile/defaultMethods.cpp
+++ b/src/hotspot/share/classfile/defaultMethods.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -931,10 +931,12 @@ static void switchover_constant_pool(BytecodeConstantPool* bpool,
 
       for (int i = 0; i < new_methods->length(); ++i) {
         new_methods->at(i)->set_constants(cp);
+        new_methods->at(i)->set_name();
       }
       for (int i = 0; i < klass->methods()->length(); ++i) {
         Method* mo = klass->methods()->at(i);
         mo->set_constants(cp);
+        mo->set_name();
       }
     }
   }

--- a/src/hotspot/share/classfile/defaultMethods.cpp
+++ b/src/hotspot/share/classfile/defaultMethods.cpp
@@ -900,7 +900,7 @@ static Method* new_method(
 
   Method* m = Method::allocate(cp->pool_holder()->class_loader_data(),
                                code_length, flags, &sizes,
-                               mt, CHECK_NULL);
+                               mt, name, CHECK_NULL);
 
   m->set_constants(NULL); // This will get filled in later
   m->set_name_index(cp->utf8(name));
@@ -931,12 +931,10 @@ static void switchover_constant_pool(BytecodeConstantPool* bpool,
 
       for (int i = 0; i < new_methods->length(); ++i) {
         new_methods->at(i)->set_constants(cp);
-        new_methods->at(i)->set_name();
       }
       for (int i = 0; i < klass->methods()->length(); ++i) {
         Method* mo = klass->methods()->at(i);
         mo->set_constants(cp);
-        mo->set_name();
       }
     }
   }

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -119,6 +119,8 @@ Method::Method(ConstMethod* xconst, AccessFlags access_flags) {
   }
 
   NOT_PRODUCT(set_compiled_invocation_count(0);)
+  // Name is very useful for debugging but needs to be set later.
+  NOT_PRODUCT(_name = NULL;)
 }
 
 // Release Method*.  The nmethod will be gone when we get here because
@@ -1451,6 +1453,7 @@ methodHandle Method::make_method_handle_intrinsic(vmIntrinsics::ID iid,
   }
   m->set_constants(cp());
   m->set_name_index(_imcp_invoke_name);
+  m->set_name();
   m->set_signature_index(_imcp_invoke_signature);
   assert(MethodHandles::is_signature_polymorphic_name(m->name()), "");
   assert(m->signature() == signature, "");

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -396,6 +396,7 @@ void Method::metaspace_pointers_do(MetaspaceClosure* it) {
   }
   it->push(&_method_data);
   it->push(&_method_counters);
+  NOT_PRODUCT(it->push(&_name);)
 }
 
 // Attempt to return method to original state.  Clear any pointers

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -119,7 +119,8 @@ Method::Method(ConstMethod* xconst, AccessFlags access_flags) {
   }
 
   NOT_PRODUCT(set_compiled_invocation_count(0);)
-  // Name is very useful for debugging but needs to be set later.
+  // Name is very useful for debugging but needs to be set later, after
+  // the _constants field is set to point to the ConstantPool.
   NOT_PRODUCT(_name = NULL;)
 }
 

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,6 +98,8 @@ class Method : public Metadata {
 
 #ifndef PRODUCT
   int64_t _compiled_invocation_count;
+
+  Symbol* _name;
 #endif
   // Entry point for calling both from and to the interpreter.
   address _i2i_entry;           // All-args-on-stack calling convention
@@ -149,6 +151,8 @@ class Method : public Metadata {
   Symbol* name() const                           { return constants()->symbol_at(name_index()); }
   int name_index() const                         { return constMethod()->name_index();         }
   void set_name_index(int index)                 { constMethod()->set_name_index(index);       }
+
+  void set_name()                                { NOT_PRODUCT(_name = name()); }
 
   // signature
   Symbol* signature() const                      { return constants()->symbol_at(signature_index()); }

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -69,6 +69,7 @@ class InterpreterOopMap;
 class Method : public Metadata {
  friend class VMStructs;
  friend class JVMCIVMStructs;
+ friend class MethodTest;
  private:
   // If you add a new field that points to any metaspace object, you
   // must add this field to Method::metaspace_pointers_do().
@@ -115,7 +116,7 @@ class Method : public Metadata {
   volatile address           _from_interpreted_entry; // Cache of _code ? _adapter->i2c_entry() : _i2i_entry
 
   // Constructor
-  Method(ConstMethod* xconst, AccessFlags access_flags);
+  Method(ConstMethod* xconst, AccessFlags access_flags, Symbol* name);
  public:
 
   static Method* allocate(ClassLoaderData* loader_data,
@@ -123,6 +124,7 @@ class Method : public Metadata {
                           AccessFlags access_flags,
                           InlineTableSizes* sizes,
                           ConstMethod::MethodType method_type,
+                          Symbol* name,
                           TRAPS);
 
   // CDS and vtbl checking can create an empty Method to get vtbl pointer.
@@ -151,8 +153,6 @@ class Method : public Metadata {
   Symbol* name() const                           { return constants()->symbol_at(name_index()); }
   int name_index() const                         { return constMethod()->name_index();         }
   void set_name_index(int index)                 { constMethod()->set_name_index(index);       }
-
-  void set_name()                                { NOT_PRODUCT(_name = name()); }
 
   // signature
   Symbol* signature() const                      { return constants()->symbol_at(signature_index()); }

--- a/test/hotspot/gtest/oops/test_instanceKlass.cpp
+++ b/test/hotspot/gtest/oops/test_instanceKlass.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,11 +22,14 @@
  */
 
 #include "precompiled.hpp"
+#include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionary.hpp"
 #include "classfile/vmClasses.hpp"
+#include "classfile/vmSymbols.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/instanceKlass.hpp"
 #include "oops/klass.inline.hpp"
+#include "oops/method.hpp"
 #include "unittest.hpp"
 
 // Tests for InstanceKlass::is_class_loader_instance_klass() function
@@ -62,3 +65,21 @@ TEST_VM(InstanceKlass, class_loader_printer) {
   ASSERT_TRUE(strstr(st.as_string(), "'java/lang/ClassLoader'") != NULL) << "Must be in ClassLoader";
 #endif
 }
+
+#ifndef PRODUCT
+// This class is friends with Method.
+class MethodTest : public ::testing::Test{
+ public:
+  static void compare_names(Method* method, Symbol* name) {
+    ASSERT_EQ(method->_name, name) << "Method name field isn't set";
+  }
+};
+
+TEST_VM(Method, method_name) {
+  InstanceKlass* ik = vmClasses::Object_klass();
+  Symbol* tostring = SymbolTable::new_symbol("toString");
+  Method* method = ik->find_method(tostring, vmSymbols::void_string_signature());
+  ASSERT_TRUE(method != nullptr) << "Object must have toString";
+  MethodTest::compare_names(method, tostring);
+}
+#endif

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import jtreg.SkippedException;
  * @test id=xcomp-process
  * @bug 8193124
  * @summary Test the clhsdb 'findpc' command with Xcomp on live process
+ * @requires vm.compMode != "Xcomp"
  * @requires vm.hasSA
  * @requires vm.compiler1.enabled
  * @requires vm.opt.DeoptimizeALot != true
@@ -49,6 +50,7 @@ import jtreg.SkippedException;
  * @requires vm.compMode != "Xcomp"
  * @requires vm.hasSA
  * @requires vm.compiler1.enabled
+ * @requires vm.opt.DeoptimizeALot != true
  * @library /test/lib
  * @run main/othervm/timeout=480 ClhsdbFindPC true true
  */
@@ -59,7 +61,6 @@ import jtreg.SkippedException;
  * @summary Test the clhsdb 'findpc' command w/o Xcomp on live process
  * @requires vm.hasSA
  * @requires vm.compiler1.enabled
- * @requires vm.opt.DeoptimizeALot != true
  * @library /test/lib
  * @run main/othervm/timeout=480 ClhsdbFindPC false false
  */
@@ -68,7 +69,6 @@ import jtreg.SkippedException;
  * @test id=no-xcomp-core
  * @bug 8193124
  * @summary Test the clhsdb 'findpc' command w/o Xcomp on core file
- * @requires vm.compMode != "Xcomp"
  * @requires vm.hasSA
  * @requires vm.compiler1.enabled
  * @library /test/lib


### PR DESCRIPTION
Whenever I'm debugging I really wish I knew the name of the method that I'm looking at, so I added this field in not-product.
Tested with tier1 on Oracle platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282240](https://bugs.openjdk.java.net/browse/JDK-8282240): Add _name field to Method for NOT_PRODUCT only


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.java.net/census#pchilanomate) (@pchilano - **Reviewer**)
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7608/head:pull/7608` \
`$ git checkout pull/7608`

Update a local copy of the PR: \
`$ git checkout pull/7608` \
`$ git pull https://git.openjdk.java.net/jdk pull/7608/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7608`

View PR using the GUI difftool: \
`$ git pr show -t 7608`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7608.diff">https://git.openjdk.java.net/jdk/pull/7608.diff</a>

</details>
