### PR TITLE
Add Ideal transformation: x + (con - y) -> (x - y) + con

### DIFF
--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -314,6 +314,16 @@ Node* AddNode::IdealIL(PhaseGVN* phase, bool can_reshape, BasicType bt) {
     return SubNode::make(in2, in1->in(2), bt);
   }
 
+  // Convert (con - y) + x into "(x - y) + con"
+  if (op1 == Op_Sub(bt) && in1->in(1)->Opcode() == Op_ConIL(bt)) {
+    return AddNode::make(phase->transform(SubNode::make(in2, in1->in(2), bt)), in1->in(1), bt);
+  }
+
+  // Convert x + (con - y) into "(x - y) + con"
+  if (op2 == Op_Sub(bt) && in2->in(1)->Opcode() == Op_ConIL(bt)) {
+    return AddNode::make(phase->transform(SubNode::make(in1, in2->in(2), bt)), in2->in(1), bt);
+  }
+
   // Associative
   if (op1 == Op_Mul(bt) && op2 == Op_Mul(bt)) {
     Node* add_in1 = NULL;

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1848,6 +1848,14 @@ Op_IL(LShift)
 Op_IL(Xor)
 Op_IL(Cmp)
 
+inline int Op_ConIL(BasicType bt) {
+  assert(bt == T_INT || bt == T_LONG, "only for int or longs");
+  if (bt == T_INT) {
+    return Op_ConI;
+  }
+  return Op_ConL;
+}
+
 inline int Op_Cmp_unsigned(BasicType bt) {
   assert(bt == T_INT || bt == T_LONG, "only for int or longs");
   if (bt == T_INT) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestIRAddIdealXPlus_ConMinusY_.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestIRAddIdealXPlus_ConMinusY_.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import jdk.test.lib.Asserts;
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @summary Test that transformation from x + (con - y) or (con - y) + x
+ *          to (x - y) + con works as intended.
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.TestIRAddIdealXPlus_ConMinusY_
+ */
+public class TestIRAddIdealXPlus_ConMinusY_ {
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    @Test
+    @IR(counts = {IRNode.SUB_I, "1",
+                  IRNode.ADD_I, "1",
+                  IRNode.CON_I, "1"})
+    public int testInt1(int x, int y) {
+        return x + (10 - y) + 200; // transformed to (x - y) + 210;
+    }
+
+    @Run(test = "testInt1")
+    public void checkTestInt1(RunInfo info) {
+        assertC2Compiled(info);
+        Asserts.assertEquals(211, testInt1(10, 9));
+        Asserts.assertEquals(210, testInt1(100, 100)); // x - y == 0
+        // con - y overflows while x - y does not
+        Asserts.assertEquals(-2147483439, testInt1(1, -2147483646));
+        // x - y underflows while con - y does not
+        Asserts.assertEquals(-2147483447, testInt1(-10, 2147483647));
+        // x - y overflows while con - y does not
+        Asserts.assertEquals(-2147483349, testInt1(100, -2147483637));
+    }
+
+    @Test
+    @IR(counts = {IRNode.SUB_I, "1",
+                  IRNode.ADD_I, "1",
+                  IRNode.CON_I, "1"})
+    public int testInt2(int x, int y) {
+        return x + (-10 - y) + 200; // transformed to (x - y) + 190;
+    }
+
+    @Run(test = "testInt2")
+    public void checkTestInt2(RunInfo info) {
+        assertC2Compiled(info);
+        // con - y underflows while x - y does not
+        Asserts.assertEquals(-2147483458, testInt2(-1, 2147483647));
+    }
+
+    @Test
+    @IR(counts = {IRNode.SUB_I, "1",
+                  IRNode.ADD_I, "1",
+                  IRNode.CON_I, "1"})
+    public int testSymInt1(int x, int y) {
+        return (10 - y) + x + 200; // transformed to (x - y) + 210;
+    }
+
+    @Run(test = "testSymInt1")
+    public void checkTestSymInt1(RunInfo info) {
+        assertC2Compiled(info);
+        Asserts.assertEquals(211, testSymInt1(10, 9));
+        Asserts.assertEquals(210, testSymInt1(100, 100)); // x - y == 0
+        // con - y overflows while x - y does not
+        Asserts.assertEquals(-2147483439, testSymInt1(1, -2147483646));
+        // x - y underflows while con - y does not
+        Asserts.assertEquals(-2147483447, testSymInt1(-10, 2147483647));
+        // x - y overflows while con - y does not
+        Asserts.assertEquals(-2147483349, testSymInt1(100, -2147483637));
+    }
+
+    @Test
+    @IR(counts = {IRNode.SUB_I, "1",
+                  IRNode.ADD_I, "1",
+                  IRNode.CON_I, "1"})
+    public int testSymInt2(int x, int y) {
+        return x + (-10 - y) + 200; // transformed to (x - y) + 190;
+    }
+
+    @Run(test = "testSymInt2")
+    public void checkTestSymInt2(RunInfo info) {
+        assertC2Compiled(info);
+        // con - y underflows while x - y does not
+        Asserts.assertEquals(-2147483458, testSymInt2(-1, 2147483647));
+    }
+
+    @Test
+    @IR(counts = {IRNode.SUB_L, "1",
+                  IRNode.ADD_L, "1",
+                  IRNode.CON_L, "1"})
+    public long testLong1(long x, long y) {
+        return x + (123_456_789_000L - y) + 123; // transformed to (x - y) + 123_456_789_123L;
+    }
+
+    @Run(test = "testLong1")
+    public void checkTestLong1(RunInfo info) {
+        assertC2Compiled(info);
+        Asserts.assertEquals(223_456_789_123L, testLong1(123_456_789_000L, 23_456_789_000L));
+        Asserts.assertEquals(123_456_789_123L, testLong1(123_456_789_000L, 123_456_789_000L)); // x - y == 0
+        // con - y overflows while x - y does not
+        Asserts.assertEquals(-9223371913397986686L, testLong1(1L, -9223372036854775806L));
+        // x - y underflows while con - y does not
+        Asserts.assertEquals(-9223371913397986694L, testLong1(-10, 9223372036854775807L));
+        // x - y overflows while con - y does not
+        Asserts.assertEquals(-9223371913397986456L, testLong1(123_456_789_230L, -9223371913397986807L));
+    }
+
+    @Test
+    @IR(counts = {IRNode.SUB_L, "1",
+                  IRNode.ADD_L, "1",
+                  IRNode.CON_L, "1"})
+    public long testLong2(long x, long y) {
+        return x + (-123_456_789_000L - y) + 123; // transformed to (x - y) + -123_456_788_877L;
+    }
+
+    @Run(test = "testLong2")
+    public void checkTestLong2(RunInfo info) {
+        assertC2Compiled(info);
+        // con - y underflows while x - y does not
+        Asserts.assertEquals(9223371913397986931L, testLong2(-1, 9223372036854775807L));
+    }
+
+    @Test
+    @IR(counts = {IRNode.SUB_L, "1",
+                  IRNode.ADD_L, "1",
+                  IRNode.CON_L, "1"})
+    public long testSymLong1(long x, long y) {
+        return x + (123_456_789_000L - y) + 123; // transformed to (x - y) + 123_456_789_123L;
+    }
+
+    @Run(test = "testSymLong1")
+    public void checkTestSymLong1(RunInfo info) {
+        assertC2Compiled(info);
+        Asserts.assertEquals(223_456_789_123L, testSymLong1(123_456_789_000L, 23_456_789_000L));
+        Asserts.assertEquals(123_456_789_123L, testSymLong1(123_456_789_000L, 123_456_789_000L)); // x - y == 0
+        // con - y overflows while x - y does not
+        Asserts.assertEquals(-9223371913397986686L, testSymLong1(1L, -9223372036854775806L));
+        // x - y underflows while con - y does not
+        Asserts.assertEquals(-9223371913397986694L, testSymLong1(-10, 9223372036854775807L));
+        // x - y overflows while con - y does not
+        Asserts.assertEquals(-9223371913397986456L, testSymLong1(123_456_789_230L, -9223371913397986807L));
+    }
+
+    @Test
+    @IR(counts = {IRNode.SUB_L, "1",
+                  IRNode.ADD_L, "1",
+                  IRNode.CON_L, "1"})
+    public long testSymLong2(long x, long y) {
+        return x + (-123_456_789_000L - y) + 123; // transformed to (x - y) + -123_456_788_877L;
+    }
+
+    @Run(test = "testSymLong2")
+    public void checkTestSymLong2(RunInfo info) {
+        assertC2Compiled(info);
+        // con - y underflows while x - y does not
+        Asserts.assertEquals(9223371913397986931L, testSymLong2(-1, 9223372036854775807L));
+    }
+
+    private void assertC2Compiled(RunInfo info) {
+        // Test VM allows C2 to work
+        Asserts.assertTrue(info.isC2CompilationEnabled());
+        if (!info.isWarmUp()) {
+            // C2 compilation happens
+            Asserts.assertTrue(info.isTestC2Compiled());
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -156,6 +156,8 @@ public class IRNode {
     public static final String MUL_I = START + "MulI" + MID + END;
     public static final String MUL_L = START + "MulL" + MID + END;
     public static final String CONV_I2L = START + "ConvI2L" + MID + END;
+    public static final String CON_I = START + "ConI" + MID + END;
+    public static final String CON_L = START + "ConL" + MID + END;
 
     public static final String VECTOR_CAST_B2X = START + "VectorCastB2X" + MID + END;
     public static final String VECTOR_CAST_S2X = START + "VectorCastS2X" + MID + END;


### PR DESCRIPTION
Hello,

`x + (con - y)  -> (x - y) + con` is a widely seen pattern; however it is missing in current implementation, which prevents some obvious constant folding from happening, such as `x + (1 - y) + 2` will be not optimized at all, rather than into `x - y + 3`.

This pull request adds this transformation.