### PR TITLE
8267319: Use larger default key sizes and algorithms based on CNSA

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/AESKeyGenerator.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/AESKeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import java.util.Arrays;
 import javax.crypto.KeyGeneratorSpi;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-
+import sun.security.util.SecurityProviderConstants;
 
 /**
  * This class generates a AES key.
@@ -46,7 +46,8 @@ import javax.crypto.spec.SecretKeySpec;
 public final class AESKeyGenerator extends KeyGeneratorSpi {
 
     private SecureRandom random = null;
-    private int keySize = 16; // default keysize (in number of bytes)
+    // default keysize (in number of bytes)
+    private int keySize = SecurityProviderConstants.getDefAESKeySize() >> 3;
 
     /**
      * Empty constructor.

--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -1857,8 +1857,6 @@ public final class Main {
                     keysize = 56;
                 } else if ("DESede".equalsIgnoreCase(keyAlgName)) {
                     keysize = 168;
-                } else if ("AES".equalsIgnoreCase(keyAlgName)) {
-                    keysize = SecurityProviderConstants.getDefAESKeySize();
                 } else {
                     throw new Exception(rb.getString
                         ("Please.provide.keysize.for.secret.key.generation"));

--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -1857,6 +1857,8 @@ public final class Main {
                     keysize = 56;
                 } else if ("DESede".equalsIgnoreCase(keyAlgName)) {
                     keysize = 168;
+                } else if ("AES".equalsIgnoreCase(keyAlgName)) {
+                    keysize = SecurityProviderConstants.getDefAESKeySize();
                 } else {
                     throw new Exception(rb.getString
                         ("Please.provide.keysize.for.secret.key.generation"));
@@ -1917,6 +1919,8 @@ public final class Main {
                     keysize = SecurityProviderConstants.DEF_EC_KEY_SIZE;
                 } else if ("RSA".equalsIgnoreCase(keyAlgName)) {
                     keysize = SecurityProviderConstants.DEF_RSA_KEY_SIZE;
+                } else if ("RSASSA-PSS".equalsIgnoreCase(keyAlgName)) {
+                    keysize = SecurityProviderConstants.DEF_RSASSA_PSS_KEY_SIZE;
                 } else if ("DSA".equalsIgnoreCase(keyAlgName)) {
                     keysize = SecurityProviderConstants.DEF_DSA_KEY_SIZE;
                 } else if ("EdDSA".equalsIgnoreCase(keyAlgName)) {

--- a/src/java.base/share/classes/sun/security/util/SecurityProviderConstants.java
+++ b/src/java.base/share/classes/sun/security/util/SecurityProviderConstants.java
@@ -134,6 +134,10 @@ public final class SecurityProviderConstants {
     public static final int DEF_EC_KEY_SIZE;
     public static final int DEF_ED_KEY_SIZE;
     public static final int DEF_XEC_KEY_SIZE;
+    // the logic for finding the max allowable value in getDefAESKeySize()
+    // interferes with provider loading logic and may lead to deadlocks if
+    // called inside a static block. So, it is deferred to a later time when
+    // DEF_AES_KEY_SIZE is actually used/needed.
     private static final AtomicInteger DEF_AES_KEY_SIZE;
 
     private static final String KEY_LENGTH_PROP =

--- a/src/java.base/share/classes/sun/security/util/SecurityProviderConstants.java
+++ b/src/java.base/share/classes/sun/security/util/SecurityProviderConstants.java
@@ -118,7 +118,7 @@ public final class SecurityProviderConstants {
                 if (v > max)  {
                     v = max;
                 }
-            } catch (NullPointerException | NoSuchAlgorithmException ne) {
+            } catch (NoSuchAlgorithmException ne) {
                 // should never happen; ignore and use the default
             }
             DEF_AES_KEY_SIZE.compareAndSet(-1, v);

--- a/src/java.base/share/classes/sun/security/util/SecurityProviderConstants.java
+++ b/src/java.base/share/classes/sun/security/util/SecurityProviderConstants.java
@@ -46,11 +46,11 @@ public final class SecurityProviderConstants {
     private static final Debug debug =
         Debug.getInstance("jca", "ProviderConfig");
 
-    // cache for provider aliases; key is the standard algorithm name
+    // Cache for provider aliases; key is the standard algorithm name
     // value is the associated aliases List
     private static final ConcurrentHashMap<String, List<String>> aliasesMap;
 
-    // utility method for generating aliases list using the supplied
+    // Utility method for generating aliases list using the supplied
     // 'oid' and 'extraAliases', then store into "aliasesMap" cache under the
     // key 'stdName'
     private static List<String> store(String stdName, KnownOIDs oid,
@@ -78,7 +78,7 @@ public final class SecurityProviderConstants {
         return value;
     }
 
-    // returns an aliases List for the specified algorithm name o
+    // Return an aliases List for the specified algorithm name o
     // NOTE: exception is thrown if no aliases nor oid found, so
     // only call this method if aliases are expected
     public static List<String> getAliases(String o) {
@@ -134,7 +134,7 @@ public final class SecurityProviderConstants {
     public static final int DEF_EC_KEY_SIZE;
     public static final int DEF_ED_KEY_SIZE;
     public static final int DEF_XEC_KEY_SIZE;
-    // the logic for finding the max allowable value in getDefAESKeySize()
+    // The logic for finding the max allowable value in getDefAESKeySize()
     // interferes with provider loading logic and may lead to deadlocks if
     // called inside a static block. So, it is deferred to a later time when
     // DEF_AES_KEY_SIZE is actually used/needed.

--- a/src/java.base/share/classes/sun/security/util/SecurityProviderConstants.java
+++ b/src/java.base/share/classes/sun/security/util/SecurityProviderConstants.java
@@ -142,7 +142,7 @@ public final class SecurityProviderConstants {
     static {
         String keyLengthStr = GetPropertyAction.privilegedGetProperty
             (KEY_LENGTH_PROP);
-        int dsaKeySize = 3072;
+        int dsaKeySize = 2048;
         int rsaKeySize = 3072;
         int rsaSsaPssKeySize = rsaKeySize; // default to same value as RSA
         int dhKeySize = 3072;

--- a/src/java.base/share/classes/sun/security/util/SignatureUtil.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureUtil.java
@@ -536,10 +536,9 @@ public class SignatureUtil {
     private static String ecStrength (int bitLength) {
         if (bitLength >= 512) { // 256 bits of strength
             return "SHA512";
-        } else if (bitLength >= 384) {  // 192 bits of strength
+        } else {
+            // per CNSA, use SHA-384
             return "SHA384";
-        } else { // 128 bits of strength and less
-            return "SHA256";
         }
     }
 
@@ -552,11 +551,17 @@ public class SignatureUtil {
      * {@link jdk.security.jarsigner.JarSigner.Builder#getDefaultSignatureAlgorithm}.
      */
     private static String ifcFfcStrength (int bitLength, boolean isDSA) {
-        if (bitLength > 7680) { // 256 bits security strength
-            return "SHA512";
-        } else {
-            // per CNSA, use SHA-384 unless keysize is too small
-            return (isDSA || bitLength >= 624 ? "SHA384" : "SHA256");
+        if (isDSA) {
+            // for backward interoperability
+            // SHA384withDSA is added under JDK-8172366 (jdk16)
+            return "SHA256";
+        } else { // RSA, RSASSA-PSS
+            if (bitLength > 7680) { // 256 bits security strength
+                return "SHA512";
+            } else {
+                // per CNSA, use SHA-384 unless keysize is too small
+                return (bitLength >= 624 ? "SHA384" : "SHA256");
+            }
         }
     }
 }

--- a/src/java.base/share/classes/sun/security/util/SignatureUtil.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureUtil.java
@@ -60,13 +60,11 @@ public class SignatureUtil {
             if (algName.startsWith("OID.")) {
                 algName = algName.substring(4);
             }
-
             KnownOIDs ko = KnownOIDs.findMatch(algName);
             if (ko != null) {
                 return ko.stdName().toUpperCase(Locale.ENGLISH);
             }
         }
-
         return algName;
     }
 
@@ -521,11 +519,16 @@ public class SignatureUtil {
                 64, PSSParameterSpec.TRAILER_FIELD_BC);
     }
 
