### PR TITLE
8281210: Add manpage changes for PAC-RET protection on Linux/AArch64

### DIFF
--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -1983,18 +1983,18 @@ Allows user to specify VM options in a file, for example,
 .RE
 .TP
 .B \f[CB]\-XX:UseBranchProtection=\f[R]\f[I]mode\f[R]
-Specifies the branch protection mode. All options other than none require
-the VM to have been built with branch protection enabled. In addition, for
-full protection, any native libraries provided by applications should be
-compiled with the same level of protection. (AArch64 Linux only).
+\f[B]Linux AArch64 only:\f[R] Specifies the branch protection mode.
+All options other than \f[CB]none\f[R] require the VM to have been built
+with branch protection enabled.
+In addition, for full protection, any native libraries provided by
+applications should be compiled with the same level of protection.
 .RS
 .PP
-Possible \f[I]mode\f[R] arguments for this option include the
-following:
-.RS
+Possible \f[I]mode\f[R] arguments for this option include the following:
 .TP
 .B \f[CB]none\f[R]
-Do not use branch protection. This is the default value.
+Do not use branch protection.
+This is the default value.
 .RS
 .RE
 .TP
@@ -2003,9 +2003,11 @@ Enables all branch protection modes available on the current platform.
 .RS
 .RE
 .TP
-.B \f[CB]pac-ret\f[R]
-Enables protection against ROP based attacks. (AArch64 8.3+ only)
+.B \f[CB]pac\-ret\f[R]
+Enables protection against ROP based attacks.
+(AArch64 8.3+ only)
 .RS
+.RE
 .RE
 .SH ADVANCED JIT COMPILER OPTIONS FOR JAVA
 .PP
@@ -3004,18 +3006,20 @@ different JDK version.
 .RE
 .TP
 .B \f[CB]\-XX:+DTraceAllocProbes\f[R]
-\f[B]Linux and macOS:\f[R] Enable \f[CB]dtrace\f[R] tool probes for object allocation.
+\f[B]Linux and macOS:\f[R] Enable \f[CB]dtrace\f[R] tool probes for object
+allocation.
 .RS
 .RE
 .TP
 .B \f[CB]\-XX:+DTraceMethodProbes\f[R]
-\f[B]Linux and macOS:\f[R] Enable \f[CB]dtrace\f[R] tool probes for method-entry
-and method-exit.
+\f[B]Linux and macOS:\f[R] Enable \f[CB]dtrace\f[R] tool probes for
+method\-entry and method\-exit.
 .RS
 .RE
 .TP
 .B \f[CB]\-XX:+DTraceMonitorProbes\f[R]
-\f[B]Linux and macOS:\f[R] Enable \f[CB]dtrace\f[R] tool probes for monitor events.
+\f[B]Linux and macOS:\f[R] Enable \f[CB]dtrace\f[R] tool probes for monitor
+events.
 .RS
 .RE
 .TP
@@ -4047,8 +4051,9 @@ Example:
 that affect performance.
 By default, this option is disabled and \f[CB]dtrace\f[R] performs only
 standard probes.
-Use the combination of these flags instead: \f[CB]\-XX:+DTraceMethodProbes\f[R],
-\f[CB]\-XX:+DTraceAllocProbes\f[R], \f[CB]\-XX:+DTraceMonitorProbes\f[R].
+Use the combination of these flags instead:
+\f[CB]\-XX:+DTraceMethodProbes\f[R], \f[CB]\-XX:+DTraceAllocProbes\f[R],
+\f[CB]\-XX:+DTraceMonitorProbes\f[R].
 .RS
 .RE
 .TP


### PR DESCRIPTION
Please review this trivial update to apply the manpage changes from JDK-8277204. Those changes had to be applied to the closed markdown sources and then the regenerated output brought back into OpenJDK. There are some minor formatting changes to suit the prevailing style of the runtime flags section, and some incidental line break differences introduced by the pandoc tool.

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281210](https://bugs.openjdk.java.net/browse/JDK-8281210): Add manpage changes for PAC-RET protection on Linux/AArch64


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7641/head:pull/7641` \
`$ git checkout pull/7641`

Update a local copy of the PR: \
`$ git checkout pull/7641` \
`$ git pull https://git.openjdk.java.net/jdk pull/7641/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7641`

View PR using the GUI difftool: \
`$ git pr show -t 7641`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7641.diff">https://git.openjdk.java.net/jdk/pull/7641.diff</a>

</details>
