### PR TITLE
8282509: [exploded image] ResolvedClassTest fails with similar output

### DIFF
--- a/test/hotspot/jtreg/compiler/inlining/ResolvedClassTest.java
+++ b/test/hotspot/jtreg/compiler/inlining/ResolvedClassTest.java
@@ -125,9 +125,9 @@ public class ResolvedClassTest {
 
         analyzer.shouldHaveExitValue(0);
 
-        analyzer.shouldNotContain("java.lang.invoke.Invokers$Holder::linkToTargetMethod (9 bytes)   not inlineable");
+        analyzer.shouldNotMatch("@ 3   java\\.lang\\.invoke\\..+::linkToTargetMethod \\(9 bytes\\)   not inlineable");
 
-        analyzer.shouldContain("java.lang.invoke.Invokers$Holder::linkToTargetMethod (9 bytes)   force inline by annotation");
+        analyzer.shouldMatch("@ 3   java\\.lang\\.invoke\\..+::linkToTargetMethod \\(9 bytes\\)   force inline by annotation");
         analyzer.shouldContain("java/lang/invoke/MethodHandle::invokeBasic (not loaded)   not inlineable");
     }
 

--- a/test/hotspot/jtreg/compiler/inlining/ResolvedClassTest.java
+++ b/test/hotspot/jtreg/compiler/inlining/ResolvedClassTest.java
@@ -125,9 +125,9 @@ public class ResolvedClassTest {
 
         analyzer.shouldHaveExitValue(0);
 
-        analyzer.shouldNotMatch("@ 3   java\\.lang\\.invoke\\..+::linkToTargetMethod \\(9 bytes\\)   not inlineable");
+        analyzer.shouldNotMatch("java\\.lang\\.invoke\\..+::linkToTargetMethod \\(9 bytes\\)   not inlineable");
 
-        analyzer.shouldMatch("@ 3   java\\.lang\\.invoke\\..+::linkToTargetMethod \\(9 bytes\\)   force inline by annotation");
+        analyzer.shouldMatch("java\\.lang\\.invoke\\..+::linkToTargetMethod \\(9 bytes\\)   force inline by annotation");
         analyzer.shouldContain("java/lang/invoke/MethodHandle::invokeBasic (not loaded)   not inlineable");
     }
 


### PR DESCRIPTION
This is a tentative solution to a failure observed on AIX. The solution is tentative because I require help to ensure that something deeper and more problematic is not happening.

The test fails because the output produced by PrintCompilation produces `LambdaForm$MH/0x00000007c0002400` instead of `Invokers$Holder` as it does on other platforms. There is one other place the output is different, when `DirectMethodHandle$Holder` is replaced with `LambdaForm$DMH/0x00000007c0001c00`. Ignoring these name changes, the output of PrintCompilation is identical. I observe the same compilations (including the OSR/non-OSR, and same level) in the same order.

I would be grateful for help understanding the root of the difference behind the change. I have a few ideas, but I will let you build your own interpretations free from my potentially incorrect understanding (i.e. no spoilers). Thanks in advance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282509](https://bugs.openjdk.java.net/browse/JDK-8282509): [exploded image] ResolvedClassTest fails with similar output


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7701/head:pull/7701` \
`$ git checkout pull/7701`

Update a local copy of the PR: \
`$ git checkout pull/7701` \
`$ git pull https://git.openjdk.java.net/jdk pull/7701/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7701`

View PR using the GUI difftool: \
`$ git pr show -t 7701`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7701.diff">https://git.openjdk.java.net/jdk/pull/7701.diff</a>

</details>
