### PR TITLE
8282633: jarsigner output does not explain why an EC key is disabled if its curve has been disabled

### DIFF
--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -42,8 +42,6 @@ import java.security.cert.TrustAnchor;
 import java.security.cert.URICertStoreParameters;
 
 
-import java.security.interfaces.ECKey;
-import java.security.interfaces.EdECKey;
 import java.security.spec.ECParameterSpec;
 import java.text.Collator;
 import java.text.MessageFormat;
@@ -2018,7 +2016,7 @@ public final class Main {
                     ("Generating.keysize.bit.keyAlgName.key.pair.and.a.certificate.sigAlgName.issued.by.signerAlias.with.a.validity.of.validality.days.for"));
             Object[] source = {
                     groupName == null ? keysize : KeyUtil.getKeySize(privKey),
-                    fullDisplayAlgName(privKey),
+                    KeyUtil.fullDisplayAlgName(privKey),
                     newCert.getSigAlgName(),
                     signerAlias,
                     validity,
@@ -2029,7 +2027,7 @@ public final class Main {
                     ("Generating.keysize.bit.keyAlgName.key.pair.and.self.signed.certificate.sigAlgName.with.a.validity.of.validality.days.for"));
             Object[] source = {
                     groupName == null ? keysize : KeyUtil.getKeySize(privKey),
-                    fullDisplayAlgName(privKey),
+                    KeyUtil.fullDisplayAlgName(privKey),
                     newCert.getSigAlgName(),
                     validity,
                     x500Name};
@@ -3560,24 +3558,10 @@ public final class Main {
         }
     }
 
-    private String fullDisplayAlgName(Key key) {
-        String result = key.getAlgorithm();
-        if (key instanceof ECKey) {
-            ECParameterSpec paramSpec = ((ECKey) key).getParams();
-            if (paramSpec instanceof NamedCurve) {
-                NamedCurve nc = (NamedCurve)paramSpec;
-                result += " (" + nc.getNameAndAliases()[0] + ")";
-            }
-        } else if (key instanceof EdECKey) {
-            result = ((EdECKey) key).getParams().getName();
-        }
-        return result;
-    }
-
     private String withWeakConstraint(Key key,
             CertPathConstraintsParameters cpcp) {
         int kLen = KeyUtil.getKeySize(key);
-        String displayAlg = fullDisplayAlgName(key);
+        String displayAlg = KeyUtil.fullDisplayAlgName(key);
         try {
             DISABLED_CHECK.permits(key.getAlgorithm(), cpcp, true);
         } catch (CertPathValidatorException e) {
@@ -4946,13 +4930,13 @@ public final class Main {
                     weakWarnings.add(String.format(
                             rb.getString("whose.key.weak"), label,
                             String.format(rb.getString("key.bit"),
-                            KeyUtil.getKeySize(key), fullDisplayAlgName(key))));
+                            KeyUtil.getKeySize(key), KeyUtil.fullDisplayAlgName(key))));
                 }
             } catch (CertPathValidatorException e) {
                 weakWarnings.add(String.format(
                         rb.getString("whose.key.disabled"), label,
                         String.format(rb.getString("key.bit"),
-                        KeyUtil.getKeySize(key), fullDisplayAlgName(key))));
+                        KeyUtil.getKeySize(key), KeyUtil.fullDisplayAlgName(key))));
             }
         }
     }
@@ -4973,12 +4957,12 @@ public final class Main {
                 weakWarnings.add(String.format(
                     rb.getString("whose.key.disabled"), label,
                     String.format(rb.getString("key.bit"),
-                    KeyUtil.getKeySize(key), fullDisplayAlgName(key))));
+                    KeyUtil.getKeySize(key), KeyUtil.fullDisplayAlgName(key))));
             } else if (!LEGACY_CHECK.permits(SIG_PRIMITIVE_SET, key)) {
                 weakWarnings.add(String.format(
                     rb.getString("whose.key.weak"), label,
                     String.format(rb.getString("key.bit"),
-                    KeyUtil.getKeySize(key), fullDisplayAlgName(key))));
+                    KeyUtil.getKeySize(key), KeyUtil.fullDisplayAlgName(key))));
             }
         }
     }

--- a/src/java.base/share/classes/sun/security/util/KeyUtil.java
+++ b/src/java.base/share/classes/sun/security/util/KeyUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -188,6 +188,28 @@ public final class KeyUtil {
         }
 
         return -1;
