### PR TITLE
8282270: java/awt/Robot Screen Capture tests fail after 8280861

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -738,8 +738,6 @@ javax/swing/plaf/metal/MetalGradient/8163193/ButtonGradientTest.java  8277816 ma
 javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java  8277816 macosx-aarch64
 javax/swing/JInternalFrame/8069348/bug8069348.java 8277816 macosx-aarch64
 java/awt/Robot/HiDPIScreenCapture/ScreenCaptureTest.java  8277816 macosx-aarch64
-java/awt/Robot/HiDPIScreenCapture/ScreenCaptureGtkTest.java 8282270 linux-all
-java/awt/Robot/HiDPIScreenCapture/HiDPIRobotScreenCaptureTest.java 8282270 windows-all
 java/awt/Robot/CheckCommonColors/CheckCommonColors.java 8277816 macosx-aarch64
 java/awt/ColorClass/AlphaColorTest.java 8277816 macosx-aarch64
 java/awt/AlphaComposite/WindowAlphaCompositeTest.java 8277816 macosx-aarch64

--- a/test/jdk/java/awt/Robot/HiDPIScreenCapture/HiDPIRobotScreenCaptureTest.java
+++ b/test/jdk/java/awt/Robot/HiDPIScreenCapture/HiDPIRobotScreenCaptureTest.java
@@ -63,6 +63,14 @@ public class HiDPIRobotScreenCaptureTest {
         }
 
         Frame frame = new Frame();
+
+        // Position the frame such that color picker will work with
+        // prime number coordinates (mind the offset) to avoid them being
+        // multiple of the desktop scale; this tests Linux color picker better.
+        // Also, the position should be far enough from the top left
+        // corner of the screen to reduce the chance of being repositioned
+        // by the system because that area's occupied by the global
+        // menu bar and such.
         frame.setBounds(83, 97, 100, 100);
         frame.setUndecorated(true);
 

--- a/test/jdk/java/awt/Robot/HiDPIScreenCapture/HiDPIRobotScreenCaptureTest.java
+++ b/test/jdk/java/awt/Robot/HiDPIScreenCapture/HiDPIRobotScreenCaptureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,26 +27,20 @@ import java.awt.Color;
 import java.awt.Frame;
 import java.awt.Graphics;
 import java.awt.Panel;
-import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.image.BufferedImage;
 import javax.swing.UIManager;
