### PR TITLE
8283225: ClassLoader.c produces incorrect OutOfMemory Exception when length is 0 (aix)

### DIFF
--- a/src/java.base/share/native/libjava/ClassLoader.c
+++ b/src/java.base/share/native/libjava/ClassLoader.c
@@ -99,9 +99,7 @@ Java_java_lang_ClassLoader_defineClass1(JNIEnv *env,
         return 0;
     }
 
-    // On malloc(0), implementators of malloc(3) have the choice to return either
-    // NULL or a unique non-NULL pointer. To unify libc behavior across our platforms
-    // we chose the latter. (see 8283225)
+    // On AIX malloc(0) returns NULL which looks like an out-of-memory condition; so adjust it to malloc(1)
     #ifdef _AIX
     body = (jbyte *)malloc(length == 0 ? 1 : length);
     #else
@@ -246,9 +244,7 @@ Java_java_lang_ClassLoader_defineClass0(JNIEnv *env,
         return 0;
     }
 
-    // On malloc(0), implementators of malloc(3) have the choice to return either
-    // NULL or a unique non-NULL pointer. To unify libc behavior across our platforms
-    // we chose the latter. (see 8283225)
+    // On AIX malloc(0) returns NULL which looks like an out-of-memory condition; so adjust it to malloc(1)
     #ifdef _AIX
     body = (jbyte *)malloc(length == 0 ? 1 : length);
     #else

--- a/src/java.base/share/native/libjava/ClassLoader.c
+++ b/src/java.base/share/native/libjava/ClassLoader.c
@@ -99,7 +99,14 @@ Java_java_lang_ClassLoader_defineClass1(JNIEnv *env,
         return 0;
     }
 
+    // On malloc(0), implementators of malloc(3) have the choice to return either
+    // NULL or a unique non-NULL pointer. To unify libc behavior across our platforms
+    // we chose the latter. (see 8283225)
+    #ifdef _AIX
+    body = (jbyte *)malloc(length == 0 ? 1 : length);
+    #else
     body = (jbyte *)malloc(length);
+    #endif
 
     if (body == 0) {
         JNU_ThrowOutOfMemoryError(env, 0);
@@ -239,7 +246,15 @@ Java_java_lang_ClassLoader_defineClass0(JNIEnv *env,
         return 0;
     }
 
+    // On malloc(0), implementators of malloc(3) have the choice to return either
+    // NULL or a unique non-NULL pointer. To unify libc behavior across our platforms
+    // we chose the latter. (see 8283225)
+    #ifdef _AIX
+    body = (jbyte *)malloc(length == 0 ? 1 : length);
+    #else
     body = (jbyte *)malloc(length);
+    #endif
+
     if (body == 0) {
         JNU_ThrowOutOfMemoryError(env, 0);
         return 0;


### PR DESCRIPTION
As described in the linked issue, NullClassBytesTest fails due an OutOfMemoryError produced on AIX when the test calls defineClass with a byte array of size of 0. The native implementation of defineClass then calls  malloc with a size of 0. On AIX malloc(0) returns NULL, while on other platforms it return a valid address. When NULL is produced by malloc for this reason, ClassLoader.c incorrectly interprets this as a failure due to a lack of memory.

~~This PR modifies ClassLoader.c to produce an OutOfMemoryError only when `errno == ENOMEM` and to produce a ClassFormatError with the message "ClassLoader internal allocation failure" in all other cases (in which malloc returns NULL).~~ [edit: The above no longer describes the PR's proposed fix. See discussion below]

In addition, I performed some minor tidy-up work in ClassLoader.c by changing instances of `return 0` to `return NULL`, and `if (some_ptr == 0)` to `if (some_ptr == NULL)`. This was done to improve the clarity of the code in ClassLoader.c, but didn't feel worthy of opening a separate issue.

### Alternatives

It would be possible to address this failure by modifying the test to accept the OutOfMemoryError on AIX. I thought it was a better solution to modify ClassLoader.c to produce an OutOfMemoryError only when the system is actually out of memory.

### Testing

This change has been tested on AIX and Linux/x86.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283225](https://bugs.openjdk.java.net/browse/JDK-8283225): ClassLoader.c produces incorrect OutOfMemory Exception when length is 0 (aix)


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to f05c8d854404fb75e5e057f61bff69f0eeb9e76a
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7829/head:pull/7829` \
`$ git checkout pull/7829`

Update a local copy of the PR: \
`$ git checkout pull/7829` \
`$ git pull https://git.openjdk.java.net/jdk pull/7829/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7829`

View PR using the GUI difftool: \
`$ git pr show -t 7829`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7829.diff">https://git.openjdk.java.net/jdk/pull/7829.diff</a>

</details>
