### PR TITLE
8282722: Regard mapping array in enum switches as stable for constant folding

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -1598,6 +1598,7 @@ void ClassFileParser::parse_fields(const ClassFileStream* const cfs,
         _has_contended_fields = true;
       }
     }
+    field->set_stable_for_enum_switch_map(name, sig, access_flags);
   }
 
   int index = length;

--- a/src/hotspot/share/oops/fieldInfo.hpp
+++ b/src/hotspot/share/oops/fieldInfo.hpp
@@ -164,6 +164,20 @@ class FieldInfo {
     if (z) _shorts[access_flags_offset] |=  JVM_ACC_FIELD_STABLE;
     else   _shorts[access_flags_offset] &= ~JVM_ACC_FIELD_STABLE;
   }
+  void set_stable_for_enum_switch_map(const Symbol *field_name,
+                                      const Symbol *field_sig,
+                                      AccessFlags field_access_flags) {
+    static const char *enum_switch_map_prefix = "$SwitchMap$";
+    static const char *enum_switch_map_sig = "[I";
+    static const jint required = JVM_ACC_SYNTHETIC | JVM_ACC_FINAL | JVM_ACC_STATIC;
+
+    if (field_access_flags.as_int() == required &&
+        field_name->starts_with(enum_switch_map_prefix) &&
+        field_sig->equals(enum_switch_map_sig)) {
+      // For enum switches, set mapping arrays stable so that constant folding works.
+      set_stable(true);
+    }
+  }
 
   Symbol* lookup_symbol(int symbol_index) const {
     assert(is_internal(), "only internal fields");


### PR DESCRIPTION
I came across a performance issue when using scatter store VectorAPI for Integer and Long simultaneously in the same application. The poor performance was caused by vector intrinsic inlining failure because of non-determined IntSpecies for a constant VectorShape of IndexMap in this scenario.

For ScatterStore operation of LongVector.SPECIES_512/IntVector.SPECIES_512, VectorShape.S_256_BIT/S_512_BIT is the actual length of indexMap vector respectively.
```
IntSpecies species(VectorShape s)
```
returns the corresponding IntSpecies by Switch on Enum type "VectorShape". [1] 

With this change introduced, elements in the SwitchMap array (initialized in clinit) can be constant-folded so that determined IntSpecies can be acquired for a constant VectorShape.

jtreg test passed without new failure.
Please help review this change and let me know if any comments.

[1] https://github.com/openjdk/jdk/blob/894ffb098c80bfeb4209038c017d01dbf53fac0f/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java#L4043

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8282722](https://bugs.openjdk.java.net/browse/JDK-8282722): Regard mapping array in enum switches as stable for constant folding


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7721/head:pull/7721` \
`$ git checkout pull/7721`

Update a local copy of the PR: \
`$ git checkout pull/7721` \
`$ git pull https://git.openjdk.java.net/jdk pull/7721/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7721`

View PR using the GUI difftool: \
`$ git pr show -t 7721`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7721.diff">https://git.openjdk.java.net/jdk/pull/7721.diff</a>

</details>
