### PR TITLE
8282932: a space is needed for the unsupported protocol exception message in ProtocolVersion

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/ProtocolVersion.java
+++ b/src/java.base/share/classes/sun/security/ssl/ProtocolVersion.java
@@ -290,7 +290,7 @@ enum ProtocolVersion {
             ProtocolVersion pv = ProtocolVersion.nameOf(pn);
             if (pv == null) {
                 throw new IllegalArgumentException(
-                        "Unsupported protocol " + pn);
+                        "Unsupported protocol: " + pn);
             }
 
             pvs.add(pv);

--- a/src/java.base/share/classes/sun/security/ssl/ProtocolVersion.java
+++ b/src/java.base/share/classes/sun/security/ssl/ProtocolVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -290,7 +290,7 @@ enum ProtocolVersion {
             ProtocolVersion pv = ProtocolVersion.nameOf(pn);
             if (pv == null) {
                 throw new IllegalArgumentException(
-                        "Unsupported protocol" + pn);
+                        "Unsupported protocol " + pn);
             }
 
             pvs.add(pv);


### PR DESCRIPTION
In class sun.security.ssl.ProtocolVersion, the exception message for unsupported protocol needs a space.
```
ProtocolVersion pv = ProtocolVersion.nameOf(pn);
if (pv == null) {
    throw new IllegalArgumentException(
           "Unsupported protocol" + pn);
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282932](https://bugs.openjdk.java.net/browse/JDK-8282932): a space is needed for the unsupported protocol exception message in ProtocolVersion


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**) ⚠️ Review applies to 51943b99583db635bb8887022f4b601d59125db3
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7769/head:pull/7769` \
`$ git checkout pull/7769`

Update a local copy of the PR: \
`$ git checkout pull/7769` \
`$ git pull https://git.openjdk.java.net/jdk pull/7769/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7769`

View PR using the GUI difftool: \
`$ git pr show -t 7769`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7769.diff">https://git.openjdk.java.net/jdk/pull/7769.diff</a>

</details>
