### PR TITLE
8282621: G1: G1SegmentedArray remove unnecessary template parameter

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
@@ -178,8 +178,6 @@ public:
     _next = next;
   }
 
-  ~G1CardSetContainer() = default;
-
   // Log of largest card index that can be stored in any G1CardSetContainer
   static uint LogCardsPerRegionLimit;
 };

--- a/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
@@ -178,6 +178,8 @@ public:
     _next = next;
   }
 
+  ~G1CardSetContainer() = default;
+
   // Log of largest card index that can be stored in any G1CardSetContainer
   static uint LogCardsPerRegionLimit;
 };

--- a/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
@@ -55,9 +55,9 @@ void G1CardSetAllocator::drop_all() {
 }
 
 size_t G1CardSetAllocator::mem_size() const {
-  return  sizeof(*this) +
-          _segmented_array.num_segments() * sizeof(G1CardSetSegment) +
-          _segmented_array.num_available_slots() * _segmented_array.slot_size();
+  return sizeof(*this) +
+         _segmented_array.num_segments() * sizeof(G1CardSetSegment) +
+         _segmented_array.num_available_slots() * _segmented_array.slot_size();
 }
 
 size_t G1CardSetAllocator::wasted_mem_size() const {

--- a/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
@@ -54,6 +54,23 @@ void G1CardSetAllocator::drop_all() {
   _segmented_array.drop_all();
 }
 
+size_t G1CardSetAllocator::mem_size() const {
+  return  sizeof(*this) +
+          _segmented_array.num_segments() * sizeof(G1CardSetSegment) +
+          _segmented_array.num_available_slots() * _segmented_array.slot_size();
+}
+
+size_t G1CardSetAllocator::wasted_mem_size() const {
+  uint num_wasted_slots = _segmented_array.num_available_slots() -
+                          _segmented_array.num_allocated_slots() -
+                          (uint)_free_slots_list.pending_count();
+  return num_wasted_slots * _segmented_array.slot_size();
+}
+
+uint G1CardSetAllocator::num_segments() const {
+  return _segmented_array.num_segments();
+}
+
 void G1CardSetAllocator::print(outputStream* os) {
   uint num_allocated_slots = _segmented_array.num_allocated_slots();
   uint num_available_slots = _segmented_array.num_available_slots();

--- a/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
@@ -44,9 +44,8 @@ G1CardSetAllocator::~G1CardSetAllocator() {
   drop_all();
 }
 
-void G1CardSetAllocator::free(G1CardSetContainer* slot) {
+void G1CardSetAllocator::free(void* slot) {
   assert(slot != nullptr, "precondition");
-  slot->~G1CardSetContainer();
   _free_slots_list.release(slot);
 }
 
@@ -101,7 +100,7 @@ G1CardSetMemoryManager::~G1CardSetMemoryManager() {
 
 void G1CardSetMemoryManager::free(uint type, void* value) {
   assert(type < num_mem_object_types(), "must be");
-  _allocators[type].free((G1CardSetContainer*)value);
+  _allocators[type].free(value);
 }
 
 void G1CardSetMemoryManager::flush() {

--- a/src/hotspot/share/gc/g1/g1CardSetMemory.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.hpp
@@ -64,8 +64,8 @@ typedef G1SegmentedArrayFreeList<mtGCCardSet> G1CardSetFreeList;
 
 // Arena-like allocator for (card set) heap memory objects.
 //
-// Allocation occurs from an internal free list of objects first, if the free list is
-// empty then tries to bump-allocate from the G1SegmentedArray.
+// Allocation occurs from an internal free list of objects first. If the free list is
+// empty then tries to allocate from the G1SegmentedArray.
 class G1CardSetAllocator {
   G1SegmentedArray<mtGCCardSet> _segmented_array;
   FreeListAllocator _free_slots_list;

--- a/src/hotspot/share/gc/g1/g1CardSetMemory.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.hpp
@@ -96,8 +96,8 @@ public:
                          G1CardSetFreeList* free_segment_list);
   ~G1CardSetAllocator();
 
-  G1CardSetContainer* allocate();
-  void free(G1CardSetContainer* slot);
+  void* allocate();
+  void free(void* slot);
 
   // Deallocate all segments to the free segment list and reset this allocator. Must
   // be called in a globally synchronized area.

--- a/src/hotspot/share/gc/g1/g1CardSetMemory.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.hpp
@@ -88,7 +88,7 @@ template <class Slot>
 class G1CardSetAllocator {
   // G1CardSetSegment management.
 
-  typedef G1SegmentedArray<Slot, mtGCCardSet> SegmentedArray;
+  typedef G1SegmentedArray<mtGCCardSet> SegmentedArray;
   // G1CardSetContainer slot management within the G1CardSetSegments allocated
   // by this allocator.
 

--- a/src/hotspot/share/gc/g1/g1CardSetMemory.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.inline.hpp
@@ -31,25 +31,25 @@
 #include "utilities/globalCounter.inline.hpp"
 #include "utilities/ostream.hpp"
 
-size_t G1CardSetAllocatorImpl::mem_size() const {
-  return  _segmented_array.num_segments() * sizeof(G1CardSetSegment) +
+inline size_t G1CardSetAllocator::mem_size() const {
+  return  sizeof(*this) +
+          _segmented_array.num_segments() * sizeof(G1CardSetSegment) +
           _segmented_array.num_available_slots() * _segmented_array.slot_size();
 }
 
-size_t G1CardSetAllocatorImpl::wasted_mem_size() const {
+inline size_t G1CardSetAllocator::wasted_mem_size() const {
   uint num_wasted_slots = _segmented_array.num_available_slots() -
                           _segmented_array.num_allocated_slots() -
                           (uint)_free_slots_list.pending_count();
   return num_wasted_slots * _segmented_array.slot_size();
 }
 
-inline uint G1CardSetAllocatorImpl::num_segments() const {
+inline uint G1CardSetAllocator::num_segments() const {
   return _segmented_array.num_segments();
 }
 
-template <class Slot>
-Slot* G1CardSetAllocator<Slot>::allocate() {
-  Slot* slot = ::new (_free_slots_list.allocate()) Slot();
+inline G1CardSetContainer* G1CardSetAllocator::allocate() {
+  G1CardSetContainer* slot = ::new (_free_slots_list.allocate()) G1CardSetContainer();
   assert(slot != nullptr, "must be");
   return slot;
 }

--- a/src/hotspot/share/gc/g1/g1CardSetMemory.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.inline.hpp
@@ -31,23 +31,6 @@
 #include "utilities/globalCounter.inline.hpp"
 #include "utilities/ostream.hpp"
 
-inline size_t G1CardSetAllocator::mem_size() const {
-  return  sizeof(*this) +
-          _segmented_array.num_segments() * sizeof(G1CardSetSegment) +
-          _segmented_array.num_available_slots() * _segmented_array.slot_size();
-}
-
-inline size_t G1CardSetAllocator::wasted_mem_size() const {
-  uint num_wasted_slots = _segmented_array.num_available_slots() -
-                          _segmented_array.num_allocated_slots() -
-                          (uint)_free_slots_list.pending_count();
-  return num_wasted_slots * _segmented_array.slot_size();
-}
-
-inline uint G1CardSetAllocator::num_segments() const {
-  return _segmented_array.num_segments();
-}
-
 inline void* G1CardSetAllocator::allocate() {
   void* slot = _free_slots_list.allocate();
   assert(slot != nullptr, "must be");

--- a/src/hotspot/share/gc/g1/g1CardSetMemory.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.inline.hpp
@@ -48,8 +48,8 @@ inline uint G1CardSetAllocator::num_segments() const {
   return _segmented_array.num_segments();
 }
 
-inline G1CardSetContainer* G1CardSetAllocator::allocate() {
-  G1CardSetContainer* slot = ::new (_free_slots_list.allocate()) G1CardSetContainer();
+inline void* G1CardSetAllocator::allocate() {
+  void* slot = _free_slots_list.allocate();
   assert(slot != nullptr, "must be");
   return slot;
 }

--- a/src/hotspot/share/gc/g1/g1CardSetMemory.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,12 +26,26 @@
 #define SHARE_GC_G1_G1CARDSETMEMORY_INLINE_HPP
 
 #include "gc/g1/g1CardSetMemory.hpp"
-#include "gc/g1/g1CardSetContainers.hpp"
+#include "gc/g1/g1CardSetContainers.inline.hpp"
 #include "gc/g1/g1SegmentedArray.inline.hpp"
+#include "utilities/globalCounter.inline.hpp"
 #include "utilities/ostream.hpp"
 
-#include "gc/g1/g1CardSetContainers.inline.hpp"
-#include "utilities/globalCounter.inline.hpp"
+size_t G1CardSetAllocatorImpl::mem_size() const {
+  return  _segmented_array.num_segments() * sizeof(G1CardSetSegment) +
+          _segmented_array.num_available_slots() * _segmented_array.slot_size();
+}
+
+size_t G1CardSetAllocatorImpl::wasted_mem_size() const {
+  uint num_wasted_slots = _segmented_array.num_available_slots() -
+                          _segmented_array.num_allocated_slots() -
+                          (uint)_free_slots_list.pending_count();
+  return num_wasted_slots * _segmented_array.slot_size();
+}
+
+inline uint G1CardSetAllocatorImpl::num_segments() const {
+  return _segmented_array.num_segments();
+}
 
 template <class Slot>
 Slot* G1CardSetAllocator<Slot>::allocate() {

--- a/src/hotspot/share/gc/g1/g1SegmentedArray.hpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArray.hpp
@@ -181,7 +181,7 @@ public:
 // The class also manages a few counters for statistics using atomic operations.
 // Their values are only consistent within each other with extra global
 // synchronization.
-template <class Slot, MEMFLAGS flag>
+template <MEMFLAGS flag>
 class G1SegmentedArray : public FreeListConfig  {
   // G1SegmentedArrayAllocOptions provides parameters for allocation segment
   // sizing and expansion.

--- a/src/hotspot/share/gc/g1/g1SegmentedArray.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArray.inline.hpp
@@ -155,7 +155,7 @@ uint G1SegmentedArray<flag>::slot_size() const {
 
 template <MEMFLAGS flag>
 G1SegmentedArray<flag>::G1SegmentedArray(const G1SegmentedArrayAllocOptions* alloc_options,
-                                               G1SegmentedArrayFreeList<flag>* free_segment_list) :
+                                         G1SegmentedArrayFreeList<flag>* free_segment_list) :
      _alloc_options(alloc_options),
      _first(nullptr),
      _last(nullptr),

--- a/src/hotspot/share/gc/g1/g1SegmentedArray.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArray.inline.hpp
@@ -115,8 +115,8 @@ void G1SegmentedArrayFreeList<flag>::free_all() {
   Atomic::sub(&_mem_size, mem_size_freed, memory_order_relaxed);
 }
 
-template <class Slot, MEMFLAGS flag>
-G1SegmentedArraySegment<flag>* G1SegmentedArray<Slot, flag>::create_new_segment(G1SegmentedArraySegment<flag>* const prev) {
+template <MEMFLAGS flag>
+G1SegmentedArraySegment<flag>* G1SegmentedArray<flag>::create_new_segment(G1SegmentedArraySegment<flag>* const prev) {
   // Take an existing segment if available.
   G1SegmentedArraySegment<flag>* next = _free_segment_list->get();
   if (next == nullptr) {
@@ -125,7 +125,7 @@ G1SegmentedArraySegment<flag>* G1SegmentedArray<Slot, flag>::create_new_segment(
     next = new G1SegmentedArraySegment<flag>(slot_size(), num_slots, prev);
   } else {
     assert(slot_size() == next->slot_size() ,
-           "Mismatch %d != %d Slot %zu", slot_size(), next->slot_size(), sizeof(Slot));
+           "Mismatch %d != %d", slot_size(), next->slot_size());
     next->reset(prev);
   }
 
@@ -148,13 +148,13 @@ G1SegmentedArraySegment<flag>* G1SegmentedArray<Slot, flag>::create_new_segment(
   }
 }
 
-template <class Slot, MEMFLAGS flag>
-uint G1SegmentedArray<Slot, flag>::slot_size() const {
+template <MEMFLAGS flag>
+uint G1SegmentedArray<flag>::slot_size() const {
   return _alloc_options->slot_size();
 }
 
-template <class Slot, MEMFLAGS flag>
-G1SegmentedArray<Slot, flag>::G1SegmentedArray(const G1SegmentedArrayAllocOptions* alloc_options,
+template <MEMFLAGS flag>
+G1SegmentedArray<flag>::G1SegmentedArray(const G1SegmentedArrayAllocOptions* alloc_options,
                                                G1SegmentedArrayFreeList<flag>* free_segment_list) :
      _alloc_options(alloc_options),
      _first(nullptr),
@@ -167,13 +167,13 @@ G1SegmentedArray<Slot, flag>::G1SegmentedArray(const G1SegmentedArrayAllocOption
   assert(_free_segment_list != nullptr, "precondition!");
 }
 
-template <class Slot, MEMFLAGS flag>
-G1SegmentedArray<Slot, flag>::~G1SegmentedArray() {
+template <MEMFLAGS flag>
+G1SegmentedArray<flag>::~G1SegmentedArray() {
   drop_all();
 }
 
-template <class Slot, MEMFLAGS flag>
-void G1SegmentedArray<Slot, flag>::drop_all() {
+template <MEMFLAGS flag>
+void G1SegmentedArray<flag>::drop_all() {
   G1SegmentedArraySegment<flag>* cur = Atomic::load_acquire(&_first);
 
   if (cur != nullptr) {
@@ -209,8 +209,8 @@ void G1SegmentedArray<Slot, flag>::drop_all() {
   _num_allocated_slots = 0;
 }
 
-template <class Slot, MEMFLAGS flag>
-void* G1SegmentedArray<Slot, flag>::allocate() {
+template <MEMFLAGS flag>
+void* G1SegmentedArray<flag>::allocate() {
   assert(slot_size() > 0, "instance size not set.");
 
   G1SegmentedArraySegment<flag>* cur = Atomic::load_acquire(&_first);
@@ -219,7 +219,7 @@ void* G1SegmentedArray<Slot, flag>::allocate() {
   }
 
   while (true) {
-    Slot* slot = (Slot*)cur->get_new_slot();
+    void* slot = cur->get_new_slot();
     if (slot != nullptr) {
       Atomic::inc(&_num_allocated_slots, memory_order_relaxed);
       guarantee(is_aligned(slot, _alloc_options->slot_alignment()),
@@ -232,8 +232,8 @@ void* G1SegmentedArray<Slot, flag>::allocate() {
   }
 }
 
-template <class Slot, MEMFLAGS flag>
-inline uint G1SegmentedArray<Slot, flag>::num_segments() const {
+template <MEMFLAGS flag>
+inline uint G1SegmentedArray<flag>::num_segments() const {
   return Atomic::load(&_num_segments);
 }
 
@@ -251,17 +251,17 @@ public:
   }
 };
 
-template <class Slot, MEMFLAGS flag>
-uint G1SegmentedArray<Slot, flag>::calculate_length() const {
+template <MEMFLAGS flag>
+uint G1SegmentedArray<flag>::calculate_length() const {
   LengthClosure<flag> closure;
   iterate_segments(closure);
   return closure.length();
 }
 #endif
 
-template <class Slot, MEMFLAGS flag>
+template <MEMFLAGS flag>
 template <typename SegmentClosure>
-void G1SegmentedArray<Slot, flag>::iterate_segments(SegmentClosure& closure) const {
+void G1SegmentedArray<flag>::iterate_segments(SegmentClosure& closure) const {
   G1SegmentedArraySegment<flag>* cur = Atomic::load_acquire(&_first);
 
   assert((cur != nullptr) == (_last != nullptr),


### PR DESCRIPTION
Hi all,

Please review this refactoring change to remove unnecessary template parameters. The change has two commits, one to remove the template parameter, this allows for the second clean up to hoist `G1CardSetAllocator` parameter independent methods and variables into a base class.

Testing: Tier 1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282621](https://bugs.openjdk.java.net/browse/JDK-8282621): G1: G1SegmentedArray remove unnecessary template parameter


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to fdb75011925c490d2a84d2ffe6ed75d437fe7db6
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to fdb75011925c490d2a84d2ffe6ed75d437fe7db6


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7689/head:pull/7689` \
`$ git checkout pull/7689`

Update a local copy of the PR: \
`$ git checkout pull/7689` \
`$ git pull https://git.openjdk.java.net/jdk pull/7689/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7689`

View PR using the GUI difftool: \
`$ git pr show -t 7689`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7689.diff">https://git.openjdk.java.net/jdk/pull/7689.diff</a>

</details>
