### PR TITLE
8282355: compiler/arguments/TestCodeEntryAlignment.java failed "guarantee(sect->end() <= tend) failed: sanity"

### DIFF
--- a/src/hotspot/share/runtime/stubRoutines.cpp
+++ b/src/hotspot/share/runtime/stubRoutines.cpp
@@ -215,7 +215,10 @@ void StubRoutines::initialize1() {
   if (_code1 == NULL) {
     ResourceMark rm;
     TraceTime timer("StubRoutines generation 1", TRACETIME_LOG(Info, startuptime));
-    _code1 = BufferBlob::create("StubRoutines (1)", code_size1);
+    // Add extra space for large CodeEntryAlignment
+    int max_stubs = 10;
+    int size = code_size1 + CodeEntryAlignment * max_stubs;
+    _code1 = BufferBlob::create("StubRoutines (1)", size);
     if (_code1 == NULL) {
       vm_exit_out_of_memory(code_size1, OOM_MALLOC_ERROR, "CodeCache: no room for StubRoutines (1)");
     }
@@ -269,7 +272,10 @@ void StubRoutines::initialize2() {
   if (_code2 == NULL) {
     ResourceMark rm;
     TraceTime timer("StubRoutines generation 2", TRACETIME_LOG(Info, startuptime));
-    _code2 = BufferBlob::create("StubRoutines (2)", code_size2);
+    // Add extra space for large CodeEntryAlignment
+    int max_stubs = 100;
+    int size = code_size2 + CodeEntryAlignment * max_stubs;
+    _code2 = BufferBlob::create("StubRoutines (2)", size);
     if (_code2 == NULL) {
       vm_exit_out_of_memory(code_size2, OOM_MALLOC_ERROR, "CodeCache: no room for StubRoutines (2)");
     }

--- a/src/hotspot/share/runtime/stubRoutines.cpp
+++ b/src/hotspot/share/runtime/stubRoutines.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -216,8 +216,8 @@ void StubRoutines::initialize1() {
     ResourceMark rm;
     TraceTime timer("StubRoutines generation 1", TRACETIME_LOG(Info, startuptime));
     // Add extra space for large CodeEntryAlignment
-    int max_stubs = 10;
-    int size = code_size1 + CodeEntryAlignment * max_stubs;
+    int max_aligned_stubs = 10;
+    int size = code_size1 + CodeEntryAlignment * max_aligned_stubs;
     _code1 = BufferBlob::create("StubRoutines (1)", size);
     if (_code1 == NULL) {
       vm_exit_out_of_memory(code_size1, OOM_MALLOC_ERROR, "CodeCache: no room for StubRoutines (1)");
@@ -273,8 +273,8 @@ void StubRoutines::initialize2() {
     ResourceMark rm;
     TraceTime timer("StubRoutines generation 2", TRACETIME_LOG(Info, startuptime));
     // Add extra space for large CodeEntryAlignment
-    int max_stubs = 100;
-    int size = code_size2 + CodeEntryAlignment * max_stubs;
+    int max_aligned_stubs = 100;
+    int size = code_size2 + CodeEntryAlignment * max_aligned_stubs;
     _code2 = BufferBlob::create("StubRoutines (2)", size);
     if (_code2 == NULL) {
       vm_exit_out_of_memory(code_size2, OOM_MALLOC_ERROR, "CodeCache: no room for StubRoutines (2)");

--- a/test/hotspot/jtreg/compiler/arguments/TestCodeEntryAlignment.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestCodeEntryAlignment.java
@@ -66,7 +66,13 @@ public class TestCodeEntryAlignment {
     }
 
     public static void driver() throws IOException {
-        for (int align = 32; align <= 1024; align *= 2) {
+        for (int align = 16; align < 256; align *= 2) {
+            shouldPass(
+                "-XX:+UnlockExperimentalVMOptions",
+                "-XX:CodeEntryAlignment=" + align
+            );
+        }
+        for (int align = 256; align <= 1024; align *= 2) {
             shouldPass(
                 "-XX:+UnlockExperimentalVMOptions",
                 "-XX:CodeCacheSegmentSize=" + align,

--- a/test/hotspot/jtreg/compiler/arguments/TestCodeEntryAlignment.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestCodeEntryAlignment.java
@@ -66,9 +66,10 @@ public class TestCodeEntryAlignment {
     }
 
     public static void driver() throws IOException {
-        for (int align = 16; align < 256; align *= 2) {
+        for (int align = 32; align <= 1024; align *= 2) {
             shouldPass(
                 "-XX:+UnlockExperimentalVMOptions",
+                "-XX:CodeCacheSegmentSize=" + align,
                 "-XX:CodeEntryAlignment=" + align
             );
         }

--- a/test/hotspot/jtreg/compiler/arguments/TestCodeEntryAlignment.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestCodeEntryAlignment.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This change adds extra stub space for large values of CodeEntryAlignment, and it changes the test to try large values of CodeEntryAlignment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282355](https://bugs.openjdk.java.net/browse/JDK-8282355): compiler/arguments/TestCodeEntryAlignment.java failed "guarantee(sect->end() <= tend) failed: sanity"


### Reviewers
 * @hakib1 (no known github.com user name / role) ⚠️ Review applies to 65fa6fda00eec84b7fcf9b247edc0078c6f93565
 * [Jie Fu](https://openjdk.java.net/census#jiefu) (@DamonFool - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7800/head:pull/7800` \
`$ git checkout pull/7800`

Update a local copy of the PR: \
`$ git checkout pull/7800` \
`$ git pull https://git.openjdk.java.net/jdk pull/7800/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7800`

View PR using the GUI difftool: \
`$ git pr show -t 7800`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7800.diff">https://git.openjdk.java.net/jdk/pull/7800.diff</a>

</details>
