### PR TITLE
8276711: compiler/codecache/cli tests failing when SegmentedCodeCache used with -Xint

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -368,7 +368,7 @@ bool CodeCache::heap_available(int code_blob_type) {
   if (!SegmentedCodeCache) {
     // No segmentation: use a single code heap
     return (code_blob_type == CodeBlobType::All);
-  } else if (Arguments::is_interpreter_only()) {
+  } else if (CompilerConfig::is_interpreter_only()) {
     // Interpreter only: we don't need any method code heaps
     return (code_blob_type == CodeBlobType::NonNMethod);
   } else if (CompilerConfig::is_c1_profiling()) {

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -310,7 +310,6 @@ void CompilerConfig::set_compilation_policy_flags() {
     }
   }
 
-
   if (CompileThresholdScaling < 0) {
     vm_exit_during_initialization("Negative value specified for CompileThresholdScaling", NULL);
   }
@@ -522,6 +521,13 @@ bool CompilerConfig::check_args_consistency(bool status) {
 #if INCLUDE_JVMCI
     status = status && JVMCIGlobals::check_jvmci_flags_are_consistent();
 #endif
+  }
+
+  // TieredStopAtLevel==0 allocates nmethod space in the code heap with
+  // SegmentedCodeCache so only disallow the option for -Xint.
+  if (Arguments::is_interpreter_only() && FLAG_IS_CMDLINE(SegmentedCodeCache)) {
+    warning("SegmentedCodeCache has no meaningful effect with -Xint");
+    FLAG_SET_DEFAULT(SegmentedCodeCache, false);
   }
 
   return status;

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -508,6 +508,10 @@ bool CompilerConfig::check_args_consistency(bool status) {
       }
       FLAG_SET_CMDLINE(TieredCompilation, false);
     }
