### PR TITLE
8283062: Uninitialized warnings in libgtest with GCC 11.2

### DIFF
--- a/make/hotspot/lib/CompileGtest.gmk
+++ b/make/hotspot/lib/CompileGtest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ $(eval $(call SetupJdkLibrary, BUILD_GTEST_LIBGTEST, \
         $(GTEST_FRAMEWORK_SRC)/googletest/src \
         $(GTEST_FRAMEWORK_SRC)/googlemock/src, \
     INCLUDE_FILES := gtest-all.cc gmock-all.cc, \
-    DISABLED_WARNINGS_gcc := undef unused-result format-nonliteral, \
+    DISABLED_WARNINGS_gcc := undef unused-result format-nonliteral maybe-uninitialized, \
     DISABLED_WARNINGS_clang := undef unused-result format-nonliteral, \
     CFLAGS := $(JVM_CFLAGS) \
         -I$(GTEST_FRAMEWORK_SRC)/googletest \


### PR DESCRIPTION
Background, from JBS:

In file included from googletest-release-1.8.1/googletest/src/gtest-all.cc:42: 
googletest-release-1.8.1/googletest/src/gtest-death-test.cc: In function 'bool testing::internal::StackGrowsDown()': 
googletest-release-1.8.1/googletest/src/gtest-death-test.cc:1224:24: error: 'dummy' may be used uninitialized [-Werror=maybe-uninitialized] 
 1224 | StackLowerThanAddress(&dummy, &result); 
      | ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~ 
googletest-release-1.8.1/googletest/src/gtest-death-test.cc:1214:13: note: by argument 1 of type 'const void*' to 'void testing::internal::StackLowerThanAddress(const void*, bool*)' declared here 
 1214 | static void StackLowerThanAddress(const void* ptr, bool* result) { 
      | ^~~~~~~~~~~~~~~~~~~~~ 
googletest-release-1.8.1/googletest/src/gtest-death-test.cc:1222:7: note: 'dummy' declared here 
 1222 | int dummy;


Details:

Since googletest is external code this change disable the relevant warning.

Testing:

tier1, builds-tier{2,3,4,5}

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283062](https://bugs.openjdk.java.net/browse/JDK-8283062): Uninitialized warnings in libgtest with GCC 11.2


### Reviewers
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7798/head:pull/7798` \
`$ git checkout pull/7798`

Update a local copy of the PR: \
`$ git checkout pull/7798` \
`$ git pull https://git.openjdk.java.net/jdk pull/7798/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7798`

View PR using the GUI difftool: \
`$ git pr show -t 7798`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7798.diff">https://git.openjdk.java.net/jdk/pull/7798.diff</a>

</details>
