### PR TITLE
8282926: AArch64: Optimize out WHILELO with PTRUE

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64_sve.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_sve.ad
@@ -305,12 +305,12 @@ instruct loadV_partial(vReg dst, vmemA mem, pRegGov pgtmp, rFlagsReg cr) %{
   match(Set dst (LoadVector mem));
   effect(TEMP pgtmp, KILL cr);
   ins_cost(6 * SVE_COST);
-  format %{ "sve_whilelo_zr_imm $pgtmp, vector_length\n\t"
+  format %{ "sve_ptrue $pgtmp, vector_length\n\t"
             "sve_ldr $dst, $pgtmp, $mem\t# load vector partial" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ sve_whilelo_zr_imm(as_PRegister($pgtmp$$reg), __ elemType_to_regVariant(bt),
-                          Matcher::vector_length(this));
+    __ sve_ptrue_lanecnt(as_PRegister($pgtmp$$reg), __ elemType_to_regVariant(bt),
+                         Matcher::vector_length(this));
     FloatRegister dst_reg = as_FloatRegister($dst$$reg);
     loadStoreA_predicated(C2_MacroAssembler(&cbuf), false, dst_reg,
                           as_PRegister($pgtmp$$reg), bt, bt, $mem->opcode(),
@@ -325,12 +325,12 @@ instruct storeV_partial(vReg src, vmemA mem, pRegGov pgtmp, rFlagsReg cr) %{
   match(Set mem (StoreVector mem src));
   effect(TEMP pgtmp, KILL cr);
   ins_cost(5 * SVE_COST);
-  format %{ "sve_whilelo_zr_imm $pgtmp, vector_length\n\t"
+  format %{ "sve_ptrue $pgtmp, vector_length\n\t"
             "sve_str $src, $pgtmp, $mem\t# store vector partial" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
-    __ sve_whilelo_zr_imm(as_PRegister($pgtmp$$reg), __ elemType_to_regVariant(bt),
-                          Matcher::vector_length(this, $src));
+    __ sve_ptrue_lanecnt(as_PRegister($pgtmp$$reg), __ elemType_to_regVariant(bt),
+                         Matcher::vector_length(this, $src));
     FloatRegister src_reg = as_FloatRegister($src$$reg);
     loadStoreA_predicated(C2_MacroAssembler(&cbuf), true, src_reg,
                           as_PRegister($pgtmp$$reg), bt, bt, $mem->opcode(),
@@ -365,8 +365,8 @@ instruct loadV_masked_partial(vReg dst, vmemA mem, pRegGov pg, pRegGov pgtmp, rF
   format %{ "sve_ldr $dst, $pg, $mem\t# load vector predicated partial (sve)" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ sve_whilelo_zr_imm(as_PRegister($pgtmp$$reg), __ elemType_to_regVariant(bt),
-                          Matcher::vector_length(this));
+    __ sve_ptrue_lanecnt(as_PRegister($pgtmp$$reg), __ elemType_to_regVariant(bt),
+                         Matcher::vector_length(this));
     __ sve_and(as_PRegister($pgtmp$$reg), as_PRegister($pgtmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     loadStoreA_predicated(C2_MacroAssembler(&cbuf), false, as_FloatRegister($dst$$reg),
@@ -400,8 +400,8 @@ instruct storeV_masked_partial(vReg src, vmemA mem, pRegGov pg, pRegGov pgtmp, r
   format %{ "sve_str $mem, $pg, $src\t# store vector predicated partial (sve)" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
-    __ sve_whilelo_zr_imm(as_PRegister($pgtmp$$reg), __ elemType_to_regVariant(bt),
-                          Matcher::vector_length(this, $src));
+    __ sve_ptrue_lanecnt(as_PRegister($pgtmp$$reg), __ elemType_to_regVariant(bt),
+                         Matcher::vector_length(this, $src));
     __ sve_and(as_PRegister($pgtmp$$reg), as_PRegister($pgtmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     loadStoreA_predicated(C2_MacroAssembler(&cbuf), true, as_FloatRegister($src$$reg),
@@ -438,7 +438,7 @@ instruct vmaskAllI(pRegGov dst, iRegIorL2I src, vReg tmp, rFlagsReg cr) %{
   effect(TEMP tmp, KILL cr);
   ins_cost(3 * SVE_COST);
   format %{ "sve_dup $tmp, $src\n\t"
-            "sve_ptrue_lanecnt $dst\n\t"
+            "sve_ptrue $dst, vector_length\n\t"
             "sve_cmpne $dst, $dst, $tmp, 0\t# mask all (sve) (B/H/S)" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -481,7 +481,7 @@ instruct vmaskAllL(pRegGov dst, iRegL src, vReg tmp, rFlagsReg cr) %{
   effect(TEMP tmp, KILL cr);
   ins_cost(3 * SVE_COST);
   format %{ "sve_dup $tmp, $src\n\t"
-            "sve_ptrue_lanecnt $dst\n\t"
+            "sve_ptrue $dst, vector_length\n\t"
             "sve_cmpne $dst, $dst, $tmp, 0\t# mask all (sve) (D)" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -591,7 +591,7 @@ instruct reinterpretResize(vReg dst, vReg src, pRegGov pgtmp, rFlagsReg cr) %{
                                   length_in_bytes_src : length_in_bytes_dst;
     assert(length_in_bytes_src <= MaxVectorSize && length_in_bytes_dst <= MaxVectorSize,
            "invalid vector length");
-    __ sve_whilelo_zr_imm(as_PRegister($pgtmp$$reg), __ B, length_in_bytes_resize);
+    __ sve_ptrue_lanecnt(as_PRegister($pgtmp$$reg), __ B, length_in_bytes_resize);
     __ sve_dup(as_FloatRegister($dst$$reg), __ B, 0);
     __ sve_sel(as_FloatRegister($dst$$reg), __ B, as_PRegister($pgtmp$$reg),
                as_FloatRegister($src$$reg), as_FloatRegister($dst$$reg));
@@ -2147,7 +2147,7 @@ instruct vloadmask_loadV_partial(pRegGov dst, indirect mem, vReg vtmp, pRegGov p
     // expected vector element type. Convert the vector to predicate.
     BasicType to_vect_bt = Matcher::vector_element_basic_type(this);
     Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(to_vect_bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this));
     loadStoreA_predicated(C2_MacroAssembler(&cbuf), false, as_FloatRegister($vtmp$$reg),
                           as_PRegister($ptmp$$reg), T_BOOLEAN, to_vect_bt, $mem->opcode(),
                           as_Register($mem$$base), $mem$$index, $mem$$scale, $mem$$disp);
@@ -2194,7 +2194,7 @@ instruct storeV_vstoremask_partial(indirect mem, pRegGov src, vReg vtmp,
     BasicType from_vect_bt = Matcher::vector_element_basic_type(this, $src);
     Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(from_vect_bt);
     __ sve_cpy(as_FloatRegister($vtmp$$reg), size, as_PRegister($src$$reg), 1, false);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src));
     loadStoreA_predicated(C2_MacroAssembler(&cbuf), true, as_FloatRegister($vtmp$$reg),
                           as_PRegister($ptmp$$reg), T_BOOLEAN, from_vect_bt, $mem->opcode(),
                           as_Register($mem$$base), $mem$$index, $mem$$scale, $mem$$disp);
@@ -2272,8 +2272,7 @@ instruct reduce_addI_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD vt
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), variant,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
                            $src1$$Register, as_FloatRegister($src2$$reg),
                            as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
@@ -2290,8 +2289,7 @@ instruct reduce_addL_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD vtmp,
   ins_cost(2 * SVE_COST);
   format %{ "sve_reduce_addL $dst, $src1, $src2\t# addL reduction partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
                            $src1$$Register, as_FloatRegister($src2$$reg),
                            as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
@@ -2307,8 +2305,7 @@ instruct reduce_addF_partial(vRegF src1_dst, vReg src2, pRegGov ptmp, rFlagsReg 
   effect(TEMP ptmp, KILL cr);
   format %{ "sve_reduce_addF $src1_dst, $src1_dst, $src2\t# addF reduction partial (sve) (S)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ S,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ S, Matcher::vector_length(this, $src2));
     __ sve_fadda(as_FloatRegister($src1_dst$$reg), __ S,
                  as_PRegister($ptmp$$reg), as_FloatRegister($src2$$reg));
   %}
@@ -2323,8 +2320,7 @@ instruct reduce_addD_partial(vRegD src1_dst, vReg src2, pRegGov ptmp, rFlagsReg 
   effect(TEMP ptmp, KILL cr);
   format %{ "sve_reduce_addD $src1_dst, $src1_dst, $src2\t# addD reduction partial (sve) (D)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
     __ sve_fadda(as_FloatRegister($src1_dst$$reg), __ D,
                  as_PRegister($ptmp$$reg), as_FloatRegister($src2$$reg));
   %}
@@ -2401,8 +2397,7 @@ instruct reduce_addI_masked_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, v
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), variant,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
@@ -2421,8 +2416,7 @@ instruct reduce_addL_masked_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD 
   ins_cost(3 * SVE_COST);
   format %{ "sve_reduce_addL $dst, $src1, $pg, $src2\t# addL reduction predicated partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
@@ -2440,8 +2434,7 @@ instruct reduce_addF_masked_partial(vRegF src1_dst, vReg src2, pRegGov pg, pRegG
   ins_cost(SVE_COST);
   format %{ "sve_reduce_addF $src1_dst, $pg, $src2\t# addF reduction predicated partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ S,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ S, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_fadda(as_FloatRegister($src1_dst$$reg), __ S,
@@ -2458,8 +2451,7 @@ instruct reduce_addD_masked_partial(vRegD src1_dst, vReg src2, pRegGov pg, pRegG
   ins_cost(SVE_COST);
   format %{ "sve_reduce_addD $src1_dst, $pg, $src2\t# addD reduction predicated partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_fadda(as_FloatRegister($src1_dst$$reg), __ D,
@@ -2515,8 +2507,7 @@ instruct reduce_andI_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD vt
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), variant,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
                            $src1$$Register, as_FloatRegister($src2$$reg),
                            as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
@@ -2534,8 +2525,7 @@ instruct reduce_andL_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD vtmp,
   ins_cost(2 * SVE_COST);
   format %{ "sve_reduce_andL $dst, $src1, $src2\t# andL reduction partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
                            $src1$$Register, as_FloatRegister($src2$$reg),
                            as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
@@ -2590,8 +2580,7 @@ instruct reduce_andI_masked_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, v
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), variant,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
@@ -2611,8 +2600,7 @@ instruct reduce_andL_masked_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD 
   ins_cost(3 * SVE_COST);
   format %{ "sve_reduce_andL $dst, $src1, $pg, $src2\t# andL reduction predicated partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
@@ -2669,8 +2657,7 @@ instruct reduce_orI_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD vtm
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), variant,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
                            $src1$$Register, as_FloatRegister($src2$$reg),
                            as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
@@ -2688,8 +2675,7 @@ instruct reduce_orL_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD vtmp,
   ins_cost(2 * SVE_COST);
   format %{ "sve_reduce_orL $dst, $src1, $src2\t# orL reduction partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
                            $src1$$Register, as_FloatRegister($src2$$reg),
                            as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
@@ -2744,8 +2730,7 @@ instruct reduce_orI_masked_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, vR
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), variant,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
@@ -2765,8 +2750,7 @@ instruct reduce_orL_masked_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD v
   ins_cost(3 * SVE_COST);
   format %{ "sve_reduce_orL $dst, $src1, $pg, $src2\t# orL reduction predicated partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
@@ -2823,8 +2807,7 @@ instruct reduce_eorI_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD vt
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), variant,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
                            $src1$$Register, as_FloatRegister($src2$$reg),
                            as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
@@ -2842,8 +2825,7 @@ instruct reduce_eorL_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD vtmp,
   ins_cost(2 * SVE_COST);
   format %{ "sve_reduce_eorL $dst, $src1, $src2\t# eorL reduction partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
                            $src1$$Register, as_FloatRegister($src2$$reg),
                            as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
@@ -2898,8 +2880,7 @@ instruct reduce_eorI_masked_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, v
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), variant,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
@@ -2919,8 +2900,7 @@ instruct reduce_eorL_masked_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD 
   ins_cost(3 * SVE_COST);
   format %{ "sve_reduce_eorL $dst, $src1, $pg, $src2\t# eorL reduction predicated partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
@@ -2979,8 +2959,7 @@ instruct reduce_maxI_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD vt
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), variant,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
                            $src1$$Register, as_FloatRegister($src2$$reg),
                            as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
@@ -2998,8 +2977,7 @@ instruct reduce_maxL_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD vtmp,
   ins_cost(2 * SVE_COST);
   format %{ "sve_reduce_maxL $dst, $src1, $src2\t# maxL reduction  partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
                            $src1$$Register, as_FloatRegister($src2$$reg),
                            as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
@@ -3032,8 +3010,7 @@ instruct reduce_maxF_partial(vRegF dst, vRegF src1, vReg src2,
   effect(TEMP_DEF dst, TEMP ptmp, KILL cr);
   format %{ "sve_reduce_maxF $dst, $src1, $src2\t# maxF reduction partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ S,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ S, Matcher::vector_length(this, $src2));
     __ sve_fmaxv(as_FloatRegister($dst$$reg), __ S, as_PRegister($ptmp$$reg), as_FloatRegister($src2$$reg));
     __ fmaxs(as_FloatRegister($dst$$reg), as_FloatRegister($dst$$reg), as_FloatRegister($src1$$reg));
   %}
@@ -3065,8 +3042,7 @@ instruct reduce_maxD_partial(vRegD dst, vRegD src1, vReg src2,
   effect(TEMP_DEF dst, TEMP ptmp, KILL cr);
   format %{ "sve_reduce_maxD $dst, $src1, $src2\t# maxD reduction partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
     __ sve_fmaxv(as_FloatRegister($dst$$reg), __ D, as_PRegister($ptmp$$reg), as_FloatRegister($src2$$reg));
     __ fmaxd(as_FloatRegister($dst$$reg), as_FloatRegister($dst$$reg), as_FloatRegister($src1$$reg));
   %}
@@ -3124,8 +3100,7 @@ instruct reduce_maxI_masked_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, v
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), variant,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
@@ -3145,8 +3120,7 @@ instruct reduce_maxL_masked_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD 
   ins_cost(3 * SVE_COST);
   format %{ "sve_reduce_maxL $dst, $src1, $pg, $src2\t# maxL reduction predicated partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
@@ -3196,8 +3170,7 @@ instruct reduce_maxF_masked_partial(vRegF dst, vRegF src1, vReg src2, pRegGov pg
   ins_cost(3 * SVE_COST);
   format %{ "sve_reduce_maxF $dst, $src1, $pg, $src2\t# maxF reduction predicated partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ S,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ S, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_fmaxv(as_FloatRegister($dst$$reg), __ S,
@@ -3217,8 +3190,7 @@ instruct reduce_maxD_masked_partial(vRegD dst, vRegD src1, vReg src2, pRegGov pg
   ins_cost(3 * SVE_COST);
   format %{ "sve_reduce_maxD $dst, $src1, $pg, $src2\t# maxD reduction predicated partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_fmaxv(as_FloatRegister($dst$$reg), __ D,
@@ -3277,8 +3249,7 @@ instruct reduce_minI_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD vt
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), variant,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
                            $src1$$Register, as_FloatRegister($src2$$reg),
                            as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
@@ -3296,8 +3267,7 @@ instruct reduce_minL_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD vtmp,
   ins_cost(2 * SVE_COST);
   format %{ "sve_reduce_minL $dst, $src1, $src2\t# minL reduction  partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
                            $src1$$Register, as_FloatRegister($src2$$reg),
                            as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
@@ -3330,8 +3300,7 @@ instruct reduce_minF_partial(vRegF dst, vRegF src1, vReg src2,
   effect(TEMP_DEF dst, TEMP ptmp, KILL cr);
   format %{ "sve_reduce_minF $dst, $src1, $src2\t# minF reduction partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ S,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ S, Matcher::vector_length(this, $src2));
     __ sve_fminv(as_FloatRegister($dst$$reg), __ S, as_PRegister($ptmp$$reg), as_FloatRegister($src2$$reg));
     __ fmins(as_FloatRegister($dst$$reg), as_FloatRegister($dst$$reg), as_FloatRegister($src1$$reg));
   %}
@@ -3363,8 +3332,7 @@ instruct reduce_minD_partial(vRegD dst, vRegD src1, vReg src2,
   effect(TEMP_DEF dst, TEMP ptmp, KILL cr);
   format %{ "sve_reduce_minD $dst, $src1, $src2\t# minD reduction partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
     __ sve_fminv(as_FloatRegister($dst$$reg), __ D, as_PRegister($ptmp$$reg), as_FloatRegister($src2$$reg));
     __ fmind(as_FloatRegister($dst$$reg), as_FloatRegister($dst$$reg), as_FloatRegister($src1$$reg));
   %}
@@ -3422,8 +3390,7 @@ instruct reduce_minI_masked_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, v
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), variant,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
@@ -3443,8 +3410,7 @@ instruct reduce_minL_masked_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD 
   ins_cost(3 * SVE_COST);
   format %{ "sve_reduce_minL $dst, $src1, $pg, $src2\t# minL reduction predicated partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
@@ -3494,8 +3460,7 @@ instruct reduce_minF_masked_partial(vRegF dst, vRegF src1, vReg src2, pRegGov pg
   ins_cost(3 * SVE_COST);
   format %{ "sve_reduce_minF $dst, $src1, $pg, $src2\t# minF reduction predicated partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ S,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ S, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_fminv(as_FloatRegister($dst$$reg), __ S,
@@ -3515,8 +3480,7 @@ instruct reduce_minD_masked_partial(vRegD dst, vRegD src1, vReg src2, pRegGov pg
   ins_cost(3 * SVE_COST);
   format %{ "sve_reduce_minD $dst, $src1, $pg, $src2\t# minD reduction predicated partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_fminv(as_FloatRegister($dst$$reg), __ D,
@@ -5074,8 +5038,7 @@ instruct vtest_alltrue_partial(iRegINoSp dst, pRegGov src1, pRegGov src2, pRegGo
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src1);
     Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), size,
-                          Matcher::vector_length(this, $src1));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src1));
     __ sve_eors(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
           as_PRegister($src1$$reg), as_PRegister($src2$$reg));
     __ csetw(as_Register($dst$$reg), Assembler::EQ);
@@ -5095,8 +5058,7 @@ instruct vtest_anytrue_partial(iRegINoSp dst, pRegGov src1, pRegGov src2, pRegGo
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src1);
     Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), size,
-                          Matcher::vector_length(this, $src1));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src1));
     __ sve_ands(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
           as_PRegister($src1$$reg), as_PRegister($src2$$reg));
     __ csetw(as_Register($dst$$reg), Assembler::NE);
@@ -5331,7 +5293,7 @@ instruct gatherI_partial(vReg dst, indirect mem, vReg idx, pRegGov ptmp, rFlagsR
   ins_cost(2 * SVE_COST + INSN_COST);
   format %{ "load_vector_gather $dst, $ptmp, $mem, $idx\t# vector load gather partial (S)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ S, Matcher::vector_length(this));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ S, Matcher::vector_length(this));
     __ sve_ld1w_gather(as_FloatRegister($dst$$reg), as_PRegister($ptmp$$reg),
                        as_Register($mem$$base), as_FloatRegister($idx$$reg));
   %}
@@ -5348,8 +5310,7 @@ instruct gatherL_partial(vReg dst, indirect mem, vReg idx, pRegGov ptmp, rFlagsR
   ins_cost(3 * SVE_COST + INSN_COST);
   format %{ "load_vector_gather $dst, $ptmp, $mem, $idx\t# vector load gather partial (D)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this));
     __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
     __ sve_ld1d_gather(as_FloatRegister($dst$$reg), as_PRegister($ptmp$$reg),
                        as_Register($mem$$base), as_FloatRegister($idx$$reg));
@@ -5402,8 +5363,7 @@ instruct gatherI_masked_partial(vReg dst, indirect mem, vReg idx, pRegGov pg, pR
   ins_cost(3 * SVE_COST);
   format %{ "load_vector_gather $dst, $pg, $mem, $idx\t# vector load gather predicated partial (S)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ S,
-                          Matcher::vector_length(this));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ S, Matcher::vector_length(this));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_ld1w_gather(as_FloatRegister($dst$$reg), as_PRegister($ptmp$$reg),
@@ -5422,7 +5382,7 @@ instruct gatherL_masked_partial(vReg dst, indirect mem, vReg idx, pRegGov pg, pR
   ins_cost(4 * SVE_COST);
   format %{ "load_vector_gather $dst, $pg, $mem, $idx\t# vector load gather predicated partial (D)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
@@ -5477,8 +5437,7 @@ instruct scatterI_partial(indirect mem, vReg src, vReg idx, pRegGov ptmp, rFlags
   ins_cost(2 * SVE_COST + INSN_COST);
   format %{ "store_vector_scatter $mem, $ptmp, $idx, $src\t# vector store scatter partial (S)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ S,
-                          Matcher::vector_length(this, $src));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ S, Matcher::vector_length(this, $src));
     __ sve_st1w_scatter(as_FloatRegister($src$$reg), as_PRegister($ptmp$$reg),
                         as_Register($mem$$base), as_FloatRegister($idx$$reg));
   %}
@@ -5495,8 +5454,7 @@ instruct scatterL_partial(indirect mem, vReg src, vReg idx, pRegGov ptmp, rFlags
   ins_cost(3 * SVE_COST + INSN_COST);
   format %{ "store_vector_scatter $mem, $ptmp, $idx, $src\t# vector store scatter partial (D)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src));
     __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
     __ sve_st1d_scatter(as_FloatRegister($src$$reg), as_PRegister($ptmp$$reg),
                         as_Register($mem$$base), as_FloatRegister($idx$$reg));
@@ -5549,8 +5507,7 @@ instruct scatterI_masked_partial(indirect mem, vReg src, vReg idx, pRegGov pg, p
   ins_cost(3 * SVE_COST);
   format %{ "store_vector_scatter $mem, $pg, $idx, $src\t# vector store scatter predicated partial (S)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ S,
-                          Matcher::vector_length(this, $src));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ S, Matcher::vector_length(this, $src));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_st1w_scatter(as_FloatRegister($src$$reg), as_PRegister($ptmp$$reg),
@@ -5569,8 +5526,7 @@ instruct scatterL_masked_partial(indirect mem, vReg src, vReg idx, pRegGov pg, p
   ins_cost(4 * SVE_COST);
   format %{ "store_vector_scatter $mem, $pg, $idx, $src\t# vector store scatter predicated partial (D)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
@@ -5688,7 +5644,7 @@ instruct vmask_truecount_partial(iRegINoSp dst, pReg src, pReg ptmp, rFlagsReg c
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
     Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src));
     __ sve_cntp($dst$$Register, size, as_PRegister($ptmp$$reg), as_PRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -5704,7 +5660,7 @@ instruct vmask_firsttrue_partial(iRegINoSp dst, pReg src, pReg ptmp1, pReg ptmp2
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
     Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp1$$reg), size,
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp1$$reg), size,
                           Matcher::vector_length(this, $src));
     __ sve_brkb(as_PRegister($ptmp2$$reg), as_PRegister($ptmp1$$reg), as_PRegister($src$$reg), false);
     __ sve_cntp($dst$$Register, size, as_PRegister($ptmp1$$reg), as_PRegister($ptmp2$$reg));
@@ -5722,7 +5678,7 @@ instruct vmask_lasttrue_partial(iRegINoSp dst, pReg src, pReg ptmp, rFlagsReg cr
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
     Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src));
     __ sve_and(as_PRegister($ptmp$$reg), ptrue, as_PRegister($ptmp$$reg), as_PRegister($src$$reg));
     __ sve_vmask_lasttrue($dst$$Register, bt, as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg));
   %}

--- a/src/hotspot/cpu/aarch64/aarch64_sve_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_sve_ad.m4
@@ -242,12 +242,12 @@ instruct loadV_partial(vReg dst, vmemA mem, pRegGov pgtmp, rFlagsReg cr) %{
   match(Set dst (LoadVector mem));
   effect(TEMP pgtmp, KILL cr);
   ins_cost(6 * SVE_COST);
-  format %{ "sve_whilelo_zr_imm $pgtmp, vector_length\n\t"
+  format %{ "sve_ptrue $pgtmp, vector_length\n\t"
             "sve_ldr $dst, $pgtmp, $mem\t# load vector partial" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ sve_whilelo_zr_imm(as_PRegister($pgtmp$$reg), __ elemType_to_regVariant(bt),
-                          Matcher::vector_length(this));
+    __ sve_ptrue_lanecnt(as_PRegister($pgtmp$$reg), __ elemType_to_regVariant(bt),
+                         Matcher::vector_length(this));
     FloatRegister dst_reg = as_FloatRegister($dst$$reg);
     loadStoreA_predicated(C2_MacroAssembler(&cbuf), false, dst_reg,
                           as_PRegister($pgtmp$$reg), bt, bt, $mem->opcode(),
@@ -262,12 +262,12 @@ instruct storeV_partial(vReg src, vmemA mem, pRegGov pgtmp, rFlagsReg cr) %{
   match(Set mem (StoreVector mem src));
   effect(TEMP pgtmp, KILL cr);
   ins_cost(5 * SVE_COST);
-  format %{ "sve_whilelo_zr_imm $pgtmp, vector_length\n\t"
+  format %{ "sve_ptrue $pgtmp, vector_length\n\t"
             "sve_str $src, $pgtmp, $mem\t# store vector partial" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
-    __ sve_whilelo_zr_imm(as_PRegister($pgtmp$$reg), __ elemType_to_regVariant(bt),
-                          Matcher::vector_length(this, $src));
+    __ sve_ptrue_lanecnt(as_PRegister($pgtmp$$reg), __ elemType_to_regVariant(bt),
+                         Matcher::vector_length(this, $src));
     FloatRegister src_reg = as_FloatRegister($src$$reg);
     loadStoreA_predicated(C2_MacroAssembler(&cbuf), true, src_reg,
                           as_PRegister($pgtmp$$reg), bt, bt, $mem->opcode(),
@@ -302,8 +302,8 @@ instruct loadV_masked_partial(vReg dst, vmemA mem, pRegGov pg, pRegGov pgtmp, rF
   format %{ "sve_ldr $dst, $pg, $mem\t# load vector predicated partial (sve)" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ sve_whilelo_zr_imm(as_PRegister($pgtmp$$reg), __ elemType_to_regVariant(bt),
-                          Matcher::vector_length(this));
+    __ sve_ptrue_lanecnt(as_PRegister($pgtmp$$reg), __ elemType_to_regVariant(bt),
+                         Matcher::vector_length(this));
     __ sve_and(as_PRegister($pgtmp$$reg), as_PRegister($pgtmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     loadStoreA_predicated(C2_MacroAssembler(&cbuf), false, as_FloatRegister($dst$$reg),
@@ -337,8 +337,8 @@ instruct storeV_masked_partial(vReg src, vmemA mem, pRegGov pg, pRegGov pgtmp, r
   format %{ "sve_str $mem, $pg, $src\t# store vector predicated partial (sve)" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
-    __ sve_whilelo_zr_imm(as_PRegister($pgtmp$$reg), __ elemType_to_regVariant(bt),
-                          Matcher::vector_length(this, $src));
+    __ sve_ptrue_lanecnt(as_PRegister($pgtmp$$reg), __ elemType_to_regVariant(bt),
+                         Matcher::vector_length(this, $src));
     __ sve_and(as_PRegister($pgtmp$$reg), as_PRegister($pgtmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     loadStoreA_predicated(C2_MacroAssembler(&cbuf), true, as_FloatRegister($src$$reg),
@@ -380,7 +380,7 @@ instruct vmaskAll$1(pRegGov dst, ifelse($1, `I', iRegIorL2I, iRegL) src, vReg tm
   effect(TEMP tmp, KILL cr);
   ins_cost(3 * SVE_COST);
   format %{ "sve_dup $tmp, $src\n\t"
-            "sve_ptrue_lanecnt $dst\n\t"
+            "sve_ptrue $dst, vector_length\n\t"
             "sve_cmpne $dst, $dst, $tmp, 0\t# mask all (sve) ($2)" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -473,7 +473,7 @@ instruct reinterpretResize(vReg dst, vReg src, pRegGov pgtmp, rFlagsReg cr) %{
                                   length_in_bytes_src : length_in_bytes_dst;
     assert(length_in_bytes_src <= MaxVectorSize && length_in_bytes_dst <= MaxVectorSize,
            "invalid vector length");
-    __ sve_whilelo_zr_imm(as_PRegister($pgtmp$$reg), __ B, length_in_bytes_resize);
+    __ sve_ptrue_lanecnt(as_PRegister($pgtmp$$reg), __ B, length_in_bytes_resize);
     __ sve_dup(as_FloatRegister($dst$$reg), __ B, 0);
     __ sve_sel(as_FloatRegister($dst$$reg), __ B, as_PRegister($pgtmp$$reg),
                as_FloatRegister($src$$reg), as_FloatRegister($dst$$reg));
@@ -1254,7 +1254,7 @@ instruct vloadmask_loadV_partial(pRegGov dst, indirect mem, vReg vtmp, pRegGov p
     // expected vector element type. Convert the vector to predicate.
     BasicType to_vect_bt = Matcher::vector_element_basic_type(this);
     Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(to_vect_bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this));
     loadStoreA_predicated(C2_MacroAssembler(&cbuf), false, as_FloatRegister($vtmp$$reg),
                           as_PRegister($ptmp$$reg), T_BOOLEAN, to_vect_bt, $mem->opcode(),
                           as_Register($mem$$base), $mem$$index, $mem$$scale, $mem$$disp);
@@ -1301,7 +1301,7 @@ instruct storeV_vstoremask_partial(indirect mem, pRegGov src, vReg vtmp,
     BasicType from_vect_bt = Matcher::vector_element_basic_type(this, $src);
     Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(from_vect_bt);
     __ sve_cpy(as_FloatRegister($vtmp$$reg), size, as_PRegister($src$$reg), 1, false);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src));
     loadStoreA_predicated(C2_MacroAssembler(&cbuf), true, as_FloatRegister($vtmp$$reg),
                           as_PRegister($ptmp$$reg), T_BOOLEAN, from_vect_bt, $mem->opcode(),
                           as_Register($mem$$base), $mem$$index, $mem$$scale, $mem$$disp);
@@ -1373,8 +1373,7 @@ instruct reduce_$1I_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD vtm
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), variant,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
                            $src1$$Register, as_FloatRegister($src2$$reg),
                            as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
@@ -1398,8 +1397,7 @@ instruct reduce_$1L_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD vtmp,
   ins_cost(2 * SVE_COST);
   format %{ "sve_reduce_$1L $dst, $src1, $src2\t# $1L reduction partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
                            $src1$$Register, as_FloatRegister($src2$$reg),
                            as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
@@ -1435,8 +1433,7 @@ instruct reduce_$1_partial($3 src1_dst, vReg src2, pRegGov ptmp, rFlagsReg cr) %
   effect(TEMP ptmp, KILL cr);
   format %{ "sve_reduce_$1 $src1_dst, $src1_dst, $src2\t# $1 reduction partial (sve) ($4)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ $4,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ $4, Matcher::vector_length(this, $src2));
     __ sve_fadda(as_FloatRegister($src1_dst$$reg), __ $4,
                  as_PRegister($ptmp$$reg), as_FloatRegister($src2$$reg));
   %}
@@ -1507,8 +1504,7 @@ instruct reduce_$1I_masked_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, vR
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), variant,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
@@ -1534,8 +1530,7 @@ instruct reduce_$1L_masked_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD v
   ins_cost(3 * SVE_COST);
   format %{ "sve_reduce_$1L $dst, $src1, $pg, $src2\t# $1L reduction predicated partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
@@ -1572,8 +1567,7 @@ instruct reduce_$1_masked_partial($3 src1_dst, vReg src2, pRegGov pg, pRegGov pt
   ins_cost(SVE_COST);
   format %{ "sve_reduce_$1 $src1_dst, $pg, $src2\t# $1 reduction predicated partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ $4,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ $4, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_fadda(as_FloatRegister($src1_dst$$reg), __ $4,
@@ -1696,8 +1690,7 @@ instruct reduce_$1I_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD vtm
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), variant,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
                            $src1$$Register, as_FloatRegister($src2$$reg),
                            as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
@@ -1718,8 +1711,7 @@ instruct reduce_$1L_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD vtmp,
   ins_cost(2 * SVE_COST);
   format %{ "sve_reduce_$1L $dst, $src1, $src2\t# $1L reduction  partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
                            $src1$$Register, as_FloatRegister($src2$$reg),
                            as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
@@ -1785,8 +1777,7 @@ instruct reduce_$1I_masked_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, vR
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src2);
     Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), variant,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
@@ -1809,8 +1800,7 @@ instruct reduce_$1L_masked_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD v
   ins_cost(3 * SVE_COST);
   format %{ "sve_reduce_$1L $dst, $src1, $pg, $src2\t# $1L reduction predicated partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
@@ -1851,8 +1841,7 @@ instruct reduce_$1$2_partial($5 dst, $5 src1, vReg src2,
   effect(TEMP_DEF dst, TEMP ptmp, KILL cr);
   format %{ "sve_reduce_$1$2 $dst, $src1, $src2\t# $1$2 reduction partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ $4,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ $4, Matcher::vector_length(this, $src2));
     __ sve_f$1v(as_FloatRegister($dst$$reg), __ $4, as_PRegister($ptmp$$reg), as_FloatRegister($src2$$reg));
     __ f`$1'translit($4, `SD', `sd')(as_FloatRegister($dst$$reg), as_FloatRegister($dst$$reg), as_FloatRegister($src1$$reg));
   %}
@@ -1890,8 +1879,7 @@ instruct reduce_$1$2_masked_partial($5 dst, $5 src1, vReg src2, pRegGov pg,
   ins_cost(3 * SVE_COST);
   format %{ "sve_reduce_$1$2 $dst, $src1, $pg, $src2\t# $1$2 reduction predicated partial (sve)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ $4,
-                          Matcher::vector_length(this, $src2));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ $4, Matcher::vector_length(this, $src2));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_f$1v(as_FloatRegister($dst$$reg), __ $4,
@@ -2595,8 +2583,7 @@ instruct vtest_$1_partial`'(iRegINoSp dst, pRegGov src1, pRegGov src2, pRegGov p
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src1);
     Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), size,
-                          Matcher::vector_length(this, $src1));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src1));
     __ $3(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
           as_PRegister($src1$$reg), as_PRegister($src2$$reg));
     __ csetw(as_Register($dst$$reg), Assembler::$4);
@@ -2818,7 +2805,7 @@ instruct gatherI_partial(vReg dst, indirect mem, vReg idx, pRegGov ptmp, rFlagsR
   ins_cost(2 * SVE_COST + INSN_COST);
   format %{ "load_vector_gather $dst, $ptmp, $mem, $idx\t# vector load gather partial (S)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ S, Matcher::vector_length(this));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ S, Matcher::vector_length(this));
     __ sve_ld1w_gather(as_FloatRegister($dst$$reg), as_PRegister($ptmp$$reg),
                        as_Register($mem$$base), as_FloatRegister($idx$$reg));
   %}
@@ -2835,8 +2822,7 @@ instruct gatherL_partial(vReg dst, indirect mem, vReg idx, pRegGov ptmp, rFlagsR
   ins_cost(3 * SVE_COST + INSN_COST);
   format %{ "load_vector_gather $dst, $ptmp, $mem, $idx\t# vector load gather partial (D)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this));
     __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
     __ sve_ld1d_gather(as_FloatRegister($dst$$reg), as_PRegister($ptmp$$reg),
                        as_Register($mem$$base), as_FloatRegister($idx$$reg));
@@ -2889,8 +2875,7 @@ instruct gatherI_masked_partial(vReg dst, indirect mem, vReg idx, pRegGov pg, pR
   ins_cost(3 * SVE_COST);
   format %{ "load_vector_gather $dst, $pg, $mem, $idx\t# vector load gather predicated partial (S)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ S,
-                          Matcher::vector_length(this));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ S, Matcher::vector_length(this));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_ld1w_gather(as_FloatRegister($dst$$reg), as_PRegister($ptmp$$reg),
@@ -2909,7 +2894,7 @@ instruct gatherL_masked_partial(vReg dst, indirect mem, vReg idx, pRegGov pg, pR
   ins_cost(4 * SVE_COST);
   format %{ "load_vector_gather $dst, $pg, $mem, $idx\t# vector load gather predicated partial (D)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
@@ -2964,8 +2949,7 @@ instruct scatterI_partial(indirect mem, vReg src, vReg idx, pRegGov ptmp, rFlags
   ins_cost(2 * SVE_COST + INSN_COST);
   format %{ "store_vector_scatter $mem, $ptmp, $idx, $src\t# vector store scatter partial (S)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ S,
-                          Matcher::vector_length(this, $src));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ S, Matcher::vector_length(this, $src));
     __ sve_st1w_scatter(as_FloatRegister($src$$reg), as_PRegister($ptmp$$reg),
                         as_Register($mem$$base), as_FloatRegister($idx$$reg));
   %}
@@ -2982,8 +2966,7 @@ instruct scatterL_partial(indirect mem, vReg src, vReg idx, pRegGov ptmp, rFlags
   ins_cost(3 * SVE_COST + INSN_COST);
   format %{ "store_vector_scatter $mem, $ptmp, $idx, $src\t# vector store scatter partial (D)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src));
     __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
     __ sve_st1d_scatter(as_FloatRegister($src$$reg), as_PRegister($ptmp$$reg),
                         as_Register($mem$$base), as_FloatRegister($idx$$reg));
@@ -3036,8 +3019,7 @@ instruct scatterI_masked_partial(indirect mem, vReg src, vReg idx, pRegGov pg, p
   ins_cost(3 * SVE_COST);
   format %{ "store_vector_scatter $mem, $pg, $idx, $src\t# vector store scatter predicated partial (S)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ S,
-                          Matcher::vector_length(this, $src));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ S, Matcher::vector_length(this, $src));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_st1w_scatter(as_FloatRegister($src$$reg), as_PRegister($ptmp$$reg),
@@ -3056,8 +3038,7 @@ instruct scatterL_masked_partial(indirect mem, vReg src, vReg idx, pRegGov pg, p
   ins_cost(4 * SVE_COST);
   format %{ "store_vector_scatter $mem, $pg, $idx, $src\t# vector store scatter predicated partial (D)" %}
   ins_encode %{
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), __ D,
-                          Matcher::vector_length(this, $src));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src));
     __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
                as_PRegister($pg$$reg), as_PRegister($pg$$reg));
     __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
@@ -3161,7 +3142,7 @@ instruct vmask_truecount_partial(iRegINoSp dst, pReg src, pReg ptmp, rFlagsReg c
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
     Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src));
     __ sve_cntp($dst$$Register, size, as_PRegister($ptmp$$reg), as_PRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -3177,7 +3158,7 @@ instruct vmask_firsttrue_partial(iRegINoSp dst, pReg src, pReg ptmp1, pReg ptmp2
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
     Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp1$$reg), size,
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp1$$reg), size,
                           Matcher::vector_length(this, $src));
     __ sve_brkb(as_PRegister($ptmp2$$reg), as_PRegister($ptmp1$$reg), as_PRegister($src$$reg), false);
     __ sve_cntp($dst$$Register, size, as_PRegister($ptmp1$$reg), as_PRegister($ptmp2$$reg));
@@ -3195,7 +3176,7 @@ instruct vmask_lasttrue_partial(iRegINoSp dst, pReg src, pReg ptmp, rFlagsReg cr
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
     Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    __ sve_whilelo_zr_imm(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src));
+    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src));
     __ sve_and(as_PRegister($ptmp$$reg), ptrue, as_PRegister($ptmp$$reg), as_PRegister($src$$reg));
     __ sve_vmask_lasttrue($dst$$Register, bt, as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg));
   %}

--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,14 +90,6 @@
   // Set elements of the dst predicate to true if the element number is
   // in the range of [0, lane_cnt), or to false otherwise.
   void sve_ptrue_lanecnt(PRegister dst, SIMD_RegVariant size, int lane_cnt);
-
-  // Generate predicate through whilelo, by comparing ZR with an unsigned
-  // immediate. rscratch1 will be clobbered.
-  inline void sve_whilelo_zr_imm(PRegister pd, SIMD_RegVariant size, uint imm) {
-    assert(UseSVE > 0, "not supported");
-    mov(rscratch1, imm);
-    sve_whilelo(pd, size, zr, rscratch1);
-  }
 
   // Extract a scalar element from an sve vector at position 'idx'.
   // rscratch1 will be clobbered.


### PR DESCRIPTION
This patch uses PTRUE instruction instead of WHILELO instruction to
create vector masks for certain length. It would be more efficient than
WHILELO instruction according to the software optimization guide of
Neoverse N2[1], Neoverse V1[2], and A64FX[3].

The final code changes as shown below:

Before:

    0x0000ffff6d4747b4:   orr     x8, xzr, #0x10
    0x0000ffff6d4747b8:   whilelo p0.b, xzr, x8

After:

    0x0000ffff89476aec:   ptrue   p0.b, vl16

The micro benchmark improves 15% ~ 20% in my SVE test system.

[TEST]
jdk/incubator/vector, hotspot/compiler/vectorapi passed on my SVE test
machine.

[1] https://developer.arm.com/documentation/PJDOC-466751330-18256/0001
[2] https://developer.arm.com/documentation/pjdoc466751330-9685/latest/
[3] https://github.com/fujitsu/A64FX/blob/master/doc/A64FX_Microarchitecture_Manual_en_1.6.pdf

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282926](https://bugs.openjdk.java.net/browse/JDK-8282926): AArch64: Optimize out WHILELO with PTRUE


### Reviewers
 * [Ningsheng Jian](https://openjdk.java.net/census#njian) (@nsjian - Committer)
 * [Nick Gasson](https://openjdk.java.net/census#ngasson) (@nick-arm - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7786/head:pull/7786` \
`$ git checkout pull/7786`

Update a local copy of the PR: \
`$ git checkout pull/7786` \
`$ git pull https://git.openjdk.java.net/jdk pull/7786/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7786`

View PR using the GUI difftool: \
`$ git pr show -t 7786`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7786.diff">https://git.openjdk.java.net/jdk/pull/7786.diff</a>

</details>
