### PR TITLE
8283041: [javadoc] Crashes using {@return} with @param

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
@@ -986,7 +986,7 @@ public class Checker extends DocTreePathScanner<Void, Void> {
         if (tree.isInline()) {
             DocCommentTree dct = getCurrentPath().getDocComment();
             if (dct.getFirstSentence().isEmpty() || tree != dct.getFirstSentence().get(0)) {
-                env.messages.warning(REFERENCE, tree, "dc.return.not.first");
+                env.messages.warning(SYNTAX, tree, "dc.return.not.first");
             }
         }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
@@ -985,7 +985,7 @@ public class Checker extends DocTreePathScanner<Void, Void> {
         }
         if (tree.isInline()) {
             DocCommentTree dct = getCurrentPath().getDocComment();
-            if (dct.getFullBody().isEmpty() || tree != dct.getFullBody().get(0)) {
+            if (dct.getFirstSentence().isEmpty() || tree != dct.getFirstSentence().get(0)) {
                 env.messages.warning(REFERENCE, tree, "dc.return.not.first");
             }
         }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -985,7 +985,7 @@ public class Checker extends DocTreePathScanner<Void, Void> {
         }
         if (tree.isInline()) {
             DocCommentTree dct = getCurrentPath().getDocComment();
-            if (tree != dct.getFirstSentence().get(0)) {
+            if (dct.getFullBody().isEmpty() || tree != dct.getFullBody().get(0)) {
                 env.messages.warning(REFERENCE, tree, "dc.return.not.first");
             }
         }

--- a/test/langtools/jdk/javadoc/doclet/testReturnTag/TestReturnTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testReturnTag/TestReturnTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug      4490068 8075778
+ * @bug      4490068 8075778 8283041
  * @summary  General tests for inline or block at-return tag
  * @library  /tools/lib ../../lib
  * @modules  jdk.javadoc/jdk.javadoc.internal.tool
@@ -265,15 +265,29 @@ public class TestReturnTag extends JavadocTester {
                          */
                         public int m() { return 0; }
                     }
+                    """,
+                """
+                    /** Comment. */
+                    public class X {
+                        /**
+                         * @author Jim
+                         * {@return the result}
+                         */
+                        public int m() { return 0; }
+                    }
                     """);
 
         javadoc("-d", base.resolve("out").toString(),
                 "-sourcepath", src.toString(),
-                src.resolve("C.java").toString());
+                src.resolve("C.java").toString(),
+                src.resolve("X.java").toString());
         checkExit(Exit.OK);
 
         checkOutput(Output.OUT, true,
                 "C.java:4: warning: {@return} not at beginning of description");
+
+        checkOutput(Output.OUT, true,
+                "X.java:5: warning: {@return} not at beginning of description");
 
         checkOutput("C.html", true,
                 """


### PR DESCRIPTION
The inline `{@return}` tag is relatively new and will require developers to change their habits. According to the [specification](https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html#return), the inline version of `@return` "may only occur at the beginning of a method's description".

When used like in the description of the issue, the tag technically belongs to the block `@param` tag and not to the body of the doc comment, which one might think is the case. Thus, the "full body" (let alone "first sentence") collection of doc nodes is empty. Hence, IndexOutOfBoundsException when trying to access its first element. 

Since we don't have a method that returns the **complete** doc comment (yes, "getFullBody" is a bit of a misleading name), whose first element we could check against `{@return}`, I check `isEmpty()` before accessing the first element.

Interestingly, `{@summary}` (must also appear first) lint is performed differently. However, I decided not to copy it since it operates on a lower level of abstraction: characters and strings thereof.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283041](https://bugs.openjdk.java.net/browse/JDK-8283041): [javadoc] Crashes using {@return} with @param


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7788/head:pull/7788` \
`$ git checkout pull/7788`

Update a local copy of the PR: \
`$ git checkout pull/7788` \
`$ git pull https://git.openjdk.java.net/jdk pull/7788/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7788`

View PR using the GUI difftool: \
`$ git pr show -t 7788`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7788.diff">https://git.openjdk.java.net/jdk/pull/7788.diff</a>

</details>
