### PR TITLE
8282770: Set source date in jib profiles from buildId

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -258,7 +258,6 @@ var getJibProfilesCommon = function (input, data) {
     common.release_profile_base = {
         configure_args: [
             "--enable-reproducible-build",
-            "--with-source-date=current",
         ],
     };
     // Extra settings for debug profiles
@@ -1447,6 +1446,14 @@ var versionArgs = function(input, common) {
     } else {
         args = concat(args, "--with-version-opt=" + common.build_id);
     }
+    var sourceDate
+    if (input.build_id_data && input.build_id_data.creationTime) {
+        sourceDate = Math.floor(Date.parse(input.build_id_data.creationTime)/1000);
+    } else {
+        sourceDate = "current";
+    }
+    args = concat(args, "--with-source-date=" + sourceDate);
+
     return args;
 }
 


### PR DESCRIPTION
For reproducability, we should set the source date on jib profiles from the buildId.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282770](https://bugs.openjdk.java.net/browse/JDK-8282770): Set source date in jib profiles from buildId


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7735/head:pull/7735` \
`$ git checkout pull/7735`

Update a local copy of the PR: \
`$ git checkout pull/7735` \
`$ git pull https://git.openjdk.java.net/jdk pull/7735/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7735`

View PR using the GUI difftool: \
`$ git pr show -t 7735`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7735.diff">https://git.openjdk.java.net/jdk/pull/7735.diff</a>

</details>
