### PR TITLE
8282723: Add constructors taking a cause to JSSE exceptions

### DIFF
--- a/src/java.base/share/classes/javax/net/ssl/SSLException.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,9 +36,7 @@ import java.io.IOException;
  * @since 1.4
  * @author David Brownell
  */
-public
-class SSLException extends IOException
-{
+public class SSLException extends IOException {
     @java.io.Serial
     private static final long serialVersionUID = 4511006460650708967L;
 
@@ -48,8 +46,7 @@ class SSLException extends IOException
      *
      * @param reason describes the problem.
      */
-    public SSLException(String reason)
-    {
+    public SSLException(String reason) {
         super(reason);
     }
 
@@ -66,8 +63,7 @@ class SSLException extends IOException
      * @since 1.5
      */
     public SSLException(String message, Throwable cause) {
-        super(message);
-        initCause(cause);
+        super(message, cause);
     }
 
     /**
@@ -83,7 +79,6 @@ class SSLException extends IOException
      * @since 1.5
      */
     public SSLException(Throwable cause) {
-        super(cause == null ? null : cause.toString());
-        initCause(cause);
+        super(cause);
     }
 }

--- a/src/java.base/share/classes/javax/net/ssl/SSLHandshakeException.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLHandshakeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,7 @@
  * questions.
  */
 
-
 package javax.net.ssl;
-
 
 /**
  * Indicates that the client and server could not negotiate the
@@ -34,9 +32,7 @@ package javax.net.ssl;
  * @since 1.4
  * @author David Brownell
  */
-public
-class SSLHandshakeException extends SSLException
-{
+public class SSLHandshakeException extends SSLException {
     @java.io.Serial
     private static final long serialVersionUID = -5045881315018326890L;
 
@@ -46,8 +42,23 @@ class SSLHandshakeException extends SSLException
      *
      * @param reason describes the problem.
      */
-    public SSLHandshakeException(String reason)
-    {
+    public SSLHandshakeException(String reason) {
         super(reason);
+    }
+
+    /**
+     * Creates a {@code SSLHandshakeException} with the specified detail
+     * message and cause.
+     *
+     * @param message the detail message (which is saved for later retrieval
+     *        by the {@link #getMessage()} method).
+     * @param cause the cause (which is saved for later retrieval by the
+     *        {@link #getCause()} method).  (A {@code null} value is
+     *        permitted, and indicates that the cause is nonexistent or
+     *        unknown.)
+     * @since 19
+     */
+    public SSLHandshakeException(String message, Throwable cause) {
+        super(message, cause);
     }
 }

--- a/src/java.base/share/classes/javax/net/ssl/SSLKeyException.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLKeyException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,9 +33,7 @@ package javax.net.ssl;
  * @since 1.4
  * @author David Brownell
  */
-public
-class SSLKeyException extends SSLException
-{
+public class SSLKeyException extends SSLException {
     @java.io.Serial
     private static final long serialVersionUID = -8071664081941937874L;
 
@@ -45,8 +43,23 @@ class SSLKeyException extends SSLException
      *
      * @param reason describes the problem.
      */
-    public SSLKeyException(String reason)
-    {
+    public SSLKeyException(String reason) {
         super(reason);
+    }
+
+    /**
+     * Creates a {@code SSLKeyException} with the specified detail
+     * message and cause.
+     *
+     * @param message the detail message (which is saved for later retrieval
+     *        by the {@link #getMessage()} method).
+     * @param cause the cause (which is saved for later retrieval by the
+     *        {@link #getCause()} method).  (A {@code null} value is
+     *        permitted, and indicates that the cause is nonexistent or
+     *        unknown.)
+     * @since 19
+     */
+    public SSLKeyException(String message, Throwable cause) {
+        super(message, cause);
     }
 }

--- a/src/java.base/share/classes/javax/net/ssl/SSLPeerUnverifiedException.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLPeerUnverifiedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,9 +39,7 @@ package javax.net.ssl;
  * @since 1.4
  * @author David Brownell
  */
-public
-class SSLPeerUnverifiedException extends SSLException
-{
+public class SSLPeerUnverifiedException extends SSLException {
     @java.io.Serial
     private static final long serialVersionUID = -8919512675000600547L;
 
@@ -51,8 +49,23 @@ class SSLPeerUnverifiedException extends SSLException
      *
      * @param reason describes the problem.
      */
-    public SSLPeerUnverifiedException(String reason)
-    {
+    public SSLPeerUnverifiedException(String reason) {
         super(reason);
+    }
+
+    /**
+     * Creates a {@code SSLPeerUnverifiedException} with the specified detail
+     * message and cause.
+     *
+     * @param message the detail message (which is saved for later retrieval
+     *        by the {@link #getMessage()} method).
+     * @param cause the cause (which is saved for later retrieval by the
+     *        {@link #getCause()} method).  (A {@code null} value is
+     *        permitted, and indicates that the cause is nonexistent or
+     *        unknown.)
+     * @since 19
+     */
+    public SSLPeerUnverifiedException(String message, Throwable cause) {
+        super(message, cause);
     }
 }

--- a/src/java.base/share/classes/javax/net/ssl/SSLProtocolException.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLProtocolException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,9 +33,7 @@ package javax.net.ssl;
  * @since 1.4
  * @author David Brownell
  */
-public
-class SSLProtocolException extends SSLException
-{
+public class SSLProtocolException extends SSLException {
     @java.io.Serial
     private static final long serialVersionUID = 5445067063799134928L;
 
@@ -45,8 +43,23 @@ class SSLProtocolException extends SSLException
      *
      * @param reason describes the problem.
      */
-    public SSLProtocolException(String reason)
-    {
+    public SSLProtocolException(String reason) {
         super(reason);
+    }
+
+    /**
+     * Creates a {@code SSLProtocolException} with the specified detail
+     * message and cause.
+     *
+     * @param message the detail message (which is saved for later retrieval
+     *        by the {@link #getMessage()} method).
+     * @param cause the cause (which is saved for later retrieval by the
+     *        {@link #getCause()} method).  (A {@code null} value is
+     *        permitted, and indicates that the cause is nonexistent or
+     *        unknown.)
+     * @since 19
+     */
+    public SSLProtocolException(String message, Throwable cause) {
+        super(message, cause);
     }
 }

--- a/src/java.base/share/classes/sun/security/ssl/Alert.java
+++ b/src/java.base/share/classes/sun/security/ssl/Alert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,22 +122,15 @@ enum Alert {
             reason = (cause != null) ? cause.getMessage() : "";
         }
 
-        SSLException ssle;
         if (cause instanceof IOException) {
-            ssle = new SSLException(reason);
+            return new SSLException(reason, cause);
         } else if ((this == UNEXPECTED_MESSAGE)) {
-            ssle = new SSLProtocolException(reason);
+            return new SSLProtocolException(reason, cause);
         } else if (handshakeOnly) {
-            ssle = new SSLHandshakeException(reason);
+            return new SSLHandshakeException(reason, cause);
         } else {
-            ssle = new SSLException(reason);
+            return new SSLException(reason, cause);
         }
-
-        if (cause != null) {
-            ssle.initCause(cause);
-        }
-
-        return ssle;
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/ssl/DHClientKeyExchange.java
+++ b/src/java.base/share/classes/sun/security/ssl/DHClientKeyExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -295,8 +295,8 @@ final class DHClientKeyExchange {
                 shc.handshakeCredentials.add(
                         new DHECredentials(peerPublicKey, namedGroup));
             } catch (GeneralSecurityException | java.io.IOException e) {
-                throw (SSLHandshakeException)(new SSLHandshakeException(
-                        "Could not generate DHPublicKey").initCause(e));
+                throw new SSLHandshakeException(
+                        "Could not generate DHPublicKey", e);
             }
 
             // update the states

--- a/src/java.base/share/classes/sun/security/ssl/ECDHKeyExchange.java
+++ b/src/java.base/share/classes/sun/security/ssl/ECDHKeyExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -160,8 +160,7 @@ final class ECDHKeyExchange {
                 ka.doPhase(peerPublicKey, true);
                 return ka.generateSecret("TlsPremasterSecret");
             } catch (GeneralSecurityException e) {
-                throw (SSLHandshakeException) new SSLHandshakeException(
-                    "Could not generate secret").initCause(e);
+                throw new SSLHandshakeException("Could not generate secret", e);
             }
         }
 
@@ -177,8 +176,7 @@ final class ECDHKeyExchange {
                 PublicKey peerPublicKey = kf.generatePublic(spec);
                 return getAgreedSecret(peerPublicKey);
             } catch (GeneralSecurityException | java.io.IOException e) {
-                throw (SSLHandshakeException) new SSLHandshakeException(
-                    "Could not generate secret").initCause(e);
+                throw new SSLHandshakeException("Could not generate secret", e);
             }
         }
 
@@ -202,8 +200,8 @@ final class ECDHKeyExchange {
                         "ECPublicKey does not comply to algorithm constraints");
                 }
             } catch (GeneralSecurityException | java.io.IOException e) {
-                throw (SSLHandshakeException) new SSLHandshakeException(
-                        "Could not generate ECPublicKey").initCause(e);
+                throw new SSLHandshakeException(
+                        "Could not generate ECPublicKey", e);
             }
         }
 

--- a/src/java.base/share/classes/sun/security/ssl/KAKeyDerivation.java
+++ b/src/java.base/share/classes/sun/security/ssl/KAKeyDerivation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,8 +88,7 @@ public class KAKeyDerivation implements SSLKeyDerivation {
                     context, preMasterSecret);
             return kd.deriveKey("MasterSecret", params);
         } catch (GeneralSecurityException gse) {
-            throw (SSLHandshakeException) new SSLHandshakeException(
-                    "Could not generate secret").initCause(gse);
+            throw new SSLHandshakeException("Could not generate secret", gse);
         }
     }
 
@@ -125,8 +124,7 @@ public class KAKeyDerivation implements SSLKeyDerivation {
             // derive handshake secret
             return hkdf.extract(saltSecret, sharedSecret, algorithm);
         } catch (GeneralSecurityException gse) {
-            throw (SSLHandshakeException) new SSLHandshakeException(
-                    "Could not generate secret").initCause(gse);
+            throw new SSLHandshakeException("Could not generate secret", gse);
         }
     }
 }

--- a/src/java.base/share/classes/sun/security/ssl/NewSessionTicket.java
+++ b/src/java.base/share/classes/sun/security/ssl/NewSessionTicket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -302,8 +302,7 @@ final class NewSessionTicket {
             return hkdf.expand(resumptionMasterSecret, hkdfInfo,
                     hashAlg.hashLength, "TlsPreSharedKey");
         } catch  (GeneralSecurityException gse) {
-            throw (SSLHandshakeException) new SSLHandshakeException(
-                    "Could not derive PSK").initCause(gse);
+            throw new SSLHandshakeException("Could not derive PSK", gse);
         }
     }
 

