### PR TITLE
8249592 : Robot.mouseMove moves cursor to incorrect location when display scale varies and Java runs in DPI Unaware mode

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Robot.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Robot.cpp
@@ -27,7 +27,6 @@
 #include "java_awt_event_InputEvent.h"
 #include "awt_Component.h"
 #include <winuser.h>
-#include <stdlib.h>
 
 static void MouseMove(jint x, jint y)
 {

--- a/src/java.desktop/windows/native/libawt/windows/awt_Robot.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Robot.cpp
@@ -29,60 +29,27 @@
 #include <winuser.h>
 #include <stdlib.h>
 
-static int signum(int i) {
-  // special version of signum which returns 1 when value is 0
-  return i >= 0 ? 1 : -1;
-}
-
 static void MouseMove(jint x, jint y)
 {
     INPUT mouseInput = {0};
     mouseInput.type = INPUT_MOUSE;
     mouseInput.mi.time = 0;
-    static int init = 0 ;
 
+    // The following calculations take into account a multi-monitor setup using a virtual screen for all monitors combined.
+    // More details from Microsoft are here -- https://docs.microsoft.com/en-us/windows/win32/gdi/the-virtual-screen
 
-     char* pValue;
-     size_t len;
-     errno_t err = _dupenv_s(&pValue, &len, "OLD_CODE");
+    x -= ::GetSystemMetrics(SM_XVIRTUALSCREEN);
+    y -= ::GetSystemMetrics(SM_YVIRTUALSCREEN);
 
-    if(init == 0 )
-    {
-        if ((pValue) && ((atoi(pValue)) ==1))
-        {
-            printf("Using Current JDK code  \n");
-        }
-        else
-        {
-            printf("Using JDK code that fixes JDK-8249592  \n");
-        }
+    mouseInput.mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_MOVE | MOUSEEVENTF_VIRTUALDESK;
 
-        init++;
-    }
+    int scW = ::GetSystemMetrics(SM_CXVIRTUALSCREEN);
+    int scH = ::GetSystemMetrics(SM_CYVIRTUALSCREEN);
 
-     if ((pValue) && (*pValue == '1'))
-     {
-        mouseInput.mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_MOVE;
-        mouseInput.mi.dx = (x * 65536 /::GetSystemMetrics(SM_CXSCREEN)) + signum(x);
-        mouseInput.mi.dy = (y * 65536 /::GetSystemMetrics(SM_CYSCREEN)) + signum(y);
-    }
-    else
-    {
+    // The following calculation to deduce mouse coordinates is based on empirical data
+    mouseInput.mi.dx = (x * 65536 + scW - 1) / scW;
+    mouseInput.mi.dy = (y * 65536 + scH - 1) / scH;
 
-        x -= ::GetSystemMetrics(SM_XVIRTUALSCREEN);
-        y -= ::GetSystemMetrics(SM_YVIRTUALSCREEN);
-
-        mouseInput.mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_MOVE | MOUSEEVENTF_VIRTUALDESK;
-
-        int scW = ::GetSystemMetrics(SM_CXVIRTUALSCREEN);
-        int scH = ::GetSystemMetrics(SM_CYVIRTUALSCREEN);
-        mouseInput.mi.dx = (x * 65536 + scW - 1) / scW;
-        mouseInput.mi.dy = (y * 65536 + scH - 1) / scH;
-
-
-
-
-    }
     ::SendInput(1, &mouseInput, sizeof(mouseInput));
 
 }

--- a/src/java.desktop/windows/native/libawt/windows/awt_Robot.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Robot.cpp
@@ -34,18 +34,22 @@ static void MouseMove(jint x, jint y)
     mouseInput.type = INPUT_MOUSE;
     mouseInput.mi.time = 0;
 
-    // The following calculations take into account a multi-monitor setup using a virtual screen for all monitors combined.
-    // More details from Microsoft are here -- https://docs.microsoft.com/en-us/windows/win32/gdi/the-virtual-screen
+    // The following calculations take into account a multi-monitor setup using
+    // a virtual screen for all monitors combined.
+    // More details from Microsoft are here --
+    // https://docs.microsoft.com/en-us/windows/win32/gdi/the-virtual-screen
 
     x -= ::GetSystemMetrics(SM_XVIRTUALSCREEN);
     y -= ::GetSystemMetrics(SM_YVIRTUALSCREEN);
 
-    mouseInput.mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_MOVE | MOUSEEVENTF_VIRTUALDESK;
+    mouseInput.mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_MOVE |
+                            MOUSEEVENTF_VIRTUALDESK;
 
     int scW = ::GetSystemMetrics(SM_CXVIRTUALSCREEN);
     int scH = ::GetSystemMetrics(SM_CYVIRTUALSCREEN);
 
-    // The following calculation to deduce mouse coordinates is based on empirical data
+    // The following calculation to deduce mouse coordinates is based on
+    // empirical data
     mouseInput.mi.dx = (x * 65536 + scW - 1) / scW;
     mouseInput.mi.dy = (y * 65536 + scH - 1) / scH;
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8249592](https://bugs.openjdk.java.net/browse/JDK-8249592): Robot.mouseMove moves cursor to incorrect location when display scale varies and Java runs in DPI Unaware mode


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7736/head:pull/7736` \
`$ git checkout pull/7736`

Update a local copy of the PR: \
`$ git checkout pull/7736` \
`$ git pull https://git.openjdk.java.net/jdk pull/7736/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7736`

View PR using the GUI difftool: \
`$ git pr show -t 7736`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7736.diff">https://git.openjdk.java.net/jdk/pull/7736.diff</a>

</details>
