### PR TITLE
8272735: Add missing SubL node transformations

### DIFF
--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -61,7 +61,7 @@ Node* SubNode::Identity(PhaseGVN* phase) {
   }
 
   // Convert "(X+Y) - Y" into X and "(X+Y) - X" into Y
-  if (in(1)->Opcode() == Op_AddI) {
+  if (in(1)->Opcode() == Op_AddI || in(1)->Opcode() == Op_AddL) {
     if (in(1)->in(2) == in(2)) {
       return in(1)->in(1);
     }
@@ -416,6 +416,10 @@ Node *SubLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   // Convert "x - (x+y)" into "-y"
   if (op2 == Op_AddL && in1 == in2->in(1)) {
     return new SubLNode(phase->makecon(TypeLong::ZERO), in2->in(2));
+  }
+  // Convert "(x-y) - x" into "-y"
+  if (op1 == Op_SubL && in1->in(1) == in2) {
+    return new SubLNode(phase->makecon(TypeLong::ZERO), in1->in(2));
   }
   // Convert "x - (y+x)" into "-y"
   if (op2 == Op_AddL && in1 == in2->in(2)) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/SubINodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/SubINodeIdealizationTests.java
@@ -112,14 +112,14 @@ public class SubINodeIdealizationTests {
     @Test
     @IR(failOn = {IRNode.ADD})
     @IR(counts = {IRNode.SUB, "1"})
-    // Checks x - (x + y) => -y
+    // Checks x - (x + y) => 0 - y
     public int test4(int x, int y) {
         return x - (x + y);
     }
 
     @Test
     @IR(counts = {IRNode.SUB, "1"})
-    // Checks (x - y) - x => -y
+    // Checks (x - y) - x => 0 - y
     public int test5(int x, int y) {
         return (x - y) - x;
     }
@@ -127,7 +127,7 @@ public class SubINodeIdealizationTests {
     @Test
     @IR(failOn = {IRNode.ADD})
     @IR(counts = {IRNode.SUB, "1"})
-    // Checks x - (y + x) => -y
+    // Checks x - (y + x) => 0 - y
     public int test6(int x, int y) {
         return x - (y + x);
     }
@@ -206,7 +206,7 @@ public class SubINodeIdealizationTests {
 
     @Test
     @IR(failOn = {IRNode.SUB, IRNode.ADD})
-    // Checks (x + y) - y => y
+    // Checks (x + y) - y => x
     public int test16(int x, int y) {
         return (x + y) - y;
     }

--- a/test/hotspot/jtreg/compiler/c2/irTests/SubLNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/SubLNodeIdealizationTests.java
@@ -64,23 +64,23 @@ public class SubLNodeIdealizationTests {
         Asserts.assertEQ((a + 1) - b      , test2(a, b));
         Asserts.assertEQ(a - (b + 2021)   , test3(a, b));
         Asserts.assertEQ(a - (a + b)      , test4(a, b));
-        Asserts.assertEQ(a - (b + a)      , test5(a, b));
-        Asserts.assertEQ(0 - (a - b)      , test6(a, b));
-        Asserts.assertEQ(0 - (a + 2021)   , test7(a, b));
-        Asserts.assertEQ((a + b) - (a + c), test8(a, b, c));
-        Asserts.assertEQ((b + a) - (c + a), test9(a, b, c));
-        Asserts.assertEQ((b + a) - (a + c), test10(a, b, c));
-        Asserts.assertEQ((a + b) - (c + a), test11(a, b, c));
-        Asserts.assertEQ(a - (b - c)      , test12(a, b, c));
-        Asserts.assertEQ(0 - (a >> 63)    , test13(a));
-        Asserts.assertEQ(0 - (0 - a)      , test14(a));
-        Asserts.assertEQ(a*b - a*c        , test15(a, b, c));
-        Asserts.assertEQ(a*b - b*c        , test16(a, b, c));
-        Asserts.assertEQ(a*c - b*c        , test17(a, b, c));
-        Asserts.assertEQ(a*b - c*a        , test18(a, b, c));
-        Asserts.assertEQ((a+b) - a        , test19(a, b));
-        Asserts.assertEQ((a+b) - b        , test20(a, b));
-        Asserts.assertEQ((a-b) - a        , test21(a, b));
+        Asserts.assertEQ((a - b) - a      , test5(a, b));
+        Asserts.assertEQ(a - (b + a)      , test6(a, b));
+        Asserts.assertEQ(0 - (a - b)      , test7(a, b));
+        Asserts.assertEQ(0 - (a + 2021)   , test8(a, b));
+        Asserts.assertEQ((a + b) - (a + c), test9(a, b, c));
+        Asserts.assertEQ((b + a) - (c + a), test10(a, b, c));
+        Asserts.assertEQ((b + a) - (a + c), test11(a, b, c));
+        Asserts.assertEQ((a + b) - (c + a), test12(a, b, c));
+        Asserts.assertEQ(a - (b - c)      , test13(a, b, c));
+        Asserts.assertEQ(0 - (a >> 63)    , test14(a));
+        Asserts.assertEQ(0 - (0 - a)      , test15(a));
+        Asserts.assertEQ((a + b) - b      , test16(a, b));
+        Asserts.assertEQ((a + b) - a      , test17(a, b));
+        Asserts.assertEQ(a*b - a*c        , test18(a, b, c));
+        Asserts.assertEQ(a*b - b*c        , test19(a, b, c));
+        Asserts.assertEQ(a*c - b*c        , test20(a, b, c));
+        Asserts.assertEQ(a*b - c*a        , test21(a, b, c));
     }
 
     @Test
@@ -118,17 +118,24 @@ public class SubLNodeIdealizationTests {
     }
 
     @Test
+    @IR(counts = {IRNode.SUB, "1"})
+    // Checks (x - y) - x => 0 - y
+    public long test5(long x, long y) {
+        return (x - y) - x;
+    }
+
+    @Test
     @IR(failOn = {IRNode.ADD})
     @IR(counts = {IRNode.SUB, "1"})
     // Checks x - (y + x) => 0 - y
-    public long test5(long x, long y) {
+    public long test6(long x, long y) {
         return x - (y + x);
     }
 
     @Test
     @IR(counts = {IRNode.SUB, "1"})
     // Checks 0 - (x - y) => y - x
-    public long test6(long x, long y) {
+    public long test7(long x, long y) {
         return 0 - (x - y);
     }
 
@@ -136,7 +143,7 @@ public class SubLNodeIdealizationTests {
     @IR(failOn = {IRNode.ADD})
     @IR(counts = {IRNode.SUB, "1"})
     // Checks 0 - (x + 2021) => -2021 - x
-    public long test7(long x, long y) {
+    public long test8(long x, long y) {
         return 0 - (x + 2021);
     }
 
@@ -144,7 +151,7 @@ public class SubLNodeIdealizationTests {
     @IR(failOn = {IRNode.ADD})
     @IR(counts = {IRNode.SUB, "1"})
     // Checks (x + a) - (x + b) => a - b;
-    public long test8(long x, long a, long b) {
+    public long test9(long x, long a, long b) {
         return (x + a) - (x + b);
     }
 
@@ -152,7 +159,7 @@ public class SubLNodeIdealizationTests {
     @IR(failOn = {IRNode.ADD})
     @IR(counts = {IRNode.SUB, "1"})
     // Checks (a + x) - (b + x) => a - b
-    public long test9(long x, long a, long b) {
+    public long test10(long x, long a, long b) {
         return (a + x) - (b + x);
     }
 
@@ -160,7 +167,7 @@ public class SubLNodeIdealizationTests {
     @IR(failOn = {IRNode.ADD})
     @IR(counts = {IRNode.SUB, "1"})
     // Checks (a + x) - (x + b) => a - b
-    public long test10(long x, long a, long b) {
+    public long test11(long x, long a, long b) {
         return (a + x) - (x + b);
     }
 
@@ -168,7 +175,7 @@ public class SubLNodeIdealizationTests {
     @IR(failOn = {IRNode.ADD})
     @IR(counts = {IRNode.SUB, "1"})
     // Checks (x + a) - (b + x) => a - b
-    public long test11(long x, long a, long b) {
+    public long test12(long x, long a, long b) {
         return (x + a) - (b + x);
     }
 
@@ -177,7 +184,7 @@ public class SubLNodeIdealizationTests {
                   IRNode.ADD, "1"
                  })
     // Checks a - (b - c) => (a + c) - b
-    public long test12(long a, long b, long c) {
+    public long test13(long a, long b, long c) {
         return a - (b - c);
     }
 
@@ -186,22 +193,36 @@ public class SubLNodeIdealizationTests {
     @IR(counts = {IRNode.URSHIFT_L, "1"})
     // Checks 0 - (a >> 63) => a >>> 63
     //        signed ^^          ^^^ unsigned
-    public long test13(long a) {
+    public long test14(long a) {
         return 0 - (a >> 63);
     }
 
     @Test
     @IR(failOn = {IRNode.SUB})
     // Checks 0 - (0 - x) => x
-    public long test14(long x) {
+    public long test15(long x) {
         return 0 - (0 - x);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.SUB, IRNode.ADD})
+    // Checks (x + y) - y => x
+    public long test16(long x, long y) {
+        return (x + y) - y;
+    }
+
+    @Test
+    @IR(failOn = {IRNode.SUB, IRNode.ADD})
+    // Checks (x + y) - x => y
+    public long test17(long x, long y) {
+        return (x + y) - x;
     }
 
     @Test
     @IR(counts = {IRNode.MUL, "1",
                   IRNode.SUB, "1"})
     // Checks "a*b-a*c => a*(b-c)
-    public long test15(long a, long b, long c) {
+    public long test18(long a, long b, long c) {
         return a*b - a*c;
     }
 
@@ -209,7 +230,7 @@ public class SubLNodeIdealizationTests {
     @IR(counts = {IRNode.MUL, "1",
                   IRNode.SUB, "1"})
     // Checks a*b-b*c => b*(a-c)
-    public long test16(long a, long b, long c) {
+    public long test19(long a, long b, long c) {
         return a*b - b*c;
     }
 
@@ -217,7 +238,7 @@ public class SubLNodeIdealizationTests {
     @IR(counts = {IRNode.MUL, "1",
                   IRNode.SUB, "1"})
     // Checks a*c-b*c => (a-b)*c
-    public long test17(long a, long b, long c) {
+    public long test20(long a, long b, long c) {
         return a*c - b*c;
     }
 
@@ -225,28 +246,7 @@ public class SubLNodeIdealizationTests {
     @IR(counts = {IRNode.MUL, "1",
                   IRNode.SUB, "1"})
     // Checks a*b-c*a => a*(b-c)
-    public long test18(long a, long b, long c) {
+    public long test21(long a, long b, long c) {
         return a*b - c*a;
-    }
-
-    @Test
-    @IR(failOn = {IRNode.ADD, IRNode.SUB})
-    // Checks "(a+b) - b" => "a"
-    public long test19(long a, long b) {
-        return (a+b) - a;
-    }
-
-    @Test
-    @IR(failOn = {IRNode.ADD, IRNode.SUB})
-    // Checks "(a+b) - a" => "b"
-    public long test20(long a, long b) {
-        return (a+b) - b;
-    }
-
-    @Test
-    @IR(counts = {IRNode.SUB, "1"})
-    // Checks "(a-b) - a" => "0 - b"
-    public long test21(long a, long b) {
-        return (a-b) - a;
     }
 }

--- a/test/hotspot/jtreg/compiler/c2/irTests/SubLNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/SubLNodeIdealizationTests.java
@@ -27,7 +27,7 @@ import compiler.lib.ir_framework.*;
 
 /*
  * @test
- * @bug 8267265
+ * @bug 8267265 8272735
  * @summary Test that Ideal transformations of SubLNode* are being performed as expected.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.SubLNodeIdealizationTests
@@ -42,7 +42,8 @@ public class SubLNodeIdealizationTests {
                  "test7", "test8", "test9",
                  "test10", "test11", "test12",
                  "test13", "test14", "test15",
-                 "test16", "test17", "test18"})
+                 "test16", "test17", "test18",
+                 "test19", "test20", "test21"})
     public void runMethod() {
         long a = RunInfo.getRandom().nextLong();
         long b = RunInfo.getRandom().nextLong();
@@ -77,6 +78,9 @@ public class SubLNodeIdealizationTests {
         Asserts.assertEQ(a*b - b*c        , test16(a, b, c));
         Asserts.assertEQ(a*c - b*c        , test17(a, b, c));
         Asserts.assertEQ(a*b - c*a        , test18(a, b, c));
+        Asserts.assertEQ((a+b) - a        , test19(a, b));
+        Asserts.assertEQ((a+b) - b        , test20(a, b));
+        Asserts.assertEQ((a-b) - a        , test21(a, b));
     }
 
     @Test
@@ -223,5 +227,26 @@ public class SubLNodeIdealizationTests {
     // Checks a*b-c*a => a*(b-c)
     public long test18(long a, long b, long c) {
         return a*b - c*a;
+    }
+
+    @Test
+    @IR(failOn = {IRNode.ADD, IRNode.SUB})
+    // Checks "(a+b) - b" => "a"
+    public long test19(long a, long b) {
+        return (a+b) - a;
+    }
+
+    @Test
+    @IR(failOn = {IRNode.ADD, IRNode.SUB})
+    // Checks "(a+b) - a" => "b"
+    public long test20(long a, long b) {
+        return (a+b) - b;
+    }
+
+    @Test
+    @IR(counts = {IRNode.SUB, "1"})
+    // Checks "(a-b) - a" => "0 - b"
+    public long test21(long a, long b) {
+        return (a-b) - a;
     }
 }


### PR DESCRIPTION
This change adds/enables missing subnode transformations for operations of type `long`.
A few comments in the test file `SubINodeIdealizationTests.java` were modified to add clarity and to fix a typo.
Hotspot:tier1 tests were run, this change does not introduce any new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272735](https://bugs.openjdk.java.net/browse/JDK-8272735): Add missing SubL node transformations


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7669/head:pull/7669` \
`$ git checkout pull/7669`

Update a local copy of the PR: \
`$ git checkout pull/7669` \
`$ git pull https://git.openjdk.java.net/jdk pull/7669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7669`

View PR using the GUI difftool: \
`$ git pr show -t 7669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7669.diff">https://git.openjdk.java.net/jdk/pull/7669.diff</a>

</details>
