### PR TITLE
Build time regression caused by JDK-8278917

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3313,6 +3313,13 @@ HeapRegion* G1CollectedHeap::alloc_highest_free_region() {
   return NULL;
 }
 
+void G1CollectedHeap::mark_evac_failure_object(const oop obj, uint worker_id) const {
+  // All objects failing evacuation are live. What we'll do is
+  // that we'll update the prev marking info so that they are
+  // all under PTAMS and explicitly marked.
+  _cm->par_mark_in_prev_bitmap(obj);
+}
+
 // Optimized nmethod scanning
 
 class RegisterNMethodOopClosure: public OopClosure {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1249,7 +1249,7 @@ public:
   inline bool is_obj_dead_full(const oop obj) const;
 
   // Mark the live object that failed evacuation in the prev bitmap.
-  inline void mark_evac_failure_object(const oop obj, uint worker_id) const;
+  void mark_evac_failure_object(const oop obj, uint worker_id) const;
 
   G1ConcurrentMark* concurrent_mark() const { return _cm; }
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -29,7 +29,6 @@
 
 #include "gc/g1/g1BarrierSet.hpp"
 #include "gc/g1/g1CollectorState.hpp"
-#include "gc/g1/g1ConcurrentMark.inline.hpp"
 #include "gc/g1/g1EvacFailureRegions.hpp"
 #include "gc/g1/g1Policy.hpp"
 #include "gc/g1/g1RemSet.hpp"
@@ -232,13 +231,6 @@ inline bool G1CollectedHeap::is_obj_dead_full(const oop obj, const HeapRegion* h
 
 inline bool G1CollectedHeap::is_obj_dead_full(const oop obj) const {
     return is_obj_dead_full(obj, heap_region_containing(obj));
-}
-
-inline void G1CollectedHeap::mark_evac_failure_object(const oop obj, uint worker_id) const {
-  // All objects failing evacuation are live. What we'll do is
-  // that we'll update the prev marking info so that they are
-  // all under PTAMS and explicitly marked.
-  _cm->par_mark_in_prev_bitmap(obj);
 }
 
 inline void G1CollectedHeap::set_humongous_reclaim_candidate(uint region, bool value) {


### PR DESCRIPTION
Move `G1CollectedHeap::mark_evac_failure_object` to cpp so that `g1CollectedHeap.inline.hpp` doesn't need to include `g1ConcurrentMark.inline.hpp`.

With the patch, the build time of clean fastdebug is reduced by ~16s.

Before: 6:25.72
After: 6:09.76