### PR TITLE
8283103: compiler/vectorapi/TestMaskedMacroLogicVector.java failed due to incorrect os.simpleArch on some platforms

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/TestMaskedMacroLogicVector.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestMaskedMacroLogicVector.java
@@ -834,6 +834,7 @@ public class TestMaskedMacroLogicVector {
 
     public static void main(String[] args) {
         TestFramework.runWithFlags("-XX:-TieredCompilation",
+                                   "-XX:+IgnoreUnrecognizedVMOptions",
                                    "-XX:UseAVX=3",
                                    "--add-modules=jdk.incubator.vector",
                                    "-XX:CompileThresholdScaling=0.3");

--- a/test/hotspot/jtreg/compiler/vectorapi/TestMaskedMacroLogicVector.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestMaskedMacroLogicVector.java
@@ -28,7 +28,7 @@
  * @summary Enhance macro logic optimization for masked logic operations.
  * @modules jdk.incubator.vector
  * @requires vm.compiler2.enabled
- * @requires os.simpleArch == "x64"
+ * @requires vm.cpu.features ~= ".*avx.*"
  * @library /test/lib /
  * @run driver compiler.vectorapi.TestMaskedMacroLogicVector
  */
@@ -834,7 +834,6 @@ public class TestMaskedMacroLogicVector {
 
     public static void main(String[] args) {
         TestFramework.runWithFlags("-XX:-TieredCompilation",
-                                   "-XX:+IgnoreUnrecognizedVMOptions",
                                    "-XX:UseAVX=3",
                                    "--add-modules=jdk.incubator.vector",
                                    "-XX:CompileThresholdScaling=0.3");


### PR DESCRIPTION
`os.simpleArch` is not set correctly on some platforms, for example on loongarch64 and mips64 ([CODETOOLS-7903120](https://bugs.openjdk.java.net/browse/CODETOOLS-7903120)). This issue aims to let the test work on these platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8283103](https://bugs.openjdk.java.net/browse/JDK-8283103): compiler/vectorapi/TestMaskedMacroLogicVector.java failed due to incorrect os.simpleArch on some platforms


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7809/head:pull/7809` \
`$ git checkout pull/7809`

Update a local copy of the PR: \
`$ git checkout pull/7809` \
`$ git pull https://git.openjdk.java.net/jdk pull/7809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7809`

View PR using the GUI difftool: \
`$ git pr show -t 7809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7809.diff">https://git.openjdk.java.net/jdk/pull/7809.diff</a>

</details>
