### PR TITLE
8283092: JMX subclass permission check redundant with strong encapsulation

### DIFF
--- a/src/java.management/share/classes/java/lang/management/ManagementFactory.java
+++ b/src/java.management/share/classes/java/lang/management/ManagementFactory.java
@@ -936,8 +936,7 @@ public class ManagementFactory {
                         all.add(new DefaultPlatformMBeanProvider());
                         return all;
                     }
-                }, null, new FilePermission("<<ALL FILES>>", "read"),
-                new RuntimePermission("sun.management.spi.PlatformMBeanProvider.subclass"));
+                }, null, new FilePermission("<<ALL FILES>>", "read"));
 
             // load all platform components into a map
             var map = new HashMap<String, PlatformComponent<?>>();

--- a/src/java.management/share/classes/sun/management/spi/PlatformMBeanProvider.java
+++ b/src/java.management/share/classes/sun/management/spi/PlatformMBeanProvider.java
@@ -207,9 +207,6 @@ public abstract class PlatformMBeanProvider {
     protected PlatformMBeanProvider () {
     }
 
-    private PlatformMBeanProvider(Void unused) {
-    }
-
     /**
      * Returns a list of PlatformComponent instances describing the Platform
      * MBeans provided by this provider.

--- a/src/java.management/share/classes/sun/management/spi/PlatformMBeanProvider.java
+++ b/src/java.management/share/classes/sun/management/spi/PlatformMBeanProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,12 +203,8 @@ public abstract class PlatformMBeanProvider {
 
     /**
      * Instantiates a new PlatformMBeanProvider.
-     *
-     * @throws SecurityException if the subclass (and calling code) does not
-     *    have {@code RuntimePermission("sun.management.spi.PlatformMBeanProvider.subclass")}
      */
     protected PlatformMBeanProvider () {
-        this(checkSubclassPermission());
     }
 
     private PlatformMBeanProvider(Void unused) {
@@ -222,13 +218,4 @@ public abstract class PlatformMBeanProvider {
      * MBeans provided by this provider.
      */
     public abstract List<PlatformComponent<?>> getPlatformComponentList();
-
-    private static Void checkSubclassPermission() {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(new RuntimePermission(PlatformMBeanProvider.class.getName()+".subclass"));
-        }
-        return null;
-    }
 }

--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/spi/AgentProvider.java
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/spi/AgentProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,25 +33,11 @@ public abstract class AgentProvider {
 
     /**
      * Instantiates a new AgentProvider.
-     *
-     * @throws SecurityException if the subclass (and calling code) does not
-     * have
-     * {@code RuntimePermission("sun.management.spi.AgentProvider.subclass")}
      */
     protected AgentProvider() {
-        this(checkSubclassPermission());
     }
 
     private AgentProvider(Void unused) {
-    }
-
-    private static Void checkSubclassPermission() {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(new RuntimePermission(AgentProvider.class.getName() + ".subclass"));
-        }
-        return null;
     }
 
     /**

--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/spi/AgentProvider.java
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/spi/AgentProvider.java
@@ -37,9 +37,6 @@ public abstract class AgentProvider {
     protected AgentProvider() {
     }
 
-    private AgentProvider(Void unused) {
-    }
-
     /**
      * Gets the name of the agent provider.
      *


### PR DESCRIPTION
Removing permission checks which, in the presence of a Security Manager, would check for a RuntimePermission "className.subclass".  This was to prevent subclassing these classes, but is no longer necessary with strong encapsulation from modules.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283092](https://bugs.openjdk.java.net/browse/JDK-8283092): JMX subclass permission check redundant with strong encapsulation


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to a6d05f7367432c0226e79238e909ecc2288e24cc
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7827/head:pull/7827` \
`$ git checkout pull/7827`

Update a local copy of the PR: \
`$ git checkout pull/7827` \
`$ git pull https://git.openjdk.java.net/jdk pull/7827/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7827`

View PR using the GUI difftool: \
`$ git pr show -t 7827`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7827.diff">https://git.openjdk.java.net/jdk/pull/7827.diff</a>

</details>
