### PR TITLE
8282863: java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java fails on Windows 10 with HiDPI screen

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/Win32GraphicsDevice.java
+++ b/src/java.desktop/windows/classes/sun/awt/Win32GraphicsDevice.java
@@ -463,11 +463,6 @@ public class Win32GraphicsDevice extends GraphicsDevice implements
             WWindowPeer peer = AWTAccessor.getComponentAccessor().getPeer(w);
             configDisplayMode(screen, peer, dm.getWidth(), dm.getHeight(),
                 dm.getBitDepth(), dm.getRefreshRate());
-            // configDisplayMode() changes the screen resolution (and potentially DPI) immediately,
-            // so we need to update the DPI scales here as well,
-            // otherwise getDefaultConfiguration().getBounds() will return incorrect results until
-            // WM_DISPLAYCHANGE or WM_DPICHANGED is received, which happens to be too late for our purposes
-            initScaleFactors();
             // resize the fullscreen window to the dimensions of the new
             // display mode
             Rectangle screenBounds = getDefaultConfiguration().getBounds();

--- a/src/java.desktop/windows/classes/sun/awt/Win32GraphicsDevice.java
+++ b/src/java.desktop/windows/classes/sun/awt/Win32GraphicsDevice.java
@@ -463,6 +463,11 @@ public class Win32GraphicsDevice extends GraphicsDevice implements
             WWindowPeer peer = AWTAccessor.getComponentAccessor().getPeer(w);
             configDisplayMode(screen, peer, dm.getWidth(), dm.getHeight(),
                 dm.getBitDepth(), dm.getRefreshRate());
+            // configDisplayMode() changes the screen resolution (and potentially DPI) immediately,
+            // so we need to update the DPI scales here as well,
+            // otherwise getDefaultConfiguration().getBounds() will return incorrect results until
+            // WM_DISPLAYCHANGE or WM_DPICHANGED is received, which happens to be too late for our purposes
+            initScaleFactors();
             // resize the fullscreen window to the dimensions of the new
             // display mode
             Rectangle screenBounds = getDefaultConfiguration().getBounds();

--- a/src/java.desktop/windows/classes/sun/awt/Win32GraphicsDevice.java
+++ b/src/java.desktop/windows/classes/sun/awt/Win32GraphicsDevice.java
@@ -46,6 +46,8 @@ import sun.java2d.SunGraphicsEnvironment;
 import sun.java2d.opengl.WGLGraphicsConfig;
 import sun.java2d.windows.WindowsFlags;
 
+import static java.awt.peer.ComponentPeer.SET_BOUNDS;
+
 import static sun.awt.Win32GraphicsEnvironment.debugScaleX;
 import static sun.awt.Win32GraphicsEnvironment.debugScaleY;
 
@@ -441,6 +443,18 @@ public class Win32GraphicsDevice extends GraphicsDevice implements
     protected native void enterFullScreenExclusive(int screen, WindowPeer w);
     protected native void exitFullScreenExclusive(int screen, WindowPeer w);
 
+    /**
+     * Reapplies the size of this device to the full-screen window.
+     */
+    private static void resizeFSWindow(final Window w, final Rectangle b) {
+        if (w != null) {
+            WindowPeer peer = AWTAccessor.getComponentAccessor().getPeer(w);
+            if (peer != null) {
+                peer.setBounds(b.x, b.y, b.width, b.height, SET_BOUNDS);
+            }
+        }
+    }
+
     @Override
     public boolean isDisplayChangeSupported() {
         return (isFullScreenSupported() && getFullScreenWindow() != null);
@@ -463,13 +477,9 @@ public class Win32GraphicsDevice extends GraphicsDevice implements
             WWindowPeer peer = AWTAccessor.getComponentAccessor().getPeer(w);
             configDisplayMode(screen, peer, dm.getWidth(), dm.getHeight(),
                 dm.getBitDepth(), dm.getRefreshRate());
-            // resize the fullscreen window to the dimensions of the new
-            // display mode
-            Rectangle screenBounds = getDefaultConfiguration().getBounds();
-            w.setBounds(screenBounds.x, screenBounds.y,
-                        screenBounds.width, screenBounds.height);
-            // Note: no call to replaceSurfaceData is required here since
-            // replacement will be caused by an upcoming display change event
+            // Note: window will get resized to actual full-screen dimensions
+            // in the upcoming display change event, when the DPI scales
+            // would already be correctly set etc. (see JDK-8282863)
         } else {
             throw new IllegalStateException("Must be in fullscreen mode " +
                                             "in order to set display mode");
@@ -529,6 +539,10 @@ public class Win32GraphicsDevice extends GraphicsDevice implements
         defaultConfig = null;
         configs = null;
         initScaleFactors();
+
+        Rectangle screenBounds = getDefaultConfiguration().getBounds();
+        resizeFSWindow(getFullScreenWindow(), screenBounds);
+
         // pass on to all top-level windows on this display
         topLevels.notifyListeners();
     }

