### PR TITLE
8282628: Potential memory leak in sun.font.FontConfigManager.getFontConfig()

### DIFF
--- a/src/java.base/share/native/libjava/jni_util.h
+++ b/src/java.base/share/native/libjava/jni_util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -259,15 +259,6 @@ JNU_GetStaticFieldByName(JNIEnv *env,
         }                                       \
     } while (0)                                 \
 
-#define JNU_CHECK_EXCEPTION_AND_CLEANUP(env, code) \
-    do {                                        \
-        if ((env)->ExceptionCheck()) {          \
-            code;                               \
-            return;                             \
-        }                                       \
-    } while (0)                                 \
-
-
 #define JNU_CHECK_EXCEPTION_RETURN(env, y)      \
     do {                                        \
         if ((env)->ExceptionCheck()) {          \
@@ -281,15 +272,6 @@ JNU_GetStaticFieldByName(JNIEnv *env,
             return;                             \
         }                                       \
     } while (0)                                 \
-
-#define JNU_CHECK_EXCEPTION_AND_CLEANUP(env, code) \
-    do {                                        \
-        if ((*env)->ExceptionCheck(env)) {      \
-            code;                               \
-            return;                             \
-        }                                       \
-    } while (0)                                 \
-
 
 #define JNU_CHECK_EXCEPTION_RETURN(env, y)      \
     do {                                        \

--- a/src/java.base/share/native/libjava/jni_util.h
+++ b/src/java.base/share/native/libjava/jni_util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -259,6 +259,15 @@ JNU_GetStaticFieldByName(JNIEnv *env,
         }                                       \
     } while (0)                                 \
 
+#define JNU_CHECK_EXCEPTION_AND_CLEANUP(env, code) \
+    do {                                        \
+        if ((env)->ExceptionCheck()) {          \
+            code;                               \
+            return;                             \
+        }                                       \
+    } while (0)                                 \
+
+
 #define JNU_CHECK_EXCEPTION_RETURN(env, y)      \
     do {                                        \
         if ((env)->ExceptionCheck()) {          \
@@ -272,6 +281,15 @@ JNU_GetStaticFieldByName(JNIEnv *env,
             return;                             \
         }                                       \
     } while (0)                                 \
+
+#define JNU_CHECK_EXCEPTION_AND_CLEANUP(env, code) \
+    do {                                        \
+        if ((*env)->ExceptionCheck(env)) {      \
+            code;                               \
+            return;                             \
+        }                                       \
+    } while (0)                                 \
+
 
 #define JNU_CHECK_EXCEPTION_RETURN(env, y)      \
     do {                                        \

--- a/src/java.desktop/unix/native/common/awt/fontpath.c
+++ b/src/java.desktop/unix/native/common/awt/fontpath.c
@@ -935,8 +935,10 @@ Java_sun_font_FontConfigManager_getFontConfig
         if (cacheDirs != NULL) {
             while ((cnt < max) && (cacheDir = (*FcStrListNext)(cacheDirs))) {
                 jstr = (*env)->NewStringUTF(env, (const char*)cacheDir);
-                JNU_CHECK_EXCEPTION_AND_CLEANUP(env, (*FcStrListDone)(cacheDirs));
-
+                if (IS_NULL(jstr)) {
+                    (*FcStrListDone)(cacheDirs);
+                    return;
+                }
                 (*env)->SetObjectArrayElement(env, cacheDirArray, cnt++, jstr);
                 (*env)->DeleteLocalRef(env, jstr);
             }

--- a/src/java.desktop/unix/native/common/awt/fontpath.c
+++ b/src/java.desktop/unix/native/common/awt/fontpath.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -935,7 +935,7 @@ Java_sun_font_FontConfigManager_getFontConfig
         if (cacheDirs != NULL) {
             while ((cnt < max) && (cacheDir = (*FcStrListNext)(cacheDirs))) {
                 jstr = (*env)->NewStringUTF(env, (const char*)cacheDir);
-                JNU_CHECK_EXCEPTION(env);
+                JNU_CHECK_EXCEPTION_AND_CLEANUP(env, (*FcStrListDone)(cacheDirs));
 
                 (*env)->SetObjectArrayElement(env, cacheDirArray, cnt++, jstr);
                 (*env)->DeleteLocalRef(env, jstr);


### PR DESCRIPTION
Please review this small patch that fixes a potential memory leak that exception return fails to release allocated `cacheDirs`

Test:

- [x] jdk_desktop on Linux x86_64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282628](https://bugs.openjdk.java.net/browse/JDK-8282628): Potential memory leak in sun.font.FontConfigManager.getFontConfig()


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7691/head:pull/7691` \
`$ git checkout pull/7691`

Update a local copy of the PR: \
`$ git checkout pull/7691` \
`$ git pull https://git.openjdk.java.net/jdk pull/7691/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7691`

View PR using the GUI difftool: \
`$ git pr show -t 7691`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7691.diff">https://git.openjdk.java.net/jdk/pull/7691.diff</a>

</details>
