### PR TITLE
8282617: sun.net.www.protocol.https.HttpsClient#putInKeepAliveCache() doesn't use a lock while dealing with "inCache" field

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -661,12 +661,17 @@ final class HttpsClient extends HttpClient
 
     @Override
     protected void putInKeepAliveCache() {
-        if (inCache) {
-            assert false : "Duplicate put to keep alive cache";
-            return;
+        lock();
+        try {
+            if (inCache) {
+                assert false : "Duplicate put to keep alive cache";
+                return;
+            }
+            inCache = true;
+            kac.put(url, sslSocketFactory, this);
+        } finally {
+            unlock();
         }
-        inCache = true;
-        kac.put(url, sslSocketFactory, this);
     }
 
     /*


### PR DESCRIPTION
Can I please get a review of this change which proposes to fix the issue noted in https://bugs.openjdk.java.net/browse/JDK-8282617? 

The `HttpClient` class uses a `inCache` (internal) field to keep track of whether a connection is in the keep-alive cache. This is a mutable field and when dealing with this field the `HttpClient` class uses a lock.

The `HttpsClient` class extends this `HttpClient` class. It additionally overrides the `putInKeepAliveCache()` method to use a Https specific way of populating the keep alive cache. While doing so it also reads and updates the `inCache` `protected` field from its super `HttpClient` class, but doesn't use a lock to do so. This can thus cause a race condition when the `inCache` field gets accessed concurrently, for example a separate thread calling the `HttpClient#isInKeepAliveCache()` method.

To fix this issue, the commit here uses the same lock/unlock construct used in the `HttpClient` super class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282617](https://bugs.openjdk.java.net/browse/JDK-8282617): sun.net.www.protocol.https.HttpsClient#putInKeepAliveCache() doesn't use a lock while dealing with "inCache" field


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Michael McMahon](https://openjdk.java.net/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7680/head:pull/7680` \
`$ git checkout pull/7680`

Update a local copy of the PR: \
`$ git checkout pull/7680` \
`$ git pull https://git.openjdk.java.net/jdk pull/7680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7680`

View PR using the GUI difftool: \
`$ git pr show -t 7680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7680.diff">https://git.openjdk.java.net/jdk/pull/7680.diff</a>

</details>
