### PR TITLE
8282936: Write a regression test for JDK-4615365

### DIFF
--- a/test/jdk/javax/swing/JSplitPane/4615365/JSplitPaneDividerLocationTest.java
+++ b/test/jdk/javax/swing/JSplitPane/4615365/JSplitPaneDividerLocationTest.java
@@ -44,12 +44,14 @@ import javax.swing.UIManager;
 import javax.swing.UIManager.LookAndFeelInfo;
 import javax.swing.UnsupportedLookAndFeelException;
 
+
 import static javax.swing.UIManager.getInstalledLookAndFeels;
 /*
  * @test
  * @key headful
  * @bug 4615365
- * @summary This test confirms that the JSplitPane current and last divider positions are correct when realized.
+ * @summary This test confirms that the JSplitPane's current and last
+ *          divider positions are correct when realized.
  * @run main JSplitPaneDividerLocationTest
  */
 public class JSplitPaneDividerLocationTest {
@@ -86,31 +88,42 @@ public class JSplitPaneDividerLocationTest {
 
                 pressButton(triggerButton);
 
-                // Verifies that JSplitPane current and last divider positions are correct and not as per JDK-4615365.
+                // Verifies that JSplitPane current and last divider
+                // positions are correct and not as per JDK-4615365.
                 if ((currentLoc == -1) || (lastLoc == 0)) {
-                    throw new RuntimeException("Test failed for " + laf + " :- last divider location: actual = " + lastLoc
-                            + ", expected = -1, current divider location: actual = " + currentLoc + ", expected > 0");
+                    throw new RuntimeException(
+                            "Test failed for " + laf + " :- last divider loc:" +
+                            "actual = " + lastLoc + ",expected = -1, current " +
+                            "divider loc:actual=" + currentLoc + ",expected>0");
                 }
                 lastLocExpected = currentLoc;
 
                 // Slide the split pane divider slightly to the right side.
                 final Point leftButtonLoc = getButtonLoc(leftButton);
-                robot.mouseMove(leftButtonLoc.x + leftButton.getWidth() + 5, leftButtonLoc.y + 35);
+                robot.mouseMove(leftButtonLoc.x + leftButton.getWidth() + 5,
+                                leftButtonLoc.y + 35);
                 robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-                robot.mouseMove(leftButtonLoc.x + leftButton.getWidth() + 8, leftButtonLoc.y + 35);
+                robot.mouseMove(leftButtonLoc.x + leftButton.getWidth() + 8,
+                                leftButtonLoc.y + 35);
                 robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
                 pressButton(triggerButton);
 
-                // Verifies that JSplitPane current and last divider positions reflects the correct positions after a right slide.
+                // Verifies that JSplitPane current and last divider positions
+                // reflects the correct positions after a right slide.
                 if ((lastLoc == lastLocExpected) && (currentLoc > lastLoc)) {
                     System.out.println("Test Passed.");
                 } else {
-                    throw new RuntimeException("Test failed for " + laf + ", because after a right slide"
-                            + ", last divider location: actual = " + lastLoc + ", expected = " + lastLocExpected
-                            + ", current divider location: actual = " + currentLoc + ", expected > " + lastLoc);
+                    throw new RuntimeException(
+                            "Test failed for " + laf + ", because after a " +
+                            "right " + "slide" + ", last divider " +
+                            "location: " + "actual = " + lastLoc +
+                            ", expected = " + lastLocExpected +
+                            ", current divider " + "location: actual = " +
+                            currentLoc + ", expected > " + lastLoc);
                 }
             } finally {
-                SwingUtilities.invokeAndWait(JSplitPaneDividerLocationTest::disposeFrame);
+                SwingUtilities.invokeAndWait(
+                        JSplitPaneDividerLocationTest::disposeFrame);
             }
         }
     }
@@ -122,7 +135,8 @@ public class JSplitPaneDividerLocationTest {
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
     }
 
