### PR TITLE
8282661: [BACKOUT] ByteBufferTest.java: replace endless recursion with RuntimeException in void ck(double x, double y)

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/unsafe/ByteBufferTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/unsafe/ByteBufferTest.java
@@ -216,10 +216,8 @@ class MyByteBuffer {
     }
 
     void ck(double x, double y) {
-        if (x != y) {
-            throw new RuntimeException(" x = " + Double.toString(x) + ", y = " + Double.toString(y)
-                                    + " (x = " + Long.toHexString(Double.doubleToRawLongBits(x))
-                                    + ", y = " + Long.toHexString(Double.doubleToRawLongBits(y)) + ")");
+        if (x == x && y == y && x != y) {
+            ck(x, y);
         }
     }
 

--- a/test/hotspot/jtreg/compiler/intrinsics/unsafe/ByteBufferTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/unsafe/ByteBufferTest.java
@@ -216,7 +216,7 @@ class MyByteBuffer {
     }
 
     void ck(double x, double y) {
-        if (x != y) {
+        if (x == x && y == y && x != y) {
             throw new RuntimeException(" x = " + Double.toString(x) + ", y = " + Double.toString(y)
                                     + " (x = " + Long.toHexString(Double.doubleToRawLongBits(x))
                                     + ", y = " + Long.toHexString(Double.doubleToRawLongBits(y)) + ")");

--- a/test/hotspot/jtreg/compiler/intrinsics/unsafe/ByteBufferTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/unsafe/ByteBufferTest.java
@@ -216,7 +216,7 @@ class MyByteBuffer {
     }
 
     void ck(double x, double y) {
-        if (x == x && y == y && x != y) {
+        if (x != y) {
             throw new RuntimeException(" x = " + Double.toString(x) + ", y = " + Double.toString(y)
                                     + " (x = " + Long.toHexString(Double.doubleToRawLongBits(x))
                                     + ", y = " + Long.toHexString(Double.doubleToRawLongBits(y)) + ")");


### PR DESCRIPTION
Backout [JDK-8282573](https://bugs.openjdk.java.net/browse/JDK-8282573).
The new fix lead to many tests failing.
And a new fix needs a little bit of thinking and testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282661](https://bugs.openjdk.java.net/browse/JDK-8282661): [BACKOUT] ByteBufferTest.java: replace endless recursion with RuntimeException in void ck(double x, double y)


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7699/head:pull/7699` \
`$ git checkout pull/7699`

Update a local copy of the PR: \
`$ git checkout pull/7699` \
`$ git pull https://git.openjdk.java.net/jdk pull/7699/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7699`

View PR using the GUI difftool: \
`$ git pr show -t 7699`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7699.diff">https://git.openjdk.java.net/jdk/pull/7699.diff</a>

</details>
