### PR TITLE
8283085: AArch64: No need to leave a breadcrumb for JavaFrameAnchor::capture_last_Java_pc when leaf call

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1777,6 +1777,9 @@ int MachCallRuntimeNode::ret_addr_offset() {
   if (cb) {
     return 1 * NativeInstruction::instruction_size;
   } else {
+    if (class_id() == Class_MachCallLeaf) {
+      return 4 * NativeInstruction::instruction_size;
+    }
     return 6 * NativeInstruction::instruction_size;
   }
 }
@@ -1787,7 +1790,7 @@ int MachCallNativeNode::ret_addr_offset() {
   if (cb) {
     return 1 * NativeInstruction::instruction_size;
   } else {
-    return 6 * NativeInstruction::instruction_size;
+    return 4 * NativeInstruction::instruction_size;
   }
 }
 
@@ -3866,14 +3869,20 @@ encode %{
         return;
       }
     } else {
-      Label retaddr;
-      __ adr(rscratch2, retaddr);
-      __ lea(rscratch1, RuntimeAddress(entry));
-      // Leave a breadcrumb for JavaFrameAnchor::capture_last_Java_pc()
-      __ stp(zr, rscratch2, Address(__ pre(sp, -2 * wordSize)));
-      __ blr(rscratch1);
-      __ bind(retaddr);
-      __ add(sp, sp, 2 * wordSize);
+      int op = ideal_Opcode();
+      if (op == Op_CallLeaf || op == Op_CallLeafNoFP || op == Op_CallNative) {
+        __ lea(rscratch1, RuntimeAddress(entry));
+        __ blr(rscratch1);
+      } else {
+        Label retaddr;
+        __ adr(rscratch2, retaddr);
+        __ lea(rscratch1, RuntimeAddress(entry));
+        // Leave a breadcrumb for JavaFrameAnchor::capture_last_Java_pc()
+        __ stp(zr, rscratch2, Address(__ pre(sp, -2 * wordSize)));
+        __ blr(rscratch1);
+        __ bind(retaddr);
+        __ add(sp, sp, 2 * wordSize);
+      }
     }
     if (Compile::current()->max_vector_size() > 0) {
       __ reinitialize_ptrue();


### PR DESCRIPTION
Hi,

Could I have a review of this fix that remove the breadcrumb in `aarch64_enc_java_to_runtime` for `Op_CallLeaf`, `Op_CallLeafNoFP` and `Op_CallNative`.

For more details please refer to the description of the issue.

Thanks,
Denghui

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8283085](https://bugs.openjdk.java.net/browse/JDK-8283085): AArch64: No need to leave a breadcrumb for JavaFrameAnchor::capture_last_Java_pc when leaf call


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7815/head:pull/7815` \
`$ git checkout pull/7815`

Update a local copy of the PR: \
`$ git checkout pull/7815` \
`$ git pull https://git.openjdk.java.net/jdk pull/7815/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7815`

View PR using the GUI difftool: \
`$ git pr show -t 7815`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7815.diff">https://git.openjdk.java.net/jdk/pull/7815.diff</a>

</details>
