### PR TITLE
8282348: Remove unused CardTable::dirty_card_iterate

### DIFF
--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -385,32 +385,6 @@ void CardTable::dirty(MemRegion mr) {
   memset(first, dirty_card, last-first);
 }
 
-// Unlike several other card table methods, dirty_card_iterate()
-// iterates over dirty cards ranges in increasing address order.
-void CardTable::dirty_card_iterate(MemRegion mr, MemRegionClosure* cl) {
-  for (int i = 0; i < _cur_covered_regions; i++) {
-    MemRegion mri = mr.intersection(_covered[i]);
-    if (!mri.is_empty()) {
-      CardValue *cur_entry, *next_entry, *limit;
-      for (cur_entry = byte_for(mri.start()), limit = byte_for(mri.last());
-           cur_entry <= limit;
-           cur_entry  = next_entry) {
-        next_entry = cur_entry + 1;
-        if (*cur_entry == dirty_card) {
-          size_t dirty_cards;
-          // Accumulate maximal dirty card range, starting at cur_entry
-          for (dirty_cards = 1;
-               next_entry <= limit && *next_entry == dirty_card;
-               dirty_cards++, next_entry++);
-          MemRegion cur_cards(addr_for(cur_entry),
-                              dirty_cards*_card_size_in_words);
-          cl->do_MemRegion(cur_cards);
-        }
-      }
-    }
-  }
-}
-
 MemRegion CardTable::dirty_card_range_after_reset(MemRegion mr,
                                                   bool reset,
                                                   int reset_val) {

--- a/src/hotspot/share/gc/shared/cardTable.hpp
+++ b/src/hotspot/share/gc/shared/cardTable.hpp
@@ -218,10 +218,6 @@ public:
 
   static uintx ct_max_alignment_constraint();
 
-  // Apply closure "cl" to the dirty cards containing some part of
-  // MemRegion "mr".
-  void dirty_card_iterate(MemRegion mr, MemRegionClosure* cl);
-
   // Return the MemRegion corresponding to the first maximal run
   // of dirty cards lying completely within MemRegion mr.
   // If reset is "true", then sets those card table entries to the given


### PR DESCRIPTION
Simple change of removing dead code.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282348](https://bugs.openjdk.java.net/browse/JDK-8282348): Remove unused CardTable::dirty_card_iterate


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7610/head:pull/7610` \
`$ git checkout pull/7610`

Update a local copy of the PR: \
`$ git checkout pull/7610` \
`$ git pull https://git.openjdk.java.net/jdk pull/7610/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7610`

View PR using the GUI difftool: \
`$ git pr show -t 7610`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7610.diff">https://git.openjdk.java.net/jdk/pull/7610.diff</a>

</details>
