### PR TITLE
JDK-8282382: Report glibc malloc tunables in error reports

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -716,6 +716,13 @@ const intx ObjectAlignmentInBytes = 8;
           "before adjusting the in_use_list_ceiling up (0 is off).")        \
           range(0, max_uintx)                                               \
                                                                             \
+                                                                            \
+  product(uintx, MaxObjectMonitors, NOT_LP64(100000) LP64_ONLY(20 * M),     \
+           "Max. number of object monitors")                                \
+                                                                            \
+  product(uintx, PreallocatedObjectMonitors, NOT_LP64(8) LP64_ONLY(64),     \
+           "Max. thread local preallocated OMs")                            \
+                                                                            \
   product(intx, hashCode, 5, EXPERIMENTAL,                                  \
                "(Unstable) select hashCode generation algorithm")           \
                                                                             \

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -247,7 +247,7 @@ void mutex_init() {
 
   def(Metaspace_lock               , PaddedMutex  , nosafepoint-3);
   def(MetaspaceCritical_lock       , PaddedMonitor, nosafepoint-1);
-  def(ObjectMonitorStorage_lock    , PaddedMutex,   nosafepoint);
+  def(ObjectMonitorStorage_lock    , PaddedMutex,   nosafepoint-3);
 
   def(Patching_lock                , PaddedMutex  , nosafepoint);      // used for safepointing and code patching.
   def(MonitorDeflation_lock        , PaddedMonitor, nosafepoint);      // used for monitor deflation thread operations

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -153,6 +153,7 @@ Mutex*   UnregisteredClassesTable_lock= NULL;
 Mutex*   LambdaFormInvokers_lock      = NULL;
 #endif // INCLUDE_CDS
 Mutex*   Bootclasspath_lock           = NULL;
+Mutex*   ObjectMonitorStorage_lock    = NULL;
 
 #if INCLUDE_JVMCI
 Monitor* JVMCI_lock                   = NULL;
@@ -246,6 +247,7 @@ void mutex_init() {
 
   def(Metaspace_lock               , PaddedMutex  , nosafepoint-3);
   def(MetaspaceCritical_lock       , PaddedMonitor, nosafepoint-1);
+  def(ObjectMonitorStorage_lock    , PaddedMutex,   nosafepoint);
 
   def(Patching_lock                , PaddedMutex  , nosafepoint);      // used for safepointing and code patching.
   def(MonitorDeflation_lock        , PaddedMonitor, nosafepoint);      // used for monitor deflation thread operations

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -147,6 +147,8 @@ extern Mutex*   ClassLoaderDataGraph_lock;       // protects CLDG list, needed f
 extern Mutex*   CodeHeapStateAnalytics_lock;     // lock print functions against concurrent analyze functions.
                                                  // Only used locally in PrintCodeCacheLayout processing.
 
+extern Mutex*   ObjectMonitorStorage_lock;       // protects ObjectMonitorStorage
+
 #if INCLUDE_JVMCI
 extern Monitor* JVMCI_lock;                      // Monitor to control initialization of JVMCI
 #endif

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -127,7 +127,7 @@ class ObjectWaiter : public StackObj {
 #define OM_CACHE_LINE_SIZE DEFAULT_CACHE_LINE_SIZE
 #endif
 
-class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
+class ObjectMonitor : public StackObj {
   friend class ObjectSynchronizer;
   friend class ObjectWaiter;
   friend class VMStructs;
@@ -202,6 +202,8 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   static PerfLongVariable * _sync_MonExtant;
 
   static int Knob_SpinLimit;
+
+  void* operator new (size_t size, void* p) throw() { return p; }
 
   // TODO-FIXME: the "offset" routines should return a type of off_t instead of int ...
   // ByteSize would also be an appropriate type.

--- a/src/hotspot/share/runtime/objectMonitorStorage.cpp
+++ b/src/hotspot/share/runtime/objectMonitorStorage.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+#include "precompiled.hpp"
+
+#include "logging/log.hpp"
+#include "logging/logStream.hpp"
+#include "memory/allocation.hpp"
+#include "runtime/globals.hpp"
+#include "runtime/objectMonitorStorage.hpp"
+#include "services/memTracker.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+//static const bool be_paranoid = true;
+static const bool be_paranoid = false;
+
+ObjectMonitorStorage::ArrayType* ObjectMonitorStorage::_array = NULL;
+
+// re-build a new list of newly allocated free monitors and return its head
+void ObjectMonitorStorage::bulk_allocate_new_list(OMFreeListType& freelist_to_fill) {
+
+  MutexLocker ml(ObjectMonitorStorage_lock, Mutex::_no_safepoint_check_flag);
+
+  for (int i = 0; i < (int)PreallocatedObjectMonitors - 1; i ++) {
+    ObjectMonitor* m = _array->allocate();
+    if (m == NULL) {
+      fatal("Maximum number of object monitors allocated (" UINTX_FORMAT "), increase MaxObjectMonitors.",
+            _array->capacity());
+    }
+    freelist_to_fill.prepend(m);
+  }
+  DEBUG_ONLY(freelist_to_fill.verify(be_paranoid);)
+  DEBUG_ONLY(verify();)
+
+  LogTarget(Debug, monitorinflation) lt;
+  if (lt.is_enabled()) {
+    LogStream ls(lt);
+    ls.print("bulk_allocate_new_list ");
+    _array->print_on(&ls);
+    ls.cr();
+  }
+}
+
+// When a thread dies, return OMs left unused to the global store.
+void ObjectMonitorStorage::cleanup_before_thread_death(Thread* t) {
+  // Note that the ObjectMonitors we are about to return to the storage are
+  // not yet initialized, so no need to destroy them.
+  OMFreeListType& tl_list = t->_om_freelist;
+  if (tl_list.empty() == false) {
+    MutexLocker ml(ObjectMonitorStorage_lock, Mutex::_no_safepoint_check_flag);
+    _array->bulk_deallocate(tl_list);
+    DEBUG_ONLY(verify();)
+
+    LogTarget(Debug, monitorinflation) lt;
+    if (lt.is_enabled()) {
+      LogStream ls(lt);
+      ls.print("cleanup_before_thread_death ");
+      _array->print_on(&ls);
+      ls.cr();
+    }
+
+  }
+  assert(tl_list.empty(), "thread local list should now be empty");
+}
+
+// deallocate a list of monitors
+void ObjectMonitorStorage::bulk_deallocate(const GrowableArray<ObjectMonitor*>& list) {
+  // Build up freelist off-lock, then prepend the whole list under lock protection
+  OMFreeListType omlist;
+  for (ObjectMonitor* m : list) {
+    // Call ObjectMonitor destructor explicitely, then add OM to freelist. Note that the
+    // latter destroys OM's content, so order matters.
+    m->~ObjectMonitor();
+    omlist.prepend(m);
+  }
+  if (omlist.empty() == false) {
+    MutexLocker ml(ObjectMonitorStorage_lock, Mutex::_no_safepoint_check_flag);
+    _array->bulk_deallocate(omlist);
+    // log log log
+    LogTarget(Debug, monitorinflation) lt;
+    if (lt.is_enabled()) {
+      LogStream ls(lt);
+      ls.print("bulk_deallocate %d oms: ", list.length());
+      _array->print_on(&ls);
+      ls.cr();
+    }
+
+  }
+  DEBUG_ONLY(verify();)
+}
+
+void ObjectMonitorStorage::initialize() {
+  assert(_array == NULL, "Already initialized?");
+  _array = new ArrayType(MAX2(MaxObjectMonitors, (uintx)1024), 1024);
+  MemTracker::record_virtual_memory_type((address)_array->base(), mtObjectMonitor);
+}
+
+void ObjectMonitorStorage::print(outputStream* st) {
+  if (_array != NULL) {
+    _array->print_on(st);
+    st->cr();
+  } else {
+    st->print_cr("Not initialized");
+  }
+}
+
+#ifdef ASSERT
+void ObjectMonitorStorage::verify() {
+  if (_array != NULL) {
+    _array->verify(be_paranoid);
+  }
+}
+#endif

--- a/src/hotspot/share/runtime/objectMonitorStorage.cpp
+++ b/src/hotspot/share/runtime/objectMonitorStorage.cpp
@@ -96,7 +96,9 @@ void ObjectMonitorStorage::bulk_deallocate(const GrowableArray<ObjectMonitor*>& 
     omlist.prepend(m);
   }
   if (omlist.empty() == false) {
+
     MutexLocker ml(ObjectMonitorStorage_lock, Mutex::_no_safepoint_check_flag);
+
     _array->bulk_deallocate(omlist);
     // log log log
     LogTarget(Debug, monitorinflation) lt;
@@ -107,8 +109,9 @@ void ObjectMonitorStorage::bulk_deallocate(const GrowableArray<ObjectMonitor*>& 
       ls.cr();
     }
 
+    DEBUG_ONLY(verify();)
   }
-  DEBUG_ONLY(verify();)
+
 }
 
 void ObjectMonitorStorage::initialize() {
@@ -128,6 +131,7 @@ void ObjectMonitorStorage::print(outputStream* st) {
 
 #ifdef ASSERT
 void ObjectMonitorStorage::verify() {
+  assert_lock_strong(ObjectMonitorStorage_lock);
   if (_array != NULL) {
     _array->verify(be_paranoid);
   }

--- a/src/hotspot/share/runtime/objectMonitorStorage.hpp
+++ b/src/hotspot/share/runtime/objectMonitorStorage.hpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_RUNTIME_OBJECTMONITORSTORAGE_HPP
+#define SHARE_RUNTIME_OBJECTMONITORSTORAGE_HPP
+
+#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
+#include "oops/oop.hpp"
+#include "runtime/mutexLocker.hpp"
+#include "runtime/objectMonitor.hpp"
+#include "runtime/thread.hpp"
+#include "utilities/addressStableArray.inline.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+class outputStream;
+
+typedef FreeList<ObjectMonitor> OMFreeListType;
+
+typedef uint32_t OMRef;
+#define INVALID_OMREF ((OMRef)-1)
+
+class ObjectMonitorStorage : public AllStatic {
+
+  typedef AddressStableHeap<ObjectMonitor> ArrayType;
+  static ArrayType* _array;
+
+  // re-build a new list of newly allocated free monitors and return its head
+  static void bulk_allocate_new_list(OMFreeListType& freelist_to_fill);
+
+  // Return the current thread's om freelist
+  static OMFreeListType& current_omlist() {
+    // Note: monitors in this list are not initialized.
+    return Thread::current()->_om_freelist;
+  }
+
+public:
+
+  // On behalf of the current thread allocate a single monitor, preferably from
+  // thread local freelist
+  static ObjectMonitor* allocate_monitor(oop object) {
+    OMFreeListType& tl_list = current_omlist();
+    ObjectMonitor* om = tl_list.take_top();
+    if (om == NULL) {
+      bulk_allocate_new_list(tl_list);
+      om = tl_list.take_top();
+      assert(om != NULL, "sanity");
+    }
+    om = new (om) ObjectMonitor(object);
+    return om; // done
+  }
+
+  // On behalf of the current thread deallocate a single monitor
+  static void deallocate_monitor(ObjectMonitor* m) {
+    m->~ObjectMonitor(); // de-initialize.
+    OMFreeListType& tl_list = current_omlist();
+    tl_list.prepend(m);
+  }
+
+  // deallocate a list of monitors
+  static void bulk_deallocate(const GrowableArray<ObjectMonitor*>& list);
+
+  static void cleanup_before_thread_death(Thread* t);
+
+  static ObjectMonitor* ref_to_om(OMRef ref)       { return _array->index_to_obj((uintx)ref); }
+  static OMRef om_to_ref(const ObjectMonitor* om)  { return (OMRef)_array->obj_to_index(om); }
+
+  static void initialize();
+
+  static void print(outputStream* st);
+
+  DEBUG_ONLY(static void verify();)
+
+};
+
+#endif // SHARE_RUNTIME_OBJECTMONITORSTORAGE_HPP

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -92,6 +92,7 @@
 #include "runtime/mutexLocker.hpp"
 #include "runtime/nonJavaThread.hpp"
 #include "runtime/objectMonitor.hpp"
+#include "runtime/objectMonitorStorage.hpp"
 #include "runtime/orderAccess.hpp"
 #include "runtime/osThread.hpp"
 #include "runtime/safepoint.hpp"
@@ -376,6 +377,8 @@ void Thread::call_run() {
 
 Thread::~Thread() {
 
+  ObjectMonitorStorage::cleanup_before_thread_death(this);
+
   // Attached threads will remain in PRE_CALL_RUN, as will threads that don't actually
   // get started due to errors etc. Any active thread should at least reach post_run
   // before it is deleted (usually in post_run()).
@@ -416,6 +419,7 @@ Thread::~Thread() {
   }
 
   CHECK_UNHANDLED_OOPS_ONLY(if (CheckUnhandledOops) delete unhandled_oops();)
+
 }
 
 #ifdef ASSERT
@@ -2802,6 +2806,7 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   main_thread->stack_overflow_state()->create_stack_guard_pages();
 
   // Initialize Java-Level synchronization subsystem
+  ObjectMonitorStorage::initialize();
   ObjectMonitor::Initialize();
   ObjectSynchronizer::initialize();
 

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -48,6 +48,7 @@
 #include "runtime/unhandledOops.hpp"
 #include "utilities/align.hpp"
 #include "utilities/exceptions.hpp"
+#include "utilities/freeList.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 #if INCLUDE_JFR
@@ -83,6 +84,8 @@ class Metadata;
 class ResourceArea;
 
 class OopStorage;
+
+class ObjectMonitor;
 
 DEBUG_ONLY(class ResourceMark;)
 
@@ -640,6 +643,10 @@ protected:
     assert(_wx_state == expected, "wrong state");
   }
 #endif // __APPLE__ && AARCH64
+
+ public:
+  FreeList<ObjectMonitor> _om_freelist;
+
 };
 
 // Inline implementation of Thread::current()

--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -25,6 +25,7 @@
 #include "memory/allocation.hpp"
 #include "memory/metaspace.hpp"
 #include "memory/metaspaceUtils.hpp"
+#include "runtime/objectMonitorStorage.hpp"
 #include "services/mallocTracker.hpp"
 #include "services/memReporter.hpp"
 #include "services/threadStackTracker.hpp"
@@ -98,6 +99,10 @@ void MemReporterBase::print_virtual_memory_region(const char* type, address base
 
 void MemSummaryReporter::report() {
   outputStream* out = output();
+
+  // Sneak in here for now
+  ObjectMonitorStorage::print(out);
+
   const size_t total_malloced_bytes = _malloc_snapshot->total();
   const size_t total_mmap_reserved_bytes = _vm_snapshot->total_reserved();
   const size_t total_mmap_committed_bytes = _vm_snapshot->total_committed();

--- a/src/hotspot/share/services/memTracker.cpp
+++ b/src/hotspot/share/services/memTracker.cpp
@@ -28,6 +28,7 @@
 #include "memory/metaspaceUtils.hpp"
 #include "runtime/atomic.hpp"
 #include "runtime/globals.hpp"
+#include "runtime/objectMonitorStorage.hpp"
 #include "runtime/orderAccess.hpp"
 #include "runtime/vmThread.hpp"
 #include "runtime/vmOperations.hpp"
@@ -146,6 +147,7 @@ void MemTracker::report(bool summary_only, outputStream* output, size_t scale) {
       MetaspaceUtils::print_basic_report(output, scale);
     }
   }
+  output->cr();
 }
 
 void MemTracker::tuning_statistics(outputStream* out) {

--- a/src/hotspot/share/utilities/addressStableArray.hpp
+++ b/src/hotspot/share/utilities/addressStableArray.hpp
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_UTILITIES_ADDRESSSTABLEARRAY_HPP
+#define SHARE_UTILITIES_ADDRESSSTABLEARRAY_HPP
+
+#include "memory/allocation.hpp"
+#include "memory/virtualspace.hpp"
+#include "runtime/os.hpp"
+#include "utilities/align.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/freeList.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+class outputStream;
+
+// An growable array of homogenous things, living in a pre-reserved address range
+//  (and hence ultimately limited in size). Does its own on-demand committing/uncommitting.
+
+template <class T>
+class AddressStableArray : public CHeapObj<mtInternal> {
+  STATIC_ASSERT(sizeof(T) >= sizeof(T*));              // (1)
+  STATIC_ASSERT(is_aligned(sizeof(T), sizeof(T*)));    // (2)
+
+  ReservedSpace _rs;              // Underlying address range
+  T* const _elements;
+  const uintx _max_capacity;      // max number of slots
+  uintx _capacity;                // number of slots usable without committing additional memory
+  uintx _used;                    // number of slots used (includes those in freelist)
+
+  static uintx capacity_of(size_t bytes)  { return bytes / sizeof(T); }
+
+  T* at(uintx idx) const                  { return _elements + idx; }
+
+  static size_t bytes_needed(uintx n)               { return sizeof(T) * n; }
+  static size_t page_align(size_t s)                { return align_up(s, os::vm_page_size()); }
+  static size_t bytes_needed_page_aligned(uintx n)  { return page_align(bytes_needed(n)); }
+  static size_t pages_needed(uintx n)               { return bytes_needed_page_aligned(n) / os::vm_page_size(); }
+
+  // Enlarge committed capacity
+  void enlarge_capacity(uintx min_needed_capacity);
+
+  void check_index(uintx index) const {
+    assert(index < _used, "invalid index (" UINTX_FORMAT ")", index);
+  }
+
+public:
+
+  AddressStableArray(uintx max_capacity, uintx initial_capacity) :
+    _rs(align_up(bytes_needed(max_capacity), os::vm_allocation_granularity())),
+    _elements((T*)_rs.base()),
+    _max_capacity(max_capacity),
+    _capacity(0), _used(0)
+  {
+    assert(_max_capacity >= initial_capacity, "sanity");
+    if ((initial_capacity) > 0) {
+      enlarge_capacity(initial_capacity);
+    }
+  }
+
+  bool contains(const T* v) const {
+    return _elements <= v && (_elements + _used) > v;
+  }
+
+  T* allocate() {
+    if (_used == _capacity) {
+      if (_capacity == _max_capacity) {
+        return NULL;
+      }
+      enlarge_capacity(_capacity + 1);
+    }
+    assert(_used < _capacity, "enlarge failed?");
+    T* p = at(_used);
+    _used ++;
+    return p;
+  }
+
+  uintx obj_to_index(const T* t) const {
+    assert(t != NULL, "element is NULL");
+    assert(contains(t), "elements outside this heap");
+    return (uintx)(t - _elements);
+  }
+
+  T* index_to_obj(uintx idx) {
+    check_index(idx);
+    return _elements + idx;
+  }
+
+  const T* index_to_obj(uintx idx) const {
+    check_index(idx);
+    return _elements + idx;
+  }
+
+  size_t committed_bytes() const {
+    return bytes_needed_page_aligned(_capacity);
+  }
+
+  uintx capacity() const {
+    return _capacity;
+  }
+
+  DEBUG_ONLY(void verify() const;)
+  void print_on(outputStream* st) const;
+
+  // Base address (exposed to set NMT cat; TODO: this is annoying, should be done better
+  const T* base() const { return _elements; }
+
+}; // AddressStableArray
+
+// Same, but with freelist supporting deallocation
+template <class T>
+class AddressStableHeap : public CHeapObj<mtInternal> {
+
+  typedef AddressStableArray<T> ArrayType;
+  typedef FreeList<T> FreeListType;
+
+  ArrayType _array;
+  FreeListType _freelist;
+
+public:
+
+  AddressStableHeap(uintx max_capacity, uintx initial_capacity) :
+    _array(max_capacity, initial_capacity),
+    _freelist()
+  {}
+
+  T* allocate() {
+    T* p = _freelist.take_top();
+    if (p == NULL) {
+      p = _array.allocate();
+    }
+    return p;
+  }
+
+  void deallocate(T* t) {
+    _freelist.prepend(t);
+  }
+
+  // Add all elements to freelist and empties out the donor list
+  void bulk_deallocate(FreeListType& list) {
+    _freelist.prepend_list(list);
+  }
+
+  uintx obj_to_index(const T* t) const   { return _array.obj_to_index(t); }
+  T* index_to_obj(uintx idx)             { return _array.index_to_obj(idx); }
+  const T* index_to_obj(uintx idx) const { return _array.index_to_obj(idx); }
+  size_t committed_bytes() const         { return _array.committed_bytes(); }
+  uintx capacity() const                 { return _array.capacity(); }
+  bool contains(const T* v) const        { return _array.contains(v); }
+
+  DEBUG_ONLY(void verify(bool paranoid = false) const;)
+  void print_on(outputStream* st) const;
+
+  // Base address (exposed to set NMT cat; TODO: this is annoying, should be done better
+  const T* base() const { return _array.base(); }
+
+};
+
+#endif // SHARE_UTILITIES_ADDRESSSTABLEARRAY_HPP

--- a/src/hotspot/share/utilities/addressStableArray.inline.hpp
+++ b/src/hotspot/share/utilities/addressStableArray.inline.hpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_UTILITIES_ADDRESSSTABLEARRAY_INLINE_HPP
+#define SHARE_UTILITIES_ADDRESSSTABLEARRAY_INLINE_HPP
+
+#include "runtime/os.hpp"
+#include "utilities/addressStableArray.hpp"
+#include "utilities/align.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/freeList.inline.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+template <class T>
+void AddressStableArray<T>::enlarge_capacity(uintx min_needed_capacity) {
+
+  assert(_capacity < _max_capacity, "cannot enlarge capacity");
+  const uintx new_capacity =
+      clamp((uintx)(_capacity * 1.25), min_needed_capacity, _max_capacity);
+
+  const size_t committed_bytes = bytes_needed_page_aligned(_capacity);
+  const size_t new_committed_bytes = bytes_needed_page_aligned(new_capacity);
+
+  // Since we always set _capacity to either _max_capacity or the limit of what is
+  // committed, this should hold always true:
+  assert(new_committed_bytes > committed_bytes, "_capacity not at commit boundary");
+
+  os::commit_memory_or_exit(_rs.base() + committed_bytes,
+                        new_committed_bytes - committed_bytes,
+                        false, "");
+  _capacity = MIN2(capacity_of(new_committed_bytes), _max_capacity);
+
+  DEBUG_ONLY(verify();)
+}
+
+#ifdef ASSERT
+template <class T>
+void AddressStableArray<T>::verify() const {
+  assert(_rs.is_reserved(), "no space");
+  assert(_elements != NULL, "elements null");
+  assert(_capacity <= _max_capacity, "Sanity");
+  assert(_max_capacity <= capacity_of(_rs.size()), "Space too small?");
+  assert(_used <= _capacity, "Sanity");
+}
+#endif // ASSERT
+
+template <class T>
+void AddressStableArray<T>::print_on(outputStream* st) const {
+  st->print("elem size: " SIZE_FORMAT ", "
+      "[" PTR_FORMAT "-" PTR_FORMAT "), res/comm " SIZE_FORMAT "/" SIZE_FORMAT ", "
+      "used/capacity/max: " UINTX_FORMAT "/" UINTX_FORMAT "/" UINTX_FORMAT
+      ,
+      sizeof(T),
+      p2i(_rs.base()), p2i(_rs.base() + _rs.size()),
+      _rs.size(), bytes_needed_page_aligned(_capacity),
+      _used, _capacity, _max_capacity
+      );
+}
+
+// AddressStableHeap = AddressStableArray + freelist
+
+template <class T>
+struct VerifyFreeListClosure : public FreeList<T>::Closure {
+  const AddressStableHeap<T>* _container;
+  bool do_it(const T* p) override {
+    assert(_container->contains(p), "kukuck");
+    return true;
+  }
+};
+
+#ifdef ASSERT
+template <class T>
+void AddressStableHeap<T>::verify(bool paranoid) const {
+  _array.verify();
+  _freelist.verify(paranoid);
+  // verify that all elements are part of the array
+  VerifyFreeListClosure<T> verifier;
+  verifier._container = this;
+  _freelist.iterate(verifier);
+}
+#endif // ASSERT
+
+template <class T>
+void AddressStableHeap<T>::print_on(outputStream* st) const {
+  _array.print_on(st);
+  st->print(", freelist: ");
+  _freelist.print_on(st, false);
+}
+
+
+#endif // SHARE_UTILITIES_ADDRESSSTABLEARRAY_INLINE_HPP

--- a/src/hotspot/share/utilities/freeList.hpp
+++ b/src/hotspot/share/utilities/freeList.hpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_UTILITIES_FREELIST_HPP
+#define SHARE_UTILITIES_FREELIST_HPP
+
+#include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+class outputStream;
+
+// Simple classic double-headed, self-counting (optional), freelist of dead elements
+
+template <class T>
+static T* Tptr_at(T* p)                   { return *((T**)p); }
+
+template <class T>
+static void set_Tptr_at(T* p, T* newval)  { *((T**)p) = newval; }
+
+template <class T>
+static void set_Tptr_at_null(T* p)        { set_Tptr_at(p, (T*) NULL); }
+
+template <class T>
+class FreeList {
+
+  static const bool _counting = true;//DEBUG_ONLY(true) NOT_DEBUG(false);
+
+  T* _head;
+  T* _tail;
+  uintx _count;
+  uintx _peak_count;
+
+#ifdef ASSERT
+  void quick_verify() const {
+    assert((_head == NULL) == (_tail == NULL), "malformed list");
+    if (_counting) {
+      assert( (_count == 0 && _head == NULL && _tail == NULL) ||
+              (_count == 1 && _head == _tail) ||
+              (_count > 1 && _head != _tail), "malformed list");
+    }
+  }
+#endif
+
+public:
+
+  FreeList() :
+    _head(NULL), _tail(NULL),
+    _count(0), _peak_count(0)
+  {}
+
+  FreeList(T* head, T* tail, uintx count) :
+    _head(head), _tail(tail),
+    _count(count), _peak_count(count)
+  {}
+
+  T* head() const { return _head; }
+  T* tail() const { return _tail; }
+
+  // Remove the topmost element from the freelist; NULL if empty
+  T* take_top() {
+    T* p = _head;
+    if (p != NULL) {
+      _head = Tptr_at(_head);
+      if (_head == NULL) {
+        _tail = NULL;
+      }
+      if (_counting) {
+        assert(_count > 0, "sanity");
+        _count --;
+      }
+      DEBUG_ONLY(set_Tptr_at_null(p);)
+      DEBUG_ONLY(quick_verify();)
+    }
+    return p;
+  }
+
+  void prepend(T* elem) {
+    if (_head == NULL) {
+      assert(!_counting || 0 == _count, "invalid freelist count");
+      _head = _tail = elem;
+      set_Tptr_at_null(_head);
+    } else {
+      assert(!_counting || 0 < _count, "invalid freelist count");
+      set_Tptr_at(elem, _head);
+      _head = elem;
+    }
+    if (_counting) {
+      _count ++;
+      _peak_count = MAX2(_peak_count, _count);
+    }
+    DEBUG_ONLY(quick_verify();)
+  }
+
+  // Take over other list, reset other list
+  void take_elements(FreeList& other) {
+    assert(empty(), "must be empty");
+    if (!other.empty()) {
+      _head = other.head();
+      _tail = other.tail();
+      if (_counting) {
+        _count = other.count();
+        _peak_count = other.peak_count();
+      }
+      other.reset();
+      DEBUG_ONLY(verify();)
+    }
+  }
+
+  // Prepends list items to this list and resets the other list.
+  void prepend_list(FreeList& other) {
+    DEBUG_ONLY(other.quick_verify();)
+    if (!other.empty()) {
+      if (empty()) {
+        take_elements(other);
+      } else {
+        set_Tptr_at(other.tail(), _head);
+        _head = other.head();
+        if (_counting) {
+          _count += other.count();
+          _peak_count = MAX2(_peak_count, _count);
+        }
+        DEBUG_ONLY(verify();)
+        other.reset();
+      }
+    }
+  }
+
+  void prepend_list(T* head, T* tail, uintx count) {
+    FreeList tmp(head, tail, count);
+    add_list_to_front(tmp);
+  }
+
+  // Reset also resets the peak count, so the history is lost.
+  void reset() {
+    _head = _tail = NULL;
+    if (_counting) {
+      _count = _peak_count = 0;
+    }
+  }
+
+  bool empty() const { return _head == NULL; }
+
+  // True if list counts itself
+  bool counting() const       { return _counting; }
+  uintx count() const         { return _count; }      // Note: only if counting
+  uintx peak_count() const    { return _peak_count; } // Note: only if counting
+
+  struct Closure {
+    // return false to stop iterating
+    virtual bool do_it(const T* element) = 0;
+  };
+  // Call Closure.doit(). If that returns false, iteration is cancelled at that point.
+  uintx iterate(Closure& closure) const;
+
+#ifdef ASSERT
+  // paranoid = true: dup check
+  void verify(bool paranoid = false) const;
+#endif
+
+  void print_on(outputStream* st, bool print_elems = false) const;
+
+}; // Freelist
+
+#endif // SHARE_UTILITIES_FREELIST_HPP

--- a/src/hotspot/share/utilities/freeList.inline.hpp
+++ b/src/hotspot/share/utilities/freeList.inline.hpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_UTILITIES_FREELIST_INLINE_HPP
+#define SHARE_UTILITIES_FREELIST_INLINE_HPP
+
+#include "utilities/freeList.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/ostream.hpp"
+
+class outputStream;
+
+template <class T>
+uintx FreeList<T>::iterate(FreeList<T>::Closure& closure) const {
+  uintx processed = 0;
+  bool go_on = true;
+  for (const T* p = head(); go_on && p != NULL; p = Tptr_at(p)) {
+    processed ++;
+    go_on = closure.do_it(p);
+  }
+  return processed;
+}
+
+#ifdef ASSERT
+template <class T>
+void FreeList<T>::verify(bool paranoid) const {
+
+  STATIC_ASSERT(sizeof(T) >= sizeof(T*));
+
+  quick_verify();
+
+  // Simple verify list and list length. Also call verify_closure if it is set.
+  if (_counting) {
+    uintx counted = 0;
+    for (const T* p = head(); p != NULL; p = Tptr_at(p)) {
+      assert(counted < _count, "too many elements (more than " UINTX_FORMAT ")?", _count);
+      counted ++;
+    }
+    assert(!_counting || _count == counted, "count is off");
+  }
+
+  // In paranoid mode, or if we have know we have fewer than n elements,
+  // we check for duplicates. Slow (O(n^2)/2).
+  if (paranoid || (_counting && _count < 10)) {
+    for (const T* p = head(); p != NULL; p = Tptr_at(p)) {
+      for (const T* p2 = Tptr_at(p); p2 != NULL; p2 = Tptr_at(p2)) {
+        assert(p2 != p, "duplicate in list");
+      }
+    }
+  }
+}
+#endif // ASSERT
+
+template <class T>
+void FreeList<T>::print_on(outputStream* st, bool print_elems) const {
+  if (_counting) {
+    st->print(UINTX_FORMAT " elems (peak: " UINTX_FORMAT " elems)", _count, _peak_count);
+  } else {
+    // No count, do the best we can
+    if (_head == NULL) {
+      st->print("0 elems");
+    } else if (_head == _tail) {
+      st->print("1 elems");
+    } else {
+      st->print(">1 elems");
+    }
+  }
+  if (print_elems) {
+    st->cr();
+    for (const T* p = head(); p != NULL; p = Tptr_at(p)) {
+      st->print(PTR_FORMAT "->", p2i(p));
+    }
+    st->cr();
+  }
+}
+
+#endif // SHARE_UTILITIES_FREELIST_INLINE_HPP

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -42,6 +42,7 @@
 #include "runtime/atomic.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/init.hpp"
+#include "runtime/objectMonitorStorage.hpp"
 #include "runtime/os.hpp"
 #include "runtime/osThread.hpp"
 #include "runtime/safefetch.inline.hpp"
@@ -1076,6 +1077,13 @@ void VMError::report(outputStream* st, bool _verbose) {
        st->cr();
      }
 
+  STEP("printing objmon storage information")
+
+     if (_verbose && Universe::is_fully_initialized()) {
+       st->print_cr("ObjectMonitorStorage:");
+       ObjectMonitorStorage::print(st);
+     }
+
   STEP("printing ring buffers")
 
      if (_verbose) {
@@ -1283,6 +1291,13 @@ void VMError::print_vm_info(outputStream* st) {
     // print code cache information before vm abort
     CodeCache::print_summary(st);
     st->cr();
+  }
+
+  // STEP("printing objmon storage information")
+
+  if (Universe::is_fully_initialized()) {
+    st->print_cr("ObjectMonitorStorage:");
+    ObjectMonitorStorage::print(st);
   }
 
   // STEP("printing ring buffers")

--- a/test/hotspot/gtest/utilities/test_addressStableArray.cpp
+++ b/test/hotspot/gtest/utilities/test_addressStableArray.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+
+ */
+
+#include "precompiled.hpp"
+
+#include "runtime/os.hpp"
+#include "utilities/addressStableArray.inline.hpp"
+#include "utilities/align.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+#include "unittest.hpp"
+#include "testutils.hpp"
+
+template <class T>
+static void test_fill_empty_repeat(uintx max_size, uintx initialsize) {
+  AddressStableHeap<T> a1(max_size, initialsize);
+  T** elems = NEW_C_HEAP_ARRAY(T*, max_size, mtTest);
+  memset(elems, 0, sizeof(T*) * max_size);
+  if (initialsize == 0) {
+    ASSERT_EQ(a1.committed_bytes(), (size_t)0);
+  }
+  DEBUG_ONLY(a1.verify();)
+  const size_t fully_committed_size = align_up(sizeof(T) * max_size, os::vm_page_size());
+  for (int cycle = 0; cycle < 3; cycle ++) {
+    // (Re)fill
+    for (uintx i = 0; i < max_size; i ++) {
+      T* p = a1.allocate();
+      if (i < max_size) {
+        ASSERT_NE(p, (T*)NULL);
+        elems[i] = p;
+      }
+    }
+    // We should be right at the limit now
+    ASSERT_EQ(a1.allocate(), (T*)NULL);
+    ASSERT_EQ(a1.committed_bytes(), fully_committed_size);
+    DEBUG_ONLY(a1.verify(true);)
+    // Empty out
+    for (uintx i = 0; i < max_size; i ++) {
+      a1.deallocate(elems[i]);
+    }
+    ASSERT_EQ(a1.committed_bytes(), fully_committed_size);
+    DEBUG_ONLY(a1.verify();)
+  }
+  FREE_C_HEAP_ARRAY(T, elems);
+}
+
+template <class T>
+static void test_fill_empty_randomly(uintx max_size, uintx initialsize) {
+  AddressStableHeap<T> a1(max_size, initialsize);
+  T** elems = NEW_C_HEAP_ARRAY(T*, max_size, mtTest);
+  memset(elems, 0, sizeof(T*) * max_size);
+  DEBUG_ONLY(a1.verify();)
+  for (uintx iter = 0; iter < MIN2(max_size * 4, (uintx)1024); iter ++) {
+    const int idx = os::random() % max_size;
+    if (elems[idx] == NULL) {
+      T* p = a1.allocate();
+      ASSERT_NE(p, (T*)NULL);
+      elems[idx] = p;
+    } else {
+      a1.deallocate(elems[idx]);
+      elems[idx] = NULL;
+    }
+    if ((iter % 256) == 0) {
+      DEBUG_ONLY(a1.verify(iter % 1024 == 0);)
+    }
+  }
+  DEBUG_ONLY(a1.verify(true);)
+  // Now allocate the full complement, just what we think is the container fill grade is right
+  for (uintx i = 0; i < max_size; i++) {
+    if (elems[i] == 0) {
+      T* p = a1.allocate();
+      ASSERT_NE(p, (T*)NULL);
+      elems[i] = p;
+    }
+  }
+  // We should be right at the limit now
+  ASSERT_EQ(a1.allocate(), (T*)NULL);
+  FREE_C_HEAP_ARRAY(T, elems);
+}
+
+template <class T>
+static void run_all_tests(uintx max_capacity, uintx initial_capacity) {
+  test_fill_empty_repeat<T>(max_capacity, initial_capacity);
+  test_fill_empty_randomly<T>(max_capacity, initial_capacity);
+}
+
+template <class T>
+static void run_all_tests() {
+  uintx max_max = (10 * M) / sizeof(T);           // don't use more than 10M in total
+  max_max = MIN2(max_max, (uintx)100000);         // and limit to 100000 entries
+  run_all_tests<T>(1, 0);
+  run_all_tests<T>(10, 0);
+  run_all_tests<T>(max_max, 0);
+  run_all_tests<T>(max_max, max_max/2);
+}
+
+#define test_stable_array(T) \
+TEST_VM(AddressStableArray, fill_empty_repeat_##T) \
+{ \
+	run_all_tests<T>(); \
+}
+
+test_stable_array(uint64_t);
+
+struct s3 { void* p[3]; };
+test_stable_array(s3);
+
+struct s216 { char p[216]; };
+test_stable_array(s216);
+
+// almost, but not quite, a page
+struct almost_one_page { char m[4096 - 8]; };
+test_stable_array(almost_one_page);

--- a/test/hotspot/gtest/utilities/test_freelist.cpp
+++ b/test/hotspot/gtest/utilities/test_freelist.cpp
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+
+ */
+
+#include "precompiled.hpp"
+
+#include "runtime/os.hpp"
+#include "utilities/freeList.inline.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/ostream.hpp"
+
+#include "unittest.hpp"
+#include "testutils.hpp"
+
+#define ASSERT_LIST_COUNT(list, n)            \
+  if (list.counting()) {                      \
+    ASSERT_EQ(list.count(), (uintx)n);        \
+  }
+
+#define ASSERT_LIST_PEAK(list, n)             \
+  if (list.counting()) {                      \
+    ASSERT_EQ(list.peak_count(), (uintx)n);   \
+  }
+
+#define ASSERT_LIST_EMPTY(list)    \
+  ASSERT_TRUE(list.empty());       \
+  ASSERT_LIST_COUNT(list, 0)
+
+template <class T>
+static void prepend_all_with_checks(FreeList<T>& list, T* elems, int num, int expected_start_count) {
+  ASSERT_LIST_COUNT(list, expected_start_count);
+  if (expected_start_count == 0) {
+    ASSERT_TRUE(list.empty());
+  }
+  for (int i = 0; i < num; i ++) {
+    list.prepend(elems + i);
+    ASSERT_LIST_COUNT(list, expected_start_count + i + 1);
+    ASSERT_FALSE(list.empty());
+  }
+}
+
+template <class T>
+static void safely_print_list(FreeList<T>& list) {
+  char tmp[1024];
+  stringStream ss(tmp, sizeof(tmp));
+  list.print_on(&ss, true);
+  printf("%s\n", tmp);
+}
+
+
+#define NUM_ELEMS 30
+
+template <class T>
+static void test_empty_list() {
+  FreeList<T> list;
+  ASSERT_LIST_EMPTY(list);
+  DEBUG_ONLY(list.verify(true);)
+}
+
+template <class T>
+static void prepare_new_list_with_checks(FreeList<T>& list, T* elems) {
+  prepend_all_with_checks(list, elems, NUM_ELEMS, 0);
+  ASSERT_LIST_COUNT(list, NUM_ELEMS);
+  ASSERT_LIST_PEAK(list, NUM_ELEMS);
+  DEBUG_ONLY(list.verify(true);)
+}
+
+template <class T>
+static void test_single_prepend() {
+
+  FreeList<T> list;
+  ASSERT_LIST_EMPTY(list);
+  DEBUG_ONLY(list.verify(true);)
+
+  T t[NUM_ELEMS];
+  prepare_new_list_with_checks<T>(list, t);
+
+  for (int i = NUM_ELEMS - 1; i >= 0; i --) {
+    T* p = list.take_top();
+    ASSERT_EQ(p, t + i);
+    ASSERT_LIST_COUNT(list, i);
+  }
+  ASSERT_LIST_EMPTY(list);
+  ASSERT_LIST_PEAK(list, NUM_ELEMS);
+  DEBUG_ONLY(list.verify(true);)
+}
+
+template <class T, int max_expected>
+struct TestIterator : public FreeList<T>::Closure {
+
+  const T* t[max_expected];
+  const int _stop_after;
+  int _found;
+
+  TestIterator(int stop_after = max_expected * 2)
+    : _stop_after(stop_after),
+      _found(0)
+  {
+    for (int i = 0; i < max_expected; i ++) {
+      t[i] = NULL;
+    }
+  }
+
+  bool do_it(const T* p) override {
+    if (_found == max_expected) {
+     return false;
+    }
+    t[_found] = p;
+    _found ++;
+    return _found < _stop_after;
+  }
+
+};
+
+template <class T>
+static void test_iteration(bool premature_stop) {
+
+  FreeList<T> list;
+  ASSERT_LIST_EMPTY(list);
+  DEBUG_ONLY(list.verify(true);)
+
+  T t[NUM_ELEMS];
+  prepare_new_list_with_checks<T>(list, t);
+
+  const int stop_after = premature_stop ? 3 : INT_MAX;
+  const int expected_stop_at = premature_stop ? 3 : NUM_ELEMS;
+  TestIterator<T, NUM_ELEMS> it(stop_after);
+
+  ASSERT_EQ(list.iterate(it), (uintx)expected_stop_at);
+  ASSERT_EQ(it._found, expected_stop_at);
+  for (int i = 0; i < NUM_ELEMS; i++) {
+//safely_print_list<T>(list);
+    if (i < expected_stop_at) {
+      ASSERT_EQ(it.t[i], t + (NUM_ELEMS - i - 1)) << i; // we prepended, so FIFO
+    } else {
+      ASSERT_NULL(it.t[i]) << i;
+    }
+  }
+}
+
+template <class T>
+static void test_iteration_full()         { test_iteration<T>(false); }
+
+template <class T>
+static void test_iteration_interrupted()  { test_iteration<T>(true); }
+
+template <class T>
+static void test_reset() {
+  FreeList<T> list;
+
+  T t[NUM_ELEMS];
+  prepare_new_list_with_checks<T>(list, t);
+
+  list.reset();
+  ASSERT_LIST_EMPTY(list);
+  ASSERT_LIST_PEAK(list, 0); // Reset also should reset peak
+  DEBUG_ONLY(list.verify(true);)
+}
+
+template <class T>
+static void test_take_over() {
+  FreeList<T> list1;
+  ASSERT_LIST_EMPTY(list1);
+
+  FreeList<T> list2;
+  T t[NUM_ELEMS];
+  prepare_new_list_with_checks<T>(list2, t);
+
+  list1.take_elements(list2);
+  ASSERT_LIST_EMPTY(list2);
+  ASSERT_LIST_COUNT(list1, NUM_ELEMS);
+  ASSERT_LIST_PEAK(list1, NUM_ELEMS);
+}
+
+template <class T>
+static void test_prepend_list(bool empty_receiver, bool empty_donor) {
+  FreeList<T> list1;
+  FreeList<T> list2;
+
+  T t1[NUM_ELEMS];
+  uintx num1 = 0;
+  T t2[NUM_ELEMS];
+  uintx num2 = 0;
+
+  if (!empty_receiver) {
+    prepare_new_list_with_checks<T>(list1, t1);
+    num1 = NUM_ELEMS;
+  }
+
+  if (!empty_donor) {
+    prepare_new_list_with_checks<T>(list2, t2);
+    num2 = NUM_ELEMS;
+  }
+
+  list1.prepend_list(list2);
+  ASSERT_LIST_COUNT(list1, num1 + num2);
+  ASSERT_LIST_PEAK(list1, num1 + num2);
+  DEBUG_ONLY(list1.verify(true);)
+
+  ASSERT_LIST_EMPTY(list2);
+  DEBUG_ONLY(list2.verify(true);)
+
+  // Prepends prepends the list2 elems in front of list1
+  // and since prepare_new_list_with_checks also prepends the individual
+  // elements, we expect elements to be in inverse address order
+  for (int i = num2 - 1; i >= 0; i --) {
+    T* p = list1.take_top();
+    ASSERT_EQ(p, t2 + i);
+    ASSERT_LIST_COUNT(list1, num1 + i);
+  }
+
+  for (int i = num1 - 1; i >= 0; i --) {
+    T* p = list1.take_top();
+    ASSERT_EQ(p, t1 + i);
+    ASSERT_LIST_COUNT(list1, i);
+  }
+
+  ASSERT_LIST_COUNT(list1, 0);
+  ASSERT_LIST_PEAK(list1, num1 + num2);
+  DEBUG_ONLY(list1.verify(true);)
+}
+
+template <class T> static void test_prepend_list_both_empty()     { test_prepend_list<T>(true, true); }
+template <class T> static void test_prepend_list_both_nonempty()  { test_prepend_list<T>(false, false); }
+template <class T> static void test_prepend_list_receiver_empty() { test_prepend_list<T>(true, false); }
+template <class T> static void test_prepend_list_donor_empty()    { test_prepend_list<T>(false, true); }
+
+#define DO_ONE_TEST(T, testname)      \
+TEST(FreeList, test_##testname##_##T) \
+{                                     \
+  testname<T>();                      \
+}
+
+#define DO_ALL_TESTS(T)                               \
+  DO_ONE_TEST(T, test_empty_list)                     \
+  DO_ONE_TEST(T, test_single_prepend)                 \
+  DO_ONE_TEST(T, test_reset)                          \
+  DO_ONE_TEST(T, test_prepend_list_both_empty)        \
+  DO_ONE_TEST(T, test_prepend_list_both_nonempty)     \
+  DO_ONE_TEST(T, test_prepend_list_receiver_empty)    \
+  DO_ONE_TEST(T, test_prepend_list_donor_empty)       \
+  DO_ONE_TEST(T, test_iteration_full)                 \
+  DO_ONE_TEST(T, test_iteration_interrupted)          \
+
+DO_ALL_TESTS(uint64_t);
+
+struct s3 { void* p[3]; };
+DO_ALL_TESTS(s3);
+
+struct s216 { char p[216]; };
+DO_ALL_TESTS(s216);

--- a/test/hotspot/jtreg/serviceability/jvmti/SuspendWithRawMonitorEnter/SuspendWithRawMonitorEnter.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/SuspendWithRawMonitorEnter/SuspendWithRawMonitorEnter.java
@@ -28,7 +28,7 @@
  * @requires vm.jvmti
  * @library /test/lib
  * @compile SuspendWithRawMonitorEnter.java
- * @run main/othervm/native -agentlib:SuspendWithRawMonitorEnter SuspendWithRawMonitorEnter
+ * @run main/othervm/native -XX:+ErrorFileToStdout -agentlib:SuspendWithRawMonitorEnter SuspendWithRawMonitorEnter
  */
 
 import java.io.PrintStream;


### PR DESCRIPTION
On Linux/glibc platforms, the hs-err file should report the malloc tunables, or at least MALLOC_ARENA_MAX, since that one can have a significant effect on footprint or malloc contention for a VM.

This patch adds this printout as a one-liner into hs-err files and jcmd VM.info reports:

```
Process Memory:                                                                    
...
glibc malloc tunables: MALLOC_PERTURB_=40, MALLOC_ARENA_MAX=1
```
If the tunables are default, we print `glibc malloc tunables: (default)`.

Thanks, Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8282382](https://bugs.openjdk.java.net/browse/JDK-8282382): Report glibc malloc tunables in error reports


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7619/head:pull/7619` \
`$ git checkout pull/7619`

Update a local copy of the PR: \
`$ git checkout pull/7619` \
`$ git pull https://git.openjdk.java.net/jdk pull/7619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7619`

View PR using the GUI difftool: \
`$ git pr show -t 7619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7619.diff">https://git.openjdk.java.net/jdk/pull/7619.diff</a>

</details>
