### PR TITLE
8282513: New gtest for JDK-8281472 fails on 32-bit systems

### DIFF
--- a/test/hotspot/gtest/runtime/test_largeOptions.cpp
+++ b/test/hotspot/gtest/runtime/test_largeOptions.cpp
@@ -72,7 +72,7 @@ TEST_VM(LARGE_OPTION, small_ints) {
 
 
 TEST_VM(LARGE_OPTION, large_int_overflow) { // Test 0x100000000
-  ASSERT_FALSE(LargeOptionsTest::test_option_value("CompilerDirectivesLimit", 4294967296));
+  ASSERT_FALSE(LargeOptionsTest::test_option_value("CompilerDirectivesLimit=4294967296"));
 }
 
 
@@ -102,9 +102,12 @@ TEST_VM(LARGE_OPTION, large_intxs) {
 
 TEST_VM(LARGE_OPTION, small_intxs) {
   ASSERT_TRUE(LargeOptionsTest::test_option_value("MaxJNILocalCapacity", min_intx + 1));
-  ASSERT_EQ(MaxJNILocalCapacity, -9223372036854775807);
+  ASSERT_EQ(MaxJNILocalCapacity, min_intx + 1);
   ASSERT_TRUE(LargeOptionsTest::test_option_value("MaxJNILocalCapacity", min_intx));
   ASSERT_EQ(MaxJNILocalCapacity, min_intx);
   // Test value that's less than min_intx (-0x8000000000000001).
-  ASSERT_FALSE(LargeOptionsTest::test_option_value("MaxJNILocalCapacity=-9223372036854775809"));
+  if (sizeof(intx) == 8)
+    ASSERT_FALSE(LargeOptionsTest::test_option_value("MaxJNILocalCapacity=-9223372036854775809"));
+  else // must be 4
+    ASSERT_FALSE(LargeOptionsTest::test_option_value("MaxJNILocalCapacity=-2147483647"));
 }

--- a/test/hotspot/gtest/runtime/test_largeOptions.cpp
+++ b/test/hotspot/gtest/runtime/test_largeOptions.cpp
@@ -46,7 +46,7 @@ public:
 
 // CompilerDirectivesLimit is a diagnostic int option.
 TEST_VM(LARGE_OPTION, large_ints) {
-  for (intx x = max_jint - 1; x <= (intx)max_jint + 1; x++) {
+  for (int64_t x = max_jint - 1; x <= (int64_t)max_jint + 1; x++) {
     bool result = LargeOptionsTest::test_option_value("CompilerDirectivesLimit", x);
     if (x > max_jint) {
       ASSERT_FALSE(result);
@@ -59,7 +59,7 @@ TEST_VM(LARGE_OPTION, large_ints) {
 
 
 TEST_VM(LARGE_OPTION, small_ints) {
-  for (intx x = min_jint + 1; x >= (intx)min_jint - 1; x--) {
+  for (int64_t x = min_jint + 1; x >= (int64_t)min_jint - 1; x--) {
     bool result = LargeOptionsTest::test_option_value("CompilerDirectivesLimit", x);
     if (x < min_jint) {
       ASSERT_FALSE(result);
@@ -78,7 +78,7 @@ TEST_VM(LARGE_OPTION, large_int_overflow) { // Test 0x100000000
 
 // HandshakeTimeout is a diagnostic uint option.
 TEST_VM(LARGE_OPTION, large_uints) {
-  for (uintx x = max_juint - 1; x <= (uintx)max_juint + 1; x++) {
+  for (uint64_t x = max_juint - 1; x <= (uint64_t)max_juint + 1; x++) {
     bool result = LargeOptionsTest::test_option_value("HandshakeTimeout", x);
     if (x <= max_juint) {
       ASSERT_TRUE(result);
@@ -93,9 +93,9 @@ TEST_VM(LARGE_OPTION, large_uints) {
 // MaxJNILocalCapacity is an intx option.
 TEST_VM(LARGE_OPTION, large_intxs) {
   // max_intx + 1 equals min_intx!
-  for (julong x = max_intx - 1; x <= (julong)max_intx + 1; x++) {
+  for (uint64_t x = max_intx - 1; x <= (uint64_t)max_intx + 1; x++) {
     ASSERT_TRUE(LargeOptionsTest::test_option_value("MaxJNILocalCapacity", x));
-    ASSERT_EQ((julong)MaxJNILocalCapacity, x);
+    ASSERT_EQ((uint64_t)MaxJNILocalCapacity, x);
   }
 }
 

--- a/test/hotspot/gtest/runtime/test_largeOptions.cpp
+++ b/test/hotspot/gtest/runtime/test_largeOptions.cpp
@@ -30,10 +30,10 @@
 
 class LargeOptionsTest : public ::testing::Test {
 public:
-  static bool test_option_value(const char* option, intx value) {
+  static bool test_option_value(const char* option, int64_t value) {
     char buffer[100];
     UnlockDiagnosticVMOptions = true;
-    os::snprintf(buffer, 100, "%s=" INTX_FORMAT, option, value);
+    os::snprintf(buffer, 100, "%s=" INT64_FORMAT, option, value);
     return Arguments::parse_argument(buffer, JVMFlagOrigin::COMMAND_LINE);
   }
 


### PR DESCRIPTION
The int tests need to use a type that is always > 32-bit so switch intx/uintx to int64_t/uint64_t.

Tested: GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8282513](https://bugs.openjdk.java.net/browse/JDK-8282513): New gtest for JDK-8281472 fails on 32-bit systems


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7653/head:pull/7653` \
`$ git checkout pull/7653`

Update a local copy of the PR: \
`$ git checkout pull/7653` \
`$ git pull https://git.openjdk.java.net/jdk pull/7653/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7653`

View PR using the GUI difftool: \
`$ git pr show -t 7653`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7653.diff">https://git.openjdk.java.net/jdk/pull/7653.diff</a>

</details>