+    }
+
+    /**
+     * Returns the algorithm name of the given key object. If an EC key is
+     * specified, returns the algorithm name and its named curve.
+     *
+     * @param key the key object, cannot be null
+     * @return the algorithm name of the given key object, or return in the
+     *       form of "EC (named curve)" if the given key object is an EC key
+     */
+    public static final String fullDisplayAlgName(Key key) {
+        String result = key.getAlgorithm();
+        if (key instanceof ECKey) {
+            ECParameterSpec paramSpec = ((ECKey) key).getParams();
+            if (paramSpec instanceof NamedCurve) {
+                NamedCurve nc = (NamedCurve)paramSpec;
+                result += " (" + nc.getNameAndAliases()[0] + ")";
+            }
+        } else if (key instanceof EdECKey) {
+            result = ((EdECKey) key).getParams().getName();
+        }
+        return result;
     }
 
     /**

--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
@@ -30,6 +30,7 @@ import java.net.UnknownHostException;
 import java.net.URLClassLoader;
 import java.security.cert.CertPathValidatorException;
 import java.security.cert.PKIXBuilderParameters;
+import java.security.interfaces.ECKey;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.zip.*;
@@ -1250,7 +1251,7 @@ public class Main {
             if ((disabledAlg & 8) == 8) {
                 errors.add(String.format(
                         rb.getString("The.1.signing.key.has.a.keysize.of.2.which.is.considered.a.security.risk.and.is.disabled."),
-                        privateKey.getAlgorithm(), KeyUtil.getKeySize(privateKey)));
+                        KeyUtil.fullDisplayAlgName(privateKey), KeyUtil.getKeySize(privateKey)));
             }
         } else {
             if ((legacyAlg & 1) != 0) {
@@ -1451,7 +1452,12 @@ public class Main {
             JAR_DISABLED_CHECK.permits(key.getAlgorithm(), jcp, true);
         } catch (CertPathValidatorException e) {
             disabledAlgFound = true;
-            return String.format(rb.getString("key.bit.disabled"), kLen);
+            if (key instanceof ECKey) {
+                return String.format(rb.getString("key.bit.eccurve.disabled"), kLen,
+                        KeyUtil.fullDisplayAlgName(key));
+            } else {
+                return String.format(rb.getString("key.bit.disabled"), kLen);
+            }
         }
         try {
             LEGACY_CHECK.permits(key.getAlgorithm(), jcp, true);
@@ -1516,7 +1522,12 @@ public class Main {
         try {
             CERTPATH_DISABLED_CHECK.permits(key.getAlgorithm(), cpcp, true);
         } catch (CertPathValidatorException e) {
-            return String.format(rb.getString("key.bit.disabled"), kLen);
+            if (key instanceof ECKey) {
+                return String.format(rb.getString("key.bit.eccurve.disabled"), kLen,
+                        KeyUtil.fullDisplayAlgName(key));
+            } else {
+                return String.format(rb.getString("key.bit.disabled"), kLen);
+            }
         }
         try {
             LEGACY_CHECK.permits(key.getAlgorithm(), cpcp, true);

--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
@@ -1245,7 +1245,7 @@ public class Main {
             if ((legacyAlg & 8) == 8) {
                 warnings.add(String.format(
                         rb.getString("The.1.signing.key.has.a.keysize.of.2.which.is.considered.a.security.risk..This.key.size.will.be.disabled.in.a.future.update."),
-                        privateKey.getAlgorithm(), KeyUtil.getKeySize(privateKey)));
+                        KeyUtil.fullDisplayAlgName(privateKey), KeyUtil.getKeySize(privateKey)));
             }
 
             if ((disabledAlg & 8) == 8) {
@@ -1275,7 +1275,7 @@ public class Main {
             if ((legacyAlg & 8) == 8) {
                 warnings.add(String.format(
                         rb.getString("The.1.signing.key.has.a.keysize.of.2.which.is.considered.a.security.risk..This.key.size.will.be.disabled.in.a.future.update."),
-                        weakPublicKey.getAlgorithm(), KeyUtil.getKeySize(weakPublicKey)));
+                        KeyUtil.fullDisplayAlgName(weakPublicKey), KeyUtil.getKeySize(weakPublicKey)));
             }
         }
 
@@ -1469,7 +1469,12 @@ public class Main {
         } catch (CertPathValidatorException e) {
             weakPublicKey = key;
             legacyAlg |= 8;
-            return String.format(rb.getString("key.bit.weak"), kLen);
+            if (key instanceof ECKey) {
+                return String.format(rb.getString("key.bit.eccurve.weak"), kLen,
+                        KeyUtil.fullDisplayAlgName(key));
+            } else {
+                return String.format(rb.getString("key.bit.weak"), kLen);
+            }
         }
     }
 
@@ -1537,7 +1542,12 @@ public class Main {
                 return rb.getString("unknown.size");
             }
         } catch (CertPathValidatorException e) {
-            return String.format(rb.getString("key.bit.weak"), kLen);
+            if (key instanceof ECKey) {
+                return String.format(rb.getString("key.bit.eccurve.weak"), kLen,
+                        KeyUtil.fullDisplayAlgName(key));
+            } else {
+                return String.format(rb.getString("key.bit.weak"), kLen);
+            }
         }
     }
 

--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Resources.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Resources.java
@@ -181,6 +181,7 @@ public class Resources extends java.util.ListResourceBundle {
         {"with.algparams.disabled", "%1$s using %2$s (disabled)"},
         {"key.bit", "%d-bit key"},
         {"key.bit.weak", "%d-bit key (weak)"},
+        {"key.bit.eccurve.weak", "%1$d-bit %2$s key (weak)"},
         {"key.bit.disabled", "%d-bit key (disabled)"},
         {"key.bit.eccurve.disabled", "%1$d-bit %2$s key (disabled)"},
         {"unknown.size", "unknown size"},

--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Resources.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Resources.java
@@ -182,6 +182,7 @@ public class Resources extends java.util.ListResourceBundle {
         {"key.bit", "%d-bit key"},
         {"key.bit.weak", "%d-bit key (weak)"},
         {"key.bit.disabled", "%d-bit key (disabled)"},
+        {"key.bit.eccurve.disabled", "%1$d-bit %2$s key (disabled)"},
         {"unknown.size", "unknown size"},
         {"extra.attributes.detected", "POSIX file permission and/or symlink attributes detected. These attributes are ignored when signing and are not protected by the signature."},
 

--- a/test/jdk/sun/security/tools/jarsigner/DisableCurveTest.java
+++ b/test/jdk/sun/security/tools/jarsigner/DisableCurveTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8282633
+ * @summary jarsigner should display the disabled named curve to better explain why
+ *          an EC key is disabled.
+ * @library /test/lib
+ */
+
+import jdk.test.lib.SecurityTools;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.util.JarUtils;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class DisableCurveTest {
+    private static final String JAVA_SECURITY_FILE = "java.security";
+
+    public static void main(String[] args) throws Exception{
+        SecurityTools.keytool("-keystore ks -storepass changeit " +
+                "-genkeypair -keyalg EC	-alias ca -dname CN=CA " +
+                "-ext bc:c")
+                .shouldHaveExitValue(0);
+
+        JarUtils.createJarFile(Path.of("a.jar"), Path.of("."), Path.of("ks"));
+
+        Files.writeString(Files.createFile(Paths.get(JAVA_SECURITY_FILE)),
+                "jdk.disabled.namedCurves=secp256r1\n" +
+                "jdk.jar.disabledAlgorithms=include jdk.disabled.namedCurves\n" +
+                "jdk.certpath.disabledAlgorithms=include jdk.disabled.namedCurves\n");
+
+        SecurityTools.jarsigner("-keystore ks -storepass changeit " +
+                "-signedjar signeda.jar -verbose " +
+                "-J-Djava.security.properties=" +
+                JAVA_SECURITY_FILE +
+                " a.jar ca")
+                .shouldContain(">>> Signer")
+                .shouldContain("Signature algorithm: SHA256withECDSA, 256-bit EC (secp256r1) key (disabled)")
+                .shouldContain("Warning:")
+                .shouldContain("The EC (secp256r1) signing key has a keysize of 256 which is considered a security risk and is disabled")
+                .shouldHaveExitValue(0);
+
+        SecurityTools.jarsigner("-verify signeda.jar " +
+                "-J-Djava.security.properties=" +
+                JAVA_SECURITY_FILE +
+                " -keystore ks -storepass changeit -verbose -debug")
+                .shouldContain("- Signed by")
+                .shouldContain("Signature algorithm: SHA256withECDSA, 256-bit EC (secp256r1) key (disabled)")
+                .shouldContain("WARNING: The jar will be treated as unsigned")
+                .shouldHaveExitValue(0);
+    }
+}

