### PR TITLE
8282878: Removed _JavaThread from PhaseTraceTime

### DIFF
--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -77,7 +77,6 @@ static int totalInstructionNodes = 0;
 
 class PhaseTraceTime: public TraceTime {
  private:
-  JavaThread* _thread;
   CompileLog* _log;
   TimerName _timer;
 


### PR DESCRIPTION
The `PhaseTraceTime` class has a private `JavaThread _thread` field which doesn't appear to be referenced anywhere, and builds fine without it. It's not clear if this can be removed but it builds cleanly when not present.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282878](https://bugs.openjdk.java.net/browse/JDK-8282878): Removed _JavaThread from PhaseTraceTime


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7756/head:pull/7756` \
`$ git checkout pull/7756`

Update a local copy of the PR: \
`$ git checkout pull/7756` \
`$ git pull https://git.openjdk.java.net/jdk pull/7756/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7756`

View PR using the GUI difftool: \
`$ git pr show -t 7756`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7756.diff">https://git.openjdk.java.net/jdk/pull/7756.diff</a>

</details>
