### PR TITLE
8282852: Debug agent asserts in classTrack_addPreparedClass()

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/classTrack.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/classTrack.c
@@ -110,21 +110,28 @@ classTrack_addPreparedClass(JNIEnv *env_unused, jclass klass)
     jvmtiError error;
     jvmtiEnv* env = trackingEnv;
 
-    if (gdata && gdata->assertOn) {
-        // Check this is not already tagged.
-        jlong tag;
-        error = JVMTI_FUNC_PTR(trackingEnv, GetTag)(env, klass, &tag);
-        if (error != JVMTI_ERROR_NONE) {
-            EXIT_ERROR(error, "Unable to GetTag with class trackingEnv");
-        }
-        JDI_ASSERT(tag == NOT_TAGGED);
-    }
-
     char* signature;
     error = classSignature(klass, &signature, NULL);
     if (error != JVMTI_ERROR_NONE) {
         EXIT_ERROR(error,"signature");
     }
+
+    if (gdata && gdata->assertOn) {
+        // Check if already tagged.
+        jlong tag;
+        error = JVMTI_FUNC_PTR(trackingEnv, GetTag)(env, klass, &tag);
+        if (error != JVMTI_ERROR_NONE) {
+            EXIT_ERROR(error, "Unable to GetTag with class trackingEnv");
+        }
+        if (tag != NOT_TAGGED) {
+            // If tagged, the old tag better be the same as the new.
+            char* oldSignature = (char*)tag;
+            JDI_ASSERT(strcmp(signature, oldSignature) == 0);
+            jvmtiDeallocate(signature);
+            return;
+        }
+    }
+
     error = JVMTI_FUNC_PTR(trackingEnv, SetTag)(env, klass, ptr_to_jlong(signature));
     if (error != JVMTI_ERROR_NONE) {
         jvmtiDeallocate(signature);

--- a/src/jdk.jdwp.agent/share/native/libjdwp/classTrack.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/classTrack.c
@@ -125,7 +125,7 @@ classTrack_addPreparedClass(JNIEnv *env_unused, jclass klass)
         }
         if (tag != NOT_TAGGED) {
             // If tagged, the old tag better be the same as the new.
-          char* oldSignature = (char*)jlong_to_ptr(tag);
+            char* oldSignature = (char*)jlong_to_ptr(tag);
             JDI_ASSERT(strcmp(signature, oldSignature) == 0);
             jvmtiDeallocate(signature);
             return;

--- a/src/jdk.jdwp.agent/share/native/libjdwp/classTrack.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/classTrack.c
@@ -125,7 +125,7 @@ classTrack_addPreparedClass(JNIEnv *env_unused, jclass klass)
         }
         if (tag != NOT_TAGGED) {
             // If tagged, the old tag better be the same as the new.
-            char* oldSignature = (char*)tag;
+          char* oldSignature = (char*)jlong_to_ptr(tag);
             JDI_ASSERT(strcmp(signature, oldSignature) == 0);
             jvmtiDeallocate(signature);
             return;


### PR DESCRIPTION
Fix incorrect assert that assumed the debug agent should never see a ClassPrepare event for a class that it already saw when calling GetLoadedClasses. Details can be found in the bug description.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282852](https://bugs.openjdk.java.net/browse/JDK-8282852): Debug agent asserts in classTrack_addPreparedClass()


### Reviewers
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7752/head:pull/7752` \
`$ git checkout pull/7752`

Update a local copy of the PR: \
`$ git checkout pull/7752` \
`$ git pull https://git.openjdk.java.net/jdk pull/7752/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7752`

View PR using the GUI difftool: \
`$ git pr show -t 7752`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7752.diff">https://git.openjdk.java.net/jdk/pull/7752.diff</a>

</details>
