### PR TITLE
8282832: Update file path for HostnameMatcher/cert5.crt in test sun/security/util/Pem/encoding.sh

### DIFF
--- a/test/jdk/sun/security/util/Pem/encoding.sh
+++ b/test/jdk/sun/security/util/Pem/encoding.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/security/util/Pem/encoding.sh
+++ b/test/jdk/sun/security/util/Pem/encoding.sh
@@ -32,4 +32,4 @@
 
 $TESTJAVA/bin/java $TESTVMOPTS -cp $TESTCLASSES \
         -Dfile.encoding=UTF-16 \
-        PemEncoding $TESTSRC/../HostnameMatcher/cert5.crt
+        PemEncoding $TESTSRC/../HostnameChecker/cert5.crt


### PR DESCRIPTION
…ecurity/util/Pem/encoding.sh

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282832](https://bugs.openjdk.java.net/browse/JDK-8282832): Update file path for HostnameMatcher/cert5.crt in test sun/security/util/Pem/encoding.sh


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**) ⚠️ Review applies to b77269d034c1e438171c1d317b75b9262508fefd


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7749/head:pull/7749` \
`$ git checkout pull/7749`

Update a local copy of the PR: \
`$ git checkout pull/7749` \
`$ git pull https://git.openjdk.java.net/jdk pull/7749/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7749`

View PR using the GUI difftool: \
`$ git pr show -t 7749`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7749.diff">https://git.openjdk.java.net/jdk/pull/7749.diff</a>

</details>
