### PR TITLE
8282314: nsk/jvmti/SuspendThread/suspendthrd003 may leak memory

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThread/suspendthrd003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThread/suspendthrd003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,6 +88,9 @@ public class suspendthrd003 extends DebugeeClass {
         int res = -1;
         long start_time = System.currentTimeMillis();
         while (System.currentTimeMillis() < start_time + (timeMax * 1000)) {
+            // Start each loop with a clear log buffer so we only
+            // track the run that can potentially fail:
+            log.clearLogBuffer();
             count++;
 
             // Original suspendthrd001 test block starts here:

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -476,6 +476,13 @@ public class Log extends FinalizableObject {
     }
 
     /////////////////////////////////////////////////////////////////
+
+    /**
+     * Clear all messages from log buffer.
+     */
+    public synchronized void clearLogBuffer() {
+        logBuffer.clear();
+    }
 
     /**
      * Print all messages from log buffer which were hidden because


### PR DESCRIPTION
A trivial fix to solve a memory leak/memory pinning for long runs of suspendthrd003.

See the bug report for the gory analysis details.

This fix was included in my jdk-19+12 stress runs so the updated test was executed
in the  NSK JVM/TI testsuite for 3 runs in {fastdebug,release,slowdebug} configs. The
test was also executed in parallel for 3 runs with my StressWrapper_StopAtExit config
for 101 minutes in {fastdebug,release,slowdebug} configs. Lastly, the updated test was
tested with Mach5 Tier[1567] with no failures on any platform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282314](https://bugs.openjdk.java.net/browse/JDK-8282314): nsk/jvmti/SuspendThread/suspendthrd003 may leak memory


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Mikhailo Seledtsov](https://openjdk.java.net/census#mseledtsov) (@mseledts - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7764/head:pull/7764` \
`$ git checkout pull/7764`

Update a local copy of the PR: \
`$ git checkout pull/7764` \
`$ git pull https://git.openjdk.java.net/jdk pull/7764/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7764`

View PR using the GUI difftool: \
`$ git pr show -t 7764`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7764.diff">https://git.openjdk.java.net/jdk/pull/7764.diff</a>

</details>