--- a/src/java.base/share/classes/sun/security/ssl/SSLBasicKeyDerivation.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLBasicKeyDerivation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,8 +52,7 @@ final class SSLBasicKeyDerivation implements SSLKeyDerivation {
             return hkdf.expand(secret, hkdfInfo,
                     ((SecretSizeSpec)keySpec).length, algorithm);
         } catch (GeneralSecurityException gse) {
-            throw (SSLHandshakeException) new SSLHandshakeException(
-                "Could not generate secret").initCause(gse);
+            throw new SSLHandshakeException("Could not generate secret", gse);
         }
     }
 

--- a/src/java.base/share/classes/sun/security/ssl/SSLEngineImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLEngineImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1167,17 +1167,13 @@ final class SSLEngineImpl extends SSLEngine implements SSLTransport {
         if (taskThrown instanceof RuntimeException) {
             throw new RuntimeException(msg, taskThrown);
         } else if (taskThrown instanceof SSLHandshakeException) {
-            return (SSLHandshakeException)
-                new SSLHandshakeException(msg).initCause(taskThrown);
+            return new SSLHandshakeException(msg, taskThrown);
         } else if (taskThrown instanceof SSLKeyException) {
-            return (SSLKeyException)
-                new SSLKeyException(msg).initCause(taskThrown);
+            return new SSLKeyException(msg, taskThrown);
         } else if (taskThrown instanceof SSLPeerUnverifiedException) {
-            return (SSLPeerUnverifiedException)
-                new SSLPeerUnverifiedException(msg).initCause(taskThrown);
+            return new SSLPeerUnverifiedException(msg, taskThrown);
         } else if (taskThrown instanceof SSLProtocolException) {
-            return (SSLProtocolException)
-                new SSLProtocolException(msg).initCause(taskThrown);
+            return new SSLProtocolException(msg, taskThrown);
         } else if (taskThrown instanceof SSLException) {
             return (SSLException)taskThrown;
         } else {

--- a/src/java.base/share/classes/sun/security/ssl/SSLEngineInputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLEngineInputRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -242,8 +242,7 @@ final class SSLEngineInputRecord extends InputRecord implements SSLRecord {
         } catch (BadPaddingException bpe) {
             throw bpe;
         } catch (GeneralSecurityException gse) {
-            throw (SSLProtocolException)(new SSLProtocolException(
-                    "Unexpected exception")).initCause(gse);
+            throw new SSLProtocolException("Unexpected exception", gse);
         } finally {
             // consume a complete record
             packet.limit(srcLim);

--- a/src/java.base/share/classes/sun/security/ssl/SSLSecretDerivation.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSecretDerivation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,8 +113,7 @@ final class SSLSecretDerivation implements SSLKeyDerivation {
             HKDF hkdf = new HKDF(hashAlg.name);
             return hkdf.expand(secret, hkdfInfo, hashAlg.hashLength, algorithm);
         } catch (GeneralSecurityException gse) {
-            throw (SSLHandshakeException) new SSLHandshakeException(
-                "Could not generate secret").initCause(gse);
+            throw new SSLHandshakeException("Could not generate secret", gse);
         }
     }
 

--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1709,19 +1709,13 @@ public final class SSLSocketImpl
 
     private Plaintext handleEOF(EOFException eofe) throws IOException {
         if (requireCloseNotify || conContext.handshakeContext != null) {
-            SSLException ssle;
             if (conContext.handshakeContext != null) {
-                ssle = new SSLHandshakeException(
-                        "Remote host terminated the handshake");
+                throw new SSLHandshakeException(
+                        "Remote host terminated the handshake",  eofe);
             } else {
-                ssle = new SSLProtocolException(
-                        "Remote host terminated the connection");
+                throw new SSLProtocolException(
+                        "Remote host terminated the connection", eofe);
             }
-
-            if (eofe != null) {
-                ssle.initCause(eofe);
-            }
-            throw ssle;
         } else {
             // treat as if we had received a close_notify
             conContext.isInputCloseNotified = true;

--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketInputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketInputRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketInputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketInputRecord.java
@@ -263,8 +263,7 @@ final class SSLSocketInputRecord extends InputRecord implements SSLRecord {
         } catch (BadPaddingException bpe) {
             throw bpe;
         } catch (GeneralSecurityException gse) {
-            throw (SSLProtocolException)(new SSLProtocolException(
-                    "Unexpected exception")).initCause(gse);
+            throw new SSLProtocolException("Unexpected exception", gse);
         }
 
         if (contentType != ContentType.HANDSHAKE.id &&

--- a/src/java.base/share/classes/sun/security/ssl/SSLTrafficKeyDerivation.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLTrafficKeyDerivation.java
@@ -155,7 +155,7 @@ enum SSLTrafficKeyDerivation implements SSLKeyDerivationGenerator {
                         ks.getAlgorithm(cs, algorithm));
             } catch (GeneralSecurityException gse) {
                 throw new SSLHandshakeException(
-                    "Could not generate secret", gse));
+                        "Could not generate secret", gse);
             }
         }
 

--- a/src/java.base/share/classes/sun/security/ssl/SSLTrafficKeyDerivation.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLTrafficKeyDerivation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -154,8 +154,8 @@ enum SSLTrafficKeyDerivation implements SSLKeyDerivationGenerator {
                         ks.getKeyLength(cs),
                         ks.getAlgorithm(cs, algorithm));
             } catch (GeneralSecurityException gse) {
-                throw (SSLHandshakeException)(new SSLHandshakeException(
-                    "Could not generate secret").initCause(gse));
+                throw new SSLHandshakeException(
+                    "Could not generate secret", gse));
             }
         }
 

