### PR TITLE
8058924: FileReader(String) documentation is insufficient

### DIFF
--- a/src/java.base/share/classes/java/io/package-info.java
+++ b/src/java.base/share/classes/java/io/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,9 +27,13 @@
  * Provides for system input and output through data streams,
  * serialization and the file system.
  *
- * Unless otherwise noted, passing a null argument to a constructor or
+ * Unless otherwise noted, passing a {@code null} argument to a constructor or
  * method in any class or interface in this package will cause a
  * {@code NullPointerException} to be thrown.
+ *
+ * A <i>pathname string</i> passed as a {@code String} argument to a
+ * constructor or method in any class or interface in this package will be
+ * interpreted as described in the class specification of {@link File}.
  *
  * <h2>Object Serialization</h2>
  * <p><strong>Warning: Deserialization of untrusted data is inherently dangerous


### PR DESCRIPTION
Add a statement to the `java.io` package documentation clarifying how a `String` representing a _pathname string_ is interpreted in the package.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8058924](https://bugs.openjdk.java.net/browse/JDK-8058924): FileReader(String) documentation is insufficient
 * [JDK-8282992](https://bugs.openjdk.java.net/browse/JDK-8282992): FileReader(String) documentation is insufficient (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7767/head:pull/7767` \
`$ git checkout pull/7767`

Update a local copy of the PR: \
`$ git checkout pull/7767` \
`$ git pull https://git.openjdk.java.net/jdk pull/7767/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7767`

View PR using the GUI difftool: \
`$ git pr show -t 7767`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7767.diff">https://git.openjdk.java.net/jdk/pull/7767.diff</a>

</details>
