### PR TITLE
8283280: Improve exception messages with -Dsun.misc.URLClassPath.disableJarChecking=false

### DIFF
--- a/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
+++ b/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
@@ -807,7 +807,7 @@ public class URLClassPath {
         static JarFile checkJar(JarFile jar) throws IOException {
             if (System.getSecurityManager() != null && !DISABLE_JAR_CHECKING
                 && !zipAccess.startsWithLocHeader(jar)) {
-                IOException x = new IOException("Invalid Jar file");
+                IOException x = new IOException("Invalid Jar file: " + jar.getName());
                 try {
                     jar.close();
                 } catch (IOException ex) {


### PR DESCRIPTION
This change improves an exception message to include a path, e.g. `Invalid Jar file: some.jar` instead of just `Invalid Jar file`.

The exception is currently [always being caught and ignored](https://github.com/openjdk/jdk/blob/3e393047e12147a81e2899784b943923fc34da8e/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java#L459-L461) so this visible to users of the API, it's just helpful for debugging.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8283280](https://bugs.openjdk.java.net/browse/JDK-8283280): Improve exception messages with -Dsun.misc.URLClassPath.disableJarChecking=false


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7848/head:pull/7848` \
`$ git checkout pull/7848`

Update a local copy of the PR: \
`$ git checkout pull/7848` \
`$ git pull https://git.openjdk.java.net/jdk pull/7848/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7848`

View PR using the GUI difftool: \
`$ git pr show -t 7848`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7848.diff">https://git.openjdk.java.net/jdk/pull/7848.diff</a>

</details>