--- a/src/java.base/share/classes/sun/security/ssl/ServerHello.java
+++ b/src/java.base/share/classes/sun/security/ssl/ServerHello.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1205,8 +1205,7 @@ final class ServerHello {
             hc.handshakeKeyDerivation =
                     new SSLSecretDerivation(hc, earlySecret);
         } catch  (GeneralSecurityException gse) {
-            throw (SSLHandshakeException) new SSLHandshakeException(
-                "Could not generate secret").initCause(gse);
+            throw new SSLHandshakeException("Could not generate secret", gse);
         }
     }
 

--- a/src/java.base/share/classes/sun/security/ssl/ServerNameExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/ServerNameExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,9 +135,8 @@ final class ServerNameExtension {
                             nameType + "), name=" +
                             (new String(encoded, StandardCharsets.UTF_8)) +
                             ", value={" +
-                            Utilities.toHexString(encoded) + "}");
-                        throw hc.conContext.fatal(Alert.ILLEGAL_PARAMETER,
-                                (SSLProtocolException)spe.initCause(iae));
+                            Utilities.toHexString(encoded) + "}", iae);
+                        throw hc.conContext.fatal(Alert.ILLEGAL_PARAMETER, spe);
                     }
                 } else {
                     try {
@@ -146,9 +145,8 @@ final class ServerNameExtension {
                         SSLProtocolException spe = new SSLProtocolException(
                             "Illegal server name, type=(" + nameType +
                             "), value={" +
-                            Utilities.toHexString(encoded) + "}");
-                        throw hc.conContext.fatal(Alert.ILLEGAL_PARAMETER,
-                                (SSLProtocolException)spe.initCause(iae));
+                            Utilities.toHexString(encoded) + "}", iae);
+                        throw hc.conContext.fatal(Alert.ILLEGAL_PARAMETER, spe);
                     }
                 }
 

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/ext/StartTlsResponseImpl.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/ext/StartTlsResponseImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -435,11 +435,10 @@ public final class StartTlsResponseImpl extends StartTlsResponse {
             /*
              * Pass up the cause of the failure
              */
-            throw(SSLPeerUnverifiedException)
-                new SSLPeerUnverifiedException("hostname of the server '" +
+            throw new SSLPeerUnverifiedException("hostname of the server '" +
                                 hostname +
                                 "' does not match the hostname in the " +
-                                "server's certificate.").initCause(e);
+                                "server's certificate.", e);
         }
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -573,9 +573,7 @@ final class HttpClientImpl extends HttpClient implements Trackable {
                 throw ce;
             } else if (throwable instanceof SSLHandshakeException) {
                 // special case for SSLHandshakeException
-                SSLHandshakeException he = new SSLHandshakeException(msg);
-                he.initCause(throwable);
-                throw he;
+                throw new SSLHandshakeException(msg, throwable);
             } else if (throwable instanceof SSLException) {
                 // any other SSLException is wrapped in a plain
                 // SSLException

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLTube.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLTube.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -592,9 +592,7 @@ public class SSLTube implements FlowTube {
                     engine.isOutboundDone(),
                     handshakeFailed);
 
-        SSLHandshakeException e = new SSLHandshakeException(handshakeFailed);
-        if (t != null) e.initCause(t);
-        return e;
+        return new SSLHandshakeException(handshakeFailed, t);
     }
 
     @Override

