### PR TITLE
8282728: Serial: Remove unused BlockOffsetArray::Action

### DIFF
--- a/src/hotspot/share/gc/shared/blockOffsetTable.cpp
+++ b/src/hotspot/share/gc/shared/blockOffsetTable.cpp
@@ -248,14 +248,10 @@ BlockOffsetArray::alloc_block(HeapWord* blk_start, HeapWord* blk_end) {
   single_block(blk_start, blk_end);
 }
 
-// Action_mark - update the BOT for the block [blk_start, blk_end).
-//               Current typical use is for splitting a block.
-// Action_single - udpate the BOT for an allocation.
-// Action_verify - BOT verification.
 void
 BlockOffsetArray::do_block_internal(HeapWord* blk_start,
                                     HeapWord* blk_end,
-                                    Action action, bool reducing) {
+                                    bool reducing) {
   assert(_sp->is_in_reserved(blk_start),
          "reference must be into the space");
   assert(_sp->is_in_reserved(blk_end-1),
@@ -284,33 +280,13 @@ BlockOffsetArray::do_block_internal(HeapWord* blk_start,
     }
     assert(start_index <= end_index, "monotonicity of index_for()");
     assert(boundary <= (HeapWord*)boundary_before_end, "tautology");
-    switch (action) {
-      case Action_mark: {
-        if (init_to_zero()) {
-          _array->set_offset_array(start_index, boundary, blk_start, reducing);
-          break;
-        } // Else fall through to the next case
-      }
-      case Action_single: {
-        _array->set_offset_array(start_index, boundary, blk_start, reducing);
-        // We have finished marking the "offset card". We need to now
-        // mark the subsequent cards that this blk spans.
-        if (start_index < end_index) {
-          HeapWord* rem_st = _array->address_for_index(start_index) + BOTConstants::card_size_in_words();
-          HeapWord* rem_end = _array->address_for_index(end_index) + BOTConstants::card_size_in_words();
-          set_remainder_to_point_to_start(rem_st, rem_end, reducing);
-        }
-        break;
-      }
-      case Action_check: {
-        _array->check_offset_array(start_index, boundary, blk_start);
-        // We have finished checking the "offset card". We need to now
-        // check the subsequent cards that this blk spans.
-        check_all_cards(start_index + 1, end_index);
-        break;
-      }
-      default:
-        ShouldNotReachHere();
+    _array->set_offset_array(start_index, boundary, blk_start, reducing);
+    // We have finished marking the "offset card". We need to now
+    // mark the subsequent cards that this blk spans.
+    if (start_index < end_index) {
+      HeapWord* rem_st = _array->address_for_index(start_index) + BOTConstants::card_size_in_words();
+      HeapWord* rem_end = _array->address_for_index(end_index) + BOTConstants::card_size_in_words();
+      set_remainder_to_point_to_start(rem_st, rem_end, reducing);
     }
   }
 }
@@ -322,7 +298,7 @@ BlockOffsetArray::do_block_internal(HeapWord* blk_start,
 void
 BlockOffsetArray::single_block(HeapWord* blk_start,
                                HeapWord* blk_end) {
-  do_block_internal(blk_start, blk_end, Action_single);
+  do_block_internal(blk_start, blk_end);
 }
 
 void BlockOffsetArray::verify() const {

--- a/src/hotspot/share/gc/shared/blockOffsetTable.hpp
+++ b/src/hotspot/share/gc/shared/blockOffsetTable.hpp
@@ -279,14 +279,6 @@ class Space;
 class BlockOffsetArray: public BlockOffsetTable {
   friend class VMStructs;
  protected:
-  // The following enums are used by do_block_internal() below
-  enum Action {
-    Action_single,      // BOT records a single block (see single_block())
-    Action_mark,        // BOT marks the start of a block (see mark_block())
-    Action_check        // Check that BOT records block correctly
-                        // (see verify_single_block()).
-  };
-
   // The shared array, which is shared with other BlockOffsetArray's
   // corresponding to different spaces within a generation or span of
   // memory.
@@ -315,7 +307,7 @@ class BlockOffsetArray: public BlockOffsetTable {
   void set_remainder_to_point_to_start_incl(size_t start, size_t end, bool reducing = false);
 
   // A helper function for BOT adjustment/verification work
-  void do_block_internal(HeapWord* blk_start, HeapWord* blk_end, Action action, bool reducing = false);
+  void do_block_internal(HeapWord* blk_start, HeapWord* blk_end, bool reducing = false);
 
  public:
   // The space may not have its bottom and top set yet, which is why the


### PR DESCRIPTION
Simple change of removing dead code.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282728](https://bugs.openjdk.java.net/browse/JDK-8282728): Serial: Remove unused BlockOffsetArray::Action


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7726/head:pull/7726` \
`$ git checkout pull/7726`

Update a local copy of the PR: \
`$ git checkout pull/7726` \
`$ git pull https://git.openjdk.java.net/jdk pull/7726/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7726`

View PR using the GUI difftool: \
`$ git pr show -t 7726`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7726.diff">https://git.openjdk.java.net/jdk/pull/7726.diff</a>

</details>
