### PR TITLE
8282713: Invalid copyright notice in new test added by JDK-8275715

### DIFF
--- a/test/jdk/sun/java2d/DirectX/MultiPaintEventTest/MultiPaintEventTest.java
+++ b/test/jdk/sun/java2d/DirectX/MultiPaintEventTest/MultiPaintEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
I would like to fix the missing comma in the copyright of the test added in JDK-8275715.
Could you please review the fix?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282713](https://bugs.openjdk.java.net/browse/JDK-8282713): Invalid copyright notice in new test added by JDK-8275715


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7716/head:pull/7716` \
`$ git checkout pull/7716`

Update a local copy of the PR: \
`$ git checkout pull/7716` \
`$ git pull https://git.openjdk.java.net/jdk pull/7716/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7716`

View PR using the GUI difftool: \
`$ git pr show -t 7716`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7716.diff">https://git.openjdk.java.net/jdk/pull/7716.diff</a>

</details>