--- a/test/jdk/javax/net/ssl/ALPN/SSLServerSocketAlpnTest.java
+++ b/test/jdk/javax/net/ssl/ALPN/SSLServerSocketAlpnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/net/ssl/ALPN/SSLServerSocketAlpnTest.java
+++ b/test/jdk/javax/net/ssl/ALPN/SSLServerSocketAlpnTest.java
@@ -484,7 +484,7 @@ public class SSLServerSocketAlpnTest {
          */
         if ((local != null) && (remote != null)) {
             // If both failed, return the curthread's exception.
-            local.initCause(remote);
+            local.addSuppressed(remote);
             exception = local;
         } else if (local != null) {
             exception = local;

--- a/test/jdk/javax/net/ssl/ALPN/SSLSocketAlpnTest.java
+++ b/test/jdk/javax/net/ssl/ALPN/SSLSocketAlpnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/net/ssl/ALPN/SSLSocketAlpnTest.java
+++ b/test/jdk/javax/net/ssl/ALPN/SSLSocketAlpnTest.java
@@ -480,7 +480,7 @@ public class SSLSocketAlpnTest {
          */
         if ((local != null) && (remote != null)) {
             // If both failed, return the curthread's exception.
-            local.initCause(remote);
+            local.addSuppressed(remote);
             exception = local;
         } else if (local != null) {
             exception = local;

--- a/test/jdk/javax/net/ssl/SSLException/CheckSSLHandshakeException.java
+++ b/test/jdk/javax/net/ssl/SSLException/CheckSSLHandshakeException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8282723
+ * @summary Add constructors taking a cause to JSSE exceptions
+ */
+import javax.net.ssl.SSLHandshakeException;
+import java.util.Objects;
+
+public class CheckSSLHandshakeException {
+    private static String exceptionMessage = "message";
+    private static Throwable exceptionCause = new RuntimeException();
+
+    public static void main(String[] args) throws Exception {
+        testException(
+                new SSLHandshakeException(exceptionMessage, exceptionCause));
+    }
+
+    private static void testException(Exception ex) {
+        if (!Objects.equals(ex.getMessage(), exceptionMessage)) {
+            throw new RuntimeException("Unexpected exception message");
+        }
+
+        if (ex.getCause() != exceptionCause) {
+            throw new RuntimeException("Unexpected exception cause");
+        }
+    }
+}

--- a/test/jdk/javax/net/ssl/SSLException/CheckSSLKeyException.java
+++ b/test/jdk/javax/net/ssl/SSLException/CheckSSLKeyException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8282723
+ * @summary Add constructors taking a cause to JSSE exceptions
+ */
+import javax.net.ssl.SSLKeyException;
+import java.util.Objects;
+
+public class CheckSSLKeyException {
+    private static String exceptionMessage = "message";
+    private static Throwable exceptionCause = new RuntimeException();
+
+    public static void main(String[] args) throws Exception {
+        testException(
+                new SSLKeyException(exceptionMessage, exceptionCause));
+    }
+
+    private static void testException(Exception ex) {
+        if (!Objects.equals(ex.getMessage(), exceptionMessage)) {
+            throw new RuntimeException("Unexpected exception message");
+        }
+
+        if (ex.getCause() != exceptionCause) {
+            throw new RuntimeException("Unexpected exception cause");
+        }
+    }
+}

--- a/test/jdk/javax/net/ssl/SSLException/CheckSSLPeerUnverifiedException.java
+++ b/test/jdk/javax/net/ssl/SSLException/CheckSSLPeerUnverifiedException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8282723
+ * @summary Add constructors taking a cause to JSSE exceptions
+ */
+import javax.net.ssl.SSLPeerUnverifiedException;
+import java.util.Objects;
+
+public class CheckSSLPeerUnverifiedException {
+    private static String exceptionMessage = "message";
+    private static Throwable exceptionCause = new RuntimeException();
+
+    public static void main(String[] args) throws Exception {
+        testException(
+            new SSLPeerUnverifiedException(exceptionMessage, exceptionCause));
+    }
+
+    private static void testException(Exception ex) {
+        if (!Objects.equals(ex.getMessage(), exceptionMessage)) {
+            throw new RuntimeException("Unexpected exception message");
+        }
+
+        if (ex.getCause() != exceptionCause) {
+            throw new RuntimeException("Unexpected exception cause");
+        }
+    }
+}

--- a/test/jdk/javax/net/ssl/SSLException/CheckSSLProtocolException.java
+++ b/test/jdk/javax/net/ssl/SSLException/CheckSSLProtocolException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8282723
+ * @summary Add constructors taking a cause to JSSE exceptions
+ */
+import javax.net.ssl.SSLProtocolException;
+import java.util.Objects;
+
+public class CheckSSLProtocolException {
+    private static String exceptionMessage = "message";
+    private static Throwable exceptionCause = new RuntimeException();
+
+    public static void main(String[] args) throws Exception {
+        testException(
+                new SSLProtocolException(exceptionMessage, exceptionCause));
+    }
+
+    private static void testException(Exception ex) {
+        if (!Objects.equals(ex.getMessage(), exceptionMessage)) {
+            throw new RuntimeException("Unexpected exception message");
+        }
+
+        if (ex.getCause() != exceptionCause) {
+            throw new RuntimeException("Unexpected exception cause");
+        }
+    }
+}

--- a/test/jdk/javax/net/ssl/templates/SSLSocketSSLEngineTemplate.java
+++ b/test/jdk/javax/net/ssl/templates/SSLSocketSSLEngineTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/net/ssl/templates/SSLSocketSSLEngineTemplate.java
+++ b/test/jdk/javax/net/ssl/templates/SSLSocketSSLEngineTemplate.java
@@ -349,13 +349,13 @@ public class SSLSocketSSLEngineTemplate {
         } finally {
             if (serverException != null) {
                 if (clientException != null) {
-                    serverException.initCause(clientException);
+                    serverException.setCause(clientException);
                 }
                 throw serverException;
             }
             if (clientException != null) {
                 if (serverException != null) {
-                    clientException.initCause(serverException);
+                    clientException.setCause(serverException);
                 }
                 throw clientException;
             }

--- a/test/jdk/javax/net/ssl/templates/SSLSocketSSLEngineTemplate.java
+++ b/test/jdk/javax/net/ssl/templates/SSLSocketSSLEngineTemplate.java
@@ -349,13 +349,13 @@ public class SSLSocketSSLEngineTemplate {
         } finally {
             if (serverException != null) {
                 if (clientException != null) {
-                    serverException.setCause(clientException);
+                    serverException.addSuppressed(clientException);
                 }
                 throw serverException;
             }
             if (clientException != null) {
                 if (serverException != null) {
-                    clientException.setCause(serverException);
+                    clientException.addSuppressed(serverException);
                 }
                 throw clientException;
             }

--- a/test/jdk/javax/net/ssl/templates/SSLSocketTemplate.java
+++ b/test/jdk/javax/net/ssl/templates/SSLSocketTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/net/ssl/templates/SSLSocketTemplate.java
+++ b/test/jdk/javax/net/ssl/templates/SSLSocketTemplate.java
@@ -544,7 +544,7 @@ public class SSLSocketTemplate {
          */
         if ((local != null) && (remote != null)) {
             // If both failed, return the curthread's exception.
-            local.setCause(remote);
+            local.addSuppressed(remote);
             exception = local;
         } else if (local != null) {
             exception = local;

--- a/test/jdk/javax/net/ssl/templates/SSLSocketTemplate.java
+++ b/test/jdk/javax/net/ssl/templates/SSLSocketTemplate.java
@@ -544,7 +544,7 @@ public class SSLSocketTemplate {
          */
         if ((local != null) && (remote != null)) {
             // If both failed, return the curthread's exception.
-            local.initCause(remote);
+            local.setCause(remote);
             exception = local;
         } else if (local != null) {
             exception = local;


### PR DESCRIPTION
Please review this small API enhancement to add the usual constructors taking a cause to javax.net.ssl exceptions.  The use of initCause in the JSSE implementation code is updated to use the new constructors accordingly.

Please review the CSR: https://bugs.openjdk.java.net/browse/JDK-8282724

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8282723](https://bugs.openjdk.java.net/browse/JDK-8282723): Add constructors taking a cause to JSSE exceptions
 * [JDK-8282724](https://bugs.openjdk.java.net/browse/JDK-8282724): Add constructors taking a cause to JSSE exceptions (**CSR**)


### Reviewers
 * [Bradford Wetmore](https://openjdk.java.net/census#wetmore) (@bradfordwetmore - **Reviewer**) ⚠️ Review applies to 61cc7934c7e541ffabc42a53c0b2a3f6a24cf869
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to 61cc7934c7e541ffabc42a53c0b2a3f6a24cf869


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7722/head:pull/7722` \
`$ git checkout pull/7722`

Update a local copy of the PR: \
`$ git checkout pull/7722` \
`$ git pull https://git.openjdk.java.net/jdk pull/7722/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7722`

View PR using the GUI difftool: \
`$ git pr show -t 7722`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7722.diff">https://git.openjdk.java.net/jdk/pull/7722.diff</a>

</details>
