### PR TITLE
8282727: Parallel: Remove PSPromotionManager::_totally_drain

### DIFF
--- a/src/hotspot/share/gc/parallel/psPromotionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.cpp
@@ -180,8 +180,7 @@ PSPromotionManager::PSPromotionManager() {
   uint queue_size;
   queue_size = claimed_stack_depth()->max_elems();
 
-  _totally_drain = (ParallelGCThreads == 1) || (GCDrainStackTargetSize == 0);
-  if (_totally_drain) {
+  if (ParallelGCThreads == 1) {
     _target_stack_size = 0;
   } else {
     // don't let the target stack size to be more than 1/4 of the entries
@@ -227,7 +226,7 @@ void PSPromotionManager::restore_preserved_marks() {
 }
 
 void PSPromotionManager::drain_stacks_depth(bool totally_drain) {
-  totally_drain = totally_drain || _totally_drain;
+  totally_drain = totally_drain || (_target_stack_size == 0);
 
   PSScannerTasksQueue* const tq = claimed_stack_depth();
   do {

--- a/src/hotspot/share/gc/parallel/psPromotionManager.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.hpp
@@ -83,7 +83,6 @@ class PSPromotionManager {
 
   PSScannerTasksQueue                 _claimed_stack_depth;
 
-  bool                                _totally_drain;
   uint                                _target_stack_size;
 
   uint                                _array_chunk_size;


### PR DESCRIPTION
Simple change of removing a redundant boolean field.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282727](https://bugs.openjdk.java.net/browse/JDK-8282727): Parallel: Remove PSPromotionManager::_totally_drain


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7725/head:pull/7725` \
`$ git checkout pull/7725`

Update a local copy of the PR: \
`$ git checkout pull/7725` \
`$ git pull https://git.openjdk.java.net/jdk pull/7725/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7725`

View PR using the GUI difftool: \
`$ git pr show -t 7725`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7725.diff">https://git.openjdk.java.net/jdk/pull/7725.diff</a>

</details>
