### PR TITLE
JDK-8283274: Improve @jvms usage in java.base

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/ClassDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ClassDesc.java
@@ -116,7 +116,7 @@ public sealed interface ClassDesc
      * followed by the field descriptor for the component type.  Examples of
      * valid type descriptor strings include {@code "Ljava/lang/String;"}, {@code "I"},
      * {@code "[I"}, {@code "V"}, {@code "[Ljava/lang/String;"}, etc.
-     * See JVMS 4.3.2 ("Field Descriptors") for more detail.
+     * See JVMS {@jvms 4.3.2 }("Field Descriptors") for more detail.
      *
      * @param descriptor a field descriptor string
      * @return a {@linkplain ClassDesc} describing the desired class

--- a/src/java.base/share/classes/java/lang/constant/Constable.java
+++ b/src/java.base/share/classes/java/lang/constant/Constable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ import java.util.Optional;
 /**
  * Represents a type which is <em>constable</em>.  A constable type is one whose
  * values are constants that can be represented in the constant pool of a Java
- * classfile as described in JVMS 4.4, and whose instances can describe themselves
+ * classfile as described in JVMS {@jvms 4.4}, and whose instances can describe themselves
  * nominally as a {@link ConstantDesc}.
  *
  * <p>Some constable types have a native representation in the constant pool:
@@ -48,7 +48,7 @@ import java.util.Optional;
  * Platform API are types that support Java language features such as {@link Enum},
  * and runtime support classes such as {@link VarHandle}.  These are typically
  * described with a {@link DynamicConstantDesc}, which describes dynamically
- * generated constants (JVMS 4.4.10).
+ * generated constants (JVMS {@jvms 4.4.10}).
  *
  * <p>The nominal form of an instance of a constable type is obtained via
  * {@link #describeConstable()}. A {@linkplain Constable} need

--- a/src/java.base/share/classes/java/lang/constant/ConstantDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ConstantDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ import java.lang.invoke.VarHandle.VarHandleDesc;
 
 /**
  * A <a href="package-summary.html#nominal">nominal descriptor</a> for a loadable
- * constant value, as defined in JVMS 4.4. Such a descriptor can be resolved via
+ * constant value, as defined in JVMS {@jvms 4.4}. Such a descriptor can be resolved via
  * {@link ConstantDesc#resolveConstantDesc(MethodHandles.Lookup)} to yield the
  * constant value itself.
  *
@@ -87,7 +87,7 @@ public sealed interface ConstantDesc
                 String {
     /**
      * Resolves this descriptor reflectively, emulating the resolution behavior
-     * of JVMS 5.4.3 and the access control behavior of JVMS 5.4.4.  The resolution
+     * of JVMS {@jvms 5.4.3} and the access control behavior of JVMS {@jvms 5.4.4}.  The resolution
      * and access control context is provided by the {@link MethodHandles.Lookup}
      * parameter.  No caching of the resulting value is performed.
      *

--- a/src/java.base/share/classes/java/lang/constant/package-info.java
+++ b/src/java.base/share/classes/java/lang/constant/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@
  * referenced in their nominal description are present and accessible.
  *
  * <p>The subtypes of {@link java.lang.constant.ConstantDesc} describe various kinds
- * of constant values.  For each type of loadable constant pool entry defined in JVMS 4.4,
+ * of constant values.  For each type of loadable constant pool entry defined in JVMS {@jvms 4.4},
  * there is a corresponding subtype of {@link java.lang.constant.ConstantDesc}:
  * {@link java.lang.constant.ClassDesc}, {@link java.lang.constant.MethodTypeDesc},
  * {@link java.lang.constant.DirectMethodHandleDesc}, {@link java.lang.String},

--- a/src/java.base/share/classes/java/lang/invoke/ConstantBootstraps.java
+++ b/src/java.base/share/classes/java/lang/invoke/ConstantBootstraps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,7 +96,7 @@ public final class ConstantBootstraps {
      * descriptor is specified by {@code name}.
      *
      * @param lookup unused
-     * @param name the descriptor (JVMS 4.3) of the desired primitive type
+     * @param name the descriptor (JVMS {@jvms 4.3}) of the desired primitive type
      * @param type the required result type (must be {@code Class.class})
      * @return the {@link Class} mirror
      * @throws IllegalArgumentException if the name is not a descriptor for a

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -2759,7 +2759,7 @@ assertEquals("[x, y, z]", pb.command().toString());
         /**
          * Looks up a class by name from the lookup context defined by this {@code Lookup} object,
          * <a href="MethodHandles.Lookup.html#equiv">as if resolved</a> by an {@code ldc} instruction.
-         * Such a resolution, as specified in JVMS 5.4.3.1 section, attempts to locate and load the class,
+         * Such a resolution, as specified in JVMS {@jvms 5.4.3.1}, attempts to locate and load the class,
          * and then determines whether the class is accessible to this lookup object.
          * <p>
          * The lookup context here is determined by the {@linkplain #lookupClass() lookup class},


### PR DESCRIPTION
As was done for JLS references under JDK-8283234, now the analogous update for JVMS references.