### PR TITLE
JDK-8283249: CompressedClassPointers.java fails on ppc with 'Narrow klass shift: 0' missing

### DIFF
--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
@@ -224,8 +224,8 @@ public class CompressedClassPointers {
             "-XX:+VerifyBeforeGC", "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldContain("Narrow klass base: 0x0000000000000000");
-        if (!Platform.isAArch64()) {
-            // Currently relax this test for Aarch64.
+        if (!Platform.isAArch64() && !Platform.isPPC()) {
+            // Currently relax this test for Aarch64 and ppc.
             output.shouldContain("Narrow klass shift: 0");
         }
         output.shouldHaveExitValue(0);
@@ -244,8 +244,8 @@ public class CompressedClassPointers {
             "-XX:+VerifyBeforeGC", "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldContain("Narrow klass base: 0x0000000000000000");
-        if (!Platform.isAArch64()) {
-            // Currently relax this test for Aarch64.
+        if (!Platform.isAArch64() && !Platform.isPPC()) {
+            // Currently relax this test for Aarch64 and ppc.
             output.shouldContain("Narrow klass shift: 0");
         }
         output.shouldHaveExitValue(0);


### PR DESCRIPTION
These tests are highly vulnerable against ASLR. On PPC, we apparently don't manage to map the heap into the lower 4G region, therefore CCS does not live there either.

The test requires for "-UseCompressedOops -Xshare:off" and a heap size of 128m and a ccs size of 1G ccs to live in the lower 4G. That is an optimistic assumption.

The VM attaches instead CCS to 0x100000000 (4GB) and calculates Narrow Base/Shift as 0/3, which is totally correct.

As a stop-gap measure, the test should be less strict for PPC and PPCLE.

---

Idle thoughts:

A future solution would be to revise this test. It is maintenance intensive and fragile. Arguably its also not that important, since it tests with CDS disabled, which is not a realistic scenario.

To me, it is not clear to me what it is supposed to test:
1) the ability of the kernel to give us memory segments at preferred addresses?
2) the ability of the VM to make the best of it, i.e. to calculate narrow klass base and shift that make sense?
3) the ability of the VM to decode/encode with exotic base/shift addresses

IMHO, 
- testing (1) makes no sense since we are at the mercy of the kernel.
- testing (2) makes a bit sense, but honestly, the logic to derive narrow klass base and shift is so simple that I don't think we need to test that. 
- testing (3) makes a lot of sense, since the CPU dependent logic for decoding and encoding can be complicated and usually only runs with a given set of base and shift (we had e.g. hidden bugs on s390 for years). But that one can be tested way better with our new option `-XX:CompressedClassSpaceBaseAddress`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283249](https://bugs.openjdk.java.net/browse/JDK-8283249): CompressedClassPointers.java fails on ppc with 'Narrow klass shift: 0' missing


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7837/head:pull/7837` \
`$ git checkout pull/7837`

Update a local copy of the PR: \
`$ git checkout pull/7837` \
`$ git pull https://git.openjdk.java.net/jdk pull/7837/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7837`

View PR using the GUI difftool: \
`$ git pr show -t 7837`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7837.diff">https://git.openjdk.java.net/jdk/pull/7837.diff</a>

</details>
