### PR TITLE
8282602: Refactor awt classes javadoc to use @throws instead of @exception

### DIFF
--- a/src/java.desktop/share/classes/java/awt/AWTEventMulticaster.java
+++ b/src/java.desktop/share/classes/java/awt/AWTEventMulticaster.java
@@ -1097,9 +1097,9 @@ public class AWTEventMulticaster implements
      *          <code><em>Foo</em>Listener</code>s by the specified multicast
      *          listener, or an empty array if no such listeners have been
      *          chained by the specified multicast listener
-     * @exception NullPointerException if the specified
+     * @throws NullPointerException if the specified
      *             {@code listenertype} parameter is {@code null}
-     * @exception ClassCastException if {@code listenerType}
+     * @throws ClassCastException if {@code listenerType}
      *          doesn't specify a class or interface that implements
      *          {@code java.util.EventListener}
      *

--- a/src/java.desktop/share/classes/java/awt/BorderLayout.java
+++ b/src/java.desktop/share/classes/java/awt/BorderLayout.java
@@ -419,7 +419,7 @@ public class BorderLayout implements LayoutManager2,
      * @param   constraints  an object that specifies how and where
      *                       the component is added to the layout.
      * @see     java.awt.Container#add(java.awt.Component, java.lang.Object)
-     * @exception   IllegalArgumentException  if the constraint object is not
+     * @throws   IllegalArgumentException  if the constraint object is not
      *              a string, or if it not one of the five specified constants.
      * @since   1.1
      */
@@ -514,7 +514,7 @@ public class BorderLayout implements LayoutManager2,
      *                       {@code LINE_START}, {@code LINE_END}
      * @return  the component at the given location, or {@code null} if
      *          the location is empty
-     * @exception   IllegalArgumentException  if the constraint object is
+     * @throws   IllegalArgumentException  if the constraint object is
      *              not one of the nine specified constants
      * @see     #addLayoutComponent(java.awt.Component, java.lang.Object)
      * @since 1.5
@@ -562,9 +562,9 @@ public class BorderLayout implements LayoutManager2,
      *                     {@code Container}'s component orientation.
      * @return  the component at the given location, or {@code null} if
      *          the location is empty
-     * @exception   IllegalArgumentException  if the constraint object is
+     * @throws   IllegalArgumentException  if the constraint object is
      *              not one of the five specified constants
-     * @exception   NullPointerException  if the target parameter is null
+     * @throws   NullPointerException  if the target parameter is null
      * @see     #addLayoutComponent(java.awt.Component, java.lang.Object)
      * @since 1.5
      */

