### PR TITLE
8282715: typo compileony in test Test8005033.java

### DIFF
--- a/test/hotspot/jtreg/compiler/codegen/Test8005033.java
+++ b/test/hotspot/jtreg/compiler/codegen/Test8005033.java
@@ -1,6 +1,6 @@
 /*
- * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * Copyright (c) 2012 SAP SE. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/codegen/Test8005033.java
+++ b/test/hotspot/jtreg/compiler/codegen/Test8005033.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary On sparcv9, C2's intrinsic for Integer.bitCount(OV) returns wrong result if OV is the result of an operation with int overflow.
  *
  * @run main/othervm -Xcomp
- *      -XX:CompileCommand=compileony,compiler.codegen.Test8005033::testBitCount
+ *      -XX:CompileCommand=compileonly,compiler.codegen.Test8005033::testBitCount
  *      compiler.codegen.Test8005033
  * @author Richard Reingruber richard DOT reingruber AT sap DOT com
  */

--- a/test/hotspot/jtreg/compiler/codegen/Test8005033.java
+++ b/test/hotspot/jtreg/compiler/codegen/Test8005033.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * Copyright (c) 2012 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This patch doesn't change the testing functionality. It was compiled before. HotSpot failed to handle compiler directive 'compileony'. As a result, it has to compile all methods.  

Here is the warning message
```
CompileCommand: An error occurred during parsing
Error: Unrecognized option 'compileony'
Line: 'compileony,compiler.codegen.Test8005033::testBitCount'

Usage: '-XX:CompileCommand=<option>,<method pattern>' - to set boolean option to true
Usage: '-XX:CompileCommand=<option>,<method pattern>,<value>'
Use: '-XX:CompileCommand=help' for more information and to list all option.
```
After correcting the typo, hotspot only compiles the method it is supposed to test. Test time of fastdebug build reduces from 16.778s to 0.226s.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282715](https://bugs.openjdk.java.net/browse/JDK-8282715): typo compileony in test Test8005033.java


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7718/head:pull/7718` \
`$ git checkout pull/7718`

Update a local copy of the PR: \
`$ git checkout pull/7718` \
`$ git pull https://git.openjdk.java.net/jdk pull/7718/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7718`

View PR using the GUI difftool: \
`$ git pr show -t 7718`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7718.diff">https://git.openjdk.java.net/jdk/pull/7718.diff</a>

</details>
