### PR TITLE
8282484: G1: Predicted old time in log always zero

### DIFF
--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1313,7 +1313,6 @@ void G1Policy::calculate_old_collection_set_regions(G1CollectionSetCandidates* c
   num_optional_regions = 0;
   uint num_expensive_regions = 0;
 
-  double predicted_old_time_ms = 0.0;
   double predicted_initial_time_ms = 0.0;
   double predicted_optional_time_ms = 0.0;
 
@@ -1344,7 +1343,7 @@ void G1Policy::calculate_old_collection_set_regions(G1CollectionSetCandidates* c
     time_remaining_ms = MAX2(time_remaining_ms - predicted_time_ms, 0.0);
     // Add regions to old set until we reach the minimum amount
     if (num_initial_regions < min_old_cset_length) {
-      predicted_old_time_ms += predicted_time_ms;
+      predicted_initial_time_ms += predicted_time_ms;
       num_initial_regions++;
       // Record the number of regions added with no time remaining
       if (time_remaining_ms == 0.0) {
@@ -1358,7 +1357,7 @@ void G1Policy::calculate_old_collection_set_regions(G1CollectionSetCandidates* c
     } else {
       // Keep adding regions to old set until we reach the optional threshold
       if (time_remaining_ms > optional_threshold_ms) {
-        predicted_old_time_ms += predicted_time_ms;
+        predicted_initial_time_ms += predicted_time_ms;
         num_initial_regions++;
       } else if (time_remaining_ms > 0) {
         // Keep adding optional regions until time is up.
@@ -1382,7 +1381,7 @@ void G1Policy::calculate_old_collection_set_regions(G1CollectionSetCandidates* c
   }
 
   log_debug(gc, ergo, cset)("Finish choosing collection set old regions. Initial: %u, optional: %u, "
-                            "predicted old time: %1.2fms, predicted optional time: %1.2fms, time remaining: %1.2f",
+                            "predicted initial time: %1.2fms, predicted optional time: %1.2fms, time remaining: %1.2f",
                             num_initial_regions, num_optional_regions,
                             predicted_initial_time_ms, predicted_optional_time_ms, time_remaining_ms);
 }


### PR DESCRIPTION
Hi all,

  can I get reviews for this change that fixes log output for the amount of expected time the initial set of old gen regions is going to take?

Previously, due to this error, this value has always been zero.

Testing: local testing, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282484](https://bugs.openjdk.java.net/browse/JDK-8282484): G1: Predicted old time in log always zero


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7657/head:pull/7657` \
`$ git checkout pull/7657`

Update a local copy of the PR: \
`$ git checkout pull/7657` \
`$ git pull https://git.openjdk.java.net/jdk pull/7657/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7657`

View PR using the GUI difftool: \
`$ git pr show -t 7657`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7657.diff">https://git.openjdk.java.net/jdk/pull/7657.diff</a>

</details>
