### PR TITLE
8282619: G1: Fix indentation in G1CollectedHeap::mark_evac_failure_object

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -235,10 +235,10 @@ inline bool G1CollectedHeap::is_obj_dead_full(const oop obj) const {
 }
 
 inline void G1CollectedHeap::mark_evac_failure_object(const oop obj, uint worker_id) const {
-    // All objects failing evacuation are live. What we'll do is
-    // that we'll update the prev marking info so that they are
-    // all under PTAMS and explicitly marked.
-    _cm->par_mark_in_prev_bitmap(obj);
+  // All objects failing evacuation are live. What we'll do is
+  // that we'll update the prev marking info so that they are
+  // all under PTAMS and explicitly marked.
+  _cm->par_mark_in_prev_bitmap(obj);
 }
 
 inline void G1CollectedHeap::set_humongous_reclaim_candidate(uint region, bool value) {


### PR DESCRIPTION
Hi all,

  please review this trivial fix to indentation in `G1CollectedHeap::mark_evac_failure_object`.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282619](https://bugs.openjdk.java.net/browse/JDK-8282619): G1: Fix indentation in G1CollectedHeap::mark_evac_failure_object


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7678/head:pull/7678` \
`$ git checkout pull/7678`

Update a local copy of the PR: \
`$ git checkout pull/7678` \
`$ git pull https://git.openjdk.java.net/jdk pull/7678/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7678`

View PR using the GUI difftool: \
`$ git pr show -t 7678`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7678.diff">https://git.openjdk.java.net/jdk/pull/7678.diff</a>

</details>
