### PR TITLE
8282414: x86: Enhance the assembler to generate more compact instructions

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -928,7 +928,7 @@ address Assembler::locate_operand(address inst, WhichOperand which) {
     }
     break;
 
-  case 0x81: // addl r, #32
+  case 0x81: // addl a, #32, addl r, #32
     // also: orl, adcl, sbbl, andl, subl, xorl, cmpl
     // on 32bit in the case of cmpl, the imm might be an oop
     tail_size = 4;
@@ -941,14 +941,14 @@ address Assembler::locate_operand(address inst, WhichOperand which) {
     tail_size = 1;
     break;
 
-  case 0x15: // adc a, #32
-  case 0x05: // add a, #32
-  case 0x25: // and a, #32
-  case 0x3D: // cmp a, #32
-  case 0x0D: // or  a, #32
-  case 0x1D: // sbb a, #32
-  case 0x2D: // sub a, #32
-  case 0x35: // xor a, #32
+  case 0x15: // adc rax, #32
+  case 0x05: // add rax, #32
+  case 0x25: // and rax, #32
+  case 0x3D: // cmp rax, #32
+  case 0x0D: // or  rax, #32
+  case 0x1D: // sbb rax, #32
+  case 0x2D: // sub rax, #32
+  case 0x35: // xor rax, #32
     return which == end_pc_operand ? ip + 4 : ip;
 
   case 0x9B:
@@ -976,9 +976,9 @@ address Assembler::locate_operand(address inst, WhichOperand which) {
     debug_only(has_disp32 = true); // has both kinds of operands!
     break;
 
-  case 0xA8: // testb a, #8
+  case 0xA8: // testb rax, #8
     return which == end_pc_operand ? ip + 1 : ip;
-  case 0xA9: // testl/testq a, #32
+  case 0xA9: // testl/testq rax, #32
     return which == end_pc_operand ? ip + 4 : ip;
 
   case 0xC1: // sal a, #8; sar a, #8; shl a, #8; shr a, #8
@@ -1707,12 +1707,6 @@ void Assembler::cmpl(Address dst, int32_t imm32) {
   prefix(dst);
   emit_int8((unsigned char)0x81);
   emit_operand(rdi, dst, 4);
-  emit_int32(imm32);
-}
-
-void Assembler::cmp(Register dst, int32_t imm32) {
-  prefix(dst);
-  emit_int8((unsigned char)0x3D);
   emit_int32(imm32);
 }
 

--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -928,7 +928,7 @@ address Assembler::locate_operand(address inst, WhichOperand which) {
     }
     break;
 
-  case 0x81: // addl a, #32; addl r, #32
+  case 0x81: // addl r, #32
     // also: orl, adcl, sbbl, andl, subl, xorl, cmpl
     // on 32bit in the case of cmpl, the imm might be an oop
     tail_size = 4;
@@ -940,6 +940,16 @@ address Assembler::locate_operand(address inst, WhichOperand which) {
     debug_only(has_disp32 = true); // has both kinds of operands!
     tail_size = 1;
     break;
+
+  case 0x15: // adc a, #32
+  case 0x05: // add a, #32
+  case 0x25: // and a, #32
+  case 0x3D: // cmp a, #32
+  case 0x0D: // or  a, #32
+  case 0x1D: // sbb a, #32
+  case 0x2D: // sub a, #32
+  case 0x35: // xor a, #32
+    return which == end_pc_operand ? ip + 4 : ip;
 
   case 0x9B:
     switch (0xFF & *ip++) {
@@ -965,6 +975,11 @@ address Assembler::locate_operand(address inst, WhichOperand which) {
   case 0x85: // test r, a
     debug_only(has_disp32 = true); // has both kinds of operands!
     break;
+
+  case 0xA8: // testb a, #8
+    return which == end_pc_operand ? ip + 1 : ip;
+  case 0xA9: // testl/testq a, #32
+    return which == end_pc_operand ? ip + 4 : ip;
 
   case 0xC1: // sal a, #8; sar a, #8; shl a, #8; shr a, #8
   case 0xC6: // movb a, #8

--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -928,7 +928,7 @@ address Assembler::locate_operand(address inst, WhichOperand which) {
     }
     break;
 
-  case 0x81: // addl a, #32, addl r, #32
+  case 0x81: // addl a, #32; addl r, #32
     // also: orl, adcl, sbbl, andl, subl, xorl, cmpl
     // on 32bit in the case of cmpl, the imm might be an oop
     tail_size = 4;

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -2092,9 +2092,10 @@ private:
   void subss(XMMRegister dst, Address src);
   void subss(XMMRegister dst, XMMRegister src);
 
-  void testb(Register dst, int imm8);
   void testb(Address dst, int imm8);
+  void testb(Register dst, int imm8);
 
+  void testl(Address dst, int32_t imm32);
   void testl(Register dst, int32_t imm32);
   void testl(Register dst, Register src);
   void testl(Register dst, Address src);

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -1081,15 +1081,12 @@ private:
   void cmpb(Address dst, int imm8);
 
   void cmpl(Address dst, int32_t imm32);
-
-  void cmp(Register dst, int32_t imm32);
   void cmpl(Register dst, int32_t imm32);
   void cmpl(Register dst, Register src);
   void cmpl(Register dst, Address src);
 
   void cmpq(Address dst, int32_t imm32);
   void cmpq(Address dst, Register src);
-
   void cmpq(Register dst, int32_t imm32);
   void cmpq(Register dst, Register src);
   void cmpq(Register dst, Address src);

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -1925,7 +1925,7 @@ encode %{
     Label normal;
     Label done;
 
-    // cmpl    $0x80000000,%eax
+    // cmp    $0x80000000,%eax
     __ cmpl(as_Register(RAX_enc), 0x80000000);
 
     // jne    e <normal>
@@ -1934,7 +1934,7 @@ encode %{
     // xor    %edx,%edx
     __ xorl(as_Register(RDX_enc), as_Register(RDX_enc));
 
-    // cmpl    $0xffffffffffffffff,%ecx
+    // cmp    $0xffffffffffffffff,%ecx
     __ cmpl($div$$Register, -1);
 
     // je     11 <done>

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -1925,8 +1925,8 @@ encode %{
     Label normal;
     Label done;
 
-    // cmp    $0x80000000,%eax
-    __ cmp(as_Register(RAX_enc), 0x80000000);
+    // cmpl    $0x80000000,%eax
+    __ cmpl(as_Register(RAX_enc), 0x80000000);
 
     // jne    e <normal>
     __ jccb(Assembler::notEqual, normal);
@@ -1934,7 +1934,7 @@ encode %{
     // xor    %edx,%edx
     __ xorl(as_Register(RDX_enc), as_Register(RDX_enc));
 
-    // cmp    $0xffffffffffffffff,%ecx
+    // cmpl    $0xffffffffffffffff,%ecx
     __ cmpl($div$$Register, -1);
 
     // je     11 <done>


### PR DESCRIPTION
Hi, this patch enhances the x86 assembler to emit more compact code for some popular instructions.

For common arithmetic instructions against immediates, if the immediate requires more than 1 byte to encode, we can still shave off 1 byte if the register operand is rax.

For test instruction, since the operation does not write the result, we can downgrade a long to an int and an int to a byte instruction if the immediate is positive and encodable using a smaller amount of bytes.

Thank you very much.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282414](https://bugs.openjdk.java.net/browse/JDK-8282414): x86: Enhance the assembler to generate more compact instructions


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Sandhya Viswanathan](https://openjdk.java.net/census#sviswanathan) (@sviswa7 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7628/head:pull/7628` \
`$ git checkout pull/7628`

Update a local copy of the PR: \
`$ git checkout pull/7628` \
`$ git pull https://git.openjdk.java.net/jdk pull/7628/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7628`

View PR using the GUI difftool: \
`$ git pr show -t 7628`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7628.diff">https://git.openjdk.java.net/jdk/pull/7628.diff</a>

</details>
