### PR TITLE
8282473: Refactor swing classes javadoc to use @throws instead of @exception

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/AbstractButton.java
+++ b/src/java.desktop/share/classes/javax/swing/AbstractButton.java
@@ -876,7 +876,7 @@ public abstract class AbstractButton extends JComponent implements ItemSelectabl
      * <li>{@code SwingConstants.LEADING}
      * <li>{@code SwingConstants.TRAILING} (the default)
      * </ul>
-     * @exception IllegalArgumentException if <code>textPosition</code>
+     * @throws IllegalArgumentException if <code>textPosition</code>
      *          is not one of the legal values listed above
      */
     @BeanProperty(visualUpdate = true, enumerationValues = {
@@ -953,7 +953,7 @@ public abstract class AbstractButton extends JComponent implements ItemSelectabl
      *        {@code IllegalArgumentException} that is thrown for an invalid
      *        value
      * @return the {@code key} argument
-     * @exception IllegalArgumentException if key is not one of the legal
+     * @throws IllegalArgumentException if key is not one of the legal
      *            values listed above
      * @see #setHorizontalTextPosition
      * @see #setHorizontalAlignment
@@ -984,7 +984,7 @@ public abstract class AbstractButton extends JComponent implements ItemSelectabl
      *        {@code IllegalArgumentException} that is thrown for an invalid
      *        value
      * @return the {@code key} argument
-     * @exception IllegalArgumentException if key is not one of the legal
+     * @throws IllegalArgumentException if key is not one of the legal
      *            values listed above
      */
     protected int checkVerticalKey(int key, String exception) {
@@ -1571,7 +1571,7 @@ public abstract class AbstractButton extends JComponent implements ItemSelectabl
      *
      * @since 1.4
      * @param index Index into the String to underline
-     * @exception IllegalArgumentException will be thrown if <code>index</code>
+     * @throws IllegalArgumentException will be thrown if <code>index</code>
      *            is &gt;= length of the text, or &lt; -1
      * @see #getDisplayedMnemonicIndex
      */
@@ -1654,7 +1654,7 @@ public abstract class AbstractButton extends JComponent implements ItemSelectabl
      * @see #getMultiClickThreshhold
      * @param threshhold the amount of time required between mouse
      *        press events to generate corresponding action events
-     * @exception   IllegalArgumentException if threshhold &lt; 0
+     * @throws   IllegalArgumentException if threshhold &lt; 0
      * @since 1.4
      */
     public void setMultiClickThreshhold(long threshhold) {
@@ -1791,10 +1791,10 @@ public abstract class AbstractButton extends JComponent implements ItemSelectabl
      * @param     index the position in the container's list at which to
      *                 insert the component, where <code>-1</code>
      *                 means append to the end
-     * @exception IllegalArgumentException if <code>index</code> is invalid
-     * @exception IllegalArgumentException if adding the container's parent
+     * @throws IllegalArgumentException if <code>index</code> is invalid
+     * @throws IllegalArgumentException if adding the container's parent
      *                  to itself
-     * @exception IllegalArgumentException if adding a window to a container
+     * @throws IllegalArgumentException if adding a window to a container
      * @since 1.5
      */
     protected void addImpl(Component comp, Object constraints, int index) {
@@ -3064,7 +3064,7 @@ public abstract class AbstractButton extends JComponent implements ItemSelectabl
              *
              * @param i zero-based index of the key bindings
              * @return a javax.lang.Object which specifies the key binding
-             * @exception IllegalArgumentException if the index is
+             * @throws IllegalArgumentException if the index is
              * out of bounds
              * @see #getAccessibleKeyBindingCount
              */

--- a/src/java.desktop/share/classes/javax/swing/AbstractListModel.java
+++ b/src/java.desktop/share/classes/javax/swing/AbstractListModel.java
@@ -218,7 +218,7 @@ public abstract class AbstractListModel<E> implements ListModel<E>, Serializable
      *          on this model,
      *          or an empty array if no such
      *          listeners have been added
-     * @exception ClassCastException if <code>listenerType</code> doesn't
+     * @throws ClassCastException if <code>listenerType</code> doesn't
      *          specify a class or interface that implements
      *          <code>java.util.EventListener</code>
      *

--- a/src/java.desktop/share/classes/javax/swing/BorderFactory.java
+++ b/src/java.desktop/share/classes/javax/swing/BorderFactory.java
@@ -332,7 +332,7 @@ public class BorderFactory
      * @param type      one of <code>EtchedBorder.RAISED</code>, or
      *                  <code>EtchedBorder.LOWERED</code>
      * @return the <code>Border</code> object
-     * @exception IllegalArgumentException if type is not either
+     * @throws IllegalArgumentException if type is not either
      *                  <code>EtchedBorder.RAISED</code> or
      *                  <code>EtchedBorder.LOWERED</code>
      * @since 1.3

--- a/src/java.desktop/share/classes/javax/swing/BoxLayout.java
+++ b/src/java.desktop/share/classes/javax/swing/BoxLayout.java
@@ -169,7 +169,7 @@ public class BoxLayout implements LayoutManager2, Serializable {
      *              {@code BoxLayout.X_AXIS, BoxLayout.Y_AXIS,
      *              BoxLayout.LINE_AXIS} or {@code BoxLayout.PAGE_AXIS}
      *
-     * @exception AWTError  if the value of {@code axis} is invalid
+     * @throws AWTError  if the value of {@code axis} is invalid
      */
     @ConstructorProperties({"target", "axis"})
     public BoxLayout(Container target, int axis) {
@@ -234,7 +234,7 @@ public class BoxLayout implements LayoutManager2, Serializable {
      *
      * @param target  the affected container
      *
-     * @exception AWTError  if the target isn't the container specified to the
+     * @throws AWTError  if the target isn't the container specified to the
      *                      BoxLayout constructor
      */
     public synchronized void invalidateLayout(Container target) {
@@ -280,7 +280,7 @@ public class BoxLayout implements LayoutManager2, Serializable {
      *
      * @param target  the container that needs to be laid out
      * @return the dimensions &gt;= 0 &amp;&amp; &lt;= Integer.MAX_VALUE
-     * @exception AWTError  if the target isn't the container specified to the
+     * @throws AWTError  if the target isn't the container specified to the
      *                      BoxLayout constructor
      * @see Container
      * @see #minimumLayoutSize
@@ -306,7 +306,7 @@ public class BoxLayout implements LayoutManager2, Serializable {
      *
      * @param target  the container that needs to be laid out
      * @return the dimensions &gt;= 0 &amp;&amp; &lt;= Integer.MAX_VALUE
-     * @exception AWTError  if the target isn't the container specified to the
+     * @throws AWTError  if the target isn't the container specified to the
      *                      BoxLayout constructor
      * @see #preferredLayoutSize
      * @see #maximumLayoutSize
@@ -331,7 +331,7 @@ public class BoxLayout implements LayoutManager2, Serializable {
      *
      * @param target  the container that needs to be laid out
      * @return the dimensions &gt;= 0 &amp;&amp; &lt;= Integer.MAX_VALUE
-     * @exception AWTError  if the target isn't the container specified to the
+     * @throws AWTError  if the target isn't the container specified to the
      *                      BoxLayout constructor
      * @see #preferredLayoutSize
      * @see #minimumLayoutSize
@@ -358,7 +358,7 @@ public class BoxLayout implements LayoutManager2, Serializable {
      *
      * @param target  the container
      * @return the alignment &gt;= 0.0f &amp;&amp; &lt;= 1.0f
-     * @exception AWTError  if the target isn't the container specified to the
+     * @throws AWTError  if the target isn't the container specified to the
      *                      BoxLayout constructor
      */
     public synchronized float getLayoutAlignmentX(Container target) {
@@ -375,7 +375,7 @@ public class BoxLayout implements LayoutManager2, Serializable {
      *
      * @param target  the container
      * @return the alignment &gt;= 0.0f &amp;&amp; &lt;= 1.0f
-     * @exception AWTError  if the target isn't the container specified to the
+     * @throws AWTError  if the target isn't the container specified to the
      *                      BoxLayout constructor
      */
     public synchronized float getLayoutAlignmentY(Container target) {
@@ -390,7 +390,7 @@ public class BoxLayout implements LayoutManager2, Serializable {
      *
      * @param target  the container to lay out
      *
-     * @exception AWTError  if the target isn't the container specified to the
+     * @throws AWTError  if the target isn't the container specified to the
      *                      BoxLayout constructor
      */
     public void layoutContainer(Container target) {

--- a/src/java.desktop/share/classes/javax/swing/DefaultBoundedRangeModel.java
+++ b/src/java.desktop/share/classes/javax/swing/DefaultBoundedRangeModel.java
@@ -417,7 +417,7 @@ public class DefaultBoundedRangeModel implements BoundedRangeModel, Serializable
      *          on this model,
      *          or an empty array if no such
      *          listeners have been added
-     * @exception ClassCastException if <code>listenerType</code> doesn't
+     * @throws ClassCastException if <code>listenerType</code> doesn't
      *          specify a class or interface that implements
      *          <code>java.util.EventListener</code>
      *

--- a/src/java.desktop/share/classes/javax/swing/DefaultButtonModel.java
+++ b/src/java.desktop/share/classes/javax/swing/DefaultButtonModel.java
@@ -488,7 +488,7 @@ public class DefaultButtonModel implements ButtonModel, Serializable {
      *          on this model,
      *          or an empty array if no such
      *          listeners have been added
-     * @exception ClassCastException if <code>listenerType</code> doesn't
+     * @throws ClassCastException if <code>listenerType</code> doesn't
      *          specify a class or interface that implements
      *          <code>java.util.EventListener</code>
      *

--- a/src/java.desktop/share/classes/javax/swing/DefaultListModel.java
+++ b/src/java.desktop/share/classes/javax/swing/DefaultListModel.java
@@ -345,7 +345,7 @@ public class DefaultListModel<E> extends AbstractListModel<E>
      *
      * @param      element the component to insert
      * @param      index   where to insert the new component
-     * @exception  ArrayIndexOutOfBoundsException if the index was invalid
+     * @throws  ArrayIndexOutOfBoundsException if the index was invalid
      * @see #add(int,Object)
      * @see Vector#insertElementAt(Object,int)
      */

--- a/src/java.desktop/share/classes/javax/swing/DefaultListSelectionModel.java
+++ b/src/java.desktop/share/classes/javax/swing/DefaultListSelectionModel.java
@@ -284,7 +284,7 @@ public class DefaultListSelectionModel implements ListSelectionModel, Cloneable,
      *          on this model,
      *          or an empty array if no such
      *          listeners have been added
-     * @exception ClassCastException if <code>listenerType</code> doesn't
+     * @throws ClassCastException if <code>listenerType</code> doesn't
      *          specify a class or interface that implements
      *          <code>java.util.EventListener</code>
      *
@@ -750,7 +750,7 @@ public class DefaultListSelectionModel implements ListSelectionModel, Cloneable,
      * Returns a clone of this selection model with the same selection.
      * <code>listenerLists</code> are not duplicated.
      *
-     * @exception CloneNotSupportedException if the selection model does not
+     * @throws CloneNotSupportedException if the selection model does not
      *    both (a) implement the Cloneable interface and (b) define a
      *    <code>clone</code> method.
      */

--- a/src/java.desktop/share/classes/javax/swing/DefaultSingleSelectionModel.java
+++ b/src/java.desktop/share/classes/javax/swing/DefaultSingleSelectionModel.java
@@ -178,7 +178,7 @@ Serializable {
      *          on this model,
      *          or an empty array if no such
      *          listeners have been added
-     * @exception ClassCastException if <code>listenerType</code> doesn't
+     * @throws ClassCastException if <code>listenerType</code> doesn't
      *          specify a class or interface that implements
      *          <code>java.util.EventListener</code>
      *

--- a/src/java.desktop/share/classes/javax/swing/JApplet.java
+++ b/src/java.desktop/share/classes/javax/swing/JApplet.java
@@ -135,7 +135,7 @@ public class JApplet extends Applet implements Accessible,
      * This constructor sets the component's locale property to the value
      * returned by <code>JComponent.getDefaultLocale</code>.
      *
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @see JComponent#getDefaultLocale
@@ -312,10 +312,10 @@ public class JApplet extends Applet implements Accessible,
      * @param comp the component to be enhanced
      * @param constraints the constraints to be respected
      * @param index the index
-     * @exception IllegalArgumentException if <code>index</code> is invalid
-     * @exception IllegalArgumentException if adding the container's parent
+     * @throws IllegalArgumentException if <code>index</code> is invalid
+     * @throws IllegalArgumentException if adding the container's parent
      *                  to itself
-     * @exception IllegalArgumentException if adding a window to a container
+     * @throws IllegalArgumentException if adding a window to a container
      *
      * @see #setRootPaneCheckingEnabled
      * @see javax.swing.RootPaneContainer
@@ -423,7 +423,7 @@ public class JApplet extends Applet implements Accessible,
      * Sets the contentPane property.  This method is called by the constructor.
      * @param contentPane the contentPane object for this applet
      *
-     * @exception java.awt.IllegalComponentStateException (a runtime
+     * @throws java.awt.IllegalComponentStateException (a runtime
      *            exception) if the content pane parameter is null
      * @see #getContentPane
      * @see RootPaneContainer#setContentPane
@@ -437,7 +437,7 @@ public class JApplet extends Applet implements Accessible,
     /**
      * Returns the layeredPane object for this applet.
      *
-     * @exception java.awt.IllegalComponentStateException (a runtime
+     * @throws java.awt.IllegalComponentStateException (a runtime
      *            exception) if the layered pane parameter is null
      * @see #setLayeredPane
      * @see RootPaneContainer#getLayeredPane

--- a/src/java.desktop/share/classes/javax/swing/JColorChooser.java
+++ b/src/java.desktop/share/classes/javax/swing/JColorChooser.java
@@ -150,7 +150,7 @@ public class JColorChooser extends JComponent implements Accessible {
      * @param title        the String containing the dialog's title
      * @param initialColor the initial Color set when the color-chooser is shown
      * @return the selected color or <code>null</code> if the user opted out
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -173,7 +173,7 @@ public class JColorChooser extends JComponent implements Accessible {
      * @param colorTransparencySelectionEnabled true if the transparency of
      *            a color can be selected
      * @return the selected color or <code>null</code> if the user opted out
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -217,7 +217,7 @@ public class JColorChooser extends JComponent implements Accessible {
      * @param okListener     the ActionListener invoked when "OK" is pressed
      * @param cancelListener the ActionListener invoked when "Cancel" is pressed
      * @return a new dialog containing the color-chooser pane
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -343,7 +343,7 @@ public class JColorChooser extends JComponent implements Accessible {
      * @param r   an int specifying the amount of Red
      * @param g   an int specifying the amount of Green
      * @param b   an int specifying the amount of Blue
-     * @exception IllegalArgumentException if r,g,b values are out of range
+     * @throws IllegalArgumentException if r,g,b values are out of range
      * @see java.awt.Color
      */
     public void setColor(int r, int g, int b) {
@@ -386,7 +386,7 @@ public class JColorChooser extends JComponent implements Accessible {
      * <code>TransferHandler</code>.
      *
      * @param b the value to set the <code>dragEnabled</code> property to
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *            <code>b</code> is <code>true</code> and
      *            <code>GraphicsEnvironment.isHeadless()</code>
      *            returns <code>true</code>
@@ -464,7 +464,7 @@ public class JColorChooser extends JComponent implements Accessible {
      *
      * @param panel   a string that specifies the panel to be removed
      * @return the color panel
-     * @exception IllegalArgumentException if panel is not in list of
+     * @throws IllegalArgumentException if panel is not in list of
      *                  known chooser panels
      */
     public AbstractColorChooserPanel removeChooserPanel( AbstractColorChooserPanel panel ) {

--- a/src/java.desktop/share/classes/javax/swing/JComboBox.java
+++ b/src/java.desktop/share/classes/javax/swing/JComboBox.java
@@ -638,7 +638,7 @@ implements ItemSelectable,ListDataListener,ActionListener, Accessible {
      *
      * @param anIndex an integer specifying the list item to select,
      *                  where 0 specifies the first item in the list and -1 indicates no selection
-     * @exception IllegalArgumentException if <code>anIndex</code> &lt; -1 or
+     * @throws IllegalArgumentException if <code>anIndex</code> &lt; -1 or
      *                  <code>anIndex</code> is greater than or equal to size
      */
     @BeanProperty(bound = false, preferred = true, description
@@ -815,7 +815,7 @@ implements ItemSelectable,ListDataListener,ActionListener, Accessible {
     /**
      * Checks that the <code>dataModel</code> is an instance of
      * <code>MutableComboBoxModel</code>.  If not, it throws an exception.
-     * @exception RuntimeException if <code>dataModel</code> is not an
+     * @throws RuntimeException if <code>dataModel</code> is not an
      *          instance of <code>MutableComboBoxModel</code>.
      */
     void checkMutableComboBoxModel() {
@@ -2298,7 +2298,7 @@ implements ItemSelectable,ListDataListener,ActionListener, Accessible {
              * @return this component's locale.  If this component does not have
              * a locale, the locale of its parent is returned.
              *
-             * @exception IllegalComponentStateException
+             * @throws IllegalComponentStateException
              * If the Component does not have its own locale and has not yet been
              * added to a containment hierarchy such that the locale can be
              * determined from the containing parent.

--- a/src/java.desktop/share/classes/javax/swing/JComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/JComponent.java
@@ -2455,7 +2455,7 @@ public abstract class JComponent extends Container implements Serializable,
      *
      * @param condition one of the values listed above
      * @param map  the <code>InputMap</code> to use for the given condition
-     * @exception IllegalArgumentException if <code>condition</code> is
+     * @throws IllegalArgumentException if <code>condition</code> is
      *          <code>WHEN_IN_FOCUSED_WINDOW</code> and <code>map</code>
      *          is not an instance of <code>ComponentInputMap</code>; or
      *          if <code>condition</code> is not one of the legal values
@@ -2554,7 +2554,7 @@ public abstract class JComponent extends Container implements Serializable,
      * @return the <code>InputMap</code> for the given <code>condition</code>;
      *          if <code>create</code> is false and the <code>InputMap</code>
      *          hasn't been created, returns <code>null</code>
-     * @exception IllegalArgumentException if <code>condition</code>
+     * @throws IllegalArgumentException if <code>condition</code>
      *          is not one of the legal values listed above
      */
     final InputMap getInputMap(int condition, boolean create) {
@@ -4623,7 +4623,7 @@ public abstract class JComponent extends Container implements Serializable,
      * @param propertyName  the name of the property that was listened on
      * @param oldValue  the old value of the property
      * @param newValue  the new value of the property
-     * @exception java.beans.PropertyVetoException when the attempt to set the
+     * @throws java.beans.PropertyVetoException when the attempt to set the
      *          property is vetoed by the component
      */
     protected void fireVetoableChange(String propertyName, Object oldValue, Object newValue)
@@ -4799,7 +4799,7 @@ public abstract class JComponent extends Container implements Serializable,
      *          <code><em>Foo</em>Listener</code>s on this component,
      *          or an empty array if no such
      *          listeners have been added
-     * @exception ClassCastException if <code>listenerType</code>
+     * @throws ClassCastException if <code>listenerType</code>
      *          doesn't specify a class or interface that implements
      *          <code>java.util.EventListener</code>
      *

--- a/src/java.desktop/share/classes/javax/swing/JEditorPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JEditorPane.java
@@ -312,7 +312,7 @@ public class JEditorPane extends JTextComponent {
      * Creates a <code>JEditorPane</code> based on a specified URL for input.
      *
      * @param initialPage the URL
-     * @exception IOException if the URL is <code>null</code>
+     * @throws IOException if the URL is <code>null</code>
      *          or cannot be accessed
      */
     public JEditorPane(URL initialPage) throws IOException {
@@ -325,7 +325,7 @@ public class JEditorPane extends JTextComponent {
      * a URL specification.
      *
      * @param url the URL
-     * @exception IOException if the URL is <code>null</code> or
+     * @throws IOException if the URL is <code>null</code> or
      *          cannot be accessed
      */
     public JEditorPane(String url) throws IOException {
@@ -340,7 +340,7 @@ public class JEditorPane extends JTextComponent {
      *
      * @param type mime type of the given text
      * @param text the text to initialize with; may be <code>null</code>
-     * @exception NullPointerException if the <code>type</code> parameter
+     * @throws NullPointerException if the <code>type</code> parameter
      *          is <code>null</code>
      */
     public JEditorPane(String type, String text) {
@@ -462,7 +462,7 @@ public class JEditorPane extends JTextComponent {
      * thread is done whether the load was successful or not.
      *
      * @param page the URL of the page
-     * @exception IOException for a <code>null</code> or invalid
+     * @throws IOException for a <code>null</code> or invalid
      *          page specification, or exception from the stream being read
      * @see #getPage
      */
@@ -578,7 +578,7 @@ public class JEditorPane extends JTextComponent {
      *
      * @param in the stream from which to read
      * @param desc an object describing the stream
-     * @exception IOException as thrown by the stream being
+     * @throws IOException as thrown by the stream being
      *          used to initialize
      * @see JTextComponent#read
      * @see #setDocument
@@ -925,7 +925,7 @@ public class JEditorPane extends JTextComponent {
      * Sets the current URL being displayed.
      *
      * @param url the URL for display
-     * @exception IOException for a <code>null</code> or invalid URL
+     * @throws IOException for a <code>null</code> or invalid URL
      *          specification
      */
     public void setPage(String url) throws IOException {

--- a/src/java.desktop/share/classes/javax/swing/JFileChooser.java
+++ b/src/java.desktop/share/classes/javax/swing/JFileChooser.java
@@ -446,7 +446,7 @@ public class JFileChooser extends JComponent implements Accessible {
      * <code>TransferHandler</code>.
      *
      * @param b the value to set the <code>dragEnabled</code> property to
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *            <code>b</code> is <code>true</code> and
      *            <code>GraphicsEnvironment.isHeadless()</code>
      *            returns <code>true</code>
@@ -658,7 +658,7 @@ public class JFileChooser extends JComponent implements Accessible {
      * <li>JFileChooser.ERROR_OPTION if an error occurs or the
      *                  dialog is dismissed
      * </ul>
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @see #showDialog
@@ -683,7 +683,7 @@ public class JFileChooser extends JComponent implements Accessible {
      * <li>JFileChooser.ERROR_OPTION if an error occurs or the
      *                  dialog is dismissed
      * </ul>
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @see #showDialog
@@ -743,7 +743,7 @@ public class JFileChooser extends JComponent implements Accessible {
      * <li>JFileChooser.ERROR_OPTION if an error occurs or the
      *                  dialog is dismissed
      * </ul>
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -800,7 +800,7 @@ public class JFileChooser extends JComponent implements Accessible {
      * @param   parent  the parent component of the dialog;
      *                  can be <code>null</code>
      * @return a new <code>JDialog</code> containing this instance
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @since 1.4
@@ -924,7 +924,7 @@ public class JFileChooser extends JComponent implements Accessible {
      * <li>JFileChooser.CUSTOM_DIALOG
      * </ul>
      *
-     * @exception IllegalArgumentException if <code>dialogType</code> is
+     * @throws IllegalArgumentException if <code>dialogType</code> is
      *                          not legal
      *
      * @see #getDialogType
@@ -1311,7 +1311,7 @@ public class JFileChooser extends JComponent implements Accessible {
      * <li>JFileChooser.FILES_AND_DIRECTORIES
      * </ul>
      *
-     * @exception IllegalArgumentException  if <code>mode</code> is an
+     * @throws IllegalArgumentException  if <code>mode</code> is an
      *                          illegal file selection mode
      *
      * @see #getFileSelectionMode

--- a/src/java.desktop/share/classes/javax/swing/JFrame.java
+++ b/src/java.desktop/share/classes/javax/swing/JFrame.java
@@ -169,7 +169,7 @@ public class JFrame  extends Frame implements WindowConstants,
      * This constructor sets the component's locale property to the value
      * returned by <code>JComponent.getDefaultLocale</code>.
      *
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @see Component#setSize
@@ -193,7 +193,7 @@ public class JFrame  extends Frame implements WindowConstants,
      *          to construct the new <code>Frame</code>;
      *          if <code>gc</code> is <code>null</code>, the system
      *          default <code>GraphicsConfiguration</code> is assumed
-     * @exception IllegalArgumentException if <code>gc</code> is not from
+     * @throws IllegalArgumentException if <code>gc</code> is not from
      *          a screen device.  This exception is always thrown when
      *      GraphicsEnvironment.isHeadless() returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -213,7 +213,7 @@ public class JFrame  extends Frame implements WindowConstants,
      * returned by <code>JComponent.getDefaultLocale</code>.
      *
      * @param title the title for the frame
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @see Component#setSize
@@ -239,7 +239,7 @@ public class JFrame  extends Frame implements WindowConstants,
      *          to construct the new <code>JFrame</code> with;
      *          if <code>gc</code> is <code>null</code>, the system
      *          default <code>GraphicsConfiguration</code> is assumed
-     * @exception IllegalArgumentException if <code>gc</code> is not from
+     * @throws IllegalArgumentException if <code>gc</code> is not from
      *          a screen device.  This exception is always thrown when
      *      GraphicsEnvironment.isHeadless() returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -357,7 +357,7 @@ public class JFrame  extends Frame implements WindowConstants,
      *
      * @param operation the operation which should be performed when the
      *        user closes the frame
-     * @exception IllegalArgumentException if defaultCloseOperation value
+     * @throws IllegalArgumentException if defaultCloseOperation value
      *             isn't one of the above valid values
      * @see #addWindowListener
      * @see #getDefaultCloseOperation
@@ -540,10 +540,10 @@ public class JFrame  extends Frame implements WindowConstants,
      * @param comp the component to be enhanced
      * @param constraints the constraints to be respected
      * @param index the index
-     * @exception IllegalArgumentException if <code>index</code> is invalid
-     * @exception IllegalArgumentException if adding the container's parent
+     * @throws IllegalArgumentException if <code>index</code> is invalid
+     * @throws IllegalArgumentException if adding the container's parent
      *                  to itself
-     * @exception IllegalArgumentException if adding a window to a container
+     * @throws IllegalArgumentException if adding a window to a container
      *
      * @see #setRootPaneCheckingEnabled
      * @see javax.swing.RootPaneContainer
@@ -668,7 +668,7 @@ public class JFrame  extends Frame implements WindowConstants,
      *
      * @param contentPane the <code>contentPane</code> object for this frame
      *
-     * @exception java.awt.IllegalComponentStateException (a runtime
+     * @throws java.awt.IllegalComponentStateException (a runtime
      *            exception) if the content pane parameter is <code>null</code>
      * @see #getContentPane
      * @see RootPaneContainer#setContentPane
@@ -696,7 +696,7 @@ public class JFrame  extends Frame implements WindowConstants,
      * This method is called by the constructor.
      * @param layeredPane the <code>layeredPane</code> object for this frame
      *
-     * @exception java.awt.IllegalComponentStateException (a runtime
+     * @throws java.awt.IllegalComponentStateException (a runtime
      *            exception) if the layered pane parameter is <code>null</code>
      * @see #getLayeredPane
      * @see RootPaneContainer#setLayeredPane

--- a/src/java.desktop/share/classes/javax/swing/JInternalFrame.java
+++ b/src/java.desktop/share/classes/javax/swing/JInternalFrame.java
@@ -497,10 +497,10 @@ public class JInternalFrame extends JComponent implements
      * @param comp the component to be enhanced
      * @param constraints the constraints to be respected
      * @param index the index
-     * @exception IllegalArgumentException if <code>index</code> is invalid
-     * @exception IllegalArgumentException if adding the container's parent
+     * @throws IllegalArgumentException if <code>index</code> is invalid
+     * @throws IllegalArgumentException if adding the container's parent
      *                  to itself
-     * @exception IllegalArgumentException if adding a window to a container
+     * @throws IllegalArgumentException if adding a window to a container
      *
      * @see #setRootPaneCheckingEnabled
      * @see javax.swing.RootPaneContainer
@@ -628,7 +628,7 @@ public class JInternalFrame extends JComponent implements
      *
      * @param c  the content pane for this internal frame
      *
-     * @exception java.awt.IllegalComponentStateException (a runtime
+     * @throws java.awt.IllegalComponentStateException (a runtime
      *           exception) if the content pane parameter is <code>null</code>
      * @see RootPaneContainer#getContentPane
      */
@@ -657,7 +657,7 @@ public class JInternalFrame extends JComponent implements
      *
      * @param layered the <code>JLayeredPane</code> for this internal frame
      *
-     * @exception java.awt.IllegalComponentStateException (a runtime
+     * @throws java.awt.IllegalComponentStateException (a runtime
      *           exception) if the layered pane parameter is <code>null</code>
      * @see RootPaneContainer#setLayeredPane
      */
@@ -794,7 +794,7 @@ public class JInternalFrame extends JComponent implements
      *
      * @param b must be <code>true</code>
      *
-     * @exception PropertyVetoException when the attempt to set the
+     * @throws PropertyVetoException when the attempt to set the
      *            property is vetoed by the <code>JInternalFrame</code>
      *
      * @see #isClosed()
@@ -906,7 +906,7 @@ public class JInternalFrame extends JComponent implements
      *
      * @param b a boolean, where <code>true</code> means to iconify this internal frame and
      *          <code>false</code> means to de-iconify it
-     * @exception PropertyVetoException when the attempt to set the
+     * @throws PropertyVetoException when the attempt to set the
      *            property is vetoed by the <code>JInternalFrame</code>
      *
      * @see InternalFrameEvent#INTERNAL_FRAME_ICONIFIED
@@ -985,7 +985,7 @@ public class JInternalFrame extends JComponent implements
      *
      * @param b  a boolean, where <code>true</code> maximizes this internal frame and <code>false</code>
      *           restores it
-     * @exception PropertyVetoException when the attempt to set the
+     * @throws PropertyVetoException when the attempt to set the
      *            property is vetoed by the <code>JInternalFrame</code>
      */
     @BeanProperty(description
@@ -1047,7 +1047,7 @@ public class JInternalFrame extends JComponent implements
      * @param selected  a boolean, where <code>true</code> means this internal frame
      *                  should become selected (currently active)
      *                  and <code>false</code> means it should become deselected
-     * @exception PropertyVetoException when the attempt to set the
+     * @throws PropertyVetoException when the attempt to set the
      *            property is vetoed by the <code>JInternalFrame</code>
      *
      * @see #isShowing

--- a/src/java.desktop/share/classes/javax/swing/JLabel.java
+++ b/src/java.desktop/share/classes/javax/swing/JLabel.java
@@ -551,7 +551,7 @@ public class JLabel extends JComponent implements SwingConstants, Accessible
      *
      * @since 1.4
      * @param index Index into the String to underline
-     * @exception IllegalArgumentException will be thrown if <code>index</code>
+     * @throws IllegalArgumentException will be thrown if <code>index</code>
      *            is &gt;= length of the text, or &lt; -1
      */
     @BeanProperty(visualUpdate = true, description
@@ -595,7 +595,7 @@ public class JLabel extends JComponent implements SwingConstants, Accessible
      * @param message the IllegalArgumentException detail message
      * @return the key value if {@code key} is a a legal value for the
      *         horizontalAlignment properties
-     * @exception IllegalArgumentException if key isn't LEFT, CENTER, RIGHT,
+     * @throws IllegalArgumentException if key isn't LEFT, CENTER, RIGHT,
      * LEADING or TRAILING.
      * @see #setHorizontalTextPosition
      * @see #setHorizontalAlignment
@@ -622,7 +622,7 @@ public class JLabel extends JComponent implements SwingConstants, Accessible
      * @param message the IllegalArgumentException detail message
      * @return the key value if {@code key} is a legal value for the
      *         verticalAlignment or verticalTextPosition properties
-     * @exception IllegalArgumentException if key isn't TOP, CENTER, or BOTTOM.
+     * @throws IllegalArgumentException if key isn't TOP, CENTER, or BOTTOM.
      * @see #setVerticalAlignment
      * @see #setVerticalTextPosition
      */
@@ -1637,7 +1637,7 @@ public class JLabel extends JComponent implements SwingConstants, Accessible
              *
              * @param i zero-based index of the key bindings
              * @return a javax.lang.Object which specifies the key binding
-             * @exception IllegalArgumentException if the index is
+             * @throws IllegalArgumentException if the index is
              * out of bounds
              * @see #getAccessibleKeyBindingCount
              */

--- a/src/java.desktop/share/classes/javax/swing/JLayer.java
+++ b/src/java.desktop/share/classes/javax/swing/JLayer.java
@@ -316,7 +316,7 @@ public final class JLayer<V extends Component>
      * a {@code JLayer}.
      *
      * @param mgr the specified layout manager
-     * @exception IllegalArgumentException this method is not supported
+     * @throws IllegalArgumentException this method is not supported
      */
     public void setLayout(LayoutManager mgr) {
         if (mgr != null) {

--- a/src/java.desktop/share/classes/javax/swing/JList.java
+++ b/src/java.desktop/share/classes/javax/swing/JList.java
@@ -445,7 +445,7 @@ public class JList<E> extends JComponent implements Scrollable, Accessible
      * allowing for tooltips to be provided by the cell renderers.
      *
      * @param dataModel the model for the list
-     * @exception IllegalArgumentException if the model is {@code null}
+     * @throws IllegalArgumentException if the model is {@code null}
      */
     public JList(ListModel<E> dataModel)
     {
@@ -1202,7 +1202,7 @@ public class JList<E> extends JComponent implements Scrollable, Accessible
      * list's {@code TransferHandler}.
      *
      * @param b whether or not to enable automatic drag handling
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *            <code>b</code> is <code>true</code> and
      *            <code>GraphicsEnvironment.isHeadless()</code>
      *            returns <code>true</code>
@@ -1493,7 +1493,7 @@ public class JList<E> extends JComponent implements Scrollable, Accessible
      * Position.Bias.Forward or Position.Bias.Backward.
      * @return the index of the next list element that
      * starts with the prefix; otherwise {@code -1}
-     * @exception IllegalArgumentException if prefix is {@code null}
+     * @throws IllegalArgumentException if prefix is {@code null}
      * or startIndex is out of bounds
      * @since 1.4
      */
@@ -1695,7 +1695,7 @@ public class JList<E> extends JComponent implements Scrollable, Accessible
      *
      * @param model  the <code>ListModel</code> that provides the
      *                                          list of items for display
-     * @exception IllegalArgumentException  if <code>model</code> is
+     * @throws IllegalArgumentException  if <code>model</code> is
      *                                          <code>null</code>
      * @see #getModel
      * @see #clearSelection
@@ -1910,7 +1910,7 @@ public class JList<E> extends JComponent implements Scrollable, Accessible
      *
      * @param selectionModel  the <code>ListSelectionModel</code> that
      *                          implements the selections
-     * @exception IllegalArgumentException   if <code>selectionModel</code>
+     * @throws IllegalArgumentException   if <code>selectionModel</code>
      *                                          is <code>null</code>
      * @see #getSelectionModel
      */

--- a/src/java.desktop/share/classes/javax/swing/JMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JMenu.java
@@ -508,7 +508,7 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
      * to manage the idiosyncrasies of the various UI implementations.
      *
      * @param       d the number of milliseconds to delay
-     * @exception   IllegalArgumentException if <code>d</code>
+     * @throws   IllegalArgumentException if <code>d</code>
      *                       is less than 0
      */
     @BeanProperty(bound = false, expert = true, description
@@ -674,7 +674,7 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
      * @param s the text for the menu item to add
      * @param pos an integer specifying the position at which to add the
      *               new menu item
-     * @exception IllegalArgumentException when the value of
+     * @throws IllegalArgumentException when the value of
      *                  <code>pos</code> &lt; 0
      */
     public void insert(String s, int pos) {
@@ -693,7 +693,7 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
      * @param pos an integer specifying the position at which to add the
      *               new <code>JMenuitem</code>
      * @return the new menu item
-     * @exception IllegalArgumentException if the value of
+     * @throws IllegalArgumentException if the value of
      *                  <code>pos</code> &lt; 0
      */
     public JMenuItem insert(JMenuItem mi, int pos) {
@@ -713,7 +713,7 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
      * @param pos an integer specifying the position at which to add the
      *               new menu item
      * @return the new menu item
-     * @exception IllegalArgumentException if the value of
+     * @throws IllegalArgumentException if the value of
      *                  <code>pos</code> &lt; 0
      */
     public JMenuItem insert(Action a, int pos) {
@@ -734,7 +734,7 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
      *
      * @param       index an integer specifying the position at which to
      *                    insert the menu separator
-     * @exception   IllegalArgumentException if the value of
+     * @throws   IllegalArgumentException if the value of
      *                       <code>index</code> &lt; 0
      */
     public void insertSeparator(int index) {
@@ -755,7 +755,7 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
      * @param pos  an integer specifying the position
      * @return  the menu item at the specified position; or <code>null</code>
      *          if the item as the specified position is not a menu item
-     * @exception  IllegalArgumentException if the value of
+     * @throws  IllegalArgumentException if the value of
      *             {@code pos} &lt; 0
      */
     public JMenuItem getItem(int pos) {
@@ -790,7 +790,7 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
      * yet implemented.
      *
      * @return true if the menu can be torn off, else false
-     * @exception  Error  if invoked -- this method is not yet implemented
+     * @throws  Error  if invoked -- this method is not yet implemented
      */
     @BeanProperty(bound = false)
     public boolean isTearOff() {
@@ -812,7 +812,7 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
      * Removes the menu item at the specified index from this menu.
      *
      * @param       pos the position of the item to be removed
-     * @exception   IllegalArgumentException if the value of
+     * @throws   IllegalArgumentException if the value of
      *                       <code>pos</code> &lt; 0, or if <code>pos</code>
      *                       is greater than the number of menu items
      */
@@ -1024,7 +1024,7 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
      * notification on this event type.  The event instance
      * is created lazily.
      *
-     * @exception Error  if there is a <code>null</code> listener
+     * @throws Error  if there is a <code>null</code> listener
      * @see EventListenerList
      */
     protected void fireMenuSelected() {
@@ -1054,7 +1054,7 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
      * notification on this event type.  The event instance
      * is created lazily.
      *
-     * @exception Error if there is a <code>null</code> listener
+     * @throws Error if there is a <code>null</code> listener
      * @see EventListenerList
      */
     protected void fireMenuDeselected() {
@@ -1084,7 +1084,7 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
      * notification on this event type.  The event instance
      * is created lazily.
      *
-     * @exception Error if there is a <code>null</code> listener
+     * @throws Error if there is a <code>null</code> listener
      * @see EventListenerList
      */
     protected void fireMenuCanceled() {
@@ -1238,7 +1238,7 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
      *
      * @param o the new component orientation of this menu and
      *        the components contained within it.
-     * @exception NullPointerException if <code>orientation</code> is null.
+     * @throws NullPointerException if <code>orientation</code> is null.
      * @see java.awt.Component#setComponentOrientation
      * @see java.awt.Component#getComponentOrientation
      * @since 1.4
@@ -1275,7 +1275,7 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
      * @param keyStroke  the keystroke combination which will invoke
      *                  the <code>JMenuItem</code>'s actionlisteners
      *                  without navigating the menu hierarchy
-     * @exception Error  if invoked -- this method is not defined for JMenu.
+     * @throws Error  if invoked -- this method is not defined for JMenu.
      *                  Use <code>setMnemonic</code> instead
      */
     public void setAccelerator(KeyStroke keyStroke) {

--- a/src/java.desktop/share/classes/javax/swing/JOptionPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JOptionPane.java
@@ -435,7 +435,7 @@ public class JOptionPane extends JComponent implements Accessible
      * the screen.
      *
      * @param message the <code>Object</code> to display
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *   <code>GraphicsEnvironment.isHeadless</code> returns
      *   <code>true</code>
      * @return user's input
@@ -471,7 +471,7 @@ public class JOptionPane extends JComponent implements Accessible
      * @param parentComponent  the parent <code>Component</code> for the
      *          dialog
      * @param message  the <code>Object</code> to display
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *    <code>GraphicsEnvironment.isHeadless</code> returns
      *    <code>true</code>
      * @return user's input
@@ -523,7 +523,7 @@ public class JOptionPane extends JComponent implements Accessible
      *                  <code>QUESTION_MESSAGE</code>,
      *                  or <code>PLAIN_MESSAGE</code>
      * @return user's input
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *   <code>GraphicsEnvironment.isHeadless</code> returns
      *   <code>true</code>
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -566,7 +566,7 @@ public class JOptionPane extends JComponent implements Accessible
      *                 field
      * @return user's input, or <code>null</code> meaning the user
      *                  canceled the input
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *   <code>GraphicsEnvironment.isHeadless</code> returns
      *   <code>true</code>
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -609,7 +609,7 @@ public class JOptionPane extends JComponent implements Accessible
      *          or if the <code>parentComponent</code> has no
      *          <code>Frame</code>, a default <code>Frame</code> is used
      * @param message   the <code>Object</code> to display
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *   <code>GraphicsEnvironment.isHeadless</code> returns
      *   <code>true</code>
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -637,7 +637,7 @@ public class JOptionPane extends JComponent implements Accessible
      *                  <code>WARNING_MESSAGE</code>,
      *                  <code>QUESTION_MESSAGE</code>,
      *                  or <code>PLAIN_MESSAGE</code>
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *   <code>GraphicsEnvironment.isHeadless</code> returns
      *   <code>true</code>
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -666,7 +666,7 @@ public class JOptionPane extends JComponent implements Accessible
      *                  or <code>PLAIN_MESSAGE</code>
      * @param icon      an icon to display in the dialog that helps the user
      *                  identify the kind of message that is being displayed
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *   <code>GraphicsEnvironment.isHeadless</code> returns
      *   <code>true</code>
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -690,7 +690,7 @@ public class JOptionPane extends JComponent implements Accessible
      *                  default <code>Frame</code> is used
      * @param message   the <code>Object</code> to display
      * @return an integer indicating the option selected by the user
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *   <code>GraphicsEnvironment.isHeadless</code> returns
      *   <code>true</code>
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -718,7 +718,7 @@ public class JOptionPane extends JComponent implements Accessible
      *                  <code>YES_NO_CANCEL_OPTION</code>,
      *                  or <code>OK_CANCEL_OPTION</code>
      * @return an int indicating the option selected by the user
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *   <code>GraphicsEnvironment.isHeadless</code> returns
      *   <code>true</code>
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -757,7 +757,7 @@ public class JOptionPane extends JComponent implements Accessible
      *                  <code>QUESTION_MESSAGE</code>,
      *                  or <code>PLAIN_MESSAGE</code>
      * @return an integer indicating the option selected by the user
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *   <code>GraphicsEnvironment.isHeadless</code> returns
      *   <code>true</code>
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -795,7 +795,7 @@ public class JOptionPane extends JComponent implements Accessible
      *                  or <code>PLAIN_MESSAGE</code>
      * @param icon      the icon to display in the dialog
      * @return an int indicating the option selected by the user
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *   <code>GraphicsEnvironment.isHeadless</code> returns
      *   <code>true</code>
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -856,7 +856,7 @@ public class JOptionPane extends JComponent implements Accessible
      * @return an integer indicating the option chosen by the user,
      *                  or <code>CLOSED_OPTION</code> if the user closed
      *                  the dialog
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *   <code>GraphicsEnvironment.isHeadless</code> returns
      *   <code>true</code>
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -919,7 +919,7 @@ public class JOptionPane extends JComponent implements Accessible
      *          no <code>Frame</code>, a default <code>Frame</code> is used
      * @param title     the title string for the dialog
      * @return a new <code>JDialog</code> containing this instance
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *   <code>GraphicsEnvironment.isHeadless</code> returns
      *   <code>true</code>
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -946,7 +946,7 @@ public class JOptionPane extends JComponent implements Accessible
      *
      * @param title     the title string for the dialog
      * @return a new <code>JDialog</code> containing this instance
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *   <code>GraphicsEnvironment.isHeadless</code> returns
      *   <code>true</code>
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -1508,7 +1508,7 @@ public class JOptionPane extends JComponent implements Accessible
      *          frame's title bar
      * @return a <code>JInternalFrame</code> containing a
      *          <code>JOptionPane</code>
-     * @exception RuntimeException if <code>parentComponent</code> does
+     * @throws RuntimeException if <code>parentComponent</code> does
      *          not have a valid parent
      */
     public JInternalFrame createInternalFrame(Component parentComponent,
@@ -1600,7 +1600,7 @@ public class JOptionPane extends JComponent implements Accessible
      *          or <code>getRootFrame</code>
      *          if the component is <code>null</code>,
      *          or does not have a valid <code>Frame</code> parent
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *   <code>GraphicsEnvironment.isHeadless</code> returns
      *   <code>true</code>
      * @see #getRootFrame
@@ -1626,7 +1626,7 @@ public class JOptionPane extends JComponent implements Accessible
      *          frame if the component is <code>null</code>,
      *          or does not have a valid
      *          <code>Frame</code> or <code>Dialog</code> parent
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *   <code>GraphicsEnvironment.isHeadless</code> returns
      *   <code>true</code>
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -1683,7 +1683,7 @@ public class JOptionPane extends JComponent implements Accessible
      * which a frame is not provided.
      *
      * @return the default <code>Frame</code> to use
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *   <code>GraphicsEnvironment.isHeadless</code> returns
      *   <code>true</code>
      * @see #setRootFrame
@@ -2050,7 +2050,7 @@ public class JOptionPane extends JComponent implements Accessible
      *                <code>ERROR_MESSAGE</code>, <code>INFORMATION_MESSAGE</code>,
      *                <code>WARNING_MESSAGE</code>,
      *                <code>QUESTION_MESSAGE</code>, or <code>PLAIN_MESSAGE</code>
-     * @exception RuntimeException if <code>newType</code> is not one of the
+     * @throws RuntimeException if <code>newType</code> is not one of the
      *          legal values listed above
 
      * @see #getMessageType
@@ -2096,7 +2096,7 @@ public class JOptionPane extends JComponent implements Accessible
      *                  <code>YES_NO_OPTION</code>,
      *                  <code>YES_NO_CANCEL_OPTION</code>,
      *                  or <code>OK_CANCEL_OPTION</code>
-     * @exception RuntimeException if <code>newType</code> is not one of
+     * @throws RuntimeException if <code>newType</code> is not one of
      *          the legal values listed above
      *
      * @see #getOptionType

--- a/src/java.desktop/share/classes/javax/swing/JPasswordField.java
+++ b/src/java.desktop/share/classes/javax/swing/JPasswordField.java
@@ -288,7 +288,7 @@ public class JPasswordField extends JTextField {
      * @param offs the offset &gt;= 0
      * @param len the length &gt;= 0
      * @return the text
-     * @exception BadLocationException if the offset or length are invalid
+     * @throws BadLocationException if the offset or length are invalid
      */
     @Deprecated
     public String getText(int offs, int len) throws BadLocationException {

--- a/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
@@ -475,7 +475,7 @@ public class JPopupMenu extends JComponent implements Accessible,MenuElement {
      * Removes the component at the specified index from this popup menu.
      *
      * @param       pos the position of the item to be removed
-     * @exception   IllegalArgumentException if the value of
+     * @throws   IllegalArgumentException if the value of
      *                          <code>pos</code> &lt; 0, or if the value of
      *                          <code>pos</code> is greater than the
      *                          number of items
@@ -573,7 +573,7 @@ public class JPopupMenu extends JComponent implements Accessible,MenuElement {
      * @param a  the <code>Action</code> object to insert
      * @param index      specifies the position at which to insert the
      *                   <code>Action</code>, where 0 is the first
-     * @exception IllegalArgumentException if <code>index</code> &lt; 0
+     * @throws IllegalArgumentException if <code>index</code> &lt; 0
      * @see Action
      */
     public void insert(Action a, int index) {
@@ -589,7 +589,7 @@ public class JPopupMenu extends JComponent implements Accessible,MenuElement {
      * @param component  the <code>Component</code> to insert
      * @param index      specifies the position at which
      *                   to insert the component, where 0 is the first
-     * @exception IllegalArgumentException if <code>index</code> &lt; 0
+     * @throws IllegalArgumentException if <code>index</code> &lt; 0
      */
     public void insert(Component component, int index) {
         if (index < 0) {

--- a/src/java.desktop/share/classes/javax/swing/JProgressBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JProgressBar.java
@@ -394,7 +394,7 @@ public class JProgressBar extends JComponent implements SwingConstants, Accessib
      * is {@code SwingConstants.HORIZONTAL}.
      *
      * @param  newOrientation  <code>HORIZONTAL</code> or <code>VERTICAL</code>
-     * @exception      IllegalArgumentException    if <code>newOrientation</code>
+     * @throws      IllegalArgumentException    if <code>newOrientation</code>
      *                                              is an illegal value
      * @see #getOrientation
      */

--- a/src/java.desktop/share/classes/javax/swing/JRootPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JRootPane.java
@@ -578,7 +578,7 @@ public class JRootPane extends JComponent implements Accessible {
      * replace it with an opaque <code>JComponent</code>.
      *
      * @param content the <code>Container</code> to use for component-contents
-     * @exception java.awt.IllegalComponentStateException (a runtime
+     * @throws java.awt.IllegalComponentStateException (a runtime
      *            exception) if the content pane parameter is <code>null</code>
      */
     public void setContentPane(Container content) {
@@ -605,7 +605,7 @@ public class JRootPane extends JComponent implements Accessible {
      * typically holds a content pane and an optional <code>JMenuBar</code>.
      *
      * @param layered  the <code>JLayeredPane</code> to use
-     * @exception java.awt.IllegalComponentStateException (a runtime
+     * @throws java.awt.IllegalComponentStateException (a runtime
      *            exception) if the layered pane parameter is <code>null</code>
      */
     public void setLayeredPane(JLayeredPane layered) {
@@ -647,7 +647,7 @@ public class JRootPane extends JComponent implements Accessible {
      *
      * @param glass the <code>Component</code> to use as the glass pane
      *              for this <code>JRootPane</code>
-     * @exception NullPointerException if the <code>glass</code> parameter is
+     * @throws NullPointerException if the <code>glass</code> parameter is
      *          <code>null</code>
      */
     public void setGlassPane(Component glass) {

--- a/src/java.desktop/share/classes/javax/swing/JScrollBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JScrollBar.java
@@ -155,7 +155,7 @@ public class JScrollBar extends JComponent implements Adjustable, Accessible
      * That way, when the user jumps the knob to an adjacent position,
      * one or two lines of the original contents remain in view.
      *
-     * @exception IllegalArgumentException if orientation is not one of VERTICAL, HORIZONTAL
+     * @throws IllegalArgumentException if orientation is not one of VERTICAL, HORIZONTAL
      *
      * @see #setOrientation
      * @see #setValue
@@ -279,7 +279,7 @@ public class JScrollBar extends JComponent implements Adjustable, Accessible
      * HORIZONTAL.
      *
      * @param orientation an orientation of the {@code JScrollBar}
-     * @exception IllegalArgumentException if orientation is not one of VERTICAL, HORIZONTAL
+     * @throws IllegalArgumentException if orientation is not one of VERTICAL, HORIZONTAL
      * @see #getOrientation
      */
     @BeanProperty(preferred = true, visualUpdate = true, enumerationValues = {

--- a/src/java.desktop/share/classes/javax/swing/JScrollPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JScrollPane.java
@@ -418,7 +418,7 @@ public class JScrollPane extends JComponent implements ScrollPaneConstants, Acce
      * will invoke <code>syncWithScrollPane</code> on it.
      *
      * @param layout the specified layout manager
-     * @exception ClassCastException if layout is not a
+     * @throws ClassCastException if layout is not a
      *                  <code>ScrollPaneLayout</code>
      * @see java.awt.Container#getLayout
      * @see java.awt.Container#setLayout
@@ -476,7 +476,7 @@ public class JScrollPane extends JComponent implements ScrollPaneConstants, Acce
      * </ul>
      *
      * @param policy one of the three values listed above
-     * @exception IllegalArgumentException if <code>policy</code>
+     * @throws IllegalArgumentException if <code>policy</code>
      *                          is not one of the legal values shown above
      * @see #getVerticalScrollBarPolicy
      */
@@ -521,7 +521,7 @@ public class JScrollPane extends JComponent implements ScrollPaneConstants, Acce
      * </ul>
      *
      * @param policy one of the three values listed above
-     * @exception IllegalArgumentException if <code>policy</code>
+     * @throws IllegalArgumentException if <code>policy</code>
      *                          is not one of the legal values shown above
      * @see #getHorizontalScrollBarPolicy
      */
@@ -1195,7 +1195,7 @@ public class JScrollPane extends JComponent implements ScrollPaneConstants, Acce
      * <li>upperLeft
      * <li>upperRight
      * </ul>
-     * @exception IllegalArgumentException if corner key is invalid
+     * @throws IllegalArgumentException if corner key is invalid
      */
     public void setCorner(String key, Component corner)
     {

--- a/src/java.desktop/share/classes/javax/swing/JSeparator.java
+++ b/src/java.desktop/share/classes/javax/swing/JSeparator.java
@@ -97,7 +97,7 @@ public class JSeparator extends JComponent implements SwingConstants, Accessible
      * @param orientation an integer specifying
      *          <code>SwingConstants.HORIZONTAL</code> or
      *          <code>SwingConstants.VERTICAL</code>
-     * @exception IllegalArgumentException if <code>orientation</code>
+     * @throws IllegalArgumentException if <code>orientation</code>
      *          is neither <code>SwingConstants.HORIZONTAL</code> nor
      *          <code>SwingConstants.VERTICAL</code>
      */
@@ -190,7 +190,7 @@ public class JSeparator extends JComponent implements SwingConstants, Accessible
      * The default value of this property is HORIZONTAL.
      * @param orientation  either <code>SwingConstants.HORIZONTAL</code>
      *                  or <code>SwingConstants.VERTICAL</code>
-     * @exception IllegalArgumentException  if <code>orientation</code>
+     * @throws IllegalArgumentException  if <code>orientation</code>
      *          is neither <code>SwingConstants.HORIZONTAL</code>
      *          nor <code>SwingConstants.VERTICAL</code>
      *

--- a/src/java.desktop/share/classes/javax/swing/JSlider.java
+++ b/src/java.desktop/share/classes/javax/swing/JSlider.java
@@ -920,7 +920,7 @@ public class JSlider extends JComponent implements SwingConstants, Accessible {
      * @return a new {@code Hashtable} of labels
      * @see #setLabelTable
      * @see #setPaintLabels
-     * @exception IllegalArgumentException if {@code start} is
+     * @throws IllegalArgumentException if {@code start} is
      *          out of range, or if {@code increment} is less than or equal
      *          to zero
      */

--- a/src/java.desktop/share/classes/javax/swing/JSpinner.java
+++ b/src/java.desktop/share/classes/javax/swing/JSpinner.java
@@ -1015,7 +1015,7 @@ public class JSpinner extends JComponent implements Accessible
          * on the new <code>JFormattedTextField</code>.
          *
          * @param spinner the spinner whose model <code>this</code> editor will monitor
-         * @exception IllegalArgumentException if the spinners model is not
+         * @throws IllegalArgumentException if the spinners model is not
          *     an instance of <code>SpinnerDateModel</code>
          *
          * @see #getModel
@@ -1039,7 +1039,7 @@ public class JSpinner extends JComponent implements Accessible
          * @param dateFormatPattern the initial pattern for the
          *     <code>SimpleDateFormat</code> object that's used to display
          *     and parse the value of the text field.
-         * @exception IllegalArgumentException if the spinners model is not
+         * @throws IllegalArgumentException if the spinners model is not
          *     an instance of <code>SpinnerDateModel</code>
          *
          * @see #getModel
@@ -1064,7 +1064,7 @@ public class JSpinner extends JComponent implements Accessible
          *        will monitor
          * @param format <code>DateFormat</code> object that's used to display
          *     and parse the value of the text field.
-         * @exception IllegalArgumentException if the spinners model is not
+         * @throws IllegalArgumentException if the spinners model is not
          *     an instance of <code>SpinnerDateModel</code>
          *
          * @see #getModel
@@ -1202,7 +1202,7 @@ public class JSpinner extends JComponent implements Accessible
          * on the new <code>JFormattedTextField</code>.
          *
          * @param spinner the spinner whose model <code>this</code> editor will monitor
-         * @exception IllegalArgumentException if the spinners model is not
+         * @throws IllegalArgumentException if the spinners model is not
          *     an instance of <code>SpinnerNumberModel</code>
          *
          * @see #getModel
@@ -1225,7 +1225,7 @@ public class JSpinner extends JComponent implements Accessible
          * @param decimalFormatPattern the initial pattern for the
          *     <code>DecimalFormat</code> object that's used to display
          *     and parse the value of the text field.
-         * @exception IllegalArgumentException if the spinners model is not
+         * @throws IllegalArgumentException if the spinners model is not
          *     an instance of <code>SpinnerNumberModel</code> or if
          *     <code>decimalFormatPattern</code> is not a legal
          *     argument to <code>DecimalFormat</code>
@@ -1251,7 +1251,7 @@ public class JSpinner extends JComponent implements Accessible
          * @param format the initial pattern for the
          *     <code>DecimalFormat</code> object that's used to display
          *     and parse the value of the text field.
-         * @exception IllegalArgumentException if the spinners model is not
+         * @throws IllegalArgumentException if the spinners model is not
          *     an instance of <code>SpinnerNumberModel</code>
          *
          * @see #getTextField
@@ -1346,7 +1346,7 @@ public class JSpinner extends JComponent implements Accessible
          * on the new <code>JFormattedTextField</code>.
          *
          * @param spinner the spinner whose model <code>this</code> editor will monitor
-         * @exception IllegalArgumentException if the spinners model is not
+         * @throws IllegalArgumentException if the spinners model is not
          *     an instance of <code>SpinnerListModel</code>
          *
          * @see #getModel

--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -262,7 +262,7 @@ public class JSplitPane extends JComponent implements Accessible
      *
      * @param newOrientation  <code>JSplitPane.HORIZONTAL_SPLIT</code> or
      *                        <code>JSplitPane.VERTICAL_SPLIT</code>
-     * @exception IllegalArgumentException if <code>orientation</code>
+     * @throws IllegalArgumentException if <code>orientation</code>
      *          is not one of HORIZONTAL_SPLIT or VERTICAL_SPLIT.
      */
     @ConstructorProperties({"orientation"})
@@ -281,7 +281,7 @@ public class JSplitPane extends JComponent implements Accessible
      * @param newContinuousLayout  a boolean, true for the components to
      *        redraw continuously as the divider changes position, false
      *        to wait until the divider position stops changing to redraw
-     * @exception IllegalArgumentException if <code>orientation</code>
+     * @throws IllegalArgumentException if <code>orientation</code>
      *          is not one of HORIZONTAL_SPLIT or VERTICAL_SPLIT
      */
     public JSplitPane(int newOrientation,
@@ -304,7 +304,7 @@ public class JSplitPane extends JComponent implements Accessible
      *          appear on the right
      *          of a horizontally-split pane, or at the bottom of a
      *          vertically-split pane
-     * @exception IllegalArgumentException if <code>orientation</code>
+     * @throws IllegalArgumentException if <code>orientation</code>
      *          is not one of: HORIZONTAL_SPLIT or VERTICAL_SPLIT
      */
     public JSplitPane(int newOrientation,
@@ -334,7 +334,7 @@ public class JSplitPane extends JComponent implements Accessible
      *          appear on the right
      *          of a horizontally-split pane, or at the bottom of a
      *          vertically-split pane
-     * @exception IllegalArgumentException if <code>orientation</code>
+     * @throws IllegalArgumentException if <code>orientation</code>
      *          is not one of HORIZONTAL_SPLIT or VERTICAL_SPLIT
      */
     public JSplitPane(int newOrientation,
@@ -622,7 +622,7 @@ public class JSplitPane extends JComponent implements Accessible
      * </ul>
      *
      * @param orientation an integer specifying the orientation
-     * @exception IllegalArgumentException if orientation is not one of:
+     * @throws IllegalArgumentException if orientation is not one of:
      *        HORIZONTAL_SPLIT or VERTICAL_SPLIT.
      */
     @BeanProperty(enumerationValues = {
@@ -701,7 +701,7 @@ public class JSplitPane extends JComponent implements Accessible
      * extra space.
      *
      * @param value as described above
-     * @exception IllegalArgumentException if <code>value</code> is &lt; 0 or &gt; 1
+     * @throws IllegalArgumentException if <code>value</code> is &lt; 0 or &gt; 1
      * @since 1.3
      */
     @BeanProperty(description
@@ -754,7 +754,7 @@ public class JSplitPane extends JComponent implements Accessible
      * @param proportionalLocation  a double-precision floating point value
      *        that specifies a percentage, from zero (top/left) to 1.0
      *        (bottom/right)
-     * @exception IllegalArgumentException if the specified location is &lt; 0
+     * @throws IllegalArgumentException if the specified location is &lt; 0
      *            or &gt; 1.0
      */
     @BeanProperty(description
@@ -964,7 +964,7 @@ public class JSplitPane extends JComponent implements Accessible
      *                    (position) for this component
      * @param index       an integer specifying the index in the container's
      *                    list.
-     * @exception IllegalArgumentException  if the <code>constraints</code>
+     * @throws IllegalArgumentException  if the <code>constraints</code>
      *          object does not match an existing component
      * @see java.awt.Container#addImpl(Component, Object, int)
      */

--- a/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
@@ -215,7 +215,7 @@ public class JTabbedPane extends JComponent
      *
      * @param tabPlacement the placement for the tabs relative to the content
      * @param tabLayoutPolicy the policy for laying out tabs when all tabs will not fit on one run
-     * @exception IllegalArgumentException if tab placement or tab layout policy are not
+     * @throws IllegalArgumentException if tab placement or tab layout policy are not
      *            one of the above supported values
      * @see #addTab
      * @since 1.4
@@ -505,7 +505,7 @@ public class JTabbedPane extends JComponent
      * The default value, if not set, is <code>SwingConstants.TOP</code>.
      *
      * @param tabPlacement the placement for the tabs relative to the content
-     * @exception IllegalArgumentException if tab placement value isn't one
+     * @throws IllegalArgumentException if tab placement value isn't one
      *                          of the above valid values
      */
     @BeanProperty(preferred = true, visualUpdate = true, enumerationValues = {
@@ -561,7 +561,7 @@ public class JTabbedPane extends JComponent
      * ignored.
      *
      * @param tabLayoutPolicy the policy used to layout the tabs
-     * @exception IllegalArgumentException if layoutPolicy value isn't one
+     * @throws IllegalArgumentException if layoutPolicy value isn't one
      *                          of the above valid values
      * @see #getTabLayoutPolicy
      * @since 1.4
@@ -609,7 +609,7 @@ public class JTabbedPane extends JComponent
      * the results will be implementation defined.
      *
      * @param index  the index to be selected
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            {@code (index < -1 || index >= tab count)}
      *
      * @see #getSelectedIndex
@@ -696,7 +696,7 @@ public class JTabbedPane extends JComponent
      * corresponding to the specified component.
      *
      * @param c the selected {@code Component} for this {@code TabbedPane}
-     * @exception IllegalArgumentException if component not found in tabbed
+     * @throws IllegalArgumentException if component not found in tabbed
      *          pane
      * @see #getSelectedComponent
      */
@@ -963,7 +963,7 @@ public class JTabbedPane extends JComponent
      * its visibility is reset to true to ensure it will be visible
      * if added to other containers.
      * @param index the index of the tab to be removed
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            {@code (index < 0 || index >= tab count)}
      *
      * @see #addTab
@@ -1084,7 +1084,7 @@ public class JTabbedPane extends JComponent
      *
      * @param index the index of the component to remove from the
      *          <code>tabbedpane</code>
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            {@code (index < 0 || index >= tab count)}
      * @see #addTab
      * @see #removeTabAt
@@ -1148,7 +1148,7 @@ public class JTabbedPane extends JComponent
      *
      * @param index  the index of the item being queried
      * @return the title at <code>index</code>
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            {@code (index < 0 || index >= tab count)}
      * @see #setTitleAt
      */
@@ -1161,7 +1161,7 @@ public class JTabbedPane extends JComponent
      *
      * @param index  the index of the item being queried
      * @return the icon at <code>index</code>
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            {@code (index < 0 || index >= tab count)}
      *
      * @see #setIconAt
@@ -1180,7 +1180,7 @@ public class JTabbedPane extends JComponent
      *
      * @param index  the index of the item being queried
      * @return the icon at <code>index</code>
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            {@code (index < 0 || index >= tab count)}
      *
      * @see #setDisabledIconAt
@@ -1198,7 +1198,7 @@ public class JTabbedPane extends JComponent
      *
      * @param index  the index of the item being queried
      * @return a string containing the tool tip text at <code>index</code>
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            {@code (index < 0 || index >= tab count)}
      *
      * @see #setToolTipTextAt
@@ -1214,7 +1214,7 @@ public class JTabbedPane extends JComponent
      * @param index  the index of the item being queried
      * @return the <code>Color</code> of the tab background at
      *          <code>index</code>
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            {@code (index < 0 || index >= tab count)}
      *
      * @see #setBackgroundAt
@@ -1229,7 +1229,7 @@ public class JTabbedPane extends JComponent
      * @param index  the index of the item being queried
      * @return the <code>Color</code> of the tab foreground at
      *          <code>index</code>
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            {@code (index < 0 || index >= tab count)}
      *
      * @see #setForegroundAt
@@ -1245,7 +1245,7 @@ public class JTabbedPane extends JComponent
      * @param index  the index of the item being queried
      * @return true if the tab at <code>index</code> is enabled;
      *          false otherwise
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            {@code (index < 0 || index >= tab count)}
      *
      * @see #setEnabledAt
@@ -1259,7 +1259,7 @@ public class JTabbedPane extends JComponent
      *
      * @param index  the index of the item being queried
      * @return the <code>Component</code> at <code>index</code>
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            {@code (index < 0 || index >= tab count)}
      *
      * @see #setComponentAt
@@ -1278,7 +1278,7 @@ public class JTabbedPane extends JComponent
      * @param tabIndex the index of the tab that the mnemonic refers to
      * @return the key code which represents the mnemonic;
      *         -1 if a mnemonic is not specified for the tab
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            (<code>tabIndex</code> &lt; 0 ||
      *              <code>tabIndex</code> &gt;= tab count)
      * @see #setDisplayedMnemonicIndexAt(int,int)
@@ -1299,7 +1299,7 @@ public class JTabbedPane extends JComponent
      * @param tabIndex the index of the tab that the mnemonic refers to
      * @return index representing mnemonic character if one exists;
      *    otherwise returns -1
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            (<code>tabIndex</code> &lt; 0 ||
      *              <code>tabIndex</code> &gt;= tab count)
      * @see #setDisplayedMnemonicIndexAt(int,int)
@@ -1324,7 +1324,7 @@ public class JTabbedPane extends JComponent
      *          <code>index</code>, or <code>null</code> if tab at
      *          <code>index</code> is not currently visible in the UI,
      *          or if there is no UI set on this <code>tabbedpane</code>
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            {@code (index < 0 || index >= tab count)}
      */
     public Rectangle getBoundsAt(int index) {
@@ -1346,7 +1346,7 @@ public class JTabbedPane extends JComponent
      *
      * @param index the tab index where the title should be set
      * @param title the title to be displayed in the tab
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            {@code (index < 0 || index >= tab count)}
      *
      * @see #getTitleAt
@@ -1386,7 +1386,7 @@ public class JTabbedPane extends JComponent
      *
      * @param index the tab index where the icon should be set
      * @param icon the icon to be displayed in the tab
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            {@code (index < 0 || index >= tab count)}
      *
      * @see #setDisabledIconAt
@@ -1428,7 +1428,7 @@ public class JTabbedPane extends JComponent
      *
      * @param index the tab index where the disabled icon should be set
      * @param disabledIcon the icon to be displayed in the tab when disabled
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            {@code (index < 0 || index >= tab count)}
      *
      * @see #getDisabledIconAt
@@ -1451,7 +1451,7 @@ public class JTabbedPane extends JComponent
      *
      * @param index the tab index where the tooltip text should be set
      * @param toolTipText the tooltip text to be displayed for the tab
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            {@code (index < 0 || index >= tab count)}
      *
      * @see #getToolTipTextAt
@@ -1486,7 +1486,7 @@ public class JTabbedPane extends JComponent
      *
      * @param index the tab index where the background should be set
      * @param background the color to be displayed in the tab's background
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            {@code (index < 0 || index >= tab count)}
      *
      * @see #getBackgroundAt
@@ -1517,7 +1517,7 @@ public class JTabbedPane extends JComponent
      *
      * @param index the tab index where the foreground should be set
      * @param foreground the color to be displayed as the tab's foreground
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            {@code (index < 0 || index >= tab count)}
      *
      * @see #getForegroundAt
@@ -1542,7 +1542,7 @@ public class JTabbedPane extends JComponent
      *
      * @param index the tab index which should be enabled/disabled
      * @param enabled whether or not the tab should be enabled
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            {@code (index < 0 || index >= tab count)}
      *
      * @see #isEnabledAt
@@ -1562,7 +1562,7 @@ public class JTabbedPane extends JComponent
      *
      * @param index the tab index where this component is being placed
      * @param component the component for the tab
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            {@code (index < 0 || index >= tab count)}
      *
      * @see #getComponentAt
@@ -1638,10 +1638,10 @@ public class JTabbedPane extends JComponent
      * @since 1.4
      * @param tabIndex the index of the tab that the mnemonic refers to
      * @param mnemonicIndex index into the <code>String</code> to underline
-     * @exception IndexOutOfBoundsException if <code>tabIndex</code> is
+     * @throws IndexOutOfBoundsException if <code>tabIndex</code> is
      *            out of range ({@code tabIndex < 0 || tabIndex >= tab
      *            count})
-     * @exception IllegalArgumentException will be thrown if
+     * @throws IllegalArgumentException will be thrown if
      *            <code>mnemonicIndex</code> is &gt;= length of the tab
      *            title , or &lt; -1
      * @see #setMnemonicAt(int,int)
@@ -1678,7 +1678,7 @@ public class JTabbedPane extends JComponent
      * @since 1.4
      * @param tabIndex the index of the tab that the mnemonic refers to
      * @param mnemonic the key code which represents the mnemonic
-     * @exception IndexOutOfBoundsException if <code>tabIndex</code> is out
+     * @throws IndexOutOfBoundsException if <code>tabIndex</code> is out
      *            of range ({@code tabIndex < 0 || tabIndex >= tab count})
      * @see #getMnemonicAt(int)
      * @see #setDisplayedMnemonicIndexAt(int,int)
@@ -2001,7 +2001,7 @@ public class JTabbedPane extends JComponent
          *
          * @param i zero-based index of child
          * @return the Accessible child of the object
-         * @exception IllegalArgumentException if index is out of bounds
+         * @throws IllegalArgumentException if index is out of bounds
          */
         public Accessible getAccessibleChild(int i) {
             if (i < 0 || i >= getTabCount()) {
@@ -2426,9 +2426,9 @@ public class JTabbedPane extends JComponent
     * @param index the tab index where the component should be set
     * @param component the component to render the title for the
     *                  specified tab
-    * @exception IndexOutOfBoundsException if index is out of range
+    * @throws IndexOutOfBoundsException if index is out of range
     *            {@code (index < 0 || index >= tab count)}
-    * @exception IllegalArgumentException if component has already been
+    * @throws IllegalArgumentException if component has already been
     *            added to this <code>JTabbedPane</code>
     *
     * @see #getTabComponentAt
@@ -2456,7 +2456,7 @@ public class JTabbedPane extends JComponent
      *
      * @param index  the index of the item being queried
      * @return the tab component at <code>index</code>
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            {@code (index < 0 || index >= tab count)}
      *
      * @see #setTabComponentAt

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -991,7 +991,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      * the row margin.
      *
      * @param   rowHeight                       new row height
-     * @exception IllegalArgumentException      if <code>rowHeight</code> is
+     * @throws IllegalArgumentException      if <code>rowHeight</code> is
      *                                          less than 1
      * @see     #getRowHeight
      */
@@ -1037,7 +1037,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      * @param   row                             the row whose height is being
                                                 changed
      * @param   rowHeight                       new row height, in pixels
-     * @exception IllegalArgumentException      if <code>rowHeight</code> is
+     * @throws IllegalArgumentException      if <code>rowHeight</code> is
      *                                          less than 1
      * @since 1.3
      */
@@ -1126,7 +1126,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      * The default color is look and feel dependent.
      *
      * @param   gridColor                       the new color of the grid lines
-     * @exception IllegalArgumentException      if <code>gridColor</code> is <code>null</code>
+     * @throws IllegalArgumentException      if <code>gridColor</code> is <code>null</code>
      * @see     #getGridColor
      */
     @BeanProperty(description
@@ -1485,7 +1485,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      * table's {@code TransferHandler}.
      *
      * @param b whether or not to enable automatic drag handling
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *            <code>b</code> is <code>true</code> and
      *            <code>GraphicsEnvironment.isHeadless()</code>
      *            returns <code>true</code>
@@ -2220,7 +2220,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      * Selects the rows from <code>index0</code> to <code>index1</code>,
      * inclusive.
      *
-     * @exception IllegalArgumentException      if <code>index0</code> or
+     * @throws IllegalArgumentException      if <code>index0</code> or
      *                                          <code>index1</code> lie outside
      *                                          [0, <code>getRowCount()</code>-1]
      * @param   index0 one end of the interval
@@ -2234,7 +2234,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      * Selects the columns from <code>index0</code> to <code>index1</code>,
      * inclusive.
      *
-     * @exception IllegalArgumentException      if <code>index0</code> or
+     * @throws IllegalArgumentException      if <code>index0</code> or
      *                                          <code>index1</code> lie outside
      *                                          [0, <code>getColumnCount()</code>-1]
      * @param   index0 one end of the interval
@@ -2248,7 +2248,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      * Adds the rows from <code>index0</code> to <code>index1</code>, inclusive, to
      * the current selection.
      *
-     * @exception IllegalArgumentException      if <code>index0</code> or <code>index1</code>
+     * @throws IllegalArgumentException      if <code>index0</code> or <code>index1</code>
      *                                          lie outside [0, <code>getRowCount()</code>-1]
      * @param   index0 one end of the interval
      * @param   index1 the other end of the interval
@@ -2261,7 +2261,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      * Adds the columns from <code>index0</code> to <code>index1</code>,
      * inclusive, to the current selection.
      *
-     * @exception IllegalArgumentException      if <code>index0</code> or
+     * @throws IllegalArgumentException      if <code>index0</code> or
      *                                          <code>index1</code> lie outside
      *                                          [0, <code>getColumnCount()</code>-1]
      * @param   index0 one end of the interval
@@ -2274,7 +2274,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
     /**
      * Deselects the rows from <code>index0</code> to <code>index1</code>, inclusive.
      *
-     * @exception IllegalArgumentException      if <code>index0</code> or
+     * @throws IllegalArgumentException      if <code>index0</code> or
      *                                          <code>index1</code> lie outside
      *                                          [0, <code>getRowCount()</code>-1]
      * @param   index0 one end of the interval
@@ -2287,7 +2287,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
     /**
      * Deselects the columns from <code>index0</code> to <code>index1</code>, inclusive.
      *
-     * @exception IllegalArgumentException      if <code>index0</code> or
+     * @throws IllegalArgumentException      if <code>index0</code> or
      *                                          <code>index1</code> lie outside
      *                                          [0, <code>getColumnCount()</code>-1]
      * @param   index0 one end of the interval
@@ -2596,7 +2596,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
      * <code>equals</code>.
      *
      * @return  the <code>TableColumn</code> object that matches the identifier
-     * @exception IllegalArgumentException      if <code>identifier</code> is <code>null</code> or no <code>TableColumn</code> has this identifier
+     * @throws IllegalArgumentException      if <code>identifier</code> is <code>null</code> or no <code>TableColumn</code> has this identifier
      *
      * @param   identifier                      the identifier object
      */
@@ -8340,7 +8340,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
              *
              * @return this component's locale; if this component does
              *    not have a locale, the locale of its parent is returned
-             * @exception IllegalComponentStateException if the
+             * @throws IllegalComponentStateException if the
              *    <code>Component</code> does not have its own locale
              *    and has not yet been added to a containment hierarchy
              *    such that the locale can be determined from the
@@ -9142,7 +9142,7 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
              *
              * @return this component's locale; if this component does
              *    not have a locale, the locale of its parent is returned
-             * @exception IllegalComponentStateException if the
+             * @throws IllegalComponentStateException if the
              *    <code>Component</code> does not have its own locale
              *    and has not yet been added to a containment hierarchy
              *    such that the locale can be determined from the

--- a/src/java.desktop/share/classes/javax/swing/JTextArea.java
+++ b/src/java.desktop/share/classes/javax/swing/JTextArea.java
@@ -166,7 +166,7 @@ public class JTextArea extends JTextComponent {
      *
      * @param rows the number of rows &gt;= 0
      * @param columns the number of columns &gt;= 0
-     * @exception IllegalArgumentException if the rows or columns
+     * @throws IllegalArgumentException if the rows or columns
      *  arguments are negative.
      */
     public JTextArea(int rows, int columns) {
@@ -180,7 +180,7 @@ public class JTextArea extends JTextComponent {
      * @param text the text to be displayed, or null
      * @param rows the number of rows &gt;= 0
      * @param columns the number of columns &gt;= 0
-     * @exception IllegalArgumentException if the rows or columns
+     * @throws IllegalArgumentException if the rows or columns
      *  arguments are negative.
      */
     public JTextArea(String text, int rows, int columns) {
@@ -206,7 +206,7 @@ public class JTextArea extends JTextComponent {
      * @param text the text to be displayed, null if none
      * @param rows the number of rows &gt;= 0
      * @param columns the number of columns &gt;= 0
-     * @exception IllegalArgumentException if the rows or columns
+     * @throws IllegalArgumentException if the rows or columns
      *  arguments are negative.
      */
     public JTextArea(Document doc, String text, int rows, int columns) {
@@ -370,7 +370,7 @@ public class JTextArea extends JTextComponent {
      *
      * @param offset the offset &gt;= 0
      * @return the line number &gt;= 0
-     * @exception BadLocationException thrown if the offset is
+     * @throws BadLocationException thrown if the offset is
      *   less than zero or greater than the document length.
      */
     public int getLineOfOffset(int offset) throws BadLocationException {
@@ -401,7 +401,7 @@ public class JTextArea extends JTextComponent {
      *
      * @param line  the line number to translate &gt;= 0
      * @return the offset &gt;= 0
-     * @exception BadLocationException thrown if the line is
+     * @throws BadLocationException thrown if the line is
      * less than zero or greater or equal to the number of
      * lines contained in the document (as reported by
      * getLineCount).
@@ -424,7 +424,7 @@ public class JTextArea extends JTextComponent {
      *
      * @param line  the line &gt;= 0
      * @return the offset &gt;= 0
-     * @exception BadLocationException Thrown if the line is
+     * @throws BadLocationException Thrown if the line is
      * less than zero or greater or equal to the number of
      * lines contained in the document (as reported by
      * getLineCount).
@@ -452,7 +452,7 @@ public class JTextArea extends JTextComponent {
      *
      * @param str the text to insert
      * @param pos the position at which to insert &gt;= 0
-     * @exception IllegalArgumentException  if pos is an
+     * @throws IllegalArgumentException  if pos is an
      *  invalid position in the model
      * @see TextComponent#setText
      * @see #replaceRange
@@ -493,7 +493,7 @@ public class JTextArea extends JTextComponent {
      * @param str the text to use as the replacement
      * @param start the start position &gt;= 0
      * @param end the end position &gt;= start
-     * @exception IllegalArgumentException  if part of the range is an
+     * @throws IllegalArgumentException  if part of the range is an
      *  invalid position in the model
      * @see #insert
      */
@@ -532,7 +532,7 @@ public class JTextArea extends JTextComponent {
      * setting the new value.
      *
      * @param rows the number of rows &gt;= 0
-     * @exception IllegalArgumentException if rows is less than 0
+     * @throws IllegalArgumentException if rows is less than 0
      * @see #getRows
      */
     @BeanProperty(bound = false, description
@@ -576,7 +576,7 @@ public class JTextArea extends JTextComponent {
      * after setting the new value.
      *
      * @param columns the number of columns &gt;= 0
-     * @exception IllegalArgumentException if columns is less than 0
+     * @throws IllegalArgumentException if columns is less than 0
      * @see #getColumns
      */
     @BeanProperty(bound = false, description
@@ -726,7 +726,7 @@ public class JTextArea extends JTextComponent {
      * @param direction Less than zero to scroll up/left,
      *   greater than zero for down/right.
      * @return The "unit" increment for scrolling in the specified direction
-     * @exception IllegalArgumentException for an invalid orientation
+     * @throws IllegalArgumentException for an invalid orientation
      * @see JScrollBar#setUnitIncrement
      * @see #getRowHeight
      * @see #getColumnWidth

--- a/src/java.desktop/share/classes/javax/swing/JTextField.java
+++ b/src/java.desktop/share/classes/javax/swing/JTextField.java
@@ -242,7 +242,7 @@ public class JTextField extends JTextComponent implements SwingConstants {
      *   the preferred width &gt;= 0; if <code>columns</code>
      *   is set to zero, the preferred width will be whatever
      *   naturally results from the component implementation
-     * @exception IllegalArgumentException if <code>columns</code> &lt; 0
+     * @throws IllegalArgumentException if <code>columns</code> &lt; 0
      */
     public JTextField(Document doc, String text, int columns) {
         if (columns < 0) {
@@ -343,7 +343,7 @@ public class JTextField extends JTextComponent implements SwingConstants {
      * and a <code>PropertyChange</code> event ("horizontalAlignment") is fired.
      *
      * @param alignment the alignment
-     * @exception IllegalArgumentException if <code>alignment</code>
+     * @throws IllegalArgumentException if <code>alignment</code>
      *  is not a valid key
      */
      @BeanProperty(preferred = true, enumerationValues = {
@@ -393,7 +393,7 @@ public class JTextField extends JTextComponent implements SwingConstants {
      * and then invalidate the layout.
      *
      * @param columns the number of columns &gt;= 0
-     * @exception IllegalArgumentException if <code>columns</code>
+     * @throws IllegalArgumentException if <code>columns</code>
      *          is less than 0
      */
     @BeanProperty(bound = false, description

--- a/src/java.desktop/share/classes/javax/swing/JTextPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JTextPane.java
@@ -138,7 +138,7 @@ public class JTextPane extends JEditorPane {
      * must be a <code>StyledDocument</code>.
      *
      * @param doc  the document to display/edit
-     * @exception IllegalArgumentException  if <code>doc</code> can't
+     * @throws IllegalArgumentException  if <code>doc</code> can't
      *   be narrowed to a <code>StyledDocument</code> which is the
      *   required type of model for this text component
      */
@@ -480,7 +480,7 @@ public class JTextPane extends JEditorPane {
      * establishes the content type of the editor.
      *
      * @param kit the desired editor behavior
-     * @exception IllegalArgumentException if kit is not a
+     * @throws IllegalArgumentException if kit is not a
      *          <code>StyledEditorKit</code>
      */
     public final void setEditorKit(EditorKit kit) {

--- a/src/java.desktop/share/classes/javax/swing/JToolBar.java
+++ b/src/java.desktop/share/classes/javax/swing/JToolBar.java
@@ -142,7 +142,7 @@ public class JToolBar extends JComponent implements SwingConstants, Accessible
      * @param name  the name of the tool bar
      * @param orientation  the initial orientation -- it must be
      *          either <code>HORIZONTAL</code> or <code>VERTICAL</code>
-     * @exception IllegalArgumentException if orientation is neither
+     * @throws IllegalArgumentException if orientation is neither
      *          <code>HORIZONTAL</code> nor <code>VERTICAL</code>
      * @since 1.3
      */
@@ -406,7 +406,7 @@ public class JToolBar extends JComponent implements SwingConstants, Accessible
      *
      * @param o  the new orientation -- either <code>HORIZONTAL</code> or
      *                  <code>VERTICAL</code>
-     * @exception IllegalArgumentException if orientation is neither
+     * @throws IllegalArgumentException if orientation is neither
      *          <code>HORIZONTAL</code> nor <code>VERTICAL</code>
      * @see #getOrientation
      */

--- a/src/java.desktop/share/classes/javax/swing/JTree.java
+++ b/src/java.desktop/share/classes/javax/swing/JTree.java
@@ -1251,7 +1251,7 @@ public class JTree extends JComponent implements Scrollable, Accessible
      * tree's {@code TransferHandler}.
      *
      * @param b whether or not to enable automatic drag handling
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *            <code>b</code> is <code>true</code> and
      *            <code>GraphicsEnvironment.isHeadless()</code>
      *            returns <code>true</code>
@@ -3087,7 +3087,7 @@ public class JTree extends JComponent implements Scrollable, Accessible
      * Position.Bias.Forward or Position.Bias.Backward.
      * @return the TreePath of the next tree element that
      * starts with the prefix; otherwise null
-     * @exception IllegalArgumentException if prefix is null
+     * @throws IllegalArgumentException if prefix is null
      * or startingRow is out of bounds
      * @since 1.4
      */
@@ -5053,7 +5053,7 @@ public class JTree extends JComponent implements Scrollable, Accessible
              *
              * @return This component's locale. If this component does not have
              * a locale, the locale of its parent is returned.
-             * @exception IllegalComponentStateException
+             * @throws IllegalComponentStateException
              * If the Component does not have its own locale and has not yet
              * been added to a containment hierarchy such that the locale can be
              * determined from the containing parent.

--- a/src/java.desktop/share/classes/javax/swing/JViewport.java
+++ b/src/java.desktop/share/classes/javax/swing/JViewport.java
@@ -565,7 +565,7 @@ public class JViewport extends JComponent implements Accessible
      * a <code>JViewPort</code>.
      *
      * @param border the <code>Border</code> to set
-     * @exception IllegalArgumentException this method is not implemented
+     * @throws IllegalArgumentException this method is not implemented
      */
     public final void setBorder(Border border) {
         if (border != null) {

--- a/src/java.desktop/share/classes/javax/swing/JWindow.java
+++ b/src/java.desktop/share/classes/javax/swing/JWindow.java
@@ -387,10 +387,10 @@ public class JWindow extends Window implements Accessible,
      * @param comp the component to be enhanced
      * @param constraints the constraints to be respected
      * @param index the index
-     * @exception IllegalArgumentException if <code>index</code> is invalid
-     * @exception IllegalArgumentException if adding the container's parent
+     * @throws IllegalArgumentException if <code>index</code> is invalid
+     * @throws IllegalArgumentException if adding the container's parent
      *                  to itself
-     * @exception IllegalArgumentException if adding a window to a container
+     * @throws IllegalArgumentException if adding a window to a container
      *
      * @see #setRootPaneCheckingEnabled
      * @see javax.swing.RootPaneContainer
@@ -504,7 +504,7 @@ public class JWindow extends Window implements Accessible,
      *
      * @param contentPane the new <code>contentPane</code>
      *
-     * @exception IllegalComponentStateException (a runtime
+     * @throws IllegalComponentStateException (a runtime
      *            exception) if the content pane parameter is <code>null</code>
      * @see #getContentPane
      * @see RootPaneContainer#setContentPane
@@ -532,7 +532,7 @@ public class JWindow extends Window implements Accessible,
      *
      * @param layeredPane the new <code>layeredPane</code> object
      *
-     * @exception IllegalComponentStateException (a runtime
+     * @throws IllegalComponentStateException (a runtime
      *            exception) if the content pane parameter is <code>null</code>
      * @see #getLayeredPane
      * @see RootPaneContainer#setLayeredPane

--- a/src/java.desktop/share/classes/javax/swing/OverlayLayout.java
+++ b/src/java.desktop/share/classes/javax/swing/OverlayLayout.java
@@ -217,7 +217,7 @@ public class OverlayLayout implements LayoutManager2,Serializable {
      *
      * @param target  the container to lay out
      *
-     * @exception AWTError  if the target isn't the container specified to the
+     * @throws AWTError  if the target isn't the container specified to the
      *                      constructor
      */
     public void layoutContainer(Container target) {

--- a/src/java.desktop/share/classes/javax/swing/Popup.java
+++ b/src/java.desktop/share/classes/javax/swing/Popup.java
@@ -82,7 +82,7 @@ public class Popup {
      * @param contents Contents of the Popup
      * @param x        Initial x screen coordinate
      * @param y        Initial y screen coordinate
-     * @exception IllegalArgumentException if contents is null
+     * @throws IllegalArgumentException if contents is null
      */
     protected Popup(Component owner, Component contents, int x, int y) {
         this();

--- a/src/java.desktop/share/classes/javax/swing/PopupFactory.java
+++ b/src/java.desktop/share/classes/javax/swing/PopupFactory.java
@@ -127,7 +127,7 @@ public class PopupFactory {
      * <code>factory</code> is null.
      *
      * @param factory Shared PopupFactory
-     * @exception IllegalArgumentException if <code>factory</code> is null
+     * @throws IllegalArgumentException if <code>factory</code> is null
      * @see #getPopup
      */
     public static void setSharedInstance(PopupFactory factory) {
@@ -186,7 +186,7 @@ public class PopupFactory {
      * @param contents Contents of the Popup
      * @param x        Initial x screen coordinate
      * @param y        Initial y screen coordinate
-     * @exception IllegalArgumentException if contents is null
+     * @throws IllegalArgumentException if contents is null
      * @return Popup containing Contents
      */
     public Popup getPopup(Component owner, Component contents,

--- a/src/java.desktop/share/classes/javax/swing/ProgressMonitor.java
+++ b/src/java.desktop/share/classes/javax/swing/ProgressMonitor.java
@@ -794,7 +794,7 @@ public class ProgressMonitor implements Accessible
          * @return this component's locale.  If this component does not have
          * a locale, the locale of its parent is returned.
          *
-         * @exception IllegalComponentStateException
+         * @throws IllegalComponentStateException
          * If the Component does not have its own locale and has not yet been
          * added to a containment hierarchy such that the locale can be
          * determined from the containing parent.

--- a/src/java.desktop/share/classes/javax/swing/RootPaneContainer.java
+++ b/src/java.desktop/share/classes/javax/swing/RootPaneContainer.java
@@ -103,7 +103,7 @@ public interface RootPaneContainer
      * Generally implemented with
      * <code>getRootPane().setContentPane(contentPane);</code>
      *
-     * @exception java.awt.IllegalComponentStateException (a runtime
+     * @throws java.awt.IllegalComponentStateException (a runtime
      *            exception) if the content pane parameter is null
      * @param contentPane the Container to use for the contents of this
      *        JRootPane
@@ -134,7 +134,7 @@ public interface RootPaneContainer
      *    getRootPane().setLayeredPane(layeredPane);</pre>
      *
      * @param layeredPane the layered pane
-     * @exception java.awt.IllegalComponentStateException (a runtime
+     * @throws java.awt.IllegalComponentStateException (a runtime
      *            exception) if the layered pane parameter is null
      * @see #getLayeredPane
      * @see JRootPane#getLayeredPane

--- a/src/java.desktop/share/classes/javax/swing/ScrollPaneLayout.java
+++ b/src/java.desktop/share/classes/javax/swing/ScrollPaneLayout.java
@@ -230,7 +230,7 @@ public class ScrollPaneLayout
      *
      * @param s the component identifier
      * @param c the component to be added
-     * @exception IllegalArgumentException if <code>s</code> is an invalid key
+     * @throws IllegalArgumentException if <code>s</code> is an invalid key
      */
     public void addLayoutComponent(String s, Component c)
     {
@@ -328,7 +328,7 @@ public class ScrollPaneLayout
      * with the Swing 1.0.2 (and earlier) versions of this class.
      *
      * @param x an integer giving the display policy
-     * @exception IllegalArgumentException if <code>x</code> is an invalid
+     * @throws IllegalArgumentException if <code>x</code> is an invalid
      *          vertical scroll bar policy, as listed above
      */
     public void setVerticalScrollBarPolicy(int x) {
@@ -366,7 +366,7 @@ public class ScrollPaneLayout
      * with the Swing 1.0.2 (and earlier) versions of this class.
      *
      * @param x an int giving the display policy
-     * @exception IllegalArgumentException if <code>x</code> is not a valid
+     * @throws IllegalArgumentException if <code>x</code> is not a valid
      *          horizontal scrollbar policy, as listed above
      */
     public void setHorizontalScrollBarPolicy(int x) {

--- a/src/java.desktop/share/classes/javax/swing/SizeSequence.java
+++ b/src/java.desktop/share/classes/javax/swing/SizeSequence.java
@@ -142,7 +142,7 @@ public class SizeSequence {
      * all initialized to have size 0.
      *
      * @param numEntries  the number of sizes to track
-     * @exception NegativeArraySizeException if
+     * @throws NegativeArraySizeException if
      *    <code>numEntries &lt; 0</code>
      */
     public SizeSequence(int numEntries) {
@@ -355,7 +355,7 @@ public class SizeSequence {
      *                in the group
      * @param length  the number of entries in the group
      * @param value   the size to be assigned to each new entry
-     * @exception ArrayIndexOutOfBoundsException if the parameters
+     * @throws ArrayIndexOutOfBoundsException if the parameters
      *   are outside of the range:
      *   (<code>0 &lt;= start &lt; (getSizes().length)) AND (length &gt;= 0)</code>
      */

--- a/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
@@ -1466,10 +1466,10 @@ public class SwingUtilities implements SwingConstants
      * <code>java.awt.EventQueue.invokeAndWait()</code>.
      *
      * @param doRun the instance of {@code Runnable}
-     * @exception  InterruptedException if we're interrupted while waiting for
+     * @throws  InterruptedException if we're interrupted while waiting for
      *             the event dispatching thread to finish executing
      *             <code>doRun.run()</code>
-     * @exception  InvocationTargetException  if an exception is thrown
+     * @throws  InvocationTargetException  if an exception is thrown
      *             while running <code>doRun</code>
      *
      * @see #invokeLater
@@ -1984,7 +1984,7 @@ public class SwingUtilities implements SwingConstants
      * Returns a toolkit-private, shared, invisible Frame
      * to be the owner for JDialogs and JWindows created with
      * {@code null} owners.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -2002,7 +2002,7 @@ public class SwingUtilities implements SwingConstants
     /**
      * Returns a SharedOwnerFrame's shutdown listener to dispose the SharedOwnerFrame
      * if it has no more displayable children.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */

--- a/src/java.desktop/share/classes/javax/swing/Timer.java
+++ b/src/java.desktop/share/classes/javax/swing/Timer.java
@@ -341,7 +341,7 @@ public class Timer implements Serializable
      *          on this timer,
      *          or an empty array if no such
      *          listeners have been added
-     * @exception ClassCastException if <code>listenerType</code> doesn't
+     * @throws ClassCastException if <code>listenerType</code> doesn't
      *          specify a class or interface that implements
      *          <code>java.util.EventListener</code>
      *

--- a/src/java.desktop/share/classes/javax/swing/TransferHandler.java
+++ b/src/java.desktop/share/classes/javax/swing/TransferHandler.java
@@ -1172,9 +1172,9 @@ public class TransferHandler implements Serializable {
          *
          * @param flavor the requested flavor for the data
          * @see DataFlavor#getRepresentationClass
-         * @exception IOException                if the data is no longer available
+         * @throws IOException                if the data is no longer available
          *              in the requested flavor.
-         * @exception UnsupportedFlavorException if the requested data flavor is
+         * @throws UnsupportedFlavorException if the requested data flavor is
          *              not supported.
          */
         public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException, IOException {

--- a/src/java.desktop/share/classes/javax/swing/colorchooser/AbstractColorChooserPanel.java
+++ b/src/java.desktop/share/classes/javax/swing/colorchooser/AbstractColorChooserPanel.java
@@ -161,7 +161,7 @@ public abstract class AbstractColorChooserPanel extends JPanel {
      * If you override this, be sure to call <code>super</code>.
      *
      * @param enclosingChooser the chooser to which the panel is to be added
-     * @exception RuntimeException  if the chooser panel has already been
+     * @throws RuntimeException  if the chooser panel has already been
      *                          installed
      */
     public void installChooserPanel(JColorChooser enclosingChooser) {

--- a/src/java.desktop/share/classes/javax/swing/event/EventListenerList.java
+++ b/src/java.desktop/share/classes/javax/swing/event/EventListenerList.java
@@ -144,7 +144,7 @@ public class EventListenerList implements Serializable {
      * @param <T> the type of {@code EventListener} to search for
      * @param t the type of {@code EventListener} classes to be returned
      * @return all of the listeners of the specified type.
-     * @exception  ClassCastException if the supplied class
+     * @throws  ClassCastException if the supplied class
      *          is not assignable to EventListener
      *
      * @since 1.3

--- a/src/java.desktop/share/classes/javax/swing/plaf/TextUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/TextUI.java
@@ -49,7 +49,7 @@ public abstract class TextUI extends ComponentUI
      * @param t the text component for which this UI is installed
      * @param pos  the local location in the model to translate &gt;= 0
      * @return the coordinates as a {@code Rectangle}
-     * @exception BadLocationException  if the given position does not
+     * @throws BadLocationException  if the given position does not
      *   represent a valid location in the associated document
      *
      * @deprecated replaced by
@@ -66,7 +66,7 @@ public abstract class TextUI extends ComponentUI
      * @param pos  the local location in the model to translate &gt;= 0
      * @param bias the bias for the position
      * @return the coordinates as a {@code Rectangle}
-     * @exception BadLocationException  if the given position does not
+     * @throws BadLocationException  if the given position does not
      *   represent a valid location in the associated document
      *
      * @deprecated replaced by
@@ -86,7 +86,7 @@ public abstract class TextUI extends ComponentUI
      * @param pos  the local location in the model to translate {@code >= 0}
      * @param bias the bias for the position
      * @return the coordinates as a {@code Rectangle2D}
-     * @exception BadLocationException  if the given position does not
+     * @throws BadLocationException  if the given position does not
      *            represent a valid location in the associated document
      *
      * @since 9
@@ -178,8 +178,8 @@ public abstract class TextUI extends ComponentUI
      * @param biasRet an array to contain the bias for the returned position
      * @return the location within the model that best represents the next
      *  location visual position
-     * @exception BadLocationException for a bad location within a document model
-     * @exception IllegalArgumentException for an invalid direction
+     * @throws BadLocationException for a bad location within a document model
+     * @throws IllegalArgumentException for an invalid direction
      */
     public abstract int getNextVisualPositionFrom(JTextComponent t,
                          int pos, Position.Bias b,

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicHTML.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicHTML.java
@@ -585,9 +585,9 @@ public class BasicHTML {
          *  position is a boundary of two views.
          * @param a the allocated region to render into
          * @return the bounding box of the given position is returned
-         * @exception BadLocationException  if the given position does
+         * @throws BadLocationException  if the given position does
          *   not represent a valid location in the associated document
-         * @exception IllegalArgumentException for an invalid bias argument
+         * @throws IllegalArgumentException for an invalid bias argument
          * @see View#viewToModel
          */
         public Shape modelToView(int p0, Position.Bias b0, int p1,

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTabbedPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTabbedPaneUI.java
@@ -775,7 +775,7 @@ public class BasicTabbedPaneUI extends TabbedPaneUI implements SwingConstants {
      * Returns the baseline for the specified tab.
      *
      * @param tab index of tab to get baseline for
-     * @exception IndexOutOfBoundsException if index is out of range
+     * @throws IndexOutOfBoundsException if index is out of range
      *            (index &lt; 0 || index &gt;= tab count)
      * @return baseline or a value &lt; 0 indicating there is no reasonable
      *                  baseline

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextFieldUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextFieldUI.java
@@ -345,7 +345,7 @@ public class BasicTextFieldUI extends BasicTextUI {
          * @param pos the position to convert >= 0
          * @param a the allocated region to render into
          * @return the bounding box of the given position
-         * @exception BadLocationException  if the given position does not
+         * @throws BadLocationException  if the given position does not
          *   represent a valid location in the associated document
          * @see View#modelToView
          */
@@ -367,9 +367,9 @@ public class BasicTextFieldUI extends BasicTextUI {
          *  position is a boundary of two views.
          * @param a the allocated region to render into
          * @return the bounding box of the given position is returned
-         * @exception BadLocationException  if the given position does
+         * @throws BadLocationException  if the given position does
          *   not represent a valid location in the associated document
-         * @exception IllegalArgumentException for an invalid bias argument
+         * @throws IllegalArgumentException for an invalid bias argument
          * @see View#viewToModel
          */
         public Shape modelToView(int p0, Position.Bias b0,

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
@@ -1045,7 +1045,7 @@ public abstract class BasicTextUI extends TextUI implements ViewFactory {
      * @param tc the text component for which this UI is installed
      * @param pos the local location in the model to translate &gt;= 0
      * @return the coordinates as a rectangle, null if the model is not painted
-     * @exception BadLocationException  if the given position does not
+     * @throws BadLocationException  if the given position does not
      *   represent a valid location in the associated document
      * @see TextUI#modelToView
      *
@@ -1067,7 +1067,7 @@ public abstract class BasicTextUI extends TextUI implements ViewFactory {
      * @param tc the text component for which this UI is installed
      * @param pos the local location in the model to translate &gt;= 0
      * @return the coordinates as a rectangle, null if the model is not painted
-     * @exception BadLocationException  if the given position does not
+     * @throws BadLocationException  if the given position does not
      *   represent a valid location in the associated document
      * @see TextUI#modelToView
      *
@@ -1626,9 +1626,9 @@ public abstract class BasicTextUI extends TextUI implements ViewFactory {
          *  position is a boundary of two views.
          * @param a the allocated region to render into
          * @return the bounding box of the given position is returned
-         * @exception BadLocationException  if the given position does
+         * @throws BadLocationException  if the given position does
          *   not represent a valid location in the associated document
-         * @exception IllegalArgumentException for an invalid bias argument
+         * @throws IllegalArgumentException for an invalid bias argument
          * @see View#viewToModel
          */
         public Shape modelToView(int p0, Position.Bias b0, int p1, Position.Bias b1, Shape a) throws BadLocationException {
@@ -1674,9 +1674,9 @@ public abstract class BasicTextUI extends TextUI implements ViewFactory {
          *  SwingConstants.NORTH, or SwingConstants.SOUTH.
          * @return the location within the model that best represents the next
          *  location visual position.
-         * @exception BadLocationException the given position is not a valid
+         * @throws BadLocationException the given position is not a valid
          *                                 position within the document
-         * @exception IllegalArgumentException for an invalid direction
+         * @throws IllegalArgumentException for an invalid direction
          */
         public int getNextVisualPositionFrom(int pos, Position.Bias b, Shape a,
                                              int direction,

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTransferable.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTransferable.java
@@ -130,9 +130,9 @@ class BasicTransferable implements Transferable, UIResource {
      *
      * @param flavor the requested flavor for the data
      * @see DataFlavor#getRepresentationClass
-     * @exception IOException                if the data is no longer available
+     * @throws IOException                if the data is no longer available
      *              in the requested flavor.
-     * @exception UnsupportedFlavorException if the requested data flavor is
+     * @throws UnsupportedFlavorException if the requested data flavor is
      *              not supported.
      */
     public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException, IOException {

--- a/src/java.desktop/share/classes/javax/swing/table/AbstractTableModel.java
+++ b/src/java.desktop/share/classes/javax/swing/table/AbstractTableModel.java
@@ -331,7 +331,7 @@ public abstract class AbstractTableModel implements TableModel, Serializable
      *          <code><em>Foo</em>Listener</code>s on this component,
      *          or an empty array if no such
      *          listeners have been added
-     * @exception ClassCastException if <code>listenerType</code>
+     * @throws ClassCastException if <code>listenerType</code>
      *          doesn't specify a class or interface that implements
      *          <code>java.util.EventListener</code>
      *

--- a/src/java.desktop/share/classes/javax/swing/table/DefaultTableColumnModel.java
+++ b/src/java.desktop/share/classes/javax/swing/table/DefaultTableColumnModel.java
@@ -109,7 +109,7 @@ public class DefaultTableColumnModel implements TableColumnModel,
      *  event to its listeners.
      *
      * @param   aColumn         the <code>TableColumn</code> to be added
-     * @exception IllegalArgumentException      if <code>aColumn</code> is
+     * @throws IllegalArgumentException      if <code>aColumn</code> is
      *                          <code>null</code>
      * @see     #removeColumn
      */
@@ -170,7 +170,7 @@ public class DefaultTableColumnModel implements TableColumnModel,
      *
      * @param   columnIndex                     the index of column to be moved
      * @param   newIndex                        new index to move the column
-     * @exception IllegalArgumentException      if <code>column</code> or
+     * @throws IllegalArgumentException      if <code>column</code> or
      *                                          <code>newIndex</code>
      *                                          are not in the valid range
      */
@@ -258,7 +258,7 @@ public class DefaultTableColumnModel implements TableColumnModel,
      * @return          the index of the first column in the
      *                  <code>tableColumns</code> array whose identifier
      *                  is equal to <code>identifier</code>
-     * @exception       IllegalArgumentException  if <code>identifier</code>
+     * @throws       IllegalArgumentException  if <code>identifier</code>
      *                          is <code>null</code>, or if no
      *                          <code>TableColumn</code> has this
      *                          <code>identifier</code>
@@ -365,7 +365,7 @@ public class DefaultTableColumnModel implements TableColumnModel,
      *  an exception is thrown.
      *
      * @param   newModel        the new selection model
-     * @exception IllegalArgumentException      if <code>newModel</code>
+     * @throws IllegalArgumentException      if <code>newModel</code>
      *                                          is <code>null</code>
      * @see     #getSelectionModel
      */
@@ -633,7 +633,7 @@ public class DefaultTableColumnModel implements TableColumnModel,
      *          <code><em>Foo</em>Listener</code>s on this model,
      *          or an empty array if no such
      *          listeners have been added
-     * @exception ClassCastException if <code>listenerType</code>
+     * @throws ClassCastException if <code>listenerType</code>
      *          doesn't specify a class or interface that implements
      *          <code>java.util.EventListener</code>
      *

--- a/src/java.desktop/share/classes/javax/swing/table/DefaultTableModel.java
+++ b/src/java.desktop/share/classes/javax/swing/table/DefaultTableModel.java
@@ -375,7 +375,7 @@ public class DefaultTableModel extends AbstractTableModel implements Serializabl
      *
      * @param   row             the row index of the row to be inserted
      * @param   rowData         optional data of the row being added
-     * @exception  ArrayIndexOutOfBoundsException  if the row was invalid
+     * @throws  ArrayIndexOutOfBoundsException  if the row was invalid
      */
     public void insertRow(int row, Vector<?> rowData) {
         dataVector.insertElementAt(rowData, row);
@@ -390,7 +390,7 @@ public class DefaultTableModel extends AbstractTableModel implements Serializabl
      *
      * @param   row      the row index of the row to be inserted
      * @param   rowData          optional data of the row being added
-     * @exception  ArrayIndexOutOfBoundsException  if the row was invalid
+     * @throws  ArrayIndexOutOfBoundsException  if the row was invalid
      */
     public void insertRow(int row, Object[] rowData) {
         insertRow(row, convertToVector(rowData));
@@ -438,7 +438,7 @@ public class DefaultTableModel extends AbstractTableModel implements Serializabl
      * @param   start       the starting row index to be moved
      * @param   end         the ending row index to be moved
      * @param   to          the destination of the rows to be moved
-     * @exception  ArrayIndexOutOfBoundsException  if any of the elements
+     * @throws  ArrayIndexOutOfBoundsException  if any of the elements
      * would be moved out of the table's range
      *
      */
@@ -463,7 +463,7 @@ public class DefaultTableModel extends AbstractTableModel implements Serializabl
      *  of the row being removed will be sent to all the listeners.
      *
      * @param   row      the row index of the row to be removed
-     * @exception  ArrayIndexOutOfBoundsException  if the row was invalid
+     * @throws  ArrayIndexOutOfBoundsException  if the row was invalid
      */
     public void removeRow(int row) {
         dataVector.removeElementAt(row);
@@ -652,7 +652,7 @@ public class DefaultTableModel extends AbstractTableModel implements Serializabl
      * @param   row             the row whose value is to be queried
      * @param   column          the column whose value is to be queried
      * @return                  the value Object at the specified cell
-     * @exception  ArrayIndexOutOfBoundsException  if an invalid row or
+     * @throws  ArrayIndexOutOfBoundsException  if an invalid row or
      *               column was given
      */
     public Object getValueAt(int row, int column) {
@@ -669,7 +669,7 @@ public class DefaultTableModel extends AbstractTableModel implements Serializabl
      * @param   aValue          the new value; this can be null
      * @param   row             the row whose value is to be changed
      * @param   column          the column whose value is to be changed
-     * @exception  ArrayIndexOutOfBoundsException  if an invalid row or
+     * @throws  ArrayIndexOutOfBoundsException  if an invalid row or
      *               column was given
      */
     public void setValueAt(Object aValue, int row, int column) {

--- a/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
+++ b/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
@@ -550,7 +550,7 @@ public class JTableHeader extends JComponent implements TableColumnModelListener
      *  for listener notifications from the new column model.
      *
      * @param   columnModel     the new data source for this table
-     * @exception IllegalArgumentException
+     * @throws IllegalArgumentException
      *                          if <code>newModel</code> is <code>null</code>
      * @see     #getColumnModel
      */

--- a/src/java.desktop/share/classes/javax/swing/table/TableColumnModel.java
+++ b/src/java.desktop/share/classes/javax/swing/table/TableColumnModel.java
@@ -79,7 +79,7 @@ public interface TableColumnModel
      *
      * @param   columnIndex                     the index of column to be moved
      * @param   newIndex                        index of the column's new location
-     * @exception IllegalArgumentException      if <code>columnIndex</code> or
+     * @throws IllegalArgumentException      if <code>columnIndex</code> or
      *                                          <code>newIndex</code>
      *                                          are not in the valid range
      */
@@ -119,7 +119,7 @@ public interface TableColumnModel
      * @param           columnIdentifier        the identifier object
      * @return          the index of the first table column
      *                  whose identifier is equal to <code>identifier</code>
-     * @exception IllegalArgumentException      if <code>identifier</code>
+     * @throws IllegalArgumentException      if <code>identifier</code>
      *                          is <code>null</code>, or no
      *                          <code>TableColumn</code> has this
      *                          <code>identifier</code>

--- a/src/java.desktop/share/classes/javax/swing/text/AbstractDocument.java
+++ b/src/java.desktop/share/classes/javax/swing/text/AbstractDocument.java
@@ -344,7 +344,7 @@ public abstract class AbstractDocument implements Document, Serializable {
      *          <code><em>Foo</em>Listener</code>s on this component,
      *          or an empty array if no such
      *          listeners have been added
-     * @exception ClassCastException if <code>listenerType</code>
+     * @throws ClassCastException if <code>listenerType</code>
      *          doesn't specify a class or interface that implements
      *          <code>java.util.EventListener</code>
      *
@@ -604,7 +604,7 @@ public abstract class AbstractDocument implements Document, Serializable {
      *
      * @param offs the starting offset &gt;= 0
      * @param len the number of characters to remove &gt;= 0
-     * @exception BadLocationException  the given remove position is not a valid
+     * @throws BadLocationException  the given remove position is not a valid
      *   position within the document
      * @see Document#remove
      */
@@ -674,7 +674,7 @@ public abstract class AbstractDocument implements Document, Serializable {
      *              <code>null</code>
      *              is legal, and typically treated as an empty attributeset,
      *              but exact interpretation is left to the subclass
-     * @exception BadLocationException the given position is not a valid
+     * @throws BadLocationException the given position is not a valid
      *            position within the document
      * @since 1.4
      */
@@ -718,7 +718,7 @@ public abstract class AbstractDocument implements Document, Serializable {
      * @param offs the starting offset &gt;= 0
      * @param str the string to insert; does nothing with null/empty strings
      * @param a the attributes for the inserted content
-     * @exception BadLocationException  the given insert position is not a valid
+     * @throws BadLocationException  the given insert position is not a valid
      *   position within the document
      * @see Document#insertString
      */
@@ -792,7 +792,7 @@ public abstract class AbstractDocument implements Document, Serializable {
      * @param offset the starting offset &gt;= 0
      * @param length the number of characters to retrieve &gt;= 0
      * @return the text
-     * @exception BadLocationException  the range given includes a position
+     * @throws BadLocationException  the range given includes a position
      *   that is not a valid position within the document
      * @see Document#getText
      */
@@ -833,7 +833,7 @@ public abstract class AbstractDocument implements Document, Serializable {
      * @param offset the starting offset &gt;= 0
      * @param length the number of characters to retrieve &gt;= 0
      * @param txt the Segment object to retrieve the text into
-     * @exception BadLocationException  the range given includes a position
+     * @throws BadLocationException  the range given includes a position
      *   that is not a valid position within the document
      */
     public void getText(int offset, int length, Segment txt) throws BadLocationException {
@@ -854,7 +854,7 @@ public abstract class AbstractDocument implements Document, Serializable {
      *
      * @param offs the position in the model &gt;= 0
      * @return the position
-     * @exception BadLocationException  if the given position does not
+     * @throws BadLocationException  if the given position does not
      *   represent a valid location in the associated document
      * @see Document#createPosition
      */
@@ -1354,7 +1354,7 @@ public abstract class AbstractDocument implements Document, Serializable {
      * <code>Document</code> will be left in a locked state so that no
      * reading or writing can be done.
      *
-     * @exception IllegalStateException thrown on illegal lock
+     * @throws IllegalStateException thrown on illegal lock
      *  attempt.  If the document is implemented properly, this can
      *  only happen if a document listener attempts to mutate the
      *  document.  This situation violates the bean event model
@@ -1633,7 +1633,7 @@ public abstract class AbstractDocument implements Document, Serializable {
          *
          * @param offset the offset in the content &gt;= 0
          * @return a Position
-         * @exception BadLocationException for an invalid offset
+         * @throws BadLocationException for an invalid offset
          */
         public Position createPosition(int offset) throws BadLocationException;
 
@@ -1652,7 +1652,7 @@ public abstract class AbstractDocument implements Document, Serializable {
          * @return  if the implementation supports a history mechanism,
          *    a reference to an <code>Edit</code> implementation will be returned,
          *    otherwise returns <code>null</code>
-         * @exception BadLocationException  thrown if the area covered by
+         * @throws BadLocationException  thrown if the area covered by
          *   the arguments is not contained in the character sequence
          */
         public UndoableEdit insertString(int where, String str) throws BadLocationException;
@@ -1666,7 +1666,7 @@ public abstract class AbstractDocument implements Document, Serializable {
          * @return  If the implementation supports a history mechanism,
          *    a reference to an Edit implementation will be returned,
          *    otherwise null.
-         * @exception BadLocationException  Thrown if the area covered by
+         * @throws BadLocationException  Thrown if the area covered by
          *   the arguments is not contained in the character sequence.
          */
         public UndoableEdit remove(int where, int nitems) throws BadLocationException;
@@ -1677,7 +1677,7 @@ public abstract class AbstractDocument implements Document, Serializable {
          * @param where   Offset into the sequence to fetch &gt;= 0.
          * @param len     number of characters to copy &gt;= 0.
          * @return the string
-         * @exception BadLocationException  Thrown if the area covered by
+         * @throws BadLocationException  Thrown if the area covered by
          *   the arguments is not contained in the character sequence.
          */
         public String getString(int where, int len) throws BadLocationException;
@@ -1688,7 +1688,7 @@ public abstract class AbstractDocument implements Document, Serializable {
          * @param where the starting offset &gt;= 0
          * @param len the number of characters &gt;= 0
          * @param txt the target location to copy into
-         * @exception BadLocationException  Thrown if the area covered by
+         * @throws BadLocationException  Thrown if the area covered by
          *   the arguments is not contained in the character sequence.
          */
         public void getChars(int where, int len, Segment txt) throws BadLocationException;
@@ -2819,7 +2819,7 @@ public abstract class AbstractDocument implements Document, Serializable {
         /**
          * Redoes a change.
          *
-         * @exception CannotRedoException if the change cannot be redone
+         * @throws CannotRedoException if the change cannot be redone
          */
         public void redo() throws CannotRedoException {
             writeLock();
@@ -2843,7 +2843,7 @@ public abstract class AbstractDocument implements Document, Serializable {
         /**
          * Undoes a change.
          *
-         * @exception CannotUndoException if the change cannot be undone
+         * @throws CannotUndoException if the change cannot be undone
          */
         public void undo() throws CannotUndoException {
             writeLock();
@@ -3187,7 +3187,7 @@ public abstract class AbstractDocument implements Document, Serializable {
         /**
          * Redoes a change.
          *
-         * @exception CannotRedoException if the change cannot be redone
+         * @throws CannotRedoException if the change cannot be redone
          */
         public void redo() throws CannotRedoException {
             super.redo();
@@ -3204,7 +3204,7 @@ public abstract class AbstractDocument implements Document, Serializable {
         /**
          * Undoes a change.
          *
-         * @exception CannotUndoException if the change cannot be undone
+         * @throws CannotUndoException if the change cannot be undone
          */
         public void undo() throws CannotUndoException {
             super.undo();

--- a/src/java.desktop/share/classes/javax/swing/text/AbstractWriter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/AbstractWriter.java
@@ -270,7 +270,7 @@ public abstract class AbstractWriter {
      * when encountered.
      *
      * @param     elem an <code>Element</code>
-     * @exception BadLocationException if pos represents an invalid
+     * @throws BadLocationException if pos represents an invalid
      *            location within the document
      * @return    the text as a <code>String</code>
      */
@@ -286,8 +286,8 @@ public abstract class AbstractWriter {
      * out.
      *
      * @param     elem an Element.
-     * @exception IOException on any I/O error
-     * @exception BadLocationException if pos represents an invalid
+     * @throws IOException on any I/O error
+     * @throws BadLocationException if pos represents an invalid
      *            location within the document.
      */
     protected void text(Element elem) throws BadLocationException,
@@ -462,7 +462,7 @@ public abstract class AbstractWriter {
      * line is empty, this will not make it so that the current line is
      * still considered empty.
      *
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     protected void indent() throws IOException {
         int max = getIndentLevel() * getIndentSpace();
@@ -485,7 +485,7 @@ public abstract class AbstractWriter {
      * the <code>write</code> method that takes a char[].
      *
      * @param     ch a char.
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     protected void write(char ch) throws IOException {
         if (tempChars == null) {
@@ -500,7 +500,7 @@ public abstract class AbstractWriter {
      * <code>write</code> method that takes a char[].
      *
      * @param     content a String.
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     protected void write(String content) throws IOException {
         if (content == null) {
@@ -671,7 +671,7 @@ public abstract class AbstractWriter {
      * pairs. It throws an IOException when encountered.
      *
      * @param     attr an AttributeSet.
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     protected void writeAttributes(AttributeSet attr) throws IOException {
 

--- a/src/java.desktop/share/classes/javax/swing/text/AsyncBoxView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/AsyncBoxView.java
@@ -640,7 +640,7 @@ public class AsyncBoxView extends View {
      *           Typically the view is told to render into the span
      *           that is returned, although there is no guarantee.
      *           The parent may choose to resize or break the view.
-     * @exception IllegalArgumentException for an invalid axis type
+     * @throws IllegalArgumentException for an invalid axis type
      */
     public float getPreferredSpan(int axis) {
         float margin = getInsetSpan(axis);
@@ -665,7 +665,7 @@ public class AsyncBoxView extends View {
      *           Typically the view is told to render into the span
      *           that is returned, although there is no guarantee.
      *           The parent may choose to resize or break the view.
-     * @exception IllegalArgumentException for an invalid axis type
+     * @throws IllegalArgumentException for an invalid axis type
      */
     public float getMinimumSpan(int axis) {
         if (axis == this.axis) {
@@ -693,7 +693,7 @@ public class AsyncBoxView extends View {
      *           Typically the view is told to render into the span
      *           that is returned, although there is no guarantee.
      *           The parent may choose to resize or break the view.
-     * @exception IllegalArgumentException for an invalid axis type
+     * @throws IllegalArgumentException for an invalid axis type
      */
     public float getMaximumSpan(int axis) {
         if (axis == this.axis) {
@@ -773,9 +773,9 @@ public class AsyncBoxView extends View {
      *  next character represented by the offset, in case the
      *  position is a boundary of two views.
      * @return the bounding box of the given position is returned
-     * @exception BadLocationException  if the given position does
+     * @throws BadLocationException  if the given position does
      *   not represent a valid location in the associated document
-     * @exception IllegalArgumentException for an invalid bias argument
+     * @throws IllegalArgumentException for an invalid bias argument
      * @see View#viewToModel
      */
     public Shape modelToView(int pos, Shape a, Position.Bias b) throws BadLocationException {
@@ -864,9 +864,9 @@ public class AsyncBoxView extends View {
      * @param biasRet an array contain the bias that was checked
      * @return the location within the model that best represents the next
      *  location visual position
-     * @exception BadLocationException the given position is not a valid
+     * @throws BadLocationException the given position is not a valid
      *                                 position within the document
-     * @exception IllegalArgumentException if <code>direction</code> is invalid
+     * @throws IllegalArgumentException if <code>direction</code> is invalid
      */
     public int getNextVisualPositionFrom(int pos, Position.Bias b, Shape a,
                                          int direction,

--- a/src/java.desktop/share/classes/javax/swing/text/BoxView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/BoxView.java
@@ -293,7 +293,7 @@ public class BoxView extends CompositeView {
      * @param axis may be either <code>View.X_AXIS</code> or
      *          <code>View.Y_AXIS</code>
      * @return the weight
-     * @exception IllegalArgumentException for an invalid axis
+     * @throws IllegalArgumentException for an invalid axis
      */
     public int getResizeWeight(int axis) {
         checkRequests(axis);
@@ -473,7 +473,7 @@ public class BoxView extends CompositeView {
      * @param pos the position to convert &gt;= 0
      * @param a the allocated region to render into
      * @return the bounding box of the given position
-     * @exception BadLocationException  if the given position does
+     * @throws BadLocationException  if the given position does
      *  not represent a valid location in the associated document
      * @see View#modelToView
      */
@@ -519,7 +519,7 @@ public class BoxView extends CompositeView {
      *   origin and 1.0 indicates alignment to the full span
      *   away from the origin; an alignment of 0.5 would be the
      *   center of the view
-     * @exception IllegalArgumentException for an invalid axis
+     * @throws IllegalArgumentException for an invalid axis
      */
     public float getAlignment(int axis) {
         checkRequests(axis);
@@ -540,7 +540,7 @@ public class BoxView extends CompositeView {
      *           typically the view is told to render into the span
      *           that is returned, although there is no guarantee;
      *           the parent may choose to resize or break the view
-     * @exception IllegalArgumentException for an invalid axis type
+     * @throws IllegalArgumentException for an invalid axis type
      */
     public float getPreferredSpan(int axis) {
         checkRequests(axis);
@@ -563,7 +563,7 @@ public class BoxView extends CompositeView {
      *           typically the view is told to render into the span
      *           that is returned, although there is no guarantee;
      *           the parent may choose to resize or break the view
-     * @exception IllegalArgumentException for an invalid axis type
+     * @throws IllegalArgumentException for an invalid axis type
      */
     public float getMinimumSpan(int axis) {
         checkRequests(axis);
@@ -586,7 +586,7 @@ public class BoxView extends CompositeView {
      *           typically the view is told to render into the span
      *           that is returned, although there is no guarantee;
      *           the parent may choose to resize or break the view
-     * @exception IllegalArgumentException for an invalid axis type
+     * @throws IllegalArgumentException for an invalid axis type
      */
     public float getMaximumSpan(int axis) {
         checkRequests(axis);
@@ -919,7 +919,7 @@ public class BoxView extends CompositeView {
     /**
      * Checks the request cache and update if needed.
      * @param axis the axis being studied
-     * @exception IllegalArgumentException if <code>axis</code> is
+     * @throws IllegalArgumentException if <code>axis</code> is
      *  neither <code>View.X_AXIS</code> nor <code>View.Y_AXIS</code>
      */
     void checkRequests(int axis) {

--- a/src/java.desktop/share/classes/javax/swing/text/ComponentView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/ComponentView.java
@@ -132,7 +132,7 @@ public class ComponentView extends View  {
      *           Typically the view is told to render into the span
      *           that is returned, although there is no guarantee.
      *           The parent may choose to resize or break the view.
-     * @exception IllegalArgumentException for an invalid axis
+     * @throws IllegalArgumentException for an invalid axis
      */
     public float getPreferredSpan(int axis) {
         if ((axis != X_AXIS) && (axis != Y_AXIS)) {
@@ -160,7 +160,7 @@ public class ComponentView extends View  {
      *           Typically the view is told to render into the span
      *           that is returned, although there is no guarantee.
      *           The parent may choose to resize or break the view.
-     * @exception IllegalArgumentException for an invalid axis
+     * @throws IllegalArgumentException for an invalid axis
      */
     public float getMinimumSpan(int axis) {
         if ((axis != X_AXIS) && (axis != Y_AXIS)) {
@@ -188,7 +188,7 @@ public class ComponentView extends View  {
      *           Typically the view is told to render into the span
      *           that is returned, although there is no guarantee.
      *           The parent may choose to resize or break the view.
-     * @exception IllegalArgumentException for an invalid axis
+     * @throws IllegalArgumentException for an invalid axis
      */
     public float getMaximumSpan(int axis) {
         if ((axis != X_AXIS) && (axis != Y_AXIS)) {
@@ -325,7 +325,7 @@ public class ComponentView extends View  {
      * @param pos the position to convert &gt;=0
      * @param a the allocated region to render into
      * @return the bounding box of the given position is returned
-     * @exception BadLocationException  if the given position does not
+     * @throws BadLocationException  if the given position does not
      *   represent a valid location in the associated document
      * @see View#modelToView
      */

--- a/src/java.desktop/share/classes/javax/swing/text/CompositeView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/CompositeView.java
@@ -244,7 +244,7 @@ public abstract class CompositeView extends View {
      * @param b a bias value of either <code>Position.Bias.Forward</code>
      *  or <code>Position.Bias.Backward</code>
      * @return the bounding box of the given position
-     * @exception BadLocationException  if the given position does
+     * @throws BadLocationException  if the given position does
      *   not represent a valid location in the associated document
      * @see View#modelToView
      */
@@ -294,9 +294,9 @@ public abstract class CompositeView extends View {
      *  position is a boundary of two views
      * @param a the allocated region to render into
      * @return the bounding box of the given position is returned
-     * @exception BadLocationException  if the given position does
+     * @throws BadLocationException  if the given position does
      *   not represent a valid location in the associated document
-     * @exception IllegalArgumentException for an invalid bias argument
+     * @throws IllegalArgumentException for an invalid bias argument
      * @see View#viewToModel
      */
     public Shape modelToView(int p0, Position.Bias b0, int p1, Position.Bias b1, Shape a) throws BadLocationException {
@@ -458,9 +458,9 @@ public abstract class CompositeView extends View {
      * @param biasRet an array containing the bias that was checked
      * @return the location within the model that best represents the next
      *  location visual position
-     * @exception BadLocationException the given position is not a valid
+     * @throws BadLocationException the given position is not a valid
      *                                 position within the document
-     * @exception IllegalArgumentException if <code>direction</code> is invalid
+     * @throws IllegalArgumentException if <code>direction</code> is invalid
      */
     public int getNextVisualPositionFrom(int pos, Position.Bias b, Shape a,
                                          int direction, Position.Bias[] biasRet)
@@ -715,8 +715,8 @@ public abstract class CompositeView extends View {
      * @param biasRet an array containing the bias that was checked
      * @return the location within the model that best represents the next
      *  north or south location
-     * @exception BadLocationException for a bad location within a document model
-     * @exception IllegalArgumentException if <code>direction</code> is invalid
+     * @throws BadLocationException for a bad location within a document model
+     * @throws IllegalArgumentException if <code>direction</code> is invalid
      * @see #getNextVisualPositionFrom
      */
     protected int getNextNorthSouthVisualPositionFrom(int pos, Position.Bias b,
@@ -748,8 +748,8 @@ public abstract class CompositeView extends View {
      * @param biasRet an array containing the bias that was checked
      * @return the location within the model that best represents the next
      *  west or east location
-     * @exception BadLocationException for a bad location within a document model
-     * @exception IllegalArgumentException if <code>direction</code> is invalid
+     * @throws BadLocationException for a bad location within a document model
+     * @throws IllegalArgumentException if <code>direction</code> is invalid
      * @see #getNextVisualPositionFrom
      */
     protected int getNextEastWestVisualPositionFrom(int pos, Position.Bias b,

--- a/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
+++ b/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
@@ -870,7 +870,7 @@ public class DefaultCaret extends Rectangle implements Caret, FocusListener, Mou
      *          <code><em>Foo</em>Listener</code>s on this component,
      *          or an empty array if no such
      *          listeners have been added
-     * @exception ClassCastException if <code>listenerType</code>
+     * @throws ClassCastException if <code>listenerType</code>
      *          doesn't specify a class or interface that implements
      *          <code>java.util.EventListener</code>
      *

--- a/src/java.desktop/share/classes/javax/swing/text/DefaultEditorKit.java
+++ b/src/java.desktop/share/classes/javax/swing/text/DefaultEditorKit.java
@@ -142,8 +142,8 @@ public class DefaultEditorKit extends EditorKit {
      * @param doc The destination for the insertion.
      * @param pos The location in the document to place the
      *   content &gt;=0.
-     * @exception IOException on any I/O error
-     * @exception BadLocationException if pos represents an invalid
+     * @throws IOException on any I/O error
+     * @throws BadLocationException if pos represents an invalid
      *   location within the document.
      */
     public void read(InputStream in, Document doc, int pos)
@@ -161,8 +161,8 @@ public class DefaultEditorKit extends EditorKit {
      * @param pos The location in the document to fetch the
      *   content &gt;=0.
      * @param len The amount to write out &gt;=0.
-     * @exception IOException on any I/O error
-     * @exception BadLocationException if pos represents an invalid
+     * @throws IOException on any I/O error
+     * @throws BadLocationException if pos represents an invalid
      *   location within the document.
      */
     public void write(OutputStream out, Document doc, int pos, int len)
@@ -193,8 +193,8 @@ public class DefaultEditorKit extends EditorKit {
      * @param doc The destination for the insertion.
      * @param pos The location in the document to place the
      *   content &gt;=0.
-     * @exception IOException on any I/O error
-     * @exception BadLocationException if pos represents an invalid
+     * @throws IOException on any I/O error
+     * @throws BadLocationException if pos represents an invalid
      *   location within the document.
      */
     public void read(Reader in, Document doc, int pos)
@@ -303,8 +303,8 @@ public class DefaultEditorKit extends EditorKit {
      * @param pos The location in the document to fetch the
      *   content from &gt;=0.
      * @param len The amount to write out &gt;=0.
-     * @exception IOException on any I/O error
-     * @exception BadLocationException if pos is not within 0 and
+     * @throws IOException on any I/O error
+     * @throws BadLocationException if pos is not within 0 and
      *   the length of the document.
      */
     public void write(Writer out, Document doc, int pos, int len)

--- a/src/java.desktop/share/classes/javax/swing/text/DefaultHighlighter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/DefaultHighlighter.java
@@ -110,7 +110,7 @@ public class DefaultHighlighter extends LayeredHighlighter {
      * @param p    the painter to use to actually render the highlight
      * @return     an object that can be used as a tag
      *   to refer to the highlight
-     * @exception BadLocationException if the specified location is invalid
+     * @throws BadLocationException if the specified location is invalid
      */
     public Object addHighlight(int p0, int p1, Highlighter.HighlightPainter p) throws BadLocationException {
         if (p0 < 0) {
@@ -222,7 +222,7 @@ public class DefaultHighlighter extends LayeredHighlighter {
      * @param tag the highlight tag
      * @param p0 the beginning of the range &gt;= 0
      * @param p1 the end of the range &gt;= p0
-     * @exception BadLocationException if the specified location is invalid
+     * @throws BadLocationException if the specified location is invalid
      */
     public void changeHighlight(Object tag, int p0, int p1) throws BadLocationException {
         if (p0 < 0) {

--- a/src/java.desktop/share/classes/javax/swing/text/DefaultStyledDocument.java
+++ b/src/java.desktop/share/classes/javax/swing/text/DefaultStyledDocument.java
@@ -182,7 +182,7 @@ public class DefaultStyledDocument extends AbstractDocument implements StyledDoc
      *
      * @param offset the starting offset &gt;= 0
      * @param data the element data
-     * @exception BadLocationException for an invalid starting offset
+     * @throws BadLocationException for an invalid starting offset
      */
     protected void insert(int offset, ElementSpec[] data) throws BadLocationException {
         if (data == null || data.length == 0) {
@@ -2548,7 +2548,7 @@ public class DefaultStyledDocument extends AbstractDocument implements StyledDoc
         /**
          * Redoes a change.
          *
-         * @exception CannotRedoException if the change cannot be redone
+         * @throws CannotRedoException if the change cannot be redone
          */
         public void redo() throws CannotRedoException {
             super.redo();
@@ -2562,7 +2562,7 @@ public class DefaultStyledDocument extends AbstractDocument implements StyledDoc
         /**
          * Undoes a change.
          *
-         * @exception CannotUndoException if the change cannot be undone
+         * @throws CannotUndoException if the change cannot be undone
          */
         public void undo() throws CannotUndoException {
             super.undo();
@@ -2604,7 +2604,7 @@ public class DefaultStyledDocument extends AbstractDocument implements StyledDoc
         /**
          * Redoes a change.
          *
-         * @exception CannotRedoException if the change cannot be redone
+         * @throws CannotRedoException if the change cannot be redone
          */
         public void redo() throws CannotRedoException {
             super.redo();
@@ -2614,7 +2614,7 @@ public class DefaultStyledDocument extends AbstractDocument implements StyledDoc
         /**
          * Undoes a change.
          *
-         * @exception CannotUndoException if the change cannot be undone
+         * @throws CannotUndoException if the change cannot be undone
          */
         public void undo() throws CannotUndoException {
             super.undo();

--- a/src/java.desktop/share/classes/javax/swing/text/Document.java
+++ b/src/java.desktop/share/classes/javax/swing/text/Document.java
@@ -453,7 +453,7 @@ public interface Document {
      *
      * @param offs  the offset from the beginning &gt;= 0
      * @param len   the number of characters to remove &gt;= 0
-     * @exception BadLocationException  some portion of the removal range
+     * @throws BadLocationException  some portion of the removal range
      *   was not a valid part of the document.  The location in the exception
      *   is the first bad position encountered.
      * @see javax.swing.event.DocumentEvent
@@ -490,7 +490,7 @@ public interface Document {
      * @param str    the string to insert
      * @param a      the attributes to associate with the inserted
      *   content.  This may be null if there are no attributes.
-     * @exception BadLocationException  the given insert position is not a valid
+     * @throws BadLocationException  the given insert position is not a valid
      * position within the document
      * @see javax.swing.event.DocumentEvent
      * @see javax.swing.event.DocumentListener
@@ -507,7 +507,7 @@ public interface Document {
      *   start of the text &gt;= 0
      * @param length  the length of the desired string &gt;= 0
      * @return the text, in a String of length &gt;= 0
-     * @exception BadLocationException  some portion of the given range
+     * @throws BadLocationException  some portion of the given range
      *   was not a valid part of the document.  The location in the exception
      *   is the first bad position encountered.
      */
@@ -546,7 +546,7 @@ public interface Document {
      * @param length  the length of the desired string &gt;= 0
      * @param txt the Segment object to return the text in
      *
-     * @exception BadLocationException  Some portion of the given range
+     * @throws BadLocationException  Some portion of the given range
      *   was not a valid part of the document.  The location in the exception
      *   is the first bad position encountered.
      */
@@ -582,7 +582,7 @@ public interface Document {
      *
      * @param offs  the offset from the start of the document &gt;= 0
      * @return the position
-     * @exception BadLocationException  if the given position does not
+     * @throws BadLocationException  if the given position does not
      *   represent a valid location in the associated document
      */
     public Position createPosition(int offs) throws BadLocationException;

--- a/src/java.desktop/share/classes/javax/swing/text/DocumentFilter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/DocumentFilter.java
@@ -75,7 +75,7 @@ public class DocumentFilter {
      * @param fb FilterBypass that can be used to mutate Document
      * @param offset the offset from the beginning &gt;= 0
      * @param length the number of characters to remove &gt;= 0
-     * @exception BadLocationException  some portion of the removal range
+     * @throws BadLocationException  some portion of the removal range
      *   was not a valid part of the document.  The location in the exception
      *   is the first bad position encountered.
      */
@@ -97,7 +97,7 @@ public class DocumentFilter {
      * @param string the string to insert
      * @param attr      the attributes to associate with the inserted
      *   content.  This may be null if there are no attributes.
-     * @exception BadLocationException  the given insert position is not a
+     * @throws BadLocationException  the given insert position is not a
      *   valid position within the document
      */
     public void insertString(FilterBypass fb, int offset, String string,
@@ -117,7 +117,7 @@ public class DocumentFilter {
      * @param text Text to insert, null indicates no text to insert
      * @param attrs AttributeSet indicating attributes of inserted text,
      *              null is legal.
-     * @exception BadLocationException  the given insert position is not a
+     * @throws BadLocationException  the given insert position is not a
      *   valid position within the document
      */
     public void replace(FilterBypass fb, int offset, int length, String text,
@@ -153,7 +153,7 @@ public class DocumentFilter {
          *
          * @param offset the offset from the beginning &gt;= 0
          * @param length the number of characters to remove &gt;= 0
-         * @exception BadLocationException some portion of the removal range
+         * @throws BadLocationException some portion of the removal range
          *   was not a valid part of the document.  The location in the
          *   exception is the first bad position encountered.
          */
@@ -169,7 +169,7 @@ public class DocumentFilter {
          * @param string the string to insert
          * @param attr the attributes to associate with the inserted
          *   content.  This may be null if there are no attributes.
-         * @exception BadLocationException  the given insert position is not a
+         * @throws BadLocationException  the given insert position is not a
          *   valid position within the document
          */
         public abstract void insertString(int offset, String string,
@@ -186,7 +186,7 @@ public class DocumentFilter {
          * @param string Text to insert, null indicates no text to insert
          * @param attrs AttributeSet indicating attributes of inserted text,
          *              null is legal.
-         * @exception BadLocationException  the given insert is not a
+         * @throws BadLocationException  the given insert is not a
          *   valid position within the document
          */
         public abstract void replace(int offset, int length, String string,

--- a/src/java.desktop/share/classes/javax/swing/text/EditorKit.java
+++ b/src/java.desktop/share/classes/javax/swing/text/EditorKit.java
@@ -141,8 +141,8 @@ public abstract class EditorKit implements Cloneable, Serializable {
      * @param doc The destination for the insertion.
      * @param pos The location in the document to place the
      *   content &gt;= 0.
-     * @exception IOException on any I/O error
-     * @exception BadLocationException if pos represents an invalid
+     * @throws IOException on any I/O error
+     * @throws BadLocationException if pos represents an invalid
      *   location within the document.
      */
     public abstract void read(InputStream in, Document doc, int pos)
@@ -157,8 +157,8 @@ public abstract class EditorKit implements Cloneable, Serializable {
      * @param pos The location in the document to fetch the
      *   content from &gt;= 0.
      * @param len The amount to write out &gt;= 0.
-     * @exception IOException on any I/O error
-     * @exception BadLocationException if pos represents an invalid
+     * @throws IOException on any I/O error
+     * @throws BadLocationException if pos represents an invalid
      *   location within the document.
      */
     public abstract void write(OutputStream out, Document doc, int pos, int len)
@@ -178,8 +178,8 @@ public abstract class EditorKit implements Cloneable, Serializable {
      * @param doc The destination for the insertion.
      * @param pos The location in the document to place the
      *   content &gt;= 0.
-     * @exception IOException on any I/O error
-     * @exception BadLocationException if pos represents an invalid
+     * @throws IOException on any I/O error
+     * @throws BadLocationException if pos represents an invalid
      *   location within the document.
      */
     public abstract void read(Reader in, Document doc, int pos)
@@ -199,8 +199,8 @@ public abstract class EditorKit implements Cloneable, Serializable {
      * @param pos The location in the document to fetch the
      *   content &gt;= 0.
      * @param len The amount to write out &gt;= 0.
-     * @exception IOException on any I/O error
-     * @exception BadLocationException if pos represents an invalid
+     * @throws IOException on any I/O error
+     * @throws BadLocationException if pos represents an invalid
      *   location within the document.
      */
     public abstract void write(Writer out, Document doc, int pos, int len)

--- a/src/java.desktop/share/classes/javax/swing/text/FieldView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/FieldView.java
@@ -258,7 +258,7 @@ public class FieldView extends PlainView {
      * @param pos the position to convert &gt;= 0
      * @param a the allocated region to render into
      * @return the bounding box of the given position
-     * @exception BadLocationException  if the given position does not
+     * @throws BadLocationException  if the given position does not
      *   represent a valid location in the associated document
      * @see View#modelToView
      */

--- a/src/java.desktop/share/classes/javax/swing/text/GapContent.java
+++ b/src/java.desktop/share/classes/javax/swing/text/GapContent.java
@@ -130,7 +130,7 @@ public class GapContent extends GapVector implements AbstractDocument.Content, S
      * @param where the starting position &gt;= 0, &lt; length()
      * @param str the non-null string to insert
      * @return an UndoableEdit object for undoing
-     * @exception BadLocationException if the specified position is invalid
+     * @throws BadLocationException if the specified position is invalid
      * @see AbstractDocument.Content#insertString
      */
     public UndoableEdit insertString(int where, String str) throws BadLocationException {
@@ -148,7 +148,7 @@ public class GapContent extends GapVector implements AbstractDocument.Content, S
      * @param where the starting position &gt;= 0, where + nitems &lt; length()
      * @param nitems the number of characters to remove &gt;= 0
      * @return an UndoableEdit object for undoing
-     * @exception BadLocationException if the specified position is invalid
+     * @throws BadLocationException if the specified position is invalid
      * @see AbstractDocument.Content#remove
      */
     public UndoableEdit remove(int where, int nitems) throws BadLocationException {
@@ -168,7 +168,7 @@ public class GapContent extends GapVector implements AbstractDocument.Content, S
      * @param where the starting position &gt;= 0
      * @param len the length to retrieve &gt;= 0
      * @return a string representing the content
-     * @exception BadLocationException if the specified position is invalid
+     * @throws BadLocationException if the specified position is invalid
      * @see AbstractDocument.Content#getString
      */
     public String getString(int where, int len) throws BadLocationException {
@@ -186,7 +186,7 @@ public class GapContent extends GapVector implements AbstractDocument.Content, S
      * @param where the starting position &gt;= 0, where + len &lt;= length()
      * @param len the number of characters to retrieve &gt;= 0
      * @param chars the Segment object to return the characters in
-     * @exception BadLocationException if the specified position is invalid
+     * @throws BadLocationException if the specified position is invalid
      * @see AbstractDocument.Content#getChars
      */
     public void getChars(int where, int len, Segment chars) throws BadLocationException {
@@ -237,7 +237,7 @@ public class GapContent extends GapVector implements AbstractDocument.Content, S
      *
      * @param offset the offset to track &gt;= 0
      * @return the position
-     * @exception BadLocationException if the specified position is invalid
+     * @throws BadLocationException if the specified position is invalid
      */
     public Position createPosition(int offset) throws BadLocationException {
         while ( queue.poll() != null ) {

--- a/src/java.desktop/share/classes/javax/swing/text/GlyphPainter2.java
+++ b/src/java.desktop/share/classes/javax/swing/text/GlyphPainter2.java
@@ -231,8 +231,8 @@ class GlyphPainter2 extends GlyphView.GlyphPainter {
          *  SwingConstants.NORTH, or SwingConstants.SOUTH.
          * @return the location within the model that best represents the next
          *  location visual position.
-         * @exception BadLocationException
-         * @exception IllegalArgumentException for an invalid direction
+         * @throws BadLocationException
+         * @throws IllegalArgumentException for an invalid direction
          */
         public int getNextVisualPositionFrom(GlyphView v, int pos,
                                              Position.Bias b, Shape a,

--- a/src/java.desktop/share/classes/javax/swing/text/GlyphView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/GlyphView.java
@@ -637,7 +637,7 @@ public class GlyphView extends View implements TabableView, Cloneable {
      * @param b   either <code>Position.Bias.Forward</code>
      *                or <code>Position.Bias.Backward</code>
      * @return the bounding box of the given position
-     * @exception BadLocationException  if the given position does not represent a
+     * @throws BadLocationException  if the given position does not represent a
      *   valid location in the associated document
      * @see View#modelToView
      */
@@ -885,9 +885,9 @@ public class GlyphView extends View implements TabableView, Cloneable {
      *  SwingConstants.NORTH, or SwingConstants.SOUTH.
      * @return the location within the model that best represents the next
      *  location visual position.
-     * @exception BadLocationException the given position is not a valid
+     * @throws BadLocationException the given position is not a valid
      *                                 position within the document
-     * @exception IllegalArgumentException for an invalid direction
+     * @throws IllegalArgumentException for an invalid direction
      */
     public int getNextVisualPositionFrom(int pos, Position.Bias b, Shape a,
                                          int direction,
@@ -1199,7 +1199,7 @@ public class GlyphView extends View implements TabableView, Cloneable {
          *                  or <code>Position.Bias.Backward</code>
          * @param a     Bounds of the View
          * @return      the bounding box of the given position
-         * @exception BadLocationException  if the given position does not represent a
+         * @throws BadLocationException  if the given position does not represent a
          *   valid location in the associated document
          * @see View#modelToView
          */
@@ -1283,8 +1283,8 @@ public class GlyphView extends View implements TabableView, Cloneable {
          *                 is returned as the zero-th element of this array
          * @return the location within the model that best represents the next
          *  location visual position.
-         * @exception BadLocationException for a bad location within a document model
-         * @exception IllegalArgumentException for an invalid direction
+         * @throws BadLocationException for a bad location within a document model
+         * @throws IllegalArgumentException for an invalid direction
          */
         public int getNextVisualPositionFrom(GlyphView v, int pos, Position.Bias b, Shape a,
                                              int direction,

--- a/src/java.desktop/share/classes/javax/swing/text/Highlighter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/Highlighter.java
@@ -70,7 +70,7 @@ public interface Highlighter {
      * @param p1 the end of the range &gt;= p0
      * @param p the painter to use for the actual highlighting
      * @return an object that refers to the highlight
-     * @exception BadLocationException for an invalid range specification
+     * @throws BadLocationException for an invalid range specification
      */
     public Object addHighlight(int p0, int p1, HighlightPainter p) throws BadLocationException;
 
@@ -95,7 +95,7 @@ public interface Highlighter {
      * @param tag  which highlight to change
      * @param p0 the beginning of the range &gt;= 0
      * @param p1 the end of the range &gt;= p0
-     * @exception BadLocationException for an invalid range specification
+     * @throws BadLocationException for an invalid range specification
      */
     public void changeHighlight(Object tag, int p0, int p1) throws BadLocationException;
 

--- a/src/java.desktop/share/classes/javax/swing/text/IconView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/IconView.java
@@ -81,7 +81,7 @@ public class IconView extends View  {
      *           Typically the view is told to render into the span
      *           that is returned, although there is no guarantee.
      *           The parent may choose to resize or break the view.
-     * @exception IllegalArgumentException for an invalid axis
+     * @throws IllegalArgumentException for an invalid axis
      */
     public float getPreferredSpan(int axis) {
         switch (axis) {
@@ -123,7 +123,7 @@ public class IconView extends View  {
      * @param pos the position to convert &gt;= 0
      * @param a the allocated region to render into
      * @return the bounding box of the given position
-     * @exception BadLocationException  if the given position does not
+     * @throws BadLocationException  if the given position does not
      *   represent a valid location in the associated document
      * @see View#modelToView
      */

--- a/src/java.desktop/share/classes/javax/swing/text/JTextComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/text/JTextComponent.java
@@ -672,7 +672,7 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
      * component's {@code TransferHandler}.
      *
      * @param b whether or not to enable automatic drag handling
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *            <code>b</code> is <code>true</code> and
      *            <code>GraphicsEnvironment.isHeadless()</code>
      *            returns <code>true</code>
@@ -1358,7 +1358,7 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
      * @param offs the offset &ge; 0
      * @param len the length &ge; 0
      * @return the text
-     * @exception BadLocationException if the offset or length are invalid
+     * @throws BadLocationException if the offset or length are invalid
      */
     public String getText(int offs, int len) throws BadLocationException {
         return getDocument().getText(offs, len);
@@ -1376,7 +1376,7 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
      * @return the coordinates as a rectangle, with (r.x, r.y) as the location
      *   in the coordinate system, or null if the component does
      *   not yet have a positive size.
-     * @exception BadLocationException if the given position does not
+     * @throws BadLocationException if the given position does not
      *   represent a valid location in the associated document
      * @see TextUI#modelToView
      *
@@ -1400,7 +1400,7 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
      * @return the coordinates as a rectangle, with (r.x, r.y) as the location
      *   in the coordinate system, or null if the component does
      *   not yet have a positive size.
-     * @exception BadLocationException if the given position does not
+     * @throws BadLocationException if the given position does not
      *   represent a valid location in the associated document
      * @see TextUI#modelToView2D
      *
@@ -1545,7 +1545,7 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
      * an exception is thrown.
      *
      * @param pos the position
-     * @exception    IllegalArgumentException if the value supplied
+     * @throws    IllegalArgumentException if the value supplied
      *               for <code>position</code> is less than zero or greater
      *               than the component's text length
      * @see #setCaretPosition
@@ -1617,7 +1617,7 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
      *   of documents (such as html for example) might be
      *   able to make use of this information; if non-<code>null</code>,
      *   it is added as a property of the document
-     * @exception IOException as thrown by the stream being
+     * @throws IOException as thrown by the stream being
      *  used to initialize
      * @see EditorKit#createDefaultDocument
      * @see #setDocument
@@ -1643,7 +1643,7 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
      * text.
      *
      * @param out the output stream
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     public void write(Writer out) throws IOException {
         Document doc = getDocument();
@@ -1672,7 +1672,7 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
      * an exception is thrown.
      *
      * @param position the position
-     * @exception    IllegalArgumentException if the value supplied
+     * @throws    IllegalArgumentException if the value supplied
      *               for <code>position</code> is less than zero or greater
      *               than the component's text length
      */
@@ -1743,7 +1743,7 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
      * use <code>DocumentListener</code>.
      *
      * @return the text
-     * @exception NullPointerException if the document is <code>null</code>
+     * @throws NullPointerException if the document is <code>null</code>
      * @see #setText
      */
     public String getText() {
@@ -1763,7 +1763,7 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
      * <code>null</code> or the document empty, returns <code>null</code>.
      *
      * @return the text
-     * @exception IllegalArgumentException if the selection doesn't
+     * @throws IllegalArgumentException if the selection doesn't
      *  have a valid mapping into the document for some reason
      * @see #setText
      */
@@ -2013,7 +2013,7 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
      * @param direction less than zero to scroll up/left, greater than
      *   zero for down/right
      * @return the "unit" increment for scrolling in the specified direction
-     * @exception IllegalArgumentException for an invalid orientation
+     * @throws IllegalArgumentException for an invalid orientation
      * @see JScrollBar#setUnitIncrement
      */
     public int getScrollableUnitIncrement(Rectangle visibleRect, int orientation, int direction) {
@@ -2043,7 +2043,7 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
      * @param direction less than zero to scroll up/left, greater than zero
      *  for down/right
      * @return the "block" increment for scrolling in the specified direction
-     * @exception IllegalArgumentException for an invalid orientation
+     * @throws IllegalArgumentException for an invalid orientation
      * @see JScrollBar#setBlockIncrement
      */
     public int getScrollableBlockIncrement(Rectangle visibleRect, int orientation, int direction) {

--- a/src/java.desktop/share/classes/javax/swing/text/NavigationFilter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/NavigationFilter.java
@@ -105,8 +105,8 @@ public class NavigationFilter {
      * @param biasRet Used to return resulting Bias of next position
      * @return the location within the model that best represents the next
      *  location visual position
-     * @exception BadLocationException for a bad location within a document model
-     * @exception IllegalArgumentException if <code>direction</code>
+     * @throws BadLocationException for a bad location within a document model
+     * @throws IllegalArgumentException if <code>direction</code>
      *          doesn't have one of the legal values above
      */
     public int getNextVisualPositionFrom(JTextComponent text, int pos,

--- a/src/java.desktop/share/classes/javax/swing/text/ParagraphView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/ParagraphView.java
@@ -876,7 +876,7 @@ public class ParagraphView extends FlowView implements TabExpander {
          * @param pos the position to convert
          * @param a the allocated region to render into
          * @return the bounding box of the given position
-         * @exception BadLocationException  if the given position does not represent a
+         * @throws BadLocationException  if the given position does not represent a
          *   valid location in the associated document
          * @see View#modelToView
          */

--- a/src/java.desktop/share/classes/javax/swing/text/PasswordView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/PasswordView.java
@@ -61,7 +61,7 @@ public class PasswordView extends FieldView {
      * @param p0 the starting offset in the model &gt;= 0
      * @param p1 the ending offset in the model &gt;= p0
      * @return the X location of the end of the range &gt;= 0
-     * @exception BadLocationException if p0 or p1 are out of range
+     * @throws BadLocationException if p0 or p1 are out of range
      *
      * @deprecated replaced by
      *     {@link #drawUnselectedText(Graphics2D, float, float, int, int)}
@@ -131,7 +131,7 @@ public class PasswordView extends FieldView {
      * @param p0 the starting offset in the model &gt;= 0
      * @param p1 the ending offset in the model &gt;= p0
      * @return the X location of the end of the range &gt;= 0
-     * @exception BadLocationException if p0 or p1 are out of range
+     * @throws BadLocationException if p0 or p1 are out of range
      *
      * @deprecated replaced by
      *     {@link #drawSelectedText(Graphics2D, float, float, int, int)}
@@ -240,7 +240,7 @@ public class PasswordView extends FieldView {
      * @param pos the position to convert &gt;= 0
      * @param a the allocated region to render into
      * @return the bounding box of the given position
-     * @exception BadLocationException  if the given position does not
+     * @throws BadLocationException  if the given position does not
      *   represent a valid location in the associated document
      * @see View#modelToView
      */

--- a/src/java.desktop/share/classes/javax/swing/text/PlainDocument.java
+++ b/src/java.desktop/share/classes/javax/swing/text/PlainDocument.java
@@ -107,7 +107,7 @@ public class PlainDocument extends AbstractDocument {
      * @param offs the starting offset &gt;= 0
      * @param str the string to insert; does nothing with null/empty strings
      * @param a the attributes for the inserted content
-     * @exception BadLocationException  the given insert position is not a valid
+     * @throws BadLocationException  the given insert position is not a valid
      *   position within the document
      * @see Document#insertString
      */

--- a/src/java.desktop/share/classes/javax/swing/text/PlainView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/PlainView.java
@@ -179,7 +179,7 @@ public class PlainView extends View implements TabExpander {
      * @param p0 the beginning position in the model &gt;= 0
      * @param p1 the ending position in the model &gt;= 0
      * @return the X location of the end of the range &gt;= 0
-     * @exception BadLocationException if the range is invalid
+     * @throws BadLocationException if the range is invalid
      *
      * @deprecated replaced by
      *     {@link #drawUnselectedText(Graphics2D, float, float, int, int)}
@@ -224,7 +224,7 @@ public class PlainView extends View implements TabExpander {
      * @param p0 the beginning position in the model {@code >= 0}
      * @param p1 the ending position in the model {@code >= 0}
      * @return the X location of the end of the range {@code >= 0}
-     * @exception BadLocationException if the range is invalid
+     * @throws BadLocationException if the range is invalid
      *
      * @since 9
      */
@@ -245,7 +245,7 @@ public class PlainView extends View implements TabExpander {
      * @param p0 the beginning position in the model &gt;= 0
      * @param p1 the ending position in the model &gt;= 0
      * @return the location of the end of the range
-     * @exception BadLocationException if the range is invalid
+     * @throws BadLocationException if the range is invalid
      *
      * @deprecated replaced by
      *     {@link #drawSelectedText(Graphics2D, float, float, int, int)}
@@ -294,7 +294,7 @@ public class PlainView extends View implements TabExpander {
      * @param p0 the beginning position in the model {@code >= 0}
      * @param p1 the ending position in the model {@code >= 0}
      * @return the location of the end of the range
-     * @exception BadLocationException if the range is invalid
+     * @throws BadLocationException if the range is invalid
      *
      * @since 9
      */
@@ -351,7 +351,7 @@ public class PlainView extends View implements TabExpander {
      *           Typically the view is told to render into the span
      *           that is returned, although there is no guarantee.
      *           The parent may choose to resize or break the view.
-     * @exception IllegalArgumentException for an invalid axis
+     * @throws IllegalArgumentException for an invalid axis
      */
     public float getPreferredSpan(int axis) {
         updateMetrics();
@@ -468,7 +468,7 @@ public class PlainView extends View implements TabExpander {
      * @param pos the position to convert &gt;= 0
      * @param a the allocated region to render into
      * @return the bounding box of the given position
-     * @exception BadLocationException  if the given position does not
+     * @throws BadLocationException  if the given position does not
      *   represent a valid location in the associated document
      * @see View#modelToView
      */

--- a/src/java.desktop/share/classes/javax/swing/text/StringContent.java
+++ b/src/java.desktop/share/classes/javax/swing/text/StringContent.java
@@ -90,7 +90,7 @@ public final class StringContent implements AbstractDocument.Content, Serializab
      * @param where the starting position &gt;= 0 &amp;&amp; &lt; length()
      * @param str the non-null string to insert
      * @return an UndoableEdit object for undoing
-     * @exception BadLocationException if the specified position is invalid
+     * @throws BadLocationException if the specified position is invalid
      * @see AbstractDocument.Content#insertString
      */
     public UndoableEdit insertString(int where, String str) throws BadLocationException {
@@ -111,7 +111,7 @@ public final class StringContent implements AbstractDocument.Content, Serializab
      * @param where the starting position &gt;= 0
      * @param nitems the number of characters to remove &gt;= 0
      * @return an UndoableEdit object for undoing
-     * @exception BadLocationException if the specified position is invalid
+     * @throws BadLocationException if the specified position is invalid
      * @see AbstractDocument.Content#remove
      */
     public UndoableEdit remove(int where, int nitems) throws BadLocationException {
@@ -134,7 +134,7 @@ public final class StringContent implements AbstractDocument.Content, Serializab
      * @param where the starting position &gt;= 0
      * @param len the length to retrieve &gt;= 0
      * @return a string representing the content; may be empty
-     * @exception BadLocationException if the specified position is invalid
+     * @throws BadLocationException if the specified position is invalid
      * @see AbstractDocument.Content#getString
      */
     public String getString(int where, int len) throws BadLocationException {
@@ -150,7 +150,7 @@ public final class StringContent implements AbstractDocument.Content, Serializab
      * @param where the starting position &gt;= 0
      * @param len the number of characters to retrieve &gt;= 0
      * @param chars the Segment object to return the characters in
-     * @exception BadLocationException if the specified position is invalid
+     * @throws BadLocationException if the specified position is invalid
      * @see AbstractDocument.Content#getChars
      */
     public void getChars(int where, int len, Segment chars) throws BadLocationException {
@@ -168,7 +168,7 @@ public final class StringContent implements AbstractDocument.Content, Serializab
      *
      * @param offset the offset to create a position for &gt;= 0
      * @return the position
-     * @exception BadLocationException if the specified position is invalid
+     * @throws BadLocationException if the specified position is invalid
      */
     public Position createPosition(int offset) throws BadLocationException {
         // some small documents won't have any sticky positions

--- a/src/java.desktop/share/classes/javax/swing/text/StyleContext.java
+++ b/src/java.desktop/share/classes/javax/swing/text/StyleContext.java
@@ -579,7 +579,7 @@ public class StyleContext implements Serializable, AbstractDocument.AttributeCon
      * Context-specific handling of writing out attributes
      * @param out the output stream
      * @param a the attribute set
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     public void writeAttributes(ObjectOutputStream out,
                                   AttributeSet a) throws IOException {
@@ -591,9 +591,9 @@ public class StyleContext implements Serializable, AbstractDocument.AttributeCon
      * @param in the object stream to read the attribute data from.
      * @param a  the attribute set to place the attribute
      *   definitions in.
-     * @exception ClassNotFoundException passed upward if encountered
+     * @throws ClassNotFoundException passed upward if encountered
      *  when reading the object stream.
-     * @exception IOException passed upward if encountered when
+     * @throws IOException passed upward if encountered when
      *  reading the object stream.
      */
     public void readAttributes(ObjectInputStream in,
@@ -613,7 +613,7 @@ public class StyleContext implements Serializable, AbstractDocument.AttributeCon
      *
      * @param out the output stream
      * @param a the attribute set
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     public static void writeAttributeSet(ObjectOutputStream out,
                                          AttributeSet a) throws IOException {
@@ -660,9 +660,9 @@ public class StyleContext implements Serializable, AbstractDocument.AttributeCon
      * @param in the object stream to read the attribute data from.
      * @param a  the attribute set to place the attribute
      *   definitions in.
-     * @exception ClassNotFoundException passed upward if encountered
+     * @throws ClassNotFoundException passed upward if encountered
      *  when reading the object stream.
-     * @exception IOException passed upward if encountered when
+     * @throws IOException passed upward if encountered when
      *  reading the object stream.
      */
     public static void readAttributeSet(ObjectInputStream in,
@@ -1077,7 +1077,7 @@ public class StyleContext implements Serializable, AbstractDocument.AttributeCon
          * Returns the next element of this enumeration.
          *
          * @return     the next element of this enumeration.
-         * @exception  NoSuchElementException  if no more elements exist.
+         * @throws  NoSuchElementException  if no more elements exist.
          * @since      1.0
          */
         public Object nextElement() {

--- a/src/java.desktop/share/classes/javax/swing/text/StyledEditorKit.java
+++ b/src/java.desktop/share/classes/javax/swing/text/StyledEditorKit.java
@@ -411,7 +411,7 @@ public class StyledEditorKit extends DefaultEditorKit {
          *
          * @param e the editor
          * @return the document
-         * @exception IllegalArgumentException for the wrong document type
+         * @throws IllegalArgumentException for the wrong document type
          */
         protected final StyledDocument getStyledDocument(JEditorPane e) {
             Document d = e.getDocument();
@@ -426,7 +426,7 @@ public class StyledEditorKit extends DefaultEditorKit {
          *
          * @param e the editor pane
          * @return the kit
-         * @exception IllegalArgumentException for the wrong document type
+         * @throws IllegalArgumentException for the wrong document type
          */
         protected final StyledEditorKit getStyledEditorKit(JEditorPane e) {
             EditorKit k = e.getEditorKit();

--- a/src/java.desktop/share/classes/javax/swing/text/TableView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/TableView.java
@@ -805,7 +805,7 @@ public abstract class TableView extends BoxView {
          *
          * @param axis may be either View.X_AXIS or View.Y_AXIS
          * @return the resize weight
-         * @exception IllegalArgumentException for an invalid axis
+         * @throws IllegalArgumentException for an invalid axis
          */
         public int getResizeWeight(int axis) {
             return 1;

--- a/src/java.desktop/share/classes/javax/swing/text/Utilities.java
+++ b/src/java.desktop/share/classes/javax/swing/text/Utilities.java
@@ -683,7 +683,7 @@ public class Utilities {
      * @param offs the offset in the document &gt;= 0
      * @return the position &gt;= 0 if the request can be computed, otherwise
      *  a value of -1 will be returned.
-     * @exception BadLocationException if the offset is out of range
+     * @throws BadLocationException if the offset is out of range
      */
     @SuppressWarnings("deprecation")
     public static final int getRowStart(JTextComponent c, int offs) throws BadLocationException {
@@ -714,7 +714,7 @@ public class Utilities {
      * @param offs the offset in the document &gt;= 0
      * @return the position &gt;= 0 if the request can be computed, otherwise
      *  a value of -1 will be returned.
-     * @exception BadLocationException if the offset is out of range
+     * @throws BadLocationException if the offset is out of range
      */
     @SuppressWarnings("deprecation")
     public static final int getRowEnd(JTextComponent c, int offs) throws BadLocationException {
@@ -747,7 +747,7 @@ public class Utilities {
      * @param x the X coordinate &gt;= 0
      * @return the position &gt;= 0 if the request can be computed, otherwise
      *  a value of -1 will be returned.
-     * @exception BadLocationException if the offset is out of range
+     * @throws BadLocationException if the offset is out of range
      *
      * @deprecated replaced by
      *     {@link #getPositionAbove(JTextComponent, int, float)}
@@ -802,7 +802,7 @@ public class Utilities {
      * @param x the X coordinate {@code >= 0}
      * @return the position {@code >= 0} if the request can be computed, otherwise
      *  a value of -1 will be returned.
-     * @exception BadLocationException if the offset is out of range
+     * @throws BadLocationException if the offset is out of range
      *
      * @since 9
      */
@@ -822,7 +822,7 @@ public class Utilities {
      * @param x the X coordinate &gt;= 0
      * @return the position &gt;= 0 if the request can be computed, otherwise
      *  a value of -1 will be returned.
-     * @exception BadLocationException if the offset is out of range
+     * @throws BadLocationException if the offset is out of range
      *
      * @deprecated replaced by
      *     {@link #getPositionBelow(JTextComponent, int, float)}
@@ -878,7 +878,7 @@ public class Utilities {
      * @param x the X coordinate {@code >= 0}
      * @return the position {@code >= 0} if the request can be computed, otherwise
      *  a value of -1 will be returned.
-     * @exception BadLocationException if the offset is out of range
+     * @throws BadLocationException if the offset is out of range
      *
      * @since 9
      */
@@ -894,7 +894,7 @@ public class Utilities {
      * @param c the editor
      * @param offs the offset in the document &gt;= 0
      * @return the location in the model of the word start &gt;= 0
-     * @exception BadLocationException if the offset is out of range
+     * @throws BadLocationException if the offset is out of range
      */
     public static final int getWordStart(JTextComponent c, int offs) throws BadLocationException {
         Document doc = c.getDocument();
@@ -928,7 +928,7 @@ public class Utilities {
      * @param c the editor
      * @param offs the offset in the document &gt;= 0
      * @return the location in the model of the word end &gt;= 0
-     * @exception BadLocationException if the offset is out of range
+     * @throws BadLocationException if the offset is out of range
      */
     public static final int getWordEnd(JTextComponent c, int offs) throws BadLocationException {
         Document doc = c.getDocument();
@@ -961,7 +961,7 @@ public class Utilities {
      * @param c the editor
      * @param offs the offset in the document &gt;= 0
      * @return the location in the model of the word start &gt;= 0
-     * @exception BadLocationException if the offset is out of range
+     * @throws BadLocationException if the offset is out of range
      */
     public static final int getNextWord(JTextComponent c, int offs) throws BadLocationException {
         int nextWord;
@@ -1039,7 +1039,7 @@ public class Utilities {
      * @param c the editor
      * @param offs the offset in the document &gt;= 0
      * @return the location in the model of the word start &gt;= 0
-     * @exception BadLocationException if the offset is out of range
+     * @throws BadLocationException if the offset is out of range
      */
     public static final int getPreviousWord(JTextComponent c, int offs) throws BadLocationException {
         int prevWord;
@@ -1271,8 +1271,8 @@ public class Utilities {
      * @param biasRet an array contain the bias that was checked
      * @return the location within the model that best represents the next
      *  location visual position
-     * @exception BadLocationException
-     * @exception IllegalArgumentException if <code>direction</code> is invalid
+     * @throws BadLocationException
+     * @throws IllegalArgumentException if <code>direction</code> is invalid
      */
     static int getNextVisualPositionFrom(View v, int pos, Position.Bias b,
                                           Shape alloc, int direction,

--- a/src/java.desktop/share/classes/javax/swing/text/View.java
+++ b/src/java.desktop/share/classes/javax/swing/text/View.java
@@ -495,9 +495,9 @@ public abstract class View implements SwingConstants {
      * @param biasRet the returned bias
      * @return the location within the model that best represents the next
      *  location visual position
-     * @exception BadLocationException the given position is not a valid
+     * @throws BadLocationException the given position is not a valid
      *                                 position within the document
-     * @exception IllegalArgumentException if <code>direction</code>
+     * @throws IllegalArgumentException if <code>direction</code>
      *          doesn't have one of the legal values above
      */
     @SuppressWarnings("deprecation")
@@ -585,9 +585,9 @@ public abstract class View implements SwingConstants {
      * </ul>
      * @return the bounding box, in view coordinate space,
      *          of the character at the specified position
-     * @exception BadLocationException  if the specified position does
+     * @throws BadLocationException  if the specified position does
      *   not represent a valid location in the associated document
-     * @exception IllegalArgumentException if <code>b</code> is not one of the
+     * @throws IllegalArgumentException if <code>b</code> is not one of the
      *          legal <code>Position.Bias</code> values listed above
      * @see View#viewToModel
      */
@@ -615,9 +615,9 @@ public abstract class View implements SwingConstants {
      * @param a the area of the view, which encompasses the requested region
      * @return the bounding box which is a union of the region specified
      *          by the first and last character positions
-     * @exception BadLocationException  if the given position does
+     * @throws BadLocationException  if the given position does
      *   not represent a valid location in the associated document
-     * @exception IllegalArgumentException if <code>b0</code> or
+     * @throws IllegalArgumentException if <code>b0</code> or
      *          <code>b1</code> are not one of the
      *          legal <code>Position.Bias</code> values listed above
      * @see View#viewToModel
@@ -1337,7 +1337,7 @@ public abstract class View implements SwingConstants {
      * @param pos the position to convert &gt;= 0
      * @param a the allocated region in which to render
      * @return the bounding box of the given position is returned
-     * @exception BadLocationException  if the given position does
+     * @throws BadLocationException  if the given position does
      *   not represent a valid location in the associated document
      * @see View#modelToView
      * @deprecated

--- a/src/java.desktop/share/classes/javax/swing/text/WrappedPlainView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/WrappedPlainView.java
@@ -207,7 +207,7 @@ public class WrappedPlainView extends BoxView implements TabExpander {
      * @param p0 the beginning position in the model &gt;= 0
      * @param p1 the ending position in the model &gt;= p0
      * @return the X location of the end of the range &gt;= 0
-     * @exception BadLocationException if the range is invalid
+     * @throws BadLocationException if the range is invalid
      *
      * @deprecated replaced by
      *     {@link #drawUnselectedText(Graphics2D, float, float, int, int)}
@@ -252,7 +252,7 @@ public class WrappedPlainView extends BoxView implements TabExpander {
      * @param p0 the beginning position in the model &gt;= 0
      * @param p1 the ending position in the model &gt;= p0
      * @return the X location of the end of the range &gt;= 0
-     * @exception BadLocationException if the range is invalid
+     * @throws BadLocationException if the range is invalid
      *
      * @since 9
      */
@@ -272,7 +272,7 @@ public class WrappedPlainView extends BoxView implements TabExpander {
      * @param p0 the beginning position in the model &gt;= 0
      * @param p1 the ending position in the model &gt;= p0
      * @return the location of the end of the range.
-     * @exception BadLocationException if the range is invalid
+     * @throws BadLocationException if the range is invalid
      *
      * @deprecated replaced by
      *     {@link #drawSelectedText(Graphics2D, float, float, int, int)}
@@ -320,7 +320,7 @@ public class WrappedPlainView extends BoxView implements TabExpander {
      * @param p0 the beginning position in the model &gt;= 0
      * @param p1 the ending position in the model &gt;= p0
      * @return the location of the end of the range.
-     * @exception BadLocationException if the range is invalid
+     * @throws BadLocationException if the range is invalid
      *
      * @since 9
      */
@@ -748,7 +748,7 @@ public class WrappedPlainView extends BoxView implements TabExpander {
          * @param pos the position to convert
          * @param a the allocated region to render into
          * @return the bounding box of the given position is returned
-         * @exception BadLocationException  if the given position does not represent a
+         * @throws BadLocationException  if the given position does not represent a
          *   valid location in the associated document
          * @see View#modelToView
          */

--- a/src/java.desktop/share/classes/javax/swing/text/ZoneView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/ZoneView.java
@@ -134,7 +134,7 @@ public class ZoneView extends BoxView {
      *
      * @param mzl the desired maximum number of zones
      *  to be actively loaded, must be greater than 0
-     * @exception IllegalArgumentException if <code>mzl</code> is &lt; 1
+     * @throws IllegalArgumentException if <code>mzl</code> is &lt; 1
      */
     public void setMaxZonesLoaded(int mzl) {
         if (mzl < 1) {
@@ -579,7 +579,7 @@ public class ZoneView extends BoxView {
          * @param pos the position to convert
          * @param a the allocated region to render into
          * @return the bounding box of the given position
-         * @exception BadLocationException  if the given position does not represent a
+         * @throws BadLocationException  if the given position does not represent a
          *   valid location in the associated document
          * @see View#modelToView
          */

--- a/src/java.desktop/share/classes/javax/swing/text/html/AccessibleHTML.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/AccessibleHTML.java
@@ -384,7 +384,7 @@ class AccessibleHTML implements Accessible {
          * @return this component's locale.  If this component does not have
          * a locale, the locale of its parent is returned.
          *
-         * @exception IllegalComponentStateException
+         * @throws IllegalComponentStateException
          * If the Component does not have its own locale and has not yet been
          * added to a containment hierarchy such that the locale can be
          * determined from the containing parent.

--- a/src/java.desktop/share/classes/javax/swing/text/html/BlockView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/BlockView.java
@@ -300,7 +300,7 @@ public class BlockView extends BoxView  {
      *
      * @param axis may be either X_AXIS or Y_AXIS
      * @return the weight
-     * @exception IllegalArgumentException for an invalid axis
+     * @throws IllegalArgumentException for an invalid axis
      */
     public int getResizeWeight(int axis) {
         switch (axis) {
@@ -356,7 +356,7 @@ public class BlockView extends BoxView  {
      *           typically the view is told to render into the span
      *           that is returned, although there is no guarantee;
      *           the parent may choose to resize or break the view
-     * @exception IllegalArgumentException for an invalid axis type
+     * @throws IllegalArgumentException for an invalid axis type
      */
     public float getPreferredSpan(int axis) {
         return super.getPreferredSpan(axis);
@@ -372,7 +372,7 @@ public class BlockView extends BoxView  {
      *           typically the view is told to render into the span
      *           that is returned, although there is no guarantee;
      *           the parent may choose to resize or break the view
-     * @exception IllegalArgumentException for an invalid axis type
+     * @throws IllegalArgumentException for an invalid axis type
      */
     public float getMinimumSpan(int axis) {
         return super.getMinimumSpan(axis);
@@ -388,7 +388,7 @@ public class BlockView extends BoxView  {
      *           typically the view is told to render into the span
      *           that is returned, although there is no guarantee;
      *           the parent may choose to resize or break the view
-     * @exception IllegalArgumentException for an invalid axis type
+     * @throws IllegalArgumentException for an invalid axis type
      */
     public float getMaximumSpan(int axis) {
         return super.getMaximumSpan(axis);

--- a/src/java.desktop/share/classes/javax/swing/text/html/FormView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/FormView.java
@@ -380,7 +380,7 @@ public class FormView extends ComponentView implements ActionListener {
      *           Typically the view is told to render into the span
      *           that is returned, although there is no guarantee.
      *           The parent may choose to resize or break the view.
-     * @exception IllegalArgumentException for an invalid axis
+     * @throws IllegalArgumentException for an invalid axis
      */
     public float getMaximumSpan(int axis) {
         switch (axis) {

--- a/src/java.desktop/share/classes/javax/swing/text/html/HRuleView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HRuleView.java
@@ -245,7 +245,7 @@ class HRuleView extends View  {
      * @param pos the position to convert
      * @param a the allocated region to render into
      * @return the bounding box of the given position
-     * @exception BadLocationException  if the given position does not
+     * @throws BadLocationException  if the given position does not
      * represent a valid location in the associated document
      * @see View#modelToView
      */

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
@@ -427,7 +427,7 @@ public class HTMLDocument extends DefaultStyledDocument {
      *
      * @param offset the starting offset
      * @param data the element data
-     * @exception BadLocationException  if the given position does not
+     * @throws BadLocationException  if the given position does not
      *   represent a valid location in the associated document.
      */
     protected void insert(int offset, ElementSpec[] data) throws BadLocationException {

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
@@ -298,10 +298,10 @@ public class HTMLEditorKit extends StyledEditorKit implements Accessible {
      * @param doc the destination for the insertion
      * @param pos the location in the document to place the
      *   content
-     * @exception IOException on any I/O error
-     * @exception BadLocationException if pos represents an invalid
+     * @throws IOException on any I/O error
+     * @throws BadLocationException if pos represents an invalid
      *   location within the document
-     * @exception RuntimeException (will eventually be a BadLocationException)
+     * @throws RuntimeException (will eventually be a BadLocationException)
      *            if pos is invalid
      */
     public void read(Reader in, Document doc, int pos) throws IOException, BadLocationException {
@@ -337,7 +337,7 @@ public class HTMLEditorKit extends StyledEditorKit implements Accessible {
      *
      * @throws BadLocationException if {@code offset} is invalid
      * @throws IOException on I/O error
-     * @exception RuntimeException (will eventually be a BadLocationException)
+     * @throws RuntimeException (will eventually be a BadLocationException)
      *            if pos is invalid
      */
     public void insertHTML(HTMLDocument doc, int offset, String html,
@@ -367,8 +367,8 @@ public class HTMLEditorKit extends StyledEditorKit implements Accessible {
      * @param pos the location in the document to fetch the
      *   content
      * @param len the amount to write out
-     * @exception IOException on any I/O error
-     * @exception BadLocationException if {@code pos} represents an invalid
+     * @throws IOException on any I/O error
+     * @throws BadLocationException if {@code pos} represents an invalid
      *   location within the document
      */
     public void write(Writer out, Document doc, int pos, int len)

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLWriter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLWriter.java
@@ -125,8 +125,8 @@ public class HTMLWriter extends AbstractWriter {
      * Element tree and controls the writing out of
      * all the tags and its attributes.
      *
-     * @exception IOException on any I/O error
-     * @exception BadLocationException if pos represents an invalid
+     * @throws IOException on any I/O error
+     * @throws BadLocationException if pos represents an invalid
      *            location within the document.
      *
      */
@@ -248,7 +248,7 @@ public class HTMLWriter extends AbstractWriter {
      * HTML.Attribute.ENDTAG.
      *
      * @param attr   an AttributeSet
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      *
      */
     protected void writeAttributes(AttributeSet attr) throws IOException {
@@ -273,8 +273,8 @@ public class HTMLWriter extends AbstractWriter {
      * corresponding end tag).
      *
      * @param elem   an Element
-     * @exception IOException on any I/O error
-     * @exception BadLocationException if pos represents an invalid
+     * @throws IOException on any I/O error
+     * @throws BadLocationException if pos represents an invalid
      *            location within the document.
      */
     protected void emptyTag(Element elem) throws BadLocationException, IOException {
@@ -451,8 +451,8 @@ public class HTMLWriter extends AbstractWriter {
      * element.
      *
      * @param attr  an AttributeSet
-     * @exception IOException on any I/O error
-     * @exception BadLocationException if pos represents an invalid
+     * @throws IOException on any I/O error
+     * @throws BadLocationException if pos represents an invalid
      *            location within the document.
      */
     protected void textAreaContent(AttributeSet attr) throws BadLocationException, IOException {
@@ -485,8 +485,8 @@ public class HTMLWriter extends AbstractWriter {
      * out.
      *
      * @param elem   an Element
-     * @exception IOException on any I/O error
-     * @exception BadLocationException if pos represents an invalid
+     * @throws IOException on any I/O error
+     * @throws BadLocationException if pos represents an invalid
      *            location within the document.
      */
     protected void text(Element elem) throws BadLocationException, IOException {
@@ -523,7 +523,7 @@ public class HTMLWriter extends AbstractWriter {
      * Writes out the content of the SELECT form element.
      *
      * @param attr the AttributeSet associated with the form element
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     protected void selectContent(AttributeSet attr) throws IOException {
         Object model = attr.getAttribute(StyleConstants.ModelAttribute);
@@ -552,7 +552,7 @@ public class HTMLWriter extends AbstractWriter {
     /**
      * Writes out the content of the Option form element.
      * @param option  an Option
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      *
      */
     protected void writeOption(Option option) throws IOException {
@@ -580,7 +580,7 @@ public class HTMLWriter extends AbstractWriter {
      * Writes out an end tag for the element.
      *
      * @param elem    an Element
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     protected void endTag(Element elem) throws IOException {
         if (synthesizedElement(elem)) {
@@ -615,8 +615,8 @@ public class HTMLWriter extends AbstractWriter {
      * Writes out comments.
      *
      * @param elem    an Element
-     * @exception IOException on any I/O error
-     * @exception BadLocationException if pos represents an invalid
+     * @throws IOException on any I/O error
+     * @throws BadLocationException if pos represents an invalid
      *            location within the document.
      */
     protected void comment(Element elem) throws BadLocationException, IOException {
@@ -637,8 +637,8 @@ public class HTMLWriter extends AbstractWriter {
      * Writes out comment string.
      *
      * @param string   the comment
-     * @exception IOException on any I/O error
-     * @exception BadLocationException if pos represents an invalid
+     * @throws IOException on any I/O error
+     * @throws BadLocationException if pos represents an invalid
      *            location within the document.
      */
     void writeComment(String string) throws IOException {
@@ -712,7 +712,7 @@ public class HTMLWriter extends AbstractWriter {
      * written out.
      *
      * @param attr a set of attributes
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     protected void writeEmbeddedTags(AttributeSet attr) throws IOException {
 
@@ -767,7 +767,7 @@ public class HTMLWriter extends AbstractWriter {
      * end tag is written out.
      *
      * @param attr a set of attributes
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     protected void closeOutUnwantedEmbeddedTags(AttributeSet attr) throws IOException {
 

--- a/src/java.desktop/share/classes/javax/swing/text/html/ImageView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/ImageView.java
@@ -557,7 +557,7 @@ public class ImageView extends View {
      * @param pos the position to convert
      * @param a the allocated region to render into
      * @return the bounding box of the given position
-     * @exception BadLocationException  if the given position does not represent a
+     * @throws BadLocationException  if the given position does not represent a
      *   valid location in the associated document
      * @see View#modelToView
      */

--- a/src/java.desktop/share/classes/javax/swing/text/html/MinimalHTMLWriter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/MinimalHTMLWriter.java
@@ -128,8 +128,8 @@ public class MinimalHTMLWriter extends AbstractWriter {
      * Generates HTML output
      * from a StyledDocument.
      *
-     * @exception IOException on any I/O error
-     * @exception BadLocationException if pos represents an invalid
+     * @throws IOException on any I/O error
+     * @throws BadLocationException if pos represents an invalid
      *            location within the document.
      *
      */
@@ -152,7 +152,7 @@ public class MinimalHTMLWriter extends AbstractWriter {
      * The attribute name and value are separated by a colon.
      * Each pair is separated by a semicolon.
      *
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     protected void writeAttributes(AttributeSet attr) throws IOException {
         Enumeration<?> attributeNames = attr.getAttributeNames();
@@ -178,7 +178,7 @@ public class MinimalHTMLWriter extends AbstractWriter {
     /**
      * Writes out text.
      *
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     protected void text(Element elem) throws IOException, BadLocationException {
         String contentStr = getText(elem);
@@ -196,7 +196,7 @@ public class MinimalHTMLWriter extends AbstractWriter {
      * indented.  Also increments the indent level.
      *
      * @param tag a start tag
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     protected void writeStartTag(String tag) throws IOException {
         indent();
@@ -211,7 +211,7 @@ public class MinimalHTMLWriter extends AbstractWriter {
      * indented.  Also decrements the indent level.
      *
      * @param endTag an end tag
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     protected void writeEndTag(String endTag) throws IOException {
         decrIndent();
@@ -230,7 +230,7 @@ public class MinimalHTMLWriter extends AbstractWriter {
      * document is viewable in applications/browsers
      * that do not support the tag.
      *
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     protected void writeHeader() throws IOException {
         writeStartTag("<head>");
@@ -248,7 +248,7 @@ public class MinimalHTMLWriter extends AbstractWriter {
      * Writes out all the named styles as the
      * content of the &lt;style&gt; tag.
      *
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     protected void writeStyles() throws IOException {
         /*
@@ -338,7 +338,7 @@ public class MinimalHTMLWriter extends AbstractWriter {
      * that all other tags that have been opened are
      * appropriately closed off.
      *
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     protected void writeEndParagraph() throws IOException {
         writeEndMask(fontMask);
@@ -359,7 +359,7 @@ public class MinimalHTMLWriter extends AbstractWriter {
      * style.
      *
      * @param elem an element
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     protected void writeStartParagraph(Element elem) throws IOException {
         AttributeSet attr = elem.getAttributes();
@@ -377,7 +377,7 @@ public class MinimalHTMLWriter extends AbstractWriter {
      * elements.
      *
      * @param elem an element
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     protected void writeLeaf(Element elem) throws IOException {
         indent();
@@ -434,8 +434,8 @@ public class MinimalHTMLWriter extends AbstractWriter {
      *
      * @param elem an element
      * @param needsIndenting indention will be added if {@code needsIndenting} is {@code true}
-     * @exception IOException on any I/O error
-     * @exception BadLocationException if pos represents an invalid
+     * @throws IOException on any I/O error
+     * @throws BadLocationException if pos represents an invalid
      *            location within the document.
      */
     protected void writeContent(Element elem,  boolean needsIndenting)
@@ -457,7 +457,7 @@ public class MinimalHTMLWriter extends AbstractWriter {
      * text based on its attribute settings.
      *
      * @param attr a set of attributes
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
 
     protected void writeHTMLTags(AttributeSet attr) throws IOException {
@@ -522,7 +522,7 @@ public class MinimalHTMLWriter extends AbstractWriter {
      * Writes out start tags &lt;u&gt;, &lt;i&gt;, and &lt;b&gt; based on
      * the mask settings.
      *
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     private void writeStartMask(int mask) throws IOException  {
         if (mask != 0) {
@@ -542,7 +542,7 @@ public class MinimalHTMLWriter extends AbstractWriter {
      * Writes out end tags for &lt;u&gt;, &lt;i&gt;, and &lt;b&gt; based on
      * the mask settings.
      *
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     private void writeEndMask(int mask) throws IOException {
         if (mask != 0) {
@@ -569,7 +569,7 @@ public class MinimalHTMLWriter extends AbstractWriter {
      * attributes just like inline styles.
      *
      * @param attr a set of attributes
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     protected void writeNonHTMLAttributes(AttributeSet attr) throws IOException {
 
@@ -636,7 +636,7 @@ public class MinimalHTMLWriter extends AbstractWriter {
      * <p>
      * Writes out an end tag for the &lt;font&gt; tag.
      *
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     protected void endFontTag() throws IOException {
         write(NEWLINE);
@@ -655,7 +655,7 @@ public class MinimalHTMLWriter extends AbstractWriter {
      * new start tag.
      *
      * @param style a font style
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     protected void startFontTag(String style) throws IOException {
         boolean callIndent = false;
@@ -676,7 +676,7 @@ public class MinimalHTMLWriter extends AbstractWriter {
      * any enclosing font tag before writing out a
      * new start tag.
      *
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     private void startSpanTag(String style) throws IOException {
         boolean callIndent = false;
@@ -693,7 +693,7 @@ public class MinimalHTMLWriter extends AbstractWriter {
     /**
      * Writes out an end tag for the &lt;span&gt; tag.
      *
-     * @exception IOException on any I/O error
+     * @throws IOException on any I/O error
      */
     private void endSpanTag() throws IOException {
         write(NEWLINE);

--- a/src/java.desktop/share/classes/javax/swing/text/html/OptionListModel.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/OptionListModel.java
@@ -464,7 +464,7 @@ class OptionListModel<E> extends DefaultListModel<E> implements ListSelectionMod
      * <code>listenerLists</code> are not duplicated.
      *
      * @return a clone of the receiver
-     * @exception CloneNotSupportedException if the receiver does not
+     * @throws CloneNotSupportedException if the receiver does not
      *    both (a) implement the <code>Cloneable</code> interface
      *    and (b) define a <code>clone</code> method
      */

--- a/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
@@ -1886,7 +1886,7 @@ public class StyleSheet extends StyleContext {
          *  used to get the AttributeSet, and may be used to
          *  resolve percentage arguments.
          * @return the inset needed for the margin, border and padding.
-         * @exception IllegalArgumentException for an invalid direction
+         * @throws IllegalArgumentException for an invalid direction
          */
         public float getInset(int side, View v) {
             AttributeSet a = v.getAttributes();

--- a/src/java.desktop/share/classes/javax/swing/text/html/TableView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/TableView.java
@@ -1611,7 +1611,7 @@ import javax.swing.text.*;
          *
          * @param axis may be either View.X_AXIS or View.Y_AXIS
          * @return the resize weight
-         * @exception IllegalArgumentException for an invalid axis
+         * @throws IllegalArgumentException for an invalid axis
          */
         public int getResizeWeight(int axis) {
             return 1;

--- a/src/java.desktop/share/classes/javax/swing/text/rtf/RTFEditorKit.java
+++ b/src/java.desktop/share/classes/javax/swing/text/rtf/RTFEditorKit.java
@@ -70,8 +70,8 @@ public class RTFEditorKit extends StyledEditorKit {
      * @param doc The destination for the insertion.
      * @param pos The location in the document to place the
      *   content.
-     * @exception IOException on any I/O error
-     * @exception BadLocationException if pos represents an invalid
+     * @throws IOException on any I/O error
+     * @throws BadLocationException if pos represents an invalid
      *   location within the document.
      */
     public void read(InputStream in, Document doc, int pos) throws IOException, BadLocationException {
@@ -97,8 +97,8 @@ public class RTFEditorKit extends StyledEditorKit {
      * @param pos The location in the document to fetch the
      *   content.
      * @param len The amount to write out.
-     * @exception IOException on any I/O error
-     * @exception BadLocationException if pos represents an invalid
+     * @throws IOException on any I/O error
+     * @throws BadLocationException if pos represents an invalid
      *   location within the document.
      */
     public void write(OutputStream out, Document doc, int pos, int len)
@@ -117,8 +117,8 @@ public class RTFEditorKit extends StyledEditorKit {
      * @param doc The destination for the insertion.
      * @param pos The location in the document to place the
      *   content.
-     * @exception IOException on any I/O error
-     * @exception BadLocationException if pos represents an invalid
+     * @throws IOException on any I/O error
+     * @throws BadLocationException if pos represents an invalid
      *   location within the document.
      */
     public void read(Reader in, Document doc, int pos)
@@ -143,8 +143,8 @@ public class RTFEditorKit extends StyledEditorKit {
      * @param pos The location in the document to fetch the
      *   content.
      * @param len The amount to write out.
-     * @exception IOException on any I/O error
-     * @exception BadLocationException if pos represents an invalid
+     * @throws IOException on any I/O error
+     * @throws BadLocationException if pos represents an invalid
      *   location within the document.
      */
     public void write(Writer out, Document doc, int pos, int len)

--- a/src/java.desktop/share/classes/javax/swing/tree/DefaultMutableTreeNode.java
+++ b/src/java.desktop/share/classes/javax/swing/tree/DefaultMutableTreeNode.java
@@ -174,12 +174,12 @@ public class DefaultMutableTreeNode implements Cloneable,
      * @param   newChild        the MutableTreeNode to insert under this node
      * @param   childIndex      the index in this node's child array
      *                          where this node is to be inserted
-     * @exception       ArrayIndexOutOfBoundsException  if
+     * @throws       ArrayIndexOutOfBoundsException  if
      *                          <code>childIndex</code> is out of bounds
-     * @exception       IllegalArgumentException        if
+     * @throws       IllegalArgumentException        if
      *                          <code>newChild</code> is null or is an
      *                          ancestor of this node
-     * @exception       IllegalStateException   if this node does not allow
+     * @throws       IllegalStateException   if this node does not allow
      *                                          children
      * @see     #isNodeDescendant
      */
@@ -211,7 +211,7 @@ public class DefaultMutableTreeNode implements Cloneable,
      *
      * @param   childIndex      the index in this node's child array
      *                          of the child to remove
-     * @exception       ArrayIndexOutOfBoundsException  if
+     * @throws       ArrayIndexOutOfBoundsException  if
      *                          <code>childIndex</code> is out of bounds
      */
     public void remove(int childIndex) {
@@ -247,7 +247,7 @@ public class DefaultMutableTreeNode implements Cloneable,
      * Returns the child at the specified index in this node's child array.
      *
      * @param   index   an index into this node's child array
-     * @exception       ArrayIndexOutOfBoundsException  if <code>index</code>
+     * @throws       ArrayIndexOutOfBoundsException  if <code>index</code>
      *                                          is out of bounds
      * @return  the TreeNode in this node's child array at  the specified index
      */
@@ -278,7 +278,7 @@ public class DefaultMutableTreeNode implements Cloneable,
      * where n is the number of children.
      *
      * @param   aChild  the TreeNode to search for among this node's children
-     * @exception       IllegalArgumentException        if <code>aChild</code>
+     * @throws       IllegalArgumentException        if <code>aChild</code>
      *                                                  is null
      * @return  an int giving the index of the node in this node's child
      *          array, or <code>-1</code> if the specified node is a not
@@ -382,7 +382,7 @@ public class DefaultMutableTreeNode implements Cloneable,
      * null parent.
      *
      * @param   aChild  a child of this node to remove
-     * @exception       IllegalArgumentException        if <code>aChild</code>
+     * @throws       IllegalArgumentException        if <code>aChild</code>
      *                                  is null or is not a child of this node
      */
     public void remove(MutableTreeNode aChild) {
@@ -412,9 +412,9 @@ public class DefaultMutableTreeNode implements Cloneable,
      *
      * @see             #insert
      * @param   newChild        node to add as a child of this node
-     * @exception       IllegalArgumentException    if <code>newChild</code>
+     * @throws       IllegalArgumentException    if <code>newChild</code>
      *                                          is null
-     * @exception       IllegalStateException   if this node does not allow
+     * @throws       IllegalStateException   if this node does not allow
      *                                          children
      */
     public void add(MutableTreeNode newChild) {
@@ -846,7 +846,7 @@ public class DefaultMutableTreeNode implements Cloneable,
      * @param           ancestor the node to start enumeration from
      * @see             #isNodeAncestor
      * @see             #isNodeDescendant
-     * @exception       IllegalArgumentException if <code>ancestor</code> is
+     * @throws       IllegalArgumentException if <code>ancestor</code> is
      *                                          not an ancestor of this node
      * @return  an enumeration for following the path from an ancestor of
      *          this node to this one
@@ -890,7 +890,7 @@ public class DefaultMutableTreeNode implements Cloneable,
      * throws NoSuchElementException.
      *
      * @return  the first child of this node
-     * @exception       NoSuchElementException  if this node has no children
+     * @throws       NoSuchElementException  if this node has no children
      */
     public TreeNode getFirstChild() {
         if (getChildCount() == 0) {
@@ -905,7 +905,7 @@ public class DefaultMutableTreeNode implements Cloneable,
      * throws NoSuchElementException.
      *
      * @return  the last child of this node
-     * @exception       NoSuchElementException  if this node has no children
+     * @throws       NoSuchElementException  if this node has no children
      */
     public TreeNode getLastChild() {
         if (getChildCount() == 0) {
@@ -925,7 +925,7 @@ public class DefaultMutableTreeNode implements Cloneable,
      *
      * @param           aChild the child node to look for next child after it
      * @see             #children
-     * @exception       IllegalArgumentException if <code>aChild</code> is
+     * @throws       IllegalArgumentException if <code>aChild</code> is
      *                                  null or is not a child of this node
      * @return  the child of this node that immediately follows
      *          <code>aChild</code>
@@ -957,7 +957,7 @@ public class DefaultMutableTreeNode implements Cloneable,
      * and is O(n) where n is the number of children.
      *
      * @param           aChild the child node to look for previous child before it
-     * @exception       IllegalArgumentException if <code>aChild</code> is null
+     * @throws       IllegalArgumentException if <code>aChild</code> is null
      *                                          or is not a child of this node
      * @return  the child of this node that immediately precedes
      *          <code>aChild</code>

--- a/src/java.desktop/share/classes/javax/swing/tree/DefaultTreeModel.java
+++ b/src/java.desktop/share/classes/javax/swing/tree/DefaultTreeModel.java
@@ -672,7 +672,7 @@ public class DefaultTreeModel implements Serializable, TreeModel {
      *          <code><em>Foo</em>Listener</code>s on this component,
      *          or an empty array if no such
      *          listeners have been added
-     * @exception ClassCastException if <code>listenerType</code>
+     * @throws ClassCastException if <code>listenerType</code>
      *          doesn't specify a class or interface that implements
      *          <code>java.util.EventListener</code>
      *

--- a/src/java.desktop/share/classes/javax/swing/tree/DefaultTreeSelectionModel.java
+++ b/src/java.desktop/share/classes/javax/swing/tree/DefaultTreeSelectionModel.java
@@ -679,7 +679,7 @@ public class DefaultTreeSelectionModel implements Cloneable, Serializable, TreeS
      *          <code><em>Foo</em>Listener</code>s on this component,
      *          or an empty array if no such
      *          listeners have been added
-     * @exception ClassCastException if <code>listenerType</code>
+     * @throws ClassCastException if <code>listenerType</code>
      *          doesn't specify a class or interface that implements
      *          <code>java.util.EventListener</code>
      *
@@ -1187,7 +1187,7 @@ public class DefaultTreeSelectionModel implements Cloneable, Serializable, TreeS
      * This method does not duplicate
      * selection listeners and property listeners.
      *
-     * @exception CloneNotSupportedException never thrown by instances of
+     * @throws CloneNotSupportedException never thrown by instances of
      *                                       this class
      */
     public Object clone() throws CloneNotSupportedException {

--- a/src/java.desktop/share/classes/javax/swing/undo/AbstractUndoableEdit.java
+++ b/src/java.desktop/share/classes/javax/swing/undo/AbstractUndoableEdit.java
@@ -102,7 +102,7 @@ public class AbstractUndoableEdit implements UndoableEdit, Serializable {
      * operation represented by this edit. Override should begin with
      * a call to super.
      *
-     * @exception CannotUndoException if <code>canUndo</code>
+     * @throws CannotUndoException if <code>canUndo</code>
      *    returns <code>false</code>
      * @see     #canUndo
      */
@@ -134,7 +134,7 @@ public class AbstractUndoableEdit implements UndoableEdit, Serializable {
      * Subclasses should override to redo the operation represented by
      * this edit. Override should begin with a call to super.
      *
-     * @exception CannotRedoException if <code>canRedo</code>
+     * @throws CannotRedoException if <code>canRedo</code>
      *     returns <code>false</code>
      * @see     #canRedo
      */


### PR DESCRIPTION
Prevailing JDK coding practices use "@throws" rather than "@exception".
Refactor existing swing classes javadoc to use @throws

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282473](https://bugs.openjdk.java.net/browse/JDK-8282473): Refactor swing classes javadoc to use @throws instead of @exception


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Dmitry Markov](https://openjdk.java.net/census#dmarkov) (@dmarkov20 - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7644/head:pull/7644` \
`$ git checkout pull/7644`

Update a local copy of the PR: \
`$ git checkout pull/7644` \
`$ git pull https://git.openjdk.java.net/jdk pull/7644/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7644`

View PR using the GUI difftool: \
`$ git pr show -t 7644`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7644.diff">https://git.openjdk.java.net/jdk/pull/7644.diff</a>

</details>
