### PR TITLE
8283289 JFR: Rename CheckPoint

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
@@ -41,7 +41,7 @@ import jdk.jfr.internal.LongMap;
 import jdk.jfr.internal.MetadataDescriptor;
 import jdk.jfr.internal.Type;
 import jdk.jfr.internal.Utils;
-import jdk.jfr.internal.consumer.filter.CheckPointEvent;
+import jdk.jfr.internal.consumer.filter.CheckpointEvent;
 import jdk.jfr.internal.consumer.filter.ChunkWriter;
 
 /**
@@ -77,7 +77,7 @@ public final class ChunkParser {
         }
     }
 
-    private enum CheckPointType {
+    private enum CheckpointType {
         // Checkpoint that finishes a flush segment
         FLUSH(1),
         // Checkpoint contains chunk header information in the first pool
@@ -87,7 +87,7 @@ public final class ChunkParser {
         // Checkpoint contains thread related information
         THREAD(8);
         private final int mask;
-        private CheckPointType(int mask) {
+        private CheckpointType(int mask) {
             this.mask = mask;
         }
 
@@ -267,7 +267,7 @@ public final class ChunkParser {
                 // Not accepted by filter
             } else {
                 if (typeId == 1) { // checkpoint event
-                    if (CheckPointType.FLUSH.is(parseCheckpointType())) {
+                    if (CheckpointType.FLUSH.is(parseCheckpointType())) {
                         input.position(pos + size);
                         return FLUSH_MARKER;
                     }
@@ -317,9 +317,9 @@ public final class ChunkParser {
         long delta = -1;
         boolean logTrace = Logger.shouldLog(LogTag.JFR_SYSTEM_PARSER, LogLevel.TRACE);
         while (thisCP != abortCP && delta != 0) {
-            CheckPointEvent cp = null;
+            CheckpointEvent cp = null;
             if (configuration.chunkWriter != null) {
-                cp = configuration.chunkWriter.newCheckPointEvent(thisCP);
+                cp = configuration.chunkWriter.newCheckpointEvent(thisCP);
             }
             input.position(thisCP);
             lastCP = thisCP;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/filter/CheckPointEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/filter/CheckPointEvent.java
@@ -35,12 +35,12 @@ import jdk.jfr.internal.Type;
  * <p>
  * All positional values are relative to file start, not the chunk.
  */
-public final class CheckPointEvent {
+public final class CheckpointEvent {
     private final ChunkWriter chunkWriter;
-    private final LinkedHashMap<Long, CheckPointPool> pools = new LinkedHashMap<>();
+    private final LinkedHashMap<Long, CheckpointPool> pools = new LinkedHashMap<>();
     private final long startPosition;
 
-    public CheckPointEvent(ChunkWriter chunkWriter, long startPosition) {
+    public CheckpointEvent(ChunkWriter chunkWriter, long startPosition) {
         this.chunkWriter = chunkWriter;
         this.startPosition = startPosition;
     }
@@ -48,7 +48,7 @@ public final class CheckPointEvent {
     public PoolEntry addEntry(Type type, long id, long startPosition, long endPosition, Object references) {
         long typeId = type.getId();
         PoolEntry pe = new PoolEntry(startPosition, endPosition, type, id, references);
-        var cpp = pools.computeIfAbsent(typeId, k -> new CheckPointPool(typeId));
+        var cpp = pools.computeIfAbsent(typeId, k -> new CheckpointPool(typeId));
         cpp.add(pe);
         chunkWriter.getPool(type).add(id, pe);
         return pe;
@@ -56,7 +56,7 @@ public final class CheckPointEvent {
 
     public long touchedPools() {
         int count = 0;
-        for (CheckPointPool cpp : pools.values()) {
+        for (CheckpointPool cpp : pools.values()) {
             if (cpp.isTouched()) {
                 count++;
             }
@@ -64,7 +64,7 @@ public final class CheckPointEvent {
         return count;
     }
 
-    public Collection<CheckPointPool> getPools() {
+    public Collection<CheckpointPool> getPools() {
         return pools.values();
     }
 
@@ -74,7 +74,7 @@ public final class CheckPointEvent {
 
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        for (CheckPointPool p : pools.values()) {
+        for (CheckpointPool p : pools.values()) {
             for (var e : p.getEntries()) {
                 if (e.isTouched()) {
                     sb.append(e.getType().getName() + " " + e.getId() + "\n");

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/filter/CheckPointPool.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/filter/CheckPointPool.java
@@ -29,11 +29,11 @@ import java.util.List;
 /**
  * Represents a constant pool in a checkpoint, both entries and type id
  */
-final class CheckPointPool {
+final class CheckpointPool {
     private final List<PoolEntry> entries = new ArrayList<>();
     private final long typeId;
 
-    public CheckPointPool(long typeId) {
+    public CheckpointPool(long typeId) {
         this.typeId = typeId;
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Summary.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Summary.java
@@ -100,7 +100,7 @@ final class Summary extends Command {
             }
             HashMap<Long, Statistics> stats = new HashMap<>();
             stats.put(0L, new Statistics(eventPrefix + "Metadata"));
-            stats.put(1L, new Statistics(eventPrefix + "CheckPoint"));
+            stats.put(1L, new Statistics(eventPrefix + "Checkpoint"));
             int minWidth = 0;
             while (true) {
                 long chunkEnd = ch.getEnd();

--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/DiskRepository.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/DiskRepository.java
@@ -179,7 +179,7 @@ final class DiskRepository implements Closeable {
                 bufferIndex = 0;
                 break;
             case CHECKPOINT_EVENT_HEADER_BYTE_ARRAY_CONTENT:
-                processCheckPointHeader();
+                processCheckpointHeader();
                 break;
             case CHECKPOINT_EVENT_FLUSH_TYPE:
                 processFlush();
@@ -286,10 +286,10 @@ final class DiskRepository implements Closeable {
         }
     }
 
-    private void processCheckPointHeader() throws IOException {
+    private void processCheckpointHeader() throws IOException {
         buffer.put(bufferIndex, nextByte(true));
         if (bufferIndex == HEADER_SIZE) {
-            writeCheckPointHeader();
+            writeCheckpointHeader();
             state = State.EVENT_PAYLOAD;
             bufferIndex = 0;
         }
@@ -321,7 +321,7 @@ final class DiskRepository implements Closeable {
         }
     }
 
-    private void writeCheckPointHeader() throws IOException {
+    private void writeCheckpointHeader() throws IOException {
         Objects.requireNonNull(raf);
         byte state = buffer.get(HEADER_FILE_STATE_POSITION);
         boolean complete = state == COMPLETE_STATE;


### PR DESCRIPTION
Hi,

Could I have a review of a fix that renames "CheckPoint" to "checkpoint". The only visible effect of the change is in the 'jfr summary' command where it now displays "jdk.Checkpoint".  

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283289](https://bugs.openjdk.java.net/browse/JDK-8283289): JFR: Rename CheckPoint


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7847/head:pull/7847` \
`$ git checkout pull/7847`

Update a local copy of the PR: \
`$ git checkout pull/7847` \
`$ git pull https://git.openjdk.java.net/jdk pull/7847/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7847`

View PR using the GUI difftool: \
`$ git pr show -t 7847`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7847.diff">https://git.openjdk.java.net/jdk/pull/7847.diff</a>

</details>
