### PR TITLE
8282764: AArch64: compiler/vectorapi/reshape/TestVectorCastNeon.java failed with incorrect result

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64_neon.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_neon.ad
@@ -350,16 +350,23 @@ instruct vcvt4Bto4I(vecX dst, vecD src)
   ins_pipe(pipe_class_default);
 %}
 
-instruct vcvt2Lto2F(vecD dst, vecX src)
+instruct vcvt2Lto2F(vecD dst, vecX src, vRegF tmp)
 %{
   predicate(n->as_Vector()->length() == 2 && n->bottom_type()->is_vect()->element_basic_type() == T_FLOAT);
   match(Set dst (VectorCastL2X src));
-  format %{ "scvtfv  T2D, $dst, $src\n\t"
-            "fcvtn   $dst, T2S, $dst, T2D\t# convert 2L to 2F vector"
+  effect(TEMP_DEF dst, TEMP tmp);
+  format %{ "umov   rscratch1, $src, D, 0\n\t"
+            "scvtfs $dst, rscratch1\n\t"
+            "umov   rscratch1, $src, D, 1\n\t"
+            "scvtfs $tmp, rscratch1\n\t"
+            "ins    $dst, S, $tmp, 1, 0\t# convert 2L to 2F vector"
   %}
   ins_encode %{
-    __ scvtfv(__ T2D, as_FloatRegister($dst$$reg), as_FloatRegister($src$$reg));
-    __ fcvtn(as_FloatRegister($dst$$reg), __ T2S, as_FloatRegister($dst$$reg), __ T2D);
+    __ umov(rscratch1, as_FloatRegister($src$$reg), __ D, 0);
+    __ scvtfs(as_FloatRegister($dst$$reg), rscratch1);
+    __ umov(rscratch1, as_FloatRegister($src$$reg), __ D, 1);
+    __ scvtfs(as_FloatRegister($tmp$$reg), rscratch1);
+    __ ins(as_FloatRegister($dst$$reg), __ S, as_FloatRegister($tmp$$reg), 1, 0);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/aarch64/aarch64_neon_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_neon_ad.m4
@@ -178,16 +178,23 @@ VECTOR_CAST_I2I_L(4, I, B, D, X, xtn,  4S, 4H, 8H, 8B)
 VECTOR_CAST_I2I_L(4, B, I, X, D, sxtl, 8B, 8H, 4H, 4S)
 dnl
 
-instruct vcvt2Lto2F(vecD dst, vecX src)
+instruct vcvt2Lto2F(vecD dst, vecX src, vRegF tmp)
 %{
   predicate(n->as_Vector()->length() == 2 && n->bottom_type()->is_vect()->element_basic_type() == T_FLOAT);
   match(Set dst (VectorCastL2X src));
-  format %{ "scvtfv  T2D, $dst, $src\n\t"
-            "fcvtn   $dst, T2S, $dst, T2D\t# convert 2L to 2F vector"
+  effect(TEMP_DEF dst, TEMP tmp);
+  format %{ "umov   rscratch1, $src, D, 0\n\t"
+            "scvtfs $dst, rscratch1\n\t"
+            "umov   rscratch1, $src, D, 1\n\t"
+            "scvtfs $tmp, rscratch1\n\t"
+            "ins    $dst, S, $tmp, 1, 0\t# convert 2L to 2F vector"
   %}
   ins_encode %{
-    __ scvtfv(__ T2D, as_FloatRegister($dst$$reg), as_FloatRegister($src$$reg));
-    __ fcvtn(as_FloatRegister($dst$$reg), __ T2S, as_FloatRegister($dst$$reg), __ T2D);
+    __ umov(rscratch1, as_FloatRegister($src$$reg), __ D, 0);
+    __ scvtfs(as_FloatRegister($dst$$reg), rscratch1);
+    __ umov(rscratch1, as_FloatRegister($src$$reg), __ D, 1);
+    __ scvtfs(as_FloatRegister($tmp$$reg), rscratch1);
+    __ ins(as_FloatRegister($dst$$reg), __ S, as_FloatRegister($tmp$$reg), 1, 0);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorCastShape128Test.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorCastShape128Test.java
@@ -114,6 +114,8 @@ public class VectorCastShape128Test {
         0,
         Long.MAX_VALUE,
         Long.MIN_VALUE,
+        // A special value to make sure correct rounding of
+        // conversion from long to float. See: JDK-8282764.
         0x561a524000000001L,
     };
 

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorCastShape128Test.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorCastShape128Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Arm Limited. All rights reserved.
+ * Copyright (c) 2021, 2022, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,6 +114,7 @@ public class VectorCastShape128Test {
         0,
         Long.MAX_VALUE,
         Long.MIN_VALUE,
+        0x561a524000000001L,
     };
 
 

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX1.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
 /*
  * @test
  * @bug 8259610
+ * @key randomness
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.misc
  * @summary Test that vector cast intrinsics work as intended on avx1.

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX2.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
 /*
  * @test
  * @bug 8259610
+ * @key randomness
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.misc
  * @summary Test that vector cast intrinsics work as intended on avx2.

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX512.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX512.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
 /*
  * @test
  * @bug 8259610
+ * @key randomness
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.misc
  * @summary Test that vector cast intrinsics work as intended on avx512.

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX512BW.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX512BW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
 /*
  * @test
  * @bug 8278623
+ * @key randomness
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.misc
  * @summary Test that vector cast intrinsics work as intended on avx512bw.

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX512DQ.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX512DQ.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
 /*
  * @test
  * @bug 8259610
+ * @key randomness
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.misc
  * @summary Test that vector cast intrinsics work as intended on avx512dq.

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastNeon.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastNeon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
 /*
  * @test
  * @bug 8259610
+ * @key randomness
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.misc
  * @summary Test that vector cast intrinsics work as intended on neon.
@@ -42,7 +43,7 @@ public class TestVectorCastNeon {
         VectorReshapeHelper.runMainHelper(
                 TestVectorCast.class,
                 TestCastMethods.NEON_CAST_TESTS.stream(),
-                "-XX:+UseNeon");
+                "-XX:UseSVE=0");
     }
 }
 

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastSVE.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastSVE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
 /*
  * @test
  * @bug 8259610
+ * @key randomness
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.misc
  * @summary Test that vector cast intrinsics work as intended on sve.

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorReinterpret.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorReinterpret.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import jdk.incubator.vector.VectorSpecies;
 /*
  * @test
  * @bug 8259610
+ * @key randomness
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.misc
  * @summary Test that vector reinterpret intrinsics work as intended.

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/utils/VectorReshapeHelper.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/utils/VectorReshapeHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import jdk.incubator.vector.*;
 import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
 
 public class VectorReshapeHelper {
     public static final int INVOCATIONS = 10_000;
@@ -105,7 +106,7 @@ public class VectorReshapeHelper {
 
     public static <T, U> void runCastHelper(VectorOperators.Conversion<T, U> castOp,
                                             VectorSpecies<T> isp, VectorSpecies<U> osp) throws Throwable {
-        var random = RandomGenerator.getDefault();
+        var random = Utils.getRandomInstance();
         boolean isUnsignedCast = castOp.name().startsWith("ZERO");
         String testMethodName = VectorSpeciesPair.makePair(isp, osp, isUnsignedCast).format();
         var caller = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass();
@@ -219,7 +220,7 @@ public class VectorReshapeHelper {
     }
 
     public static void runExpandShrinkHelper(VectorSpecies<Byte> isp, VectorSpecies<Byte> osp) throws Throwable {
-        var random = RandomGenerator.getDefault();
+        var random = Utils.getRandomInstance();
         String testMethodName = VectorSpeciesPair.makePair(isp, osp).format();
         var caller = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass();
         var testMethod = MethodHandles.lookup().findStatic(caller,
@@ -249,7 +250,7 @@ public class VectorReshapeHelper {
     }
 
     public static void runDoubleExpandShrinkHelper(VectorSpecies<Byte> isp, VectorSpecies<Byte> osp) throws Throwable {
-        var random = RandomGenerator.getDefault();
+        var random = Utils.getRandomInstance();
         String testMethodName = VectorSpeciesPair.makePair(isp, osp).format();
         var caller = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass();
         var testMethod = MethodHandles.lookup().findStatic(caller,
@@ -278,7 +279,7 @@ public class VectorReshapeHelper {
     }
 
     public static <T, U> void runRebracketHelper(VectorSpecies<T> isp, VectorSpecies<U> osp) throws Throwable {
-        var random = RandomGenerator.getDefault();
+        var random = Utils.getRandomInstance();
         String testMethodName = VectorSpeciesPair.makePair(isp, osp).format();
         var caller = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass();
         var testMethod = MethodHandles.lookup().findStatic(caller,


### PR DESCRIPTION
Vector API long to float conversion operation on NEON converts vector of 2 longs to 2 floats. In current implementation, we convert 2 longs to 2 doubles first and then converts 2 doubles to 2 floats. However, this two-steps conversion may have two roundings, while the expected behavior, conversion from long to float directly, has only one rounding. This will result in inconsistent result. E.g. for the failure test case:

```
jshell> long l = 0x561a524000000001L;
l ==> 6204361871487664129

jshell> float l2f = (float)l;
l2f ==> 6.2043621E18

jshell> float l2d2f = (float)((double)l);
l2d2f ==> 6.2043616E18
```

Since we don't have NEON instruction to support vector long to float conversion, we fix the codegen by doing it in scalar operation one element by one element.

TEST: vector api jtreg tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282764](https://bugs.openjdk.java.net/browse/JDK-8282764): AArch64: compiler/vectorapi/reshape/TestVectorCastNeon.java failed with incorrect result


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Nick Gasson](https://openjdk.java.net/census#ngasson) (@nick-arm - **Reviewer**)
 * [Eric Liu](https://openjdk.java.net/census#eliu) - Author ⚠️ Added manually

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7850/head:pull/7850` \
`$ git checkout pull/7850`

Update a local copy of the PR: \
`$ git checkout pull/7850` \
`$ git pull https://git.openjdk.java.net/jdk pull/7850/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7850`

View PR using the GUI difftool: \
`$ git pr show -t 7850`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7850.diff">https://git.openjdk.java.net/jdk/pull/7850.diff</a>

</details>
