### PR TITLE
8282874: Bad performance on gather/scatter API caused by different IntSpecies of indexMap

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -4336,12 +4336,12 @@ public abstract class ByteVector extends AbstractVector<Byte> {
      */
     static ByteSpecies species(VectorShape s) {
         Objects.requireNonNull(s);
-        switch (s) {
-            case S_64_BIT: return (ByteSpecies) SPECIES_64;
-            case S_128_BIT: return (ByteSpecies) SPECIES_128;
-            case S_256_BIT: return (ByteSpecies) SPECIES_256;
-            case S_512_BIT: return (ByteSpecies) SPECIES_512;
-            case S_Max_BIT: return (ByteSpecies) SPECIES_MAX;
+        switch (s.switchKey) {
+            case VectorShape.SK_64_BIT: return (ByteSpecies) SPECIES_64;
+            case VectorShape.SK_128_BIT: return (ByteSpecies) SPECIES_128;
+            case VectorShape.SK_256_BIT: return (ByteSpecies) SPECIES_256;
+            case VectorShape.SK_512_BIT: return (ByteSpecies) SPECIES_512;
+            case VectorShape.SK_Max_BIT: return (ByteSpecies) SPECIES_MAX;
             default: throw new IllegalArgumentException("Bad shape: " + s);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -3963,12 +3963,12 @@ public abstract class DoubleVector extends AbstractVector<Double> {
      */
     static DoubleSpecies species(VectorShape s) {
         Objects.requireNonNull(s);
-        switch (s) {
-            case S_64_BIT: return (DoubleSpecies) SPECIES_64;
-            case S_128_BIT: return (DoubleSpecies) SPECIES_128;
-            case S_256_BIT: return (DoubleSpecies) SPECIES_256;
-            case S_512_BIT: return (DoubleSpecies) SPECIES_512;
-            case S_Max_BIT: return (DoubleSpecies) SPECIES_MAX;
+        switch (s.switchKey) {
+            case VectorShape.SK_64_BIT: return (DoubleSpecies) SPECIES_64;
+            case VectorShape.SK_128_BIT: return (DoubleSpecies) SPECIES_128;
+            case VectorShape.SK_256_BIT: return (DoubleSpecies) SPECIES_256;
+            case VectorShape.SK_512_BIT: return (DoubleSpecies) SPECIES_512;
+            case VectorShape.SK_Max_BIT: return (DoubleSpecies) SPECIES_MAX;
             default: throw new IllegalArgumentException("Bad shape: " + s);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -3913,12 +3913,12 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     static FloatSpecies species(VectorShape s) {
         Objects.requireNonNull(s);
-        switch (s) {
-            case S_64_BIT: return (FloatSpecies) SPECIES_64;
-            case S_128_BIT: return (FloatSpecies) SPECIES_128;
-            case S_256_BIT: return (FloatSpecies) SPECIES_256;
-            case S_512_BIT: return (FloatSpecies) SPECIES_512;
-            case S_Max_BIT: return (FloatSpecies) SPECIES_MAX;
+        switch (s.switchKey) {
+            case VectorShape.SK_64_BIT: return (FloatSpecies) SPECIES_64;
+            case VectorShape.SK_128_BIT: return (FloatSpecies) SPECIES_128;
+            case VectorShape.SK_256_BIT: return (FloatSpecies) SPECIES_256;
+            case VectorShape.SK_512_BIT: return (FloatSpecies) SPECIES_512;
+            case VectorShape.SK_Max_BIT: return (FloatSpecies) SPECIES_MAX;
             default: throw new IllegalArgumentException("Bad shape: " + s);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -4061,12 +4061,12 @@ public abstract class IntVector extends AbstractVector<Integer> {
      */
     static IntSpecies species(VectorShape s) {
         Objects.requireNonNull(s);
-        switch (s) {
-            case S_64_BIT: return (IntSpecies) SPECIES_64;
-            case S_128_BIT: return (IntSpecies) SPECIES_128;
-            case S_256_BIT: return (IntSpecies) SPECIES_256;
-            case S_512_BIT: return (IntSpecies) SPECIES_512;
-            case S_Max_BIT: return (IntSpecies) SPECIES_MAX;
+        switch (s.switchKey) {
+            case VectorShape.SK_64_BIT: return (IntSpecies) SPECIES_64;
+            case VectorShape.SK_128_BIT: return (IntSpecies) SPECIES_128;
+            case VectorShape.SK_256_BIT: return (IntSpecies) SPECIES_256;
+            case VectorShape.SK_512_BIT: return (IntSpecies) SPECIES_512;
+            case VectorShape.SK_Max_BIT: return (IntSpecies) SPECIES_MAX;
             default: throw new IllegalArgumentException("Bad shape: " + s);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -3987,12 +3987,12 @@ public abstract class LongVector extends AbstractVector<Long> {
      */
     static LongSpecies species(VectorShape s) {
         Objects.requireNonNull(s);
-        switch (s) {
-            case S_64_BIT: return (LongSpecies) SPECIES_64;
-            case S_128_BIT: return (LongSpecies) SPECIES_128;
-            case S_256_BIT: return (LongSpecies) SPECIES_256;
-            case S_512_BIT: return (LongSpecies) SPECIES_512;
-            case S_Max_BIT: return (LongSpecies) SPECIES_MAX;
+        switch (s.switchKey) {
+            case VectorShape.SK_64_BIT: return (LongSpecies) SPECIES_64;
+            case VectorShape.SK_128_BIT: return (LongSpecies) SPECIES_128;
+            case VectorShape.SK_256_BIT: return (LongSpecies) SPECIES_256;
+            case VectorShape.SK_512_BIT: return (LongSpecies) SPECIES_512;
+            case VectorShape.SK_Max_BIT: return (LongSpecies) SPECIES_MAX;
             default: throw new IllegalArgumentException("Bad shape: " + s);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -4330,12 +4330,12 @@ public abstract class ShortVector extends AbstractVector<Short> {
      */
     static ShortSpecies species(VectorShape s) {
         Objects.requireNonNull(s);
-        switch (s) {
-            case S_64_BIT: return (ShortSpecies) SPECIES_64;
-            case S_128_BIT: return (ShortSpecies) SPECIES_128;
-            case S_256_BIT: return (ShortSpecies) SPECIES_256;
-            case S_512_BIT: return (ShortSpecies) SPECIES_512;
-            case S_Max_BIT: return (ShortSpecies) SPECIES_MAX;
+        switch (s.switchKey) {
+            case VectorShape.SK_64_BIT: return (ShortSpecies) SPECIES_64;
+            case VectorShape.SK_128_BIT: return (ShortSpecies) SPECIES_128;
+            case VectorShape.SK_256_BIT: return (ShortSpecies) SPECIES_256;
+            case VectorShape.SK_512_BIT: return (ShortSpecies) SPECIES_512;
+            case VectorShape.SK_Max_BIT: return (ShortSpecies) SPECIES_MAX;
             default: throw new IllegalArgumentException("Bad shape: " + s);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -5543,12 +5543,12 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      */
     static $Type$Species species(VectorShape s) {
         Objects.requireNonNull(s);
-        switch (s) {
-            case S_64_BIT: return ($Type$Species) SPECIES_64;
-            case S_128_BIT: return ($Type$Species) SPECIES_128;
-            case S_256_BIT: return ($Type$Species) SPECIES_256;
-            case S_512_BIT: return ($Type$Species) SPECIES_512;
-            case S_Max_BIT: return ($Type$Species) SPECIES_MAX;
+        switch (s.switchKey) {
+            case VectorShape.SK_64_BIT: return ($Type$Species) SPECIES_64;
+            case VectorShape.SK_128_BIT: return ($Type$Species) SPECIES_128;
+            case VectorShape.SK_256_BIT: return ($Type$Species) SPECIES_256;
+            case VectorShape.SK_512_BIT: return ($Type$Species) SPECIES_512;
+            case VectorShape.SK_Max_BIT: return ($Type$Species) SPECIES_MAX;
             default: throw new IllegalArgumentException("Bad shape: " + s);
         }
     }


### PR DESCRIPTION
I came across a performance issue when using scatter store VectorAPI for Integer and Long in the same application. The poor performance was caused by vector intrinsic inlining failure because of non-determined IntSpecies for a constant VectorShape of IndexMap in this scenario.
As discussion at https://github.com/openjdk/jdk/pull/7721 , I change the code in VectorAPI.
Please help review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282874](https://bugs.openjdk.java.net/browse/JDK-8282874): Bad performance on gather/scatter API caused by different IntSpecies of indexMap


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7757/head:pull/7757` \
`$ git checkout pull/7757`

Update a local copy of the PR: \
`$ git checkout pull/7757` \
`$ git pull https://git.openjdk.java.net/jdk pull/7757/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7757`

View PR using the GUI difftool: \
`$ git pr show -t 7757`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7757.diff">https://git.openjdk.java.net/jdk/pull/7757.diff</a>

</details>
