### PR TITLE
8282641: Make jdb "threadgroup" command with no args reset the current threadgroup back to the default

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/Commands.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/Commands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -501,7 +501,7 @@ class Commands {
 
     void commandThreadGroup(StringTokenizer t) {
         if (!t.hasMoreTokens()) {
-            MessageOutput.println("Threadgroup name not specified.");
+            ThreadInfo.setThreadGroup(null); // reset to default (top level ThreadGroup)
             return;
         }
         String name = t.nextToken();

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTYResources.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTYResources.java
@@ -353,7 +353,7 @@ public class TTYResources extends java.util.ListResourceBundle {
              "\n" +
              "run [class [args]]        -- start execution of application's main class\n" +
              "\n" +
-             "threads [threadgroup]     -- list threads in threadgroup. uses current threadgroup if none specified.\n" +
+             "threads [threadgroup]     -- list threads in threadgroup. Use current threadgroup if none specified.\n" +
              "thread <thread id>        -- set default thread\n" +
              "suspend [thread id(s)]    -- suspend threads (default: all)\n" +
              "resume [thread id(s)]     -- resume threads (default: all)\n" +

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTYResources.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTYResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -312,7 +312,6 @@ public class TTYResources extends java.util.ListResourceBundle {
         {"Thread has been resumed", "Thread has been resumed"},
         {"Thread not suspended", "Thread not suspended"},
         {"thread group number description name", "{0,number,integer}. {1} {2}"},
-        {"Threadgroup name not specified.", "Threadgroup name not specified."},
         {"<thread_id> option not valid until the VM is started with the run command",
          "<thread_id> option not valid until the VM is started with the run command"},
         {"Threads must be suspended", "Threads must be suspended"},
@@ -354,7 +353,7 @@ public class TTYResources extends java.util.ListResourceBundle {
              "\n" +
              "run [class [args]]        -- start execution of application's main class\n" +
              "\n" +
-             "threads [threadgroup]     -- list threads\n" +
+             "threads [threadgroup]     -- list threads in threadgroup. uses current threadgroup if none specified.\n" +
              "thread <thread id>        -- set default thread\n" +
              "suspend [thread id(s)]    -- suspend threads (default: all)\n" +
              "resume [thread id(s)]     -- resume threads (default: all)\n" +
@@ -377,7 +376,8 @@ public class TTYResources extends java.util.ListResourceBundle {
              "fields <class id>         -- list a class's fields\n" +
              "\n" +
              "threadgroups              -- list threadgroups\n" +
-             "threadgroup <name>        -- set current threadgroup\n" +
+             "threadgroup <name>        -- set current threadgroup to <name>\n" +
+             "threadgroup               -- set current threadgroup back to the top level threadgroup\n" +
              "\n" +
              "stop [go|thread] [<thread_id>] <at|in> <location>\n" +
              "                          -- set a breakpoint\n" +

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTYResources_ja.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTYResources_ja.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -302,7 +302,6 @@ public class TTYResources_ja extends java.util.ListResourceBundle {
         {"Thread has been resumed", "\u30B9\u30EC\u30C3\u30C9\u304C\u518D\u958B\u3057\u307E\u3057\u305F"},
         {"Thread not suspended", "\u30B9\u30EC\u30C3\u30C9\u306F\u4E2D\u65AD\u3057\u3066\u3044\u307E\u305B\u3093"},
         {"thread group number description name", "{0,number,integer}. {1} {2}"},
-        {"Threadgroup name not specified.", "\u30B9\u30EC\u30C3\u30C9\u30B0\u30EB\u30FC\u30D7\u540D\u304C\u6307\u5B9A\u3055\u308C\u3066\u3044\u307E\u305B\u3093\u3002"},
         {"<thread_id> option not valid until the VM is started with the run command",
          "<thread_id>\u30AA\u30D7\u30B7\u30E7\u30F3\u306F\u3001VM\u304Crun\u30B3\u30DE\u30F3\u30C9\u3067\u958B\u59CB\u3055\u308C\u308B\u307E\u3067\u7121\u52B9\u3067\u3059"},
         {"Threads must be suspended", "\u30B9\u30EC\u30C3\u30C9\u3092\u4E2D\u65AD\u3059\u308B\u5FC5\u8981\u304C\u3042\u308A\u307E\u3059"},

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTYResources_zh_CN.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTYResources_zh_CN.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -302,7 +302,6 @@ public class TTYResources_zh_CN extends java.util.ListResourceBundle {
         {"Thread has been resumed", "\u5DF2\u6062\u590D\u7EBF\u7A0B"},
         {"Thread not suspended", "\u672A\u6302\u8D77\u7EBF\u7A0B"},
         {"thread group number description name", "{0,number,integer}\u3002{1} {2}"},
-        {"Threadgroup name not specified.", "\u672A\u6307\u5B9A\u7EBF\u7A0B\u7EC4\u540D\u3002"},
         {"<thread_id> option not valid until the VM is started with the run command",
          "\u5728\u4F7F\u7528 run \u547D\u4EE4\u542F\u52A8 VM \u524D\uFF0C<thread_id> \u9009\u9879\u65E0\u6548"},
         {"Threads must be suspended", "\u5FC5\u987B\u6302\u8D77\u7EBF\u7A0B"},

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002.java
@@ -108,7 +108,7 @@ public class threadgroup002 extends JdbTest {
         reply = jdb.receiveReplyFor(JdbCommand.threadgroup);
         reply = jdb.receiveReplyFor(JdbCommand.threads);
         grep = new Paragrep(reply);
-        count = grep.find("MyThreadGroup#");
+        count = grep.find(threadgroup002a.THREADGROUP_NAME);
         if (count != threadgroup002a.numThreadGroups) {
             failure("jdb cannot switch to default top level threadgroup");
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,11 +29,15 @@
  * VM Testbase keywords: [jpda, jdb]
  * VM Testbase readme:
  * DECSRIPTION
- *  This is a test for jdb 'threadgroup <threadgroup_name>' command.
+ *  This is a test for jdb 'threadgroup <threadgroup_name>' command and
+ *  also for the 'threadgroup' command with no argument.
  *  The main thread creates 3 threadgroups of 5 threads each.
  *  All threads are locked in their 'run' method on a lock that the main
- *  thread holds. The test passes if jdb correctly switches between
- *  three user-defined threadgroups using 'threadgroup' command.
+ *  thread holds. The test then makes sure jdb correctly switches between
+ *  the three user-defined threadgroups using 'threadgroup' command. It then
+ *  resets the current threadgroup back to the default top level threadgroup
+ *  by using the 'threadgroup' command with no argument. It then tests that
+ *  all 3 created threadgroups can be found in the 'threads' output.
  * COMMENTS
  *  This test functionally equals to nsk/jdb/threadgroup/threadgroup001
  *  test and replaces it.
@@ -44,7 +48,7 @@
  * @run main/othervm
  *      nsk.jdb.threadgroup.threadgroup002.threadgroup002
  *      -arch=${os.family}-${os.simpleArch}
- *      -waittime=5
+ *      -waittime=5 -verbose
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb
@@ -98,6 +102,15 @@ public class threadgroup002 extends JdbTest {
             if (count > 0) {
                 failure("jdb cannot switch to valid threadgroup: " + threadgroup002a.THREADGROUP_NAME + i);
             }
+        }
+
+        // Test switching back to the default top level group.
+        reply = jdb.receiveReplyFor(JdbCommand.threadgroup);
+        reply = jdb.receiveReplyFor(JdbCommand.threads);
+        grep = new Paragrep(reply);
+        count = grep.find("MyThreadGroup#");
+        if (count != threadgroup002a.numThreadGroups) {
+            failure("jdb cannot switch to default top level threadgroup");
         }
 
         jdb.contToExit(1);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002.java
@@ -48,7 +48,8 @@
  * @run main/othervm
  *      nsk.jdb.threadgroup.threadgroup002.threadgroup002
  *      -arch=${os.family}-${os.simpleArch}
- *      -waittime=5 -verbose
+ *      -waittime=5
+ *      -verbose
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb


### PR DESCRIPTION
jdb has a probably very little used command called "threadgroup" which is used to set the current TheadGroup. The only purpose of the current ThreadGroup is as the default ThreadGroup to use for the "threads" command when no ThreadGroup argument is passed to it.

"threads" prints out every thread in the ThreadGroup specified as the first argument. If none is specified, it uses the current ThreadGroup. If the current ThreadGroup has not yet been specified, it automatically gets set to the top level ThreadGroup.

Once the current ThreadGroup has been set by using the threadgroup command, it's not that obvious how to reset it back to the default. It turns out the way to do this to set it to the "system" ThreadGroup, which is the top level ThreadGroup (and therefore the initial current ThreadGroup).

With this enhancement I've made it so if you use the "threadgroup" command with no argument, it resets the current ThreadGroup back to the top level ThreadGroup ("system"). Previously with no argument it produces an error for not specifying the ThreadGroup argument.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282641](https://bugs.openjdk.java.net/browse/JDK-8282641): Make jdb "threadgroup" command with no args reset the current threadgroup back to the default


### Reviewers
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to fb7ac63f89efe433b0923858a593fd0420ffe15f
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7687/head:pull/7687` \
`$ git checkout pull/7687`

Update a local copy of the PR: \
`$ git checkout pull/7687` \
`$ git pull https://git.openjdk.java.net/jdk pull/7687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7687`

View PR using the GUI difftool: \
`$ git pr show -t 7687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7687.diff">https://git.openjdk.java.net/jdk/pull/7687.diff</a>

</details>
