### PR TITLE
8254786: java/net/httpclient/CancelRequestTest.java failing intermittently

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -878,6 +878,10 @@ class Http2Connection  {
 
             default -> protocolError(ErrorFrame.PROTOCOL_ERROR);
         }
+    }
+
+    boolean isOpen() {
+        return !closed && connection.channel().isOpen();
     }
 
     void resetStream(int streamid, int code) {

--- a/test/jdk/java/net/httpclient/CancelRequestTest.java
+++ b/test/jdk/java/net/httpclient/CancelRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/httpclient/CancelRequestTest.java
+++ b/test/jdk/java/net/httpclient/CancelRequestTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8245462 8229822
+ * @bug 8245462 8229822 8254786
  * @summary Tests cancelling the request.
  * @library /test/lib http2/server
  * @key randomness


### PR DESCRIPTION
Please find enclosed a patch that solves an intermittent issue detected by the CancelRequestTest.java

If during an HTTP upgrade from HTTP/1.1 to HTTP/2, the request is cancelled after the Http2Connection has been created, and the handshake has proceeded, and the response headers to the upgrade have been received, but before the HTTP/2 connection is offered to the HTTP/2 connection pool, the underlying TCP connection might get closed at a time where it won't be noticed immediately, resulting in putting a "dead" HTTP/2 connection in the pool. The next request to the same server will then fail with "ClosedChannelException".

The fix is to check the state of the underlying TCP connection before offering the HTTP/2 connection to the pool, and when retrieving it from the pool, and disabling the "connectionAborter" (which is there to abort the connection in case of connect timeout, or cancellation before connect is done) before offering the connection to the pool as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254786](https://bugs.openjdk.java.net/browse/JDK-8254786): java/net/httpclient/CancelRequestTest.java failing intermittently


### Reviewers
 * [Jaikiran Pai](https://openjdk.java.net/census#jpai) (@jaikiran - Committer)
 * [Michael McMahon](https://openjdk.java.net/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7776/head:pull/7776` \
`$ git checkout pull/7776`

Update a local copy of the PR: \
`$ git checkout pull/7776` \
`$ git pull https://git.openjdk.java.net/jdk pull/7776/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7776`

View PR using the GUI difftool: \
`$ git pr show -t 7776`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7776.diff">https://git.openjdk.java.net/jdk/pull/7776.diff</a>

</details>
