### PR TITLE
8283097: Parallel: Move filler object logic inside PSPromotionLAB::unallocate_object

### DIFF
--- a/src/hotspot/share/gc/parallel/psPromotionLAB.cpp
+++ b/src/hotspot/share/gc/parallel/psPromotionLAB.cpp
@@ -85,18 +85,19 @@ void PSPromotionLAB::flush() {
   _state = flushed;
 }
 
-bool PSPromotionLAB::unallocate_object(HeapWord* obj, size_t obj_size) {
+void PSPromotionLAB::unallocate_object(HeapWord* obj, size_t obj_size) {
   assert(ParallelScavengeHeap::heap()->is_in(obj), "Object outside heap");
 
+  // If the object is inside this LAB, we just bump-down the `top` pointer.
+  // Otherwise, we overwrite it with a filler object.
   if (contains(obj)) {
     HeapWord* object_end = obj + obj_size;
     assert(object_end == top(), "Not matching last allocation");
 
     set_top(obj);
-    return true;
+  } else {
+    CollectedHeap::fill_with_object(obj, obj_size);
   }
-
-  return false;
 }
 
 // Fill all remaining lab space with an unreachable object.

--- a/src/hotspot/share/gc/parallel/psPromotionLAB.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionLAB.hpp
@@ -72,7 +72,7 @@ class PSPromotionLAB : public CHeapObj<mtGC> {
 
   bool is_flushed()                  { return _state == flushed; }
 
-  bool unallocate_object(HeapWord* obj, size_t obj_size);
+  void unallocate_object(HeapWord* obj, size_t obj_size);
 
   // Returns a subregion containing all objects in this space.
   MemRegion used_region()            { return MemRegion(bottom(), top()); }

--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -290,15 +290,10 @@ inline oop PSPromotionManager::copy_unmarked_to_survivor_space(oop o,
     assert(o->is_forwarded(), "Object must be forwarded if the cas failed.");
     assert(o->forwardee() == forwardee, "invariant");
 
-    // Try to deallocate the space.  If it was directly allocated we cannot
-    // deallocate it, so we have to test.  If the deallocation fails,
-    // overwrite with a filler object.
     if (new_obj_is_tenured) {
-      if (!_old_lab.unallocate_object(cast_from_oop<HeapWord*>(new_obj), new_obj_size)) {
-        CollectedHeap::fill_with_object(cast_from_oop<HeapWord*>(new_obj), new_obj_size);
-      }
-    } else if (!_young_lab.unallocate_object(cast_from_oop<HeapWord*>(new_obj), new_obj_size)) {
-      CollectedHeap::fill_with_object(cast_from_oop<HeapWord*>(new_obj), new_obj_size);
+      _old_lab.unallocate_object(cast_from_oop<HeapWord*>(new_obj), new_obj_size);
+    } else {
+      _young_lab.unallocate_object(cast_from_oop<HeapWord*>(new_obj), new_obj_size);
     }
     return forwardee;
   }


### PR DESCRIPTION
Simple cleanup in the unallocation path in `PSPromotionManager::copy_unmarked_to_survivor_space`.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283097](https://bugs.openjdk.java.net/browse/JDK-8283097): Parallel: Move filler object logic inside PSPromotionLAB::unallocate_object


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7808/head:pull/7808` \
`$ git checkout pull/7808`

Update a local copy of the PR: \
`$ git checkout pull/7808` \
`$ git pull https://git.openjdk.java.net/jdk pull/7808/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7808`

View PR using the GUI difftool: \
`$ git pr show -t 7808`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7808.diff">https://git.openjdk.java.net/jdk/pull/7808.diff</a>

</details>
