### PR TITLE
JDK-8282464: Remove author tags from java.compiler

### DIFF
--- a/src/java.compiler/share/classes/javax/annotation/processing/AbstractProcessor.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/AbstractProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/annotation/processing/AbstractProcessor.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/AbstractProcessor.java
@@ -53,9 +53,6 @@ import javax.tools.Diagnostic;
  * general {@link javax.annotation.processing.Processor Processor}
  * contract for that method is obeyed.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public abstract class AbstractProcessor implements Processor {

--- a/src/java.compiler/share/classes/javax/annotation/processing/Completion.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/Completion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/annotation/processing/Completion.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/Completion.java
@@ -30,9 +30,6 @@ package javax.annotation.processing;
  * annotation.  A completion is text meant to be inserted into a
  * program as part of an annotation.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public interface Completion {

--- a/src/java.compiler/share/classes/javax/annotation/processing/Completions.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/Completions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/annotation/processing/Completions.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/Completions.java
@@ -28,9 +28,6 @@ package javax.annotation.processing;
 /**
  * Utility class for assembling {@link Completion} objects.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public class Completions {

--- a/src/java.compiler/share/classes/javax/annotation/processing/Filer.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/Filer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/annotation/processing/Filer.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/Filer.java
@@ -132,9 +132,6 @@ import java.io.IOException;
  * factories instead of public constructors so that only subclass
  * instances would be presented to clients of the parent class.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public interface Filer {

--- a/src/java.compiler/share/classes/javax/annotation/processing/FilerException.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/FilerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/annotation/processing/FilerException.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/FilerException.java
@@ -35,9 +35,6 @@ import java.io.IOException;
  * interface or package, and not creating files for classes or
  * interfaces with invalid names.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public class FilerException extends IOException {

--- a/src/java.compiler/share/classes/javax/annotation/processing/Messager.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/Messager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/annotation/processing/Messager.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/Messager.java
@@ -46,9 +46,6 @@ import javax.lang.model.element.*;
  * choose to present this information in a different fashion, such as
  * messages in a window.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see ProcessingEnvironment#getLocale
  * @since 1.6
  */

--- a/src/java.compiler/share/classes/javax/annotation/processing/ProcessingEnvironment.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/ProcessingEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/annotation/processing/ProcessingEnvironment.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/ProcessingEnvironment.java
@@ -53,9 +53,6 @@ import javax.lang.model.util.Types;
  * of a wrapper class must know whether or not the same base facility
  * object has been wrapped before.)
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public interface ProcessingEnvironment {

--- a/src/java.compiler/share/classes/javax/annotation/processing/Processor.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/Processor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/annotation/processing/Processor.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/Processor.java
@@ -198,9 +198,6 @@ import javax.lang.model.SourceVersion;
  * to extend {@link AbstractProcessor} rather than implementing this
  * interface directly.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public interface Processor {

--- a/src/java.compiler/share/classes/javax/annotation/processing/RoundEnvironment.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/RoundEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/annotation/processing/RoundEnvironment.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/RoundEnvironment.java
@@ -37,9 +37,6 @@ import java.lang.annotation.Annotation;
  * implementing this interface} so that the processor can query for
  * information about a round of annotation processing.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public interface RoundEnvironment {

--- a/src/java.compiler/share/classes/javax/annotation/processing/SupportedAnnotationTypes.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/SupportedAnnotationTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/annotation/processing/SupportedAnnotationTypes.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/SupportedAnnotationTypes.java
@@ -38,9 +38,6 @@ import static java.lang.annotation.ElementType.*;
  * Processor#getSupportedAnnotationTypes strings conforming to the
  * grammar} should be used as values.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 @Documented

--- a/src/java.compiler/share/classes/javax/annotation/processing/SupportedOptions.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/SupportedOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/annotation/processing/SupportedOptions.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/SupportedOptions.java
@@ -37,9 +37,6 @@ import static java.lang.annotation.ElementType.*;
  * Processor#getSupportedOptions strings conforming to the
  * grammar} should be used as values.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 @Documented

--- a/src/java.compiler/share/classes/javax/annotation/processing/SupportedSourceVersion.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/SupportedSourceVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/annotation/processing/SupportedSourceVersion.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/SupportedSourceVersion.java
@@ -38,9 +38,6 @@ import javax.lang.model.SourceVersion;
  * result from the value of this annotation, as done by {@link
  * AbstractProcessor#getSupportedSourceVersion}.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 @Documented

--- a/src/java.compiler/share/classes/javax/annotation/processing/package-info.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/annotation/processing/package-info.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/package-info.java
@@ -35,9 +35,6 @@
  * <p> Unless otherwise specified, methods in this package will throw
  * a {@code NullPointerException} if given a {@code null} argument.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 package javax.annotation.processing;

--- a/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
+++ b/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
+++ b/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
@@ -39,9 +39,6 @@ import java.util.HashSet;
  * <p>Note that additional source version constants will be added to
  * model future releases of the language.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public enum SourceVersion {

--- a/src/java.compiler/share/classes/javax/lang/model/UnknownEntityException.java
+++ b/src/java.compiler/share/classes/javax/lang/model/UnknownEntityException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/UnknownEntityException.java
+++ b/src/java.compiler/share/classes/javax/lang/model/UnknownEntityException.java
@@ -32,7 +32,6 @@ package javax.lang.model;
  * this exception may be thrown by visitors to indicate that the
  * visitor was created for a prior version of the language.
  *
- * @author Joseph D. Darcy
  * @see javax.lang.model.element.UnknownElementException
  * @see javax.lang.model.element.UnknownAnnotationValueException
  * @see javax.lang.model.type.UnknownTypeException

--- a/src/java.compiler/share/classes/javax/lang/model/element/AnnotationMirror.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/AnnotationMirror.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/AnnotationMirror.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/AnnotationMirror.java
@@ -36,9 +36,6 @@ import javax.lang.model.type.DeclaredType;
  * method.  There is no guarantee that any particular annotation will
  * always be represented by the same object.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public interface AnnotationMirror {

--- a/src/java.compiler/share/classes/javax/lang/model/element/AnnotationValue.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/AnnotationValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/AnnotationValue.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/AnnotationValue.java
@@ -37,9 +37,6 @@ package javax.lang.model.element;
  *              (representing the elements, in declared order, if the value is an array)
  * </ul>
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public interface AnnotationValue {

--- a/src/java.compiler/share/classes/javax/lang/model/element/AnnotationValueVisitor.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/AnnotationValueVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/AnnotationValueVisitor.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/AnnotationValueVisitor.java
@@ -115,9 +115,6 @@ import javax.lang.model.util.*;
  *
  * @param <R> the return type of this visitor's methods
  * @param <P> the type of the additional parameter to this visitor's methods.
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public interface AnnotationValueVisitor<R, P> {

--- a/src/java.compiler/share/classes/javax/lang/model/element/Element.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Element.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/Element.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Element.java
@@ -52,9 +52,6 @@ import javax.lang.model.util.*;
  * hierarchy since an implementation may choose to have a single object
  * implement multiple {@code Element} subinterfaces.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see Elements
  * @see TypeMirror
  * @since 1.6

--- a/src/java.compiler/share/classes/javax/lang/model/element/ElementKind.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/ElementKind.java
@@ -32,9 +32,6 @@ package javax.lang.model.element;
  * to accommodate new, currently unknown, language structures added to
  * future versions of the Java programming language.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see Element
  * @since 1.6
  */

--- a/src/java.compiler/share/classes/javax/lang/model/element/ElementVisitor.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/ElementVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/ElementVisitor.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/ElementVisitor.java
@@ -117,9 +117,6 @@ import javax.lang.model.util.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public interface ElementVisitor<R, P> {

--- a/src/java.compiler/share/classes/javax/lang/model/element/ExecutableElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/ExecutableElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/ExecutableElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/ExecutableElement.java
@@ -33,9 +33,6 @@ import javax.lang.model.type.*;
  * instance) of a class or interface, including annotation type
  * elements.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see ExecutableType
  * @since 1.6
  */

--- a/src/java.compiler/share/classes/javax/lang/model/element/Modifier.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Modifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/Modifier.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Modifier.java
@@ -44,9 +44,6 @@ package javax.lang.model.element;
  * @jls 8.8.3 Constructor Modifiers
  * @jls 9.1.1 Interface Modifiers
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 

--- a/src/java.compiler/share/classes/javax/lang/model/element/Name.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Name.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/Name.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Name.java
@@ -46,9 +46,6 @@ package javax.lang.model.element;
  * to each other, including successive annotation processing
  * {@linkplain javax.annotation.processing.RoundEnvironment rounds}.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see javax.lang.model.util.Elements#getName
  * @since 1.6
  */

--- a/src/java.compiler/share/classes/javax/lang/model/element/NestingKind.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/NestingKind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/NestingKind.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/NestingKind.java
@@ -76,9 +76,6 @@ package javax.lang.model.element;
  * }
  * </pre></blockquote>
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public enum NestingKind {

--- a/src/java.compiler/share/classes/javax/lang/model/element/PackageElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/PackageElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/PackageElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/PackageElement.java
@@ -32,9 +32,6 @@ import javax.lang.model.type.TypeMirror;
  * Represents a package program element.  Provides access to information
  * about the package and its members.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see javax.lang.model.util.Elements#getPackageOf
  * @since 1.6
  */

--- a/src/java.compiler/share/classes/javax/lang/model/element/Parameterizable.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Parameterizable.java
@@ -30,7 +30,6 @@ import java.util.List;
 /**
  * A mixin interface for an element that has type parameters.
  *
- * @author Joseph D. Darcy
  * @since 1.7
  */
 public interface Parameterizable extends Element {

--- a/src/java.compiler/share/classes/javax/lang/model/element/Parameterizable.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Parameterizable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/QualifiedNameable.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/QualifiedNameable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/QualifiedNameable.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/QualifiedNameable.java
@@ -28,7 +28,6 @@ package javax.lang.model.element;
 /**
  * A mixin interface for an element that has a qualified name.
  *
- * @author Joseph D. Darcy
  * @since 1.7
  */
 public interface QualifiedNameable extends Element {

--- a/src/java.compiler/share/classes/javax/lang/model/element/TypeElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/TypeElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/TypeElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/TypeElement.java
@@ -53,9 +53,6 @@ import javax.lang.model.util.*;
  * source of information is Java source code, then the elements will be
  * returned in source code order.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see DeclaredType
  * @since 1.6
  */

--- a/src/java.compiler/share/classes/javax/lang/model/element/TypeParameterElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/TypeParameterElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/TypeParameterElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/TypeParameterElement.java
@@ -34,9 +34,6 @@ import javax.lang.model.type.TypeVariable;
  * or constructor element.
  * A type parameter declares a {@link TypeVariable}.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see TypeVariable
  * @since 1.6
  */

--- a/src/java.compiler/share/classes/javax/lang/model/element/UnknownAnnotationValueException.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/UnknownAnnotationValueException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/UnknownAnnotationValueException.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/UnknownAnnotationValueException.java
@@ -35,9 +35,6 @@ import javax.lang.model.UnknownEntityException;
  * indicate that the visitor was created for a prior version of the
  * language.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see AnnotationValueVisitor#visitUnknown
  * @since 1.6
  */

--- a/src/java.compiler/share/classes/javax/lang/model/element/UnknownDirectiveException.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/UnknownDirectiveException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/UnknownDirectiveException.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/UnknownDirectiveException.java
@@ -34,9 +34,6 @@ import javax.lang.model.UnknownEntityException;
  * {@linkplain ModuleElement.DirectiveVisitor directive visitor} to
  * indicate that the visitor was created for a prior version of the language.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see ModuleElement.DirectiveVisitor#visitUnknown
  * @since 9
  */

--- a/src/java.compiler/share/classes/javax/lang/model/element/UnknownElementException.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/UnknownElementException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/UnknownElementException.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/UnknownElementException.java
@@ -34,9 +34,6 @@ import javax.lang.model.UnknownEntityException;
  * {@linkplain ElementVisitor element visitor} to indicate that the
  * visitor was created for a prior version of the language.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see ElementVisitor#visitUnknown
  * @since 1.6
  */

--- a/src/java.compiler/share/classes/javax/lang/model/element/VariableElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/VariableElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/VariableElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/VariableElement.java
@@ -34,9 +34,6 @@ import javax.lang.model.type.TypeKind;
  * parameter, local variable, resource variable, or exception
  * parameter.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public interface VariableElement extends Element {

--- a/src/java.compiler/share/classes/javax/lang/model/element/package-info.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/element/package-info.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/package-info.java
@@ -107,9 +107,6 @@
  * <p> Unless otherwise specified, methods in this package will throw
  * a {@code NullPointerException} if given a {@code null} argument.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see javax.lang.model.util.Elements
  * @jls 6.1 Declarations
  * @jls 7.4 Package Declarations

--- a/src/java.compiler/share/classes/javax/lang/model/package-info.java
+++ b/src/java.compiler/share/classes/javax/lang/model/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/package-info.java
+++ b/src/java.compiler/share/classes/javax/lang/model/package-info.java
@@ -52,9 +52,6 @@
  * <p>Unless otherwise specified, methods in this package will throw
  * a {@code NullPointerException} if given a {@code null} argument.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 

--- a/src/java.compiler/share/classes/javax/lang/model/type/ArrayType.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/ArrayType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/type/ArrayType.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/ArrayType.java
@@ -31,9 +31,6 @@ package javax.lang.model.type;
  * A multidimensional array type is represented as an array type
  * whose component type is also an array type.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public interface ArrayType extends ReferenceType {

--- a/src/java.compiler/share/classes/javax/lang/model/type/DeclaredType.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/DeclaredType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/type/DeclaredType.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/DeclaredType.java
@@ -49,9 +49,6 @@ import javax.lang.model.util.Types;
  * Types#directSupertypes(TypeMirror)} method.  This returns the
  * supertypes with any type arguments substituted in.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see TypeElement
  * @since 1.6
  */

--- a/src/java.compiler/share/classes/javax/lang/model/type/ErrorType.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/ErrorType.java
@@ -33,9 +33,6 @@ package javax.lang.model.type;
  * information derived from such a type (such as its members or its
  * supertype) will not, in general, return meaningful results.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public interface ErrorType extends DeclaredType {

--- a/src/java.compiler/share/classes/javax/lang/model/type/ErrorType.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/ErrorType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/type/ExecutableType.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/ExecutableType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/type/ExecutableType.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/ExecutableType.java
@@ -41,9 +41,6 @@ import javax.lang.model.element.ExecutableElement;
  * type arguments are substituted into any types returned by the methods of
  * this interface.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see ExecutableElement
  * @since 1.6
  */

--- a/src/java.compiler/share/classes/javax/lang/model/type/MirroredTypeException.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/MirroredTypeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/type/MirroredTypeException.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/MirroredTypeException.java
@@ -34,9 +34,6 @@ import javax.lang.model.element.Element;
  * Thrown when an application attempts to access the {@link Class} object
  * corresponding to a {@link TypeMirror}.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see MirroredTypesException
  * @see Element#getAnnotation(Class)
  * @since 1.6

--- a/src/java.compiler/share/classes/javax/lang/model/type/MirroredTypesException.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/MirroredTypesException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/type/MirroredTypesException.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/MirroredTypesException.java
@@ -37,9 +37,6 @@ import javax.lang.model.element.Element;
  * Thrown when an application attempts to access a sequence of {@link
  * Class} objects each corresponding to a {@link TypeMirror}.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see MirroredTypeException
  * @see Element#getAnnotation(Class)
  * @since 1.6

--- a/src/java.compiler/share/classes/javax/lang/model/type/NoType.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/NoType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/type/NoType.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/NoType.java
@@ -40,9 +40,6 @@ import javax.lang.model.element.ExecutableElement;
  *   of {@code java.lang.Object}.
  * </ul>
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see ExecutableElement#getReturnType()
  * @see javax.lang.model.util.Types#getNoType(TypeKind)
  * @since 1.6

--- a/src/java.compiler/share/classes/javax/lang/model/type/NullType.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/NullType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/type/NullType.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/NullType.java
@@ -30,9 +30,6 @@ package javax.lang.model.type;
  * Represents the null type.
  * This is the type of the expression {@code null},
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @jls 3.10.7 The Null Literal
  * @jls 4.1 The Kinds of Types and Values
  * @see javax.lang.model.util.Types#getNullType()

--- a/src/java.compiler/share/classes/javax/lang/model/type/PrimitiveType.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/PrimitiveType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/type/PrimitiveType.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/PrimitiveType.java
@@ -31,9 +31,6 @@ package javax.lang.model.type;
  * {@code boolean}, {@code byte}, {@code short}, {@code int},
  * {@code long}, {@code char}, {@code float}, and {@code double}.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @jls 4.2 Primitive Types and Values
  * @see javax.lang.model.util.Types#getPrimitiveType(TypeKind)
  * @since 1.6

--- a/src/java.compiler/share/classes/javax/lang/model/type/ReferenceType.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/ReferenceType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/type/ReferenceType.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/ReferenceType.java
@@ -31,9 +31,6 @@ package javax.lang.model.type;
  * These include class and interface types, array types, type variables,
  * and the null type.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @jls 4.3 Reference Types and Values
  * @since 1.6
  */

--- a/src/java.compiler/share/classes/javax/lang/model/type/TypeKind.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/TypeKind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/type/TypeKind.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/TypeKind.java
@@ -33,9 +33,6 @@ package javax.lang.model.type;
  * accommodate new, currently unknown, language structures added to
  * future versions of the Java programming language.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see TypeMirror
  * @since 1.6
  */

--- a/src/java.compiler/share/classes/javax/lang/model/type/TypeMirror.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/TypeMirror.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/type/TypeMirror.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/TypeMirror.java
@@ -50,9 +50,6 @@ import javax.lang.model.util.Types;
  * hierarchy since an implementation may choose to have a single
  * object implement multiple {@code TypeMirror} subinterfaces.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see Element
  * @see Types
  * @jls 4.1 The Kinds of Types and Values

--- a/src/java.compiler/share/classes/javax/lang/model/type/TypeVariable.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/TypeVariable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/type/TypeVariable.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/TypeVariable.java
@@ -41,9 +41,6 @@ import javax.lang.model.util.Types;
  * (see chapter {@jls 5} of
  * <cite>The Java Language Specification</cite>).
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see TypeParameterElement
  * @jls 4.4 Type Variables
  * @since 1.6

--- a/src/java.compiler/share/classes/javax/lang/model/type/TypeVisitor.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/TypeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/type/TypeVisitor.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/TypeVisitor.java
@@ -112,9 +112,6 @@ import javax.lang.model.util.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public interface TypeVisitor<R, P> {

--- a/src/java.compiler/share/classes/javax/lang/model/type/UnknownTypeException.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/UnknownTypeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/type/UnknownTypeException.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/UnknownTypeException.java
@@ -34,9 +34,6 @@ import javax.lang.model.UnknownEntityException;
  * TypeVisitor type visitor} to indicate that the visitor was created
  * for a prior version of the language.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see TypeVisitor#visitUnknown
  * @since 1.6
  */

--- a/src/java.compiler/share/classes/javax/lang/model/type/WildcardType.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/WildcardType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/type/WildcardType.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/WildcardType.java
@@ -38,9 +38,6 @@ package javax.lang.model.type;
  * {@code extends} clause, its lower bound explicitly set by a
  * {@code super} clause, or neither (but not both).
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @jls 4.5.1 Type Arguments of Parameterized Types
  * @since 1.6
  */

--- a/src/java.compiler/share/classes/javax/lang/model/type/package-info.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/type/package-info.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/package-info.java
@@ -33,9 +33,6 @@
  * <p> Unless otherwise specified, methods in this package will throw
  * a {@code NullPointerException} if given a {@code null} argument.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see javax.lang.model.util.Types
  * @jls 4.1 The Kinds of Types and Values
  * @jls 4.2 Primitive Types and Values

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitor6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitor6.java
@@ -60,10 +60,6 @@ import javax.annotation.processing.SupportedSourceVersion;
  * @param <R> the return type of this visitor's methods
  * @param <P> the type of the additional parameter to this visitor's methods.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
- *
  * @see AbstractAnnotationValueVisitor7
  * @see AbstractAnnotationValueVisitor8
  * @see AbstractAnnotationValueVisitor9

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor6.java
@@ -62,10 +62,6 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
- *
  * @see AbstractElementVisitor7
  * @see AbstractElementVisitor8
  * @see AbstractElementVisitor9

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor6.java
@@ -61,10 +61,6 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
- *
  * @see AbstractTypeVisitor7
  * @see AbstractTypeVisitor8
  * @see AbstractTypeVisitor9

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementFilter.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementFilter.java
@@ -55,10 +55,6 @@ import javax.lang.model.element.ModuleElement.UsesDirective;
  * arguments to methods in this class, a {@code NullPointerException}
  * will be thrown.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
- * @author Martin Buchholz
  * @since 1.6
  */
 public class ElementFilter {

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor6.java
@@ -73,10 +73,6 @@ import javax.lang.model.SourceVersion;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
- *
  * @see ElementKindVisitor7
  * @see ElementKindVisitor8
  * @see ElementKindVisitor9

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner6.java
@@ -83,10 +83,6 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
- *
  * @see ElementScanner7
  * @see ElementScanner8
  * @see ElementScanner9

--- a/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
@@ -42,9 +42,6 @@ import javax.lang.model.element.*;
  * <p><b>Compatibility Note:</b> Methods may be added to this interface
  * in future releases of the platform.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see javax.annotation.processing.ProcessingEnvironment#getElementUtils
  * @since 1.6
  */

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitor6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitor6.java
@@ -67,10 +67,6 @@ import javax.annotation.processing.SupportedSourceVersion;
  * @param <R> the return type of this visitor's methods
  * @param <P> the type of the additional parameter to this visitor's methods.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
- *
  * @see SimpleAnnotationValueVisitor7
  * @see SimpleAnnotationValueVisitor8
  * @see SimpleAnnotationValueVisitor9

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor6.java
@@ -72,10 +72,6 @@ import static javax.lang.model.SourceVersion.*;
  * @param <P> the type of the additional parameter to this visitor's methods.  Use {@code Void}
  *              for visitors that do not need an additional parameter.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
- *
  * @see SimpleElementVisitor7
  * @see SimpleElementVisitor8
  * @see SimpleElementVisitor9

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor6.java
@@ -72,10 +72,6 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
- *
  * @see SimpleTypeVisitor7
  * @see SimpleTypeVisitor8
  * @see SimpleTypeVisitor9

--- a/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor6.java
@@ -71,10 +71,6 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
- *
  * @see TypeKindVisitor7
  * @see TypeKindVisitor8
  * @see TypeKindVisitor9

--- a/src/java.compiler/share/classes/javax/lang/model/util/Types.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Types.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/Types.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Types.java
@@ -38,9 +38,6 @@ import javax.lang.model.type.*;
  * <p><b>Compatibility Note:</b> Methods may be added to this interface
  * in future releases of the platform.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @see javax.annotation.processing.ProcessingEnvironment#getTypeUtils
  * @since 1.6
  */

--- a/src/java.compiler/share/classes/javax/lang/model/util/package-info.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/package-info.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/package-info.java
@@ -35,9 +35,6 @@
  * <p> Unless otherwise specified, methods in this package will throw
  * a {@code NullPointerException} if given a {@code null} argument.
  *
- * @author Joseph D. Darcy
- * @author Scott Seligman
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 package javax.lang.model.util;

--- a/src/java.compiler/share/classes/javax/tools/Diagnostic.java
+++ b/src/java.compiler/share/classes/javax/tools/Diagnostic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/tools/Diagnostic.java
+++ b/src/java.compiler/share/classes/javax/tools/Diagnostic.java
@@ -41,8 +41,6 @@ import java.util.Locale;
  *
  * @param <S> the type of source object used by this diagnostic
  *
- * @author Peter von der Ah&eacute;
- * @author Jonathan Gibbons
  * @since 1.6
  */
 public interface Diagnostic<S> {

--- a/src/java.compiler/share/classes/javax/tools/DiagnosticCollector.java
+++ b/src/java.compiler/share/classes/javax/tools/DiagnosticCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/tools/DiagnosticCollector.java
+++ b/src/java.compiler/share/classes/javax/tools/DiagnosticCollector.java
@@ -36,7 +36,6 @@ import java.util.Objects;
  * @param <S> the type of source objects used by diagnostics received
  * by this object
  *
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public final class DiagnosticCollector<S> implements DiagnosticListener<S> {

--- a/src/java.compiler/share/classes/javax/tools/DiagnosticListener.java
+++ b/src/java.compiler/share/classes/javax/tools/DiagnosticListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/tools/DiagnosticListener.java
+++ b/src/java.compiler/share/classes/javax/tools/DiagnosticListener.java
@@ -31,8 +31,6 @@ package javax.tools;
  * @param <S> the type of source objects used by diagnostics received
  * by this listener
  *
- * @author Jonathan Gibbons
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public interface DiagnosticListener<S> {

--- a/src/java.compiler/share/classes/javax/tools/FileObject.java
+++ b/src/java.compiler/share/classes/javax/tools/FileObject.java
@@ -44,8 +44,6 @@ import java.net.URI;
  * <p>Unless explicitly allowed, all methods in this interface might
  * throw a NullPointerException if given a {@code null} argument.
  *
- * @author Peter von der Ah&eacute;
- * @author Jonathan Gibbons
  * @since 1.6
  */
 public interface FileObject {

--- a/src/java.compiler/share/classes/javax/tools/FileObject.java
+++ b/src/java.compiler/share/classes/javax/tools/FileObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/tools/ForwardingFileObject.java
+++ b/src/java.compiler/share/classes/javax/tools/ForwardingFileObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/tools/ForwardingFileObject.java
+++ b/src/java.compiler/share/classes/javax/tools/ForwardingFileObject.java
@@ -42,7 +42,6 @@ import java.util.Objects;
  * should be interpreted as referring indirectly to the {@link #fileObject delegate file object}.
  *
  * @param <F> the kind of file object forwarded to by this object
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public class ForwardingFileObject<F extends FileObject> implements FileObject {

--- a/src/java.compiler/share/classes/javax/tools/ForwardingJavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/ForwardingJavaFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/tools/ForwardingJavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/ForwardingJavaFileManager.java
@@ -42,7 +42,6 @@ import javax.tools.JavaFileObject.Kind;
  * should be interpreted as referring indirectly to the {@link #fileManager delegate file manager}.
  *
  * @param <M> the kind of file manager forwarded to by this object
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public class ForwardingJavaFileManager<M extends JavaFileManager> implements JavaFileManager {

--- a/src/java.compiler/share/classes/javax/tools/ForwardingJavaFileObject.java
+++ b/src/java.compiler/share/classes/javax/tools/ForwardingJavaFileObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/tools/ForwardingJavaFileObject.java
+++ b/src/java.compiler/share/classes/javax/tools/ForwardingJavaFileObject.java
@@ -37,7 +37,6 @@ import javax.lang.model.element.NestingKind;
  * should be interpreted as referring indirectly to the {@link #fileObject delegate file object}.
  *
  * @param <F> the kind of file object forwarded to by this object
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public class ForwardingJavaFileObject<F extends JavaFileObject>

--- a/src/java.compiler/share/classes/javax/tools/JavaCompiler.java
+++ b/src/java.compiler/share/classes/javax/tools/JavaCompiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/tools/JavaCompiler.java
+++ b/src/java.compiler/share/classes/javax/tools/JavaCompiler.java
@@ -190,8 +190,6 @@ import javax.annotation.processing.Processor;
  *   </dd>
  * </dl>
  *
- * @author Peter von der Ah&eacute;
- * @author Jonathan Gibbons
  * @see DiagnosticListener
  * @see Diagnostic
  * @see JavaFileManager

--- a/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
@@ -103,8 +103,6 @@ import static javax.tools.JavaFileObject.Kind;
  * <p>Unless explicitly allowed, all methods in this interface might
  * throw a NullPointerException if given a {@code null} argument.
  *
- * @author Peter von der Ah&eacute;
- * @author Jonathan Gibbons
  * @see JavaFileObject
  * @see FileObject
  * @since 1.6

--- a/src/java.compiler/share/classes/javax/tools/JavaFileObject.java
+++ b/src/java.compiler/share/classes/javax/tools/JavaFileObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/tools/JavaFileObject.java
+++ b/src/java.compiler/share/classes/javax/tools/JavaFileObject.java
@@ -39,8 +39,6 @@ import java.util.Objects;
  * <p>Unless explicitly allowed, all methods in this interface might
  * throw a NullPointerException if given a {@code null} argument.
  *
- * @author Peter von der Ah&eacute;
- * @author Jonathan Gibbons
  * @see JavaFileManager
  * @since 1.6
  */

--- a/src/java.compiler/share/classes/javax/tools/OptionChecker.java
+++ b/src/java.compiler/share/classes/javax/tools/OptionChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/tools/OptionChecker.java
+++ b/src/java.compiler/share/classes/javax/tools/OptionChecker.java
@@ -28,7 +28,6 @@ package javax.tools;
 /**
  * Interface for recognizing options.
  *
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public interface OptionChecker {

--- a/src/java.compiler/share/classes/javax/tools/SimpleJavaFileObject.java
+++ b/src/java.compiler/share/classes/javax/tools/SimpleJavaFileObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/tools/SimpleJavaFileObject.java
+++ b/src/java.compiler/share/classes/javax/tools/SimpleJavaFileObject.java
@@ -39,7 +39,6 @@ import javax.lang.model.element.NestingKind;
  * implementation and specification of any method of this class as
  * long as the general contract of JavaFileObject is obeyed.
  *
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public class SimpleJavaFileObject implements JavaFileObject {

--- a/src/java.compiler/share/classes/javax/tools/StandardJavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/StandardJavaFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/tools/StandardJavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/StandardJavaFileManager.java
@@ -155,8 +155,6 @@ import java.util.List;
  * correct to call these methods with a single {@code Path} and have it be treated as
  * an {@code Iterable} of its components.
  *
- *
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public interface StandardJavaFileManager extends JavaFileManager {

--- a/src/java.compiler/share/classes/javax/tools/StandardLocation.java
+++ b/src/java.compiler/share/classes/javax/tools/StandardLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/tools/StandardLocation.java
+++ b/src/java.compiler/share/classes/javax/tools/StandardLocation.java
@@ -32,7 +32,6 @@ import java.util.concurrent.*;
 /**
  * Standard locations of file objects.
  *
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public enum StandardLocation implements Location {

--- a/src/java.compiler/share/classes/javax/tools/Tool.java
+++ b/src/java.compiler/share/classes/javax/tools/Tool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/tools/Tool.java
+++ b/src/java.compiler/share/classes/javax/tools/Tool.java
@@ -39,9 +39,6 @@ import javax.lang.model.SourceVersion;
  * <p>Tools can be located using {@link
  * java.util.ServiceLoader#load(Class)}.
  *
- * @author Neal M Gafter
- * @author Peter von der Ah&eacute;
- * @author Jonathan Gibbons
  * @since 1.6
  */
 public interface Tool {

--- a/src/java.compiler/share/classes/javax/tools/ToolProvider.java
+++ b/src/java.compiler/share/classes/javax/tools/ToolProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/tools/ToolProvider.java
+++ b/src/java.compiler/share/classes/javax/tools/ToolProvider.java
@@ -36,7 +36,6 @@ import java.util.ServiceLoader;
  * providers of compilers.  This class complements the
  * functionality of {@link java.util.ServiceLoader}.
  *
- * @author Peter von der Ah&eacute;
  * @since 1.6
  */
 public class ToolProvider {

--- a/src/java.compiler/share/classes/javax/tools/package-info.java
+++ b/src/java.compiler/share/classes/javax/tools/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/tools/package-info.java
+++ b/src/java.compiler/share/classes/javax/tools/package-info.java
@@ -77,8 +77,6 @@
  *     JavaCompiler compiler = ServiceLoader.load(JavaCompiler.class).iterator().next();
  *     }
  *
- * @author Peter von der Ah&eacute;
- * @author Jonathan Gibbons
  * @since 1.6
  */
 package javax.tools;


### PR DESCRIPTION
To align with current coding conventions, the @author tags in the java.compiler module should be removed. The tags have not been maintained and updated in many years. These tags date back to the addition of JSRs 199 and 269 in JDK 6.

The authors at the time for these files were generally some nonempty subset of Scott Seligman, Peter von der Ahé, Jon Gibbons, Scott Seligman, and myself. The tag information will remain in the history of course.

I'll update the copyright years on the files before any push.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282464](https://bugs.openjdk.java.net/browse/JDK-8282464): Remove author tags from java.compiler


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to 872f8371acf8ee2541769255b2c4f2c7eb41e2ca


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7639/head:pull/7639` \
`$ git checkout pull/7639`

Update a local copy of the PR: \
`$ git checkout pull/7639` \
`$ git pull https://git.openjdk.java.net/jdk pull/7639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7639`

View PR using the GUI difftool: \
`$ git pr show -t 7639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7639.diff">https://git.openjdk.java.net/jdk/pull/7639.diff</a>

</details>
