### PR TITLE
8282536: java.net.InetAddress should be a sealed class

### DIFF
--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -44,6 +44,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectInputStream.GetField;
 import java.io.ObjectOutputStream;
 import java.io.ObjectOutputStream.PutField;
+import java.io.Serializable;
 import java.lang.annotation.Native;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
@@ -223,7 +224,7 @@ import static java.net.spi.InetAddressResolver.LookupPolicy.IPV6_FIRST;
  * @see     java.net.InetAddress#getLocalHost()
  * @since 1.0
  */
-public sealed class InetAddress implements java.io.Serializable permits Inet4Address, Inet6Address {
+public sealed class InetAddress implements Serializable permits Inet4Address, Inet6Address {
 
     /**
      * Specify the address family: Internet Protocol, Version 4

--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -223,7 +223,7 @@ import static java.net.spi.InetAddressResolver.LookupPolicy.IPV6_FIRST;
  * @see     java.net.InetAddress#getLocalHost()
  * @since 1.0
  */
-public class InetAddress implements java.io.Serializable {
+public sealed class InetAddress implements java.io.Serializable permits Inet4Address, Inet6Address {
 
     /**
      * Specify the address family: Internet Protocol, Version 4


### PR DESCRIPTION
The following fix seals the `java.net.InetAddress` class and permits only two implementations - `java.net.Inet4Address` and `java.net.Inet6Address`. 

No issues have been detected by regression and JCK tests.

Links: [JBS](https://bugs.openjdk.java.net/browse/JDK-8282536) [CSR](https://bugs.openjdk.java.net/browse/JDK-8282880)