### PR TITLE
8283067: Incorrect comment in java.base/share/classes/java/util/ArrayList.java

### DIFF
--- a/src/java.base/share/classes/java/util/ArrayList.java
+++ b/src/java.base/share/classes/java/util/ArrayList.java
@@ -163,7 +163,7 @@ public class ArrayList<E> extends AbstractList<E>
     }
 
     /**
-     * Constructs an empty list with an initial capacity of ten.
+     * Constructs an empty list with default sized empty instances.
      */
     public ArrayList() {
         this.elementData = DEFAULTCAPACITY_EMPTY_ELEMENTDATA;


### PR DESCRIPTION
```
* Constructs an empty list with an initial capacity of ten
```
=>
```
* Constructs an empty list with default sized empty instances.
```
```
  private static final Object[] DEFAULTCAPACITY_EMPTY_ELEMENTDATA = {};
```
DEFAULTCAPACITY_EMPTY_ELEMENTDATA is empty and the length is 0

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8283067](https://bugs.openjdk.java.net/browse/JDK-8283067): Incorrect comment in java.base/share/classes/java/util/ArrayList.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7799/head:pull/7799` \
`$ git checkout pull/7799`

Update a local copy of the PR: \
`$ git checkout pull/7799` \
`$ git pull https://git.openjdk.java.net/jdk pull/7799/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7799`

View PR using the GUI difftool: \
`$ git pr show -t 7799`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7799.diff">https://git.openjdk.java.net/jdk/pull/7799.diff</a>

</details>