-import javax.imageio.ImageIO;
-import java.io.File;
-import java.io.IOException;
 
 /**
  * @test
  * @key headful
- * @bug 8073320 8280861
- * @summary  Linux and Windows HiDPI support
+ * @bug 8073320
+ * @summary  Windows HiDPI support
  * @author Alexander Scherbatiy
  * @requires (os.family == "linux" | os.family == "windows")
  * @run main/othervm -Dsun.java2d.win.uiScaleX=3 -Dsun.java2d.win.uiScaleY=2
  *                    HiDPIRobotScreenCaptureTest
- * @run main/othervm -Dsun.java2d.uiScale=1 HiDPIRobotScreenCaptureTest
- * @run main/othervm -Dsun.java2d.uiScale=2 HiDPIRobotScreenCaptureTest
  */
 
 public class HiDPIRobotScreenCaptureTest {
@@ -66,14 +60,7 @@ public class HiDPIRobotScreenCaptureTest {
         }
 
         Frame frame = new Frame();
-        // Position the frame on prime number coordinates to avoid
-        // them being multiple of the desktop scale; this tests Linux
-        // color picker better.
-        // Also, the position should be far enough from the top left
-        // corner of the screen to reduce the chance of being repositioned
-        // by the system because that area's occupied by the global
-        // menu bar and such.
-        frame.setBounds(83, 97, 400, 300);
+        frame.setBounds(40, 30, 400, 300);
         frame.setUndecorated(true);
 
         Panel panel = new Panel(new BorderLayout());
@@ -99,12 +86,11 @@ public class HiDPIRobotScreenCaptureTest {
         frame.setVisible(true);
         Robot robot = new Robot();
         robot.waitForIdle();
-        robot.delay(500);
+        Thread.sleep(200);
 
         Rectangle rect = canvas.getBounds();
         rect.setLocation(canvas.getLocationOnScreen());
 
-        System.out.println("Creating screen capture of " + rect);
         BufferedImage image = robot.createScreenCapture(rect);
         frame.dispose();
 
@@ -115,38 +101,20 @@ public class HiDPIRobotScreenCaptureTest {
             throw new RuntimeException("Wrong image size!");
         }
 
-        checkRectColor(image, new Rectangle(0, 0, w / 2, h / 2), COLORS[0]);
-        checkRectColor(image, new Rectangle(w / 2, 0, w / 2, h / 2), COLORS[1]);
-        checkRectColor(image, new Rectangle(0, h / 2, w / 2, h / 2), COLORS[2]);
-        checkRectColor(image, new Rectangle(w / 2, h / 2, w / 2, h / 2), COLORS[3]);
-    }
+        if (image.getRGB(w / 4, h / 4) != COLORS[0].getRGB()) {
+            throw new RuntimeException("Wrong image color!");
+        }
 
-    private static final int OFFSET = 5;
-    static void checkRectColor(BufferedImage image, Rectangle rect, Color expectedColor) {
-        System.out.println("Checking rectangle " + rect + " to have color " + expectedColor);
-        final Point[] pointsToCheck = new Point[] {
-                new Point(rect.x + OFFSET, rect.y + OFFSET),                           // top left corner
-                new Point(rect.x + rect.width - OFFSET, rect.y + OFFSET),              // top right corner
-                new Point(rect.x + rect.width / 2, rect.y + rect.height / 2),          // center
-                new Point(rect.x + OFFSET, rect.y + rect.height - OFFSET),             // bottom left corner
-                new Point(rect.x + rect.width - OFFSET, rect.y + rect.height - OFFSET) // bottom right corner
-        };
+        if (image.getRGB(3 * w / 4, h / 4) != COLORS[1].getRGB()) {
+            throw new RuntimeException("Wrong image color!");
+        }
 
-        for (final var point : pointsToCheck) {
-            System.out.print("Checking color at " + point + " to be equal to " + expectedColor);
-            final int actualColor = image.getRGB(point.x, point.y);
-            if (actualColor != expectedColor.getRGB()) {
-                System.out.println("... Mismatch: found " + new Color(actualColor) + " instead. Check image.png.");
-                try {
-                    ImageIO.write(image, "png", new File("image.png"));
-                } catch(IOException e) {
-                    System.out.println("failed to save image.png.");
-                    e.printStackTrace();
-                }
-                throw new RuntimeException("Wrong image color!");
-            } else {
-                System.out.println("... OK");
-            }
+        if (image.getRGB(w / 4, 3 * h / 4) != COLORS[2].getRGB()) {
+            throw new RuntimeException("Wrong image color!");
+        }
+
+        if (image.getRGB(3 * w / 4, 3 * h / 4) != COLORS[3].getRGB()) {
+            throw new RuntimeException("Wrong image color!");
         }
     }
 }

--- a/test/jdk/java/awt/Robot/HiDPIScreenCapture/HiDPIRobotScreenCaptureTest.java
+++ b/test/jdk/java/awt/Robot/HiDPIScreenCapture/HiDPIRobotScreenCaptureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,9 @@ import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.image.BufferedImage;
 import javax.swing.UIManager;
+import javax.imageio.ImageIO;
+import java.io.File;
+import java.io.IOException;
 
 /**
  * @test
@@ -60,7 +63,7 @@ public class HiDPIRobotScreenCaptureTest {
         }
 
         Frame frame = new Frame();
-        frame.setBounds(40, 30, 400, 300);
+        frame.setBounds(83, 97, 400, 300);
         frame.setUndecorated(true);
 
         Panel panel = new Panel(new BorderLayout());
@@ -86,11 +89,12 @@ public class HiDPIRobotScreenCaptureTest {
         frame.setVisible(true);
         Robot robot = new Robot();
         robot.waitForIdle();
-        Thread.sleep(200);
+        robot.delay(500);
 
         Rectangle rect = canvas.getBounds();
         rect.setLocation(canvas.getLocationOnScreen());
 
+        System.out.println("Creating screen capture of " + rect);
         BufferedImage image = robot.createScreenCapture(rect);
         frame.dispose();
 
@@ -101,20 +105,26 @@ public class HiDPIRobotScreenCaptureTest {
             throw new RuntimeException("Wrong image size!");
         }
 
-        if (image.getRGB(w / 4, h / 4) != COLORS[0].getRGB()) {
-            throw new RuntimeException("Wrong image color!");
-        }
+        checkRectColor(image, w / 4, h / 4, COLORS[0]);
+        checkRectColor(image, 3 * w / 4, h / 4, COLORS[1]);
+        checkRectColor(image, w / 4, 3 * h / 4, COLORS[2]);
+        checkRectColor(image, 3 * w / 4, 3 * h / 4, COLORS[3]);
+    }
 
-        if (image.getRGB(3 * w / 4, h / 4) != COLORS[1].getRGB()) {
+    static void checkRectColor(BufferedImage image, int x, int y, Color expectedColor) {
+        System.out.println("Checking (" + x + ", " + y + ") to have color " + expectedColor);
+        final int actualColor = image.getRGB(x, y);
+        if (actualColor != expectedColor.getRGB()) {
+            System.out.println("... Mismatch: found " + new Color(actualColor) + " instead. Check image.png.");
+            try {
+                ImageIO.write(image, "png", new File("image.png"));
+            } catch(IOException e) {
+                System.out.println("failed to save image.png.");
+                e.printStackTrace();
+            }
             throw new RuntimeException("Wrong image color!");
-        }
-
-        if (image.getRGB(w / 4, 3 * h / 4) != COLORS[2].getRGB()) {
-            throw new RuntimeException("Wrong image color!");
-        }
-
-        if (image.getRGB(3 * w / 4, 3 * h / 4) != COLORS[3].getRGB()) {
-            throw new RuntimeException("Wrong image color!");
+        } else {
+            System.out.println("... OK");
         }
     }
 }

--- a/test/jdk/java/awt/Robot/HiDPIScreenCapture/HiDPIRobotScreenCaptureTest.java
+++ b/test/jdk/java/awt/Robot/HiDPIScreenCapture/HiDPIRobotScreenCaptureTest.java
@@ -63,7 +63,7 @@ public class HiDPIRobotScreenCaptureTest {
         }
 
         Frame frame = new Frame();
-        frame.setBounds(83, 97, 400, 300);
+        frame.setBounds(83, 97, 100, 100);
         frame.setUndecorated(true);
 
         Panel panel = new Panel(new BorderLayout());

--- a/test/jdk/java/awt/Robot/HiDPIScreenCapture/ScreenCaptureGtkTest.java
+++ b/test/jdk/java/awt/Robot/HiDPIScreenCapture/ScreenCaptureGtkTest.java
@@ -59,8 +59,8 @@ public class ScreenCaptureGtkTest {
 
         Frame frame = new Frame();
         // Position the frame such that color picker will work with
-        // prime number coordinates to avoid them being multiple
-        // of the desktop scale; this tests Linux color picker better.
+        // prime number coordinates (mind the offset) to avoid them being
+        // multiple of the desktop scale; this tests Linux color picker better.
         // Also, the position should be far enough from the top left
         // corner of the screen to reduce the chance of being repositioned
         // by the system because that area's occupied by the global
@@ -79,7 +79,7 @@ public class ScreenCaptureGtkTest {
                 g.fillRect(0, 0, w, h);
                 // Paint several distinct pixels next to one another
                 // in order to test color picker's precision.
-                for (int i = 1; i < 4; i++) {
+                for (int i = 1; i < COLORS.length; i++) {
                     g.setColor(COLORS[i]);
                     g.fillRect(leftOffset + i, topOffset, 1, 1);
                 }
@@ -106,7 +106,7 @@ public class ScreenCaptureGtkTest {
     }
 
     static void checkPixelColors(Robot robot, int x, int y) {
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < COLORS.length; i++) {
             final Color actualColor = robot.getPixelColor(x + i, y);
             System.out.print("Checking color at " + (x + i) + ", " + y + " to be equal to " + COLORS[i]);
             if (!actualColor.equals(COLORS[i])) {

--- a/test/jdk/java/awt/Robot/HiDPIScreenCapture/ScreenCaptureGtkTest.java
+++ b/test/jdk/java/awt/Robot/HiDPIScreenCapture/ScreenCaptureGtkTest.java
@@ -31,6 +31,12 @@ import java.awt.Panel;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import javax.swing.UIManager;
+import javax.imageio.ImageIO;
+import java.io.File;
+import java.io.IOException;
+
 
 /**
  * @test
@@ -48,8 +54,8 @@ public class ScreenCaptureGtkTest {
             Color.GREEN, Color.BLUE, Color.ORANGE, Color.RED};
 
     public static void main(String[] args) throws Exception {
-        final int topOffset = 100;
-        final int leftOffset = 100;
+        final int topOffset = 50;
+        final int leftOffset = 50;
 
         Frame frame = new Frame();
         // Position the frame such that color picker will work with
@@ -59,7 +65,7 @@ public class ScreenCaptureGtkTest {
         // corner of the screen to reduce the chance of being repositioned
         // by the system because that area's occupied by the global
         // menu bar and such.
-        frame.setBounds(91, 97, 400, 300);
+        frame.setBounds(89, 99, 100, 100);
         frame.setUndecorated(true);
 
         Panel panel = new Panel(new BorderLayout());
@@ -87,12 +93,16 @@ public class ScreenCaptureGtkTest {
         robot.waitForIdle();
         robot.delay(500);
 
-        final Point screenLocation = frame.getLocationOnScreen();
-        checkPixelColors(robot, screenLocation.x + leftOffset,
-                screenLocation.y + topOffset);
+        captureImageOf(frame, robot);
 
-        robot.delay(100);
-        frame.dispose();
+        final Point screenLocation = frame.getLocationOnScreen();
+        try {
+            checkPixelColors(robot, screenLocation.x + leftOffset,
+                    screenLocation.y + topOffset);
+        } finally {
+            robot.delay(100);
+            frame.dispose();
+        }
     }
 
     static void checkPixelColors(Robot robot, int x, int y) {
@@ -101,11 +111,32 @@ public class ScreenCaptureGtkTest {
             System.out.print("Checking color at " + (x + i) + ", " + y + " to be equal to " + COLORS[i]);
             if (!actualColor.equals(COLORS[i])) {
                 System.out.println("... Mismatch: found " + actualColor + " instead");
+                saveImage();
                 throw new RuntimeException("Wrong screen pixel color");
 
             } else {
                 System.out.println("... OK");
             }
+        }
+    }
+
+    private static BufferedImage image;
+
+    static void captureImageOf(Frame frame, Robot robot) {
+        Rectangle rect = frame.getBounds();
+        rect.setLocation(frame.getLocationOnScreen());
+
+        System.out.println("Creating screen capture of " + rect);
+        image = robot.createScreenCapture(rect);
+    }
+
+    static void saveImage() {
+        System.out.println("Check image.png");
+        try {
+            ImageIO.write(image, "png", new File("image.png"));
+        } catch(IOException e) {
+            System.out.println("failed to save image.png.");
+            e.printStackTrace();
         }
     }
 }

--- a/test/jdk/java/awt/Robot/HiDPIScreenCapture/ScreenCaptureGtkTest.java
+++ b/test/jdk/java/awt/Robot/HiDPIScreenCapture/ScreenCaptureGtkTest.java
@@ -40,11 +40,7 @@ import java.awt.Robot;
  *           Gtk backends and presence of UI scaling
  * @requires os.family == "linux"
  * @run main/othervm -Djdk.gtk.version=2 -Dsun.java2d.uiScale=1 ScreenCaptureGtkTest
- * @run main/othervm -Djdk.gtk.version=2 -Dsun.java2d.uiScale=2 ScreenCaptureGtkTest
- * @run main/othervm -Djdk.gtk.version=2 -Dsun.java2d.uiScale=3 ScreenCaptureGtkTest
  * @run main/othervm -Djdk.gtk.version=3 -Dsun.java2d.uiScale=1 ScreenCaptureGtkTest
- * @run main/othervm -Djdk.gtk.version=3 -Dsun.java2d.uiScale=2 ScreenCaptureGtkTest
- * @run main/othervm -Djdk.gtk.version=3 -Dsun.java2d.uiScale=3 ScreenCaptureGtkTest
  */
 
 public class ScreenCaptureGtkTest {
@@ -52,15 +48,18 @@ public class ScreenCaptureGtkTest {
             Color.GREEN, Color.BLUE, Color.ORANGE, Color.RED};
 
     public static void main(String[] args) throws Exception {
+        final int topOffset = 100;
+        final int leftOffset = 100;
+
         Frame frame = new Frame();
-        // Position the frame on prime number coordinates to avoid
-        // them being multiple of the desktop scale; this tests Linux
-        // color picker better.
+        // Position the frame such that color picker will work with
+        // prime number coordinates to avoid them being multiple
+        // of the desktop scale; this tests Linux color picker better.
         // Also, the position should be far enough from the top left
         // corner of the screen to reduce the chance of being repositioned
         // by the system because that area's occupied by the global
         // menu bar and such.
-        frame.setBounds(83, 97, 400, 300);
+        frame.setBounds(91, 97, 400, 300);
         frame.setUndecorated(true);
 
         Panel panel = new Panel(new BorderLayout());
@@ -76,7 +75,7 @@ public class ScreenCaptureGtkTest {
                 // in order to test color picker's precision.
                 for (int i = 1; i < 4; i++) {
                     g.setColor(COLORS[i]);
-                    g.fillRect(i, 0, 1, 1);
+                    g.fillRect(leftOffset + i, topOffset, 1, 1);
                 }
             }
         };
@@ -89,7 +88,8 @@ public class ScreenCaptureGtkTest {
         robot.delay(500);
 
         final Point screenLocation = frame.getLocationOnScreen();
-        checkPixelColors(robot, screenLocation.x, screenLocation.y);
+        checkPixelColors(robot, screenLocation.x + leftOffset,
+                screenLocation.y + topOffset);
 
         robot.delay(100);
         frame.dispose();


### PR DESCRIPTION
The two tests `ScreenCaptureGtkTest.java` and `HiDPIRobotScreenCaptureTest.java` under `java/awt/Robot/HiDPIScreenCapture` started to intermittently fail under Windows and Linux after the [recent changes](https://github.com/openjdk/jdk/commit/cc7cf81256ed4d74493472017b1c4df20fa2208a) made exclusively for the Linux `Robot` implementation.

`HiDPIRobotScreenCaptureTest.java`
Since the Windows failures cannot possibly have their origin in the fix made - the latter being Linux-only - the test apparently either exposes an existing bug in the Windows `Robot` or is bumping against a peculiarity of that platform. The test is reverted back to its original form that didn't fail.

`ScreenCaptureGtkTest.java`
The coordinates in the log `(83, 78)` of a failure are higher up than the test suggests `(83, 97)`. I've seen similar failures on Ubuntu 20.04 when the coordinates were set to `(0, 0)`. The color then picked matched the color of the bar drawn at the top of the screen. I believe it's best to place the test pixels towards the center of the window to avoid desktop elements interference.

The other possible reason for intermittent failures are window coordinates. Suppose that the test is executing with `sun.java2d.uiScale` set to 2. This effectively means that it can only pick colors of pixels at even coordinates (in the absolute desktop space). So if the window is placed at, say, `(201, 201)`, `Robot` can only pick the color at either `(200, 200)` or `(202, 202)`. Since the test only makes sense if it is pixel-accurate, I removed all `@run`s with `sun.java2d.uiScale` other than 1. This way window placement will not cause a failure.

This was tested on Ubuntu 20.04 and 18.04 with desktop scaling set to 100%, 200%, and 300%.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282270](https://bugs.openjdk.java.net/browse/JDK-8282270): java/awt/Robot Screen Capture tests fail after 8280861


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7613/head:pull/7613` \
`$ git checkout pull/7613`

Update a local copy of the PR: \
`$ git checkout pull/7613` \
`$ git pull https://git.openjdk.java.net/jdk pull/7613/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7613`

View PR using the GUI difftool: \
`$ git pr show -t 7613`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7613.diff">https://git.openjdk.java.net/jdk/pull/7613.diff</a>

</details>
