### PR TITLE
JDK-8283143: Use minimal-length literals to initialize PI and E constants

### DIFF
--- a/src/java.base/share/classes/java/lang/Math.java
+++ b/src/java.base/share/classes/java/lang/Math.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/Math.java
+++ b/src/java.base/share/classes/java/lang/Math.java
@@ -131,14 +131,14 @@ public final class Math {
      * The {@code double} value that is closer than any other to
      * <i>e</i>, the base of the natural logarithms.
      */
-    public static final double E = 2.7182818284590452354;
+    public static final double E = 2.718281828459045;
 
     /**
      * The {@code double} value that is closer than any other to
      * <i>pi</i>, the ratio of the circumference of a circle to its
      * diameter.
      */
-    public static final double PI = 3.14159265358979323846;
+    public static final double PI = 3.141592653589793;
 
     /**
      * Constant by which to multiply an angular value in degrees to obtain an

--- a/src/java.base/share/classes/java/lang/StrictMath.java
+++ b/src/java.base/share/classes/java/lang/StrictMath.java
@@ -92,14 +92,14 @@ public final class StrictMath {
      * The {@code double} value that is closer than any other to
      * <i>e</i>, the base of the natural logarithms.
      */
-    public static final double E = 2.7182818284590452354;
+    public static final double E = 2.718281828459045;
 
     /**
      * The {@code double} value that is closer than any other to
      * <i>pi</i>, the ratio of the circumference of a circle to its
      * diameter.
      */
-    public static final double PI = 3.14159265358979323846;
+    public static final double PI = 3.141592653589793;
 
     /**
      * Returns the trigonometric sine of an angle. Special cases:


### PR DESCRIPTION
Depending on the range of the number line, a double value has between 15 and 17 digits of decimal precision. The literals used to initialize Math.PI and Math.E have several digits more precision than that maximum.

That is potentially confusing to readers of the code and the minimum length strings to exactly represent the value in question should be used instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283143](https://bugs.openjdk.java.net/browse/JDK-8283143): Use minimal-length literals to initialize PI and E constants


### Reviewers
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**) ⚠️ Review applies to 3bf9de9fb3c6fe2dc0bcb3eb1384309e92008be8


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7814/head:pull/7814` \
`$ git checkout pull/7814`

Update a local copy of the PR: \
`$ git checkout pull/7814` \
`$ git pull https://git.openjdk.java.net/jdk pull/7814/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7814`

View PR using the GUI difftool: \
`$ git pr show -t 7814`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7814.diff">https://git.openjdk.java.net/jdk/pull/7814.diff</a>

</details>
