### PR TITLE
JDK-8282593: JDK-8281472 breaks 32-bit builds and gtests

### DIFF
--- a/test/hotspot/gtest/runtime/test_largeOptions.cpp
+++ b/test/hotspot/gtest/runtime/test_largeOptions.cpp
@@ -43,7 +43,7 @@ public:
   }
 };
 
-
+#ifdef _LP64
 // CompilerDirectivesLimit is a diagnostic int option.
 TEST_VM(LARGE_OPTION, large_ints) {
   for (intx x = max_jint - 1; x <= (intx)max_jint + 1; x++) {
@@ -57,7 +57,6 @@ TEST_VM(LARGE_OPTION, large_ints) {
   }
 }
 
-
 TEST_VM(LARGE_OPTION, small_ints) {
   for (intx x = min_jint + 1; x >= (intx)min_jint - 1; x--) {
     bool result = LargeOptionsTest::test_option_value("CompilerDirectivesLimit", x);
@@ -70,11 +69,10 @@ TEST_VM(LARGE_OPTION, small_ints) {
   }
 }
 
-
 TEST_VM(LARGE_OPTION, large_int_overflow) { // Test 0x100000000
   ASSERT_FALSE(LargeOptionsTest::test_option_value("CompilerDirectivesLimit", 4294967296));
 }
-
+#endif
 
 // HandshakeTimeout is a diagnostic uint option.
 TEST_VM(LARGE_OPTION, large_uints) {
@@ -89,7 +87,7 @@ TEST_VM(LARGE_OPTION, large_uints) {
   }
 }
 
-
+#ifdef _LP64
 // MaxJNILocalCapacity is an intx option.
 TEST_VM(LARGE_OPTION, large_intxs) {
   // max_intx + 1 equals min_intx!
@@ -99,7 +97,6 @@ TEST_VM(LARGE_OPTION, large_intxs) {
   }
 }
 
-
 TEST_VM(LARGE_OPTION, small_intxs) {
   ASSERT_TRUE(LargeOptionsTest::test_option_value("MaxJNILocalCapacity", min_intx + 1));
   ASSERT_EQ(MaxJNILocalCapacity, -9223372036854775807);
@@ -108,3 +105,4 @@ TEST_VM(LARGE_OPTION, small_intxs) {
   // Test value that's less than min_intx (-0x8000000000000001).
   ASSERT_FALSE(LargeOptionsTest::test_option_value("MaxJNILocalCapacity=-9223372036854775809"));
 }
+#endif


### PR DESCRIPTION
Hi, may I please have reviews for this trivial fix.

JDK-8281472 added a test_largeOptions.cpp gtest. Parts of it don't build for 32-bits, parts build but don't run. 

I propose to exclude the failing parts. AFAICS they check that numerical arguments are handled correctly when going beyond INT_MAX and INT_MIN, which is not an issue on 32-bit with 32-bit ints.

Thanks, Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282593](https://bugs.openjdk.java.net/browse/JDK-8282593): JDK-8281472 breaks 32-bit builds and gtests


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7672/head:pull/7672` \
`$ git checkout pull/7672`

Update a local copy of the PR: \
`$ git checkout pull/7672` \
`$ git pull https://git.openjdk.java.net/jdk pull/7672/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7672`

View PR using the GUI difftool: \
`$ git pr show -t 7672`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7672.diff">https://git.openjdk.java.net/jdk/pull/7672.diff</a>

</details>
