### PR TITLE
JDK-8282811: Typo in IAE details message of `RecordedObject.getValueDescriptor`

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
@@ -329,7 +329,7 @@ public class RecordedObject {
                 return v;
             }
         }
-        throw new IllegalArgumentException("\"Attempt to get unknown field \"" + name + "\"");
+        throw new IllegalArgumentException("Attempt to get unknown field \"" + name + "\"");
     }
 
     // Gets a value, but checks that type and name is correct first


### PR DESCRIPTION
Remove superfluous `\"` from the beginning of the illegal argument exception's details message.

https://bugs.openjdk.java.net/browse/JDK-8282811