### PR TITLE
JDK-8282933: Create a test for JDK-4529616

### DIFF
--- a/test/jdk/javax/accessibility/4529616/AccessibleJTableCellTest.java
+++ b/test/jdk/javax/accessibility/4529616/AccessibleJTableCellTest.java
@@ -62,7 +62,7 @@ public class AccessibleJTableCellTest {
                 }
             }
         } finally {
-            jFrame.dispose();
+            SwingUtilities.invokeAndWait(() -> jFrame.dispose());
         }
     }
 

--- a/test/jdk/javax/accessibility/4529616/AccessibleJTableCellTest.java
+++ b/test/jdk/javax/accessibility/4529616/AccessibleJTableCellTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,13 @@
  * @test
  * @key headful
  * @bug 4529616
- * @summary AccessibleJTableCell.isShowing() returns false when the cell on the screen
+ * @summary AccessibleJTableCell.isShowing() returns false 
+ * when the cell is actually on the screen.
  * @run main AccessibleJTableCellTest
  */
 
 import java.awt.Robot;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.swing.JFrame;
 import javax.swing.JTable;
@@ -39,25 +41,24 @@ public class AccessibleJTableCellTest {
     private static JTable jTable;
     private static JFrame jFrame;
 
-    private static Object[][] rowData = {
-        { "01", "02", "03", "04", "05" },
-        { "11", "12", "13", "14", "15" },
-        { "21", "22", "23", "24", "25" },
-        { "31", "32", "33", "34", "35" },
-        { "41", "42", "43", "44", "45" } };
+    private static Object[][] rowData = { { "01", "02", "03", "04", "05" },
+        { "11", "12", "13", "14", "15" }, { "21", "22", "23", "24", "25" },
+        { "31", "32", "33", "34", "35" }, { "41", "42", "43", "44", "45" } };
 
     private static Object[] colNames = { "1", "2", "3", "4", "5" };
 
     private static void doTest() throws Exception {
         try {
             SwingUtilities.invokeAndWait(() -> createGUI());
+
             Robot robot = new Robot();
             robot.setAutoDelay(500);
             robot.waitForIdle();
+
             for (int i = 0; i <= colNames.length - 1; i++) {
-                if (!jTable.getAccessibleContext().getAccessibleChild(i).getAccessibleContext()
-                    .getAccessibleComponent().isShowing()) {
-                    throw new RuntimeException("Assertion Failed: JTable accessible child " + i
+                if (!isJTableCellShowing(i)) {
+                    throw new RuntimeException(
+                        "Assertion Failed: JTable accessible child " + i
                         + " isShowing returns false");
                 }
             }
@@ -66,11 +67,21 @@ public class AccessibleJTableCellTest {
         }
     }
 
+    private static boolean isJTableCellShowing(int i) throws Exception {
+        AtomicBoolean isShowing = new AtomicBoolean();
+        SwingUtilities.invokeAndWait(() -> isShowing
+            .set(jTable.getAccessibleContext().getAccessibleChild(i)
+                .getAccessibleContext().getAccessibleComponent().isShowing()));
+        
+        return isShowing.get();
+    }
+
     private static void createGUI() {
         jTable = new JTable(rowData, colNames);
         jFrame = new JFrame();
         jFrame.setBounds(100, 100, 300, 300);
         jFrame.getContentPane().add(jTable);
+        jFrame.setLocationRelativeTo(null);
         jFrame.setVisible(true);
     }
 
@@ -79,4 +90,3 @@ public class AccessibleJTableCellTest {
         System.out.println("Test Passed");
     }
 }
-

--- a/test/jdk/javax/accessibility/4529616/AccessibleJTableCellTest.java
+++ b/test/jdk/javax/accessibility/4529616/AccessibleJTableCellTest.java
@@ -25,7 +25,7 @@
  * @test
  * @key headful
  * @bug 4529616
- * @summary AccessibleJTableCell.isShowing() returns false 
+ * @summary AccessibleJTableCell.isShowing() returns false
  * when the cell is actually on the screen.
  * @run main AccessibleJTableCellTest
  */
@@ -72,7 +72,7 @@ public class AccessibleJTableCellTest {
         SwingUtilities.invokeAndWait(() -> isShowing
             .set(jTable.getAccessibleContext().getAccessibleChild(i)
                 .getAccessibleContext().getAccessibleComponent().isShowing()));
-        
+
         return isShowing.get();
     }
 

--- a/test/jdk/javax/accessibility/4529616/AccessibleJTableCellTest.java
+++ b/test/jdk/javax/accessibility/4529616/AccessibleJTableCellTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key headful
+ * @bug 4529616
+ * @summary AccessibleJTableCell.isShowing() returns false when the cell on the screen
+ * @run main AccessibleJTableCellTest
+ */
+
+import java.awt.Robot;
+
+import javax.swing.JFrame;
+import javax.swing.JTable;
+import javax.swing.SwingUtilities;
+
+public class AccessibleJTableCellTest {
+    private static JTable jTable;
+    private static JFrame jFrame;
+
+    private static Object[][] rowData = { 
+        { "01", "02", "03", "04", "05" },
+        { "11", "12", "13", "14", "15" },
+        { "21", "22", "23", "24", "25" },
+        { "31", "32", "33", "34", "35" },
+        { "41", "42", "43", "44", "45" } };
+
+    private static Object[] colNames = { "1", "2", "3", "4", "5" };
+
+    private static void doTest() throws Exception {
+        try {
+            SwingUtilities.invokeAndWait(() -> createGUI());
+            Robot robot = new Robot();
+            robot.setAutoDelay(500);
+            robot.waitForIdle();
+            for (int i = 0; i <= colNames.length - 1; i++) {
+                if (!jTable.getAccessibleContext().getAccessibleChild(i).getAccessibleContext()
+                    .getAccessibleComponent().isShowing()) {
+                    throw new RuntimeException("Assertion Failed: JTable accessible child " + i
+                        + " isShowing returns false");
+                }
+            }
+        } finally {
+            jFrame.dispose();
+        }
+    }
+
+    private static void createGUI() {
+        jTable = new JTable(rowData, colNames);
+        jFrame = new JFrame();
+        jFrame.setBounds(100, 100, 300, 300);
+        jFrame.getContentPane().add(jTable);
+        jFrame.setVisible(true);
+    }
+
+    public static void main(String args[]) throws Exception {
+        doTest();
+        System.out.println("Test Passed");
+    }
+}
+

--- a/test/jdk/javax/accessibility/4529616/AccessibleJTableCellTest.java
+++ b/test/jdk/javax/accessibility/4529616/AccessibleJTableCellTest.java
@@ -39,7 +39,7 @@ public class AccessibleJTableCellTest {
     private static JTable jTable;
     private static JFrame jFrame;
 
-    private static Object[][] rowData = { 
+    private static Object[][] rowData = {
         { "01", "02", "03", "04", "05" },
         { "11", "12", "13", "14", "15" },
         { "21", "22", "23", "24", "25" },


### PR DESCRIPTION
JDK-8282933: Create a test for JDK-4529616 
AccessibleJTableCell.isShowing() returns false when the cell is actually on
the screen.
The test validates the fix for the above issue by verifying that the isShowing call returns true when invoked via the  accessiblity context.
This review is for migrating tests from a closed test suite to open.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282933](https://bugs.openjdk.java.net/browse/JDK-8282933): Create a test for JDK-4529616


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7783/head:pull/7783` \
`$ git checkout pull/7783`

Update a local copy of the PR: \
`$ git checkout pull/7783` \
`$ git pull https://git.openjdk.java.net/jdk pull/7783/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7783`

View PR using the GUI difftool: \
`$ git pr show -t 7783`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7783.diff">https://git.openjdk.java.net/jdk/pull/7783.diff</a>

</details>
