### PR TITLE
JDK-8283087: Create a test or JDK-4715503

### DIFF
--- a/test/jdk/javax/accessibility/4715503/AccessibleJTableCellBoundingRectangleTest.java
+++ b/test/jdk/javax/accessibility/4715503/AccessibleJTableCellBoundingRectangleTest.java
@@ -29,6 +29,7 @@
  * @run main AccessibleJTableCellBoundingRectangleTest
  */
 
+import java.awt.Rectangle;
 import java.awt.Robot;
 
 import javax.swing.JFrame;
@@ -54,9 +55,16 @@ public class AccessibleJTableCellBoundingRectangleTest {
 
             for (int i = 0; i <= colNames.length - 1; i++) {
                 try {
-                    System.out.println("Column " + i + " Bounds: "
-                        + jTable.getTableHeader().getAccessibleContext().getAccessibleChild(i)
-                        .getAccessibleContext().getAccessibleComponent().getBounds());
+                    Rectangle bounds =
+                        jTable.getTableHeader().getAccessibleContext().getAccessibleChild(i)
+                        .getAccessibleContext().getAccessibleComponent().getBounds();
+
+                    if (bounds != null) {
+                        System.out.println("Column " + i + " Bounds: " + bounds);
+                    } else {
+                        throw new RuntimeException(
+                            "Bounding Rectangles getting bounding rectangle for table header cells is null");
+                    }
                 } catch (Exception e) {
                     throw new RuntimeException("Bounding Rectangles getting bounding rectangle for "
                         + "table header cells threw an exception:\n" + e);

--- a/test/jdk/javax/accessibility/4715503/AccessibleJTableCellBoundingRectangleTest.java
+++ b/test/jdk/javax/accessibility/4715503/AccessibleJTableCellBoundingRectangleTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key headful
+ * @bug 4715503
+ * @summary AccessibleTable cannot get the Bounding Rectangle of Table Header Cells.
+ * @run main AccessibleJTableCellBoundingRectangleTest
+ */
+
+import java.awt.Robot;
+
+import javax.swing.JFrame;
+import javax.swing.JTable;
+import javax.swing.SwingUtilities;
+
+public class AccessibleJTableCellBoundingRectangleTest {
+    private static JTable jTable;
+    private static JFrame jFrame;
+
+    private static Object[][] rowData = { { "01", "02", "03", "04", "05" },
+        { "11", "12", "13", "14", "15" }, { "21", "22", "23", "24", "25" },
+        { "31", "32", "33", "34", "35" }, { "41", "42", "43", "44", "45" } };
+
+    private static Object[] colNames = { "1", "2", "3", "4", "5" };
+
+    private static void doTest() throws Exception {
+        try {
+            SwingUtilities.invokeAndWait(() -> createGUI());
+            Robot robot = new Robot();
+            robot.setAutoDelay(500);
+            robot.waitForIdle();
+
+            for (int i = 0; i <= colNames.length - 1; i++) {
+                try {
+                    System.out.println("Column " + i + " Bounds: "
+                        + jTable.getTableHeader().getAccessibleContext().getAccessibleChild(i)
+                        .getAccessibleContext().getAccessibleComponent().getBounds());
+                } catch (Exception e) {
+                    throw new RuntimeException("Bounding Rectangles getting bounding rectangle for "
+                        + "table header cells threw an exception:\n" + e);
+                }
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> jFrame.dispose());
+        }
+    }
+
+    private static void createGUI() {
+        jTable = new JTable(rowData, colNames);
+        jFrame = new JFrame();
+        jFrame.setBounds(100, 100, 300, 300);
+        jFrame.getContentPane().add(jTable);
+        jFrame.setVisible(true);
+    }
+
+    public static void main(String args[]) throws Exception {
+        doTest();
+        System.out.println("Test Passed");
+    }
+}
+


### PR DESCRIPTION
Create a test or [JDK-4715503](https://bugs.openjdk.java.net/browse/JDK-4715503)

The getAccessibleContext method for JTable column header cells returns an
 AccessibleContext which cannot get the Bounding Rectangle for table header cells. The Bug causes problems with screen reader review mode.

The test added verifies that the are not exceptions and Bounding rectangles are returned for the Accessible Table Header Cells.

This review is for migrating tests from a closed test suite to open.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283087](https://bugs.openjdk.java.net/browse/JDK-8283087): Create a test or JDK-4715503


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7807/head:pull/7807` \
`$ git checkout pull/7807`

Update a local copy of the PR: \
`$ git checkout pull/7807` \
`$ git pull https://git.openjdk.java.net/jdk pull/7807/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7807`

View PR using the GUI difftool: \
`$ git pr show -t 7807`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7807.diff">https://git.openjdk.java.net/jdk/pull/7807.diff</a>

</details>
