### PR TITLE
8282483: Ensure that Utils.getAllInterfaces returns unique instances

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -905,21 +905,21 @@ public class Utils {
      */
     public Set<TypeMirror> getAllInterfaces(TypeElement te) {
         Set<TypeMirror> results = new LinkedHashSet<>();
-        addSuperInterfaces(te.asType(), results);
+        addSuperInterfaces(te.asType(), results, new HashSet<>());
         return results;
     }
 
-    private void addSuperInterfaces(TypeMirror type, Set<TypeMirror> results) {
+    private void addSuperInterfaces(TypeMirror type, Set<TypeMirror> results, Set<Element> visited) {
         TypeMirror superType = null;
         for (TypeMirror t : typeUtils.directSupertypes(type)) {
             if (typeUtils.isSameType(t, getObjectType()))
                 continue;
             TypeElement e = asTypeElement(t);
             if (isInterface(e)) {
-                if (isPublic(e) || isLinkable(e)) {
+                if ((isPublic(e) || isLinkable(e)) && visited.add(typeUtils.asElement(t))) {
                     results.add(t);
                 }
-                addSuperInterfaces(t, results);
+                addSuperInterfaces(t, results, visited);
             } else {
                 // there can be at most one superclass and it is not null
                 assert superType == null && t != null : superType;
@@ -929,7 +929,7 @@ public class Utils {
         }
         // Collect the super-interfaces of the supertype.
         if (superType != null)
-            addSuperInterfaces(superType, results);
+            addSuperInterfaces(superType, results, visited);
     }
 
     /**


### PR DESCRIPTION
Instances of TypeMirror that are equal (TypeMirror::equals), aren't necessarily the same (Types::isSameType). If care is not taken when putting instances of TypeMirror into a set, that set might end up containing the same instances.

If Utils.getAllInterfaces is called on a type that extends or implements a particular interface multiple times (on different levels of that type's hierarchy), the returned set might contain multiple representations of that interface. For example, I've seen a case where getAllInterfaces that was passed a TypeElement corresponding to java.util.ArrayList returned a set containing 3 instances of TypeMirror corresponding to `java.util.Collection<E>`.

A bit of archaeology. The old standard doclet (removed in JDK-8177511, commit 33ab1995) collected instances of com.sun.javadoc.Type in a TreeMap, keying them by instances of com.sun.tools.javadoc.main.ClassDocImpl (removed in JDK-8215584, commit 151e628) which implemented Comparable. ClassDocImpl.compareTo worked by comparing instances of CollationKey derived from FQNs of types represented by respective instances of ClassDocImpl.

I'm not sure why `TreeMap<ClassDocImpl, Type>` was changed to `LinkedHashSet<TypeMirror>`.