--- a/test/jdk/sun/security/tools/jarsigner/DisableCurveTest.java
+++ b/test/jdk/sun/security/tools/jarsigner/DisableCurveTest.java
@@ -42,7 +42,7 @@ public class DisableCurveTest {
 
     public static void main(String[] args) throws Exception{
         SecurityTools.keytool("-keystore ks -storepass changeit " +
-                "-genkeypair -keyalg EC	-alias ca -dname CN=CA " +
+                "-genkeypair -keyalg EC -alias ca -dname CN=CA " +
                 "-ext bc:c")
                 .shouldHaveExitValue(0);
 


### PR DESCRIPTION
When a named curve is disabled in `jdk.disabled.namedCurves` property which is included in `jdk.jar.disabledAlgorithms` and `jdk.certpath.disabledAlgorithms`, `jarsigner` should display the disabled named curve as a result of its disabled algorithm constraint checking. This clarifies why an EC key is disabled in its warning and verbose output.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282633](https://bugs.openjdk.java.net/browse/JDK-8282633): jarsigner output does not explain why an EC key is disabled if its curve has been disabled


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7810/head:pull/7810` \
`$ git checkout pull/7810`

Update a local copy of the PR: \
`$ git checkout pull/7810` \
`$ git pull https://git.openjdk.java.net/jdk pull/7810/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7810`

View PR using the GUI difftool: \
`$ git pr show -t 7810`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7810.diff">https://git.openjdk.java.net/jdk/pull/7810.diff</a>

</details>
