### PR TITLE
javax.net.ssl.SSLSocket: Fixed API Note in javadoc

### DIFF
--- a/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLSocket.java
@@ -175,9 +175,8 @@ import java.util.function.BiFunction;
  * When the connection is no longer needed, the client and server
  * applications should each close both sides of their respective connection.
  * For {@code SSLSocket} objects, for example, an application can call
- * {@link Socket#shutdownOutput()} or {@link java.io.OutputStream#close()}
- * for output stream close and call {@link Socket#shutdownInput()} or
- * {@link java.io.InputStream#close()} for input stream close.  Note that
+ * {@link Socket#shutdownOutput()} for output stream close and call
+ * {@link Socket#shutdownInput()} for input stream close.  Note that
  * in some cases, closing the input stream may depend on the peer's output
  * stream being closed first.  If the connection is not closed in an orderly
  * manner (for example {@link Socket#shutdownInput()} is called before the


### PR DESCRIPTION
Fixed API Note in javadoc for javax.net.ssl.SSLSocket class. API Note was introduced by JDK-8208526 [1]. At that point both Socket.shutdownInput() / Socket.shutdownOutput() and InputStream.close() / OutputStream.close() performed half-close of TLS-1.3 connection. However this behaviour has changed as result of JDK-8216326. InputStream.close() / OutputStream.close() no longer perform half-close but full socket close, but API Note was never updated.

[1] https://bugs.openjdk.java.net/browse/JDK-8208526
[2] https://bugs.openjdk.java.net/browse/JDK-8216326