### PR TITLE
8274788: Support archived heap objects in ParallelGC

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1994,7 +1994,7 @@ void FileMapInfo::map_or_load_heap_regions() {
     } else if (HeapShared::can_load()) {
       success = HeapShared::load_heap_regions(this);
     } else {
-      log_info(cds)("Cannot use CDS heap data. UseEpsilonGC, UseG1GC or UseSerialGC are required.");
+      log_info(cds)("Cannot use CDS heap data. UseEpsilonGC, UseG1GC, UseSerialGC or UseParallelGC are required.");
     }
   }
 

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -798,6 +798,16 @@ void ParallelScavengeHeap::resize_old_gen(size_t desired_free_space) {
   _old_gen->resize(desired_free_space);
 }
 
+HeapWord* ParallelScavengeHeap::allocate_loaded_archive_space(size_t size) {
+  return _old_gen->allocate(size);
+}
+
+void ParallelScavengeHeap::complete_loaded_archive_space(MemRegion archive_space) {
+  assert(_old_gen->object_space()->used_region().contains(archive_space),
+         "Archive space not contained in old gen");
+  _old_gen->complete_loaded_archive_space(archive_space);
+}
+
 #ifndef PRODUCT
 void ParallelScavengeHeap::record_gen_tops_before_GC() {
   if (ZapUnusedHeapArea) {

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -273,6 +273,11 @@ class ParallelScavengeHeap : public CollectedHeap {
   WorkerThreads& workers() {
     return _workers;
   }
+
+  // Support for loading objects from CDS archive into the heap
+  bool can_load_archived_objects() const { return UseCompressedOops; }
+  HeapWord* allocate_loaded_archive_space(size_t size);
+  void complete_loaded_archive_space(MemRegion archive_space);
 };
 
 // Class that can be used to print information about the

--- a/src/hotspot/share/gc/parallel/psOldGen.cpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.cpp
@@ -283,6 +283,15 @@ void PSOldGen::shrink(size_t bytes) {
   }
 }
 
+void PSOldGen::complete_loaded_archive_space(MemRegion archive_space) {
+  HeapWord* cur = archive_space.start();
+  while (cur < archive_space.end()) {
+    _start_array.allocate_block(cur);
+    size_t word_size = cast_to_oop(cur)->size();
+    cur += word_size;
+  }
+}
+
 void PSOldGen::resize(size_t desired_free_space) {
   const size_t alignment = virtual_space()->alignment();
   const size_t size_before = virtual_space()->committed_size();

--- a/src/hotspot/share/gc/parallel/psOldGen.hpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.hpp
@@ -133,6 +133,8 @@ class PSOldGen : public CHeapObj<mtGC> {
     return virtual_space()->uncommitted_size() == 0;
   }
 
+  void complete_loaded_archive_space(MemRegion archive_space);
+
   // Calculating new sizes
   void resize(size_t desired_free_space);
 

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -428,6 +428,7 @@ hotspot_appcds_dynamic = \
  -runtime/cds/appcds/StaticArchiveWithLambda.java \
  -runtime/cds/appcds/TestCombinedCompressedFlags.java \
  -runtime/cds/appcds/TestEpsilonGCWithCDS.java \
+ -runtime/cds/appcds/TestParallelGCWithCDS.java \
  -runtime/cds/appcds/TestSerialGCWithCDS.java \
  -runtime/cds/appcds/TestZGCWithCDS.java \
  -runtime/cds/appcds/UnusedCPDuringDump.java \

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test Loading CDS archived heap objects into ParallelGC
+ * @bug 8274788
+ * @requires vm.cds
+ * @requires vm.gc.Parallel
+ * @requires vm.gc.G1
+ *
+ * @comment don't run this test if any -XX::+Use???GC options are specified, since they will
+ *          interfere with the the test.
+ * @requires vm.gc == null
+ *
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ * @compile test-classes/Hello.java
+ * @run driver TestParallelGCWithCDS
+ */
+
+import jdk.test.lib.Platform;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class TestParallelGCWithCDS {
+    public final static String HELLO = "Hello World";
+    static String helloJar;
+
+    public static void main(String... args) throws Exception {
+        helloJar = JarBuilder.build("hello", "Hello");
+
+        // Check if we can use ParallelGC during dump time, or run time, or both.
+        test(false, true);
+        test(true,  false);
+        test(true,  true);
+
+        // With G1 we usually have 2 heap regions. To increase test coverage, we can have 3 heap regions
+        // by using "-Xmx256m -XX:ObjectAlignmentInBytes=64"
+        if (Platform.is64bit()) test(false, true, true);
+    }
+
+    final static String G1 = "-XX:+UseG1GC";
+    final static String Parallel = "-XX:+UseParallelGC";
+
+    static void test(boolean dumpWithParallel, boolean execWithParallel) throws Exception {
+        test(dumpWithParallel, execWithParallel, false);
+    }
+
+    static void test(boolean dumpWithParallel, boolean execWithParallel, boolean useSmallRegions) throws Exception {
+        String dumpGC = dumpWithParallel ? Parallel : G1;
+        String execGC = execWithParallel ? Parallel : G1;
+        String small1 = useSmallRegions ? "-Xmx256m" : "-showversion";
+        String small2 = useSmallRegions ? "-XX:ObjectAlignmentInBytes=64" : "-showversion";
+        OutputAnalyzer out;
+
+        System.out.println("0. Dump with " + dumpGC);
+        out = TestCommon.dump(helloJar,
+                              new String[] {"Hello"},
+                              dumpGC,
+                              small1,
+                              small2,
+                              "-Xlog:cds");
+        out.shouldContain("Dumping shared data to file:");
+        out.shouldHaveExitValue(0);
+
+        System.out.println("1. Exec with " + execGC);
+        out = TestCommon.exec(helloJar,
+                              execGC,
+                              small1,
+                              small2,
+                              "-Xlog:cds",
+                              "Hello");
+        out.shouldContain(HELLO);
+        out.shouldHaveExitValue(0);
+
+        int n = 2;
+        if (!dumpWithParallel && execWithParallel) {
+            // We dumped with G1, so we have an archived heap. At exec time, try to load them into
+            // a small ParallelGC heap that may be too small.
+            String[] sizes = {
+                "4m",   // usually this will success load the archived heap
+                "2m",   // usually this will fail to load the archived heap, but app can launch
+                        // or fail with "GC triggered before VM initialization completed"
+                "1m"    // usually this will cause VM launch to fail with "Too small maximum heap"
+            };
+            for (String sz : sizes) {
+                String xmx = "-Xmx" + sz;
+                System.out.println("=======\n" + n + ". Exec with " + execGC + " " + xmx);
+                out = TestCommon.exec(helloJar,
+                                      execGC,
+                                      small1,
+                                      small2,
+                                      xmx,
+                                      "-Xlog:cds",
+                                      "Hello");
+                if (out.getExitValue() == 0) {
+                    out.shouldContain(HELLO);
+                } else {
+                    String output = out.getStdout() + out.getStderr();
+                    String exp1 = "Too small maximum heap";
+                    String exp2 = "GC triggered before VM initialization completed";
+                    if (!output.contains(exp1) && !output.contains(exp2)) {
+                        throw new RuntimeException("Either '" + exp1 + "' or '" + exp2 + "' must be in stdout/stderr \n");
+                    }
+                }
+                n++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
With this change when the UseParallelGC is enabled, the CDS archived heap objects could be loaded
into the PSOldGen during VM bootstrap. This improves startup time since the module graph could be
loaded from the archive.

```
$ perf stat -r 40 -XX:+UseParallelGC -version

before: 0.069244290 seconds time elapsed            ( +-  0.49% )
after:    0.058555167 seconds time elapsed          ( +-  0.49% )
```
Passed CI tiers 1 - 4 tests.

Thanks @tschatzl for his help on GC changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274788](https://bugs.openjdk.java.net/browse/JDK-8274788): Support archived heap objects in ParallelGC


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to 350a1300dc6ff27cd6ca502c5b819c298ab99ff4
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to 350a1300dc6ff27cd6ca502c5b819c298ab99ff4
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 350a1300dc6ff27cd6ca502c5b819c298ab99ff4


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7655/head:pull/7655` \
`$ git checkout pull/7655`

Update a local copy of the PR: \
`$ git checkout pull/7655` \
`$ git pull https://git.openjdk.java.net/jdk pull/7655/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7655`

View PR using the GUI difftool: \
`$ git pr show -t 7655`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7655.diff">https://git.openjdk.java.net/jdk/pull/7655.diff</a>

</details>
