### PR TITLE
8282347: AARCH64: Untaken branch in has_negatives stub

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -4672,7 +4672,7 @@ class StubGenerator: public StubCodeGenerator {
 
     __ enter();
 
-  Label RET_TRUE, RET_TRUE_NO_POP, RET_FALSE, ALIGNED, LOOP16, CHECK_16, DONE,
+  Label RET_TRUE, RET_TRUE_NO_POP, RET_FALSE, ALIGNED, LOOP16, CHECK_16,
         LARGE_LOOP, POST_LOOP16, LEN_OVER_15, LEN_OVER_8, POST_LOOP16_LOAD_TAIL;
 
   __ cmp(len, (u1)15);
@@ -4814,10 +4814,6 @@ class StubGenerator: public StubCodeGenerator {
     __ mov(result, 1);
     __ ret(lr);
 
-  __ bind(DONE);
-    __ pop(spilled_regs, sp);
-    __ leave();
-    __ ret(lr);
     return entry;
   }
 


### PR DESCRIPTION
Trivial(?) cleanup removing an untaken branch in the aarch64 has_negatives stub.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282347](https://bugs.openjdk.java.net/browse/JDK-8282347): AARCH64: Untaken branch in has_negatives stub


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [Hao Sun](https://openjdk.java.net/census#haosun) (@shqking - Author)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7611/head:pull/7611` \
`$ git checkout pull/7611`

Update a local copy of the PR: \
`$ git checkout pull/7611` \
`$ git pull https://git.openjdk.java.net/jdk pull/7611/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7611`

View PR using the GUI difftool: \
`$ git pr show -t 7611`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7611.diff">https://git.openjdk.java.net/jdk/pull/7611.diff</a>

</details>
