### PR TITLE
8283189: Bad copyright header in UnsafeCopyMemory.java

### DIFF
--- a/test/hotspot/jtreg/compiler/unsafe/UnsafeCopyMemory.java
+++ b/test/hotspot/jtreg/compiler/unsafe/UnsafeCopyMemory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Please review this trivial fix that adds a missing comma after the copyright date.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283189](https://bugs.openjdk.java.net/browse/JDK-8283189): Bad copyright header in UnsafeCopyMemory.java


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7824/head:pull/7824` \
`$ git checkout pull/7824`

Update a local copy of the PR: \
`$ git checkout pull/7824` \
`$ git pull https://git.openjdk.java.net/jdk pull/7824/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7824`

View PR using the GUI difftool: \
`$ git pr show -t 7824`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7824.diff">https://git.openjdk.java.net/jdk/pull/7824.diff</a>

</details>
