### PR TITLE
8282081: java.time.DateTimeFormatter: wrong definition of symbol F

### DIFF
--- a/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
@@ -297,7 +297,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *   <tr><th scope="row">W</th>       <td>week-of-month</td>               <td>number</td>            <td>4</td>
  *   <tr><th scope="row">E</th>       <td>day-of-week</td>                 <td>text</td>              <td>Tue; Tuesday; T</td>
  *   <tr><th scope="row">e/c</th>     <td>localized day-of-week</td>       <td>number/text</td>       <td>2; 02; Tue; Tuesday; T</td>
- *   <tr><th scope="row">F</th>       <td>day-of-week-in-month</td>        <td>number</td>            <td>3</td>
+ *   <tr><th scope="row">F</th>       <td>aligned-week-of-month</td>       <td>number</td>            <td>3</td>
  *
  *   <tr><th scope="row">a</th>       <td>am-pm-of-day</td>                <td>text</td>              <td>PM</td>
  *   <tr><th scope="row">B</th>       <td>period-of-day</td>               <td>text</td>              <td>in the morning</td>

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -1774,7 +1774,7 @@ public final class DateTimeFormatterBuilder {
      *    D       1      appendValue(ChronoField.DAY_OF_YEAR)
      *    DD      2      appendValue(ChronoField.DAY_OF_YEAR, 2, 3, SignStyle.NOT_NEGATIVE)
      *    DDD     3      appendValue(ChronoField.DAY_OF_YEAR, 3)
-     *    F       1      appendValue(ChronoField.ALIGNED_DAY_OF_WEEK_IN_MONTH)
+     *    F       1      appendValue(ChronoField.ALIGNED_WEEK_OF_MONTH)
      *    g..g    1..n   appendValue(JulianFields.MODIFIED_JULIAN_DAY, n, 19, SignStyle.NORMAL)
      *    E       1      appendText(ChronoField.DAY_OF_WEEK, TextStyle.SHORT)
      *    EE      2      appendText(ChronoField.DAY_OF_WEEK, TextStyle.SHORT)
@@ -2183,7 +2183,7 @@ public final class DateTimeFormatterBuilder {
         FIELD_MAP.put('L', ChronoField.MONTH_OF_YEAR);             // SDF, LDML (stand-alone)
         FIELD_MAP.put('D', ChronoField.DAY_OF_YEAR);               // SDF, LDML
         FIELD_MAP.put('d', ChronoField.DAY_OF_MONTH);              // SDF, LDML
-        FIELD_MAP.put('F', ChronoField.ALIGNED_DAY_OF_WEEK_IN_MONTH);  // SDF, LDML
+        FIELD_MAP.put('F', ChronoField.ALIGNED_WEEK_OF_MONTH);     // SDF, LDML
         FIELD_MAP.put('E', ChronoField.DAY_OF_WEEK);               // SDF, LDML (different to both for 1/2 chars)
         FIELD_MAP.put('c', ChronoField.DAY_OF_WEEK);               // LDML (stand-alone)
         FIELD_MAP.put('e', ChronoField.DAY_OF_WEEK);               // LDML (needs localized week number)

--- a/test/jdk/java/time/test/java/time/format/TestDateTimeFormatterBuilder.java
+++ b/test/jdk/java/time/test/java/time/format/TestDateTimeFormatterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1051,7 +1051,7 @@ public class TestDateTimeFormatterBuilder {
             {"d", "Value(DayOfMonth)"},
             {"dd", "Value(DayOfMonth,2)"},
 
-            {"F", "Value(AlignedDayOfWeekInMonth)"},
+            {"F", "Value(AlignedWeekOfMonth)"},
 
             {"Q", "Value(QuarterOfYear)"},
             {"QQ", "Value(QuarterOfYear,2)"},


### PR DESCRIPTION
Fixing the definition and implementation of the pattern symbol `F`. Although it is an incompatible change, I believe it is worth the fix. For that, a CSR has been drafted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8282081](https://bugs.openjdk.java.net/browse/JDK-8282081): java.time.DateTimeFormatter: wrong definition of symbol F
 * [JDK-8282377](https://bugs.openjdk.java.net/browse/JDK-8282377): java.time.DateTimeFormatter: wrong definition of symbol F (**CSR**)


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Stephen Colebourne](https://openjdk.java.net/census#scolebourne) (@jodastephen - Author)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7640/head:pull/7640` \
`$ git checkout pull/7640`

Update a local copy of the PR: \
`$ git checkout pull/7640` \
`$ git pull https://git.openjdk.java.net/jdk pull/7640/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7640`

View PR using the GUI difftool: \
`$ git pr show -t 7640`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7640.diff">https://git.openjdk.java.net/jdk/pull/7640.diff</a>

</details>
