### PR TITLE
8280152: Duplicated trampolines in C2 NMethod Stub Code section

### DIFF
--- a/src/hotspot/share/asm/assembler.hpp
+++ b/src/hotspot/share/asm/assembler.hpp
@@ -344,6 +344,12 @@ class AbstractAssembler : public ResourceObj  {
         "call relocate() between instructions");
     code_section()->relocate(code_section()->end(), rspec, format);
   }
+  void relocate(address addr, RelocationHolder const& rspec, int format = 0) {
+    assert(!pd_check_instruction_mark()
+        || inst_mark() == NULL || inst_mark() == code_section()->end(),
+        "call relocate() between instructions");
+    code_section()->relocate(addr, rspec, format);
+  }
   void relocate(   relocInfo::relocType rtype, int format = 0) {
     code_section()->relocate(code_section()->end(), rtype, format);
   }

--- a/src/hotspot/share/code/relocInfo.cpp
+++ b/src/hotspot/share/code/relocInfo.cpp
@@ -49,7 +49,7 @@ relocInfo::relocType relocInfo::check_relocType(relocType type) {
 }
 
 void relocInfo::check_offset_and_format(int offset, int format) {
-  assert(offset >= 0 && offset < offset_limit(), "offset out off bounds");
+  assert(offset_min() <= offset && offset < offset_max(), "offset out off bounds");
   assert(is_aligned(offset, offset_unit), "misaligned offset");
   assert((format & format_mask) == format, "wrong format");
 }

--- a/src/hotspot/share/utilities/hashtable.cpp
+++ b/src/hotspot/share/utilities/hashtable.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "asm/codeBuffer.hpp"
 #include "classfile/dictionary.hpp"
 #include "classfile/javaClasses.inline.hpp"
 #include "classfile/moduleEntry.hpp"
@@ -284,6 +285,8 @@ template class BasicHashtable<mtCompiler>;
 template class BasicHashtable<mtTracing>;
 template class BasicHashtable<mtServiceability>;
 template class BasicHashtable<mtLogging>;
+template class Hashtable<SharedStub, mtCode>;
+template class HashtableEntry<SharedStub, mtCode>;
 
 template void BasicHashtable<mtClass>::verify_table<DictionaryEntry>(char const*);
 template void BasicHashtable<mtModule>::verify_table<ModuleEntry>(char const*);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8280152](https://bugs.openjdk.java.net/browse/JDK-8280152)

### Issue
 * [JDK-8280152](https://bugs.openjdk.java.net/browse/JDK-8280152): AArch64: Reuse runtime call trampolines in C2 ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7836/head:pull/7836` \
`$ git checkout pull/7836`

Update a local copy of the PR: \
`$ git checkout pull/7836` \
`$ git pull https://git.openjdk.java.net/jdk pull/7836/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7836`

View PR using the GUI difftool: \
`$ git pr show -t 7836`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7836.diff">https://git.openjdk.java.net/jdk/pull/7836.diff</a>

</details>
