### PR TITLE
8282769: BSD date cannot handle all ISO 8601 formats

### DIFF
--- a/make/autoconf/util.m4
+++ b/make/autoconf/util.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -230,8 +230,6 @@ AC_DEFUN([UTIL_GET_MATCHING_VALUES],
 # Converts an ISO-8601 date/time string to a unix epoch timestamp. If no
 # suitable conversion method was found, an empty string is returned.
 #
-# Sets the specified variable to the resulting list.
-#
 # $1: result variable name
 # $2: input date/time string
 AC_DEFUN([UTIL_GET_EPOCH_TIMESTAMP],
@@ -241,11 +239,11 @@ AC_DEFUN([UTIL_GET_EPOCH_TIMESTAMP],
     timestamp=$($DATE --utc --date=$2 +"%s" 2> /dev/null)
   else
     # BSD date
-    timestamp=$($DATE -u -j -f "%F %T" "$2" "+%s" 2> /dev/null)
+    timestamp=$($DATE -u -j -f "%FZ %TZ" "$2" "+%s" 2> /dev/null)
     if test "x$timestamp" = x; then
-      # Perhaps the time was missing
-      timestamp=$($DATE -u -j -f "%F %T" "$2 00:00:00" "+%s" 2> /dev/null)
-      # If this did not work, we give up and return the empty string
+      # BSD date cannot handle trailing milliseconds.
+      # Try again ignoring characters at end
+      timestamp=$($DATE -u -j -f "%Y-%m-%dT%H:%M:%S" "$2" "+%s" 2> /dev/null)
     fi
   fi
   $1=$timestamp


### PR DESCRIPTION
The BSD version of the date command that ships with macOS cannot handle all ISO 8601 formats. More specifically, it cannot handle trailing milliseconds.

This fix will allow it to be more tolerant.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282769](https://bugs.openjdk.java.net/browse/JDK-8282769): BSD date cannot handle all ISO 8601 formats


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7733/head:pull/7733` \
`$ git checkout pull/7733`

Update a local copy of the PR: \
`$ git checkout pull/7733` \
`$ git pull https://git.openjdk.java.net/jdk pull/7733/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7733`

View PR using the GUI difftool: \
`$ git pr show -t 7733`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7733.diff">https://git.openjdk.java.net/jdk/pull/7733.diff</a>

</details>
