### PR TITLE
Fixed error in RandomGeneratorFactory documentation

### DIFF
--- a/src/java.base/share/classes/java/util/random/RandomGeneratorFactory.java
+++ b/src/java.base/share/classes/java/util/random/RandomGeneratorFactory.java
@@ -89,9 +89,7 @@ import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
  *
  * <pre>{@code
  *     RandomGeneratorFactory<RandomGenerator> best = RandomGeneratorFactory.all()
- *         .sorted(Comparator.<RandomGeneratorFactory<RandomGenerator>, Integer>comparing(
- *             RandomGeneratorFactory::stateBits).reversed())
- *         .findFirst()
+ *         .max(Comparator.comparing(RandomGeneratorFactory::stateBits))
  *         .orElse(RandomGeneratorFactory.of("Random"));
  *     System.out.println(best.name() + " in " + best.group() + " was selected");
  *

--- a/src/java.base/share/classes/java/util/random/RandomGeneratorFactory.java
+++ b/src/java.base/share/classes/java/util/random/RandomGeneratorFactory.java
@@ -89,7 +89,8 @@ import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
  *
  * <pre>{@code
  *     RandomGeneratorFactory<RandomGenerator> best = RandomGeneratorFactory.all()
- *         .sorted(Comparator.comparingInt(RandomGenerator::stateBits).reversed())
+ *         .sorted(Comparator.<RandomGeneratorFactory<RandomGenerator>, Integer>comparing(
+ *             RandomGeneratorFactory::stateBits).reversed())
  *         .findFirst()
  *         .orElse(RandomGeneratorFactory.of("Random"));
  *     System.out.println(best.name() + " in " + best.group() + " was selected");


### PR DESCRIPTION
Example attempts to use undefined RandomGenerator::stateBits when it should use RandomGeneratorFactory::stateBits. Also since we are using .reversed(), a hint is required for the type inference system.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7647/head:pull/7647` \
`$ git checkout pull/7647`

Update a local copy of the PR: \
`$ git checkout pull/7647` \
`$ git pull https://git.openjdk.java.net/jdk pull/7647/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7647`

View PR using the GUI difftool: \
`$ git pr show -t 7647`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7647.diff">https://git.openjdk.java.net/jdk/pull/7647.diff</a>

</details>
