### PR TITLE
8282295: SymbolPropertyEntry::set_method_type fails with assert

### DIFF
--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -1248,6 +1248,7 @@ bool Universe::release_fullgc_alot_dummy() {
     if (_fullgc_alot_dummy_next >= fullgc_alot_dummy_array->length()) {
       // No more dummies to release, release entire array instead
       _fullgc_alot_dummy_array.release(Universe::vm_global());
+      _fullgc_alot_dummy_array = OopHandle(); // NULL out OopStorage pointer.
       return false;
     }
 


### PR DESCRIPTION
This is somewhat trivial change to zero out OopHandle in fullgc_alot_dummy_array.  Other OopHandle releases are for data that is deallocated or not reused so zeroing _obj is not needed in those places.  I didn't want to zero _obj in OopHandle::release anyway without zeroing it in the analogous WeakHandle::release. WeakHandle release code operates on const objects, also which are deallocated after release.
Tested with tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282295](https://bugs.openjdk.java.net/browse/JDK-8282295): SymbolPropertyEntry::set_method_type fails with assert


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7730/head:pull/7730` \
`$ git checkout pull/7730`

Update a local copy of the PR: \
`$ git checkout pull/7730` \
`$ git pull https://git.openjdk.java.net/jdk pull/7730/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7730`

View PR using the GUI difftool: \
`$ git pr show -t 7730`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7730.diff">https://git.openjdk.java.net/jdk/pull/7730.diff</a>

</details>
