### PR TITLE
8282665: [REDO] ByteBufferTest.java: replace endless recursion with RuntimeException in void ck(double x, double y)

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/unsafe/ByteBufferTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/unsafe/ByteBufferTest.java
@@ -220,9 +220,9 @@ class MyByteBuffer {
         // Remember: NaN == x is false for ANY x, including if x is NaN (IEEE standard).
         // Therefore, if x and y are NaN, x != y would return true, which is not what we want.
         // We do not want an Exception if both are NaN.
-        // Hence, we only use x != y, if both are not NaN.
-        // Additionally, we also check if exactly one of them is NaN, via XOR (^).
-        if ((!Double.isNaN(x) && !Double.isNaN(y) && x != y) || (Double.isNaN(x) ^ Double.isNaN(y))) {
+        // Double.compare takes care of these special cases
+        // including NaNs, and comparing -0.0 to 0.0
+        if (Double.compare(x,y) != 0) {
             throw new RuntimeException("expect x == y:"
                                     + "  x = " + Double.toString(x) + ", y = " + Double.toString(y)
                                     + " (x = " + Long.toHexString(Double.doubleToRawLongBits(x))

--- a/test/hotspot/jtreg/compiler/intrinsics/unsafe/ByteBufferTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/unsafe/ByteBufferTest.java
@@ -216,8 +216,16 @@ class MyByteBuffer {
     }
 
     void ck(double x, double y) {
-        if (x == x && y == y && x != y) {
-            ck(x, y);
+        // Check if x and y have identical values.
+        // Remember: NaN == x is false for ANY x, including if x is NaN (IEEE standard).
+	// Therefore, if x and y are NaN, x != y would return true, which is not what we want.
+	// We do not want an Exception if both are NaN.
+	// Hence, we only use x != y, if both are not NaN.
+	// Additionally, we also check if exactly one of them is NaN, via XOR (^).
+	if ((!Double.isNaN(x) && !Double.isNaN(y) && x != y) || (Double.isNaN(x) ^ Double.isNaN(y))) {
+            throw new RuntimeException(" x = " + Double.toString(x) + ", y = " + Double.toString(y)
+                                    + " (x = " + Long.toHexString(Double.doubleToRawLongBits(x))
+                                    + ", y = " + Long.toHexString(Double.doubleToRawLongBits(y)) + ")");
         }
     }
 

--- a/test/hotspot/jtreg/compiler/intrinsics/unsafe/ByteBufferTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/unsafe/ByteBufferTest.java
@@ -218,11 +218,11 @@ class MyByteBuffer {
     void ck(double x, double y) {
         // Check if x and y have identical values.
         // Remember: NaN == x is false for ANY x, including if x is NaN (IEEE standard).
-	// Therefore, if x and y are NaN, x != y would return true, which is not what we want.
-	// We do not want an Exception if both are NaN.
-	// Hence, we only use x != y, if both are not NaN.
-	// Additionally, we also check if exactly one of them is NaN, via XOR (^).
-	if ((!Double.isNaN(x) && !Double.isNaN(y) && x != y) || (Double.isNaN(x) ^ Double.isNaN(y))) {
+        // Therefore, if x and y are NaN, x != y would return true, which is not what we want.
+        // We do not want an Exception if both are NaN.
+        // Hence, we only use x != y, if both are not NaN.
+        // Additionally, we also check if exactly one of them is NaN, via XOR (^).
+        if ((!Double.isNaN(x) && !Double.isNaN(y) && x != y) || (Double.isNaN(x) ^ Double.isNaN(y))) {
             throw new RuntimeException(" x = " + Double.toString(x) + ", y = " + Double.toString(y)
                                     + " (x = " + Long.toHexString(Double.doubleToRawLongBits(x))
                                     + ", y = " + Long.toHexString(Double.doubleToRawLongBits(y)) + ")");

--- a/test/hotspot/jtreg/compiler/intrinsics/unsafe/ByteBufferTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/unsafe/ByteBufferTest.java
@@ -211,7 +211,7 @@ class MyByteBuffer {
 
     void ck(long x, long y) {
         if (x != y) {
-            throw new RuntimeException(" x = " + Long.toHexString(x) + ", y = " + Long.toHexString(y));
+            throw new RuntimeException("expect x == y: x = " + Long.toHexString(x) + ", y = " + Long.toHexString(y));
         }
     }
 
@@ -223,7 +223,8 @@ class MyByteBuffer {
         // Hence, we only use x != y, if both are not NaN.
         // Additionally, we also check if exactly one of them is NaN, via XOR (^).
         if ((!Double.isNaN(x) && !Double.isNaN(y) && x != y) || (Double.isNaN(x) ^ Double.isNaN(y))) {
-            throw new RuntimeException(" x = " + Double.toString(x) + ", y = " + Double.toString(y)
+            throw new RuntimeException("expect x == y:"
+                                    + "  x = " + Double.toString(x) + ", y = " + Double.toString(y)
                                     + " (x = " + Long.toHexString(Double.doubleToRawLongBits(x))
                                     + ", y = " + Long.toHexString(Double.doubleToRawLongBits(y)) + ")");
         }


### PR DESCRIPTION
Until now, ck for doubles ignored the case when either x or y was NaN, it for example would let pass x=NaN and y=2.0.
Further, instead of throwing an exception, it went into infinite recursion, with an eventual StackOverflowError.
Now, we throw an exception that prints the values. I fixed the logic, and added an explanation.

All tests are passing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282665](https://bugs.openjdk.java.net/browse/JDK-8282665): [REDO] ByteBufferTest.java: replace endless recursion with RuntimeException in void ck(double x, double y)


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7723/head:pull/7723` \
`$ git checkout pull/7723`

Update a local copy of the PR: \
`$ git checkout pull/7723` \
`$ git pull https://git.openjdk.java.net/jdk pull/7723/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7723`

View PR using the GUI difftool: \
`$ git pr show -t 7723`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7723.diff">https://git.openjdk.java.net/jdk/pull/7723.diff</a>

</details>
