### PR TITLE
8283298: Make CodeCacheSegmentSize a product flag

### DIFF
--- a/src/hotspot/share/interpreter/templateInterpreter.cpp
+++ b/src/hotspot/share/interpreter/templateInterpreter.cpp
@@ -48,7 +48,7 @@ void TemplateInterpreter::initialize_stub() {
   int code_size = InterpreterCodeSize;
   NOT_PRODUCT(code_size *= 4;)  // debug uses extra interpreter code space
   // 270+ interpreter codelets are generated and each of them is required to be aligned to
-  // CodeEntryAlignment twice. So we additional size due to alignment.
+  // CodeEntryAlignment twice. So we need additional size due to alignment.
   int max_aligned_codelets = 280;
   int max_aligned_bytes = max_aligned_codelets * CodeEntryAlignment * 2;
   _code = new StubQueue(new InterpreterCodeletInterface, code_size + max_aligned_bytes, NULL,

--- a/src/hotspot/share/interpreter/templateInterpreter.cpp
+++ b/src/hotspot/share/interpreter/templateInterpreter.cpp
@@ -47,6 +47,8 @@ void TemplateInterpreter::initialize_stub() {
   // allocate interpreter
   int code_size = InterpreterCodeSize;
   NOT_PRODUCT(code_size *= 4;)  // debug uses extra interpreter code space
+  // 270+ interpreter codelets are generated and each of them is required to be aligned to
+  // CodeEntryAlignment twice. So we additional size due to alignment.
   int max_aligned_codelets = 280;
   int max_aligned_bytes = max_aligned_codelets * CodeEntryAlignment * 2;
   _code = new StubQueue(new InterpreterCodeletInterface, code_size + max_aligned_bytes, NULL,

--- a/src/hotspot/share/interpreter/templateInterpreter.cpp
+++ b/src/hotspot/share/interpreter/templateInterpreter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,9 @@ void TemplateInterpreter::initialize_stub() {
   // allocate interpreter
   int code_size = InterpreterCodeSize;
   NOT_PRODUCT(code_size *= 4;)  // debug uses extra interpreter code space
-  _code = new StubQueue(new InterpreterCodeletInterface, code_size, NULL,
+  int max_aligned_codelets = 280;
+  int max_aligned_bytes = max_aligned_codelets * CodeEntryAlignment * 2;
+  _code = new StubQueue(new InterpreterCodeletInterface, code_size + max_aligned_bytes, NULL,
                         "Interpreter");
 }
 

--- a/src/hotspot/share/prims/methodHandles.cpp
+++ b/src/hotspot/share/prims/methodHandles.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,7 +89,9 @@ void MethodHandles::generate_adapters() {
 
   ResourceMark rm;
   TraceTime timer("MethodHandles adapters generation", TRACETIME_LOG(Info, startuptime));
-  _adapter_code = MethodHandlesAdapterBlob::create(adapter_code_size);
+  int adapter_num = (int)Interpreter::method_handle_invoke_LAST - (int)Interpreter::method_handle_invoke_FIRST + 1;
+  int max_aligned_bytes = adapter_num * CodeEntryAlignment;
+  _adapter_code = MethodHandlesAdapterBlob::create(adapter_code_size + max_aligned_bytes);
   CodeBuffer code(_adapter_code);
   MethodHandlesAdapterGenerator g(&code);
   g.generate();

--- a/src/hotspot/share/prims/methodHandles.cpp
+++ b/src/hotspot/share/prims/methodHandles.cpp
@@ -89,6 +89,8 @@ void MethodHandles::generate_adapters() {
 
   ResourceMark rm;
   TraceTime timer("MethodHandles adapters generation", TRACETIME_LOG(Info, startuptime));
+  // The adapter entry is required to be aligned to CodeEntryAlignment.
+  // So we need additional bytes due to alignment.
   int adapter_num = (int)Interpreter::method_handle_invoke_LAST - (int)Interpreter::method_handle_invoke_FIRST + 1;
   int max_aligned_bytes = adapter_num * CodeEntryAlignment;
   _adapter_code = MethodHandlesAdapterBlob::create(adapter_code_size + max_aligned_bytes);

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1522,7 +1522,7 @@ const intx ObjectAlignmentInBytes = 8;
           "Stack space (bytes) required for JVM_InvokeMethod to complete")  \
                                                                             \
   /* code cache parameters                                    */            \
-  develop_pd(uintx, CodeCacheSegmentSize,                                   \
+  product_pd(uintx, CodeCacheSegmentSize, EXPERIMENTAL,                     \
           "Code cache segment size (in bytes) - smallest unit of "          \
           "allocation")                                                     \
           range(1, 1024)                                                    \

--- a/test/hotspot/jtreg/compiler/arguments/TestCodeEntryAlignment.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestCodeEntryAlignment.java
@@ -27,7 +27,6 @@
  * @library /test/lib /
  * @bug 8281467
  * @requires vm.flagless
- * @requires vm.debug
  * @requires os.arch=="amd64" | os.arch=="x86_64"
  *
  * @summary Test large CodeEntryAlignments are accepted


### PR DESCRIPTION
Hi all,

As discussed in https://github.com/openjdk/jdk/pull/7830, this patch makes `CodeCacheSegmentSize` a product flag.
It also fixes two bugs when testing the release VM with CodeEntryAlignment={512, 1024}.
Please review it.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283298](https://bugs.openjdk.java.net/browse/JDK-8283298): Make CodeCacheSegmentSize a product flag


### Reviewers
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to c84c659c288a167b941023870b0fc829cda2b9cc
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to af65cbaaca422cd451740eff65c5c8e68fcf4a05


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7851/head:pull/7851` \
`$ git checkout pull/7851`

Update a local copy of the PR: \
`$ git checkout pull/7851` \
`$ git pull https://git.openjdk.java.net/jdk pull/7851/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7851`

View PR using the GUI difftool: \
`$ git pr show -t 7851`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7851.diff">https://git.openjdk.java.net/jdk/pull/7851.diff</a>

</details>
