### PR TITLE
8282638: [JVMCI] Export array fill stubs to JVMCI compiler

### DIFF
--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -272,6 +272,13 @@
                                                                                                                                      \
   static_field(StubRoutines,                _throw_delayed_StackOverflowError_entry,          address)                               \
                                                                                                                                      \
+  static_field(StubRoutines,                _jshort_fill,                                     address)                               \
+  static_field(StubRoutines,                _jint_fill,                                       address)                               \
+  static_field(StubRoutines,                _jbyte_fill,                                      address)                               \
+  static_field(StubRoutines,                _arrayof_jshort_fill,                             address)                               \
+  static_field(StubRoutines,                _arrayof_jint_fill,                               address)                               \
+  static_field(StubRoutines,                _arrayof_jbyte_fill,                              address)                               \
+                                                                                                                                     \
   static_field(StubRoutines,                _jbyte_arraycopy,                                 address)                               \
   static_field(StubRoutines,                _jshort_arraycopy,                                address)                               \
   static_field(StubRoutines,                _jint_arraycopy,                                  address)                               \


### PR DESCRIPTION
Export array _jint_fill,_jshort_fill,jbyte_fill,_arrayof_jshort_fill,_arrayof_jbyte_fill,_arrayof_jint_fill to JVMCI compiler

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8282638](https://bugs.openjdk.java.net/browse/JDK-8282638): [JVMCI] Export array fill stubs to JVMCI compiler


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7685/head:pull/7685` \
`$ git checkout pull/7685`

Update a local copy of the PR: \
`$ git checkout pull/7685` \
`$ git pull https://git.openjdk.java.net/jdk pull/7685/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7685`

View PR using the GUI difftool: \
`$ git pr show -t 7685`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7685.diff">https://git.openjdk.java.net/jdk/pull/7685.diff</a>

</details>
