### PR TITLE
8282548: Create a regression test for JDK-4330998

### DIFF
--- a/test/jdk/javax/swing/JEditorPane/4330998/JEditorPaneSetTextNullTest.java
+++ b/test/jdk/javax/swing/JEditorPane/4330998/JEditorPaneSetTextNullTest.java
@@ -31,7 +31,7 @@
   * @run main JEditorPaneSetTextNullTest
   */
  public class JEditorPaneSetTextNullTest {
-     public static void main(String[] s) throws Exception {
+     public static void main(String[] args) throws Exception {
          try {
              SwingUtilities.invokeAndWait(() -> new JEditorPane().setText(null));
              System.out.println("Test passed");

--- a/test/jdk/javax/swing/JEditorPane/4330998/JEditorPaneSetTextNullTest.java
+++ b/test/jdk/javax/swing/JEditorPane/4330998/JEditorPaneSetTextNullTest.java
@@ -31,6 +31,7 @@
   * @run main JEditorPaneSetTextNullTest
   */
  public class JEditorPaneSetTextNullTest {
+
      public static void main(String[] args) throws Exception {
          try {
              SwingUtilities.invokeAndWait(() -> new JEditorPane().setText(null));

--- a/test/jdk/javax/swing/JEditorPane/4330998/JEditorPaneSetTextNullTest.java
+++ b/test/jdk/javax/swing/JEditorPane/4330998/JEditorPaneSetTextNullTest.java
@@ -31,7 +31,6 @@
   * @run main JEditorPaneSetTextNullTest
   */
  public class JEditorPaneSetTextNullTest {
-     
      public static void main(String[] s) throws Exception {
          try {
              SwingUtilities.invokeAndWait(() -> new JEditorPane().setText(null));

--- a/test/jdk/javax/swing/JEditorPane/4330998/JEditorPaneSetTextNullTest.java
+++ b/test/jdk/javax/swing/JEditorPane/4330998/JEditorPaneSetTextNullTest.java
@@ -22,7 +22,6 @@
   */
 
  import javax.swing.JEditorPane;
- import javax.swing.JPanel;
  import javax.swing.SwingUtilities;
 
  /*
@@ -32,24 +31,15 @@
   * @run main JEditorPaneSetTextNullTest
   */
  public class JEditorPaneSetTextNullTest {
-     private static JEditorPane editorPane;
-
+     
      public static void main(String[] s) throws Exception {
-         SwingUtilities.invokeAndWait(() -> createUI());
-
          try {
-             SwingUtilities.invokeAndWait(() -> editorPane.setText(null));
+             SwingUtilities.invokeAndWait(() -> new JEditorPane().setText(null));
              System.out.println("Test passed");
          } catch (Exception e) {
              throw new RuntimeException("Test failed, caught Exception " + e
                      + " when calling JEditorPane.setText(null)");
          }
-     }
-
-     private static void createUI() {
-         JPanel panel = new JPanel();
-         editorPane = new JEditorPane();
-         panel.add(editorPane);
      }
 
  }

--- a/test/jdk/javax/swing/JEditorPane/4330998/JEditorPaneSetTextNullTest.java
+++ b/test/jdk/javax/swing/JEditorPane/4330998/JEditorPaneSetTextNullTest.java
@@ -1,0 +1,55 @@
+ /*
+  * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+  *
+  * This code is free software; you can redistribute it and/or modify it
+  * under the terms of the GNU General Public License version 2 only, as
+  * published by the Free Software Foundation.
+  *
+  * This code is distributed in the hope that it will be useful, but WITHOUT
+  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+  * version 2 for more details (a copy is included in the LICENSE file that
+  * accompanied this code).
+  *
+  * You should have received a copy of the GNU General Public License version
+  * 2 along with this work; if not, write to the Free Software Foundation,
+  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+  *
+  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+  * or visit www.oracle.com if you need additional information or have any
+  * questions.
+  */
+
+ import javax.swing.JEditorPane;
+ import javax.swing.JPanel;
+ import javax.swing.SwingUtilities;
+
+ /*
+  * @test
+  * @bug 4330998
+  * @summary Verifies that JEditorPane.setText(null) doesn't throw NullPointerException.
+  * @run main JEditorPaneSetTextNullTest
+  */
+ public class JEditorPaneSetTextNullTest {
+     private static JEditorPane editorPane;
+
+     public static void main(String[] s) throws Exception {
+         SwingUtilities.invokeAndWait(() -> createUI());
+
+         try {
+             SwingUtilities.invokeAndWait(() -> editorPane.setText(null));
+             System.out.println("Test passed");
+         } catch (Exception e) {
+             throw new RuntimeException("Test failed, caught Exception " + e
+                     + " when calling JEditorPane.setText(null)");
+         }
+     }
+
+     private static void createUI() {
+         JPanel panel = new JPanel();
+         editorPane = new JEditorPane();
+         panel.add(editorPane);
+     }
+
+ }


### PR DESCRIPTION
Create a regression test for [JDK-4330998](https://bugs.openjdk.java.net/browse/JDK-4330998)


Issue tested:
When calling JEditorPane.setText(null), the following exception is thrown:

java.lang.NullPointerException:
        at java.io.StringReader.<init>(StringReader.java:38)

Testing:
Java 1.4.0 -> Test Failed.
$ ./j2sdk1.4.0/bin/java bug4330998Win
java.lang.RuntimeException: Test failed, caught Exception java.lang.NullPointerException when calling text.setText(null)
        at bug4330998Win.runTest(bug4330998Win.java:45)
        at bug4330998Win.main(bug4330998Win.java:51)
Exception in thread "main"

Java 1.4.1 -> Test Passed.
$ ./j2sdk1.4.1/bin/java bug4330998Win
Test passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282548](https://bugs.openjdk.java.net/browse/JDK-8282548): Create a regression test for JDK-4330998


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**) ⚠️ Review applies to 03d7475a31c1b6dc171bfc5b2a617d1b158aaedf


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7740/head:pull/7740` \
`$ git checkout pull/7740`

Update a local copy of the PR: \
`$ git checkout pull/7740` \
`$ git pull https://git.openjdk.java.net/jdk pull/7740/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7740`

View PR using the GUI difftool: \
`$ git pr show -t 7740`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7740.diff">https://git.openjdk.java.net/jdk/pull/7740.diff</a>

</details>
