### PR TITLE
8283122: [AIX, s390] UnsafeCopyMemory 'Mismatched' Tests Fail on Big Endian Systems

### DIFF
--- a/test/hotspot/jtreg/compiler/unsafe/UnsafeCopyMemory.java
+++ b/test/hotspot/jtreg/compiler/unsafe/UnsafeCopyMemory.java
@@ -25,7 +25,6 @@
  * @test
  * @key stress randomness
  * @library /test/lib
- * @bug 8283122
  *
  * @modules java.base/jdk.internal.misc
  *

--- a/test/hotspot/jtreg/compiler/unsafe/UnsafeCopyMemory.java
+++ b/test/hotspot/jtreg/compiler/unsafe/UnsafeCopyMemory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @key stress randomness
  * @library /test/lib
+ * @bug 8283122
  *
  * @modules java.base/jdk.internal.misc
  *
@@ -36,10 +37,13 @@
 package compiler.unsafe;
 
 import jdk.internal.misc.Unsafe;
+import java.nio.ByteOrder;
 import static jdk.test.lib.Asserts.assertEQ;
 
 public class UnsafeCopyMemory {
     static private Unsafe UNSAFE = Unsafe.getUnsafe();
+
+    static final boolean IS_BIG_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN;
 
     // On-heap arrays
     static int[] srcArr = new int[1];
@@ -104,8 +108,12 @@ public class UnsafeCopyMemory {
         srcArr [readIdx]  = v1;
         dstArrL[writeIdx] = v2;
 
+        // On LE systems, low-order bytes of long and int overlap, but
+        // on BE systems, they differ by the size of an int.
+        long mismatchedOffset = Unsafe.ARRAY_LONG_BASE_OFFSET + (IS_BIG_ENDIAN ? 4 : 0);
+
         UNSAFE.copyMemory(srcArr,  Unsafe.ARRAY_INT_BASE_OFFSET,
-                          dstArrL, Unsafe.ARRAY_LONG_BASE_OFFSET, 4); // mismatched
+                          dstArrL, mismatchedOffset, 4); // mismatched
         long r = resArrL[0]; // snapshot
 
         srcArr[readIdx]  = v3;
@@ -156,6 +164,7 @@ public class UnsafeCopyMemory {
 
         Object srcArrLocal = (flag ? srcArrIntLocal               : srcArrLongLocal);
         long   srcOffset   = (flag ? Unsafe.ARRAY_INT_BASE_OFFSET : Unsafe.ARRAY_LONG_BASE_OFFSET);
+        srcOffset += (!flag && IS_BIG_ENDIAN ? 4 : 0);
 
         srcArrIntLocal[0]  = v1;
         srcArrLongLocal[0] = v1;
@@ -179,6 +188,7 @@ public class UnsafeCopyMemory {
 
         Object dstArrLocal = (flag ? dstArrIntLocal               : dstArrLongLocal);
         long   dstOffset   = (flag ? Unsafe.ARRAY_INT_BASE_OFFSET : Unsafe.ARRAY_LONG_BASE_OFFSET);
+        dstOffset += (!flag && IS_BIG_ENDIAN ? 4 : 0);
 
         srcArr[readIdx] = v1;
         dstArrIntLocal[0]  = v2;


### PR DESCRIPTION
This is a testbug present on big endian systems. UnsafeCopyMemory.java contains a few tests with 'mismatched' source and destination size. These tests use Unsafe.copyMemory to copy 4 bytes between longs and ints. The location of the bytes to be copied (if the copy comes from a long), or the offset into which the bytes should be copied (if the copy is into a long) are different on big and little endian systems.

Copying from a long to int on a little endian system, the bytes to be copied are those present at the long's address.

```
src: _ _ _ _ | _ _ _ _
     ^ ~ ~ ^ LE copy
dst: _ _ _ _
```

On BE systems, the bytes are offset by 4.

```
src: _ _ _ _ | _ _ _ _
               ^ ~ ~ ^ BE copy
dst: _ _ _ _
```

The situation for copying into a long from an int is analogous.

This PR adds the required offset for the 'mismatched copy' tests. With this change, UnsafeCopyMemory.java now passes on AIX and s390.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283122](https://bugs.openjdk.java.net/browse/JDK-8283122): [AIX, s390] UnsafeCopyMemory 'Mismatched' Tests Fail on Big Endian Systems


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to 8a592c01d8e24a01ffbdd30e69747d2e34084733
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to 8a592c01d8e24a01ffbdd30e69747d2e34084733


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7811/head:pull/7811` \
`$ git checkout pull/7811`

Update a local copy of the PR: \
`$ git checkout pull/7811` \
`$ git pull https://git.openjdk.java.net/jdk pull/7811/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7811`

View PR using the GUI difftool: \
`$ git pr show -t 7811`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7811.diff">https://git.openjdk.java.net/jdk/pull/7811.diff</a>

</details>
