### PR TITLE
8282293: Domain value for system property jdk.https.negotiate.cbt should be case-insensitive

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/https/AbstractDelegateHttpsURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/https/AbstractDelegateHttpsURLConnection.java
@@ -335,9 +335,8 @@ public abstract class AbstractDelegateHttpsURLConnection extends
                 if (target.equalsIgnoreCase(domain)) {
                     return true;
                 }
-                String afterWildCard = domain.substring(1);
                 if (domain.startsWith("*.") && target.regionMatches(
-                        true, target.length() - afterWildCard.length(), afterWildCard, 0, afterWildCard.length())) {
+                        true, target.length() - domain.length() + 1, domain, 1, domain.length() - 1)) {
                     return true;
                 }
             }

--- a/src/java.base/share/classes/sun/net/www/protocol/https/AbstractDelegateHttpsURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/https/AbstractDelegateHttpsURLConnection.java
@@ -332,10 +332,12 @@ public abstract class AbstractDelegateHttpsURLConnection extends
         if (prop.startsWith("domain:")) {
             String[] domains = prop.substring(7).split(",");
             for (String domain : domains) {
-                if (target.equals(domain)) {
+                if (target.equalsIgnoreCase(domain)) {
                     return true;
                 }
-                if (domain.startsWith("*.") && target.endsWith(domain.substring(1))) {
+                String afterWildCard = domain.substring(1);
+                if (domain.startsWith("*.") && target.regionMatches(
+                        true, target.length() - afterWildCard.length(), afterWildCard, 0, afterWildCard.length())) {
                     return true;
                 }
             }

--- a/test/jdk/sun/security/krb5/auto/HttpsCB.java
+++ b/test/jdk/sun/security/krb5/auto/HttpsCB.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8279842
+ * @bug 8279842 8282293
  * @modules java.base/sun.security.util
  *          java.security.jgss/sun.security.jgss
  *          java.security.jgss/sun.security.jgss.krb5
@@ -52,7 +52,11 @@
  * @run main/othervm -Djdk.net.hosts.file=TestHosts
  *          -Djdk.https.negotiate.cbt=domain:host.web.domain HttpsCB true true
  * @run main/othervm -Djdk.net.hosts.file=TestHosts
+ *          -Djdk.https.negotiate.cbt=domain:HOST.WEB.DOMAIN HttpsCB true true
+ * @run main/othervm -Djdk.net.hosts.file=TestHosts
  *          -Djdk.https.negotiate.cbt=domain:*.web.domain HttpsCB true true
+ * @run main/othervm -Djdk.net.hosts.file=TestHosts
+ *          -Djdk.https.negotiate.cbt=domain:*.WEB.Domain HttpsCB true true
  */
 
 import com.sun.net.httpserver.Headers;
@@ -198,6 +202,7 @@ public class HttpsCB {
                     conn.getInputStream()));
             return reader.readLine().equals(CONTENT);
         } catch (IOException e) {
+            e.printStackTrace(System.out);
             return false;
         }
     }

--- a/test/jdk/sun/security/krb5/auto/HttpsCB.java
+++ b/test/jdk/sun/security/krb5/auto/HttpsCB.java
@@ -57,6 +57,8 @@
  *          -Djdk.https.negotiate.cbt=domain:*.web.domain HttpsCB true true
  * @run main/othervm -Djdk.net.hosts.file=TestHosts
  *          -Djdk.https.negotiate.cbt=domain:*.WEB.Domain HttpsCB true true
+ * @run main/othervm -Djdk.net.hosts.file=TestHosts
+ *          -Djdk.https.negotiate.cbt=domain:*.Invalid,*.WEB.Domain HttpsCB true true
  */
 
 import com.sun.net.httpserver.Headers;


### PR DESCRIPTION
Domain value for system property jdk.https.negotiate.cbt  is case-insensitive now. Included Test has been updated to address the change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282293](https://bugs.openjdk.java.net/browse/JDK-8282293): Domain value for system property jdk.https.negotiate.cbt should be case-insensitive


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)
 * [Rajan Halade](https://openjdk.java.net/census#rhalade) (@rhalade - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7759/head:pull/7759` \
`$ git checkout pull/7759`

Update a local copy of the PR: \
`$ git checkout pull/7759` \
`$ git pull https://git.openjdk.java.net/jdk pull/7759/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7759`

View PR using the GUI difftool: \
`$ git pr show -t 7759`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7759.diff">https://git.openjdk.java.net/jdk/pull/7759.diff</a>

</details>
