### PR TITLE
8283008: KRegister documentation out of date

### DIFF
--- a/src/hotspot/cpu/x86/register_x86.hpp
+++ b/src/hotspot/cpu/x86/register_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/register_x86.hpp
+++ b/src/hotspot/cpu/x86/register_x86.hpp
@@ -135,7 +135,7 @@ inline XMMRegister as_XMMRegister(int encoding) {
 }
 
 
-// The implementation of XMM registers for the IA32 architecture
+// The implementation of XMM registers.
 class XMMRegisterImpl: public AbstractRegisterImpl {
  public:
   enum {
@@ -201,11 +201,7 @@ CONSTANT_REGISTER_DECLARATION(XMMRegister, xmm30,    (30));
 CONSTANT_REGISTER_DECLARATION(XMMRegister, xmm31,    (31));
 #endif // AMD64
 
-// Only used by the 32bit stubGenerator. These can't be described by vmreg and hence
-// can't be described in oopMaps and therefore can't be used by the compilers (at least
-// were deopt might wan't to see them).
-
-// Use XMMRegister as shortcut
+// Use KRegister as shortcut
 class KRegisterImpl;
 typedef KRegisterImpl* KRegister;
 
@@ -213,7 +209,7 @@ inline KRegister as_KRegister(int encoding) {
   return (KRegister)(intptr_t)encoding;
 }
 
-// The implementation of XMM registers for the IA32 architecture
+// The implementation of AVX-3 (AVX-512) opmask registers.
 class KRegisterImpl : public AbstractRegisterImpl {
 public:
   enum {


### PR DESCRIPTION
Hi all,

  can I have reviews for this cleanup of `KRegister(Impl)` documentation, currently being a mix of copy&paste from `XMMRegister` and obsolete MMX support.

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283008](https://bugs.openjdk.java.net/browse/JDK-8283008): KRegister documentation out of date


### Reviewers
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to 4ea657d27420b204963daa2acee0415cf830a46a
 * [Sandhya Viswanathan](https://openjdk.java.net/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)
 * [Jatin Bhateja](https://openjdk.java.net/census#jbhateja) (@jatin-bhateja - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7784/head:pull/7784` \
`$ git checkout pull/7784`

Update a local copy of the PR: \
`$ git checkout pull/7784` \
`$ git pull https://git.openjdk.java.net/jdk pull/7784/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7784`

View PR using the GUI difftool: \
`$ git pr show -t 7784`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7784.diff">https://git.openjdk.java.net/jdk/pull/7784.diff</a>

</details>
