### PR TITLE
8282160: JShell circularly-required classes cannot be defined

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/Diag.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/Diag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -129,6 +129,13 @@ public abstract class Diag {
      */
     boolean isNotAStatementError() {
         return getCode().equals("compiler.err.not.stmt");
+    }
+
+    /**
+     * This is a method does not override superclass error
+     */
+    boolean isOverrideError() {
+        return getCode().equals("compiler.err.method.does.not.override.superclass");
     }
 
     /**

--- a/src/jdk.jshell/share/classes/jdk/jshell/DiagList.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/DiagList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,7 @@ final class DiagList extends ArrayList<Diag> {
     private int cntNotStmt = 0;
     private int cntUnreach = 0;
     private int cntResolve = 0;
+    private int cntOverride = 0;
     private int cntOther = 0;
 
     DiagList() {
@@ -64,6 +65,8 @@ final class DiagList extends ArrayList<Diag> {
                 ++cntNotStmt;
             } else if (d.isResolutionError()) {
                 ++cntResolve;
+            } else if (d.isOverrideError()) {
+                ++cntOverride;
             } else {
                 ++cntOther;
             }
@@ -114,7 +117,7 @@ final class DiagList extends ArrayList<Diag> {
     }
 
     boolean hasErrors() {
-        return (cntNotStmt + cntResolve + cntUnreach + cntOther) > 0;
+        return (cntNotStmt + cntResolve + cntUnreach + cntOverride + cntOther) > 0;
     }
 
     boolean hasResolutionErrorsAndNoOthers() {
@@ -130,7 +133,7 @@ final class DiagList extends ArrayList<Diag> {
     }
 
     boolean hasOtherThanNotStatementErrors() {
-        return (cntResolve + cntUnreach + cntOther) > 0;
+        return (cntResolve + cntUnreach + cntOverride + cntOther) > 0;
     }
 
 }

--- a/test/langtools/jdk/jshell/ClassesTest.java
+++ b/test/langtools/jdk/jshell/ClassesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8145239 8129559 8080354 8189248 8010319 8246353 8247456
+ * @bug 8145239 8129559 8080354 8189248 8010319 8246353 8247456 8282160
  * @summary Tests for EvaluationState.classes
  * @build KullaTesting TestingInputStream ExpectedDiagnostic
  * @run testng ClassesTest
@@ -340,6 +340,24 @@ public class ClassesTest extends KullaTesting {
                    added(VALID),
                    ste(aClass, Status.RECOVERABLE_DEFINED, Status.VALID, false, null));
         assertEval("new A()");
+    }
+
+    public void testCircular8282160() {
+        TypeDeclSnippet classKey = classKey(assertEval("""
+                                                       class B {
+                                                           C c;
+                                                           public void run() {}
+                                                       }
+                                                       """,
+                                                       added(RECOVERABLE_NOT_DEFINED)));
+        assertEval("""
+                   class C extends B {
+                       @Override
+                       public void run() {}
+                   }
+                   """,
+                   added(VALID),
+                   ste(classKey, Status.RECOVERABLE_NOT_DEFINED, Status.VALID, true, null));
     }
 
 }


### PR DESCRIPTION
Consider JShell snippets like:
```
jshell> class B {
            C c;
            public void run() {
            }
        }
jshell> class C extends B {
            public void run() {
            }
        }
```

When the first snippet is processed, it cannot be fully compiled, because `C` is missing. When the second snippet is processed, it is first processed separately, but it will turn out it needs `B` to be defined, and that there are no errors in `C` except resolution errors, and JShell will process both the snippets together, which will pass.

If the second snippet is changed to:
```
jshell> class C extends B {
            @Override
            public void run() {
            }
        }
```

then when processing `C`, there will be error: "method does not override or implement a method from a supertype" (in addition to the "`B` does not exist"). But that error is not considered a resolution error by JShell.

The proposal here is to ignore the "does not override" errors and join the `C` and `B` snippet processing. An alternative would be to not produce the error when there are erroneous supertypes, but that turns out to be tricky when the error is not in the direct supertype. So the proposal is to tweak JShell for now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282160](https://bugs.openjdk.java.net/browse/JDK-8282160): JShell circularly-required classes cannot be defined


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7635/head:pull/7635` \
`$ git checkout pull/7635`

Update a local copy of the PR: \
`$ git checkout pull/7635` \
`$ git pull https://git.openjdk.java.net/jdk pull/7635/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7635`

View PR using the GUI difftool: \
`$ git pr show -t 7635`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7635.diff">https://git.openjdk.java.net/jdk/pull/7635.diff</a>

</details>