--- a/src/java.desktop/windows/classes/sun/awt/Win32GraphicsDevice.java
+++ b/src/java.desktop/windows/classes/sun/awt/Win32GraphicsDevice.java
@@ -444,7 +444,10 @@ public class Win32GraphicsDevice extends GraphicsDevice implements
     protected native void exitFullScreenExclusive(int screen, WindowPeer w);
 
     /**
-     * Reapplies the size of this device to the full-screen window.
+     * Reapplies the size of this graphics device to
+     * the given full-screen window.
+     * @param w a Window that needs resizing
+     * @param b new full-screen window bounds
      */
     private static void resizeFSWindow(final Window w, final Rectangle b) {
         if (w != null) {
@@ -479,7 +482,7 @@ public class Win32GraphicsDevice extends GraphicsDevice implements
                 dm.getBitDepth(), dm.getRefreshRate());
             // Note: window will get resized to actual full-screen dimensions
             // in the upcoming display change event, when the DPI scales
-            // would already be correctly set etc. (see JDK-8282863)
+            // would already be correctly set etc.
         } else {
             throw new IllegalStateException("Must be in fullscreen mode " +
                                             "in order to set display mode");

--- a/src/java.desktop/windows/classes/sun/awt/Win32GraphicsDevice.java
+++ b/src/java.desktop/windows/classes/sun/awt/Win32GraphicsDevice.java
@@ -480,8 +480,8 @@ public class Win32GraphicsDevice extends GraphicsDevice implements
             WWindowPeer peer = AWTAccessor.getComponentAccessor().getPeer(w);
             configDisplayMode(screen, peer, dm.getWidth(), dm.getHeight(),
                 dm.getBitDepth(), dm.getRefreshRate());
-            // Note: window will get resized to actual full-screen dimensions
-            // in the upcoming display change event, when the DPI scales
+            // Note: the full-screen window will get resized to the dimensions of the new
+            // display mode in the upcoming display change event, when the DPI scales
             // would already be correctly set etc.
         } else {
             throw new IllegalStateException("Must be in fullscreen mode " +

--- a/test/jdk/java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java
+++ b/test/jdk/java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java
@@ -32,7 +32,7 @@ import java.awt.Rectangle;
 
 /**
  * @test
- * @bug 8211999
+ * @bug 8211999 8282863
  * @key headful
  * @summary verifies the full-screen window bounds and graphics configuration
  */


### PR DESCRIPTION
Hello,
Please review this fix for JDK-8282863.

The failing `java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java` test basically checks that full-screen window remains full-screen when a display mode change occurs. It has been introduced in JDK-8211999, which also contains numerous fixes for HiDPI displays. In particular, JDK-8211999 changed the code of `Win32GraphicsDevice.setDisplayMode()` so that it uses screen dimensions in user space instead of device space, which is correct. However, if the display mode change incurs display scaling change, as it has been observed on Windows 10 laptop with HiDPI screen, the method used for obtaining screen bounds in user space returns incorrect values under certain conditions.

The issue is reproducible on Windows 10, when resolution of the primary screen is higher than 1024x768 with scaling greater than 100%. Resolution and scaling of secondary screen(s) is irrelevant. I used a laptop with 2160x1350 display resolution and scaling set to 150%. When the `java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java` test is run with these initial conditions, roughly the following happens:

1. `java.awt.Frame` is created and set as full-screen.
2. `Win32GraphicsDevice.setDisplayMode()` is called to change screen resolution from 2160x1350 to 1024x768.
3. `Win32GraphicsDevice.configDisplayMode()` call immediately changes the display resolution to 1024x768, which also incurs the immediate display scaling change from 150% to 100%.
4. Inside the `Win32GraphicsDevice.setDisplayMode()` screen bounds in user space are obtained via `Win32GraphicsConfig.getBounds()`:
5. In the native code of `Win32GraphicsConfig.getBounds()` new screen bounds in device space (1024x768) are correctly obtained via `MonitorBounds()`.
6. Then screen bounds are converted to user space by applying **scaling factors, which are not yet updated and correspond to previous display mode**. In our case, 1024x768 is scaled down by 150% and becomes 683x512.
7. Back in `Win32GraphicsDevice.setDisplayMode()` full-screen window bounds are set to incorrectly scaled 683x512 instead of 1024x768.
8. After returning from `Win32GraphicsDevice.setDisplayMode()` the test waits 4 seconds.
9. `WM_DISPLAYCHANGE` message is received and processed, followed by `WM_DPICHANGED`, which updates the scaling factors used by `Win32GraphicsConfig.getBounds()` to the correct value of 100%.
10. After 4 seconds test wakes up and obtains screen bounds in user space by calling `Win32GraphicsConfig.getBounds()`, which now correctly returns 1024x768.
11. Test compares full-screen window bounds with screen bounds, and fails with `java.lang.RuntimeException: width is wrong` as 683 is not equal to 1024 ± 30 pixels.

Proposed fix adds a `Win32GraphicsDevice.initScaleFactors()` call to `Win32GraphicsDevice.setDisplayMode()` code, between calling `Win32GraphicsDevice.configDisplayMode()` and `Win32GraphicsConfig.getBounds()`. This updates the scaling factors without waiting for `WM_DISPLAYCHANGE` or `WM_DPICHANGED`, `Win32GraphicsConfig.getBounds()` returns correctly scaled screen bounds in user space, and full-screen window remains correctly sized after display mode change.

I've run tests from `jdk_awt` group on Windows 10 using a laptop with the same settings that caused the issue (primary screen with 2160x1350 resolution and 150% scaling), and applying the fix did not introduce any new test failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282863](https://bugs.openjdk.java.net/browse/JDK-8282863): java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java fails on Windows 10 with HiDPI screen


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to [008e9c19](https://git.openjdk.java.net/jdk/pull/7835/files/008e9c192c23181f08dc3baaea937be83b05aa43)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7835/head:pull/7835` \
`$ git checkout pull/7835`

Update a local copy of the PR: \
`$ git checkout pull/7835` \
`$ git pull https://git.openjdk.java.net/jdk pull/7835/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7835`

View PR using the GUI difftool: \
`$ git pr show -t 7835`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7835.diff">https://git.openjdk.java.net/jdk/pull/7835.diff</a>

</details>
