### PR TITLE
JDK-8283124: Add constant for tau to Math and StrictMath

### DIFF
--- a/src/java.base/share/classes/java/lang/Math.java
+++ b/src/java.base/share/classes/java/lang/Math.java
@@ -135,10 +135,23 @@ public final class Math {
 
     /**
      * The {@code double} value that is closer than any other to
-     * <i>pi</i>, the ratio of the circumference of a circle to its
-     * diameter.
+     * <i>pi</i> (&pi;), the ratio of the circumference of a circle to
+     * its diameter.
      */
     public static final double PI = 3.14159265358979323846;
+
+    /**
+     * The {@code double} value that is closer than any other to
+     * <i>tau</i> (&tau;), the ratio of the circumference of a circle
+     * to its radius.
+     *
+     * @apiNote
+     * The value of <i>pi</i> is one half that of <i>tau</i>; in other
+     * words, <i>tau</i> is double <i>pi</i> .
+     *
+     * @since 19
+     */
+    public static final double TAU = 6.283185307179586;
 
     /**
      * Constant by which to multiply an angular value in degrees to obtain an

--- a/src/java.base/share/classes/java/lang/StrictMath.java
+++ b/src/java.base/share/classes/java/lang/StrictMath.java
@@ -96,10 +96,23 @@ public final class StrictMath {
 
     /**
      * The {@code double} value that is closer than any other to
-     * <i>pi</i>, the ratio of the circumference of a circle to its
+     * <i>pi</i> (&pi;), the ratio of the circumference of a circle to its
      * diameter.
      */
     public static final double PI = 3.14159265358979323846;
+
+    /**
+     * The {@code double} value that is closer than any other to
+     * <i>tau</i> (&tau;), the ratio of the circumference of a circle
+     * to its radius.
+     *
+     * @apiNote
+     * The value of <i>pi</i> is one half that of <i>tau</i>; in other
+     * words, <i>tau</i> is double <i>pi</i> .
+     *
+     * @since 19
+     */
+    public static final double TAU = 6.283185307179586;
 
     /**
      * Returns the trigonometric sine of an angle. Special cases:


### PR DESCRIPTION
Add a constant for tau, 2*pi, to Math and StrictMath. Since 2*pi is a very common value in mathematical formulas, it is helpful to give it a distinct constant.

Please also review the CSR https://bugs.openjdk.java.net/browse/JDK-8283136