### PR TITLE
8279317: compiler/jvmci/compilerToVM/DisassembleCodeBlobTest.java assumes immutable code

### DIFF
--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/DisassembleCodeBlobTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/DisassembleCodeBlobTest.java
@@ -117,9 +117,9 @@ public class DisassembleCodeBlobTest {
         int foundEntryPointLine = -1;
         for (; l < strLines.length; ++l) {
             String line = strLines[l];
-            if (line.equals("[Disassembly]")) {
+            if (line.equals("[Disassembly]") || line.equals("[MachCode]")) {
                 Asserts.assertTrue(foundDisassemblyLine == -1,
-                    testCase + " : [Disassembly] found at lines " + foundDisassemblyLine + " and " + l);
+                    testCase + " : Duplicate disassembly section markers found at lines " + foundDisassemblyLine + " and " + l);
                 foundDisassemblyLine = l;
             }
             if (line.equals("[Entry Point]") || line.equals("[Verified Entry Point]")) {
@@ -129,7 +129,7 @@ public class DisassembleCodeBlobTest {
                 break;
             }
         }
-        Asserts.assertTrue(foundDisassemblyLine != -1, testCase + " : Disassembly section found");
+        Asserts.assertTrue(foundDisassemblyLine != -1, testCase + " : no disassembly section found");
         Asserts.assertTrue(foundEntryPointLine != -1, testCase + " : no entry point found");
     }
 }

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/DisassembleCodeBlobTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/DisassembleCodeBlobTest.java
@@ -105,7 +105,7 @@ public class DisassembleCodeBlobTest {
         // architecture: [Disassembling for mach='i386:x86-64']
         // so discard it and try again.
         String str2 = CompilerToVMHelper.disassembleCodeBlob(installedCode);
-        String[] strLines = str2.split(System.lineSeparator());
+        String[] strLines = str2.split("\\R");
         // Check some basic layout
         int MIN_LINES = 5;
         Asserts.assertTrue(strLines.length > 2,

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/DisassembleCodeBlobTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/DisassembleCodeBlobTest.java
@@ -83,6 +83,11 @@ public class DisassembleCodeBlobTest {
                 + " : non-null return value for invalid installCode");
     }
 
+    private void checkLineStart(CompileCodeTestCase testCase, String line, String match) {
+        Asserts.assertTrue(line.startsWith(match),
+                testCase + " : line \"" + line + "\" does not start with: \"" + match +"\"");
+    }
+
     private void check(CompileCodeTestCase testCase) {
         System.out.println(testCase);
         // to have a clean state
@@ -98,19 +103,33 @@ public class DisassembleCodeBlobTest {
         }
         // The very first call to the disassembler contains a string specifying the
         // architecture: [Disassembling for mach='i386:x86-64']
-        // Therefore compare strings 2 and 3.
+        // so discard it and try again.
         String str2 = CompilerToVMHelper.disassembleCodeBlob(installedCode);
-        String str3 = CompilerToVMHelper.disassembleCodeBlob(installedCode);
-        String[] str2Lines = str2.split(System.lineSeparator());
-        String[] str3Lines = str3.split(System.lineSeparator());
-        // skip the first two lines since it contains a timestamp that may vary from different invocations
-        // <empty-line>
-        // Compiled method (c2)     309  463       4       compiler.jvmci.compilerToVM.CompileCodeTestCase$Dummy::staticMethod (1 bytes)
-        // <empty-line>
-        // Compiled method (c2)     310  463       4       compiler.jvmci.compilerToVM.CompileCodeTestCase$Dummy::staticMethod (1 bytes)
-        for (int i = 2; i < str2Lines.length; i++) {
-            Asserts.assertEQ(str2Lines[i], str3Lines[i],
-                testCase + " : 3nd invocation returned different value from 2nd");
+        String[] strLines = str2.split(System.lineSeparator());
+        // Check some basic layout
+        int MIN_LINES = 5;
+        Asserts.assertTrue(strLines.length > 2,
+            testCase + " : read " + strLines.length + " lines, " + MIN_LINES + " expected");
+        int l = 1;
+        checkLineStart(testCase, strLines[l++], "Compiled method "); // 2
+        checkLineStart(testCase, strLines[l++], " total in heap  "); // 3
+        int foundDisassemblyLine = -1;
+        int foundEntryPointLine = -1;
+        for (; l < strLines.length; ++l) {
+            String line = strLines[l];
+            if (line.equals("[Disassembly]")) {
+                Asserts.assertTrue(foundDisassemblyLine == -1,
+                    testCase + " : [Disassembly] found at lines " + foundDisassemblyLine + " and " + l);
+                foundDisassemblyLine = l;
+            }
+            if (line.equals("[Entry Point]") || line.equals("[Verified Entry Point]")) {
+                Asserts.assertTrue(foundDisassemblyLine != -1,
+                    testCase + " : entry point found but [Disassembly] section missing ");
+                foundEntryPointLine = l;
+                break;
+            }
         }
+        Asserts.assertTrue(foundDisassemblyLine != -1, testCase + " : Disassembly section found");
+        Asserts.assertTrue(foundEntryPointLine != -1, testCase + " : no entry point found");
     }
 }


### PR DESCRIPTION
This test was failing in loom because of nmethod entry barriers, but there are other reasons why it shouldn't assume immutable code, such as embedded oops and NativeJump::patch_verified_entry().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279317](https://bugs.openjdk.java.net/browse/JDK-8279317): compiler/jvmci/compilerToVM/DisassembleCodeBlobTest.java assumes immutable code


### Reviewers
 * [Doug Simon](https://openjdk.java.net/census#dnsimon) (@dougxc - Committer) ⚠️ Review applies to b62af58b6e0c53108f9a357cf06a644cb420a95d
 * [Igor Veresov](https://openjdk.java.net/census#iveresov) (@veresov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7781/head:pull/7781` \
`$ git checkout pull/7781`

Update a local copy of the PR: \
`$ git checkout pull/7781` \
`$ git pull https://git.openjdk.java.net/jdk pull/7781/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7781`

View PR using the GUI difftool: \
`$ git pr show -t 7781`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7781.diff">https://git.openjdk.java.net/jdk/pull/7781.diff</a>

</details>
