### PR TITLE
8282632: Cleanup unnecessary calls to Throwable.initCause() in java.security.jgss

### DIFF
--- a/src/java.security.jgss/share/classes/sun/net/www/protocol/http/spnego/NegotiatorImpl.java
+++ b/src/java.security.jgss/share/classes/sun/net/www/protocol/http/spnego/NegotiatorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -127,9 +127,7 @@ public class NegotiatorImpl extends Negotiator {
                         "fallback to other scheme if allowed. Reason:");
                 e.printStackTrace();
             }
-            IOException ioe = new IOException("Negotiate support not initiated");
-            ioe.initCause(e);
-            throw ioe;
+            throw new IOException("Negotiate support not initiated", e);
         }
     }
 
@@ -157,9 +155,7 @@ public class NegotiatorImpl extends Negotiator {
                 System.out.println("Negotiate support cannot continue. Reason:");
                 e.printStackTrace();
             }
-            IOException ioe = new IOException("Negotiate support cannot continue");
-            ioe.initCause(e);
-            throw ioe;
+            throw new IOException("Negotiate support cannot continue", e);
         }
     }
 }

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/KRBError.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/KRBError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -234,10 +234,8 @@ public class KRBError implements java.io.Serializable {
                     System.out.println("Unable to parse eData field of KRB-ERROR:\n" +
                             new sun.security.util.HexDumpEncoder().encodeBuffer(data));
                 }
-                IOException ioe = new IOException(
-                        "Unable to parse eData field of KRB-ERROR");
-                ioe.initCause(e);
-                throw ioe;
+                throw new IOException(
+                        "Unable to parse eData field of KRB-ERROR", e);
             }
         } else {
             if (DEBUG) {

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/crypto/dk/ArcFourCrypto.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/crypto/dk/ArcFourCrypto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ import java.security.*;
 import javax.crypto.*;
 import javax.crypto.spec.*;
 import java.util.*;
-import sun.security.krb5.EncryptedData;
 import sun.security.krb5.KrbCryptoException;
 import sun.security.krb5.Confounder;
 import sun.security.krb5.internal.crypto.KeyUsage;
@@ -159,10 +158,7 @@ public class ArcFourCrypto extends DkCrypto {
            System.arraycopy(ss, 0, new_ss, 0, ss.length);
            Ksign = getHmac(baseKey, new_ss);
         } catch (Exception e) {
-            GeneralSecurityException gse =
-                new GeneralSecurityException("Calculate Checkum Failed!");
-            gse.initCause(e);
-            throw gse;
+            throw new GeneralSecurityException("Calculate Checkum Failed!", e);
         }
 
         // get the salt using key usage
@@ -173,10 +169,7 @@ public class ArcFourCrypto extends DkCrypto {
         try {
             messageDigest = MessageDigest.getInstance("MD5");
         } catch (NoSuchAlgorithmException e) {
-            GeneralSecurityException gse =
-                new GeneralSecurityException("Calculate Checkum Failed!");
-            gse.initCause(e);
-            throw gse;
+            throw new GeneralSecurityException("Calculate Checkum Failed!", e);
         }
         messageDigest.update(salt);
         messageDigest.update(input, start, len);

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/crypto/dk/ArcFourCrypto.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/crypto/dk/ArcFourCrypto.java
@@ -158,7 +158,7 @@ public class ArcFourCrypto extends DkCrypto {
            System.arraycopy(ss, 0, new_ss, 0, ss.length);
            Ksign = getHmac(baseKey, new_ss);
         } catch (Exception e) {
-            throw new GeneralSecurityException("Calculate Checkum Failed!", e);
+            throw new GeneralSecurityException("Calculate Checksum Failed!", e);
         }
 
         // get the salt using key usage
@@ -169,7 +169,7 @@ public class ArcFourCrypto extends DkCrypto {
         try {
             messageDigest = MessageDigest.getInstance("MD5");
         } catch (NoSuchAlgorithmException e) {
-            throw new GeneralSecurityException("Calculate Checkum Failed!", e);
+            throw new GeneralSecurityException("Calculate Checksum Failed!", e);
         }
         messageDigest.update(salt);
         messageDigest.update(input, start, len);


### PR DESCRIPTION
Pass cause exception as constructor parameter is shorter and easier to read.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282632](https://bugs.openjdk.java.net/browse/JDK-8282632): Cleanup unnecessary calls to Throwable.initCause() in java.security.jgss


### Reviewers
 * @stsypanov (no known github.com user name / role) ⚠️ Review applies to 524ba92d43f65852a8f24029ee257b0ff7cd32d3
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)
 * [Rajan Halade](https://openjdk.java.net/census#rhalade) (@rhalade - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7682/head:pull/7682` \
`$ git checkout pull/7682`

Update a local copy of the PR: \
`$ git checkout pull/7682` \
`$ git pull https://git.openjdk.java.net/jdk pull/7682/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7682`

View PR using the GUI difftool: \
`$ git pr show -t 7682`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7682.diff">https://git.openjdk.java.net/jdk/pull/7682.diff</a>

</details>
