### PR TITLE
8272493: Suboptimal code generation around Preconditions.checkIndex intrinsic with AVX2

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -1092,7 +1092,6 @@ bool LibraryCallKit::inline_preconditions_checkIndex(BasicType bt) {
   result = _gvn.transform(result);
   set_result(result);
   replace_in_map(index, result);
-  clear_upper_avx();
   return true;
 }
 


### PR DESCRIPTION
8272493 reports a minor regression when using Preconditions.checkIndex in String.checkIndex. The reason is some unnecessary vzeroupper instructions were emitted. The vzerouppers are introduced in [JDK-8190934](https://bugs.openjdk.java.net/browse/JDK-8190934), which are emitted by clear_upper_avx within inline_preconditions_checkIndex. I did some digging into the history of this code. Please correct me if I misunderstand something

[JDK-8178811](https://bugs.openjdk.java.net/browse/JDK-8178811) emits vzeroupper on every MachEpilogueNode to avoid AVX <-> SSE transition penalty during the call.

[JDK-8190934](https://bugs.openjdk.java.net/browse/JDK-8190934) emits vzeroupper on some MachEpilogueNode by setting clear_upper_avx flag, because vzeroupper itself is a high-cost instruction, we don't want to emit it everywhere a function is finished.

[JDK-8272493](https://bugs.openjdk.java.net/browse/JDK-8272493) emits vzeroupper because inline_preconditions_checkIndex sets clear_upper_avx flag.

Micro benchmark are as follows
```
-------Preconditions.checkIndex without clear_upper_avx
Benchmark Mode Cnt Score Error Units
StringBuilders.charAtLatin1 avgt 15 6.257 ± 0.011 ns/op

Benchmark Mode Cnt Score Error Units
StringBuilders.charAtLatin1 avgt 15 6.251 ± 0.008 ns/op

Benchmark Mode Cnt Score Error Units
StringBuilders.charAtLatin1 avgt 15 6.254 ± 0.003 ns/op

-------Preconditions.checkIndex with clear_upper_avx(Current Implementation)
Benchmark Mode Cnt Score Error Units
StringBuilders.charAtLatin1 avgt 15 6.421 ± 0.003 ns/op

Benchmark Mode Cnt Score Error Units
StringBuilders.charAtLatin1 avgt 15 6.419 ± 0.002 ns/op

Benchmark Mode Cnt Score Error Units
StringBuilders.charAtLatin1 avgt 15 6.433 ± 0.044 ns/op

------- -XX:DisableIntrinsic=_Preconditions_checkIndex
Benchmark Mode Cnt Score Error Units
StringBuilders.charAtLatin1 avgt 15 6.229 ± 0.018 ns/op

Benchmark Mode Cnt Score Error Units
StringBuilders.charAtLatin1 avgt 15 6.224 ± 0.006 ns/op

Benchmark Mode Cnt Score Error Units
StringBuilders.charAtLatin1 avgt 15 6.218 ± 0.011 ns/op

------- -XX:UseAVX=1
Benchmark Mode Cnt Score Error Units
StringBuilders.charAtLatin1 avgt 15 6.247 ± 0.022 ns/op

Benchmark Mode Cnt Score Error Units
StringBuilders.charAtLatin1 avgt 15 6.234 ± 0.018 ns/op

Benchmark Mode Cnt Score Error Units
StringBuilders.charAtLatin1 avgt 15 6.261 ± 0.042 ns/op
```
As I understand, inline_Preconditions_checkIndex only do some simple range check, there is no xmm(sse)/ymm(avx) 
 registers involved, so I propose to remove clear_upper_avx flag to avoid emitting vzeroupper for this intrinsic.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272493](https://bugs.openjdk.java.net/browse/JDK-8272493): Suboptimal code generation around Preconditions.checkIndex intrinsic with AVX2


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7770/head:pull/7770` \
`$ git checkout pull/7770`

Update a local copy of the PR: \
`$ git checkout pull/7770` \
`$ git pull https://git.openjdk.java.net/jdk pull/7770/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7770`

View PR using the GUI difftool: \
`$ git pr show -t 7770`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7770.diff">https://git.openjdk.java.net/jdk/pull/7770.diff</a>

</details>
