### PR TITLE
8281093: JDK 11.0.14 violates Attribute-Value Normalization in the XML specification 1.0

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityScanner.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityScanner.java
@@ -57,7 +57,7 @@ import java.util.Locale;
  * @author Arnaud  Le Hors, IBM
  * @author K.Venugopal Sun Microsystems
  *
- * @LastModified: Sep 2021
+ * @LastModified: Feb 2022
  */
 public class XMLEntityScanner implements XMLLocator  {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityScanner.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 
 /*
@@ -2162,7 +2162,7 @@ public class XMLEntityScanner implements XMLLocator  {
                             break;
                         }
                     }
-                    if (c == '\r') {
+                    if (c == '\r' && isExternal) {
                         int cc = fCurrentEntity.ch[fCurrentEntity.position];
                         if (cc == '\n' || (version == XML_VERSION_1_1 && cc == 0x85)) {
                             fCurrentEntity.position++;


### PR DESCRIPTION
While normalizing entity with '\r' , we should be checking if the entity is
external before changing the position and offset.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281093](https://bugs.openjdk.java.net/browse/JDK-8281093): JDK 11.0.14 violates Attribute-Value Normalization in the XML specification 1.0 ⚠️ Issue is not open.


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to f7de9a238912e6a9426863ac092d7395c98e654d


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7617/head:pull/7617` \
`$ git checkout pull/7617`

Update a local copy of the PR: \
`$ git checkout pull/7617` \
`$ git pull https://git.openjdk.java.net/jdk pull/7617/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7617`

View PR using the GUI difftool: \
`$ git pr show -t 7617`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7617.diff">https://git.openjdk.java.net/jdk/pull/7617.diff</a>

</details>
