### PR TITLE
8282929: Localized monetary symbols are not reflected in `toLocalizedPattern` return value

### DIFF
--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3210,16 +3210,18 @@ public class DecimalFormat extends NumberFormat {
             for (i = digitCount; i > 0; --i) {
                 if (i != digitCount && isGroupingUsed() && groupingSize != 0 &&
                     i % groupingSize == 0) {
-                    result.append(localized ? symbols.getGroupingSeparator() :
-                                  PATTERN_GROUPING_SEPARATOR);
+                    result.append(localized ?
+                        (isCurrencyFormat ? symbols.getMonetaryGroupingSeparator() : symbols.getGroupingSeparator()) :
+                        PATTERN_GROUPING_SEPARATOR);
                 }
                 result.append(i <= getMinimumIntegerDigits()
                     ? (localized ? symbols.getZeroDigit() : PATTERN_ZERO_DIGIT)
                     : (localized ? symbols.getDigit() : PATTERN_DIGIT));
             }
             if (getMaximumFractionDigits() > 0 || decimalSeparatorAlwaysShown)
-                result.append(localized ? symbols.getDecimalSeparator() :
-                              PATTERN_DECIMAL_SEPARATOR);
+                result.append(localized ?
+                    (isCurrencyFormat ? symbols.getMonetaryDecimalSeparator() : symbols.getDecimalSeparator()) :
+                    PATTERN_DECIMAL_SEPARATOR);
             for (i = 0; i < getMaximumFractionDigits(); ++i) {
                 if (i < getMinimumFractionDigits()) {
                     result.append(localized ? symbols.getZeroDigit() :

--- a/test/jdk/java/text/Format/DecimalFormat/ToLocalizedPatternTest.java
+++ b/test/jdk/java/text/Format/DecimalFormat/ToLocalizedPatternTest.java
@@ -43,8 +43,6 @@ public class ToLocalizedPatternTest {
 
     public void testToLocalizedPattern() {
         var dfs = new DecimalFormatSymbols(Locale.US);
-        var grouping = dfs.getGroupingSeparator();
-        var decimal = dfs.getDecimalSeparator();
 
         // Customize the decimal format symbols
         dfs.setMonetaryGroupingSeparator(MONETARY_GROUPING);
@@ -57,7 +55,7 @@ public class ToLocalizedPatternTest {
         // check
         assertEquals(cf.toLocalizedPattern(),
             cf.toPattern()
-               .replace(grouping, MONETARY_GROUPING)
-               .replace(decimal, MONETARY_DECIMAL));
+               .replace(',', MONETARY_GROUPING)
+               .replace('.', MONETARY_DECIMAL));
     }
 }

--- a/test/jdk/java/text/Format/DecimalFormat/ToLocalizedPatternTest.java
+++ b/test/jdk/java/text/Format/DecimalFormat/ToLocalizedPatternTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8282929
+ * @summary Verifies that toLocalizedPattern() method correctly returns
+ *          monetary symbols in a currency formatter
+ * @run testng ToLocalizedPatternTest
+ */
+
+import static org.testng.Assert.assertEquals;
+import org.testng.annotations.Test;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+
+@Test
+public class ToLocalizedPatternTest {
+    private static final char MONETARY_GROUPING = 'g';
+    private static final char MONETARY_DECIMAL = 'd';
+
+    public void testToLocalizedPattern() {
+        var dfs = new DecimalFormatSymbols(Locale.US);
+        var grouping = dfs.getGroupingSeparator();
+        var decimal = dfs.getDecimalSeparator();
+
+        // Customize the decimal format symbols
+        dfs.setMonetaryGroupingSeparator(MONETARY_GROUPING);
+        dfs.setMonetaryDecimalSeparator(MONETARY_DECIMAL);
+
+        // create a currency formatter
+        var cf = (DecimalFormat)DecimalFormat.getCurrencyInstance(Locale.US);
+        cf.setDecimalFormatSymbols(dfs);
+
+        // check
+        assertEquals(cf.toLocalizedPattern(),
+            cf.toPattern()
+               .replace(grouping, MONETARY_GROUPING)
+               .replace(decimal, MONETARY_DECIMAL));
+    }
+}


### PR DESCRIPTION
`DecimalFormat.toLocalizedPattern()` was not honoring the monetary decimal/grouping separator symbols. Fix is straightforward to use the correct symbols depending on the formatter type.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282929](https://bugs.openjdk.java.net/browse/JDK-8282929): Localized monetary symbols are not reflected in `toLocalizedPattern` return value


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7790/head:pull/7790` \
`$ git checkout pull/7790`

Update a local copy of the PR: \
`$ git checkout pull/7790` \
`$ git pull https://git.openjdk.java.net/jdk pull/7790/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7790`

View PR using the GUI difftool: \
`$ git pr show -t 7790`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7790.diff">https://git.openjdk.java.net/jdk/pull/7790.diff</a>

</details>
