### PR TITLE
JDK-8177107: Reduce memory footprint of java.lang.reflect.Constructor/Method

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/Constructor.java
+++ b/src/java.base/share/classes/java/lang/reflect/Constructor.java
@@ -125,8 +125,10 @@ public final class Constructor<T> extends Executable {
                 byte[] annotations,
                 byte[] parameterAnnotations) {
         this.clazz = declaringClass;
-        this.parameterTypes = parameterTypes;
-        this.exceptionTypes = checkedExceptions;
+        this.parameterTypes = (parameterTypes.length == 0) ?
+            Executable.NO_TYPES : parameterTypes;
+        this.exceptionTypes = (checkedExceptions.length == 0) ?
+            Executable.NO_TYPES : checkedExceptions;
         this.modifiers = modifiers;
         this.slot = slot;
         this.signature = signature;
@@ -244,7 +246,7 @@ public final class Constructor<T> extends Executable {
       if (getSignature() != null) {
         return (TypeVariable<Constructor<T>>[])getGenericInfo().getTypeParameters();
       } else
-          return (TypeVariable<Constructor<T>>[])new TypeVariable[0];
+          return (TypeVariable<Constructor<T>>[])Executable.NO_TYPE_VARS;
     }
 
 

--- a/src/java.base/share/classes/java/lang/reflect/Executable.java
+++ b/src/java.base/share/classes/java/lang/reflect/Executable.java
@@ -55,6 +55,11 @@ public abstract sealed class Executable extends AccessibleObject
     @SuppressWarnings("deprecation")
     Executable() {}
 
+    @SuppressWarnings({"rawtypes"})
+    static final TypeVariable[] NO_TYPE_VARS = new TypeVariable[0];
+
+    static final Class<?>[] NO_TYPES = new Class<?>[0];
+
     /**
      * Accessor method to allow code sharing
      */

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -132,9 +132,11 @@ public final class Method extends Executable {
            byte[] annotationDefault) {
         this.clazz = declaringClass;
         this.name = name;
-        this.parameterTypes = parameterTypes;
+        this.parameterTypes = (parameterTypes.length == 0) ?
+            Executable.NO_TYPES : parameterTypes;
         this.returnType = returnType;
-        this.exceptionTypes = checkedExceptions;
+        this.exceptionTypes = (checkedExceptions.length == 0) ?
+            Executable.NO_TYPES : checkedExceptions;
         this.modifiers = modifiers;
         this.slot = slot;
         this.signature = signature;
@@ -254,7 +256,7 @@ public final class Method extends Executable {
         if (getGenericSignature() != null)
             return (TypeVariable<Method>[])getGenericInfo().getTypeParameters();
         else
-            return (TypeVariable<Method>[])new TypeVariable[0];
+            return (TypeVariable<Method>[])Executable.NO_TYPE_VARS;
     }
 
     /**


### PR DESCRIPTION
Refactoring of Method and Constructor to share a single empty array for parameters and exceptions as well as type variables.

Existing core reflection regression tests pass with the change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8177107](https://bugs.openjdk.java.net/browse/JDK-8177107): Reduce memory footprint of java.lang.reflect.Constructor/Method


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7667/head:pull/7667` \
`$ git checkout pull/7667`

Update a local copy of the PR: \
`$ git checkout pull/7667` \
`$ git pull https://git.openjdk.java.net/jdk pull/7667/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7667`

View PR using the GUI difftool: \
`$ git pr show -t 7667`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7667.diff">https://git.openjdk.java.net/jdk/pull/7667.diff</a>

</details>
