### PR TITLE
8282573: ByteBufferTest.java: replace endless recursion with RuntimeException in void ck(double x, double y)

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/unsafe/ByteBufferTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/unsafe/ByteBufferTest.java
@@ -217,7 +217,6 @@ class MyByteBuffer {
 
     void ck(double x, double y) {
         if (x == x && y == y && x != y) {
-            ck(x, y);
             throw new RuntimeException(" x = " + Double.toString(x) + ", y = " + Double.toString(y)
                                     + " (x = " + Long.toHexString(Double.doubleToRawLongBits(x))
                                     + ", y = " + Long.toHexString(Double.doubleToRawLongBits(y)) + ")");

--- a/test/hotspot/jtreg/compiler/intrinsics/unsafe/ByteBufferTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/unsafe/ByteBufferTest.java
@@ -218,6 +218,9 @@ class MyByteBuffer {
     void ck(double x, double y) {
         if (x == x && y == y && x != y) {
             ck(x, y);
+            throw new RuntimeException(" x = " + Double.toString(x) + ", y = " + Double.toString(y)
+                                    + " (x = " + Long.toHexString(Double.doubleToRawLongBits(x))
+                                    + ", y = " + Long.toHexString(Double.doubleToRawLongBits(y)) + ")");
         }
     }
 

--- a/test/hotspot/jtreg/compiler/intrinsics/unsafe/ByteBufferTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/unsafe/ByteBufferTest.java
@@ -216,7 +216,7 @@ class MyByteBuffer {
     }
 
     void ck(double x, double y) {
-        if (x == x && y == y && x != y) {
+        if (x != y) {
             throw new RuntimeException(" x = " + Double.toString(x) + ", y = " + Double.toString(y)
                                     + " (x = " + Long.toHexString(Double.doubleToRawLongBits(x))
                                     + ", y = " + Long.toHexString(Double.doubleToRawLongBits(y)) + ")");


### PR DESCRIPTION
There are two functions that check for equality.
void ck(long x, long y): already throws a RuntimeException if we observe inequality
void ck(double x, double y): called itself, leading to endless recursion and a StackOverflowError.

Instead of the recursion, I now also throw a RuntimeException.

This can currently be triggered with
`path-to-jtreg/jtreg -va -s -jdk:jdk-path -javaoptions:"-XX:+UnlockDiagnosticVMOptions -XX:-TieredCompilation -XX:+StressGCM -XX:+OptoScheduling -XX:StressSeed=293843391" test/hotspot/jtreg/compiler/intrinsics/unsafe/HeapByteBufferTest.java `
(see bug [JDK-8282555](https://bugs.openjdk.java.net/browse/JDK-8282555))

This way I could verify that instead of StackOverflowError we now get RuntimeException, as desired.
Ran some basic tests to ensure I didn't break things.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282573](https://bugs.openjdk.java.net/browse/JDK-8282573): ByteBufferTest.java: replace endless recursion with RuntimeException in void ck(double x, double y)


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7674/head:pull/7674` \
`$ git checkout pull/7674`

Update a local copy of the PR: \
`$ git checkout pull/7674` \
`$ git pull https://git.openjdk.java.net/jdk pull/7674/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7674`

View PR using the GUI difftool: \
`$ git pr show -t 7674`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7674.diff">https://git.openjdk.java.net/jdk/pull/7674.diff</a>

</details>