+    if (SegmentedCodeCache) {
+      warning("SegmentedCodeCache has no meaningful effect with -Xint");
+      FLAG_SET_DEFAULT(SegmentedCodeCache, false);
+    }
 #if INCLUDE_JVMCI
     if (EnableJVMCI) {
       if (!FLAG_IS_DEFAULT(EnableJVMCI) || !FLAG_IS_DEFAULT(UseJVMCICompiler)) {
@@ -521,13 +525,6 @@ bool CompilerConfig::check_args_consistency(bool status) {
 #if INCLUDE_JVMCI
     status = status && JVMCIGlobals::check_jvmci_flags_are_consistent();
 #endif
-  }
-
-  // TieredStopAtLevel==0 allocates nmethod space in the code heap with
-  // SegmentedCodeCache so only disallow the option for -Xint.
-  if (Arguments::is_interpreter_only() && FLAG_IS_CMDLINE(SegmentedCodeCache)) {
-    warning("SegmentedCodeCache has no meaningful effect with -Xint");
-    FLAG_SET_DEFAULT(SegmentedCodeCache, false);
   }
 
   return status;

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -4114,6 +4114,13 @@ jint Arguments::apply_ergo() {
     return code;
   }
 
+  if (_mode == _int) {
+    if (SegmentedCodeCache) {
+      warning("SegmentedCodeCache has no meaningful effect with -Xint");
+      FLAG_SET_DEFAULT(SegmentedCodeCache, false);
+    }
+  }
+
 #ifdef ZERO
   // Clear flags not supported on zero.
   FLAG_SET_DEFAULT(ProfileInterpreter, false);

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -4114,13 +4114,6 @@ jint Arguments::apply_ergo() {
     return code;
   }
 
-  if (_mode == _int) {
-    if (SegmentedCodeCache) {
-      warning("SegmentedCodeCache has no meaningful effect with -Xint");
-      FLAG_SET_DEFAULT(SegmentedCodeCache, false);
-    }
-  }
-
 #ifdef ZERO
   // Clear flags not supported on zero.
   FLAG_SET_DEFAULT(ProfileInterpreter, false);

--- a/test/hotspot/jtreg/compiler/codecache/cli/TestSegmentedCodeCacheOption.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/TestSegmentedCodeCacheOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,6 +56,9 @@ public class TestSegmentedCodeCacheOption {
     private static final String[] UNEXPECTED_MESSAGES = new String[] {
             ".*" + SEGMENTED_CODE_CACHE + ".*"
     };
+    private static final String[] XINT_EXPECTED_MESSAGE = new String[] {
+            "SegmentedCodeCache has no meaningful effect with -Xint"
+    };
 
 
     private static enum TestCase {
@@ -86,10 +89,11 @@ public class TestSegmentedCodeCacheOption {
                 // ... and even w/ Xint.
                 testCaseExitCodeMessage = "It should be possible to use "
                         + USE_SEGMENTED_CODE_CACHE + " in interpreted mode "
-                        + "without any errors.";
+                        + "but it produces a warning that it is ignored.";
 
                 CommandLineOptionTest.verifyJVMStartup(
-                        /* expected messages */ null, UNEXPECTED_MESSAGES,
+                        XINT_EXPECTED_MESSAGE,
+                        /* unexpected messages */ null,
                         testCaseExitCodeMessage, testCaseWarningMessage,
                         ExitCode.OK, false, INT_MODE, USE_SEGMENTED_CODE_CACHE);
             }
@@ -117,14 +121,6 @@ public class TestSegmentedCodeCacheOption {
                         CommandLineOptionTest.prepareNumericFlag(
                                 BlobType.All.sizeOptionName,
                                 BELOW_THRESHOLD_CC_SIZE));
-                // SCC could be explicitly enabled w/ Xint
-                errorMessage = String.format("It should be possible to "
-                                + "explicitly enable %s in interpreted mode.",
-                        SEGMENTED_CODE_CACHE);
-
-                CommandLineOptionTest.verifyOptionValue(SEGMENTED_CODE_CACHE,
-                        "true", errorMessage, false, INT_MODE,
-                        USE_SEGMENTED_CODE_CACHE);
                 // SCC could be explicitly enabled w/o TieredCompilation and w/
                 // small ReservedCodeCacheSize value
                 errorMessage = String.format("It should be possible to "

--- a/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/TestCodeHeapSizeOptions.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/TestCodeHeapSizeOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,9 +63,6 @@ public class TestCodeHeapSizeOptions extends CodeCacheCLITestBase {
 
     private TestCodeHeapSizeOptions() {
         super(CodeCacheCLITestBase.OPTIONS_SET,
-                new CodeCacheCLITestCase(CodeCacheCLITestCase
-                        .CommonDescriptions.INT_MODE.description,
-                        GENERIC_RUNNER),
                 new CodeCacheCLITestCase(CodeCacheCLITestCase
                         .CommonDescriptions.NON_TIERED.description,
                         GENERIC_RUNNER),

--- a/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/TestCodeHeapSizeOptions.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/TestCodeHeapSizeOptions.java
@@ -67,9 +67,6 @@ public class TestCodeHeapSizeOptions extends CodeCacheCLITestBase {
                         .CommonDescriptions.NON_TIERED.description,
                         GENERIC_RUNNER),
                 new CodeCacheCLITestCase(CodeCacheCLITestCase
-                        .CommonDescriptions.TIERED_LEVEL_0.description,
-                        GENERIC_RUNNER),
-                new CodeCacheCLITestCase(CodeCacheCLITestCase
                         .CommonDescriptions.TIERED_LEVEL_1.description,
                         GENERIC_RUNNER),
                 new CodeCacheCLITestCase(CodeCacheCLITestCase

--- a/test/hotspot/jtreg/compiler/codecache/cli/common/CodeCacheCLITestCase.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/common/CodeCacheCLITestCase.java
@@ -87,11 +87,11 @@ public class CodeCacheCLITestCase {
                         false)),
         /**
          * Verifies that with TieredStopAtLevel=0 PrintCodeCache output will
-         * contain information about non-nmethods and non-profiled nmethods
+         * warn about SegmentedCodeCache and contain information about all
          * heaps only.
          */
         TIERED_LEVEL_0(SEGMENTED_SERVER,
-                EnumSet.of(BlobType.NonNMethod, BlobType.MethodNonProfiled),
+                EnumSet.of(BlobType.All),
                 CommandLineOptionTest.prepareBooleanFlag(TIERED_COMPILATION,
                         true),
                 CommandLineOptionTest.prepareNumericFlag(TIERED_STOP_AT, 0)),

--- a/test/hotspot/jtreg/compiler/codecache/cli/common/CodeCacheCLITestCase.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/common/CodeCacheCLITestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,9 +66,9 @@ public class CodeCacheCLITestCase {
     public enum CommonDescriptions {
         /**
          * Verifies that in interpreted mode PrintCodeCache output contains
-         * only NonNMethod code heap.
+         * the whole code cache. Int mode disables SegmentedCodeCache with a warning.
          */
-        INT_MODE(ONLY_SEGMENTED, EnumSet.of(BlobType.NonNMethod), USE_INT_MODE),
+        INT_MODE(ONLY_SEGMENTED, EnumSet.of(BlobType.All), USE_INT_MODE),
         /**
          * Verifies that with disabled SegmentedCodeCache PrintCodeCache output
          * contains only CodeCache's entry.


### PR DESCRIPTION
In Loom, when using -Xint, the +SegmentedCodeCache option cannot be used because it doesn't generate a code heap for nmethods, and in loom the compiler needs to generate an nmethod for Continuation.enterSpecial even with -Xint.
This change is @rickard 's loom change with the tests fixed so they pass for it.  One tests for the new warning message and code cache usage, and the others remove the Xint tests.
Tested with tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276711](https://bugs.openjdk.java.net/browse/JDK-8276711): compiler/codecache/cli tests failing when SegmentedCodeCache used with -Xint


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7650/head:pull/7650` \
`$ git checkout pull/7650`

Update a local copy of the PR: \
`$ git checkout pull/7650` \
`$ git pull https://git.openjdk.java.net/jdk pull/7650/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7650`

View PR using the GUI difftool: \
`$ git pr show -t 7650`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7650.diff">https://git.openjdk.java.net/jdk/pull/7650.diff</a>

</details>
