### PR TITLE
8279185: Support for IsoFields in JapaneseDate/MinguoDate/ThaiBuddhistDate

### DIFF
--- a/src/java.base/share/classes/java/time/chrono/Chronology.java
+++ b/src/java.base/share/classes/java/time/chrono/Chronology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -736,7 +736,7 @@ public interface Chronology extends Comparable<Chronology> {
      * @throws DateTimeException if any of the values are out of range
      * @since 9
      */
-    public default long epochSecond(int prolepticYear, int month, int dayOfMonth,
+    default long epochSecond(int prolepticYear, int month, int dayOfMonth,
                                     int hour, int minute, int second, ZoneOffset zoneOffset) {
         Objects.requireNonNull(zoneOffset, "zoneOffset");
         HOUR_OF_DAY.checkValidValue(hour);
@@ -765,11 +765,34 @@ public interface Chronology extends Comparable<Chronology> {
      * @throws DateTimeException if any of the values are out of range
      * @since 9
      */
-    public default long epochSecond(Era era, int yearOfEra, int month, int dayOfMonth,
+    default long epochSecond(Era era, int yearOfEra, int month, int dayOfMonth,
                                     int hour, int minute, int second, ZoneOffset zoneOffset) {
         Objects.requireNonNull(era, "era");
         return epochSecond(prolepticYear(era, yearOfEra), month, dayOfMonth, hour, minute, second, zoneOffset);
     }
+
+    /**
+     * Checks if this chronology is ISO-like.
+     * <p>
+     * An ISO-like chronology has the same basic structure of days and months
+     * as the ISO chronology, with month lengths generally aligned with those
+     * in the ISO January to December definitions.
+     * For example, the Minguo, ThaiBuddhist and Japanese chronologies.
+     *
+     * @implSpec
+     * The default implementation returns {@code false}.
+     *
+     * @return true if the chronology is ISO-like
+     * @see IsoChronology
+     * @see JapaneseChronology
+     * @see MinguoChronology
+     * @see ThaiBuddhistChronology
+     * @since 19
+     */
+    default boolean isIsoLike() {
+        return false;
+    }
+
     //-----------------------------------------------------------------------
     /**
      * Compares this chronology to another chronology.

--- a/src/java.base/share/classes/java/time/chrono/IsoChronology.java
+++ b/src/java.base/share/classes/java/time/chrono/IsoChronology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -675,6 +675,18 @@ public final class IsoChronology extends AbstractChronology implements Serializa
     @Override  // override with covariant return type
     public Period period(int years, int months, int days) {
         return Period.of(years, months, days);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * {@inheritDoc}
+     * @implSpec Always returns {@code true}.
+     * @return {@code true}
+     * @since 19
+     */
+    @Override
+    public boolean isIsoLike() {
+        return true;
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/chrono/JapaneseChronology.java
+++ b/src/java.base/share/classes/java/time/chrono/JapaneseChronology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -502,6 +502,18 @@ public final class JapaneseChronology extends AbstractChronology implements Seri
         }
         int doy = range(DAY_OF_YEAR).checkValidIntValue(fieldValues.remove(DAY_OF_YEAR), DAY_OF_YEAR);
         return dateYearDay(era, yoe, doy);  // smart is same as strict
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * {@inheritDoc}
+     * @implSpec Always returns {@code true}.
+     * @return {@code true}
+     * @since 19
+     */
+    @Override
+    public boolean isIsoLike() {
+        return true;
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/chrono/JapaneseDate.java
+++ b/src/java.base/share/classes/java/time/chrono/JapaneseDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -465,13 +465,13 @@ public final class JapaneseDate
 
     @Override
     public long getLong(TemporalField field) {
-        if (field instanceof ChronoField) {
+        if (field instanceof ChronoField cf) {
             // same as ISO:
             // DAY_OF_WEEK, DAY_OF_MONTH, EPOCH_DAY, MONTH_OF_YEAR, PROLEPTIC_MONTH, YEAR
             //
             // calendar specific fields
             // DAY_OF_YEAR, YEAR_OF_ERA, ERA
-            switch ((ChronoField) field) {
+            switch (cf) {
                 case ALIGNED_DAY_OF_WEEK_IN_MONTH:
                 case ALIGNED_DAY_OF_WEEK_IN_YEAR:
                 case ALIGNED_WEEK_OF_MONTH:

--- a/src/java.base/share/classes/java/time/chrono/MinguoChronology.java
+++ b/src/java.base/share/classes/java/time/chrono/MinguoChronology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -333,6 +333,18 @@ public final class MinguoChronology extends AbstractChronology implements Serial
     @Override  // override for return type
     public MinguoDate resolveDate(Map<TemporalField, Long> fieldValues, ResolverStyle resolverStyle) {
         return (MinguoDate) super.resolveDate(fieldValues, resolverStyle);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * {@inheritDoc}
+     * @implSpec Always returns {@code true}.
+     * @return {@code true}
+     * @since 19
+     */
+    @Override
+    public boolean isIsoLike() {
+        return true;
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/chrono/ThaiBuddhistChronology.java
+++ b/src/java.base/share/classes/java/time/chrono/ThaiBuddhistChronology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -333,6 +333,18 @@ public final class ThaiBuddhistChronology extends AbstractChronology implements 
     @Override  // override for return type
     public ThaiBuddhistDate resolveDate(Map<TemporalField, Long> fieldValues, ResolverStyle resolverStyle) {
         return (ThaiBuddhistDate) super.resolveDate(fieldValues, resolverStyle);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * {@inheritDoc}
+     * @implSpec Always returns {@code true}.
+     * @return {@code true}
+     * @since 19
+     */
+    @Override
+    public boolean isIsoLike() {
+        return true;
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/temporal/IsoFields.java
+++ b/src/java.base/share/classes/java/time/temporal/IsoFields.java
@@ -309,7 +309,7 @@ public final class IsoFields {
             @Override
             public boolean isSupportedBy(TemporalAccessor temporal) {
                 return temporal.isSupported(DAY_OF_YEAR) && temporal.isSupported(MONTH_OF_YEAR) &&
-                        temporal.isSupported(YEAR) && isIso(temporal);
+                        temporal.isSupported(YEAR) && isIsoLike(temporal);
             }
             @Override
             public ValueRange rangeRefinedBy(TemporalAccessor temporal) {
@@ -355,7 +355,7 @@ public final class IsoFields {
                 }
                 int y = YEAR.checkValidIntValue(yearLong);  // always validate
                 long doq = fieldValues.get(DAY_OF_QUARTER);
-                ensureIso(partialTemporal);
+                ensureIsoLike(partialTemporal);
                 LocalDate date;
                 if (resolverStyle == ResolverStyle.LENIENT) {
                     date = LocalDate.of(y, 1, 1).plusMonths(Math.multiplyExact(Math.subtractExact(qoyLong, 1), 3));
@@ -397,7 +397,7 @@ public final class IsoFields {
             }
             @Override
             public boolean isSupportedBy(TemporalAccessor temporal) {
-                return temporal.isSupported(MONTH_OF_YEAR) && isIso(temporal);
+                return temporal.isSupported(MONTH_OF_YEAR) && isIsoLike(temporal);
             }
             @Override
             public long getFrom(TemporalAccessor temporal) {
@@ -452,7 +452,7 @@ public final class IsoFields {
             }
             @Override
             public boolean isSupportedBy(TemporalAccessor temporal) {
-                return temporal.isSupported(EPOCH_DAY) && isIso(temporal);
+                return temporal.isSupported(EPOCH_DAY) && isIsoLike(temporal);
             }
             @Override
             public ValueRange rangeRefinedBy(TemporalAccessor temporal) {
@@ -485,7 +485,7 @@ public final class IsoFields {
                 }
                 int wby = WEEK_BASED_YEAR.range().checkValidIntValue(wbyLong, WEEK_BASED_YEAR);  // always validate
                 long wowby = fieldValues.get(WEEK_OF_WEEK_BASED_YEAR);
-                ensureIso(partialTemporal);
+                ensureIsoLike(partialTemporal);
                 LocalDate date = LocalDate.of(wby, 1, 4);
                 if (resolverStyle == ResolverStyle.LENIENT) {
                     long dow = dowLong;  // unvalidated
@@ -533,7 +533,7 @@ public final class IsoFields {
             }
             @Override
             public boolean isSupportedBy(TemporalAccessor temporal) {
-                return temporal.isSupported(EPOCH_DAY) && isIso(temporal);
+                return temporal.isSupported(EPOCH_DAY) && isIsoLike(temporal);
             }
             @Override
             public long getFrom(TemporalAccessor temporal) {
@@ -546,7 +546,10 @@ public final class IsoFields {
                 if (isSupportedBy(temporal) == false) {
                     throw new UnsupportedTemporalTypeException("Unsupported field: WeekBasedYear");
                 }
-                return super.rangeRefinedBy(temporal);
+                var range = super.rangeRefinedBy(temporal);
+                var chronoRange = Chronology.from(temporal).range(YEAR);
+                return ValueRange.of(Math.max(range.getMinimum(), chronoRange.getMinimum()),
+                        Math.min(range.getMaximum(), chronoRange.getMaximum()));
             }
             @SuppressWarnings("unchecked")
             @Override
@@ -591,9 +594,9 @@ public final class IsoFields {
         private static final int[] QUARTER_DAYS = {0, 90, 181, 273, 0, 91, 182, 274};
 
 
-        private static void ensureIso(TemporalAccessor temporal) {
-            if (isIso(temporal) == false) {
-                throw new DateTimeException("Resolve requires IsoChronology");
+        private static void ensureIsoLike(TemporalAccessor temporal) {
+            if (!isIsoLike(temporal)) {
+                throw new DateTimeException("Resolve requires ISO-like Chronology");
             }
         }
 
@@ -697,7 +700,7 @@ public final class IsoFields {
 
         @Override
         public boolean isSupportedBy(Temporal temporal) {
-            return temporal.isSupported(EPOCH_DAY) && isIso(temporal);
+            return temporal.isSupported(EPOCH_DAY) && isIsoLike(temporal);
         }
 
         @SuppressWarnings("unchecked")
@@ -731,7 +734,7 @@ public final class IsoFields {
         }
     }
 
-    static boolean isIso(TemporalAccessor temporal) {
-        return Chronology.from(temporal).equals(IsoChronology.INSTANCE);
+    static boolean isIsoLike(TemporalAccessor temporal) {
+        return Chronology.from(temporal).isIsoLike();
     }
 }

--- a/src/java.base/share/classes/java/time/temporal/IsoFields.java
+++ b/src/java.base/share/classes/java/time/temporal/IsoFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/time/tck/java/time/chrono/TCKChronology.java
+++ b/test/jdk/java/time/tck/java/time/chrono/TCKChronology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -424,4 +424,22 @@ public class TCKChronology {
         chrono.epochSecond(y, m, d, h, min, s, offset);
     }
 
+    @DataProvider(name = "data_isIsoLike")
+    Object[][]  data_isIsoLike() {
+        return new Object[][] {
+                {IsoChronology.INSTANCE, true},
+                {JapaneseChronology.INSTANCE, true},
+                {MinguoChronology.INSTANCE, true},
+                {ThaiBuddhistChronology.INSTANCE, true},
+                {HijrahChronology.INSTANCE, false},
+        };
+    }
+
+    //-----------------------------------------------------------------------
+    // isIsoLike()
+    //-----------------------------------------------------------------------
+    @Test(dataProvider = "data_isIsoLike")
+    public void test_isIsoLike(Chronology chrono, boolean expected) {
+        assertEquals(chrono.isIsoLike(), expected);
+    }
 }

--- a/test/jdk/java/time/tck/java/time/chrono/TCKTestServiceLoader.java
+++ b/test/jdk/java/time/tck/java/time/chrono/TCKTestServiceLoader.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,6 +80,7 @@ public class TCKTestServiceLoader {
         ChronoLocalDate copticDate = chrono.date(1729, 4, 27);
         LocalDate ld = LocalDate.from(copticDate);
         assertEquals(ld, LocalDate.of(2013, 1, 5), "CopticDate does not match LocalDate");
+        assertEquals(chrono.isIsoLike(), false);
     }
 
 }

--- a/test/jdk/java/time/tck/java/time/temporal/TCKIsoFields.java
+++ b/test/jdk/java/time/tck/java/time/temporal/TCKIsoFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,7 @@ import static org.testng.Assert.fail;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.chrono.ThaiBuddhistDate;
+import java.time.chrono.HijrahDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
@@ -463,7 +463,7 @@ public class TCKIsoFields {
 
     @Test(dataProvider = "isofields", expectedExceptions = UnsupportedTemporalTypeException.class)
     public void test_nonisofields_rangerefinedby(TemporalField field, int value, ValueRange valueRange) {
-        field.rangeRefinedBy(ThaiBuddhistDate.now());
+        field.rangeRefinedBy(HijrahDate.now());
     }
 
     //-----------------------------------------------------------------------
@@ -477,7 +477,7 @@ public class TCKIsoFields {
 
     @Test(dataProvider = "isofields", expectedExceptions = UnsupportedTemporalTypeException.class)
     public void test_nonisofields_getFrom(TemporalField field, int value, ValueRange valueRange) {
-        field.getFrom(ThaiBuddhistDate.now());
+        field.getFrom(HijrahDate.now());
     }
 
     //-----------------------------------------------------------------------

--- a/test/jdk/java/time/test/java/time/temporal/TestIsoFields.java
+++ b/test/jdk/java/time/test/java/time/temporal/TestIsoFields.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.java.time.temporal;
+
+import static java.time.temporal.IsoFields.DAY_OF_QUARTER;
+import static java.time.temporal.IsoFields.QUARTER_OF_YEAR;
+import static java.time.temporal.IsoFields.WEEK_BASED_YEAR;
+import static java.time.temporal.IsoFields.WEEK_OF_WEEK_BASED_YEAR;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.time.LocalDate;
+import java.time.chrono.ChronoLocalDate;
+import java.time.chrono.JapaneseDate;
+import java.time.chrono.MinguoDate;
+import java.time.chrono.ThaiBuddhistDate;
+import java.time.temporal.TemporalField;
+import java.time.temporal.ValueRange;
+import java.util.List;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Tests fields in IsoFields class are supported in Japanese/Minguo/ThaiBuddhist
+ * date classes
+ * @bug 8279185
+ */
+@Test
+public class TestIsoFields {
+    private static final LocalDate ld = LocalDate.of(2022, 2, 25);
+    private static final ChronoLocalDate J_DATE = JapaneseDate.from(ld);
+    private static final ChronoLocalDate M_DATE = MinguoDate.from(ld);
+    private static final ChronoLocalDate TB_DATE = ThaiBuddhistDate.from(ld);
+    private static final List<ChronoLocalDate> CLDATES = List.of(J_DATE, M_DATE, TB_DATE);
+
+    @DataProvider(name = "isSupported")
+    Object[][] data_isSupported() {
+        return new Object[][]{
+                {DAY_OF_QUARTER},
+                {QUARTER_OF_YEAR},
+                {WEEK_BASED_YEAR},
+                {WEEK_OF_WEEK_BASED_YEAR},
+        };
+    }
+
+    @DataProvider(name = "range")
+    Object[][] data_range() {
+        return new Object[][]{
+                {J_DATE, DAY_OF_QUARTER, ValueRange.of(1, 90)},
+                {J_DATE, QUARTER_OF_YEAR, ValueRange.of(1, 4)},
+                {J_DATE, WEEK_BASED_YEAR, ValueRange.of(1_873, 999_999_999)},
+                {J_DATE, WEEK_OF_WEEK_BASED_YEAR, ValueRange.of(1, 52)},
+                {M_DATE, DAY_OF_QUARTER, ValueRange.of(1, 90)},
+                {M_DATE, QUARTER_OF_YEAR, ValueRange.of(1, 4)},
+                {M_DATE, WEEK_BASED_YEAR, ValueRange.of(-999_999_999, 999_998_088)},
+                {M_DATE, WEEK_OF_WEEK_BASED_YEAR, ValueRange.of(1, 52)},
+                {TB_DATE, DAY_OF_QUARTER, ValueRange.of(1, 90)},
+                {TB_DATE, QUARTER_OF_YEAR, ValueRange.of(1, 4)},
+                {TB_DATE, WEEK_BASED_YEAR, ValueRange.of(-999_999_456, 999_999_999)},
+                {TB_DATE, WEEK_OF_WEEK_BASED_YEAR, ValueRange.of(1, 52)},
+        };
+    }
+
+    @DataProvider(name = "with_getLong")
+    Object[][] data_with_getLong() {
+        return new Object[][]{
+                {DAY_OF_QUARTER, 45},
+                {QUARTER_OF_YEAR, 2},
+                {WEEK_BASED_YEAR, 2_022},
+                {WEEK_OF_WEEK_BASED_YEAR, 10},
+        };
+    }
+
+    @Test(dataProvider = "isSupported")
+    public void test_isSupported(TemporalField f) {
+        CLDATES.forEach(d -> assertTrue(d.isSupported(f)));
+    }
+
+    @Test(dataProvider = "range")
+    public void test_range(ChronoLocalDate cld, TemporalField f, ValueRange r) {
+        assertEquals(cld.range(f), r);
+    }
+
+    @Test(dataProvider = "with_getLong")
+    public void test_with_getLong(TemporalField f, long val) {
+        CLDATES.forEach(d -> {
+            var min = d.range(f).getMinimum();
+            var max = d.range(f).getMaximum();
+            assertEquals(d.with(f, min).getLong(f), min);
+            assertEquals(d.with(f, max).getLong(f), max);
+            assertEquals(d.with(f, val).getLong(f), val);
+        });
+    }
+}

--- a/test/jdk/java/time/test/java/time/temporal/TestIsoWeekFields.java
+++ b/test/jdk/java/time/test/java/time/temporal/TestIsoWeekFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import java.time.LocalTime;
 import java.time.MonthDay;
 import java.time.OffsetDateTime;
 import java.time.Year;
+import java.time.chrono.HijrahDate;
 import java.time.chrono.ThaiBuddhistDate;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.IsoFields;
@@ -75,12 +76,13 @@ public class TestIsoWeekFields {
         assertEquals(weekField.isSupportedBy(MonthDay.of(2, 1)), false);
         assertEquals(weekField.isSupportedBy(LocalDate.MIN), true);
         assertEquals(weekField.isSupportedBy(OffsetDateTime.MAX), true);
+        assertEquals(weekField.isSupportedBy(ThaiBuddhistDate.now()), true);
     }
 
     @Test
     public void test_WOWBY_isSupportedBy_fieldsDiffer() {
-        assertEquals(IsoFields.WEEK_OF_WEEK_BASED_YEAR.isSupportedBy(ThaiBuddhistDate.now()), false);
-        assertEquals(WeekFields.ISO.weekOfWeekBasedYear().isSupportedBy(ThaiBuddhistDate.now()), true);
+        assertEquals(IsoFields.WEEK_OF_WEEK_BASED_YEAR.isSupportedBy(HijrahDate.now()), false);
+        assertEquals(WeekFields.ISO.weekOfWeekBasedYear().isSupportedBy(HijrahDate.now()), true);
     }
 
     @Test(dataProvider = "fields")
@@ -116,19 +118,22 @@ public class TestIsoWeekFields {
         assertEquals(yearField.isSupportedBy(MonthDay.of(2, 1)), false);
         assertEquals(yearField.isSupportedBy(LocalDate.MIN), true);
         assertEquals(yearField.isSupportedBy(OffsetDateTime.MAX), true);
+        assertEquals(yearField.isSupportedBy(ThaiBuddhistDate.now()), true);
     }
 
     @Test
     public void test_WBY_isSupportedBy_ISO() {
-        assertEquals(IsoFields.WEEK_BASED_YEAR.isSupportedBy(ThaiBuddhistDate.now()), false);
+        assertEquals(IsoFields.WEEK_BASED_YEAR.isSupportedBy(HijrahDate.now()), false);
     }
 
     @Test
     public void test_Unit_isSupportedBy_ISO() {
         assertEquals(IsoFields.WEEK_BASED_YEARS.isSupportedBy(LocalDate.now()),true);
-        assertEquals(IsoFields.WEEK_BASED_YEARS.isSupportedBy(ThaiBuddhistDate.now()),false);
+        assertEquals(IsoFields.WEEK_BASED_YEARS.isSupportedBy(ThaiBuddhistDate.now()),true);
+        assertEquals(IsoFields.WEEK_BASED_YEARS.isSupportedBy(HijrahDate.now()),false);
         assertEquals(IsoFields.QUARTER_YEARS.isSupportedBy(LocalDate.now()),true);
-        assertEquals(IsoFields.QUARTER_YEARS.isSupportedBy(ThaiBuddhistDate.now()),false);
+        assertEquals(IsoFields.QUARTER_YEARS.isSupportedBy(ThaiBuddhistDate.now()),true);
+        assertEquals(IsoFields.QUARTER_YEARS.isSupportedBy(HijrahDate.now()),false);
     }
 
     @Test(dataProvider = "fields")


### PR DESCRIPTION
Supporting `IsoFields` temporal fields in chronologies that are similar to ISO chronology. Corresponding CSR has also been drafted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed
- [ ] Change requires a CSR request to be approved

### Issues
 * [JDK-8279185](https://bugs.openjdk.java.net/browse/JDK-8279185): Support for IsoFields in JapaneseDate/MinguoDate/ThaiBuddhistDate
 * [JDK-8282278](https://bugs.openjdk.java.net/browse/JDK-8282278): Support for IsoFields in JapaneseDate/MinguoDate/ThaiBuddhistDate (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7683/head:pull/7683` \
`$ git checkout pull/7683`

Update a local copy of the PR: \
`$ git checkout pull/7683` \
`$ git pull https://git.openjdk.java.net/jdk pull/7683/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7683`

View PR using the GUI difftool: \
`$ git pr show -t 7683`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7683.diff">https://git.openjdk.java.net/jdk/pull/7683.diff</a>

</details>
