### PR TITLE
8282620: G1/Parallel: Constify is_in_young() predicates

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1178,7 +1178,7 @@ public:
   size_t max_tlab_size() const override;
   size_t unsafe_max_tlab_alloc(Thread* ignored) const override;
 
-  inline bool is_in_young(const oop obj);
+  inline bool is_in_young(const oop obj) const;
 
   // Returns "true" iff the given word_size is "very large".
   static bool is_humongous(size_t word_size) {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -208,7 +208,7 @@ void G1CollectedHeap::register_optional_region_with_region_attr(HeapRegion* r) {
   _region_attr.set_optional(r->hrm_index(), r->rem_set()->is_tracked());
 }
 
-inline bool G1CollectedHeap::is_in_young(const oop obj) {
+inline bool G1CollectedHeap::is_in_young(const oop obj) const {
   if (obj == NULL) {
     return false;
   }

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -184,8 +184,7 @@ class ParallelScavengeHeap : public CollectedHeap {
 
   bool is_in_reserved(const void* p) const;
 
-  bool is_in_young(oop p);  // reserved part
-  bool is_in_old(oop p);    // reserved part
+  bool is_in_young(oop p) const;
 
   MemRegion reserved_region() const { return _reserved; }
   HeapWord* base() const { return _reserved.start(); }

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -184,7 +184,7 @@ class ParallelScavengeHeap : public CollectedHeap {
 
   bool is_in_reserved(const void* p) const;
 
-  bool is_in_young(oop p) const;
+  bool is_in_young(oop const p) const;
 
   MemRegion reserved_region() const { return _reserved; }
   HeapWord* base() const { return _reserved.start(); }

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -184,7 +184,7 @@ class ParallelScavengeHeap : public CollectedHeap {
 
   bool is_in_reserved(const void* p) const;
 
-  bool is_in_young(oop const p) const;
+  bool is_in_young(const oop p) const;
 
   MemRegion reserved_region() const { return _reserved; }
   HeapWord* base() const { return _reserved.start(); }

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.inline.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.inline.hpp
@@ -43,7 +43,7 @@ inline void ParallelScavengeHeap::invoke_scavenge() {
   PSScavenge::invoke();
 }
 
-inline bool ParallelScavengeHeap::is_in_young(oop p) {
+inline bool ParallelScavengeHeap::is_in_young(oop const p) const {
   // Assumes the the old gen address range is lower than that of the young gen.
   bool result = cast_from_oop<HeapWord*>(p) >= young_gen()->reserved().start();
   assert(result == young_gen()->is_in_reserved(p),

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.inline.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.inline.hpp
@@ -43,7 +43,7 @@ inline void ParallelScavengeHeap::invoke_scavenge() {
   PSScavenge::invoke();
 }
 
-inline bool ParallelScavengeHeap::is_in_young(oop const p) const {
+inline bool ParallelScavengeHeap::is_in_young(const oop p) const {
   // Assumes the the old gen address range is lower than that of the young gen.
   bool result = cast_from_oop<HeapWord*>(p) >= young_gen()->reserved().start();
   assert(result == young_gen()->is_in_reserved(p),


### PR DESCRIPTION
Hi all,

  can I have reviews for this trivial change to further constify `G1Collectedheap/ParallelScavengeHeap::is_in_young()`? Also removes `is_in_old` that does not have a definition.

Testing: local compilation, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282620](https://bugs.openjdk.java.net/browse/JDK-8282620): G1/Parallel: Constify is_in_young() predicates


### Reviewers
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7679/head:pull/7679` \
`$ git checkout pull/7679`

Update a local copy of the PR: \
`$ git checkout pull/7679` \
`$ git pull https://git.openjdk.java.net/jdk pull/7679/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7679`

View PR using the GUI difftool: \
`$ git pr show -t 7679`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7679.diff">https://git.openjdk.java.net/jdk/pull/7679.diff</a>

</details>
