### PR TITLE
8283229: compiler/arguments/TestCodeEntryAlignment.java fails with release VMs

### DIFF
--- a/test/hotspot/jtreg/compiler/arguments/TestCodeEntryAlignment.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestCodeEntryAlignment.java
@@ -27,6 +27,7 @@
  * @library /test/lib /
  * @bug 8281467
  * @requires vm.flagless
+ * @requires vm.debug
  * @requires os.arch=="amd64" | os.arch=="x86_64"
  *
  * @summary Test large CodeEntryAlignments are accepted
@@ -39,7 +40,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Arrays;
 import java.util.ArrayList;
-import jdk.test.lib.Platform;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 
@@ -74,14 +74,12 @@ public class TestCodeEntryAlignment {
                 "-XX:CodeEntryAlignment=" + align
             );
         }
-        if (Platform.isDebugBuild()) {
-            for (int align = 256; align <= 1024; align *= 2) {
-                shouldPass(
-                    "-XX:+UnlockExperimentalVMOptions",
-                    "-XX:CodeCacheSegmentSize=" + align,
-                    "-XX:CodeEntryAlignment=" + align
-                );
-            }
+        for (int align = 256; align <= 1024; align *= 2) {
+            shouldPass(
+                "-XX:+UnlockExperimentalVMOptions",
+                "-XX:CodeCacheSegmentSize=" + align,
+                "-XX:CodeEntryAlignment=" + align
+            );
         }
     }
 

--- a/test/hotspot/jtreg/compiler/arguments/TestCodeEntryAlignment.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestCodeEntryAlignment.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Arrays;
 import java.util.ArrayList;
+import jdk.test.lib.Platform;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 
@@ -73,12 +74,14 @@ public class TestCodeEntryAlignment {
                 "-XX:CodeEntryAlignment=" + align
             );
         }
-        for (int align = 256; align <= 1024; align *= 2) {
-            shouldPass(
-                "-XX:+UnlockExperimentalVMOptions",
-                "-XX:CodeCacheSegmentSize=" + align,
-                "-XX:CodeEntryAlignment=" + align
-            );
+        if (Platform.isDebugBuild()) {
+            for (int align = 256; align <= 1024; align *= 2) {
+                shouldPass(
+                    "-XX:+UnlockExperimentalVMOptions",
+                    "-XX:CodeCacheSegmentSize=" + align,
+                    "-XX:CodeEntryAlignment=" + align
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Hi all,

compiler/arguments/TestCodeEntryAlignment.java fails with release VMs due to 'CodeCacheSegmentSize' is develop and is available only in debug version of VM.
The fix would only run with 'CodeCacheSegmentSize' for debug VMs.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283229](https://bugs.openjdk.java.net/browse/JDK-8283229): compiler/arguments/TestCodeEntryAlignment.java fails with release VMs


### Reviewers
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7830/head:pull/7830` \
`$ git checkout pull/7830`

Update a local copy of the PR: \
`$ git checkout pull/7830` \
`$ git pull https://git.openjdk.java.net/jdk pull/7830/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7830`

View PR using the GUI difftool: \
`$ git pr show -t 7830`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7830.diff">https://git.openjdk.java.net/jdk/pull/7830.diff</a>

</details>
