### PR TITLE
8282480: IGV: Use description instead of enum name for phases

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4833,7 +4833,7 @@ void Compile::print_method(CompilerPhaseType cpt, int level, Node* n) {
 #ifndef PRODUCT
   ResourceMark rm;
   stringStream ss;
-  ss.print_raw(CompilerPhaseTypeHelper::to_name(cpt));
+  ss.print_raw(CompilerPhaseTypeHelper::to_description(cpt));
   if (n != nullptr) {
     ss.print(": %d %s ", n->_idx, NodeClassNames[n->Opcode()]);
   }


### PR DESCRIPTION
[JDK-8281505](https://bugs.openjdk.java.net/browse/JDK-8281505) changed the `PrintIdeal` output to use the enum name of a phase when used with `PrintIdealPhase` instead of the description. However, it also changed the phase name shown in the IGV to the enum name. This should be reverted back for a better readability.

IGV after JDK-8281505:
![Screenshot from 2022-03-01 13-59-15](https://user-images.githubusercontent.com/17833009/156173248-7f6450cb-9816-437a-b5fa-816a2e214ad9.png)

IGV before JDK-8281505/with this patch:
![Screenshot from 2022-03-01 13-58-36](https://user-images.githubusercontent.com/17833009/156173243-0a0f975a-a44d-46a6-a48a-5183ff7600e1.png)

Thanks,
Christian