### PR TITLE
JDK-8283015: Create a test for JDK-4715496

### DIFF
--- a/test/jdk/javax/accessibility/8283015/AccessibleJTableCellNameTest.java
+++ b/test/jdk/javax/accessibility/8283015/AccessibleJTableCellNameTest.java
@@ -40,6 +40,7 @@ import javax.swing.SwingUtilities;
 public class AccessibleJTableCellNameTest {
     private static JTable jTable;
     private static JFrame jFrame;
+    private static volatile Accessible accessible;
 
     private static Object[][] rowData = {
         { "01", "02", "03", "04", "05" },
@@ -57,15 +58,17 @@ public class AccessibleJTableCellNameTest {
             robot.setAutoDelay(500);
             robot.waitForIdle();
 
-            for (int i = 0; i <= colNames.length - 1; i++) {
-                Accessible accessible = jTable.getAccessibleContext().getAccessibleTable()
-                    .getAccessibleColumnHeader().getAccessibleAt(0, i);
+            SwingUtilities.invokeAndWait(() -> {
+                for (int i = 0; i <= colNames.length - 1; i++) {
+                    Accessible accessible = jTable.getAccessibleContext().getAccessibleTable()
+                        .getAccessibleColumnHeader().getAccessibleAt(0, i);
 
-                if (!(accessible.getAccessibleContext().getAccessibleName().equals(colNames[i]))) {
-                    throw new RuntimeException(
-                        "AccessibleJTableCell.getAccessibleName returns correct name for header cells");
+                    if (!(accessible.getAccessibleContext().getAccessibleName().equals(colNames[i]))) {
+                        throw new RuntimeException(
+                            "AccessibleJTableCell.getAccessibleName returns correct name for header cells");
+                    }
                 }
-            }
+	    });
         } finally {
             SwingUtilities.invokeAndWait(() -> jFrame.dispose());
         }

--- a/test/jdk/javax/accessibility/8283015/AccessibleJTableCellNameTest.java
+++ b/test/jdk/javax/accessibility/8283015/AccessibleJTableCellNameTest.java
@@ -66,7 +66,7 @@ public class AccessibleJTableCellNameTest {
                 }
             }
         } finally {
-            jFrame.dispose();
+            SwingUtilities.invokeAndWait(() -> jFrame.dispose());
         }
     }
 

--- a/test/jdk/javax/accessibility/8283015/AccessibleJTableCellNameTest.java
+++ b/test/jdk/javax/accessibility/8283015/AccessibleJTableCellNameTest.java
@@ -25,7 +25,8 @@
  * @test
  * @key headful
  * @bug 4715496
- * @summary AccessibleJTableCell.getAccessible name incorrectly returns cell instance string instead of cell text.
+ * @summary AccessibleJTableCell.getAccessible name incorrectly returns
+ * cell instance string instead of cell text.
  * @run main AccessibleJTableCellNameTest
  */
 

--- a/test/jdk/javax/accessibility/8283015/AccessibleJTableCellNameTest.java
+++ b/test/jdk/javax/accessibility/8283015/AccessibleJTableCellNameTest.java
@@ -68,7 +68,7 @@ public class AccessibleJTableCellNameTest {
                             "AccessibleJTableCell.getAccessibleName returns correct name for header cells");
                     }
                 }
-	    });
+            });
         } finally {
             SwingUtilities.invokeAndWait(() -> jFrame.dispose());
         }

--- a/test/jdk/javax/accessibility/8283015/AccessibleJTableCellNameTest.java
+++ b/test/jdk/javax/accessibility/8283015/AccessibleJTableCellNameTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key headful
+ * @bug 4715496
+ * @summary AccessibleJTableCell.getAccessible name incorrectly returns cell instance string instead of cell text.
+ * @run main AccessibleJTableCellNameTest
+ */
+
+import java.awt.Robot;
+
+import javax.accessibility.Accessible;
+import javax.swing.JFrame;
+import javax.swing.JTable;
+import javax.swing.SwingUtilities;
+
+public class AccessibleJTableCellNameTest {
+    private static JTable jTable;
+    private static JFrame jFrame;
+
+    private static Object[][] rowData = {
+        { "01", "02", "03", "04", "05" },
+        { "11", "12", "13", "14", "15" },
+        { "21", "22", "23", "24", "25" },
+        { "31", "32", "33", "34", "35" },
+        { "41", "42", "43", "44", "45" } };
+
+    private static Object[] colNames = { "1", "2", "3", "4", "5" };
+
+    private static void doTest() throws Exception {
+        try {
+            SwingUtilities.invokeAndWait(() -> createGUI());
+            Robot robot = new Robot();
+            robot.setAutoDelay(500);
+            robot.waitForIdle();
+
+            for (int i = 0; i <= colNames.length - 1; i++) {
+                Accessible accessible = jTable.getAccessibleContext().getAccessibleTable()
+                    .getAccessibleColumnHeader().getAccessibleAt(0, i);
+
+                if (!(accessible.getAccessibleContext().getAccessibleName().equals(colNames[i]))) {
+                    throw new RuntimeException(
+                        "AccessibleJTableCell.getAccessibleName returns correct name for header cells");
+                }
+            }
+        } finally {
+            jFrame.dispose();
+        }
+    }
+
+    private static void createGUI() {
+        jTable = new JTable(rowData, colNames);
+        jFrame = new JFrame();
+        jFrame.setBounds(100, 100, 300, 300);
+        jFrame.getContentPane().add(jTable);
+        jFrame.setVisible(true);
+    }
+
+    public static void main(String args[]) throws Exception {
+        doTest();
+        System.out.println("Test Passed");
+    }
+}
+


### PR DESCRIPTION
Create a test for JDK-4715496

Issue observed in the above bug is that the JTable.AccessibleJTableCell.getAccessible name returns the cell instance string instead of the cell text.
The test is being added to verify the same.
This review is for migrating tests from a closed test suite to open.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283015](https://bugs.openjdk.java.net/browse/JDK-8283015): Create a test for JDK-4715496


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7787/head:pull/7787` \
`$ git checkout pull/7787`

Update a local copy of the PR: \
`$ git checkout pull/7787` \
`$ git pull https://git.openjdk.java.net/jdk pull/7787/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7787`

View PR using the GUI difftool: \
`$ git pr show -t 7787`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7787.diff">https://git.openjdk.java.net/jdk/pull/7787.diff</a>

</details>
