### PR TITLE
8282422: JTable.print() failed with UnsupportedCharsetException on AIX ko_KR locale

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
+++ b/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -960,7 +960,9 @@ public abstract class FontConfiguration {
             return fc.newEncoder();
         }
 
-        if (!charsetName.startsWith("sun.awt.") && !charsetName.equals("default")) {
+        if (!charsetName.startsWith("sun.awt.") &&
+            !charsetName.equals("default") &&
+            !charsetName.startsWith("sun.font.")) {
             fc = Charset.forName(charsetName);
         } else {
             @SuppressWarnings("removal")


### PR DESCRIPTION
On AIX ko_KR locale, I could see following exception after JTable.print() was called
```
java.nio.charset.UnsupportedCharsetException: sun.font.X11KSC5601
        at java.base/java.nio.charset.Charset.forName(Charset.java:527)
        at java.desktop/sun.awt.FontConfiguration.getFontCharsetEncoder(FontConfiguration.java:964)
......
```
According to my investigation, sun.font.X11KSC5601 moved from sun.awt.motif.X11KSC5601.
