### PR TITLE
8282763: G1: G1CardSetContainer remove intrusive-list details.

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
@@ -144,7 +144,7 @@ public:
 // All but inline pointers are of this kind. For those, card entries are stored
 // directly in the CardSetPtr of the ConcurrentHashTable node.
 class G1CardSetContainer {
-    uintptr_t _ref_count;
+  uintptr_t _ref_count;
 protected:
   ~G1CardSetContainer() = default;
 public:

--- a/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
@@ -26,6 +26,7 @@
 #define SHARE_GC_G1_G1CARDSETCONTAINERS_HPP
 
 #include "gc/g1/g1CardSet.hpp"
+#include "memory/allocation.hpp"
 #include "runtime/atomic.hpp"
 #include "utilities/bitMap.hpp"
 #include "utilities/globalDefinitions.hpp"

--- a/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
@@ -26,15 +26,13 @@
 #define SHARE_GC_G1_G1CARDSETCONTAINERS_HPP
 
 #include "gc/g1/g1CardSet.hpp"
+#include "logging/log.hpp"
 #include "memory/allocation.hpp"
 #include "runtime/atomic.hpp"
+#include "runtime/thread.hpp"
 #include "utilities/bitMap.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/spinYield.hpp"
-
-#include "logging/log.hpp"
-
-#include "runtime/thread.inline.hpp"
 
 // A helper class to encode a few card indexes within a CardSetPtr.
 //
@@ -143,18 +141,12 @@ public:
 // To maintain these constraints, live objects should have ((_ref_count & 0x1) == 1),
 // which requires that we increment the reference counts by 2 starting at _ref_count = 3.
 //
-// When such an object is on a free list, we reuse the same field for linking
-// together those free objects.
-//
 // All but inline pointers are of this kind. For those, card entries are stored
 // directly in the CardSetPtr of the ConcurrentHashTable node.
 class G1CardSetContainer {
-private:
-  union {
-    G1CardSetContainer* _next;
     uintptr_t _ref_count;
-  };
-
+protected:
+  ~G1CardSetContainer() = default;
 public:
   G1CardSetContainer() : _ref_count(3) { }
 
@@ -165,18 +157,6 @@ public:
   // Decrement refcount potentially while racing increment, so we need
   // to check the value after attempting to decrement.
   uintptr_t decrement_refcount();
-
-  G1CardSetContainer* next() {
-    return _next;
-  }
-
-  G1CardSetContainer** next_addr() {
-    return &_next;
-  }
-
-  void set_next(G1CardSetContainer* next) {
-    _next = next;
-  }
 
   // Log of largest card index that can be stored in any G1CardSetContainer
   static uint LogCardsPerRegionLimit;

--- a/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
@@ -26,13 +26,9 @@
 #define SHARE_GC_G1_G1CARDSETCONTAINERS_HPP
 
 #include "gc/g1/g1CardSet.hpp"
-#include "logging/log.hpp"
-#include "memory/allocation.hpp"
 #include "runtime/atomic.hpp"
-#include "runtime/thread.hpp"
 #include "utilities/bitMap.hpp"
 #include "utilities/globalDefinitions.hpp"
-#include "utilities/spinYield.hpp"
 
 // A helper class to encode a few card indexes within a CardSetPtr.
 //

--- a/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
@@ -29,6 +29,7 @@
 #include "gc/g1/g1GCPhaseTimes.hpp"
 #include "utilities/bitMap.inline.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "utilities/spinYield.hpp"
 
 inline G1CardSetInlinePtr::CardSetPtr G1CardSetInlinePtr::merge(CardSetPtr orig_value, uint card_in_region, uint idx, uint bits_per_card) {
   assert((idx & (SizeFieldMask >> SizeFieldPos)) == idx, "Index %u too large to fit into size field", idx);


### PR DESCRIPTION
Hi all,

Please review this trivial cleanup to remove unnecessary G1CardSetContainer list details.

Testing: tier 1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282763](https://bugs.openjdk.java.net/browse/JDK-8282763): G1: G1CardSetContainer remove intrusive-list details.


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to 804e1558afacc994c219dccc0af77306d446450a
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to cf1ea626207ab42c4427a1490300157d95354334
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7743/head:pull/7743` \
`$ git checkout pull/7743`

Update a local copy of the PR: \
`$ git checkout pull/7743` \
`$ git pull https://git.openjdk.java.net/jdk pull/7743/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7743`

View PR using the GUI difftool: \
`$ git pr show -t 7743`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7743.diff">https://git.openjdk.java.net/jdk/pull/7743.diff</a>

</details>
