### PR TITLE
8283056: show abstract machine code in hs-err for all VM crashes

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -911,8 +911,6 @@ void VMError::report(outputStream* st, bool _verbose) {
   STEP("printing code blobs if possible")
 
      if (_verbose) {
-       frame fr = _context ? os::fetch_frame_from_context(_context)
-                           : os::current_frame();
        const int printed_capacity = max_error_log_print_code;
        address printed[printed_capacity];
        printed[0] = nullptr;
@@ -931,6 +929,8 @@ void VMError::report(outputStream* st, bool _verbose) {
              printed_len++;
            }
          } else {
+           frame fr = _context ? os::fetch_frame_from_context(_context)
+                               : os::current_frame();
            while (printed_len < limit && fr.pc() != nullptr) {
              if (print_code(st, _thread, fr.pc(), fr.pc() == _pc, printed, printed_capacity)) {
                printed_len++;

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -910,7 +910,9 @@ void VMError::report(outputStream* st, bool _verbose) {
 
   STEP("printing code blobs if possible")
 
-     if (_verbose && _context) {
+     if (_verbose) {
+       frame fr = _context ? os::fetch_frame_from_context(_context)
+                           : os::current_frame();
        const int printed_capacity = max_error_log_print_code;
        address printed[printed_capacity];
        printed[0] = nullptr;
@@ -929,7 +931,6 @@ void VMError::report(outputStream* st, bool _verbose) {
              printed_len++;
            }
          } else {
-           frame fr = os::fetch_frame_from_context(_context);
            while (printed_len < limit && fr.pc() != nullptr) {
              if (print_code(st, _thread, fr.pc(), fr.pc() == _pc, printed, printed_capacity)) {
                printed_len++;


### PR DESCRIPTION
[JDK-8272586](https://bugs.openjdk.java.net/browse/JDK-8272586) added abstract assembly to hs-err for methods on the stack of the crashing thread. However, it only does this if the crash is due to an unhandled signal. It can also be useful to see assembly for crashes due to failing VM assertions or guarantees. This PR implements this improvement.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283056](https://bugs.openjdk.java.net/browse/JDK-8283056): show abstract machine code in hs-err for all VM crashes


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to 3ef8637d5defb149748e85691b235b4da93680c5
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to 3ef8637d5defb149748e85691b235b4da93680c5


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7791/head:pull/7791` \
`$ git checkout pull/7791`

Update a local copy of the PR: \
`$ git checkout pull/7791` \
`$ git pull https://git.openjdk.java.net/jdk pull/7791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7791`

View PR using the GUI difftool: \
`$ git pr show -t 7791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7791.diff">https://git.openjdk.java.net/jdk/pull/7791.diff</a>

</details>