--- a/src/java.desktop/share/classes/java/awt/BufferCapabilities.java
+++ b/src/java.desktop/share/classes/java/awt/BufferCapabilities.java
@@ -47,7 +47,7 @@ public class BufferCapabilities implements Cloneable {
      * cannot be {@code null}
      * @param flipContents the contents of the back buffer after page-flipping,
      * {@code null} if page flipping is not used (implies blitting)
-     * @exception IllegalArgumentException if frontCaps or backCaps are
+     * @throws IllegalArgumentException if frontCaps or backCaps are
      * {@code null}
      */
     public BufferCapabilities(ImageCapabilities frontCaps,

--- a/src/java.desktop/share/classes/java/awt/Button.java
+++ b/src/java.desktop/share/classes/java/awt/Button.java
@@ -140,7 +140,7 @@ public class Button extends Component implements Accessible {
     /**
      * Constructs a button with an empty string for its label.
      *
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -153,7 +153,7 @@ public class Button extends Component implements Accessible {
      *
      * @param label  a string label for the button, or
      *               {@code null} for no label
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -339,7 +339,7 @@ public class Button extends Component implements Accessible {
      *          <code><em>Foo</em>Listener</code>s on this button,
      *          or an empty array if no such
      *          listeners have been added
-     * @exception ClassCastException if {@code listenerType}
+     * @throws ClassCastException if {@code listenerType}
      *          doesn't specify a class or interface that implements
      *          {@code java.util.EventListener}
      *

--- a/src/java.desktop/share/classes/java/awt/Canvas.java
+++ b/src/java.desktop/share/classes/java/awt/Canvas.java
@@ -166,8 +166,8 @@ public class Canvas extends Component implements Accessible {
      * Each time this method is called,
      * the existing buffer strategy for this component is discarded.
      * @param numBuffers number of buffers to create, including the front buffer
-     * @exception IllegalArgumentException if numBuffers is less than 1.
-     * @exception IllegalStateException if the component is not displayable
+     * @throws IllegalArgumentException if numBuffers is less than 1.
+     * @throws IllegalStateException if the component is not displayable
      * @see #isDisplayable
      * @see #getBufferStrategy
      * @since 1.4
@@ -187,11 +187,11 @@ public class Canvas extends Component implements Accessible {
      * @param numBuffers number of buffers to create
      * @param caps the required capabilities for creating the buffer strategy;
      * cannot be {@code null}
-     * @exception AWTException if the capabilities supplied could not be
+     * @throws AWTException if the capabilities supplied could not be
      * supported or met; this may happen, for example, if there is not enough
      * accelerated memory currently available, or if page flipping is specified
      * but not possible.
-     * @exception IllegalArgumentException if numBuffers is less than 1, or if
+     * @throws IllegalArgumentException if numBuffers is less than 1, or if
      * caps is {@code null}
      * @see #getBufferStrategy
      * @since 1.4

--- a/src/java.desktop/share/classes/java/awt/CardLayout.java
+++ b/src/java.desktop/share/classes/java/awt/CardLayout.java
@@ -206,7 +206,7 @@ public class CardLayout implements LayoutManager2,
      * @param     constraints   a tag that identifies a particular
      *                                        card in the layout.
      * @see       java.awt.CardLayout#show(java.awt.Container, java.lang.String)
-     * @exception  IllegalArgumentException  if the constraint is not a string.
+     * @throws  IllegalArgumentException  if the constraint is not a string.
      */
     public void addLayoutComponent(Component comp, Object constraints) {
       synchronized (comp.getTreeLock()) {

--- a/src/java.desktop/share/classes/java/awt/Checkbox.java
+++ b/src/java.desktop/share/classes/java/awt/Checkbox.java
@@ -146,7 +146,7 @@ public class Checkbox extends Component implements ItemSelectable, Accessible {
      * Creates a check box with an empty string for its label.
      * The state of this check box is set to "off," and it is not
      * part of any check box group.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -161,7 +161,7 @@ public class Checkbox extends Component implements ItemSelectable, Accessible {
      *
      * @param     label   a string label for this check box,
      *                        or {@code null} for no label.
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *      {@code GraphicsEnvironment.isHeadless}
      *      returns {@code true}
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -178,7 +178,7 @@ public class Checkbox extends Component implements ItemSelectable, Accessible {
      * @param     label   a string label for this check box,
      *                        or {@code null} for no label
      * @param     state    the initial state of this check box
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *     {@code GraphicsEnvironment.isHeadless}
      *     returns {@code true}
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -196,7 +196,7 @@ public class Checkbox extends Component implements ItemSelectable, Accessible {
      * @param     state   the initial state of this check box.
      * @param     group   a check box group for this check box,
      *                           or {@code null} for no group.
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *     {@code GraphicsEnvironment.isHeadless}
      *     returns {@code true}
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -222,7 +222,7 @@ public class Checkbox extends Component implements ItemSelectable, Accessible {
      * @param     group   a check box group for this check box,
      *                           or {@code null} for no group.
      * @param     state   the initial state of this check box.
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *    {@code GraphicsEnvironment.isHeadless}
      *    returns {@code true}
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -508,7 +508,7 @@ public class Checkbox extends Component implements ItemSelectable, Accessible {
      *          <code><em>Foo</em>Listener</code>s on this checkbox,
      *          or an empty array if no such
      *          listeners have been added
-     * @exception ClassCastException if {@code listenerType}
+     * @throws ClassCastException if {@code listenerType}
      *          doesn't specify a class or interface that implements
      *          {@code java.util.EventListener}
      *

--- a/src/java.desktop/share/classes/java/awt/CheckboxMenuItem.java
+++ b/src/java.desktop/share/classes/java/awt/CheckboxMenuItem.java
@@ -110,7 +110,7 @@ public class CheckboxMenuItem extends MenuItem implements ItemSelectable, Access
     /**
      * Create a check box menu item with an empty label.
      * The item's state is initially set to "off."
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @since   1.1
@@ -125,7 +125,7 @@ public class CheckboxMenuItem extends MenuItem implements ItemSelectable, Access
 
      * @param     label   a string label for the check box menu item,
      *                or {@code null} for an unlabeled menu item.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -140,7 +140,7 @@ public class CheckboxMenuItem extends MenuItem implements ItemSelectable, Access
      * @param      state   the initial state of the menu item, where
      *                     {@code true} indicates "on" and
      *                     {@code false} indicates "off."
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @since      1.1
@@ -316,7 +316,7 @@ public class CheckboxMenuItem extends MenuItem implements ItemSelectable, Access
      *          <code><em>Foo</em>Listener</code>s on this checkbox menuitem,
      *          or an empty array if no such
      *          listeners have been added
-     * @exception ClassCastException if {@code listenerType}
+     * @throws ClassCastException if {@code listenerType}
      *          doesn't specify a class or interface that implements
      *          {@code java.util.EventListener}
      *

--- a/src/java.desktop/share/classes/java/awt/Choice.java
+++ b/src/java.desktop/share/classes/java/awt/Choice.java
@@ -124,7 +124,7 @@ public class Choice extends Component implements ItemSelectable, Accessible {
      * By default, the first item added to the choice menu becomes the
      * selected item, until a different selection is made by the user
      * by calling one of the {@code select} methods.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true
      * @see       java.awt.GraphicsEnvironment#isHeadless
      * @see       #select(int)
@@ -205,7 +205,7 @@ public class Choice extends Component implements ItemSelectable, Accessible {
     /**
      * Adds an item to this {@code Choice} menu.
      * @param      item    the item to be added
-     * @exception  NullPointerException   if the item's value is
+     * @throws  NullPointerException   if the item's value is
      *                  {@code null}
      * @since      1.1
      */
@@ -219,7 +219,7 @@ public class Choice extends Component implements ItemSelectable, Accessible {
      * <p>
      * Adds an item to this {@code Choice} menu.
      * @param item the item to be added
-     * @exception NullPointerException if the item's value is equal to
+     * @throws NullPointerException if the item's value is equal to
      *          {@code null}
      */
     public void addItem(String item) {
@@ -238,7 +238,7 @@ public class Choice extends Component implements ItemSelectable, Accessible {
      * invoking this method.
      * @param item the item to be added
      * @param index the new item position
-     * @exception NullPointerException if the item's value is equal to
+     * @throws NullPointerException if the item's value is equal to
      *          {@code null}
      */
     private void insertNoInvalidate(String item, int index) {
@@ -274,7 +274,7 @@ public class Choice extends Component implements ItemSelectable, Accessible {
      * the selected item.
      * @param item the non-{@code null} item to be inserted
      * @param index the position at which the item should be inserted
-     * @exception IllegalArgumentException if index is less than 0
+     * @throws IllegalArgumentException if index is less than 0
      */
     public void insert(String item, int index) {
         synchronized (this) {
@@ -300,7 +300,7 @@ public class Choice extends Component implements ItemSelectable, Accessible {
      * item remains selected (and the selected index is
      * updated accordingly).
      * @param      item  the item to remove from this {@code Choice} menu
-     * @exception  IllegalArgumentException  if the item doesn't
+     * @throws  IllegalArgumentException  if the item doesn't
      *                     exist in the choice menu
      * @since      1.1
      */
@@ -430,7 +430,7 @@ public class Choice extends Component implements ItemSelectable, Accessible {
      * {@code ItemEvent} is by user interaction.
      *
      * @param      pos      the position of the selected item
-     * @exception  IllegalArgumentException if the specified
+     * @throws  IllegalArgumentException if the specified
      *                            position is greater than the
      *                            number of items or less than zero
      * @see        #getSelectedItem
@@ -561,7 +561,7 @@ public class Choice extends Component implements ItemSelectable, Accessible {
      *          <code><em>Foo</em>Listener</code>s on this choice,
      *          or an empty array if no such
      *          listeners have been added
-     * @exception ClassCastException if {@code listenerType}
+     * @throws ClassCastException if {@code listenerType}
      *          doesn't specify a class or interface that implements
      *          {@code java.util.EventListener}
      *

--- a/src/java.desktop/share/classes/java/awt/Color.java
+++ b/src/java.desktop/share/classes/java/awt/Color.java
@@ -722,7 +722,7 @@ public class Color implements Paint, java.io.Serializable {
      *                            an opaque color as a 24-bit integer
      * @return     the new {@code Color} object.
      * @see        java.lang.Integer#decode
-     * @exception  NumberFormatException  if the specified string cannot
+     * @throws  NumberFormatException  if the specified string cannot
      *                      be interpreted as a decimal,
      *                      octal, or hexadecimal integer.
      * @since      1.1

--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -1420,7 +1420,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
      * pointer. If the return value of this method is {@code null}, mouse
      * pointer is not directly above the {@code Component}.
      *
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless() returns true
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless() returns true
      * @see       #isShowing
      * @see       Container#getMousePosition
      * @return    mouse coordinates relative to this {@code Component}, or null
@@ -1984,7 +1984,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
      * @return this component's locale; if this component does not
      *          have a locale, the locale of its parent is returned
      * @see #setLocale
-     * @exception IllegalComponentStateException if the {@code Component}
+     * @throws IllegalComponentStateException if the {@code Component}
      *          does not have its own locale and has not yet been added to
      *          a containment hierarchy such that the locale can be determined
      *          from the containing parent
@@ -3827,8 +3827,8 @@ public abstract class Component implements ImageObserver, MenuContainer,
      * Each time this method is called,
      * the existing buffer strategy for this component is discarded.
      * @param numBuffers number of buffers to create, including the front buffer
-     * @exception IllegalArgumentException if numBuffers is less than 1.
-     * @exception IllegalStateException if the component is not displayable
+     * @throws IllegalArgumentException if numBuffers is less than 1.
+     * @throws IllegalStateException if the component is not displayable
      * @see #isDisplayable
      * @see Window#getBufferStrategy()
      * @see Canvas#getBufferStrategy()
@@ -3884,11 +3884,11 @@ public abstract class Component implements ImageObserver, MenuContainer,
      * @param numBuffers number of buffers to create
      * @param caps the required capabilities for creating the buffer strategy;
      * cannot be {@code null}
-     * @exception AWTException if the capabilities supplied could not be
+     * @throws AWTException if the capabilities supplied could not be
      * supported or met; this may happen, for example, if there is not enough
      * accelerated memory currently available, or if page flipping is specified
      * but not possible.
-     * @exception IllegalArgumentException if numBuffers is less than 1, or if
+     * @throws IllegalArgumentException if numBuffers is less than 1, or if
      * caps is {@code null}
      * @see Window#getBufferStrategy()
      * @see Canvas#getBufferStrategy()
@@ -4032,12 +4032,12 @@ public abstract class Component implements ImageObserver, MenuContainer,
          * @see Applet
          * @param numBuffers the number of buffers
          * @param caps the capabilities of the buffers
-         * @exception AWTException if the capabilities supplied could not be
+         * @throws AWTException if the capabilities supplied could not be
          * supported or met
-         * @exception ClassCastException if the component is not a canvas or
+         * @throws ClassCastException if the component is not a canvas or
          * window.
-         * @exception IllegalStateException if the component has no peer
-         * @exception IllegalArgumentException if {@code numBuffers} is less than two,
+         * @throws IllegalStateException if the component has no peer
+         * @throws IllegalArgumentException if {@code numBuffers} is less than two,
          * or if {@code BufferCapabilities.isPageFlipping} is not
          * {@code true}.
          * @see #createBuffers(int, BufferCapabilities)
@@ -4066,10 +4066,10 @@ public abstract class Component implements ImageObserver, MenuContainer,
          * @param caps the capabilities of the buffers.
          * {@code BufferCapabilities.isPageFlipping} must be
          * {@code true}.
-         * @exception AWTException if the capabilities supplied could not be
+         * @throws AWTException if the capabilities supplied could not be
          * supported or met
-         * @exception IllegalStateException if the component has no peer
-         * @exception IllegalArgumentException if numBuffers is less than two,
+         * @throws IllegalStateException if the component has no peer
+         * @throws IllegalArgumentException if numBuffers is less than two,
          * or if {@code BufferCapabilities.isPageFlipping} is not
          * {@code true}.
          * @see java.awt.BufferCapabilities#isPageFlipping()
@@ -4135,7 +4135,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
          * Provides direct access to the back buffer as an image.
          *
          * @return the back buffer as an image
-         * @exception IllegalStateException if the buffers have not yet
+         * @throws IllegalStateException if the buffers have not yet
          * been created
          */
         protected Image getBackBuffer() {
@@ -4154,7 +4154,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
          * for the contents of the back buffer.  This should be one of the
          * values of the {@code BufferCapabilities.FlipContents}
          * property.
-         * @exception IllegalStateException if the buffers have not yet
+         * @throws IllegalStateException if the buffers have not yet
          * been created
          * @see java.awt.BufferCapabilities#getFlipContents()
          */
@@ -6060,7 +6060,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
      * @return an array of all objects registered as
      *          <code><em>Foo</em>Listener</code>s on this component,
      *          or an empty array if no such listeners have been added
-     * @exception ClassCastException if {@code listenerType}
+     * @throws ClassCastException if {@code listenerType}
      *          doesn't specify a class or interface that implements
      *          {@code java.util.EventListener}
      * @throws NullPointerException if {@code listenerType} is {@code null}
@@ -8352,7 +8352,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
      * Adds the specified popup menu to the component.
      * @param     popup the popup menu to be added to the component.
      * @see       #remove(MenuComponent)
-     * @exception NullPointerException if {@code popup} is {@code null}
+     * @throws NullPointerException if {@code popup} is {@code null}
      * @since     1.1
      */
     public void add(PopupMenu popup) {
@@ -9192,7 +9192,7 @@ public abstract class Component implements ImageObserver, MenuContainer,
      *
      * @param orientation the new component orientation of this component and
      *        the components contained within it.
-     * @exception NullPointerException if {@code orientation} is null.
+     * @throws NullPointerException if {@code orientation} is null.
      * @see #setComponentOrientation
      * @see #getComponentOrientation
      * @see #invalidate

--- a/src/java.desktop/share/classes/java/awt/Container.java
+++ b/src/java.desktop/share/classes/java/awt/Container.java
@@ -340,7 +340,7 @@ public class Container extends Component {
      *
      * @param      n   the index of the component to get.
      * @return     the n<sup>th</sup> component in this container.
-     * @exception  ArrayIndexOutOfBoundsException
+     * @throws  ArrayIndexOutOfBoundsException
      *                 if the n<sup>th</sup> value does not exist.
      * @see Component#getTreeLock()
      */
@@ -429,7 +429,7 @@ public class Container extends Component {
      * display the added component.
      *
      * @param     comp   the component to be added
-     * @exception NullPointerException if {@code comp} is {@code null}
+     * @throws NullPointerException if {@code comp} is {@code null}
      * @see #addImpl
      * @see #invalidate
      * @see #validate
@@ -456,7 +456,7 @@ public class Container extends Component {
      * @param  name the name of the component to be added
      * @param  comp the component to be added
      * @return the component added
-     * @exception NullPointerException if {@code comp} is {@code null}
+     * @throws NullPointerException if {@code comp} is {@code null}
      * @see #add(Component, Object)
      * @see #invalidate
      */
@@ -479,8 +479,8 @@ public class Container extends Component {
      * @param     comp   the component to be added
      * @param     index    the position at which to insert the component,
      *                   or {@code -1} to append the component to the end
-     * @exception NullPointerException if {@code comp} is {@code null}
-     * @exception IllegalArgumentException if {@code index} is invalid (see
+     * @throws NullPointerException if {@code comp} is {@code null}
+     * @throws IllegalArgumentException if {@code index} is invalid (see
      *            {@link #addImpl} for details)
      * @return    the component {@code comp}
      * @see #addImpl
@@ -764,17 +764,17 @@ public class Container extends Component {
      * @param     index the position in the container's list to
      *            insert the component, where {@code getComponentCount()}
      *            appends to the end
-     * @exception NullPointerException if {@code comp} is
+     * @throws NullPointerException if {@code comp} is
      *            {@code null}
-     * @exception IllegalArgumentException if {@code comp} is one of the
+     * @throws IllegalArgumentException if {@code comp} is one of the
      *            container's parents
-     * @exception IllegalArgumentException if {@code index} is not in
+     * @throws IllegalArgumentException if {@code index} is not in
      *            the range {@code [0, getComponentCount()]} for moving
      *            between containers, or not in the range
      *            {@code [0, getComponentCount()-1]} for moving inside
      *            a container
-     * @exception IllegalArgumentException if adding a container to itself
-     * @exception IllegalArgumentException if adding a {@code Window}
+     * @throws IllegalArgumentException if adding a container to itself
+     * @throws IllegalArgumentException if adding a {@code Window}
      *            to a container
      * @see #getComponentZOrder(java.awt.Component)
      * @see #invalidate
@@ -989,7 +989,7 @@ public class Container extends Component {
      * @param     comp the component to be added
      * @param     constraints an object expressing
      *                  layout constraints for this component
-     * @exception NullPointerException if {@code comp} is {@code null}
+     * @throws NullPointerException if {@code comp} is {@code null}
      * @see #addImpl
      * @see #invalidate
      * @see #validate
@@ -1019,8 +1019,8 @@ public class Container extends Component {
      * @param index the position in the container's list at which to insert
      * the component; {@code -1} means insert at the end
      * component
-     * @exception NullPointerException if {@code comp} is {@code null}
-     * @exception IllegalArgumentException if {@code index} is invalid (see
+     * @throws NullPointerException if {@code comp} is {@code null}
+     * @throws IllegalArgumentException if {@code index} is invalid (see
      *            {@link #addImpl} for details)
      * @see #addImpl
      * @see #invalidate
@@ -1082,16 +1082,16 @@ public class Container extends Component {
      * @param     index the position in the container's list at which to
      *                 insert the component, where {@code -1}
      *                 means append to the end
-     * @exception IllegalArgumentException if {@code index} is invalid;
+     * @throws IllegalArgumentException if {@code index} is invalid;
      *            if {@code comp} is a child of this container, the valid
      *            range is {@code [-1, getComponentCount()-1]}; if component is
      *            not a child of this container, the valid range is
      *            {@code [-1, getComponentCount()]}
      *
-     * @exception IllegalArgumentException if {@code comp} is an ancestor of
+     * @throws IllegalArgumentException if {@code comp} is an ancestor of
      *                                     this container
-     * @exception IllegalArgumentException if adding a window to a container
-     * @exception NullPointerException if {@code comp} is {@code null}
+     * @throws IllegalArgumentException if adding a window to a container
+     * @throws NullPointerException if {@code comp} is {@code null}
      * @see       #add(Component)
      * @see       #add(Component, int)
      * @see       #add(Component, java.lang.Object)
@@ -2213,10 +2213,10 @@ public class Container extends Component {
      * @return an array of all objects registered as
      *          <code><em>Foo</em>Listener</code>s on this container,
      *          or an empty array if no such listeners have been added
-     * @exception ClassCastException if {@code listenerType}
+     * @throws ClassCastException if {@code listenerType}
      *          doesn't specify a class or interface that implements
      *          {@code java.util.EventListener}
-     * @exception NullPointerException if {@code listenerType} is {@code null}
+     * @throws NullPointerException if {@code listenerType} is {@code null}
      *
      * @see #getContainerListeners
      *
@@ -2622,7 +2622,7 @@ public class Container extends Component {
      * a non-null value if the mouse pointer is above {@code Container} or any
      * of its descendants.
      *
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless() returns true
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless() returns true
      * @param     allowChildren true if children should be taken into account
      * @see       Component#getMousePosition
      * @return    mouse coordinates relative to this {@code Component}, or null
@@ -3556,7 +3556,7 @@ public class Container extends Component {
      *
      * @param o the new component orientation of this container and
      *        the components contained within it.
-     * @exception NullPointerException if {@code orientation} is null.
+     * @throws NullPointerException if {@code orientation} is null.
      * @see Component#setComponentOrientation
      * @see Component#getComponentOrientation
      * @see #invalidate

--- a/src/java.desktop/share/classes/java/awt/Cursor.java
+++ b/src/java.desktop/share/classes/java/awt/Cursor.java
@@ -285,9 +285,9 @@ public class Cursor implements java.io.Serializable {
      *
      * @param name a string describing the desired system-specific custom cursor
      * @return the system specific custom cursor named
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      * {@code GraphicsEnvironment.isHeadless} returns true
-     * @exception AWTException in case of erroneous retrieving of the cursor
+     * @throws AWTException in case of erroneous retrieving of the cursor
      */
     public static Cursor getSystemCustomCursor(final String name)
         throws AWTException, HeadlessException {

--- a/src/java.desktop/share/classes/java/awt/Dialog.java
+++ b/src/java.desktop/share/classes/java/awt/Dialog.java
@@ -329,9 +329,9 @@ public class Dialog extends Window {
      *
      * @param owner the owner of the dialog or {@code null} if
      *     this dialog has no owner
-     * @exception java.lang.IllegalArgumentException if the {@code owner}'s
+     * @throws java.lang.IllegalArgumentException if the {@code owner}'s
      *    {@code GraphicsConfiguration} is not from a screen device
-     * @exception HeadlessException when
+     * @throws HeadlessException when
      *    {@code GraphicsEnvironment.isHeadless()} returns {@code true}
      *
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -352,9 +352,9 @@ public class Dialog extends Window {
      *     windows when shown. If {@code false}, the dialog is {@code MODELESS};
      *     if {@code true}, the modality type property is set to
      *     {@code DEFAULT_MODALITY_TYPE}
-     * @exception java.lang.IllegalArgumentException if the {@code owner}'s
+     * @throws java.lang.IllegalArgumentException if the {@code owner}'s
      *    {@code GraphicsConfiguration} is not from a screen device
-     * @exception HeadlessException when
+     * @throws HeadlessException when
      *     {@code GraphicsEnvironment.isHeadless()} returns {@code true}
      *
      * @see java.awt.Dialog.ModalityType
@@ -376,9 +376,9 @@ public class Dialog extends Window {
      *     this dialog has no owner
      * @param title the title of the dialog or {@code null} if this dialog
      *     has no title
-     * @exception IllegalArgumentException if the {@code owner}'s
+     * @throws IllegalArgumentException if the {@code owner}'s
      *     {@code GraphicsConfiguration} is not from a screen device
-     * @exception HeadlessException when
+     * @throws HeadlessException when
      *     {@code GraphicsEnvironment.isHeadless()} returns {@code true}
      *
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -401,9 +401,9 @@ public class Dialog extends Window {
      *     windows when shown. If {@code false}, the dialog is {@code MODELESS};
      *     if {@code true}, the modality type property is set to
      *     {@code DEFAULT_MODALITY_TYPE}
-     * @exception java.lang.IllegalArgumentException if the {@code owner}'s
+     * @throws java.lang.IllegalArgumentException if the {@code owner}'s
      *    {@code GraphicsConfiguration} is not from a screen device
-     * @exception HeadlessException when
+     * @throws HeadlessException when
      *    {@code GraphicsEnvironment.isHeadless()} returns {@code true}
      *
      * @see java.awt.Dialog.ModalityType
@@ -433,9 +433,9 @@ public class Dialog extends Window {
      * @param gc the {@code GraphicsConfiguration} of the target screen device;
      *     if {@code null}, the default system {@code GraphicsConfiguration}
      *     is assumed
-     * @exception java.lang.IllegalArgumentException if {@code gc}
+     * @throws java.lang.IllegalArgumentException if {@code gc}
      *     is not from a screen device
-     * @exception HeadlessException when
+     * @throws HeadlessException when
      *     {@code GraphicsEnvironment.isHeadless()} returns {@code true}
      *
      * @see java.awt.Dialog.ModalityType
@@ -459,9 +459,9 @@ public class Dialog extends Window {
      *
      * @param owner the owner of the dialog or {@code null} if this
      *     dialog has no owner
-     * @exception java.lang.IllegalArgumentException if the {@code owner}'s
+     * @throws java.lang.IllegalArgumentException if the {@code owner}'s
      *     {@code GraphicsConfiguration} is not from a screen device
-     * @exception HeadlessException when
+     * @throws HeadlessException when
      *     {@code GraphicsEnvironment.isHeadless()} returns {@code true}
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @since 1.2
@@ -478,9 +478,9 @@ public class Dialog extends Window {
      *     has no owner
      * @param title the title of the dialog or {@code null} if this dialog
      *     has no title
-     * @exception java.lang.IllegalArgumentException if the {@code owner}'s
+     * @throws java.lang.IllegalArgumentException if the {@code owner}'s
      *     {@code GraphicsConfiguration} is not from a screen device
-     * @exception HeadlessException when
+     * @throws HeadlessException when
      *     {@code GraphicsEnvironment.isHeadless()} returns {@code true}
      *
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -502,9 +502,9 @@ public class Dialog extends Window {
      *     windows when shown. If {@code false}, the dialog is {@code MODELESS};
      *     if {@code true}, the modality type property is set to
      *     {@code DEFAULT_MODALITY_TYPE}
-     * @exception IllegalArgumentException if the {@code owner}'s
+     * @throws IllegalArgumentException if the {@code owner}'s
      *    {@code GraphicsConfiguration} is not from a screen device
-     * @exception HeadlessException when
+     * @throws HeadlessException when
      *    {@code GraphicsEnvironment.isHeadless()} returns {@code true}
      *
      * @see java.awt.Dialog.ModalityType
@@ -536,9 +536,9 @@ public class Dialog extends Window {
      * @param gc the {@code GraphicsConfiguration} of the target screen device;
      *     if {@code null}, the default system {@code GraphicsConfiguration}
      *     is assumed
-     * @exception java.lang.IllegalArgumentException if {@code gc}
+     * @throws java.lang.IllegalArgumentException if {@code gc}
      *    is not from a screen device
-     * @exception HeadlessException when
+     * @throws HeadlessException when
      *    {@code GraphicsEnvironment.isHeadless()} returns {@code true}
      *
      * @see java.awt.Dialog.ModalityType
@@ -565,12 +565,12 @@ public class Dialog extends Window {
      *     {@link java.awt.Dialog Dialog}, {@link java.awt.Frame Frame}, any
      *     of their descendants or {@code null}
      *
-     * @exception java.lang.IllegalArgumentException if the {@code owner}
+     * @throws java.lang.IllegalArgumentException if the {@code owner}
      *     is not an instance of {@link java.awt.Dialog Dialog} or {@link
      *     java.awt.Frame Frame}
-     * @exception java.lang.IllegalArgumentException if the {@code owner}'s
+     * @throws java.lang.IllegalArgumentException if the {@code owner}'s
      *     {@code GraphicsConfiguration} is not from a screen device
-     * @exception HeadlessException when
+     * @throws HeadlessException when
      *     {@code GraphicsEnvironment.isHeadless()} returns {@code true}
      *
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -591,12 +591,12 @@ public class Dialog extends Window {
      * @param title the title of the dialog or {@code null} if this dialog
      *    has no title
      *
-     * @exception java.lang.IllegalArgumentException if the {@code owner}
+     * @throws java.lang.IllegalArgumentException if the {@code owner}
      *    is not an instance of {@link java.awt.Dialog Dialog} or {@link
      *    java.awt.Frame Frame}
-     * @exception java.lang.IllegalArgumentException if the {@code owner}'s
+     * @throws java.lang.IllegalArgumentException if the {@code owner}'s
      *    {@code GraphicsConfiguration} is not from a screen device
-     * @exception HeadlessException when
+     * @throws HeadlessException when
      *    {@code GraphicsEnvironment.isHeadless()} returns {@code true}
      *
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -618,14 +618,14 @@ public class Dialog extends Window {
      *    windows when shown. {@code null} value and unsupported modality
      *    types are equivalent to {@code MODELESS}
      *
-     * @exception java.lang.IllegalArgumentException if the {@code owner}
+     * @throws java.lang.IllegalArgumentException if the {@code owner}
      *    is not an instance of {@link java.awt.Dialog Dialog} or {@link
      *    java.awt.Frame Frame}
-     * @exception java.lang.IllegalArgumentException if the {@code owner}'s
+     * @throws java.lang.IllegalArgumentException if the {@code owner}'s
      *    {@code GraphicsConfiguration} is not from a screen device
-     * @exception HeadlessException when
+     * @throws HeadlessException when
      *    {@code GraphicsEnvironment.isHeadless()} returns {@code true}
-     * @exception SecurityException if the calling thread does not have permission
+     * @throws SecurityException if the calling thread does not have permission
      *    to create modal dialogs with the given {@code modalityType}
      *
      * @see java.awt.Dialog.ModalityType
@@ -653,14 +653,14 @@ public class Dialog extends Window {
      *    windows when shown. {@code null} value and unsupported modality
      *    types are equivalent to {@code MODELESS}
      *
-     * @exception java.lang.IllegalArgumentException if the {@code owner}
+     * @throws java.lang.IllegalArgumentException if the {@code owner}
      *     is not an instance of {@link java.awt.Dialog Dialog} or {@link
      *     java.awt.Frame Frame}
-     * @exception java.lang.IllegalArgumentException if the {@code owner}'s
+     * @throws java.lang.IllegalArgumentException if the {@code owner}'s
      *     {@code GraphicsConfiguration} is not from a screen device
-     * @exception HeadlessException when
+     * @throws HeadlessException when
      *     {@code GraphicsEnvironment.isHeadless()} returns {@code true}
-     * @exception SecurityException if the calling thread does not have permission
+     * @throws SecurityException if the calling thread does not have permission
      *     to create modal dialogs with the given {@code modalityType}
      *
      * @see java.awt.Dialog.ModalityType
@@ -704,14 +704,14 @@ public class Dialog extends Window {
      *     if {@code null}, the default system {@code GraphicsConfiguration}
      *     is assumed
      *
-     * @exception java.lang.IllegalArgumentException if the {@code owner}
+     * @throws java.lang.IllegalArgumentException if the {@code owner}
      *     is not an instance of {@link java.awt.Dialog Dialog} or {@link
      *     java.awt.Frame Frame}
-     * @exception java.lang.IllegalArgumentException if {@code gc}
+     * @throws java.lang.IllegalArgumentException if {@code gc}
      *     is not from a screen device
-     * @exception HeadlessException when
+     * @throws HeadlessException when
      *     {@code GraphicsEnvironment.isHeadless()} returns {@code true}
-     * @exception SecurityException if the calling thread does not have permission
+     * @throws SecurityException if the calling thread does not have permission
      *     to create modal dialogs with the given {@code modalityType}
      *
      * @see java.awt.Dialog.ModalityType
@@ -848,7 +848,7 @@ public class Dialog extends Window {
      * @param type specifies whether dialog blocks input to other
      *     windows when shown. {@code null} value and unsupported modality
      *     types are equivalent to {@code MODELESS}
-     * @exception SecurityException if the calling thread does not have permission
+     * @throws SecurityException if the calling thread does not have permission
      *     to create modal dialogs with the given {@code modalityType}
      *
      * @see       java.awt.Dialog#getModalityType

--- a/src/java.desktop/share/classes/java/awt/EventQueue.java
+++ b/src/java.desktop/share/classes/java/awt/EventQueue.java
@@ -544,7 +544,7 @@ public class EventQueue {
      * returns it.  This method will block until an event has
      * been posted by another thread.
      * @return the next {@code AWTEvent}
-     * @exception InterruptedException
+     * @throws InterruptedException
      *            if any thread has interrupted this thread
      */
     public AWTEvent getNextEvent() throws InterruptedException {
@@ -946,7 +946,7 @@ public class EventQueue {
      * Warning: To avoid deadlock, do not declare this method
      * synchronized in a subclass.
      *
-     * @exception EmptyStackException if no previous push was made
+     * @throws EmptyStackException if no previous push was made
      *  on this {@code EventQueue}
      * @see      java.awt.EventQueue#push
      * @since           1.2
@@ -1331,9 +1331,9 @@ public class EventQueue {
      *                  synchronously in the
      *                  {@link #isDispatchThread event dispatch thread}
      *                  of {@link Toolkit#getSystemEventQueue the system EventQueue}
-     * @exception       InterruptedException  if any thread has
+     * @throws       InterruptedException  if any thread has
      *                  interrupted this thread
-     * @exception       InvocationTargetException  if an throwable is thrown
+     * @throws       InvocationTargetException  if an throwable is thrown
      *                  when running {@code runnable}
      * @see             #invokeLater
      * @see             Toolkit#getSystemEventQueue

--- a/src/java.desktop/share/classes/java/awt/FileDialog.java
+++ b/src/java.desktop/share/classes/java/awt/FileDialog.java
@@ -232,7 +232,7 @@ public class FileDialog extends Dialog {
      * @param     title   the title of the dialog
      * @param     mode   the mode of the dialog; either
      *            {@code FileDialog.LOAD} or {@code FileDialog.SAVE}
-     * @exception  IllegalArgumentException if an illegal file
+     * @throws  IllegalArgumentException if an illegal file
      *                 dialog mode is supplied
      * @see       java.awt.FileDialog#LOAD
      * @see       java.awt.FileDialog#SAVE
@@ -255,10 +255,10 @@ public class FileDialog extends Dialog {
      * displayed.
      *
      * @param     parent   the owner of the dialog
-     * @exception java.lang.IllegalArgumentException if the {@code parent}'s
+     * @throws java.lang.IllegalArgumentException if the {@code parent}'s
      *            {@code GraphicsConfiguration}
      *            is not from a screen device;
-     * @exception java.lang.IllegalArgumentException if {@code parent}
+     * @throws java.lang.IllegalArgumentException if {@code parent}
      *            is {@code null}; this exception is always thrown when
      *            {@code GraphicsEnvironment.isHeadless}
      *            returns {@code true}
@@ -285,10 +285,10 @@ public class FileDialog extends Dialog {
      * @param     title    the title of the dialog; a {@code null} value
      *                     will be accepted without causing a
      *                     {@code NullPointerException} to be thrown
-     * @exception java.lang.IllegalArgumentException if the {@code parent}'s
+     * @throws java.lang.IllegalArgumentException if the {@code parent}'s
      *            {@code GraphicsConfiguration}
      *            is not from a screen device;
-     * @exception java.lang.IllegalArgumentException if {@code parent}
+     * @throws java.lang.IllegalArgumentException if {@code parent}
      *            is {@code null}; this exception is always thrown when
      *            {@code GraphicsEnvironment.isHeadless}
      *            returns {@code true}
@@ -321,12 +321,12 @@ public class FileDialog extends Dialog {
      *                     {@code NullPointerException} to be thrown
      * @param     mode     the mode of the dialog; either
      *                     {@code FileDialog.LOAD} or {@code FileDialog.SAVE}
-     * @exception java.lang.IllegalArgumentException if an illegal
+     * @throws java.lang.IllegalArgumentException if an illegal
      *            file dialog mode is supplied;
-     * @exception java.lang.IllegalArgumentException if the {@code parent}'s
+     * @throws java.lang.IllegalArgumentException if the {@code parent}'s
      *            {@code GraphicsConfiguration}
      *            is not from a screen device;
-     * @exception java.lang.IllegalArgumentException if {@code parent}
+     * @throws java.lang.IllegalArgumentException if {@code parent}
      *            is {@code null}; this exception is always thrown when
      *            {@code GraphicsEnvironment.isHeadless}
      *            returns {@code true}
@@ -408,7 +408,7 @@ public class FileDialog extends Dialog {
      * @see        java.awt.FileDialog#LOAD
      * @see        java.awt.FileDialog#SAVE
      * @see        java.awt.FileDialog#getMode
-     * @exception  IllegalArgumentException if an illegal file
+     * @throws  IllegalArgumentException if an illegal file
      *                 dialog mode is supplied
      * @since      1.1
      */

--- a/src/java.desktop/share/classes/java/awt/Frame.java
+++ b/src/java.desktop/share/classes/java/awt/Frame.java
@@ -383,7 +383,7 @@ public class Frame extends Window implements MenuContainer {
      * Constructs a new instance of {@code Frame} that is
      * initially invisible.  The title of the {@code Frame}
      * is empty.
-     * @exception HeadlessException when
+     * @throws HeadlessException when
      *     {@code GraphicsEnvironment.isHeadless()} returns {@code true}
      * @see java.awt.GraphicsEnvironment#isHeadless()
      * @see Component#setSize
@@ -401,9 +401,9 @@ public class Frame extends Window implements MenuContainer {
      * of the target screen device. If {@code gc}
      * is {@code null}, the system default
      * {@code GraphicsConfiguration} is assumed.
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      * {@code gc} is not from a screen device.
-     * @exception HeadlessException when
+     * @throws HeadlessException when
      *     {@code GraphicsEnvironment.isHeadless()} returns {@code true}
      * @see java.awt.GraphicsEnvironment#isHeadless()
      * @since     1.3
@@ -418,7 +418,7 @@ public class Frame extends Window implements MenuContainer {
      * @param title the title to be displayed in the frame's border.
      *              A {@code null} value
      *              is treated as an empty string, "".
-     * @exception HeadlessException when
+     * @throws HeadlessException when
      *     {@code GraphicsEnvironment.isHeadless()} returns {@code true}
      * @see java.awt.GraphicsEnvironment#isHeadless()
      * @see java.awt.Component#setSize
@@ -440,9 +440,9 @@ public class Frame extends Window implements MenuContainer {
      * of the target screen device.  If {@code gc} is
      * {@code null}, the system default
      * {@code GraphicsConfiguration} is assumed.
-     * @exception IllegalArgumentException if {@code gc}
+     * @throws IllegalArgumentException if {@code gc}
      * is not from a screen device.
-     * @exception HeadlessException when
+     * @throws HeadlessException when
      *     {@code GraphicsEnvironment.isHeadless()} returns {@code true}
      * @see java.awt.GraphicsEnvironment#isHeadless()
      * @see java.awt.Component#setSize

--- a/src/java.desktop/share/classes/java/awt/GraphicsConfiguration.java
+++ b/src/java.desktop/share/classes/java/awt/GraphicsConfiguration.java
@@ -261,7 +261,7 @@ public abstract class GraphicsConfiguration {
      * @param width the width of the returned {@code VolatileImage}
      * @param height the height of the returned {@code VolatileImage}
      * @param caps the image capabilities
-     * @exception AWTException if the supplied image capabilities could not
+     * @throws AWTException if the supplied image capabilities could not
      * be met by this graphics configuration
      * @since 1.4
      */
@@ -294,7 +294,7 @@ public abstract class GraphicsConfiguration {
      * @see Transparency#BITMASK
      * @see Transparency#TRANSLUCENT
      * @throws IllegalArgumentException if the transparency is not a valid value
-     * @exception AWTException if the supplied image capabilities could not
+     * @throws AWTException if the supplied image capabilities could not
      * be met by this graphics configuration
      * @see Component#createVolatileImage(int, int)
      * @since 1.5

--- a/src/java.desktop/share/classes/java/awt/GraphicsDevice.java
+++ b/src/java.desktop/share/classes/java/awt/GraphicsDevice.java
@@ -418,10 +418,10 @@ public abstract class GraphicsDevice {
      * </code></pre>
      *
      * @param dm The new display mode of this graphics device.
-     * @exception IllegalArgumentException if the {@code DisplayMode}
+     * @throws IllegalArgumentException if the {@code DisplayMode}
      * supplied is {@code null}, or is not available in the array returned
      * by {@code getDisplayModes}
-     * @exception UnsupportedOperationException if
+     * @throws UnsupportedOperationException if
      * {@code isDisplayChangeSupported} returns {@code false}
      * @see #getDisplayMode
      * @see #getDisplayModes

--- a/src/java.desktop/share/classes/java/awt/GraphicsEnvironment.java
+++ b/src/java.desktop/share/classes/java/awt/GraphicsEnvironment.java
@@ -191,7 +191,7 @@ public abstract class GraphicsEnvironment {
      * objects.
      * @return an array containing all the {@code GraphicsDevice}
      * objects that represent screen devices
-     * @exception HeadlessException if isHeadless() returns true
+     * @throws HeadlessException if isHeadless() returns true
      * @see #isHeadless()
      */
     public abstract GraphicsDevice[] getScreenDevices()
@@ -201,7 +201,7 @@ public abstract class GraphicsEnvironment {
      * Returns the default screen {@code GraphicsDevice}.
      * @return the {@code GraphicsDevice} that represents the
      * default screen device
-     * @exception HeadlessException if isHeadless() returns true
+     * @throws HeadlessException if isHeadless() returns true
      * @see #isHeadless()
      */
     public abstract GraphicsDevice getDefaultScreenDevice()
@@ -383,7 +383,7 @@ public abstract class GraphicsEnvironment {
      * within the available display area using getMaximumWindowBounds().
      * @return the point where Windows should be centered
      *
-     * @exception HeadlessException if isHeadless() returns true
+     * @throws HeadlessException if isHeadless() returns true
      * @see #getMaximumWindowBounds
      * @since 1.4
      */
@@ -409,7 +409,7 @@ public abstract class GraphicsEnvironment {
      * {@code Toolkit.getScreenInsets()}.
      * @return  the maximum bounds for centered Windows
      *
-     * @exception HeadlessException if isHeadless() returns true
+     * @throws HeadlessException if isHeadless() returns true
      * @see #getCenterPoint
      * @see GraphicsConfiguration#getBounds
      * @see Toolkit#getScreenInsets

--- a/src/java.desktop/share/classes/java/awt/GridBagLayout.java
+++ b/src/java.desktop/share/classes/java/awt/GridBagLayout.java
@@ -688,7 +688,7 @@ java.io.Serializable {
      * @param      comp         the component to be added
      * @param      constraints  an object that determines how
      *                          the component is added to the layout
-     * @exception IllegalArgumentException if {@code constraints}
+     * @throws IllegalArgumentException if {@code constraints}
      *            is not a {@code GridBagConstraint}
      */
     public void addLayoutComponent(Component comp, Object constraints) {

--- a/src/java.desktop/share/classes/java/awt/GridLayout.java
+++ b/src/java.desktop/share/classes/java/awt/GridLayout.java
@@ -186,7 +186,7 @@ public class GridLayout implements LayoutManager, java.io.Serializable {
      *                   any number of columns
      * @param     hgap   the horizontal gap
      * @param     vgap   the vertical gap
-     * @exception   IllegalArgumentException  if the value of both
+     * @throws   IllegalArgumentException  if the value of both
      *                  {@code rows} and {@code cols} is
      *                  set to zero
      */
@@ -212,7 +212,7 @@ public class GridLayout implements LayoutManager, java.io.Serializable {
     /**
      * Sets the number of rows in this layout to the specified value.
      * @param        rows   the number of rows in this layout
-     * @exception    IllegalArgumentException  if the value of both
+     * @throws    IllegalArgumentException  if the value of both
      *               {@code rows} and {@code cols} is set to zero
      * @since        1.1
      */
@@ -240,7 +240,7 @@ public class GridLayout implements LayoutManager, java.io.Serializable {
      * of columns displayed in the layout is determined by the total
      * number of components and the number of rows specified.
      * @param        cols   the number of columns in this layout
-     * @exception    IllegalArgumentException  if the value of both
+     * @throws    IllegalArgumentException  if the value of both
      *               {@code rows} and {@code cols} is set to zero
      * @since        1.1
      */

--- a/src/java.desktop/share/classes/java/awt/Image.java
+++ b/src/java.desktop/share/classes/java/awt/Image.java
@@ -105,7 +105,7 @@ public abstract class Image {
      * Creates a graphics context for drawing to an off-screen image.
      * This method can only be called for off-screen images.
      * @return  a graphics context to draw to the off-screen image.
-     * @exception UnsupportedOperationException if called for a
+     * @throws UnsupportedOperationException if called for a
      *            non-off-screen image.
      * @see     java.awt.Graphics
      * @see     java.awt.Component#createImage(int, int)
@@ -162,7 +162,7 @@ public abstract class Image {
      * @param hints flags to indicate the type of algorithm to use
      * for image resampling.
      * @return     a scaled version of the image.
-     * @exception IllegalArgumentException if {@code width}
+     * @throws IllegalArgumentException if {@code width}
      *             or {@code height} is zero.
      * @see        java.awt.Image#SCALE_DEFAULT
      * @see        java.awt.Image#SCALE_FAST

--- a/src/java.desktop/share/classes/java/awt/Label.java
+++ b/src/java.desktop/share/classes/java/awt/Label.java
@@ -114,7 +114,7 @@ public class Label extends Component implements Accessible {
     /**
      * Constructs an empty label.
      * The text of the label is the empty string {@code ""}.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -129,7 +129,7 @@ public class Label extends Component implements Accessible {
      *        A {@code null} value
      *        will be accepted without causing a NullPointerException
      *        to be thrown.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -147,7 +147,7 @@ public class Label extends Component implements Accessible {
      *        will be accepted without causing a NullPointerException
      *        to be thrown.
      * @param     alignment   the alignment value.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -216,7 +216,7 @@ public class Label extends Component implements Accessible {
      * Possible values are {@code Label.LEFT},
      * {@code Label.RIGHT}, and {@code Label.CENTER}.
      * @param      alignment    the alignment to be set.
-     * @exception  IllegalArgumentException if an improper value for
+     * @throws  IllegalArgumentException if an improper value for
      *                          {@code alignment} is given.
      * @see        java.awt.Label#getAlignment
      */

--- a/src/java.desktop/share/classes/java/awt/List.java
+++ b/src/java.desktop/share/classes/java/awt/List.java
@@ -193,7 +193,7 @@ public class List extends Component implements ItemSelectable, Accessible {
      * not allowed.  Note that this is a convenience method for
      * {@code List(0, false)}.  Also note that the number of visible
      * lines in the list cannot be changed after it has been created.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -209,7 +209,7 @@ public class List extends Component implements ItemSelectable, Accessible {
      * of visible rows in the list cannot be changed after it has
      * been created.
      * @param       rows the number of items to show.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @since       1.1
@@ -238,7 +238,7 @@ public class List extends Component implements ItemSelectable, Accessible {
      * @param       multipleMode   if {@code true},
      *                     then multiple selections are allowed;
      *                     otherwise, only one item can be selected at a time.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -411,7 +411,7 @@ public class List extends Component implements ItemSelectable, Accessible {
      * with the new string.
      * @param       newValue   a new string to replace an existing item
      * @param       index      the position of the item to replace
-     * @exception ArrayIndexOutOfBoundsException if {@code index}
+     * @throws ArrayIndexOutOfBoundsException if {@code index}
      *          is out of range
      */
     public synchronized void replaceItem(String newValue, int index) {
@@ -448,7 +448,7 @@ public class List extends Component implements ItemSelectable, Accessible {
      * If the specified item is selected, and is the only selected
      * item in the list, the list is set to have no selection.
      * @param        item  the item to remove from the list
-     * @exception    IllegalArgumentException
+     * @throws    IllegalArgumentException
      *                     if the item doesn't exist in the list
      * @since        1.1
      */
@@ -470,7 +470,7 @@ public class List extends Component implements ItemSelectable, Accessible {
      * @param      position   the index of the item to delete
      * @see        #add(String, int)
      * @since      1.1
-     * @exception    ArrayIndexOutOfBoundsException
+     * @throws    ArrayIndexOutOfBoundsException
      *               if the {@code position} is less than 0 or
      *               greater than {@code getItemCount()-1}
      */
@@ -1053,7 +1053,7 @@ public class List extends Component implements ItemSelectable, Accessible {
      *          <code><em>Foo</em>Listener</code>s on this list,
      *          or an empty array if no such
      *          listeners have been added
-     * @exception ClassCastException if {@code listenerType}
+     * @throws ClassCastException if {@code listenerType}
      *          doesn't specify a class or interface that implements
      *          {@code java.util.EventListener}
      *
@@ -1631,7 +1631,7 @@ public class List extends Component implements ItemSelectable, Accessible {
              * @return This component's locale.  If this component does not have
              * a locale, the locale of its parent is returned.
              *
-             * @exception IllegalComponentStateException
+             * @throws IllegalComponentStateException
              * If the Component does not have its own locale and has not yet
              * been added to a containment hierarchy such that the locale can
              * be determined from the containing parent.

--- a/src/java.desktop/share/classes/java/awt/MediaTracker.java
+++ b/src/java.desktop/share/classes/java/awt/MediaTracker.java
@@ -396,7 +396,7 @@ public class MediaTracker implements java.io.Serializable {
      * @see         java.awt.MediaTracker#waitForAll(long)
      * @see         java.awt.MediaTracker#isErrorAny
      * @see         java.awt.MediaTracker#isErrorID
-     * @exception   InterruptedException  if any thread has
+     * @throws   InterruptedException  if any thread has
      *                                     interrupted this thread
      */
     public void waitForAll() throws InterruptedException {
@@ -421,7 +421,7 @@ public class MediaTracker implements java.io.Serializable {
      * @see         java.awt.MediaTracker#waitForAll(long)
      * @see         java.awt.MediaTracker#isErrorAny
      * @see         java.awt.MediaTracker#isErrorID
-     * @exception   InterruptedException  if any thread has
+     * @throws   InterruptedException  if any thread has
      *                                     interrupted this thread.
      */
     public synchronized boolean waitForAll(long ms)
@@ -627,7 +627,7 @@ public class MediaTracker implements java.io.Serializable {
      * @see           java.awt.MediaTracker#waitForAll
      * @see           java.awt.MediaTracker#isErrorAny()
      * @see           java.awt.MediaTracker#isErrorID(int)
-     * @exception     InterruptedException  if any thread has
+     * @throws     InterruptedException  if any thread has
      *                          interrupted this thread.
      */
     public void waitForID(int id) throws InterruptedException {
@@ -655,7 +655,7 @@ public class MediaTracker implements java.io.Serializable {
      * @see           java.awt.MediaTracker#statusID
      * @see           java.awt.MediaTracker#isErrorAny()
      * @see           java.awt.MediaTracker#isErrorID(int)
-     * @exception     InterruptedException  if any thread has
+     * @throws     InterruptedException  if any thread has
      *                          interrupted this thread.
      */
     public synchronized boolean waitForID(int id, long ms)

--- a/src/java.desktop/share/classes/java/awt/Menu.java
+++ b/src/java.desktop/share/classes/java/awt/Menu.java
@@ -125,7 +125,7 @@ public class Menu extends MenuItem implements MenuContainer, Accessible {
     /**
      * Constructs a new menu with an empty label. This menu is not
      * a tear-off menu.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @since      1.1
@@ -139,7 +139,7 @@ public class Menu extends MenuItem implements MenuContainer, Accessible {
      * a tear-off menu.
      * @param       label the menu's label in the menu bar, or in
      *                   another menu of which this menu is a submenu.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -158,7 +158,7 @@ public class Menu extends MenuItem implements MenuContainer, Accessible {
      *                   another menu of which this menu is a submenu.
      * @param       tearOff   if {@code true}, the menu
      *                   is a tear-off menu.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -313,7 +313,7 @@ public class Menu extends MenuItem implements MenuContainer, Accessible {
      *                          item should be inserted.
      * @see           java.awt.Menu#add(java.lang.String)
      * @see           java.awt.Menu#add(java.awt.MenuItem)
-     * @exception     IllegalArgumentException if the value of
+     * @throws     IllegalArgumentException if the value of
      *                    {@code index} is less than zero
      * @since         1.1
      */
@@ -357,7 +357,7 @@ public class Menu extends MenuItem implements MenuContainer, Accessible {
      *                      should be inserted
      * @see         java.awt.Menu#add(java.lang.String)
      * @see         java.awt.Menu#add(java.awt.MenuItem)
-     * @exception     IllegalArgumentException if the value of
+     * @throws     IllegalArgumentException if the value of
      *                    {@code index} is less than zero
      * @since       1.1
      */
@@ -378,7 +378,7 @@ public class Menu extends MenuItem implements MenuContainer, Accessible {
      * Inserts a separator at the specified position.
      * @param       index the position at which the
      *                       menu separator should be inserted.
-     * @exception   IllegalArgumentException if the value of
+     * @throws   IllegalArgumentException if the value of
      *                       {@code index} is less than 0.
      * @see         java.awt.Menu#addSeparator
      * @since       1.1

--- a/src/java.desktop/share/classes/java/awt/MenuBar.java
+++ b/src/java.desktop/share/classes/java/awt/MenuBar.java
@@ -127,7 +127,7 @@ public class MenuBar extends MenuComponent implements MenuContainer, Accessible 
 
     /**
      * Creates a new menu bar.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */

--- a/src/java.desktop/share/classes/java/awt/MenuComponent.java
+++ b/src/java.desktop/share/classes/java/awt/MenuComponent.java
@@ -176,7 +176,7 @@ public abstract class MenuComponent implements java.io.Serializable {
 
     /**
      * Creates a {@code MenuComponent}.
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *    {@code GraphicsEnvironment.isHeadless}
      *    returns {@code true}
      * @see java.awt.GraphicsEnvironment#isHeadless

--- a/src/java.desktop/share/classes/java/awt/MenuItem.java
+++ b/src/java.desktop/share/classes/java/awt/MenuItem.java
@@ -185,7 +185,7 @@ public class MenuItem extends MenuComponent implements Accessible {
     /**
      * Constructs a new MenuItem with an empty label and no keyboard
      * shortcut.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @since    1.1
@@ -201,7 +201,7 @@ public class MenuItem extends MenuComponent implements Accessible {
      * menu items. By default, all menu items except for
      * separators are enabled.
      * @param       label the label for this menu item.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @since       1.0
@@ -218,7 +218,7 @@ public class MenuItem extends MenuComponent implements Accessible {
      * @param       label the label for this menu item.
      * @param       s the instance of {@code MenuShortcut}
      *                       associated with this menu item.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @since       1.1
@@ -616,7 +616,7 @@ public class MenuItem extends MenuComponent implements Accessible {
      *          <code><em>Foo</em>Listener</code>s on this menu item,
      *          or an empty array if no such
      *          listeners have been added
-     * @exception ClassCastException if {@code listenerType}
+     * @throws ClassCastException if {@code listenerType}
      *          doesn't specify a class or interface that implements
      *          {@code java.util.EventListener}
      *

--- a/src/java.desktop/share/classes/java/awt/MouseInfo.java
+++ b/src/java.desktop/share/classes/java/awt/MouseInfo.java
@@ -62,8 +62,8 @@ public class MouseInfo {
      * permission before creating and returning a {@code PointerInfo}
      * object. This may result in a {@code SecurityException}.
      *
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless() returns true
-     * @exception SecurityException if a security manager exists and its
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless() returns true
+     * @throws SecurityException if a security manager exists and its
      *            {@code checkPermission} method doesn't allow the operation
      * @see       GraphicsConfiguration
      * @see       SecurityManager#checkPermission
@@ -124,7 +124,7 @@ public class MouseInfo {
      * by requesting the {@code "awt.mouse.numButtons"} desktop property
      * which is set by the underlying native platform.
      *
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless() returns true
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless() returns true
      * @return number of buttons on the mouse
      * @see Toolkit#getDesktopProperty
      * @since 1.5

--- a/src/java.desktop/share/classes/java/awt/Polygon.java
+++ b/src/java.desktop/share/classes/java/awt/Polygon.java
@@ -139,12 +139,12 @@ public class Polygon implements Shape, java.io.Serializable {
      * @param ypoints an array of Y coordinates
      * @param npoints the total number of points in the
      *                          {@code Polygon}
-     * @exception  NegativeArraySizeException if the value of
+     * @throws  NegativeArraySizeException if the value of
      *                       {@code npoints} is negative.
-     * @exception  IndexOutOfBoundsException if {@code npoints} is
+     * @throws  IndexOutOfBoundsException if {@code npoints} is
      *             greater than the length of {@code xpoints}
      *             or the length of {@code ypoints}.
-     * @exception  NullPointerException if {@code xpoints} or
+     * @throws  NullPointerException if {@code xpoints} or
      *             {@code ypoints} is {@code null}.
      * @since 1.0
      */

--- a/src/java.desktop/share/classes/java/awt/PopupMenu.java
+++ b/src/java.desktop/share/classes/java/awt/PopupMenu.java
@@ -69,7 +69,7 @@ public class PopupMenu extends Menu {
 
     /**
      * Creates a new popup menu with an empty name.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -82,7 +82,7 @@ public class PopupMenu extends Menu {
      *
      * @param label a non-{@code null} string specifying
      *                the popup menu's label
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -149,12 +149,12 @@ public class PopupMenu extends Menu {
      * @param origin the component which defines the coordinate space
      * @param x the x coordinate position to popup the menu
      * @param y the y coordinate position to popup the menu
-     * @exception NullPointerException  if the parent is {@code null}
-     * @exception IllegalArgumentException  if this {@code PopupMenu}
+     * @throws NullPointerException  if the parent is {@code null}
+     * @throws IllegalArgumentException  if this {@code PopupMenu}
      *                has a non-{@code Component} parent
-     * @exception IllegalArgumentException if the origin is not in the
+     * @throws IllegalArgumentException if the origin is not in the
      *                parent's hierarchy
-     * @exception RuntimeException if the parent is not showing on screen
+     * @throws RuntimeException if the parent is not showing on screen
      */
     @SuppressWarnings("deprecation")
     public void show(Component origin, int x, int y) {

--- a/src/java.desktop/share/classes/java/awt/RenderingHints.java
+++ b/src/java.desktop/share/classes/java/awt/RenderingHints.java
@@ -1064,7 +1064,7 @@ public class RenderingHints
      * {@code RenderingHints} is to be tested.
      * @return {@code true} if this {@code RenderingHints}
      *          contains a mapping for the specified key.
-     * @exception ClassCastException if the key can not
+     * @throws ClassCastException if the key can not
      *            be cast to {@code RenderingHints.Key}
      */
     public boolean containsKey(Object key) {
@@ -1099,7 +1099,7 @@ public class RenderingHints
      * @return  the value to which the key is mapped in this object or
      *          {@code null} if the key is not mapped to any value in
      *          this object.
-     * @exception ClassCastException if the key can not
+     * @throws ClassCastException if the key can not
      *            be cast to {@code RenderingHints.Key}
      * @see     #put(Object, Object)
      */
@@ -1117,11 +1117,11 @@ public class RenderingHints
      * @param      value   the rendering hint value.
      * @return     the previous value of the specified key in this object
      *             or {@code null} if it did not have one.
-     * @exception NullPointerException if the key is
+     * @throws NullPointerException if the key is
      *            {@code null}.
-     * @exception ClassCastException if the key can not
+     * @throws ClassCastException if the key can not
      *            be cast to {@code RenderingHints.Key}
-     * @exception IllegalArgumentException if the
+     * @throws IllegalArgumentException if the
      *            {@link Key#isCompatibleValue(java.lang.Object)
      *                   Key.isCompatibleValue()}
      *            method of the specified key returns false for the
@@ -1163,7 +1163,7 @@ public class RenderingHints
      * {@code RenderingHints} object. This method does nothing if the
      * key is not in this {@code RenderingHints} object.
      * @param   key   the rendering hints key that needs to be removed
-     * @exception ClassCastException if the key can not
+     * @throws ClassCastException if the key can not
      *            be cast to {@code RenderingHints.Key}
      * @return  the value to which the key had previously been mapped in this
      *          {@code RenderingHints} object, or {@code null}
@@ -1179,10 +1179,10 @@ public class RenderingHints
      * any mappings that this {@code RenderingHints} had for any
      * of the keys currently in the specified {@code Map}.
      * @param m the specified {@code Map}
-     * @exception ClassCastException class of a key or value
+     * @throws ClassCastException class of a key or value
      *          in the specified {@code Map} prevents it from being
      *          stored in this {@code RenderingHints}.
-     * @exception IllegalArgumentException some aspect
+     * @throws IllegalArgumentException some aspect
      *          of a key or value in the specified {@code Map}
      *           prevents it from being stored in
      *            this {@code RenderingHints}.

--- a/src/java.desktop/share/classes/java/awt/Scrollbar.java
+++ b/src/java.desktop/share/classes/java/awt/Scrollbar.java
@@ -349,7 +349,7 @@ public class Scrollbar extends Component implements Adjustable, Accessible {
      * </tbody>
      * </table>
      *
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -366,9 +366,9 @@ public class Scrollbar extends Component implements Adjustable, Accessible {
      * indicating a horizontal or vertical scroll bar, respectively.
      *
      * @param       orientation   indicates the orientation of the scroll bar
-     * @exception   IllegalArgumentException    when an illegal value for
+     * @throws   IllegalArgumentException    when an illegal value for
      *                    the {@code orientation} argument is supplied
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -394,9 +394,9 @@ public class Scrollbar extends Component implements Adjustable, Accessible {
      *                      represented by the size of the bubble
      * @param     minimum   the minimum value of the scroll bar
      * @param     maximum   the maximum value of the scroll bar
-     * @exception IllegalArgumentException    when an illegal value for
+     * @throws IllegalArgumentException    when an illegal value for
      *                    the {@code orientation} argument is supplied
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see #setValues
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -457,7 +457,7 @@ public class Scrollbar extends Component implements Adjustable, Accessible {
      *               {@code Scrollbar.HORIZONTAL} or
      *               {@code Scrollbar.VERTICAL}
      * @see       java.awt.Scrollbar#getOrientation
-     * @exception   IllegalArgumentException  if the value supplied
+     * @throws   IllegalArgumentException  if the value supplied
      *                   for {@code orientation} is not a
      *                   legal value
      * @since     1.1
@@ -1062,7 +1062,7 @@ public class Scrollbar extends Component implements Adjustable, Accessible {
      * @return an array of all objects registered as
      *          <code><em>Foo</em>Listener</code>s on this component,
      *          or an empty array if no such listeners have been added
-     * @exception ClassCastException if {@code listenerType}
+     * @throws ClassCastException if {@code listenerType}
      *          doesn't specify a class or interface that implements
      *          {@code java.util.EventListener}
      *

--- a/src/java.desktop/share/classes/java/awt/TextArea.java
+++ b/src/java.desktop/share/classes/java/awt/TextArea.java
@@ -157,7 +157,7 @@ public class TextArea extends TextComponent {
      * This text area is created with scrollbar visibility equal to
      * {@link #SCROLLBARS_BOTH}, so both vertical and horizontal
      * scrollbars will be visible for this text area.
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *    {@code GraphicsEnvironment.isHeadless} returns true
      * @see java.awt.GraphicsEnvironment#isHeadless()
      */
@@ -173,7 +173,7 @@ public class TextArea extends TextComponent {
      * @param      text       the text to be displayed; if
      *             {@code text} is {@code null}, the empty
      *             string {@code ""} will be displayed
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *        {@code GraphicsEnvironment.isHeadless} returns true
      * @see java.awt.GraphicsEnvironment#isHeadless()
      */
@@ -191,7 +191,7 @@ public class TextArea extends TextComponent {
      * text area.
      * @param rows the number of rows
      * @param columns the number of columns
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *     {@code GraphicsEnvironment.isHeadless} returns true
      * @see java.awt.GraphicsEnvironment#isHeadless()
      */
@@ -212,7 +212,7 @@ public class TextArea extends TextComponent {
      *             string {@code ""} will be displayed
      * @param     rows      the number of rows
      * @param     columns   the number of columns
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *   {@code GraphicsEnvironment.isHeadless} returns true
      * @see java.awt.GraphicsEnvironment#isHeadless()
      */
@@ -252,7 +252,7 @@ public class TextArea extends TextComponent {
      * @param      scrollbars  a constant that determines what
      *             scrollbars are created to view the text area
      * @since      1.1
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *    {@code GraphicsEnvironment.isHeadless} returns true
      * @see java.awt.GraphicsEnvironment#isHeadless()
      */
@@ -421,7 +421,7 @@ public class TextArea extends TextComponent {
      * @param       rows   the number of rows
      * @see         #getRows()
      * @see         #setColumns(int)
-     * @exception   IllegalArgumentException   if the value
+     * @throws   IllegalArgumentException   if the value
      *                 supplied for {@code rows}
      *                 is less than {@code 0}
      * @since       1.1
@@ -452,7 +452,7 @@ public class TextArea extends TextComponent {
      * @param       columns   the number of columns
      * @see         #getColumns()
      * @see         #setRows(int)
-     * @exception   IllegalArgumentException   if the value
+     * @throws   IllegalArgumentException   if the value
      *                 supplied for {@code columns}
      *                 is less than {@code 0}
      * @since       1.1

--- a/src/java.desktop/share/classes/java/awt/TextComponent.java
+++ b/src/java.desktop/share/classes/java/awt/TextComponent.java
@@ -137,7 +137,7 @@ public class TextComponent extends Component implements Accessible {
      * @param      text       the text to be displayed; if
      *             {@code text} is {@code null}, the empty
      *             string {@code ""} will be displayed
-     * @exception  HeadlessException if
+     * @throws  HeadlessException if
      *             {@code GraphicsEnvironment.isHeadless}
      *             returns true
      * @see        java.awt.GraphicsEnvironment#isHeadless
@@ -511,7 +511,7 @@ public class TextComponent extends Component implements Accessible {
      * is thrown.
      *
      * @param        position the position of the text insertion caret
-     * @exception    IllegalArgumentException if {@code position}
+     * @throws    IllegalArgumentException if {@code position}
      *               is less than zero
      * @since        1.1
      */
@@ -645,7 +645,7 @@ public class TextComponent extends Component implements Accessible {
      *          <code><em>Foo</em>Listener</code>s on this text component,
      *          or an empty array if no such
      *          listeners have been added
-     * @exception ClassCastException if {@code listenerType}
+     * @throws ClassCastException if {@code listenerType}
      *          doesn't specify a class or interface that implements
      *          {@code java.util.EventListener}
      *

--- a/src/java.desktop/share/classes/java/awt/TextField.java
+++ b/src/java.desktop/share/classes/java/awt/TextField.java
@@ -152,7 +152,7 @@ public class TextField extends TextComponent {
 
     /**
      * Constructs a new text field.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -167,7 +167,7 @@ public class TextField extends TextComponent {
      *             string {@code ""} will be displayed.
      *             If {@code text} contains EOL and/or LF characters, then
      *             each will be replaced by space character.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -182,7 +182,7 @@ public class TextField extends TextComponent {
      * @param      columns     the number of columns.  If
      *             {@code columns} is less than {@code 0},
      *             {@code columns} is set to {@code 0}.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -203,7 +203,7 @@ public class TextField extends TextComponent {
      * @param      columns     the number of columns.  If
      *             {@code columns} is less than {@code 0},
      *             {@code columns} is set to {@code 0}.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -369,7 +369,7 @@ public class TextField extends TextComponent {
      * approximate average character width that is platform-dependent.
      * @param      columns   the number of columns.
      * @see        java.awt.TextField#getColumns
-     * @exception  IllegalArgumentException   if the value
+     * @throws  IllegalArgumentException   if the value
      *                 supplied for {@code columns}
      *                 is less than {@code 0}.
      * @since      1.1
@@ -585,7 +585,7 @@ public class TextField extends TextComponent {
      *          <code><em>Foo</em>Listener</code>s on this textfield,
      *          or an empty array if no such
      *          listeners have been added
-     * @exception ClassCastException if {@code listenerType}
+     * @throws ClassCastException if {@code listenerType}
      *          doesn't specify a class or interface that implements
      *          {@code java.util.EventListener}
      *

--- a/src/java.desktop/share/classes/java/awt/Toolkit.java
+++ b/src/java.desktop/share/classes/java/awt/Toolkit.java
@@ -149,7 +149,7 @@ public abstract class Toolkit {
      * with the current system color values.
      *
      * @param     systemColors an integer array.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true
      * @see       java.awt.GraphicsEnvironment#isHeadless
      * @since     1.1
@@ -181,7 +181,7 @@ public abstract class Toolkit {
      * @param     dynamic  If true, Containers should re-layout their
      *            components as the Container is being resized.  If false,
      *            the layout will be validated after resizing is completed.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      *            returns true
      * @see       #isDynamicLayoutSet()
      * @see       #isDynamicLayoutActive()
@@ -208,7 +208,7 @@ public abstract class Toolkit {
      *
      * @return    true if validation of Containers is done dynamically,
      *            false if validation is done after resizing is finished.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      *            returns true
      * @see       #setDynamicLayout(boolean dynamic)
      * @see       #isDynamicLayoutActive()
@@ -274,7 +274,7 @@ public abstract class Toolkit {
      * available from {@code GraphicsConfiguration} and
      * {@code GraphicsDevice}.
      * @return    the size of this toolkit's screen, in pixels.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true
      * @see       java.awt.GraphicsConfiguration#getBounds
      * @see       java.awt.GraphicsDevice#getDisplayMode
@@ -286,7 +286,7 @@ public abstract class Toolkit {
     /**
      * Returns the screen resolution in dots-per-inch.
      * @return    this toolkit's screen resolution, in dots-per-inch.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true
      * @see       java.awt.GraphicsEnvironment#isHeadless
      */
@@ -297,7 +297,7 @@ public abstract class Toolkit {
      * Gets the insets of the screen.
      * @param     gc a {@code GraphicsConfiguration}
      * @return    the insets of this toolkit's screen, in pixels.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true
      * @see       java.awt.GraphicsEnvironment#isHeadless
      * @since     1.4
@@ -324,7 +324,7 @@ public abstract class Toolkit {
      * {@code getColorModel} method
      * of the {@code Component} class.
      * @return    the color model of this toolkit's screen.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true
      * @see       java.awt.GraphicsEnvironment#isHeadless
      * @see       java.awt.image.ColorModel
@@ -973,7 +973,7 @@ public abstract class Toolkit {
      * checkPermission} method to check {@code AWTPermission("accessClipboard")}.
      *
      * @return    the system Clipboard
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true
      * @see       java.awt.GraphicsEnvironment#isHeadless
      * @see       java.awt.datatransfer.Clipboard
@@ -1020,7 +1020,7 @@ public abstract class Toolkit {
      * @return the system selection as a {@code Clipboard}, or
      *         {@code null} if the native platform does not support a
      *         system selection {@code Clipboard}
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      *            returns true
      *
      * @see java.awt.datatransfer.Clipboard
@@ -1057,7 +1057,7 @@ public abstract class Toolkit {
      * <b>Control</b> key isn't the correct key for accelerators.
      * @return    the modifier mask on the {@code Event} class
      *                 that is used for menu shortcuts on this toolkit.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true
      * @see       java.awt.GraphicsEnvironment#isHeadless
      * @see       java.awt.MenuBar
@@ -1111,12 +1111,12 @@ public abstract class Toolkit {
      * @param  keyCode the key code
      * @return {@code true} if the given key is currently in its "on" state;
      *          otherwise {@code false}
-     * @exception java.lang.IllegalArgumentException if {@code keyCode}
+     * @throws java.lang.IllegalArgumentException if {@code keyCode}
      * is not one of the valid key codes
-     * @exception java.lang.UnsupportedOperationException if the host system doesn't
+     * @throws java.lang.UnsupportedOperationException if the host system doesn't
      * allow getting the state of this key programmatically, or if the keyboard
      * doesn't have this key
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true
      * @see       java.awt.GraphicsEnvironment#isHeadless
      * @since 1.3
@@ -1147,12 +1147,12 @@ public abstract class Toolkit {
      *
      * @param  keyCode the key code
      * @param  on the state of the key
-     * @exception java.lang.IllegalArgumentException if {@code keyCode}
+     * @throws java.lang.IllegalArgumentException if {@code keyCode}
      * is not one of the valid key codes
-     * @exception java.lang.UnsupportedOperationException if the host system doesn't
+     * @throws java.lang.UnsupportedOperationException if the host system doesn't
      * allow setting the state of this key programmatically, or if the keyboard
      * doesn't have this key
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true
      * @see       java.awt.GraphicsEnvironment#isHeadless
      * @since 1.3
@@ -1193,10 +1193,10 @@ public abstract class Toolkit {
      *   hotSpot values must be less than the Dimension returned by
      *   {@code getBestCursorSize}
      * @param     name a localized description of the cursor, for Java Accessibility use
-     * @exception IndexOutOfBoundsException if the hotSpot values are outside
+     * @throws IndexOutOfBoundsException if the hotSpot values are outside
      *   the bounds of the cursor
      * @return the cursor created
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true
      * @see       java.awt.GraphicsEnvironment#isHeadless
      * @since     1.2
@@ -1232,7 +1232,7 @@ public abstract class Toolkit {
      * to use.
      * @return    the closest matching supported cursor size, or a dimension of 0,0 if
      * the Toolkit implementation doesn't support custom cursors.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true
      * @see       java.awt.GraphicsEnvironment#isHeadless
      * @since     1.2
@@ -1262,7 +1262,7 @@ public abstract class Toolkit {
      *
      * @return    the maximum number of colors, or zero if custom cursors are not
      * supported by this Toolkit implementation.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true
      * @see       java.awt.GraphicsEnvironment#isHeadless
      * @since     1.2
@@ -1310,7 +1310,7 @@ public abstract class Toolkit {
      * @param state one of named frame state constants.
      * @return {@code true} is this frame state is supported by
      *     this Toolkit implementation, {@code false} otherwise.
-     * @exception HeadlessException
+     * @throws HeadlessException
      *     if {@code GraphicsEnvironment.isHeadless()}
      *     returns {@code true}.
      * @see java.awt.Window#addWindowStateListener
@@ -2203,7 +2203,7 @@ public abstract class Toolkit {
      * returned is unmodifiable.
      * @param highlight input method highlight
      * @return style attribute map, or {@code null}
-     * @exception HeadlessException if
+     * @throws HeadlessException if
      *     {@code GraphicsEnvironment.isHeadless} returns true
      * @see       java.awt.GraphicsEnvironment#isHeadless
      * @since 1.3
@@ -2360,7 +2360,7 @@ public abstract class Toolkit {
     * initialized with {@code true}.
     * Changing this value after the {@code Toolkit} class initialization will have no effect.
     *
-    * @exception HeadlessException if GraphicsEnvironment.isHeadless() returns true
+    * @throws HeadlessException if GraphicsEnvironment.isHeadless() returns true
     * @return {@code true} if events from extra mouse buttons are allowed to be processed and posted;
     *         {@code false} otherwise
     * @see System#getProperty(String propertyName)

--- a/src/java.desktop/share/classes/java/awt/Window.java
+++ b/src/java.desktop/share/classes/java/awt/Window.java
@@ -442,9 +442,9 @@ public class Window extends Container implements Accessible {
      * @param gc the {@code GraphicsConfiguration} of the target screen
      *     device. If {@code gc} is {@code null}, the system default
      *     {@code GraphicsConfiguration} is assumed
-     * @exception IllegalArgumentException if {@code gc}
+     * @throws IllegalArgumentException if {@code gc}
      *    is not from a screen device
-     * @exception HeadlessException when
+     * @throws HeadlessException when
      *     {@code GraphicsEnvironment.isHeadless()} returns {@code true}
      *
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -544,7 +544,7 @@ public class Window extends Container implements Accessible {
      * If that check fails with a {@code SecurityException} then a warning
      * banner is created.
      *
-     * @exception HeadlessException when
+     * @throws HeadlessException when
      *     {@code GraphicsEnvironment.isHeadless()} returns {@code true}
      *
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -566,9 +566,9 @@ public class Window extends Container implements Accessible {
      *
      * @param owner the {@code Frame} to act as owner or {@code null}
      *    if this window has no owner
-     * @exception IllegalArgumentException if the {@code owner}'s
+     * @throws IllegalArgumentException if the {@code owner}'s
      *    {@code GraphicsConfiguration} is not from a screen device
-     * @exception HeadlessException when
+     * @throws HeadlessException when
      *    {@code GraphicsEnvironment.isHeadless} returns {@code true}
      *
      * @see java.awt.GraphicsEnvironment#isHeadless
@@ -593,9 +593,9 @@ public class Window extends Container implements Accessible {
      *
      * @param owner the {@code Window} to act as owner or
      *     {@code null} if this window has no owner
-     * @exception IllegalArgumentException if the {@code owner}'s
+     * @throws IllegalArgumentException if the {@code owner}'s
      *     {@code GraphicsConfiguration} is not from a screen device
-     * @exception HeadlessException when
+     * @throws HeadlessException when
      *     {@code GraphicsEnvironment.isHeadless()} returns
      *     {@code true}
      *
@@ -627,9 +627,9 @@ public class Window extends Container implements Accessible {
      * @param gc the {@code GraphicsConfiguration} of the target
      *     screen device; if {@code gc} is {@code null},
      *     the system default {@code GraphicsConfiguration} is assumed
-     * @exception IllegalArgumentException if {@code gc}
+     * @throws IllegalArgumentException if {@code gc}
      *     is not from a screen device
-     * @exception HeadlessException when
+     * @throws HeadlessException when
      *     {@code GraphicsEnvironment.isHeadless()} returns
      *     {@code true}
      *
@@ -1964,10 +1964,10 @@ public class Window extends Container implements Accessible {
      *          <code><em>Foo</em>Listener</code>s on this window,
      *          or an empty array if no such
      *          listeners have been added
-     * @exception ClassCastException if {@code listenerType}
+     * @throws ClassCastException if {@code listenerType}
      *          doesn't specify a class or interface that implements
      *          {@code java.util.EventListener}
-     * @exception NullPointerException if {@code listenerType} is {@code null}
+     * @throws NullPointerException if {@code listenerType} is {@code null}
      *
      * @see #getWindowListeners
      * @since 1.3
@@ -3372,8 +3372,8 @@ public class Window extends Container implements Accessible {
      * Each time this method is called,
      * the existing buffer strategy for this component is discarded.
      * @param numBuffers number of buffers to create
-     * @exception IllegalArgumentException if numBuffers is less than 1.
-     * @exception IllegalStateException if the component is not displayable
+     * @throws IllegalArgumentException if numBuffers is less than 1.
+     * @throws IllegalStateException if the component is not displayable
      * @see #isDisplayable
      * @see #getBufferStrategy
      * @since 1.4
@@ -3393,11 +3393,11 @@ public class Window extends Container implements Accessible {
      * @param numBuffers number of buffers to create, including the front buffer
      * @param caps the required capabilities for creating the buffer strategy;
      * cannot be {@code null}
-     * @exception AWTException if the capabilities supplied could not be
+     * @throws AWTException if the capabilities supplied could not be
      * supported or met; this may happen, for example, if there is not enough
      * accelerated memory currently available, or if page flipping is specified
      * but not possible.
-     * @exception IllegalArgumentException if numBuffers is less than 1, or if
+     * @throws IllegalArgumentException if numBuffers is less than 1, or if
      * caps is {@code null}
      * @see #getBufferStrategy
      * @since 1.4

--- a/src/java.desktop/share/classes/java/awt/dnd/DragSource.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DragSource.java
@@ -217,7 +217,7 @@ public class DragSource implements Serializable {
      * the underlying platform.
      *
      * @return the platform DragSource
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      *            returns true
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -255,7 +255,7 @@ public class DragSource implements Serializable {
     /**
      * Creates a new {@code DragSource}.
      *
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      *            returns true
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -682,7 +682,7 @@ public class DragSource implements Serializable {
      *          <code><em>Foo</em>Listener</code>s on this
      *          {@code DragSource}, or an empty array if no such listeners
      *          have been added
-     * @exception ClassCastException if {@code listenerType}
+     * @throws ClassCastException if {@code listenerType}
      *          doesn't specify a class or interface that implements
      *          {@code java.util.EventListener}
      *

--- a/src/java.desktop/share/classes/java/awt/dnd/DropTarget.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DropTarget.java
@@ -89,7 +89,7 @@ public class DropTarget implements DropTargetListener, Serializable {
      * @param dtl       The {@code DropTargetListener} for this {@code DropTarget}
      * @param act       Is the {@code DropTarget} accepting drops.
      * @param fm        The {@code FlavorMap} to use, or null for the default {@code FlavorMap}
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      *            returns true
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -136,7 +136,7 @@ public class DropTarget implements DropTargetListener, Serializable {
      * @param ops       The default acceptable actions for this {@code DropTarget}
      * @param dtl       The {@code DropTargetListener} for this {@code DropTarget}
      * @param act       Is the {@code DropTarget} accepting drops.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      *            returns true
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -149,7 +149,7 @@ public class DropTarget implements DropTargetListener, Serializable {
 
     /**
      * Creates a {@code DropTarget}.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      *            returns true
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -165,7 +165,7 @@ public class DropTarget implements DropTargetListener, Serializable {
      * The Component will receive drops only if it is enabled.
      * @param c         The {@code Component} with which this {@code DropTarget} is associated
      * @param dtl       The {@code DropTargetListener} for this {@code DropTarget}
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      *            returns true
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -185,7 +185,7 @@ public class DropTarget implements DropTargetListener, Serializable {
      * @param c         The {@code Component} with which this {@code DropTarget} is associated
      * @param ops       The default acceptable actions for this {@code DropTarget}
      * @param dtl       The {@code DropTargetListener} for this {@code DropTarget}
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      *            returns true
      * @see java.awt.GraphicsEnvironment#isHeadless
      */

--- a/src/java.desktop/share/classes/java/awt/event/InputMethodEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/InputMethodEvent.java
@@ -436,7 +436,7 @@ public class InputMethodEvent extends AWTEvent {
      * belongs to.
      *
      * @param source the source of the event
-     * @exception  IllegalArgumentException  if source is null.
+     * @throws  IllegalArgumentException  if source is null.
      * @return most recent event time in the {@code EventQueue}
      */
     private static long getMostRecentEventTimeForSource(Object source) {

--- a/src/java.desktop/share/classes/java/awt/font/TextLayout.java
+++ b/src/java.desktop/share/classes/java/awt/font/TextLayout.java
@@ -789,7 +789,7 @@ public final class TextLayout implements Cloneable {
      * For best results, it should not be too different from the current
      * advance of the line.
      * @return a {@code TextLayout} justified to the specified width.
-     * @exception Error if this layout has already been justified, an Error is
+     * @throws Error if this layout has already been justified, an Error is
      * thrown.
      */
     public TextLayout getJustifiedLayout(float justificationWidth) {

--- a/src/java.desktop/share/classes/java/awt/geom/AffineTransform.java
+++ b/src/java.desktop/share/classes/java/awt/geom/AffineTransform.java
@@ -2667,7 +2667,7 @@ public class AffineTransform implements Cloneable, java.io.Serializable {
      * @return a new {@code AffineTransform} object representing the
      * inverse transformation.
      * @see #getDeterminant
-     * @exception NoninvertibleTransformException
+     * @throws NoninvertibleTransformException
      * if the matrix cannot be inverted.
      * @since 1.2
      */
@@ -2762,7 +2762,7 @@ public class AffineTransform implements Cloneable, java.io.Serializable {
      * transform has no inverse, in which case an exception will be
      * thrown if the {@code invert} method is called.
      * @see #getDeterminant
-     * @exception NoninvertibleTransformException
+     * @throws NoninvertibleTransformException
      * if the matrix cannot be inverted.
      * @since 1.6
      */
@@ -3464,7 +3464,7 @@ public class AffineTransform implements Cloneable, java.io.Serializable {
      * @param ptDst the resulting transformed point
      * @return {@code ptDst}, which contains the result of the
      * inverse transform.
-     * @exception NoninvertibleTransformException  if the matrix cannot be
+     * @throws NoninvertibleTransformException  if the matrix cannot be
      *                                         inverted.
      * @since 1.2
      */
@@ -3550,7 +3550,7 @@ public class AffineTransform implements Cloneable, java.io.Serializable {
      * @param dstOff the offset to the location of the first
      * transformed point that is stored in the destination array
      * @param numPts the number of point objects to be transformed
-     * @exception NoninvertibleTransformException  if the matrix cannot be
+     * @throws NoninvertibleTransformException  if the matrix cannot be
      *                                         inverted.
      * @since 1.2
      */

--- a/src/java.desktop/share/classes/java/awt/geom/CubicCurve2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/CubicCurve2D.java
@@ -1564,7 +1564,7 @@ public abstract class CubicCurve2D implements Shape, Cloneable {
      * Creates a new object of the same class as this object.
      *
      * @return     a clone of this instance.
-     * @exception  OutOfMemoryError            if there is not enough memory.
+     * @throws  OutOfMemoryError            if there is not enough memory.
      * @see        java.lang.Cloneable
      * @since      1.2
      */

--- a/src/java.desktop/share/classes/java/awt/geom/Dimension2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Dimension2D.java
@@ -99,7 +99,7 @@ public abstract class Dimension2D implements Cloneable {
      * Creates a new object of the same class as this object.
      *
      * @return     a clone of this instance.
-     * @exception  OutOfMemoryError            if there is not enough memory.
+     * @throws  OutOfMemoryError            if there is not enough memory.
      * @see        java.lang.Cloneable
      * @since      1.2
      */

--- a/src/java.desktop/share/classes/java/awt/geom/FlatteningPathIterator.java
+++ b/src/java.desktop/share/classes/java/awt/geom/FlatteningPathIterator.java
@@ -109,7 +109,7 @@ public class FlatteningPathIterator implements PathIterator {
      * control points and the flattened curve
      * @param limit the maximum number of recursive subdivisions
      * allowed for any curved segment
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      *          {@code flatness} or {@code limit}
      *          is less than zero
      */
@@ -336,7 +336,7 @@ public class FlatteningPathIterator implements PathIterator {
      * @param coords an array that holds the data returned from
      * this method
      * @return the path segment type of the current path segment.
-     * @exception NoSuchElementException if there
+     * @throws NoSuchElementException if there
      *          are no more elements in the flattening path to be
      *          returned.
      * @see PathIterator#SEG_MOVETO
@@ -371,7 +371,7 @@ public class FlatteningPathIterator implements PathIterator {
      * @param coords an array that holds the data returned from
      * this method
      * @return the path segment type of the current path segment.
-     * @exception NoSuchElementException if there
+     * @throws NoSuchElementException if there
      *          are no more elements in the flattening path to be
      *          returned.
      * @see PathIterator#SEG_MOVETO

--- a/src/java.desktop/share/classes/java/awt/geom/Line2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Line2D.java
@@ -1111,7 +1111,7 @@ public abstract class Line2D implements Shape, Cloneable {
      * Creates a new object of the same class as this object.
      *
      * @return     a clone of this instance.
-     * @exception  OutOfMemoryError            if there is not enough memory.
+     * @throws  OutOfMemoryError            if there is not enough memory.
      * @see        java.lang.Cloneable
      * @since      1.2
      */

--- a/src/java.desktop/share/classes/java/awt/geom/Path2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Path2D.java
@@ -842,7 +842,7 @@ public abstract class Path2D implements Shape, Cloneable {
          * Creates a new object of the same class as this object.
          *
          * @return     a clone of this instance.
-         * @exception  OutOfMemoryError    if there is not enough memory.
+         * @throws  OutOfMemoryError    if there is not enough memory.
          * @see        java.lang.Cloneable
          * @since      1.6
          */
@@ -1638,7 +1638,7 @@ public abstract class Path2D implements Shape, Cloneable {
          * Creates a new object of the same class as this object.
          *
          * @return     a clone of this instance.
-         * @exception  OutOfMemoryError    if there is not enough memory.
+         * @throws  OutOfMemoryError    if there is not enough memory.
          * @see        java.lang.Cloneable
          * @since      1.6
          */
@@ -2018,7 +2018,7 @@ public abstract class Path2D implements Shape, Cloneable {
      *
      * @param rule an integer representing the specified
      *             winding rule
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      *          {@code rule} is not either
      *          {@link #WIND_EVEN_ODD} or
      *          {@link #WIND_NON_ZERO}
@@ -2530,7 +2530,7 @@ public abstract class Path2D implements Shape, Cloneable {
      * Creates a new object of the same class as this object.
      *
      * @return     a clone of this instance.
-     * @exception  OutOfMemoryError            if there is not enough memory.
+     * @throws  OutOfMemoryError            if there is not enough memory.
      * @see        java.lang.Cloneable
      * @since      1.6
      */

--- a/src/java.desktop/share/classes/java/awt/geom/Point2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Point2D.java
@@ -387,7 +387,7 @@ public abstract class Point2D implements Cloneable {
      * Creates a new object of the same class and with the
      * same contents as this object.
      * @return     a clone of this instance.
-     * @exception  OutOfMemoryError            if there is not enough memory.
+     * @throws  OutOfMemoryError            if there is not enough memory.
      * @see        java.lang.Cloneable
      * @since      1.2
      */

--- a/src/java.desktop/share/classes/java/awt/geom/QuadCurve2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/QuadCurve2D.java
@@ -1388,7 +1388,7 @@ public abstract class QuadCurve2D implements Shape, Cloneable {
      * as this object.
      *
      * @return     a clone of this instance.
-     * @exception  OutOfMemoryError            if there is not enough memory.
+     * @throws  OutOfMemoryError            if there is not enough memory.
      * @see        java.lang.Cloneable
      * @since      1.2
      */

--- a/src/java.desktop/share/classes/java/awt/geom/RectangularShape.java
+++ b/src/java.desktop/share/classes/java/awt/geom/RectangularShape.java
@@ -382,7 +382,7 @@ public abstract class RectangularShape implements Shape, Cloneable {
      * Creates a new object of the same class and with the same
      * contents as this object.
      * @return     a clone of this instance.
-     * @exception  OutOfMemoryError            if there is not enough memory.
+     * @throws  OutOfMemoryError            if there is not enough memory.
      * @see        java.lang.Cloneable
      * @since      1.2
      */

--- a/src/java.desktop/share/classes/java/awt/im/InputContext.java
+++ b/src/java.desktop/share/classes/java/awt/im/InputContext.java
@@ -140,7 +140,7 @@ public class InputContext {
      * @param locale The desired new locale.
      * @return true if the input method or keyboard layout that's active after
      *         this call supports the desired locale.
-     * @exception NullPointerException if {@code locale} is null
+     * @throws NullPointerException if {@code locale} is null
      */
     public boolean selectInputMethod(Locale locale) {
         // real implementation is in sun.awt.im.InputContext
@@ -268,7 +268,7 @@ public class InputContext {
      * If no input method is available, then the event will never be consumed.
      *
      * @param event The event
-     * @exception NullPointerException if {@code event} is null
+     * @throws NullPointerException if {@code event} is null
      */
     public void dispatchEvent(AWTEvent event) {
         // real implementation is in sun.awt.im.InputContext
@@ -286,7 +286,7 @@ public class InputContext {
      * If no input methods are available, then this method has no effect.
      *
      * @param client Client component
-     * @exception NullPointerException if {@code client} is null
+     * @throws NullPointerException if {@code client} is null
      */
     public void removeNotify(Component client) {
         // real implementation is in sun.awt.im.InputContext

--- a/src/java.desktop/share/classes/java/awt/im/InputMethodHighlight.java
+++ b/src/java.desktop/share/classes/java/awt/im/InputMethodHighlight.java
@@ -111,7 +111,7 @@ public class InputMethodHighlight {
      * @param state The conversion state for the text range - RAW_TEXT or CONVERTED_TEXT
      * @see InputMethodHighlight#RAW_TEXT
      * @see InputMethodHighlight#CONVERTED_TEXT
-     * @exception IllegalArgumentException if a state other than RAW_TEXT or CONVERTED_TEXT is given
+     * @throws IllegalArgumentException if a state other than RAW_TEXT or CONVERTED_TEXT is given
      */
     public InputMethodHighlight(boolean selected, int state) {
         this(selected, state, 0, null);
@@ -125,7 +125,7 @@ public class InputMethodHighlight {
      * @param variation The style variation for the text range
      * @see InputMethodHighlight#RAW_TEXT
      * @see InputMethodHighlight#CONVERTED_TEXT
-     * @exception IllegalArgumentException if a state other than RAW_TEXT or CONVERTED_TEXT is given
+     * @throws IllegalArgumentException if a state other than RAW_TEXT or CONVERTED_TEXT is given
      */
     public InputMethodHighlight(boolean selected, int state, int variation) {
         this(selected, state, variation, null);
@@ -140,7 +140,7 @@ public class InputMethodHighlight {
      * @param style the rendering style attributes for the text range, or null
      * @see InputMethodHighlight#RAW_TEXT
      * @see InputMethodHighlight#CONVERTED_TEXT
-     * @exception IllegalArgumentException if a state other than RAW_TEXT or CONVERTED_TEXT is given
+     * @throws IllegalArgumentException if a state other than RAW_TEXT or CONVERTED_TEXT is given
      * @since 1.3
      */
     public InputMethodHighlight(boolean selected, int state, int variation,

--- a/src/java.desktop/share/classes/java/awt/im/spi/InputMethod.java
+++ b/src/java.desktop/share/classes/java/awt/im/spi/InputMethod.java
@@ -59,7 +59,7 @@ public interface InputMethod {
      * method.
      *
      * @param context the input method context for this input method
-     * @exception NullPointerException if {@code context} is null
+     * @throws NullPointerException if {@code context} is null
      */
     public void setInputMethodContext(InputMethodContext context);
 
@@ -80,7 +80,7 @@ public interface InputMethod {
      *
      * @param locale locale to input
      * @return whether the specified locale is supported
-     * @exception NullPointerException if {@code locale} is null
+     * @throws NullPointerException if {@code locale} is null
      */
     public boolean setLocale(Locale locale);
 
@@ -211,7 +211,7 @@ public interface InputMethod {
      * This method is called by {@link java.awt.im.InputContext#dispatchEvent InputContext.dispatchEvent}.
      *
      * @param event the event being dispatched to the input method
-     * @exception NullPointerException if {@code event} is null
+     * @throws NullPointerException if {@code event} is null
      */
     public void dispatchEvent(AWTEvent event);
 

--- a/src/java.desktop/share/classes/java/awt/im/spi/InputMethodContext.java
+++ b/src/java.desktop/share/classes/java/awt/im/spi/InputMethodContext.java
@@ -92,7 +92,7 @@ public interface InputMethodContext extends InputMethodRequests {
      * @param attachToInputContext whether this window should share the input context
      *              that corresponds to this input method context
      * @return a window with special characteristics for use by input methods
-     * @exception HeadlessException if {@code GraphicsEnvironment.isHeadless}
+     * @throws HeadlessException if {@code GraphicsEnvironment.isHeadless}
      *            returns {@code true}
      */
     public Window createInputMethodWindow(String title, boolean attachToInputContext);
@@ -124,7 +124,7 @@ public interface InputMethodContext extends InputMethodRequests {
      * @param attachToInputContext whether this window should share the input context
      *              that corresponds to this input method context
      * @return a JFrame with special characteristics for use by input methods
-     * @exception HeadlessException if {@code GraphicsEnvironment.isHeadless}
+     * @throws HeadlessException if {@code GraphicsEnvironment.isHeadless}
      *            returns {@code true}
      *
      * @since 1.4

--- a/src/java.desktop/share/classes/java/awt/im/spi/InputMethodDescriptor.java
+++ b/src/java.desktop/share/classes/java/awt/im/spi/InputMethodDescriptor.java
@@ -63,7 +63,7 @@ public interface InputMethodDescriptor {
      * unavailable.
      *
      * @return the locales supported by the input method
-     * @exception AWTException if it can be determined that the input method
+     * @throws AWTException if it can be determined that the input method
      * is inoperable, for example, because of incomplete installation.
      */
     Locale[] getAvailableLocales() throws AWTException;
@@ -122,7 +122,7 @@ public interface InputMethodDescriptor {
      * Creates a new instance of the corresponding input method.
      *
      * @return a new instance of the corresponding input method
-     * @exception Exception any exception that may occur while creating the
+     * @throws Exception any exception that may occur while creating the
      * input method instance
      */
     InputMethod createInputMethod() throws Exception;

--- a/src/java.desktop/share/classes/java/awt/image/BufferedImage.java
+++ b/src/java.desktop/share/classes/java/awt/image/BufferedImage.java
@@ -594,12 +594,12 @@ public class BufferedImage extends java.awt.Image
      *                  the raster has been premultiplied with alpha.
      * @param properties {@code Hashtable} of
      *                  {@code String}/{@code Object} pairs.
-     * @exception RasterFormatException if the number and
+     * @throws RasterFormatException if the number and
      * types of bands in the {@code SampleModel} of the
      * {@code Raster} do not match the number and types required by
      * the {@code ColorModel} to represent its color and alpha
      * components.
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      *          {@code raster} is incompatible with {@code cm}
      * @see ColorModel
      * @see Raster
@@ -1195,7 +1195,7 @@ public class BufferedImage extends java.awt.Image
      * @param h the height of the specified rectangular region
      * @return a {@code BufferedImage} that is the subimage of this
      *          {@code BufferedImage}.
-     * @exception RasterFormatException if the specified
+     * @throws RasterFormatException if the specified
      * area is not contained within this {@code BufferedImage}.
      */
     public BufferedImage getSubimage (int x, int y, int w, int h) {
@@ -1391,7 +1391,7 @@ public class BufferedImage extends java.awt.Image
      * @param tileY the y index of the requested tile in the tile array
      * @return a {@code Raster} that is the tile defined by the
      *          arguments {@code tileX} and {@code tileY}.
-     * @exception ArrayIndexOutOfBoundsException if both
+     * @throws ArrayIndexOutOfBoundsException if both
      *          {@code tileX} and {@code tileY} are not
      *          equal to 0
      */
@@ -1561,7 +1561,7 @@ public class BufferedImage extends java.awt.Image
      * @return {@code true} if the tile specified by the specified
      *          indices is checked out for writing; {@code false}
      *          otherwise.
-     * @exception ArrayIndexOutOfBoundsException if both
+     * @throws ArrayIndexOutOfBoundsException if both
      *          {@code tileX} and {@code tileY} are not equal
      *          to 0
      */

--- a/src/java.desktop/share/classes/java/awt/image/ByteLookupTable.java
+++ b/src/java.desktop/share/classes/java/awt/image/ByteLookupTable.java
@@ -117,7 +117,7 @@ public class ByteLookupTable extends LookupTable {
      *         same length as {@code src}.
      * @return the array {@code dst}, an {@code int} array of
      *         samples.
-     * @exception ArrayIndexOutOfBoundsException if {@code src} is
+     * @throws ArrayIndexOutOfBoundsException if {@code src} is
      *            longer than {@code dst} or if for any element
      *            {@code i} of {@code src},
      *            {@code src[i]-offset} is either less than zero or
@@ -168,7 +168,7 @@ public class ByteLookupTable extends LookupTable {
      *         same length as {@code src}.
      * @return the array {@code dst}, an {@code int} array of
      *         samples.
-     * @exception ArrayIndexOutOfBoundsException if {@code src} is
+     * @throws ArrayIndexOutOfBoundsException if {@code src} is
      *            longer than {@code dst} or if for any element
      *            {@code i} of {@code src},
      *            {@code (src[i]&0xff)-offset} is either less than

--- a/src/java.desktop/share/classes/java/awt/image/ColorConvertOp.java
+++ b/src/java.desktop/share/classes/java/awt/image/ColorConvertOp.java
@@ -194,9 +194,9 @@ public class ColorConvertOp implements BufferedImageOp, RasterOp {
      * @param profiles the array of {@code ICC_Profile} objects
      * @param hints the {@code RenderingHints} object used to control
      *        the color conversion, or {@code null}
-     * @exception IllegalArgumentException when the profile sequence does not
+     * @throws IllegalArgumentException when the profile sequence does not
      *             specify a well-defined color conversion
-     * @exception NullPointerException if profiles is null
+     * @throws NullPointerException if profiles is null
      */
     public ColorConvertOp (ICC_Profile[] profiles, RenderingHints hints)
     {
@@ -242,7 +242,7 @@ public class ColorConvertOp implements BufferedImageOp, RasterOp {
      * @return {@code dest} color converted from {@code src}
      *         or a new, converted {@code BufferedImage}
      *         if {@code dest} is {@code null}
-     * @exception IllegalArgumentException if dest is null and this op was
+     * @throws IllegalArgumentException if dest is null and this op was
      *             constructed using the constructor which takes only a
      *             RenderingHints argument, since the operation is ill defined.
      */
@@ -456,7 +456,7 @@ public class ColorConvertOp implements BufferedImageOp, RasterOp {
      * @return {@code dest} color converted from {@code src}
      *         or a new, converted {@code WritableRaster}
      *         if {@code dest} is {@code null}
-     * @exception IllegalArgumentException if the number of source or
+     * @throws IllegalArgumentException if the number of source or
      *             destination bands is incorrect, the source or destination
      *             color spaces are undefined, or this op was constructed
      *             with one of the constructors that applies only to

--- a/src/java.desktop/share/classes/java/awt/image/DirectColorModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/DirectColorModel.java
@@ -642,12 +642,12 @@ public class DirectColorModel extends PackedColorModel {
      * @param inData the specified pixel
      * @return the alpha component of the specified pixel, scaled from
      *         0 to 255.
-     * @exception ClassCastException if {@code inData}
+     * @throws ClassCastException if {@code inData}
      *  is not a primitive array of type {@code transferType}
-     * @exception ArrayIndexOutOfBoundsException if
+     * @throws ArrayIndexOutOfBoundsException if
      *  {@code inData} is not large enough to hold a pixel value
      *  for this {@code ColorModel}
-     * @exception UnsupportedOperationException if this
+     * @throws UnsupportedOperationException if this
      *  {@code tranferType} is not supported by this
      *  {@code ColorModel}
      */
@@ -694,7 +694,7 @@ public class DirectColorModel extends PackedColorModel {
      *
      * @param inData the specified pixel
      * @return the color and alpha components of the specified pixel.
-     * @exception UnsupportedOperationException if this
+     * @throws UnsupportedOperationException if this
      *            {@code transferType} is not supported by this
      *            {@code ColorModel}
      * @see ColorModel#getRGBdefault
@@ -744,12 +744,12 @@ public class DirectColorModel extends PackedColorModel {
      * @param pixel the specified pixel
      * @return an array representation of the specified pixel in this
      *         {@code ColorModel}
-     * @exception ClassCastException if {@code pixel}
+     * @throws ClassCastException if {@code pixel}
      *  is not a primitive array of type {@code transferType}
-     * @exception ArrayIndexOutOfBoundsException if
+     * @throws ArrayIndexOutOfBoundsException if
      *  {@code pixel} is not large enough to hold a pixel value
      *  for this {@code ColorModel}
-     * @exception UnsupportedOperationException if this
+     * @throws UnsupportedOperationException if this
      *  {@code transferType} is not supported by this
      *  {@code ColorModel}
      * @see WritableRaster#setDataElements
@@ -963,14 +963,14 @@ public class DirectColorModel extends PackedColorModel {
      *        which to start storing the color and alpha components
      * @return an array containing the color and alpha components of the
      * specified pixel starting at the specified offset.
-     * @exception ClassCastException if {@code pixel}
+     * @throws ClassCastException if {@code pixel}
      *  is not a primitive array of type {@code transferType}
-     * @exception ArrayIndexOutOfBoundsException if
+     * @throws ArrayIndexOutOfBoundsException if
      *  {@code pixel} is not large enough to hold a pixel value
      *  for this {@code ColorModel}, or if {@code components}
      *  is not {@code null} and is not large enough to hold all the
      *  color and alpha components, starting at {@code offset}
-     * @exception UnsupportedOperationException if this
+     * @throws UnsupportedOperationException if this
      *            {@code transferType} is not supported by this
      *            color model
      */
@@ -1055,7 +1055,7 @@ public class DirectColorModel extends PackedColorModel {
      * begin retrieving the color and alpha components
      * @return an {@code int} pixel value in this
      * {@code ColorModel} corresponding to the specified components.
-     * @exception ArrayIndexOutOfBoundsException if
+     * @throws ArrayIndexOutOfBoundsException if
      *  the {@code components} array is not large enough to
      *  hold all of the color and alpha components starting at
      *  {@code offset}
@@ -1097,14 +1097,14 @@ public class DirectColorModel extends PackedColorModel {
      * and alpha components
      * @return an {@code Object} representing an array of color and
      * alpha components.
-     * @exception ClassCastException if {@code obj}
+     * @throws ClassCastException if {@code obj}
      *  is not a primitive array of type {@code transferType}
-     * @exception ArrayIndexOutOfBoundsException if
+     * @throws ArrayIndexOutOfBoundsException if
      *  {@code obj} is not large enough to hold a pixel value
      *  for this {@code ColorModel} or the {@code components}
      *  array is not large enough to hold all of the color and alpha
      *  components starting at {@code offset}
-     * @exception UnsupportedOperationException if this
+     * @throws UnsupportedOperationException if this
      *            {@code transferType} is not supported by this
      *            color model
      * @see WritableRaster#setDataElements
@@ -1169,7 +1169,7 @@ public class DirectColorModel extends PackedColorModel {
      * premultiplied; {@code false} otherwise
      * @return a {@code ColorModel} object that represents the
      * coerced data.
-     * @exception UnsupportedOperationException if this
+     * @throws UnsupportedOperationException if this
      *            {@code transferType} is not supported by this
      *            color model
      */

--- a/src/java.desktop/share/classes/java/awt/image/ImageFilter.java
+++ b/src/java.desktop/share/classes/java/awt/image/ImageFilter.java
@@ -107,7 +107,7 @@ public class ImageFilter implements ImageConsumer, Cloneable {
      * with the filtering operation.
      *
      * @param props the properties from the source object
-     * @exception NullPointerException if {@code props} is null
+     * @throws NullPointerException if {@code props} is null
      */
     public void setProperties(Hashtable<?,?> props) {
         @SuppressWarnings("unchecked")
@@ -245,7 +245,7 @@ public class ImageFilter implements ImageConsumer, Cloneable {
      * @param ip the ImageProducer that is feeding this instance of
      * the filter - also the ImageProducer that the request should be
      * forwarded to if necessary
-     * @exception NullPointerException if {@code ip} is null
+     * @throws NullPointerException if {@code ip} is null
      */
     public void resendTopDownLeftRight(ImageProducer ip) {
         ip.requestTopDownLeftRightResend(this);

--- a/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/MultiPixelPackedSampleModel.java
@@ -130,7 +130,7 @@ public class MultiPixelPackedSampleModel extends SampleModel
      * @param scanlineStride the line stride of the image data
      * @param dataBitOffset the data bit offset for the region of image
      *                  data described
-     * @exception RasterFormatException if the number of bits per pixel
+     * @throws RasterFormatException if the number of bits per pixel
      *                  is not a power of 2 or if a power of 2 number of
      *                  pixels do not fit in one data element.
      * @throws IllegalArgumentException if {@code w} or
@@ -321,7 +321,7 @@ public class MultiPixelPackedSampleModel extends SampleModel
      * @param bands the specified bands
      * @return a new {@code SampleModel} with a subset of bands of
      * this {@code MultiPixelPackedSampleModel}.
-     * @exception RasterFormatException if the number of bands requested
+     * @throws RasterFormatException if the number of bands requested
      * is not one.
      * @throws IllegalArgumentException if {@code w} or
      *         {@code h} is not greater than 0
@@ -348,7 +348,7 @@ public class MultiPixelPackedSampleModel extends SampleModel
      *                  data
      * @return the specified band containing the sample of the specified
      * pixel.
-     * @exception ArrayIndexOutOfBoundsException if the specified
+     * @throws ArrayIndexOutOfBoundsException if the specified
      *          coordinates are not in bounds.
      * @see #setSample(int, int, int, int, DataBuffer)
      */
@@ -377,7 +377,7 @@ public class MultiPixelPackedSampleModel extends SampleModel
      * @param b the band to return, which is assumed to be 0
      * @param s the input sample as an {@code int}
      * @param data the {@code DataBuffer} where image data is stored
-     * @exception ArrayIndexOutOfBoundsException if the coordinates are
+     * @throws ArrayIndexOutOfBoundsException if the coordinates are
      * not in bounds.
      * @see #getSample(int, int, int, DataBuffer)
      */
@@ -442,9 +442,9 @@ public class MultiPixelPackedSampleModel extends SampleModel
      * @param data the {@code DataBuffer} containing the image data.
      * @return an {@code Object} containing data for the specified
      *  pixel.
-     * @exception ClassCastException if {@code obj} is not a
+     * @throws ClassCastException if {@code obj} is not a
      *  primitive array of type TransferType or is not {@code null}
-     * @exception ArrayIndexOutOfBoundsException if the coordinates are
+     * @throws ArrayIndexOutOfBoundsException if the coordinates are
      * not in bounds, or if {@code obj} is not {@code null} or
      * not large enough to hold the pixel data
      * @see #setDataElements(int, int, Object, DataBuffer)
@@ -526,7 +526,7 @@ public class MultiPixelPackedSampleModel extends SampleModel
      *  {@code null}
      * @param data the {@code DataBuffer} where image data is stored
      * @return an array containing the specified pixel.
-     * @exception ArrayIndexOutOfBoundsException if the coordinates
+     * @throws ArrayIndexOutOfBoundsException if the coordinates
      *  are not in bounds
      * @see #setPixel(int, int, int[], DataBuffer)
      */

--- a/src/java.desktop/share/classes/java/awt/image/PixelGrabber.java
+++ b/src/java.desktop/share/classes/java/awt/image/PixelGrabber.java
@@ -219,7 +219,7 @@ public class PixelGrabber implements ImageConsumer {
      * delivered.
      * @return true if the pixels were successfully grabbed, false on
      * abort, error or timeout
-     * @exception InterruptedException
+     * @throws InterruptedException
      *            Another thread has interrupted this thread.
      */
     public boolean grabPixels() throws InterruptedException {
@@ -243,7 +243,7 @@ public class PixelGrabber implements ImageConsumer {
      * to arrive before timing out
      * @return true if the pixels were successfully grabbed, false on
      * abort, error or timeout
-     * @exception InterruptedException
+     * @throws InterruptedException
      *            Another thread has interrupted this thread.
      */
     public synchronized boolean grabPixels(long ms)

--- a/src/java.desktop/share/classes/java/awt/image/RGBImageFilter.java
+++ b/src/java.desktop/share/classes/java/awt/image/RGBImageFilter.java
@@ -146,7 +146,7 @@ public abstract class RGBImageFilter extends ImageFilter {
      * a color table entry is being filtered rather than an actual
      * pixel value.
      * @param icm the IndexColorModel object to be filtered
-     * @exception NullPointerException if {@code icm} is null
+     * @throws NullPointerException if {@code icm} is null
      * @return a new IndexColorModel representing the filtered colors
      */
     public IndexColorModel filterIndexColorModel(IndexColorModel icm) {

--- a/src/java.desktop/share/classes/java/awt/image/Raster.java
+++ b/src/java.desktop/share/classes/java/awt/image/Raster.java
@@ -1375,7 +1375,7 @@ public class Raster {
      * @param h the specified height of the new {@code WritableRaster}
      * @return a compatible {@code WritableRaster} with the specified
      *         size and a new sample model and data buffer.
-     * @exception RasterFormatException if the width or height is less than
+     * @throws RasterFormatException if the width or height is less than
      *                               or equal to zero.
      */
     public WritableRaster createCompatibleWritableRaster(int w, int h) {
@@ -1501,7 +1501,7 @@ public class Raster {
      *                   of the returned Raster
      * @param bandList   Array of band indices, or null to use all bands
      * @return a new {@code Raster}.
-     * @exception RasterFormatException if the specified subregion is outside
+     * @throws RasterFormatException if the specified subregion is outside
      *                               of the raster bounds.
      * @throws RasterFormatException if {@code width} or
      *         {@code height}

--- a/src/java.desktop/share/classes/java/awt/image/ShortLookupTable.java
+++ b/src/java.desktop/share/classes/java/awt/image/ShortLookupTable.java
@@ -111,7 +111,7 @@ public class ShortLookupTable extends LookupTable {
      *         same length as {@code src}.
      * @return the array {@code dst}, an {@code int} array of
      *         samples.
-     * @exception ArrayIndexOutOfBoundsException if {@code src} is
+     * @throws ArrayIndexOutOfBoundsException if {@code src} is
      *            longer than {@code dst} or if for any element
      *            {@code i} of {@code src},
      *            {@code (src[i]&0xffff)-offset} is either less than
@@ -162,7 +162,7 @@ public class ShortLookupTable extends LookupTable {
      *         same length as {@code src}.
      * @return the array {@code dst}, an {@code int} array of
      *         samples.
-     * @exception ArrayIndexOutOfBoundsException if {@code src} is
+     * @throws ArrayIndexOutOfBoundsException if {@code src} is
      *            longer than {@code dst} or if for any element
      *            {@code i} of {@code src},
      *            {@code (src[i]&0xffff)-offset} is either less than

--- a/src/java.desktop/share/classes/java/awt/image/SinglePixelPackedSampleModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/SinglePixelPackedSampleModel.java
@@ -302,7 +302,7 @@ public class SinglePixelPackedSampleModel extends SampleModel
      * SinglePixelPackedSampleModel/DataBuffer combination will represent
      * an image with a subset of the bands of the original
      * SinglePixelPackedSampleModel/DataBuffer combination.
-     * @exception RasterFormatException if the length of the bands argument is
+     * @throws RasterFormatException if the length of the bands argument is
      *                                  greater than the number of bands in
      *                                  the sample model.
      */

--- a/src/java.desktop/share/classes/java/awt/image/WritableRaster.java
+++ b/src/java.desktop/share/classes/java/awt/image/WritableRaster.java
@@ -204,7 +204,7 @@ public class WritableRaster extends Raster {
      * @param bandList   Array of band indices, or null to use all bands.
      * @return a {@code WritableRaster} sharing all or part of the
      *         {@code DataBuffer} of this {@code WritableRaster}.
-     * @exception RasterFormatException if the subregion is outside of the
+     * @throws RasterFormatException if the subregion is outside of the
      *                               raster bounds.
      * @throws RasterFormatException if {@code w} or
      *         {@code h}

--- a/src/java.desktop/share/classes/java/awt/print/PageFormat.java
+++ b/src/java.desktop/share/classes/java/awt/print/PageFormat.java
@@ -286,7 +286,7 @@ public class PageFormat implements Cloneable
      * {@code PageFormat}.
      * @param paper the {@code Paper} object to which to set
      * the {@code Paper} object for this {@code PageFormat}.
-     * @exception NullPointerException
+     * @throws NullPointerException
      *              a null paper instance was passed as a parameter.
      * @see #getPaper
      */

--- a/src/java.desktop/share/classes/java/awt/print/Printable.java
+++ b/src/java.desktop/share/classes/java/awt/print/Printable.java
@@ -134,7 +134,7 @@ public interface Printable {
      * @return PAGE_EXISTS if the page is rendered successfully
      *         or NO_SUCH_PAGE if {@code pageIndex} specifies a
      *         non-existent page.
-     * @exception java.awt.print.PrinterException
+     * @throws java.awt.print.PrinterException
      *         thrown when the print job is terminated.
      */
     int print(Graphics graphics, PageFormat pageFormat, int pageIndex)

--- a/src/java.desktop/share/classes/java/awt/print/PrinterJob.java
+++ b/src/java.desktop/share/classes/java/awt/print/PrinterJob.java
@@ -168,7 +168,7 @@ public abstract class PrinterJob {
      * cannot support the {@code Pageable} and
      * {@code Printable} interfaces necessary to support 2D printing.
      * @param service a print service that supports 2D printing
-     * @exception PrinterException if the specified service does not support
+     * @throws PrinterException if the specified service does not support
      * 2D printing, or this PrinterJob class does not support
      * setting a 2D print service, or the specified service is
      * otherwise not a valid print service.
@@ -212,7 +212,7 @@ public abstract class PrinterJob {
      * {@code document}.
      * @param document the pages to be printed. It can not be
      * {@code null}.
-     * @exception NullPointerException the {@code Pageable} passed in
+     * @throws NullPointerException the {@code Pageable} passed in
      * was {@code null}.
      * @see PageFormat
      * @see Printable
@@ -235,7 +235,7 @@ public abstract class PrinterJob {
      * selected by the user.
      * @return {@code true} if the user does not cancel the dialog;
      * {@code false} otherwise.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -279,9 +279,9 @@ public abstract class PrinterJob {
      * This parameter may not be null.
      * @return {@code true} if the user does not cancel the dialog;
      * {@code false} otherwise.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
-     * @exception NullPointerException if {@code attributes} parameter
+     * @throws NullPointerException if {@code attributes} parameter
      * is null.
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @since     1.4
@@ -313,7 +313,7 @@ public abstract class PrinterJob {
      *            is cancelled; a new {@code PageFormat} object
      *            containing the format indicated by the user if the
      *            dialog is acknowledged.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @since     1.2
@@ -342,9 +342,9 @@ public abstract class PrinterJob {
      * This parameter may not be null.
      * @return a page format if the user does not cancel the dialog;
      * {@code null} otherwise.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
-     * @exception NullPointerException if {@code attributes} parameter
+     * @throws NullPointerException if {@code attributes} parameter
      * is null.
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @since     1.4
@@ -495,7 +495,7 @@ public abstract class PrinterJob {
 
     /**
      * Prints a set of pages.
-     * @exception PrinterException an error in the print system
+     * @throws PrinterException an error in the print system
      *            caused the job to be aborted.
      * @see Book
      * @see Pageable
@@ -533,7 +533,7 @@ public abstract class PrinterJob {
      * this print() method.
      *
      * @param attributes a set of attributes for the job
-     * @exception PrinterException an error in the print system
+     * @throws PrinterException an error in the print system
      *            caused the job to be aborted.
      * @see Book
      * @see Pageable


### PR DESCRIPTION
Prevailing JDK coding practices use "@throws" rather than "@exception".
Refactor existing java/awt classes javadoc to use @throws

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282602](https://bugs.openjdk.java.net/browse/JDK-8282602): Refactor awt classes javadoc to use @throws instead of @exception


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7675/head:pull/7675` \
`$ git checkout pull/7675`

Update a local copy of the PR: \
`$ git checkout pull/7675` \
`$ git pull https://git.openjdk.java.net/jdk pull/7675/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7675`

View PR using the GUI difftool: \
`$ git pr show -t 7675`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7675.diff">https://git.openjdk.java.net/jdk/pull/7675.diff</a>

</details>
