### PR TITLE
8282608: RawNativeLibraryImpl can't be passed to NativeLibraries::findEntry0

### DIFF
--- a/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
+++ b/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
@@ -281,7 +281,7 @@ public final class NativeLibraries {
      * the VM when it loads the library, and used by the VM to pass the correct
      * version of JNI to the native methods.
      */
-    static class NativeLibraryImpl implements NativeLibrary {
+    static class NativeLibraryImpl extends NativeLibrary {
         // the class from which the library is loaded, also indicates
         // the loader this native library belongs.
         final Class<?> fromClass;
@@ -534,10 +534,4 @@ public final class NativeLibraries {
      */
     private static native void unload(String name, boolean isBuiltin, long handle);
     private static native String findBuiltinLib(String name);
-
-    /*
-     * Returns the address of the named symbol defined in the library of
-     * the given handle.  Returns 0 if not found.
-     */
-    static native long findEntry0(long handle, String name);
 }

--- a/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
+++ b/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
@@ -309,7 +309,7 @@ public final class NativeLibraries {
 
         @Override
         public long find(String name) {
-            return findEntry0(this, name);
+            return findEntry0(handle, name);
         }
 
         /*
@@ -536,8 +536,8 @@ public final class NativeLibraries {
     private static native String findBuiltinLib(String name);
 
     /*
-     * Returns the address of the named symbol defined in the given library.
-     * Returns 0 if not found.
+     * Returns the address of the named symbol defined in the library of
+     * the given handle.  Returns 0 if not found.
      */
-    static native long findEntry0(NativeLibrary lib, String name);
+    static native long findEntry0(long handle, String name);
 }

--- a/src/java.base/share/classes/jdk/internal/loader/NativeLibrary.java
+++ b/src/java.base/share/classes/jdk/internal/loader/NativeLibrary.java
@@ -28,8 +28,8 @@ package jdk.internal.loader;
 /**
  * NativeLibrary represents a loaded native library instance.
  */
-public interface NativeLibrary {
-    String name();
+public abstract class NativeLibrary {
+    public abstract String name();
 
     /**
      * Finds the address of the entry of the given name.  Returns 0
@@ -37,7 +37,7 @@ public interface NativeLibrary {
      *
      * @param name the name of the symbol to be found
      */
-    long find(String name);
+    public abstract long find(String name);
 
     /**
      * Finds the address of the entry of the given name.
@@ -45,11 +45,17 @@ public interface NativeLibrary {
      * @param name the name of the symbol to be found
      * @throws NoSuchMethodException if the named entry is not found.
      */
-    default long lookup(String name) throws NoSuchMethodException {
+    public final long lookup(String name) throws NoSuchMethodException {
         long addr = find(name);
         if (0 == addr) {
             throw new NoSuchMethodException("Cannot find symbol " + name + " in library " + name());
         }
         return addr;
     }
+
+    /*
+     * Returns the address of the named symbol defined in the library of
+     * the given handle.  Returns 0 if not found.
+     */
+    static native long findEntry0(long handle, String name);
 }

--- a/src/java.base/share/classes/jdk/internal/loader/RawNativeLibraries.java
+++ b/src/java.base/share/classes/jdk/internal/loader/RawNativeLibraries.java
@@ -35,8 +35,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static jdk.internal.loader.NativeLibraries.*;
-
+import static jdk.internal.loader.NativeLibraries.findEntry0;
 
 /**
  * RawNativeLibraries has the following properties:
@@ -153,7 +152,7 @@ public final class RawNativeLibraries {
 
         @Override
         public long find(String name) {
-            return findEntry0(this, name);
+            return findEntry0(handle, name);
         }
 
         /*

--- a/src/java.base/share/classes/jdk/internal/loader/RawNativeLibraries.java
+++ b/src/java.base/share/classes/jdk/internal/loader/RawNativeLibraries.java
@@ -35,8 +35,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static jdk.internal.loader.NativeLibraries.findEntry0;
-
 /**
  * RawNativeLibraries has the following properties:
  * 1. Native libraries loaded in this RawNativeLibraries instance are
@@ -135,7 +133,7 @@ public final class RawNativeLibraries {
         nl.close();
     }
 
-    static class RawNativeLibraryImpl implements NativeLibrary {
+    static class RawNativeLibraryImpl extends NativeLibrary {
         // the name of the raw native library.
         final String name;
         // opaque handle to raw native library, used in native code.

--- a/src/java.base/share/native/libjava/NativeLibraries.c
+++ b/src/java.base/share/native/libjava/NativeLibraries.c
@@ -218,24 +218,18 @@ Java_jdk_internal_loader_NativeLibraries_unload
     JNU_ReleaseStringPlatformChars(env, name, cname);
 }
 
-
 /*
  * Class:     jdk_internal_loader_NativeLibraries
  * Method:    findEntry0
- * Signature: (Ljdk/internal/loader/NativeLibrary;Ljava/lang/String;)J
+ * Signature: (JLjava/lang/String;)J
  */
 JNIEXPORT jlong JNICALL
 Java_jdk_internal_loader_NativeLibraries_findEntry0
-  (JNIEnv *env, jclass cls, jobject lib, jstring name)
+  (JNIEnv *env, jclass cls, jlong handle, jstring name)
 {
-    jlong handle;
     const char *cname;
     jlong res;
 
-    if (!initIDs(env))
-        return jlong_zero;
-
-    handle = (*env)->GetLongField(env, lib, handleID);
     cname = (*env)->GetStringUTFChars(env, name, 0);
     if (cname == 0)
         return jlong_zero;

--- a/src/java.base/share/native/libjava/NativeLibraries.c
+++ b/src/java.base/share/native/libjava/NativeLibraries.c
@@ -219,12 +219,12 @@ Java_jdk_internal_loader_NativeLibraries_unload
 }
 
 /*
- * Class:     jdk_internal_loader_NativeLibraries
+ * Class:     jdk_internal_loader_NativeLibrary
  * Method:    findEntry0
  * Signature: (JLjava/lang/String;)J
  */
 JNIEXPORT jlong JNICALL
-Java_jdk_internal_loader_NativeLibraries_findEntry0
+Java_jdk_internal_loader_NativeLibrary_findEntry0
   (JNIEnv *env, jclass cls, jlong handle, jstring name)
 {
     const char *cname;


### PR DESCRIPTION
This fixes a bug in JDK-8282515 that `NativeLibraries::findEntry0` reads the handle from the given native library instance with the field ID for `NativeLibraryImpl::handle` which is wrong for `RawNativeLibraryImpl`.  The `NativeLibraries::findEntry0` now takes the handle of the library instead and that can be used to look up symbols in the native library loaded by System::loadLibrary and also RawNativeLibraries.

Tier 1-4 testing is in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282608](https://bugs.openjdk.java.net/browse/JDK-8282608): RawNativeLibraryImpl can't be passed to NativeLibraries::findEntry0


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to 419159fea3eed9d5efbc18a8a44b86c6206edc38
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7684/head:pull/7684` \
`$ git checkout pull/7684`

Update a local copy of the PR: \
`$ git checkout pull/7684` \
`$ git pull https://git.openjdk.java.net/jdk pull/7684/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7684`

View PR using the GUI difftool: \
`$ git pr show -t 7684`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7684.diff">https://git.openjdk.java.net/jdk/pull/7684.diff</a>

</details>
