### PR TITLE
8282452: Use of Preview API in preview methods should not trigger preview warning for the enclosing class

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -2403,6 +2403,10 @@ public class HtmlDocletWriter {
             if (!utils.isIncluded(enclosed)) {
                 continue;
             }
+            if (utils.isPreviewAPI(enclosed)) {
+                //for class summary, ignore methods that are themselves preview:
+                continue;
+            }
             if (!enclosed.getKind().isClass() && !enclosed.getKind().isInterface()) {
                 PreviewSummary memberAPITypes = utils.declaredUsingPreviewAPIs(enclosed);
                 declaredUsingPreviewFeature.addAll(memberAPITypes.declaredUsingPreviewFeature);

--- a/test/langtools/jdk/javadoc/doclet/testPreview/TestPreview.java
+++ b/test/langtools/jdk/javadoc/doclet/testPreview/TestPreview.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug      8250768 8261976 8277300
+ * @bug      8250768 8261976 8277300 8282452
  * @summary  test generated docs for items declared using preview
  * @library  ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -119,5 +119,19 @@ public class TestPreview extends JavadocTester {
                     "<a href=\"API3.html#test()\"><code>API3.test()</code></a><sup><a href=\"API3.html#preview-test()\">PREVIEW</a></sup>");
         checkOutput("api2/api/API3.html", true,
                     "<div class=\"block\"><a href=\"#test()\"><code>test()</code></a><sup><a href=\"#preview-test()\">PREVIEW</a></sup></div>");
+    }
+
+    @Test
+    public void test8282452() {
+        javadoc("-d", "out-8282452",
+                "--patch-module", "java.base=" + Paths.get(testSrc, "api").toAbsolutePath().toString(),
+                "--add-exports", "java.base/preview=m",
+                "--source-path", Paths.get(testSrc, "api").toAbsolutePath().toString(),
+                "--show-packages=all",
+                "preview");
+        checkExit(Exit.OK);
+
+        checkOutput("java.base/preview/NoPreview.html", false,
+                    "refers to one or more preview");
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testPreview/api/preview/NoPreview.java
+++ b/test/langtools/jdk/javadoc/doclet/testPreview/api/preview/NoPreview.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package preview;
+
+import jdk.internal.javac.PreviewFeature;
+import jdk.internal.javac.PreviewFeature.Feature;
+
+public class NoPreview {
+
+    @PreviewFeature(feature=Feature.TEST)
+    public T get() {
+        return null;
+    }
+
+    @PreviewFeature(feature=Feature.TEST)
+    public static class T {}
+}


### PR DESCRIPTION
When a member of a class refers to a preview API, the whole class is marked with a preview warning. This (presumably) should be disabled when the member referring to the preview API is marked as preview.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282452](https://bugs.openjdk.java.net/browse/JDK-8282452): Use of Preview API in preview methods should not trigger preview warning for the enclosing class


### Reviewers
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7634/head:pull/7634` \
`$ git checkout pull/7634`

Update a local copy of the PR: \
`$ git checkout pull/7634` \
`$ git pull https://git.openjdk.java.net/jdk pull/7634/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7634`

View PR using the GUI difftool: \
`$ git pr show -t 7634`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7634.diff">https://git.openjdk.java.net/jdk/pull/7634.diff</a>

</details>