-    private static Point getButtonLoc(AbstractButton button) throws InterruptedException, InvocationTargetException {
+    private static Point getButtonLoc(AbstractButton button)
+            throws InterruptedException, InvocationTargetException {
         final AtomicReference<Point> loc = new AtomicReference<>();
         SwingUtilities.invokeAndWait(() -> {
             loc.set(button.getLocationOnScreen());
@@ -138,7 +152,9 @@ public class JSplitPaneDividerLocationTest {
         leftButton = new JButton("Left Button");
         JButton rightButton = new JButton("Right Button");
 
-        final JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, true, leftButton, rightButton);
+        final JSplitPane splitPane =
+                new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, true, leftButton,
+                               rightButton);
         panel.add(splitPane, BorderLayout.CENTER);
 
         splitPane.setDividerSize(10);
@@ -148,7 +164,9 @@ public class JSplitPaneDividerLocationTest {
             public void actionPerformed(ActionEvent event) {
                 currentLoc = splitPane.getDividerLocation();
                 lastLoc = splitPane.getLastDividerLocation();
-                System.out.println("currentLoc = " + currentLoc + ", lastLoc = " + lastLoc);
+                System.out.println(
+                        "currentLoc = " + currentLoc + ", lastLoc = " +
+                        lastLoc);
             }
         });
         panel.add(triggerButton, BorderLayout.SOUTH);

--- a/test/jdk/javax/swing/JSplitPane/4615365/JSplitPaneDividerLocationTest.java
+++ b/test/jdk/javax/swing/JSplitPane/4615365/JSplitPaneDividerLocationTest.java
@@ -44,7 +44,6 @@ import javax.swing.UIManager;
 import javax.swing.UIManager.LookAndFeelInfo;
 import javax.swing.UnsupportedLookAndFeelException;
 
-
 import static javax.swing.UIManager.getInstalledLookAndFeels;
 /*
  * @test

--- a/test/jdk/javax/swing/JSplitPane/4615365/JSplitPaneDividerLocationTest.java
+++ b/test/jdk/javax/swing/JSplitPane/4615365/JSplitPaneDividerLocationTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import javax.swing.AbstractButton;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JSplitPane;
+import javax.swing.JToggleButton;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UIManager.LookAndFeelInfo;
+import javax.swing.UnsupportedLookAndFeelException;
+
+import static javax.swing.UIManager.getInstalledLookAndFeels;
+/*
+ * @test
+ * @key headful
+ * @bug 4615365
+ * @summary This test confirms that the JSplitPane current and last divider positions are correct when realized.
+ * @run main JSplitPaneDividerLocationTest
+ */
+public class JSplitPaneDividerLocationTest {
+
+    private static JFrame frame;
+    private static JPanel panel;
+    private static JButton leftButton;
+    private static JToggleButton triggerButton;
+    private static volatile int currentLoc;
+    private static volatile int lastLoc;
+    private static volatile int lastLocExpected;
+    private static Robot robot;
+
+    public static void main(String[] s) throws Exception {
+        robot = new Robot();
+        robot.setAutoWaitForIdle(true);
+        robot.setAutoDelay(200);
+        List<String> lafs = Arrays.stream(getInstalledLookAndFeels())
+                                  .map(LookAndFeelInfo::getClassName)
+                                  .collect(Collectors.toList());
+        for (final String laf : lafs) {
+            try {
+                AtomicBoolean lafSetSuccess = new AtomicBoolean(false);
+                SwingUtilities.invokeAndWait(() -> {
+                    lafSetSuccess.set(setLookAndFeel(laf));
+                    if (lafSetSuccess.get()) {
+                        createUI();
+                    }
+                });
+                if (!lafSetSuccess.get()) {
+                    continue;
+                }
+                robot.waitForIdle();
+
+                pressButton(triggerButton);
+
+                // Verifies that JSplitPane current and last divider positions are correct and not as per JDK-4615365.
+                if ((currentLoc == -1) || (lastLoc == 0)) {
+                    throw new RuntimeException("Test failed for " + laf + " :- last divider location: actual = " + lastLoc
+                            + ", expected = -1, current divider location: actual = " + currentLoc + ", expected > 0");
+                }
+                lastLocExpected = currentLoc;
+
+                // Slide the split pane divider slightly to the right side.
+                final Point leftButtonLoc = getButtonLoc(leftButton);
+                robot.mouseMove(leftButtonLoc.x + leftButton.getWidth() + 5, leftButtonLoc.y + 35);
+                robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+                robot.mouseMove(leftButtonLoc.x + leftButton.getWidth() + 8, leftButtonLoc.y + 35);
+                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+                pressButton(triggerButton);
+
+                // Verifies that JSplitPane current and last divider positions reflects the correct positions after a right slide.
+                if ((lastLoc == lastLocExpected) && (currentLoc > lastLoc)) {
+                    System.out.println("Test Passed.");
+                } else {
+                    throw new RuntimeException("Test failed for " + laf + ", because after a right slide"
+                            + ", last divider location: actual = " + lastLoc + ", expected = " + lastLocExpected
+                            + ", current divider location: actual = " + currentLoc + ", expected > " + lastLoc);
+                }
+            } finally {
+                SwingUtilities.invokeAndWait(JSplitPaneDividerLocationTest::disposeFrame);
+            }
+        }
+    }
+
+    private static void pressButton(JToggleButton button) throws Exception {
+        final Point buttonLoc = getButtonLoc(button);
+        robot.mouseMove(buttonLoc.x + 8, buttonLoc.y + 8);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+    }
+
+    private static Point getButtonLoc(AbstractButton button) throws InterruptedException, InvocationTargetException {
+        final AtomicReference<Point> loc = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> {
+            loc.set(button.getLocationOnScreen());
+        });
+        final Point buttonLoc = loc.get();
+        return buttonLoc;
+    }
+
+    private static void createUI() {
+        frame = new JFrame();
+        panel = new JPanel();
+        panel.setLayout(new BorderLayout());
+        leftButton = new JButton("Left Button");
+        JButton rightButton = new JButton("Right Button");
+
+        final JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, true, leftButton, rightButton);
+        panel.add(splitPane, BorderLayout.CENTER);
+
+        splitPane.setDividerSize(10);
+
+        triggerButton = new JToggleButton("Trigger");
+        triggerButton.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent event) {
+                currentLoc = splitPane.getDividerLocation();
+                lastLoc = splitPane.getLastDividerLocation();
+                System.out.println("currentLoc = " + currentLoc + ", lastLoc = " + lastLoc);
+            }
+        });
+        panel.add(triggerButton, BorderLayout.SOUTH);
+
+        frame.setContentPane(panel);
+        frame.setSize(300, 300);
+        frame.setLocationRelativeTo(null);
+        frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+        frame.setVisible(true);
+    }
+
+    private static boolean setLookAndFeel(String lafName) {
+        try {
+            UIManager.setLookAndFeel(lafName);
+        } catch (UnsupportedLookAndFeelException ignored) {
+            System.out.println("Ignoring Unsupported L&F: " + lafName);
+            return false;
+        } catch (ClassNotFoundException | InstantiationException
+                | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+        return true;
+    }
+
+    private static void disposeFrame() {
+        if (frame != null) {
+            frame.dispose();
+            frame = null;
+        }
+    }
+
+}


