### PR TITLE
8282881: Print exception message in VM crash with -XX:AbortVMOnException

### DIFF
--- a/src/hotspot/share/utilities/exceptions.cpp
+++ b/src/hotspot/share/utilities/exceptions.cpp
@@ -538,7 +538,11 @@ void Exceptions::debug_check_abort(const char *value_string, const char* message
       strstr(value_string, AbortVMOnException)) {
     if (AbortVMOnExceptionMessage == NULL || (message != NULL &&
         strstr(message, AbortVMOnExceptionMessage))) {
-      fatal("Saw %s, aborting", value_string);
+      if (message == NULL) {
+        fatal("Saw %s, aborting", value_string);
+      } else {
+        fatal("Saw %s: %s, aborting", value_string, message);
+      }
     }
   }
 }


### PR DESCRIPTION
In `Exceptions::debug_check_abort`, we crash the VM if the exception matches with `-XX:AbortVMOnException`. For example `-XX:AbortVMOnException=java.lang.RuntimeEx`.

Currently, in the VM crash description, we only print the exception name (`value_string`), and not its message (`message`). For completeness and consistency, we should also print the exception message.

I tested it with these two exceptions, the first results in `message` being `NULL`:
`throw new RuntimeException();`
`throw new RuntimeException("some message");`

Running tests to make sure nothing else broke.