### PR TITLE
8282948: JDK-8274980 missed correct handling of MACOSX_BUNDLE_BUILD_VERSION

### DIFF
--- a/make/autoconf/jdk-version.m4
+++ b/make/autoconf/jdk-version.m4
@@ -549,7 +549,12 @@ AC_DEFUN_ONCE([JDKVER_SETUP_JDK_VERSION_NUMBERS],
   elif test "x$with_macosx_bundle_build_version" != x; then
     MACOSX_BUNDLE_BUILD_VERSION="$with_macosx_bundle_build_version"
   else
-    MACOSX_BUNDLE_BUILD_VERSION="$VERSION_BUILD"
+    if test "x$VERSION_BUILD" != x; then
+      MACOSX_BUNDLE_BUILD_VERSION="$VERSION_BUILD"
+    else
+      MACOSX_BUNDLE_BUILD_VERSION=0
+    fi
+
     # If VERSION_OPT consists of only numbers and periods, add it.
     if [ [[ $VERSION_OPT =~ ^[0-9\.]+$ ]] ]; then
       MACOSX_BUNDLE_BUILD_VERSION="$MACOSX_BUNDLE_BUILD_VERSION.$VERSION_OPT"


### PR DESCRIPTION
If VERSION_BUILD is empty, we must still store a "0" in MACOSX_BUNDLE_BUILD_VERSION.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282948](https://bugs.openjdk.java.net/browse/JDK-8282948): JDK-8274980 missed correct handling of MACOSX_BUNDLE_BUILD_VERSION


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7773/head:pull/7773` \
`$ git checkout pull/7773`

Update a local copy of the PR: \
`$ git checkout pull/7773` \
`$ git pull https://git.openjdk.java.net/jdk pull/7773/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7773`

View PR using the GUI difftool: \
`$ git pr show -t 7773`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7773.diff">https://git.openjdk.java.net/jdk/pull/7773.diff</a>

</details>
