### PR TITLE
8276333: jdk/jfr/event/oldobject/TestLargeRootSet.java failed "assert(!contains(edge->reference())) failed: invariant"

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/chains/dfsClosure.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/dfsClosure.cpp
@@ -80,24 +80,23 @@ void DFSClosure::closure_impl(UnifiedOopRef reference, const oop pointee) {
   if (GranularTimer::is_finished()) {
     return;
   }
+
   if (_depth == 0 && _ignore_root_set) {
     // Root set is already marked, but we want
     // to continue, so skip is_marked check.
     assert(_mark_bits->is_marked(pointee), "invariant");
-  }  else {
+    _reference_stack[_depth] = reference;
+  } else {
     if (_mark_bits->is_marked(pointee)) {
       return;
     }
+    _mark_bits->mark_obj(pointee);
+    _reference_stack[_depth] = reference;
+    // is the pointee a sample object?
+    if (pointee->mark().is_marked()) {
+      add_chain();
+    }
   }
-  _reference_stack[_depth] = reference;
-  _mark_bits->mark_obj(pointee);
-  assert(_mark_bits->is_marked(pointee), "invariant");
-
-  // is the pointee a sample object?
-  if (pointee->mark().is_marked()) {
-    add_chain();
-  }
-
   assert(_max_depth >= 1, "invariant");
   if (_depth < _max_depth - 1) {
     _depth++;

--- a/src/hotspot/share/jfr/leakprofiler/chains/edgeStore.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/edgeStore.cpp
@@ -234,7 +234,15 @@ static int leak_context_edge_idx(const ObjectSample* sample) {
 }
 
 bool EdgeStore::has_leak_context(const ObjectSample* sample) const {
-  return leak_context_edge_idx(sample) != 0;
+  const int idx = leak_context_edge_idx(sample);
+  if (idx == 0) {
+    return false;
+  }
+  assert(idx > 0, "invariant");
+  assert(_leak_context_edges != nullptr, "invariant");
+  assert(idx < _leak_context_edges->length(), "invariant");
+  assert(_leak_context_edges->at(idx) != nullptr, "invariant");
+  return true;
 }
 
 const StoredEdge* EdgeStore::get(const ObjectSample* sample) const {
@@ -243,7 +251,10 @@ const StoredEdge* EdgeStore::get(const ObjectSample* sample) const {
     assert(SafepointSynchronize::is_at_safepoint(), "invariant");
     const int idx = leak_context_edge_idx(sample);
     if (idx > 0) {
-      return _leak_context_edges->at(idx);
+      assert(idx < _leak_context_edges->length(), "invariant");
+      const StoredEdge* const edge =_leak_context_edges->at(idx);
+      assert(edge != nullptr, "invariant");
+      return edge;
     }
   }
   return get(UnifiedOopRef::encode_in_native(sample->object_addr()));

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -826,7 +826,6 @@ jdk/jfr/event/compiler/TestCodeSweeper.java                     8225209 generic-
 jdk/jfr/event/os/TestThreadContextSwitches.java                 8247776 windows-all
 jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
-jdk/jfr/event/oldobject/TestLargeRootSet.java                   8276333 generic-x64
 jdk/jfr/api/consumer/recordingstream/TestOnEvent.java           8255404 linux-x64
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all
 


### PR DESCRIPTION
Greetings,

This is a specific issue related to how the DFSClosure process roots.

It traverses roots twice to avoid going sideways. To prevent premature termination during the second pass, a marker, "_ignore_root_set", is set to signal they have already been processed. It lets the recursion continue, but there is a problem with how the code is laid out. It skips the "is_marked" check, but it does not skip add_chain(). If the reference is a stack root, and the pointee is a leak sample candidate, it attempts to construct the reference chain twice. The assertion fires because a reference is only to be added once.

It also includes stronger asserts to give more information for related issue tracked in [JDK-8282067](https://bugs.openjdk.java.net/browse/JDK-8282067) .

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276333](https://bugs.openjdk.java.net/browse/JDK-8276333): jdk/jfr/event/oldobject/TestLargeRootSet.java failed "assert(!contains(edge->reference())) failed: invariant"


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7715/head:pull/7715` \
`$ git checkout pull/7715`

Update a local copy of the PR: \
`$ git checkout pull/7715` \
`$ git pull https://git.openjdk.java.net/jdk pull/7715/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7715`

View PR using the GUI difftool: \
`$ git pr show -t 7715`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7715.diff">https://git.openjdk.java.net/jdk/pull/7715.diff</a>

</details>
