### PR TITLE
8230382: Clean up ConvI2L, CastII and CastLL::Ideal methods

### DIFF
--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -194,6 +194,42 @@ void ConstraintCastNode::dump_spec(outputStream *st) const {
 
 const Type* CastIINode::Value(PhaseGVN* phase) const {
   const Type *res = ConstraintCastNode::Value(phase);
+  if(res == Type::TOP) { return res; }
+  assert(res->isa_int(), "res must be int");
+
+  // Similar to ConvI2LNode::Value() for the same reasons
+  // see if we can remove type assertion after loop opts
+  // But here we have to pay extra attention:
+  // Do not narrow the type of range check dependent CastIINodes to
+  // avoid corruption of the graph if a CastII is replaced by TOP but
+  // the corresponding range check is not removed.
+  if (!_range_check_dependency) {
+    if (phase->C->post_loop_opts_phase()) {
+      const TypeInt* this_type = res->is_int();
+      const TypeInt* in_type = phase->type(in(1))->isa_int();
+      if (in_type != NULL && this_type != NULL &&
+          (in_type->_lo != this_type->_lo ||
+           in_type->_hi != this_type->_hi)) {
+        jint lo1 = this_type->_lo;
+        jint hi1 = this_type->_hi;
+        int w1  = this_type->_widen;
+
+        if (lo1 >= 0) {
+          // Keep a range assertion of >=0.
+          lo1 = 0;        hi1 = max_jint;
+        } else if (hi1 < 0) {
+          // Keep a range assertion of <0.
+          lo1 = min_jint; hi1 = -1;
+        } else {
+          lo1 = min_jint; hi1 = max_jint;
+        }
+        const TypeInt* wtype = TypeInt::make(MAX2(in_type->_lo, lo1),
+                                             MIN2(in_type->_hi, hi1),
+                                             MAX2((int)in_type->_widen, w1));
+        res = wtype;
+      }
+    }
+  }
 
   // Try to improve the type of the CastII if we recognize a CmpI/If
   // pattern.
@@ -248,7 +284,6 @@ const Type* CastIINode::Value(PhaseGVN* phase) const {
             t = TypeInt::make(lo_int, hi_int, Type::WidenMax);
 
             res = res->filter_speculative(t);
-
             return res;
           }
         }
@@ -300,40 +335,9 @@ Node *CastIINode::Ideal(PhaseGVN *phase, bool can_reshape) {
       default:       ShouldNotReachHere();
     }
   }
