### PR TITLE
8282694: ProblemList runtime/CommandLine/VMDeprecatedOptions.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -102,7 +102,7 @@ runtime/os/TestTracePageSizes.java#compiler-options 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#G1 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
-runtime/CommandLine/VMDeprecatedOptions.java 8282694 generic-all
+runtime/CommandLine/VMDeprecatedOptions.java 8282690 generic-all
 runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
 applications/jcstress/copy.java 8229852 linux-all
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -104,6 +104,7 @@ runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 runtime/CommandLine/VMDeprecatedOptions.java 8282690 generic-all
 runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
+
 applications/jcstress/copy.java 8229852 linux-all
 
 containers/docker/TestJcmd.java 8278102 linux-aarch64

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -102,8 +102,8 @@ runtime/os/TestTracePageSizes.java#compiler-options 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#G1 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
+runtime/CommandLine/VMDeprecatedOptions.java 8282694 generic-all
 runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
-
 applications/jcstress/copy.java 8229852 linux-all
 
 containers/docker/TestJcmd.java 8278102 linux-aarch64


### PR DESCRIPTION
Add runtime/CommandLine/VMDeprecatedOptions.java to the problem list until [JDK-8282690](https://bugs.openjdk.java.net/browse/JDK-8282690) has been fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282694](https://bugs.openjdk.java.net/browse/JDK-8282694): ProblemList runtime/CommandLine/VMDeprecatedOptions.java


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to c7c196ed895296870d3dc8e3cd3eb1e21d99b19f


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7710/head:pull/7710` \
`$ git checkout pull/7710`

Update a local copy of the PR: \
`$ git checkout pull/7710` \
`$ git pull https://git.openjdk.java.net/jdk pull/7710/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7710`

View PR using the GUI difftool: \
`$ git pr show -t 7710`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7710.diff">https://git.openjdk.java.net/jdk/pull/7710.diff</a>

</details>
