### PR TITLE
8282690: runtime/CommandLine/VMDeprecatedOptions.java fails after JDK-8281181

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -102,7 +102,6 @@ runtime/os/TestTracePageSizes.java#compiler-options 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#G1 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
-runtime/CommandLine/VMDeprecatedOptions.java 8282690 generic-all
 runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
 
 applications/jcstress/copy.java 8229852 linux-all

--- a/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
@@ -44,8 +44,9 @@ public class VMDeprecatedOptions {
      * (true/false/n/string)}.
      */
     public static final String[][] DEPRECATED_OPTIONS;
-    public static final String[][] DEPRECATED_OPTIONS_LINUX;
     static {
+        // Use an ArrayList so platform-specific flags can be
+        // optionally added.
         ArrayList<String[]> deprecated = new ArrayList(
           Arrays.asList(new String[][] {
             // deprecated non-alias flags:
@@ -61,16 +62,11 @@ public class VMDeprecatedOptions {
             {"CreateMinidumpOnCrash", "false"}
           }
         ));
+        if (Platform.isLinux()) {
+            deprecated.add(new String[] {"UseContainerCpuShares",           "false"});
+            deprecated.add(new String[] {"PreferContainerQuotaForCPUCount", "true"});
+        }
         DEPRECATED_OPTIONS = deprecated.toArray(new String[][]{});
-
-        ArrayList<String[]> deprecated_linux = new ArrayList(
-          Arrays.asList(new String[][] {
-            // deprecated non-alias flags:
-            {"UseContainerCpuShares",            "false"},
-            {"PreferContainerQuotaForCPUCount",  "true"},
-          }
-        ));
-        DEPRECATED_OPTIONS_LINUX = deprecated_linux.toArray(new String[][]{});
     };
 
     static String getDeprecationString(String optionName) {
@@ -124,8 +120,5 @@ public class VMDeprecatedOptions {
 
     public static void main(String[] args) throws Throwable {
         testDeprecated(DEPRECATED_OPTIONS);  // Make sure that each deprecated option is mentioned in the output.
-        if (Platform.isLinux()) {
-            testDeprecated(DEPRECATED_OPTIONS_LINUX);
-        }
     }
 }

--- a/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
@@ -44,6 +44,7 @@ public class VMDeprecatedOptions {
      * (true/false/n/string)}.
      */
     public static final String[][] DEPRECATED_OPTIONS;
+    public static final String[][] DEPRECATED_OPTIONS_LINUX;
     static {
         ArrayList<String[]> deprecated = new ArrayList(
           Arrays.asList(new String[][] {
@@ -54,8 +55,6 @@ public class VMDeprecatedOptions {
             {"InitialRAMFraction",        "64"},
             {"TLABStats",                 "false"},
             {"AllowRedefinitionToAddDeleteMethods", "true"},
-            {"UseContainerCpuShares",      "false"},
-            {"PreferContainerQuotaForCPUCount", "true"},
 
             // deprecated alias flags (see also aliased_jvm_flags):
             {"DefaultMaxRAMFraction", "4"},
@@ -63,6 +62,15 @@ public class VMDeprecatedOptions {
           }
         ));
         DEPRECATED_OPTIONS = deprecated.toArray(new String[][]{});
+
+        ArrayList<String[]> deprecated_linux = new ArrayList(
+          Arrays.asList(new String[][] {
+            // deprecated non-alias flags:
+            {"UseContainerCpuShares",            "false"},
+            {"PreferContainerQuotaForCPUCount",  "true"},
+          }
+        ));
+        DEPRECATED_OPTIONS_LINUX = deprecated_linux.toArray(new String[][]{});
     };
 
     static String getDeprecationString(String optionName) {
@@ -116,5 +124,8 @@ public class VMDeprecatedOptions {
 
     public static void main(String[] args) throws Throwable {
         testDeprecated(DEPRECATED_OPTIONS);  // Make sure that each deprecated option is mentioned in the output.
+        if (Platform.isLinux()) {
+            testDeprecated(DEPRECATED_OPTIONS_LINUX);
+        }
     }
 }


### PR DESCRIPTION
Please review this small fix. The two options `UseContainerCpuShares` and `PreferContainerQuotaForCPUCount` are available only on Linux, so they are tested under `if (Platform.isLinux()) { ...}`

Tested with tiers 1-4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282690](https://bugs.openjdk.java.net/browse/JDK-8282690): runtime/CommandLine/VMDeprecatedOptions.java fails after JDK-8281181


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7712/head:pull/7712` \
`$ git checkout pull/7712`

Update a local copy of the PR: \
`$ git checkout pull/7712` \
`$ git pull https://git.openjdk.java.net/jdk pull/7712/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7712`

View PR using the GUI difftool: \
`$ git pr show -t 7712`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7712.diff">https://git.openjdk.java.net/jdk/pull/7712.diff</a>

</details>