### PR DESCRIPTION
Write a regression test for [JDK-4615365](https://bugs.openjdk.java.net/browse/JDK-4615365) : JSplitPane current and last divider positions incorrect when realized

Issue:
JSplitPane component with a left and right component has its current divider
position incorrectly set to -1 once it is fully realized. For JDK 1.3.1, its
value is set to 0. The current position of the divider should be the current
position of the divider once layout management is complete. If the divider is
moved one pixel, the current divider position is updated to the correct value
but the last divider position is then set to -1 (i.e. the last value of the
current divider position). If the divider is moved again, everything is OK.

Testing:
Java 1.4.0 -> Test Failed.
$ j2sdk1.4.0/bin/java bug4615365
current= -1, last= 0
Test Failed.

Java 1.4.1 -> Test Passed.
$ j2sdk1.4.1/bin/java bug4615365
current= 97, last= -1
Test Passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282936](https://bugs.openjdk.java.net/browse/JDK-8282936): Write a regression test for JDK-4615365


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7802/head:pull/7802` \
`$ git checkout pull/7802`

Update a local copy of the PR: \
`$ git checkout pull/7802` \
`$ git pull https://git.openjdk.java.net/jdk pull/7802/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7802`

View PR using the GUI difftool: \
`$ git pr show -t 7802`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7802.diff">https://git.openjdk.java.net/jdk/pull/7802.diff</a>

</details>
