### PR TITLE
8283049: Fix non-singleton LoggerFinder error message: s/on/one

### DIFF
--- a/src/java.base/share/classes/jdk/internal/logger/LoggerFinderLoader.java
+++ b/src/java.base/share/classes/jdk/internal/logger/LoggerFinderLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -129,7 +129,7 @@ public final class LoggerFinderLoader {
                 result = iterator.next();
                 if (iterator.hasNext() && ensureSingletonProvider()) {
                     throw new ServiceConfigurationError(
-                            "More than on LoggerFinder implementation");
+                            "More than one LoggerFinder implementation");
                 }
             } else {
                 result = loadDefaultImplementation();

--- a/test/jdk/java/lang/System/LoggerFinder/internal/LoggerFinderLoaderTest/LoggerFinderLoaderTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/internal/LoggerFinderLoaderTest/LoggerFinderLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -230,7 +230,7 @@ public class LoggerFinderLoaderTest {
                             throw new RuntimeException("Expected message not found. Error stream contained: " + warning);
                         }
                     } else if (singleton) {
-                        if (!warning.contains("java.util.ServiceConfigurationError: More than on LoggerFinder implementation")) {
+                        if (!warning.contains("java.util.ServiceConfigurationError: More than one LoggerFinder implementation")) {
                             throw new RuntimeException("Expected message not found. Error stream contained: " + warning);
                         }
                     }

--- a/test/jdk/java/lang/System/LoggerFinder/internal/LoggerFinderLoaderTest/LoggerFinderLoaderTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/internal/LoggerFinderLoaderTest/LoggerFinderLoaderTest.java
@@ -53,7 +53,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @test
- * @bug     8140364 8189291
+ * @bug     8140364 8189291 8283049
  * @summary JDK implementation specific unit test for LoggerFinderLoader.
  *          Tests the behavior of LoggerFinderLoader with respect to the
  *          value of the internal diagnosability switches. Also test the


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283049](https://bugs.openjdk.java.net/browse/JDK-8283049): Fix non-singleton LoggerFinder error message: s/on/one


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7780/head:pull/7780` \
`$ git checkout pull/7780`

Update a local copy of the PR: \
`$ git checkout pull/7780` \
`$ git pull https://git.openjdk.java.net/jdk pull/7780/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7780`

View PR using the GUI difftool: \
`$ git pr show -t 7780`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7780.diff">https://git.openjdk.java.net/jdk/pull/7780.diff</a>

</details>