-    // The following values are from SP800-57 part 1 rev 4 tables 2 and 3
+    // SP800-57 part 1 rev5 table 2 "Comparable security strengths of
+    // symmetric block cipher and asymmetric-key algorithms", and table 3
+    // "Maximum security strengths for hash and hash-based functions"
+    // define security strength for various algorithms.
+    // Besides matching the security strength, the default algorithms may
+    // also be chosen based on various recommendations such as NIST CNSA.
 
     /**
-     * Return the default message digest algorithm with the same security
-     * strength as the specified EC key size.
+     * Return the default message digest algorithm based on the specified
+     * EC key size.
      *
      * Attention: sync with the @implNote inside
      * {@link jdk.security.jarsigner.JarSigner.Builder#getDefaultSignatureAlgorithm}.
@@ -541,16 +544,17 @@ public class SignatureUtil {
     }
 
     /**
-     * Return the default message digest algorithm with the same security
-     * strength as the specified IFC/FFC key size.
+     * Return the default message digest algorithm based on both the
+     * security strength of the specified IFC/FFC key size and the
+     * recommendation from NIST CNSA, e.g. use SHA-384 for 3072-bit.
      *
      * Attention: sync with the @implNote inside
      * {@link jdk.security.jarsigner.JarSigner.Builder#getDefaultSignatureAlgorithm}.
      */
     private static String ifcFfcStrength (int bitLength) {
-        if (bitLength > 7680) { // 256 bits
+        if (bitLength >= 7680) { // 192 bits
             return "SHA512";
-        } else if (bitLength > 3072) {  // 192 bits
+        } else if (bitLength >= 3072) {  // 128 bits
             return "SHA384";
         } else  { // 128 bits and less
             return "SHA256";

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyGenerator.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.security.spec.AlgorithmParameterSpec;
 
 import javax.crypto.*;
 
+import sun.security.util.SecurityProviderConstants;;
 import static sun.security.pkcs11.TemplateManager.*;
 import sun.security.pkcs11.wrapper.*;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
@@ -225,7 +226,8 @@ final class P11KeyGenerator extends KeyGeneratorSpi {
             significantKeySize = 168;
             break;
         case (int)CKM_AES_KEY_GEN:
-            keySize = adjustKeySize(128, range);
+            keySize = adjustKeySize
+                    (SecurityProviderConstants.getDefAESKeySize(), range);
             keyType = CKK_AES;
             break;
         case (int)CKM_RC4_KEY_GEN:

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyPairGenerator.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyPairGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,28 +99,34 @@ final class P11KeyPairGenerator extends KeyPairGeneratorSpi {
         // set default key sizes and apply our own algorithm-specific limits
         // override lower limit to disallow unsecure keys being generated
         // override upper limit to deter DOS attack
-        if (algorithm.equals("EC")) {
-            keySize = DEF_EC_KEY_SIZE;
-            if (minKeyLen < 112) {
-                minKeyLen = 112;
+        int jdkMinKeyLen = 512;
+        int jdkMaxKeyLen = Integer.MAX_VALUE;
+        switch (algorithm) {
+            case "EC" -> {
+                keySize = DEF_EC_KEY_SIZE;
+                jdkMinKeyLen = 112;
+                jdkMaxKeyLen = 2048;
             }
-            if (maxKeyLen > 2048) {
-                maxKeyLen = 2048;
-            }
-        } else {
-            if (algorithm.equals("DSA")) {
+            case "DSA" -> {
                 keySize = DEF_DSA_KEY_SIZE;
-            } else if (algorithm.equals("RSA")) {
+            }
+            case "RSA" -> {
                 keySize = DEF_RSA_KEY_SIZE;
-                if (maxKeyLen > 64 * 1024) {
-                    maxKeyLen = 64 * 1024;
-                }
-            } else {
+                jdkMaxKeyLen = 64 * 1024;
+            }
+            case "DH" -> {
                 keySize = DEF_DH_KEY_SIZE;
             }
-            if (minKeyLen < 512) {
-                minKeyLen = 512;
+            default -> {
+                throw new ProviderException
+                        ("Unrecognized algorithm for checking key size");
             }
+        }
+        if (minKeyLen < jdkMinKeyLen) {
+            minKeyLen = jdkMinKeyLen;
+        }
+        if (maxKeyLen > jdkMaxKeyLen) {
+            maxKeyLen = jdkMaxKeyLen;
         }
 
         // auto-adjust default keysize in case it's out-of-range

--- a/src/jdk.jartool/share/classes/jdk/security/jarsigner/JarSigner.java
+++ b/src/jdk.jartool/share/classes/jdk/security/jarsigner/JarSigner.java
@@ -434,13 +434,13 @@ public final class JarSigner {
          * @implNote This implementation makes use of comparable strengths
          * as defined in Tables 2 and 3 of NIST SP 800-57 Part 1-Rev.5 as
          * well as NIST recommendations as appropriate.
-         * Specifically, if a DSA or RSA key with a key size greater than 7680
+         * Specifically, if an RSA key with a key size greater than 7680
          * bits, or an EC key with a key size greater than or equal to 512 bits,
          * SHA-512 will be used as the hash function for the signature.
          * Otherwise, SHA-384 will be used unless the key size is too small
-         * for resulting signature algorithm. For example, an RSA 512-bit key
-         * is too short for SHA384withRSA signature. For such keys, SHA-256
-         * will be used. The value may change in the future.
+         * for resulting signature algorithm. As for DSA keys, the SHA256withDSA
+         * signature algorithm is returned regardless of key size.
+         * The value may change in the future.
          *
          * @param key the private key.
          * @return the default signature algorithm. Returns null if a default

--- a/src/jdk.jartool/share/classes/jdk/security/jarsigner/JarSigner.java
+++ b/src/jdk.jartool/share/classes/jdk/security/jarsigner/JarSigner.java
@@ -428,14 +428,14 @@ public final class JarSigner {
 
         /**
          * Gets the default signature algorithm for a private key.
-         * For example, SHA384withRSA for a 3072-bit RSA key, and
+         * For example, SHA384withRSA for a 2048-bit RSA key, and
          * SHA384withECDSA for a 384-bit EC key.
          *
          * @implNote This implementation makes use of comparable strengths
          * as defined in Tables 2 and 3 of NIST SP 800-57 Part 1-Rev.5 as
          * well as NIST recommendations as appropriate.
-         * Specifically, if a DSA or RSA key with a key size no less than 7680
-         * bits, or an EC key with a key size no less than 512 bits,
+         * Specifically, if a DSA or RSA key with a key size greater than 7680
+         * bits, or an EC key with a key size greater than or equal to 512 bits,
          * SHA-512 will be used as the hash function for the signature.
          * Otherwise, SHA-384 will be used unless the key size is too small
          * for resulting signature algorithm. For example, an RSA 512-bit key

--- a/src/jdk.jartool/share/classes/jdk/security/jarsigner/JarSigner.java
+++ b/src/jdk.jartool/share/classes/jdk/security/jarsigner/JarSigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -417,13 +417,13 @@ public final class JarSigner {
         /**
          * Gets the default digest algorithm.
          *
-         * @implNote This implementation returns "SHA-256". The value may
+         * @implNote This implementation returns "SHA-384". The value may
          * change in the future.
          *
          * @return the default digest algorithm.
          */
         public static String getDefaultDigestAlgorithm() {
-            return "SHA-256";
+            return "SHA-384";
         }
 
         /**
@@ -432,11 +432,12 @@ public final class JarSigner {
          * SHA384withECDSA for a 384-bit EC key.
          *
          * @implNote This implementation makes use of comparable strengths
-         * as defined in Tables 2 and 3 of NIST SP 800-57 Part 1-Rev.4.
-         * Specifically, if a DSA or RSA key with a key size greater than 7680
-         * bits, or an EC key with a key size greater than or equal to 512 bits,
+         * as defined in Tables 2 and 3 of NIST SP 800-57 Part 1-Rev.5 as
+         * well as NIST recommendations as appropriate.
+         * Specifically, if a DSA or RSA key with a key size no less than 7680
+         * bits, or an EC key with a key size no less than 512 bits,
          * SHA-512 will be used as the hash function for the signature.
-         * If a DSA or RSA key has a key size greater than 3072 bits, or an
+         * If a DSA or RSA key has a key size no less than 3072 bits, or an
          * EC key has a key size greater than or equal to 384 bits, SHA-384 will
          * be used. Otherwise, SHA-256 will be used. The value may
          * change in the future.

--- a/src/jdk.jartool/share/classes/jdk/security/jarsigner/JarSigner.java
+++ b/src/jdk.jartool/share/classes/jdk/security/jarsigner/JarSigner.java
@@ -428,7 +428,7 @@ public final class JarSigner {
 
         /**
          * Gets the default signature algorithm for a private key.
-         * For example, SHA256withRSA for a 2048-bit RSA key, and
+         * For example, SHA384withRSA for a 3072-bit RSA key, and
          * SHA384withECDSA for a 384-bit EC key.
          *
          * @implNote This implementation makes use of comparable strengths
@@ -437,10 +437,10 @@ public final class JarSigner {
          * Specifically, if a DSA or RSA key with a key size no less than 7680
          * bits, or an EC key with a key size no less than 512 bits,
          * SHA-512 will be used as the hash function for the signature.
-         * If a DSA or RSA key has a key size no less than 3072 bits, or an
-         * EC key has a key size greater than or equal to 384 bits, SHA-384 will
-         * be used. Otherwise, SHA-256 will be used. The value may
-         * change in the future.
+         * Otherwise, SHA-384 will be used unless the key size is too small
+         * for resulting signature algorithm. For example, an RSA 512-bit key
+         * is too short for SHA384withRSA signature. For such keys, SHA-256
+         * will be used. The value may change in the future.
          *
          * @param key the private key.
          * @return the default signature algorithm. Returns null if a default

--- a/test/jdk/com/sun/crypto/provider/KeyAgreement/TestExponentSize.java
+++ b/test/jdk/com/sun/crypto/provider/KeyAgreement/TestExponentSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 6330287 6331386 7044060
+ * @bug 6330287 6331386 7044060 8267319
  * @summary verify that DHKeyPairGenerator returns keys of the expected size
  * (modulus and exponent)
  * -and-
@@ -58,7 +58,7 @@ public class TestExponentSize {
      */
     private enum Sizes {
         two56(256), three84(384), five12(512), seven68(768), ten24(1024),
-        twenty48(2048);
+        fifteen36(1536), twenty48(2048), thirty72(3072);
 
         private final int intSize;
         private final BigInteger bigIntValue;
@@ -83,11 +83,14 @@ public class TestExponentSize {
         KeyPair kp;
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH", "SunJCE");
 
-        // Sun's default uses a default psize of 2048 and
+        // Sun's default uses a default psize of 3072 and
         // lsize of (pSize / 2) but at least 384 bits
         kp = kpg.generateKeyPair();
-        checkKeyPair(kp, Sizes.twenty48, Sizes.ten24);
+        checkKeyPair(kp, Sizes.thirty72, Sizes.fifteen36);
 
+        kpg.initialize(Sizes.twenty48.getIntSize());
+        kp = kpg.generateKeyPair();
+        checkKeyPair(kp, Sizes.twenty48, Sizes.ten24);
         DHPublicKey publicKey = (DHPublicKey)kp.getPublic();
         BigInteger p = publicKey.getParams().getP();
         BigInteger g = publicKey.getParams().getG();

--- a/test/jdk/com/sun/crypto/provider/KeyGenerator/Test4628062.java
+++ b/test/jdk/com/sun/crypto/provider/KeyGenerator/Test4628062.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4628062 4963723
+ * @bug 4628062 4963723 8267319
  * @summary Verify that AES KeyGenerator supports default initialization
  *      when init is not called
  * @author Valerie Peng
@@ -34,7 +34,8 @@ import java.util.*;
 
 public class Test4628062 {
 
-    private static final int[] AES_SIZES = { 16, 24, 32 }; // in bytes
+    // first value is the default key size
+    private static final int[] AES_SIZES = { 32, 16, 24 }; // in bytes
     private static final int[] HMACSHA224_SIZES = { 28 };
     private static final int[] HMACSHA256_SIZES = { 32 };
     private static final int[] HMACSHA384_SIZES = { 48 };

--- a/test/jdk/jdk/security/jarsigner/Properties.java
+++ b/test/jdk/jdk/security/jarsigner/Properties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8242068
+ * @bug 8242068 8267319
  * @summary test the properties
  * @library /test/lib
  * @modules java.base/sun.security.tools.keytool
@@ -49,6 +49,9 @@ import java.util.jar.JarInputStream;
 import java.util.zip.ZipFile;
 
 public class Properties {
+
+    private static final String DEF_DIGEST_STR =
+            JarSigner.Builder.getDefaultDigestAlgorithm() + "-Digest-Manifest:";
 
     public static void main(String[] args) throws Exception {
 
@@ -82,12 +85,12 @@ public class Properties {
         // Has a hash for the whole manifest
         byte[] s0 = sign(jsb.setProperty("sectionsonly", "false"));
         sf = new String(DerUtils.innerDerValue(s0, "10210").getOctetString());
-        Asserts.assertTrue(sf.contains("SHA-256-Digest-Manifest:"));
+        Asserts.assertTrue(sf.contains(DEF_DIGEST_STR));
 
         // Has no hash for the whole manifest
         byte[] s1 = sign(jsb.setProperty("sectionsonly", "true"));
         sf = new String(DerUtils.innerDerValue(s1, "10210").getOctetString());
-        Asserts.assertFalse(sf.contains("SHA-256-Digest-Manifest:"));
+        Asserts.assertFalse(sf.contains(DEF_DIGEST_STR));
     }
 
     // Sign and returns the content of the PKCS7 signature block inside

--- a/test/jdk/jdk/security/jarsigner/Spec.java
+++ b/test/jdk/jdk/security/jarsigner/Spec.java
@@ -192,13 +192,13 @@ public class Spec {
         kpg.initialize(1024);
         assertTrue(JarSigner.Builder
                 .getDefaultSignatureAlgorithm(kpg.generateKeyPair().getPrivate())
-                .equals("SHA384withDSA"));
+                .equals("SHA256withDSA"));
 
         kpg = KeyPairGenerator.getInstance("EC");
         kpg.initialize(256);
         assertTrue(JarSigner.Builder
                 .getDefaultSignatureAlgorithm(kpg.generateKeyPair().getPrivate())
-                .equals("SHA256withECDSA"));
+                .equals("SHA384withECDSA"));
         kpg.initialize(384);
         assertTrue(JarSigner.Builder
                 .getDefaultSignatureAlgorithm(kpg.generateKeyPair().getPrivate())

--- a/test/jdk/jdk/security/jarsigner/Spec.java
+++ b/test/jdk/jdk/security/jarsigner/Spec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8056174 8242068 8255536
+ * @bug 8056174 8242068 8255536 8267319
  * @summary Make sure JarSigner impl conforms to spec
  * @library /test/lib
  * @modules java.base/sun.security.tools.keytool
@@ -178,7 +178,8 @@ public class Spec {
         assertTrue(js3.getProperty("altsigner").equals("MyContentSigner"));
         assertTrue(js3.getProperty("altsignerpath") == null);
 
-        assertTrue(JarSigner.Builder.getDefaultDigestAlgorithm().equals("SHA-256"));
+        assertTrue(JarSigner.Builder.getDefaultDigestAlgorithm()
+                .equals("SHA-384"));
 
         // Calculating large DSA and RSA keys are too slow.
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");

--- a/test/jdk/jdk/security/jarsigner/Spec.java
+++ b/test/jdk/jdk/security/jarsigner/Spec.java
@@ -186,13 +186,13 @@ public class Spec {
         kpg.initialize(1024);
         assertTrue(JarSigner.Builder
                 .getDefaultSignatureAlgorithm(kpg.generateKeyPair().getPrivate())
-                    .equals("SHA256withRSA"));
+                    .equals("SHA384withRSA"));
 
         kpg = KeyPairGenerator.getInstance("DSA");
         kpg.initialize(1024);
         assertTrue(JarSigner.Builder
                 .getDefaultSignatureAlgorithm(kpg.generateKeyPair().getPrivate())
-                .equals("SHA256withDSA"));
+                .equals("SHA384withDSA"));
 
         kpg = KeyPairGenerator.getInstance("EC");
         kpg.initialize(256);

--- a/test/jdk/sun/security/pkcs11/KeyGenerator/TestAES.java
+++ b/test/jdk/sun/security/pkcs11/KeyGenerator/TestAES.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8267319
+ * @modules java.base/sun.security.util
+ *          jdk.crypto.cryptoki
+ * @summary Check AES key generator.
+ * @library /test/lib ..
+ * @run main TestAES
+ */
+import java.security.Provider;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidParameterException;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import static sun.security.util.SecurityProviderConstants.*;
+
+public class TestAES extends PKCS11Test {
+
+    private static final String ALGO = "AES";
+
+    public static void main(String[] args) throws Exception {
+        main(new TestAES(), args);
+    }
+
+    @Override
+    public void main(Provider p) throws Exception {
+        System.out.println("Testing " + p.getName());
+        KeyGenerator kg;
+        try {
+            kg = KeyGenerator.getInstance(ALGO, p);
+        } catch (NoSuchAlgorithmException nsae) {
+            System.out.println("Skip; no support for " + ALGO);
+            return;
+        }
+
+        // first try w/o setting a key length and check if the generated key
+        // length matches
+        SecretKey key = kg.generateKey();
+        byte[] keyValue = key.getEncoded();
+        if (key.getEncoded().length != getDefAESKeySize() >> 3) {
+            throw new RuntimeException("Default AES key length should be " +
+                    getDefAESKeySize());
+        }
+
+        for (int keySize : new int[] { 16, 32, 64, 128, 256, 512, 1024 }) {
+            boolean isValid = (keySize == 128 || keySize == 192 ||
+                    keySize == 256);
+            try {
+                kg.init(keySize);
+                if (!isValid) {
+                    throw new RuntimeException(keySize + " is invalid keysize");
+                }
+                key = kg.generateKey();
+                if (key.getEncoded().length != keySize >> 3) {
+                    throw new RuntimeException("Generated key len mismatch!");
+                }
+            } catch (InvalidParameterException e) {
+                if (isValid) {
+                    throw new RuntimeException("IPE thrown for valid keySize");
+                } else {
+                    System.out.println("Expected IPE thrown for " + keySize);
+                }
+            }
+        }
+    }
+}

--- a/test/jdk/sun/security/pkcs11/KeyPairGenerator/TestDefaultSize.java
+++ b/test/jdk/sun/security/pkcs11/KeyPairGenerator/TestDefaultSize.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8267319
+ * @summary Ensure that DSA/RSA/DH/EC KPG in PKCS11 provider uses the
+ *     same default key length
+ * @library /test/lib ..
+ * @modules java.base/sun.security.util
+ *          jdk.crypto.cryptoki
+ * @run main TestDefaultSize
+ */
+
+import java.security.InvalidParameterException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Provider;
+import java.security.PrivateKey;
+import java.security.interfaces.*;
+import javax.crypto.interfaces.DHKey;
+
+import static sun.security.util.SecurityProviderConstants.*;
+
+public class TestDefaultSize extends PKCS11Test {
+
+    @Override
+    public void main(Provider p) throws Exception {
+        System.out.println("Testing " + p.getName());
+
+        String[] ALGOS = { "DSA", "RSA", "DH", "EC" };
+
+        for (String algo : ALGOS) {
+            if (p.getService("KeyPairGenerator", algo) == null) {
+                System.out.println("Skip, no support for KPG: " + algo);
+                return;
+            }
+
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance(algo, p);
+            KeyPair kp = kpg.generateKeyPair();
+            PrivateKey priv = kp.getPrivate();
+            int actualSize = -1;
+            int expectedSize;
+            if (algo == "DSA") {
+                expectedSize = DEF_DSA_KEY_SIZE;
+                if (priv instanceof DSAKey) {
+                    actualSize = ((DSAKey) priv).getParams().getP().bitLength();
+                }
+            } else if (algo == "RSA") {
+                expectedSize = DEF_RSA_KEY_SIZE;
+                if (priv instanceof RSAKey) {
+                    actualSize = ((RSAKey) priv).getModulus().bitLength();
+                }
+            } else if (algo == "DH") {
+                expectedSize = DEF_DH_KEY_SIZE;
+                if (priv instanceof DHKey) {
+                    actualSize = ((DHKey) priv).getParams().getP().bitLength();
+                }
+            } else if (algo == "EC") {
+                expectedSize = DEF_EC_KEY_SIZE;
+                if (priv instanceof ECKey) {
+                    actualSize = ((ECKey) priv).getParams().getCurve()
+                            .getField().getFieldSize();
+                }
+            } else {
+                throw new RuntimeException("Error: Unrecognized algo " +
+                    algo + " or opaque private key object " + priv);
+            }
+            if (actualSize != expectedSize) {
+                throw new RuntimeException("key size check failed, got " +
+                    actualSize);
+            } else {
+                System.out.println(algo + ": passed, " + actualSize);
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        main(new TestDefaultSize(), args);
+    }
+}

--- a/test/jdk/sun/security/tools/jarsigner/CheckSignerCertChain.java
+++ b/test/jdk/sun/security/tools/jarsigner/CheckSignerCertChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8259401 8266225
+ * @bug 8259401 8266225 8267319
  * @summary Check certificates in signer's cert chain to see if warning emitted
  * @library /test/lib
  */
@@ -39,6 +39,8 @@ import java.nio.file.Paths;
 public class CheckSignerCertChain {
 
     private static final String JAVA_SECURITY_FILE = "java.security";
+
+    private static final String keysizeOpt = "-keysize 2048";
 
     static OutputAnalyzer kt(String cmd, String ks) throws Exception {
         return SecurityTools.keytool("-storepass changeit " + cmd +
@@ -57,8 +59,11 @@ public class CheckSignerCertChain {
         System.out.println("Generating a root cert using SHA1withRSA and 1024-bit key");
         kt("-genkeypair -keyalg rsa -alias ca -dname CN=CA -ext bc:c " +
                 "-keysize 1024 -sigalg SHA1withRSA", "ks");
-        kt("-genkeypair -keyalg rsa -alias ca1 -dname CN=CA1", "ks");
-        kt("-genkeypair -keyalg rsa -alias e1 -dname CN=E1", "ks");
+
+        kt("-genkeypair -keyalg rsa -alias ca1 -dname CN=CA1 " + keysizeOpt,
+                "ks");
+        kt("-genkeypair -keyalg rsa -alias e1 -dname CN=E1 " + keysizeOpt,
+                "ks");
 
         // intermediate certificate using SHA1withRSA and 2048-bit key
         System.out.println("Generating an intermediate cert using SHA1withRSA and 2048-bit key");
@@ -97,8 +102,10 @@ public class CheckSignerCertChain {
          * Generate a non-self-signed certificate using MD5withRSA as its signature
          * algorithm to sign a JAR file.
          */
-        kt("-genkeypair -keyalg rsa -alias cacert -dname CN=CACERT -ext bc:c ", "ks");
-        kt("-genkeypair -keyalg rsa -alias ee -dname CN=EE -ext bc:c ", "ks");
+        kt("-genkeypair -keyalg rsa -alias cacert -dname CN=CACERT -ext bc:c "
+                + keysizeOpt, "ks");
+        kt("-genkeypair -keyalg rsa -alias ee -dname CN=EE -ext bc:c "
+                + keysizeOpt, "ks");
         gencert("ee", "-alias cacert -ext san=dns:ee -sigalg MD5withRSA");
 
         Files.writeString(Files.createFile(Paths.get(JAVA_SECURITY_FILE)),

--- a/test/jdk/sun/security/tools/jarsigner/CheckSignerCertChain.java
+++ b/test/jdk/sun/security/tools/jarsigner/CheckSignerCertChain.java
@@ -119,7 +119,7 @@ public class CheckSignerCertChain {
                 JAVA_SECURITY_FILE +
                 " a.jar ee")
                 .shouldNotContain("Signature algorithm: MD5withRSA (disabled), 2048-bit key")
-                .shouldContain("Signature algorithm: SHA256withRSA, 2048-bit key")
+                .shouldContain("Signature algorithm: SHA384withRSA, 2048-bit key")
                 .shouldNotContain("Invalid certificate chain: Algorithm constraints check failed on signature algorithm: MD5withRSA")
                 .shouldHaveExitValue(0);
 
@@ -135,7 +135,7 @@ public class CheckSignerCertChain {
                 JAVA_SECURITY_FILE +
                 " a.jar ee")
                 .shouldContain("Signature algorithm: MD5withRSA (disabled), 2048-bit key")
-                .shouldContain("Signature algorithm: SHA256withRSA, 2048-bit key")
+                .shouldContain("Signature algorithm: SHA384withRSA, 2048-bit key")
                 .shouldContain("Invalid certificate chain: Algorithm constraints check failed on disabled algorithm: MD5 used with certificate: CN=EE")
                 .shouldHaveExitValue(0);
 
@@ -145,7 +145,7 @@ public class CheckSignerCertChain {
         SecurityTools.jarsigner("-verify -certs signeda.jar " +
                 "-keystore caks1 -storepass changeit -verbose -debug")
                 .shouldContain("Signature algorithm: MD5withRSA (disabled), 2048-bit key")
-                .shouldContain("Signature algorithm: SHA256withRSA, 2048-bit key")
+                .shouldContain("Signature algorithm: SHA384withRSA, 2048-bit key")
                 .shouldContain("Invalid certificate chain: Algorithm constraints check failed on disabled algorithm: MD5 used with certificate: CN=EE")
                 .shouldHaveExitValue(0);
     }

--- a/test/jdk/sun/security/tools/jarsigner/DefaultSigalg.java
+++ b/test/jdk/sun/security/tools/jarsigner/DefaultSigalg.java
@@ -52,12 +52,12 @@ public class DefaultSigalg {
         // Three test cases
         String[] keyalgs = {"DSA", "RSA", "EC", "RSASSA-PSS"};
         // Expected default keytool sigalg
-        String[] sigalgs = {"SHA384withDSA", "SHA384withRSA",
+        String[] sigalgs = {"SHA256withDSA", "SHA384withRSA",
                 "SHA384withECDSA", "RSASSA-PSS"};
         // Expected keysizes
-        int[] keysizes = {3072, 3072, 384, 3072};
+        int[] keysizes = {2048, 3072, 384, 3072};
         // Expected jarsigner digest alg used in signature
-        String[] digestalgs = {"SHA-384", "SHA-384", "SHA-384", "SHA-384"};
+        String[] digestalgs = {"SHA-256", "SHA-384", "SHA-384", "SHA-384"};
 
         // Create a jar file
         sun.tools.jar.Main m =

--- a/test/jdk/sun/security/tools/jarsigner/DefaultSigalg.java
+++ b/test/jdk/sun/security/tools/jarsigner/DefaultSigalg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,8 @@
 
 /**
  * @test
- * @bug 8057810
- * @summary New defaults for DSA keys in jarsigner and keytool
+ * @bug 8057810 8267319
+ * @summary New defaults for DSA, RSA, EC keys in jarsigner and keytool
  * @modules java.base/sun.security.pkcs
  *          java.base/sun.security.tools.keytool
  *          java.base/sun.security.util
@@ -42,20 +42,22 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.security.cert.X509Certificate;
-import java.util.jar.JarFile;
+import java.util.jar.*;
+import java.util.Enumeration;
 
 public class DefaultSigalg {
 
     public static void main(String[] args) throws Exception {
 
         // Three test cases
-        String[] keyalgs = {"DSA", "RSA", "EC"};
+        String[] keyalgs = {"DSA", "RSA", "EC", "RSASSA-PSS"};
         // Expected default keytool sigalg
-        String[] sigalgs = {"SHA256withDSA", "SHA256withRSA", "SHA256withECDSA"};
+        String[] sigalgs = {"SHA384withDSA", "SHA384withRSA",
+                "SHA384withECDSA", "RSASSA-PSS"};
         // Expected keysizes
-        int[] keysizes = {2048, 2048, 256};
+        int[] keysizes = {3072, 3072, 384, 3072};
         // Expected jarsigner digest alg used in signature
-        String[] digestalgs = {"SHA-256", "SHA-256", "SHA-256"};
+        String[] digestalgs = {"SHA-384", "SHA-384", "SHA-384", "SHA-384"};
 
         // Create a jar file
         sun.tools.jar.Main m =
@@ -96,7 +98,20 @@ public class DefaultSigalg {
                             "keytool keysize for " + keyalg + " is " + keysize);
                 }
                 // jarsigner
-                String bk = "META-INF/" + keyalg + "." + keyalg;
+                // truncated to the first 8 chars if alias name is longer
+                String jeName = (keyalg.equals("RSASSA-PSS")? "RSASSA-P.RSA" :
+                        keyalg + "." + keyalg);
+                String bk = "META-INF/" + jeName;
+                if (jf.getEntry(bk) == null) {
+                    System.out.println("JarFile entries:");
+                    Enumeration<JarEntry> entries = jf.entries();
+                    while (entries.hasMoreElements()) {
+                        System.out.println("je: " +
+                                entries.nextElement().getRealName());
+                    }
+                    throw new Exception("Expected jarfile entry name " +
+                            jeName + " not found");
+                }
                 try (InputStream is = jf.getInputStream(jf.getEntry(bk))) {
                     String digestalg = new PKCS7(is).getSignerInfos()[0]
                             .getDigestAlgorithmId().toString();

--- a/test/jdk/sun/security/tools/jarsigner/NewSize7.java
+++ b/test/jdk/sun/security/tools/jarsigner/NewSize7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,8 @@
 
 /*
  * @test
- * @bug 6561126
+ * @bug 6561126 8267319
+ * @modules jdk.jartool/jdk.security.jarsigner
  * @summary keytool should use larger default keysize for keypairs
  * @library /test/lib
  */
@@ -37,8 +38,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
+import jdk.security.jarsigner.JarSigner;
 
 public class NewSize7 {
+
+    private static final String DEF_DIGEST_ALGO =
+            JarSigner.Builder.getDefaultDigestAlgorithm();
+
     public static void main(String[] args) throws Exception {
         String common = "-storepass changeit -keypass changeit -keystore ks ";
         SecurityTools.keytool(common
@@ -53,13 +59,13 @@ public class NewSize7 {
                     jf.getEntry("META-INF/MANIFEST.MF"))) {
                 Asserts.assertTrue(new Manifest(is).getAttributes("ns7.txt")
                         .keySet().stream()
-                        .anyMatch(s -> s.toString().contains("SHA-256")));
+                        .anyMatch(s -> s.toString().contains(DEF_DIGEST_ALGO)));
             }
             try (InputStream is = jf.getInputStream(
                     jf.getEntry("META-INF/ME.SF"))) {
                 Asserts.assertTrue(new Manifest(is).getAttributes("ns7.txt")
                         .keySet().stream()
-                        .anyMatch(s -> s.toString().contains("SHA-256")));
+                        .anyMatch(s -> s.toString().contains(DEF_DIGEST_ALGO)));
             }
         }
     }

--- a/test/jdk/sun/security/tools/jarsigner/SectionNameContinuedVsLineBreak.java
+++ b/test/jdk/sun/security/tools/jarsigner/SectionNameContinuedVsLineBreak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.util.jar.Manifest;
 import java.util.jar.JarFile;
 import jdk.test.lib.util.JarUtils;
 import jdk.test.lib.SecurityTools;
+import jdk.security.jarsigner.JarSigner;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
@@ -39,8 +40,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * @test
- * @bug 8217375
+ * @bug 8217375 8267319
  * @library /test/lib
+ * @modules jdk.jartool/jdk.security.jarsigner
  * @run testng SectionNameContinuedVsLineBreak
  * @summary Checks some specific line break character sequences in section name
  * continuation line breaks.
@@ -48,6 +50,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class SectionNameContinuedVsLineBreak {
 
     static final String KEYSTORE_FILENAME = "test.jks";
+    private static final String DEF_DIGEST_STR =
+            JarSigner.Builder.getDefaultDigestAlgorithm() + "-Digest";
 
     @BeforeTest
     public void prepareCertificate() throws Exception {
@@ -107,12 +111,12 @@ public class SectionNameContinuedVsLineBreak {
     public void testContinueNameAfterCr() throws Exception {
         String filename = "abc";
         test("testContinueNameAfterCr", m -> {
-            String digest = m.getAttributes("abc").getValue("SHA-256-Digest");
+            String digest = m.getAttributes("abc").getValue(DEF_DIGEST_STR);
             m.getEntries().remove("abc");
             return (manifestToString(m)
                     + "Name: a\r"
                     + " bc\r\n"
-                    + "SHA-256-Digest: " + digest + "\r\n"
+                    + DEF_DIGEST_STR + ": " + digest + "\r\n"
                     + "\r\n").getBytes(UTF_8);
         }, filename);
     }
@@ -126,13 +130,13 @@ public class SectionNameContinuedVsLineBreak {
     public void testContinueNameAfterCrOnContinuationLine() throws Exception {
         String filename = "abc";
         test("testContinueNameAfterCr", m -> {
-            String digest = m.getAttributes("abc").getValue("SHA-256-Digest");
+            String digest = m.getAttributes("abc").getValue(DEF_DIGEST_STR);
             m.getEntries().remove("abc");
             return (manifestToString(m)
                     + "Name: a\r\n"
                     + " b\r"
                     + " c\r\n"
-                    + "SHA-256-Digest: " + digest + "\r\n"
+                    + DEF_DIGEST_STR + ": " + digest + "\r\n"
                     + "\r\n").getBytes(UTF_8);
         }, filename);
     }
@@ -146,12 +150,12 @@ public class SectionNameContinuedVsLineBreak {
     public void testEndNameWithCrOnContinuationLine() throws Exception {
         String filename = "abc";
         test("testContinueNameAfterCr", m -> {
-            String digest = m.getAttributes("abc").getValue("SHA-256-Digest");
+            String digest = m.getAttributes("abc").getValue(DEF_DIGEST_STR);
             m.getEntries().remove("abc");
             return (manifestToString(m)
                     + "Name: a\r\n"
                     + " bc\r"
-                    + "SHA-256-Digest: " + digest + "\r\n"
+                    + DEF_DIGEST_STR + ": " + digest + "\r\n"
                     + "\r\n").getBytes(UTF_8);
         }, filename);
     }

--- a/test/jdk/sun/security/tools/jarsigner/SignedAgain.java
+++ b/test/jdk/sun/security/tools/jarsigner/SignedAgain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,8 @@
 
 /*
  * @test
- * @bug 8215922
+ * @bug 8215922 8267319
+ * @modules jdk.jartool/jdk.security.jarsigner
  * @summary jar spec is not precise when describing jar file re-signing
  * @library /test/lib
  */
@@ -37,10 +38,15 @@ import java.util.Base64;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
+import jdk.security.jarsigner.JarSigner;
 
 import static jdk.test.lib.SecurityTools.*;
 
 public class SignedAgain {
+
+    private static final String DEF_DIGEST =
+            JarSigner.Builder.getDefaultDigestAlgorithm();
+
     public static void main(String[] args) throws Exception {
 
         String opt = "-storepass changeit -keystore ks";
@@ -73,20 +79,20 @@ public class SignedAgain {
 
             // Hash of manifest for 2 signed JAR files
             String da = Base64.getEncoder().encodeToString(MessageDigest
-                    .getInstance("SHA-256").digest(ma.readAllBytes()));
+                    .getInstance(DEF_DIGEST).digest(ma.readAllBytes()));
             String db = Base64.getEncoder().encodeToString(MessageDigest
-                    .getInstance("SHA-256").digest(mb.readAllBytes()));
+                    .getInstance(DEF_DIGEST).digest(mb.readAllBytes()));
 
             // They are not the same
             Asserts.assertNotEquals(da, db);
 
             // Digest-Manifest in A.SF matches da
             Asserts.assertEQ(new Manifest(sa).getMainAttributes()
-                    .getValue("SHA-256-Digest-Manifest"), da);
+                    .getValue(DEF_DIGEST + "-Digest-Manifest"), da);
 
             // Digest-Manifest in B.SF matches db
             Asserts.assertEQ(new Manifest(sb).getMainAttributes()
-                    .getValue("SHA-256-Digest-Manifest"), db);
+                    .getValue(DEF_DIGEST + "-Digest-Manifest"), db);
         }
     }
 }

--- a/test/jdk/sun/security/tools/jarsigner/TimestampCheck.java
+++ b/test/jdk/sun/security/tools/jarsigner/TimestampCheck.java
@@ -82,15 +82,16 @@ public class TimestampCheck {
     private static final String PASSWORD = "changeit";
     private static final String defaultPolicyId = "2.3.4";
     private static String host = null;
-    private static final String DEF_DIGEST; // for signature algorithm, no "-"
-
-    static {
-        String digest = JarSigner.Builder.getDefaultDigestAlgorithm();
-        int idx = digest.indexOf("-");
-        if (idx != -1) {
-            DEF_DIGEST = digest.substring(0, idx) + digest.substring(idx + 1);
-        } else {
-            DEF_DIGEST = digest;
+    private static final String getDefaultSigAlg(String keyAlg) {
+        switch(keyAlg) {
+            case "DSA":
+                return "SHA256withDSA";
+            case "RSA":
+                return "SHA384withRSA";
+            case "EC":
+                return "SHA384withECDSA";
+            default:
+                throw new RuntimeException("Error: unsupported algo " + keyAlg);
         }
     }
 
@@ -393,10 +394,10 @@ public class TimestampCheck {
                         .shouldContain("Signature algorithm: SHA3-256withRSA")
                         .shouldContain("Signature algorithm: RSASSA-PSS")
                         .shouldContain("Signature algorithm: " +
-                                DEF_DIGEST + "withECDSA")
+                                getDefaultSigAlg("EC"))
                         .shouldContain("Signature algorithm: Ed25519")
                         .shouldContain("Signature algorithm: " +
-                                DEF_DIGEST + "withDSA");
+                                getDefaultSigAlg("DSA"));
 
                 // Disabled algorithms
                 sign("tsweak", "-digestalg", "SHA1",

--- a/test/jdk/sun/security/tools/jarsigner/TimestampCheck.java
+++ b/test/jdk/sun/security/tools/jarsigner/TimestampCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.security.KeyStoreUtils;
 import jdk.test.lib.security.timestamp.*;
 import jdk.test.lib.util.JarUtils;
+import jdk.security.jarsigner.JarSigner;
 import sun.security.pkcs.PKCS7;
 import sun.security.pkcs.PKCS9Attribute;
 import sun.security.pkcs.SignerInfo;
@@ -55,13 +56,14 @@ import sun.security.timestamp.TimestampToken;
 /*
  * @test
  * @bug 6543842 6543440 6939248 8009636 8024302 8163304 8169911 8180289 8172404
- *      8247960 8242068 8269039 8275887
+ *      8247960 8242068 8269039 8275887 8267319
  * @summary checking response of timestamp
  * @modules java.base/sun.security.pkcs
  *          java.base/sun.security.timestamp
  *          java.base/sun.security.x509
  *          java.base/sun.security.util
  *          java.base/sun.security.tools.keytool
+ *          jdk.jartool/jdk.security.jarsigner
  * @library /lib/testlibrary
  * @library /test/lib
  * @build jdk.test.lib.util.JarUtils
@@ -80,6 +82,17 @@ public class TimestampCheck {
     private static final String PASSWORD = "changeit";
     private static final String defaultPolicyId = "2.3.4";
     private static String host = null;
+    private static final String DEF_DIGEST; // for signature algorithm, no "-"
+
+    static {
+        String digest = JarSigner.Builder.getDefaultDigestAlgorithm();
+        int idx = digest.indexOf("-");
+        if (idx != -1) {
+            DEF_DIGEST = digest.substring(0, idx) + digest.substring(idx + 1);
+        } else {
+            DEF_DIGEST = digest;
+        }
+    }
 
     private static class Interceptor implements RespInterceptor {
 
@@ -291,7 +304,8 @@ public class TimestampCheck {
 
                 sign("policy", "-tsapolicyid",  "1.2.3")
                         .shouldHaveExitValue(0);
-                checkTimestamp("policy.jar", "1.2.3", "SHA-256");
+                checkTimestamp("policy.jar", "1.2.3",
+                        JarSigner.Builder.getDefaultDigestAlgorithm());
 
                 sign("diffpolicy", "-tsapolicyid", "1.2.3")
                         .shouldContain("TSAPolicyID changed in timestamp token")
@@ -378,9 +392,11 @@ public class TimestampCheck {
                         .shouldHaveExitValue(0)
                         .shouldContain("Signature algorithm: SHA3-256withRSA")
                         .shouldContain("Signature algorithm: RSASSA-PSS")
-                        .shouldContain("Signature algorithm: SHA256withECDSA")
+                        .shouldContain("Signature algorithm: " +
+                                DEF_DIGEST + "withECDSA")
                         .shouldContain("Signature algorithm: Ed25519")
-                        .shouldContain("Signature algorithm: SHA256withDSA");
+                        .shouldContain("Signature algorithm: " +
+                                DEF_DIGEST + "withDSA");
 
                 // Disabled algorithms
                 sign("tsweak", "-digestalg", "SHA1",

--- a/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
+++ b/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8217375 8260286
+ * @bug 8217375 8260286 8267319
  * @summary This test is used to verify the compatibility of jarsigner across
  *     different JDK releases. It also can be used to check jar signing (w/
  *     and w/o TSA) and to verify some specific signing and digest algorithms.
@@ -1192,9 +1192,9 @@ public class Compatibility {
 
             // defaults
             if (RSA.equals(keyAlgorithm) || DSA.equals(keyAlgorithm)) {
-                return 2048;
+                return 3072;
             } else if (EC.equals(keyAlgorithm)) {
-                return 256;
+                return 384;
             } else {
                 throw new RuntimeException("problem determining key size");
             }

--- a/test/jdk/sun/security/tools/jarsigner/compatibility/SignTwice.java
+++ b/test/jdk/sun/security/tools/jarsigner/compatibility/SignTwice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /**
- * @bug 8217375
+ * @bug 8217375 8267319
  * @summary This test runs those test cases of {@link Compatibility} test nearby
  * which can be executed within the currently built and tested JDK and without
  * TSA, with only one digest algorithm and with only one key (algorithm and
@@ -36,6 +36,19 @@
  * @test
  * @library /test/lib ../warnings
  * @compile Compatibility.java
+ * @run main/othervm/timeout=600
+ *  -Djava.security.properties=./java.security
+ *  -Duser.language=en
+ *  -Duser.country=US
+ *  -DjdkList=TEST_JDK
+ *  -DtsaList=notsa
+ *  -Dexpired=false
+ *  -DtestComprehensiveJarContents=true
+ *  -DtestJarUpdate=true
+ *  -Dstrict=true
+ *  -DkeyAlgs=EC;0
+ *  -DdigestAlgs=SHA-384
+ *  SignTwice
  * @run main/othervm/timeout=600
  *  -Djava.security.properties=./java.security
  *  -Duser.language=en

--- a/test/jdk/sun/security/tools/keytool/GenKeyPairSigner.java
+++ b/test/jdk/sun/security/tools/keytool/GenKeyPairSigner.java
@@ -186,7 +186,7 @@ public class GenKeyPairSigner {
         System.out.println("Generating a DH cert with -signer option");
         SecurityTools.keytool("-keystore ks -storepass changeit " +
                 "-genkeypair -keyalg DH -alias e3 -dname CN=E3 -signer ca3")
-                .shouldContain("Generating 3,072 bit DH key pair and a certificate (SHA384withDSA) issued by <ca3> with a validity of 90 days")
+                .shouldContain("Generating 3,072 bit DH key pair and a certificate (SHA256withDSA) issued by <ca3> with a validity of 90 days")
                 .shouldContain("for: CN=E3")
                 .shouldHaveExitValue(0);
 
@@ -194,7 +194,7 @@ public class GenKeyPairSigner {
         kstore = KeyStore.getInstance(new File("ks"), "changeit".toCharArray());
         cert = (X509Certificate)kstore.getCertificate("e3");
         sigName = cert.getSigAlgName();
-        if (sigName != "SHA384withDSA") {
+        if (sigName != "SHA256withDSA") {
             throw new Exception("Signature algorithm name is in error");
         }
 
@@ -249,7 +249,7 @@ public class GenKeyPairSigner {
         SecurityTools.keytool("-keystore ksjks -storepass changeit -storetype jks " +
                 "-genkeypair -keyalg XDH -alias e1 -dname CN=E1 " +
                 "-keypass e1keypass -signer ca1 -signerkeypass ca1keypass")
-                .shouldContain("Generating 255 bit XDH key pair and a certificate (SHA384withDSA) issued by <ca1> with a validity of 90 days")
+                .shouldContain("Generating 255 bit XDH key pair and a certificate (SHA256withDSA) issued by <ca1> with a validity of 90 days")
                 .shouldContain("for: CN=E1")
                 .shouldContain("The generated certificate #2 of 3 uses a 1024-bit DSA key which is considered a security risk")
                 .shouldContain("The generated certificate #3 of 3 uses a 1024-bit RSA key which is considered a security risk")
@@ -265,7 +265,7 @@ public class GenKeyPairSigner {
         }
 
         sigName = cert.getSigAlgName();
-        if (sigName != "SHA384withDSA") {
+        if (sigName != "SHA256withDSA") {
             throw new Exception("Signature algorithm name is in error");
         }
 
@@ -284,7 +284,7 @@ public class GenKeyPairSigner {
                 "-list -v")
                 .shouldContain("Alias name: e1")
                 .shouldContain("Certificate chain length: 3")
-                .shouldContain("Signature algorithm name: SHA384withDSA")
+                .shouldContain("Signature algorithm name: SHA256withDSA")
                 .shouldContain("Subject Public Key Algorithm: 255-bit XDH key")
                 .shouldHaveExitValue(0);
     }

--- a/test/jdk/sun/security/tools/keytool/GenKeyPairSigner.java
+++ b/test/jdk/sun/security/tools/keytool/GenKeyPairSigner.java
@@ -239,7 +239,7 @@ public class GenKeyPairSigner {
         SecurityTools.keytool("-keystore ksjks -storepass changeit -storetype jks " +
                 "-genkeypair -keyalg DSA -keysize 1024 -alias ca1 -dname CN=CA1 " +
                 "-keypass ca1keypass -signer ca -signerkeypass cakeypass")
-                .shouldContain("Generating 1,024 bit DSA key pair and a certificate (SHA256withRSA) issued by <ca> with a validity of 90 days")
+                .shouldContain("Generating 1,024 bit DSA key pair and a certificate (SHA384withRSA) issued by <ca> with a validity of 90 days")
                 .shouldContain("for: CN=CA1")
                 .shouldContain("The generated certificate #1 of 2 uses a 1024-bit DSA key which is considered a security risk")
                 .shouldContain("The generated certificate #2 of 2 uses a 1024-bit RSA key which is considered a security risk")
@@ -249,7 +249,7 @@ public class GenKeyPairSigner {
         SecurityTools.keytool("-keystore ksjks -storepass changeit -storetype jks " +
                 "-genkeypair -keyalg XDH -alias e1 -dname CN=E1 " +
                 "-keypass e1keypass -signer ca1 -signerkeypass ca1keypass")
-                .shouldContain("Generating 255 bit XDH key pair and a certificate (SHA256withDSA) issued by <ca1> with a validity of 90 days")
+                .shouldContain("Generating 255 bit XDH key pair and a certificate (SHA384withDSA) issued by <ca1> with a validity of 90 days")
                 .shouldContain("for: CN=E1")
                 .shouldContain("The generated certificate #2 of 3 uses a 1024-bit DSA key which is considered a security risk")
                 .shouldContain("The generated certificate #3 of 3 uses a 1024-bit RSA key which is considered a security risk")
@@ -265,7 +265,7 @@ public class GenKeyPairSigner {
         }
 
         sigName = cert.getSigAlgName();
-        if (sigName != "SHA256withDSA") {
+        if (sigName != "SHA384withDSA") {
             throw new Exception("Signature algorithm name is in error");
         }
 
@@ -284,7 +284,7 @@ public class GenKeyPairSigner {
                 "-list -v")
                 .shouldContain("Alias name: e1")
                 .shouldContain("Certificate chain length: 3")
-                .shouldContain("Signature algorithm name: SHA256withDSA")
+                .shouldContain("Signature algorithm name: SHA384withDSA")
                 .shouldContain("Subject Public Key Algorithm: 255-bit XDH key")
                 .shouldHaveExitValue(0);
     }

--- a/test/jdk/sun/security/tools/keytool/GenKeyPairSigner.java
+++ b/test/jdk/sun/security/tools/keytool/GenKeyPairSigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8260693
+ * @bug 8260693 8267319
  * @summary Test for keytool -genkeypair with -signer and -signerkeypass options
  * @library /test/lib
  * @modules java.base/sun.security.util
@@ -186,7 +186,7 @@ public class GenKeyPairSigner {
         System.out.println("Generating a DH cert with -signer option");
         SecurityTools.keytool("-keystore ks -storepass changeit " +
                 "-genkeypair -keyalg DH -alias e3 -dname CN=E3 -signer ca3")
-                .shouldContain("Generating 2,048 bit DH key pair and a certificate (SHA256withDSA) issued by <ca3> with a validity of 90 days")
+                .shouldContain("Generating 3,072 bit DH key pair and a certificate (SHA384withDSA) issued by <ca3> with a validity of 90 days")
                 .shouldContain("for: CN=E3")
                 .shouldHaveExitValue(0);
 
@@ -194,13 +194,13 @@ public class GenKeyPairSigner {
         kstore = KeyStore.getInstance(new File("ks"), "changeit".toCharArray());
         cert = (X509Certificate)kstore.getCertificate("e3");
         sigName = cert.getSigAlgName();
-        if (sigName != "SHA256withDSA") {
+        if (sigName != "SHA384withDSA") {
             throw new Exception("Signature algorithm name is in error");
         }
 
         pKey = cert.getPublicKey();
         keyLen = KeyUtil.getKeySize(pKey);
-        if (keyLen != 2048) {
+        if (keyLen != 3072) {
             throw new Exception("Key size is in error");
         }
 
@@ -212,8 +212,8 @@ public class GenKeyPairSigner {
         SecurityTools.keytool("-keystore ks -storepass changeit " +
                 "-list -v")
                 .shouldContain("Alias name: e3")
-                .shouldContain("Signature algorithm name: SHA256withRSA")
-                .shouldContain("Subject Public Key Algorithm: 2048-bit DH key")
+                .shouldContain("Signature algorithm name: SHA384withRSA")
+                .shouldContain("Subject Public Key Algorithm: 3072-bit DH key")
                 .shouldHaveExitValue(0);
     }
 

--- a/test/jdk/sun/security/tools/keytool/GenerateAll.java
+++ b/test/jdk/sun/security/tools/keytool/GenerateAll.java
@@ -118,7 +118,7 @@ public class GenerateAll {
     public Object[][] dataProvider() {
         return new Object[][]{
                 {"rsa", "rsa", null, "RSA", SHA_384, SHA384withRSA},
-                {"dsa", "dsa", null, "DSA", SHA_384, SHA384withDSA},
+                {"dsa", "dsa", null, "DSA", SHA_256, SHA256withDSA},
                 {"r", "rsa", "rsassa-pss", "RSA", SHA_384, RSASSA_PSS},
                 {"pss", "rsassa-pss", null, "RSA", SHA_384, RSASSA_PSS},
                 {"ec", "ec", null, "EC", SHA_384, SHA384withECDSA},

--- a/test/jdk/sun/security/tools/keytool/GenerateAll.java
+++ b/test/jdk/sun/security/tools/keytool/GenerateAll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8242184 8242068
+ * @bug 8242184 8242068 8267319
  * @summary keytool and jarsigner for all algorithms
  * @library /test/lib
  * @modules java.base/sun.security.util
@@ -117,11 +117,11 @@ public class GenerateAll {
     @DataProvider(name = "all")
     public Object[][] dataProvider() {
         return new Object[][]{
-                {"rsa", "rsa", null, "RSA", SHA_256, SHA256withRSA},
-                {"dsa", "dsa", null, "DSA", SHA_256, SHA256withDSA},
-                {"r", "rsa", "rsassa-pss", "RSA", SHA_256, RSASSA_PSS},
-                {"pss", "rsassa-pss", null, "RSA", SHA_256, RSASSA_PSS},
-                {"ec", "ec", null, "EC", SHA_256, SHA256withECDSA},
+                {"rsa", "rsa", null, "RSA", SHA_384, SHA384withRSA},
+                {"dsa", "dsa", null, "DSA", SHA_384, SHA384withDSA},
+                {"r", "rsa", "rsassa-pss", "RSA", SHA_384, RSASSA_PSS},
+                {"pss", "rsassa-pss", null, "RSA", SHA_384, RSASSA_PSS},
+                {"ec", "ec", null, "EC", SHA_384, SHA384withECDSA},
                 {"ed25519", "ed25519", null, "EC", SHA_512, Ed25519},
                 {"ed448", "ed448", null, "EC", SHAKE256_LEN, Ed448},
         };

--- a/test/jdk/sun/security/tools/keytool/GroupName.java
+++ b/test/jdk/sun/security/tools/keytool/GroupName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import java.security.interfaces.ECKey;
 
 /**
  * @test
- * @bug 8213400 8214179
+ * @bug 8213400 8214179 8267319
  * @summary Support choosing group name in keytool keypair generation
  * @library /test/lib
  */
@@ -48,7 +48,7 @@ public class GroupName {
         gen("b", "-keyalg EC")
                 .shouldHaveExitValue(0)
                 .shouldNotContain("Specifying -keysize for generating EC keys is deprecated");
-        checkCurveName("b", "secp256r1");
+        checkCurveName("b", "secp384r1"); // default; if none specified
 
         gen("c", "-keyalg EC -keysize 256")
                 .shouldHaveExitValue(0)
@@ -67,7 +67,8 @@ public class GroupName {
 
         kt("-list -v")
                 .shouldHaveExitValue(0)
-                .shouldContain("Subject Public Key Algorithm: 256-bit EC (secp256r1) key");
+                .shouldContain("Subject Public Key Algorithm: 256-bit EC (secp256r1) key")
+                .shouldContain("Subject Public Key Algorithm: 384-bit EC (secp384r1) key");
     }
 
     private static void checkCurveName(String a, String name)

--- a/test/jdk/sun/security/tools/keytool/KeyAlg.java
+++ b/test/jdk/sun/security/tools/keytool/KeyAlg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8029659 8214179
+ * @bug 8029659 8214179 8267319
  * @summary Keytool, print key algorithm of certificate or key entry
  * @library /test/lib
  */
@@ -41,9 +41,9 @@ public class KeyAlg {
         keytool("-printcert -file user.crt")
                 .shouldMatch("Signature algorithm name:.*SHA1withECDSA")
                 .shouldMatch("Subject Public Key Algorithm:.*1024.*RSA");
-        keytool("-genkeypair -alias f -dname CN=f -keyalg EC")
+        keytool("-genkeypair -alias g -dname CN=g -keyalg EC -keysize 256")
                 .shouldContain("Generating 256 bit EC (secp256r1) key pair");
-        keytool("-genkeypair -alias g -dname CN=g -keyalg EC -keysize 384")
+        keytool("-genkeypair -alias f -dname CN=f -keyalg EC")
                 .shouldContain("Generating 384 bit EC (secp384r1) key pair");
     }
 

--- a/test/jdk/sun/security/tools/keytool/NewSize7.java
+++ b/test/jdk/sun/security/tools/keytool/NewSize7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,10 +23,10 @@
 
 /*
  * @test
- * @bug 6561126
+ * @bug 6561126 8267319
  * @summary keytool should use larger default keysize for keypairs
- * @modules java.base/sun.security.tools.keytool
- * @compile -XDignore.symbol.file NewSize7.java
+ * @modules java.base/sun.security.util
+ *          java.base/sun.security.tools.keytool
  * @run main NewSize7
  */
 
@@ -37,6 +37,7 @@ import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPublicKey;
+import sun.security.util.SecurityProviderConstants;
 
 public class NewSize7 {
     public static void main(String[] args) throws Exception {
@@ -52,11 +53,11 @@ public class NewSize7 {
         }
         Files.delete(Paths.get(FILE));
         RSAPublicKey r = (RSAPublicKey)ks.getCertificate("a").getPublicKey();
-        if (r.getModulus().bitLength() != 2048) {
+        if (r.getModulus().bitLength() != 3072) {
             throw new Exception("Bad keysize");
         }
         X509Certificate x = (X509Certificate)ks.getCertificate("a");
-        if (!x.getSigAlgName().equals("SHA256withRSA")) {
+        if (!x.getSigAlgName().equals("SHA384withRSA")) {
             throw new Exception("Bad sigalg");
         }
     }

--- a/test/jdk/sun/security/tools/keytool/fakegen/DefaultSignatureAlgorithm.java
+++ b/test/jdk/sun/security/tools/keytool/fakegen/DefaultSignatureAlgorithm.java
@@ -52,8 +52,8 @@ public class DefaultSignatureAlgorithm {
         check("RSA", 7680, null, "SHA384withRSA");
         check("RSA", 7681, null, "SHA512withRSA");
 
-        check("DSA", 1024, null, "SHA384withDSA");
-        check("DSA", 3072, null, "SHA384withDSA");
+        check("DSA", 1024, null, "SHA256withDSA");
+        check("DSA", 3072, null, "SHA256withDSA");
 
         check("EC", 384, null, "SHA384withECDSA");
 

--- a/test/jdk/sun/security/tools/keytool/fakegen/DefaultSignatureAlgorithm.java
+++ b/test/jdk/sun/security/tools/keytool/fakegen/DefaultSignatureAlgorithm.java
@@ -46,11 +46,13 @@ public class DefaultSignatureAlgorithm {
     static int pos = 0;
 
     public static void main(String[] args) throws Exception {
-        check("RSA", 1024, null, "SHA256withRSA");
+        check("RSA", 1024, null, "SHA384withRSA");
         check("RSA", 3072, null, "SHA384withRSA");
-        check("RSA", 7680, null, "SHA512withRSA");
+        check("RSA", 3073, null, "SHA384withRSA");
+        check("RSA", 7680, null, "SHA384withRSA");
+        check("RSA", 7681, null, "SHA512withRSA");
 
-        check("DSA", 1024, null, "SHA256withDSA");
+        check("DSA", 1024, null, "SHA384withDSA");
         check("DSA", 3072, null, "SHA384withDSA");
 
         check("EC", 384, null, "SHA384withECDSA");

--- a/test/jdk/sun/security/tools/keytool/fakegen/DefaultSignatureAlgorithm.java
+++ b/test/jdk/sun/security/tools/keytool/fakegen/DefaultSignatureAlgorithm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8138766 8227059 8227595
+ * @bug 8138766 8227059 8227595 8267319
  * @summary New default -sigalg for keytool
  * @library /test/lib
  * @build java.base/sun.security.rsa.RSAKeyPairGenerator
@@ -47,13 +47,11 @@ public class DefaultSignatureAlgorithm {
 
     public static void main(String[] args) throws Exception {
         check("RSA", 1024, null, "SHA256withRSA");
-        check("RSA", 3072, null, "SHA256withRSA");
-        check("RSA", 3073, null, "SHA384withRSA");
-        check("RSA", 7680, null, "SHA384withRSA");
-        check("RSA", 7681, null, "SHA512withRSA");
+        check("RSA", 3072, null, "SHA384withRSA");
+        check("RSA", 7680, null, "SHA512withRSA");
 
         check("DSA", 1024, null, "SHA256withDSA");
-        check("DSA", 3072, null, "SHA256withDSA");
+        check("DSA", 3072, null, "SHA384withDSA");
 
         check("EC", 384, null, "SHA384withECDSA");
 

--- a/test/jdk/sun/security/tools/keytool/fakegen/PSS.java
+++ b/test/jdk/sun/security/tools/keytool/fakegen/PSS.java
@@ -66,7 +66,7 @@ public class PSS {
                 AlgorithmId.SHA384_oid);
 
         check((X509Certificate)ks.getCertificate("a"), "RSA",
-                AlgorithmId.SHA256_oid);
+                AlgorithmId.SHA384_oid);
 
         check((X509Certificate)ks.getCertificate("b"), "RSA",
                 AlgorithmId.SHA384_oid);

--- a/test/jdk/sun/security/tools/keytool/fakegen/PSS.java
+++ b/test/jdk/sun/security/tools/keytool/fakegen/PSS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8215694 8222987 8225257
+ * @bug 8215694 8222987 8225257 8267319
  * @summary keytool cannot generate RSASSA-PSS certificates
  * @library /test/lib
  * @build java.base/sun.security.rsa.RSAKeyPairGenerator
@@ -63,7 +63,7 @@ public class PSS {
                 new File("ks"), "changeit".toCharArray());
 
         check((X509Certificate)ks.getCertificate("p"), "RSASSA-PSS",
-                AlgorithmId.SHA256_oid);
+                AlgorithmId.SHA384_oid);
 
         check((X509Certificate)ks.getCertificate("a"), "RSA",
                 AlgorithmId.SHA256_oid);


### PR DESCRIPTION
It's been several years since we increased the default key sizes. Before shifting to PQC, NSA replaced its Suite B cryptography recommendations with the Commercial National Security Algorithm Suite which suggests:

- SHA-384 for secure hashing
- AES-256 for symmetric encryption
- RSA with 3072 bit keys for digital signatures and for key exchange
- Diffie Hellman (DH) with 3072 bit keys for key exchange
- Elliptic curve [P-384] for key exchange (ECDH) and for digital signatures (ECDSA)

So, this proposed changes made the suggested key size and algorithm changes. The changes are mostly in keytool, jarsigner and their regression tests, so @wangweij Could you please take a look?

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8267319](https://bugs.openjdk.java.net/browse/JDK-8267319): Use larger default key sizes and algorithms based on CNSA
 * [JDK-8282995](https://bugs.openjdk.java.net/browse/JDK-8282995): Use larger default key sizes and algorithms based on CNSA (**CSR**)


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**) ⚠️ Review applies to 1eb6329248502f6d5e19ced35b164d3976230566
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**) ⚠️ Review applies to a48ccef573ef74a5f26028e32b6e5d8629497ca2


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7652/head:pull/7652` \
`$ git checkout pull/7652`

Update a local copy of the PR: \
`$ git checkout pull/7652` \
`$ git pull https://git.openjdk.java.net/jdk pull/7652/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7652`

View PR using the GUI difftool: \
`$ git pr show -t 7652`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7652.diff">https://git.openjdk.java.net/jdk/pull/7652.diff</a>

</details>
