### PR TITLE
8267820: (fs) Files.copy should attempt to copy POSIX attributes when target file in custom file system

### DIFF
--- a/src/java.base/share/classes/java/nio/file/CopyMoveHelper.java
+++ b/src/java.base/share/classes/java/nio/file/CopyMoveHelper.java
@@ -158,11 +158,6 @@ class CopyMoveHelper {
                 if (srcAttrs instanceof PosixFileAttributes srcPosixAttrs &&
                     dstView instanceof PosixFileAttributeView dstPosixView) {
                     dstPosixView.setPermissions(srcPosixAttrs.permissions());
-                    try {
-                        dstPosixView.setOwner(srcPosixAttrs.owner());
-                        dstPosixView.setGroup(srcPosixAttrs.group());
-                    } catch (ProviderMismatchException ignore) {
-                    }
                 }
             } catch (Throwable x) {
                 // rollback

--- a/src/java.base/share/classes/java/nio/file/CopyMoveHelper.java
+++ b/src/java.base/share/classes/java/nio/file/CopyMoveHelper.java
@@ -106,11 +106,11 @@ class CopyMoveHelper {
             new LinkOption[] { LinkOption.NOFOLLOW_LINKS };
 
         // retrieve source posix view, null if unsupported
-        final PosixFileAttributeView srcPosixView =
+        final PosixFileAttributeView sourcePosixView =
             Files.getFileAttributeView(source, PosixFileAttributeView.class);
 
         // attributes of source file
-        BasicFileAttributes srcAttrs = srcPosixView != null ?
+        BasicFileAttributes sourceAttrs = sourcePosixView != null ?
             Files.readAttributes(source,
                                  PosixFileAttributes.class,
                                  linkOptions) :
@@ -118,7 +118,7 @@ class CopyMoveHelper {
                                  BasicFileAttributes.class,
                                  linkOptions);
 
-        if (srcAttrs.isSymbolicLink())
+        if (sourceAttrs.isSymbolicLink())
             throw new IOException("Copying of symbolic links not supported");
 
         // delete target if it exists and REPLACE_EXISTING is specified
@@ -128,7 +128,7 @@ class CopyMoveHelper {
             throw new FileAlreadyExistsException(target.toString());
 
         // create directory or copy file
-        if (srcAttrs.isDirectory()) {
+        if (sourceAttrs.isDirectory()) {
             Files.createDirectory(target);
         } else {
             try (InputStream in = Files.newInputStream(source)) {
@@ -138,26 +138,26 @@ class CopyMoveHelper {
 
         // copy basic and, if supported, POSIX attributes to target
         if (opts.copyAttributes) {
-            BasicFileAttributeView dstView = null;
-            if (srcPosixView != null) {
-                dstView = Files.getFileAttributeView(target,
+            BasicFileAttributeView targetView = null;
+            if (sourcePosixView != null) {
+                targetView = Files.getFileAttributeView(target,
                                                      PosixFileAttributeView.class);
             }
 
             // target might not support posix even if source does
-            if (dstView == null) {
-                dstView = Files.getFileAttributeView(target,
+            if (targetView == null) {
+                targetView = Files.getFileAttributeView(target,
                                                      BasicFileAttributeView.class);
             }
 
             try {
-                dstView.setTimes(srcAttrs.lastModifiedTime(),
-                                 srcAttrs.lastAccessTime(),
-                                 srcAttrs.creationTime());
+                targetView.setTimes(sourceAttrs.lastModifiedTime(),
+                                 sourceAttrs.lastAccessTime(),
+                                 sourceAttrs.creationTime());
 
-                if (srcAttrs instanceof PosixFileAttributes srcPosixAttrs &&
-                    dstView instanceof PosixFileAttributeView dstPosixView) {
-                    dstPosixView.setPermissions(srcPosixAttrs.permissions());
+                if (sourceAttrs instanceof PosixFileAttributes sourcePosixAttrs &&
+                    targetView instanceof PosixFileAttributeView targetPosixView) {
+                    targetPosixView.setPermissions(sourcePosixAttrs.permissions());
                 }
             } catch (Throwable x) {
                 // rollback

--- a/test/jdk/java/nio/file/Files/CopyAndMove.java
+++ b/test/jdk/java/nio/file/Files/CopyAndMove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4313887 6838333 6917021 7006126 6950237 8006645 8201407
+ * @bug 4313887 6838333 6917021 7006126 6950237 8006645 8201407 8267820
  * @summary Unit test for java.nio.file.Files copy and move methods (use -Dseed=X to set PRNG seed)
  * @library .. /test/lib
  * @build jdk.test.lib.Platform jdk.test.lib.RandomFactory
@@ -672,16 +672,15 @@ public class CopyAndMove {
             checkBasicAttributes(basicAttributes,
                 readAttributes(source, BasicFileAttributes.class, linkOptions));
 
+            // check POSIX attributes are copied
+            if (!Platform.isWindows() && testPosixAttributes) {
+                checkPosixAttributes(
+                    readAttributes(source, PosixFileAttributes.class, linkOptions),
+                    readAttributes(target, PosixFileAttributes.class, linkOptions));
+            }
+
             // verify other attributes when same provider
             if (source.getFileSystem().provider() == target.getFileSystem().provider()) {
-
-                // check POSIX attributes are copied
-                if (!Platform.isWindows() && testPosixAttributes) {
-                    checkPosixAttributes(
-                        readAttributes(source, PosixFileAttributes.class, linkOptions),
-                        readAttributes(target, PosixFileAttributes.class, linkOptions));
-                }
-
                 // check DOS attributes are copied
                 if (Platform.isWindows()) {
                     checkDosAttributes(

--- a/test/jdk/jdk/nio/zipfs/TestPosix.java
+++ b/test/jdk/jdk/nio/zipfs/TestPosix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, SAP SE. All rights reserved.
+ * Copyright (c) 2019, 2022, SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,11 +69,11 @@ import static org.testng.Assert.fail;
 /**
  * @test
  * @bug 8213031 8273935
+ * @summary Test POSIX ZIP file operations.
  * @modules jdk.zipfs
  *          jdk.jartool
  * @run testng TestPosix
  * @run testng/othervm/java.security.policy=test.policy.posix TestPosix
- * @summary Test POSIX zip file operations.
  */
 public class TestPosix {
     private static final ToolProvider JAR_TOOL = ToolProvider.findFirst("jar")
@@ -528,9 +528,11 @@ public class TestPosix {
         }
 
         // check entries on copied zipfs - no permission data should exist
-        try (FileSystem zip = FileSystems.newFileSystem(ZIP_FILE_COPY, ENV_DEFAULT)) {
-            checkEntries(zip, checkExpects.noPermDataInZip);
-        }
+        if (System.getProperty("os.name").toLowerCase().contains("windows"))
+            try (FileSystem zip = FileSystems.newFileSystem(ZIP_FILE_COPY,
+                ENV_DEFAULT)) {
+                checkEntries(zip, checkExpects.noPermDataInZip);
+            }
     }
 
     /**

--- a/test/jdk/jdk/nio/zipfs/test.policy
+++ b/test/jdk/jdk/nio/zipfs/test.policy
@@ -3,4 +3,5 @@ grant {
     permission java.util.PropertyPermission "test.jdk","read";
     permission java.util.PropertyPermission "test.src","read";
     permission java.util.PropertyPermission "user.dir","read";
+    permission java.lang.RuntimePermission "accessUserInformation";
 };

--- a/test/jdk/jdk/nio/zipfs/test.policy.posix
+++ b/test/jdk/jdk/nio/zipfs/test.policy.posix
@@ -5,4 +5,5 @@ grant {
     permission java.util.PropertyPermission "test.src","read";
     permission java.util.PropertyPermission "user.dir","read";
     permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.module";
+    permission java.lang.RuntimePermission "accessUserInformation";
 };


### PR DESCRIPTION
In `java.nio.file.Files.copy()` copy POSIX attributes even if the target is from a different file system provided both the source and target file systems support such attributes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267820](https://bugs.openjdk.java.net/browse/JDK-8267820): (fs) Files.copy should attempt to copy POSIX attributes when target file in custom file system


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7627/head:pull/7627` \
`$ git checkout pull/7627`

Update a local copy of the PR: \
`$ git checkout pull/7627` \
`$ git pull https://git.openjdk.java.net/jdk pull/7627/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7627`

View PR using the GUI difftool: \
`$ git pr show -t 7627`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7627.diff">https://git.openjdk.java.net/jdk/pull/7627.diff</a>

</details>