-
-  // Similar to ConvI2LNode::Ideal() for the same reasons
-  // Do not narrow the type of range check dependent CastIINodes to
-  // avoid corruption of the graph if a CastII is replaced by TOP but
-  // the corresponding range check is not removed.
   if (can_reshape && !_range_check_dependency) {
-    if (phase->C->post_loop_opts_phase()) {
-      const TypeInt* this_type = this->type()->is_int();
-      const TypeInt* in_type = phase->type(in(1))->isa_int();
-      if (in_type != NULL && this_type != NULL &&
-          (in_type->_lo != this_type->_lo ||
-           in_type->_hi != this_type->_hi)) {
-        jint lo1 = this_type->_lo;
-        jint hi1 = this_type->_hi;
-        int w1  = this_type->_widen;
-
-        if (lo1 >= 0) {
-          // Keep a range assertion of >=0.
-          lo1 = 0;        hi1 = max_jint;
-        } else if (hi1 < 0) {
-          // Keep a range assertion of <0.
-          lo1 = min_jint; hi1 = -1;
-        } else {
-          lo1 = min_jint; hi1 = max_jint;
-        }
-        const TypeInt* wtype = TypeInt::make(MAX2(in_type->_lo, lo1),
-                                             MIN2(in_type->_hi, hi1),
-                                             MAX2((int)in_type->_widen, w1));
-        if (wtype != type()) {
-          set_type(wtype);
-          return this;
-        }
-      }
-    } else {
+    if (!phase->C->post_loop_opts_phase()) {
+      // makes sure we run ::Value to potentially remove type assertion after loop opts
       phase->C->record_for_post_loop_opts_igvn(this);
     }
   }

--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -194,7 +194,9 @@ void ConstraintCastNode::dump_spec(outputStream *st) const {
 
 const Type* CastIINode::Value(PhaseGVN* phase) const {
   const Type *res = ConstraintCastNode::Value(phase);
-  if(res == Type::TOP) return Type::TOP;
+  if (res == Type::TOP) {
+    return Type::TOP;
+  }
   assert(res->isa_int(), "res must be int");
 
   // Similar to ConvI2LNode::Value() for the same reasons
@@ -211,7 +213,7 @@ const Type* CastIINode::Value(PhaseGVN* phase) const {
          in_type->_hi != this_type->_hi)) {
       jint lo1 = this_type->_lo;
       jint hi1 = this_type->_hi;
-      int w1  = this_type->_widen;
+      int w1 = this_type->_widen;
       if (lo1 >= 0) {
         // Keep a range assertion of >=0.
         lo1 = 0;        hi1 = max_jint;

--- a/src/hotspot/share/opto/convertnode.cpp
+++ b/src/hotspot/share/opto/convertnode.cpp
@@ -252,12 +252,16 @@ Node* ConvI2FNode::Identity(PhaseGVN* phase) {
 //------------------------------Value------------------------------------------
 const Type* ConvI2LNode::Value(PhaseGVN* phase) const {
   const Type *t = phase->type( in(1) );
-  if( t == Type::TOP ) return Type::TOP;
+  if (t == Type::TOP) {
+    return Type::TOP;
+  }
   const TypeInt *ti = t->is_int();
   const Type* tl = TypeLong::make(ti->_lo, ti->_hi, ti->_widen);
   // Join my declared type against my incoming type.
   tl = tl->filter(_type);
-  if(!tl->isa_long()) return tl;
+  if (!tl->isa_long()) {
+    return tl;
+  }
   const TypeLong* this_type = tl->is_long();
   // Do NOT remove this node's type assertion until no more loop ops can happen.
   if (phase->C->post_loop_opts_phase()) {

--- a/src/hotspot/share/opto/convertnode.cpp
+++ b/src/hotspot/share/opto/convertnode.cpp
@@ -257,7 +257,49 @@ const Type* ConvI2LNode::Value(PhaseGVN* phase) const {
   const Type* tl = TypeLong::make(ti->_lo, ti->_hi, ti->_widen);
   // Join my declared type against my incoming type.
   tl = tl->filter(_type);
-  return tl;
+  if(!tl->isa_long()) return tl;
+  const TypeLong* this_type = tl->is_long();
+  PhaseIterGVN *igvn = phase->is_IterGVN();
+  if (igvn != NULL) {
+    // Do NOT remove this node's type assertion until no more loop ops can happen.
+    if (phase->C->post_loop_opts_phase()) {
+      const TypeInt* in_type = phase->type(in(1))->isa_int();
+      if (in_type != NULL && this_type != NULL &&
+          (in_type->_lo != this_type->_lo ||
+           in_type->_hi != this_type->_hi)) {
+        // Although this WORSENS the type, it increases GVN opportunities,
+        // because I2L nodes with the same input will common up, regardless
+        // of slightly differing type assertions.  Such slight differences
+        // arise routinely as a result of loop unrolling, so this is a
+        // post-unrolling graph cleanup.  Choose a type which depends only
+        // on my input.  (Exception:  Keep a range assertion of >=0 or <0.)
+        jlong lo1 = this_type->_lo;
+        jlong hi1 = this_type->_hi;
+        assert(lo1 <= hi1, "valid Long range");
+        assert(in_type->_lo <= in_type->_hi, "valid Int range");
+        int   w1  = this_type->_widen;
+        if (lo1 != (jint)lo1 ||
+            hi1 != (jint)hi1 ||
+            lo1 > hi1) {
+          // Overflow leads to wraparound, wraparound leads to range saturation.
+          lo1 = min_jint; hi1 = max_jint;
+        } else if (lo1 >= 0) {
+          // Keep a range assertion of >=0.
+          lo1 = 0;        hi1 = max_jint;
+        } else if (hi1 < 0) {
+          // Keep a range assertion of <0.
+          lo1 = min_jint; hi1 = -1;
+        } else {
+          lo1 = min_jint; hi1 = max_jint;
+        }
+        const TypeLong* wtype = TypeLong::make(MAX2((jlong)in_type->_lo, lo1),
+                                               MIN2((jlong)in_type->_hi, hi1),
+                                               MAX2((int)in_type->_widen, w1));
+        return wtype;
+      }
+    }
+  }
+  return this_type;
 }
 
 static inline bool long_ranges_overlap(jlong lo1, jlong hi1,
@@ -361,50 +403,10 @@ bool Compile::push_thru_add(PhaseGVN* phase, Node* z, const TypeInteger* tz, con
 Node *ConvI2LNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   PhaseIterGVN *igvn = phase->is_IterGVN();
   const TypeLong* this_type = this->type()->is_long();
-  Node* this_changed = NULL;
 
-  if (igvn != NULL) {
-    // Do NOT remove this node's type assertion until no more loop ops can happen.
-    if (phase->C->post_loop_opts_phase()) {
-      const TypeInt* in_type = phase->type(in(1))->isa_int();
-      if (in_type != NULL && this_type != NULL &&
-          (in_type->_lo != this_type->_lo ||
-           in_type->_hi != this_type->_hi)) {
-        // Although this WORSENS the type, it increases GVN opportunities,
-        // because I2L nodes with the same input will common up, regardless
-        // of slightly differing type assertions.  Such slight differences
-        // arise routinely as a result of loop unrolling, so this is a
-        // post-unrolling graph cleanup.  Choose a type which depends only
-        // on my input.  (Exception:  Keep a range assertion of >=0 or <0.)
-        jlong lo1 = this_type->_lo;
-        jlong hi1 = this_type->_hi;
-        int   w1  = this_type->_widen;
-        if (lo1 != (jint)lo1 ||
-            hi1 != (jint)hi1 ||
-            lo1 > hi1) {
-          // Overflow leads to wraparound, wraparound leads to range saturation.
-          lo1 = min_jint; hi1 = max_jint;
-        } else if (lo1 >= 0) {
-          // Keep a range assertion of >=0.
-          lo1 = 0;        hi1 = max_jint;
-        } else if (hi1 < 0) {
-          // Keep a range assertion of <0.
-          lo1 = min_jint; hi1 = -1;
-        } else {
-          lo1 = min_jint; hi1 = max_jint;
-        }
-        const TypeLong* wtype = TypeLong::make(MAX2((jlong)in_type->_lo, lo1),
-                                               MIN2((jlong)in_type->_hi, hi1),
-                                               MAX2((int)in_type->_widen, w1));
-        if (wtype != type()) {
-          set_type(wtype);
-          // Note: this_type still has old type value, for the logic below.
-          this_changed = this;
-        }
-      }
-    } else {
-      phase->C->record_for_post_loop_opts_igvn(this);
-    }
+  if (igvn != NULL && !phase->C->post_loop_opts_phase()) {
+    // makes sure we run ::Value to potentially remove type assertion after loop opts
+    phase->C->record_for_post_loop_opts_igvn(this);
   }
 #ifdef _LP64
   // Convert ConvI2L(AddI(x, y)) to AddL(ConvI2L(x), ConvI2L(y))
@@ -437,7 +439,7 @@ Node *ConvI2LNode::Ideal(PhaseGVN *phase, bool can_reshape) {
       // Postpone this optimization to iterative GVN, where we can handle deep
       // AddI chains without an exponential number of recursive Ideal() calls.
       phase->record_for_igvn(this);
-      return this_changed;
+      return NULL;
     }
     int op = z->Opcode();
     Node* x = z->in(1);
@@ -453,7 +455,7 @@ Node *ConvI2LNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   }
 #endif //_LP64
 
-  return this_changed;
+  return NULL;
 }
 
 //=============================================================================


### PR DESCRIPTION
This is a cleanup job: move code from `::Ideal` methods that only change types to `::Value` where the code belongs.

`CastLLNode::Ideal` was introduced in [JDK-8229496](https://bugs.openjdk.java.net/browse/JDK-8229496) and reverted (deleted) in [JDK-8242108](https://bugs.openjdk.java.net/browse/JDK-8242108).
Currently, `CastLLNode` does not have its own `::Ideal` method. Hence, I changed nothing for it.

For `ConvI2LNode` and `CastIINode`, I went through a process of first copying the relevant code to `::Value`, calling it from `::Ideal` and asserting that they deliver equivalent results.
These intermediate code results can be found in the comments of [JDK-8230382](https://bugs.openjdk.java.net/browse/JDK-8230382).
I also tried to make the two code versions more similar, where they were unnecessarily different (used `can_reshape` instead of `igvn != NULL`, and removed the dead Overflow/wraparound case which can never happen).
I ran tests: final code and intermediate code versions. Ensures code behaves equivalent and nothing broke.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8230382](https://bugs.openjdk.java.net/browse/JDK-8230382): Clean up ConvI2L, CastII and CastLL::Ideal methods


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7609/head:pull/7609` \
`$ git checkout pull/7609`

Update a local copy of the PR: \
`$ git checkout pull/7609` \
`$ git pull https://git.openjdk.java.net/jdk pull/7609/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7609`

View PR using the GUI difftool: \
`$ git pr show -t 7609`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7609.diff">https://git.openjdk.java.net/jdk/pull/7609.diff</a>

</details>
