### PR TITLE
8282701: Use Class.getInterfaces(false) where possible to reduce allocation pressure

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -1172,7 +1172,7 @@ public final class Class<T> implements java.io.Serializable,
         return getInterfaces(true);
     }
 
-    private Class<?>[] getInterfaces(boolean cloneArray) {
+    Class<?>[] getInterfaces(boolean cloneArray) {
         ReflectionData<T> rd = reflectionData();
         if (rd == null) {
             // no cloning required
@@ -3125,7 +3125,7 @@ public final class Class<T> implements java.io.Serializable,
         }
         // check package access on the proxy interfaces
         if (checkProxyInterfaces && Proxy.isProxyClass(this)) {
-            ReflectUtil.checkProxyPackageAccess(ccl, this.getInterfaces());
+            ReflectUtil.checkProxyPackageAccess(ccl, this.getInterfaces(/* cloneArray */ false));
         }
     }
 
@@ -3373,7 +3373,7 @@ public final class Class<T> implements java.io.Serializable,
         addAll(fields, privateGetDeclaredFields(true));
 
         // Direct superinterfaces, recursively
-        for (Class<?> si : getInterfaces()) {
+        for (Class<?> si : getInterfaces(/* cloneArray */ false)) {
             addAll(fields, si.privateGetPublicFields());
         }
 

--- a/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -678,7 +678,7 @@ public abstract class ClassLoader {
         final SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
             if (ReflectUtil.isNonPublicProxyClass(cls)) {
-                for (Class<?> intf: cls.getInterfaces()) {
+                for (Class<?> intf: cls.getInterfaces(false)) {
                     checkPackageAccess(intf, pd);
                 }
                 return;


### PR DESCRIPTION
`Class.getInterfaces(false)` does not clone underlying array and can be used in cases when the returned array is only read from.
