### PR TITLE
8279573: compiler/codecache/CodeCacheFullCountTest.java fails with "RuntimeException: the value of full_count is wrong."

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1238,9 +1238,9 @@ void CodeCache::report_codemem_full(int code_blob_type, bool print) {
   CodeHeap* heap = get_code_heap(code_blob_type);
   assert(heap != NULL, "heap is null");
 
-  heap->report_full();
+  int full_count = heap->report_full();
 
-  if ((heap->full_count() == 1) || print) {
+  if ((full_count == 1) || print) {
     // Not yet reported for this heap, report
     if (SegmentedCodeCache) {
       ResourceMark rm;
@@ -1277,7 +1277,7 @@ void CodeCache::report_codemem_full(int code_blob_type, bool print) {
       tty->print("%s", s.as_string());
     }
 
-    if (heap->full_count() == 1) {
+    if (full_count == 1) {
       if (PrintCodeHeapAnalytics) {
         CompileBroker::print_heapinfo(tty, "all", 4096); // details, may be a lot!
       }

--- a/src/hotspot/share/memory/heap.hpp
+++ b/src/hotspot/share/memory/heap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
 #include "code/codeBlob.hpp"
 #include "memory/allocation.hpp"
 #include "memory/virtualspace.hpp"
+#include "runtime/atomic.hpp"
 #include "utilities/macros.hpp"
 
 // Blocks
@@ -216,7 +217,7 @@ class CodeHeap : public CHeapObj<mtCode> {
   int         adapter_count()                    { return _adapter_count; }
   void    set_adapter_count(int count)           {        _adapter_count = count; }
   int         full_count()                       { return _full_count; }
-  void        report_full()                      {        _full_count++; }
+  int         report_full()                      { return Atomic::add(&_full_count, 1); }
 
 private:
   size_t heap_unallocated_capacity() const;

--- a/src/hotspot/share/runtime/sweeper.cpp
+++ b/src/hotspot/share/runtime/sweeper.cpp
@@ -496,9 +496,11 @@ NMethodSweeper::MethodStateChange NMethodSweeper::process_compiled_method(Compil
     // All inline caches that referred to this nmethod were cleaned in the
     // previous sweeper cycle. Now flush the nmethod from the code cache.
     assert(!cm->is_locked_by_vm(), "must not flush locked Compiled Methods");
-    cm->flush();
-    assert(result == None, "sanity");
-    result = Flushed;
+    if (UseCodeCacheFlushing) {
+      cm->flush();
+      assert(result == None, "sanity");
+      result = Flushed;
+   }
   } else if (cm->is_not_entrant()) {
     // If there are no current activations of this method on the
     // stack we can safely convert it to a zombie method

--- a/src/hotspot/share/runtime/sweeper.cpp
+++ b/src/hotspot/share/runtime/sweeper.cpp
@@ -496,11 +496,9 @@ NMethodSweeper::MethodStateChange NMethodSweeper::process_compiled_method(Compil
     // All inline caches that referred to this nmethod were cleaned in the
     // previous sweeper cycle. Now flush the nmethod from the code cache.
     assert(!cm->is_locked_by_vm(), "must not flush locked Compiled Methods");
-    if (UseCodeCacheFlushing) {
-      cm->flush();
-      assert(result == None, "sanity");
-      result = Flushed;
-   }
+    cm->flush();
+    assert(result == None, "sanity");
+    result = Flushed;
   } else if (cm->is_not_entrant()) {
     // If there are no current activations of this method on the
     // stack we can safely convert it to a zombie method

--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -55,7 +55,7 @@ public class CodeCacheFullCountTest {
 
     public static void runTest() throws Throwable {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-          "-XX:ReservedCodeCacheSize=2496k", "-XX:-MethodFlushing", "CodeCacheFullCountTest", "WasteCodeCache");
+          "-XX:ReservedCodeCacheSize=2496k", "-XX:-UseCodeCacheFlushing", "-XX:-MethodFlushing", "CodeCacheFullCountTest", "WasteCodeCache");
         OutputAnalyzer oa = ProcessTools.executeProcess(pb);
         oa.shouldHaveExitValue(0);
         String stdout = oa.getStdout();

--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -64,7 +64,7 @@ public class CodeCacheFullCountTest {
         Matcher stdoutMatcher = pattern.matcher(stdout);
         if (stdoutMatcher.find()) {
             int fullCount = Integer.parseInt(stdoutMatcher.group(1));
-            if (fullCount != 1) {
+            if (fullCount == 0) {
                 throw new RuntimeException("the value of full_count is wrong.");
             }
         } else {

--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -55,7 +55,7 @@ public class CodeCacheFullCountTest {
 
     public static void runTest() throws Throwable {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-          "-XX:ReservedCodeCacheSize=2496k", "-XX:-UseCodeCacheFlushing", "CodeCacheFullCountTest", "WasteCodeCache");
+          "-XX:ReservedCodeCacheSize=2496k", "-XX:-MethodFlushing", "CodeCacheFullCountTest", "WasteCodeCache");
         OutputAnalyzer oa = ProcessTools.executeProcess(pb);
         oa.shouldHaveExitValue(0);
         String stdout = oa.getStdout();


### PR DESCRIPTION
This change adds a conditional to make -XX:-UseCodeCacheFlushing not flush the code cache so that the test passes on loom.  It also makes full_count atomic so that the test in codeCache for printing is correct.  This change also fixes the test because the full_count field and the message printing are not synchronized, so you can get 2 or more depending on the number of compiler threads.
Tested with tier1-3 on linux and windows x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279573](https://bugs.openjdk.java.net/browse/JDK-8279573): compiler/codecache/CodeCacheFullCountTest.java fails with "RuntimeException: the value of full_count is wrong."


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to 7b790e07fb5d54fe0fbc1b580f354108276b297a
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to 03950bf0c8cb370c477fca0f5dcae8b168901612


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7629/head:pull/7629` \
`$ git checkout pull/7629`

Update a local copy of the PR: \
`$ git checkout pull/7629` \
`$ git pull https://git.openjdk.java.net/jdk pull/7629/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7629`

View PR using the GUI difftool: \
`$ git pr show -t 7629`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7629.diff">https://git.openjdk.java.net/jdk/pull/7629.diff</a>

</details>
