### PR TITLE
8283315: jrt-fs.jar not always deterministically built

### DIFF
--- a/make/common/JarArchive.gmk
+++ b/make/common/JarArchive.gmk
@@ -193,7 +193,7 @@ define SetupJarArchiveBody
   $1_UPDATE_CONTENTS=\
       if [ "`$(WC) -l $$($1_BIN)/_the.$$($1_JARNAME)_contents | $(AWK) '{ print $$$$1 }'`" -gt "0" ]; then \
         $(ECHO) "  updating" `$(WC) -l $$($1_BIN)/_the.$$($1_JARNAME)_contents | $(AWK) '{ print $$$$1 }'` files && \
-        $(CAT) $$($1_BIN)/_the.$$($1_JARNAME)_contents | $(SORT) > $$($1_BIN)/_the.$$($1_JARNAME)_contents_sorted && \
+        $(SORT) $$($1_BIN)/_the.$$($1_JARNAME)_contents > $$($1_BIN)/_the.$$($1_JARNAME)_contents_sorted && \
         $$($1_JAR_CMD) --update $$($1_JAR_OPTIONS) --file $$@ @$$($1_BIN)/_the.$$($1_JARNAME)_contents_sorted; \
       fi $$(NEWLINE)
   # The s-variants of the above macros are used when the jar is created from scratch.
@@ -214,7 +214,7 @@ define SetupJarArchiveBody
         $$($1_BIN)/_the.$$($1_JARNAME)_contents) $$(NEWLINE) )
   endif
   $1_SUPDATE_CONTENTS=\
-      $(CAT) $$($1_BIN)/_the.$$($1_JARNAME)_contents | $(SORT) > $$($1_BIN)/_the.$$($1_JARNAME)_contents_sorted && \
+      $(SORT) $$($1_BIN)/_the.$$($1_JARNAME)_contents > $$($1_BIN)/_the.$$($1_JARNAME)_contents_sorted && \
       $$($1_JAR_CMD) --update $$($1_JAR_OPTIONS) --file $$@ @$$($1_BIN)/_the.$$($1_JARNAME)_contents_sorted $$(NEWLINE)
 
   # Use a slightly shorter name for logging, but with enough path to identify this jar.

--- a/make/common/JarArchive.gmk
+++ b/make/common/JarArchive.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -193,7 +193,8 @@ define SetupJarArchiveBody
   $1_UPDATE_CONTENTS=\
       if [ "`$(WC) -l $$($1_BIN)/_the.$$($1_JARNAME)_contents | $(AWK) '{ print $$$$1 }'`" -gt "0" ]; then \
         $(ECHO) "  updating" `$(WC) -l $$($1_BIN)/_the.$$($1_JARNAME)_contents | $(AWK) '{ print $$$$1 }'` files && \
-        $$($1_JAR_CMD) --update $$($1_JAR_OPTIONS) --file $$@ @$$($1_BIN)/_the.$$($1_JARNAME)_contents; \
+        $(CAT) $$($1_BIN)/_the.$$($1_JARNAME)_contents | $(SORT) > $$($1_BIN)/_the.$$($1_JARNAME)_contents_sorted && \
+        $$($1_JAR_CMD) --update $$($1_JAR_OPTIONS) --file $$@ @$$($1_BIN)/_the.$$($1_JARNAME)_contents_sorted; \
       fi $$(NEWLINE)
   # The s-variants of the above macros are used when the jar is created from scratch.
   # NOTICE: please leave the parentheses space separated otherwise the AIX build will break!
@@ -212,7 +213,9 @@ define SetupJarArchiveBody
             | $(SED) 's|$$(src)/|-C $$(src) |g' >> \
         $$($1_BIN)/_the.$$($1_JARNAME)_contents) $$(NEWLINE) )
   endif
-  $1_SUPDATE_CONTENTS=$$($1_JAR_CMD) --update $$($1_JAR_OPTIONS) --file $$@ @$$($1_BIN)/_the.$$($1_JARNAME)_contents $$(NEWLINE)
+  $1_SUPDATE_CONTENTS=\
+      $(CAT) $$($1_BIN)/_the.$$($1_JARNAME)_contents | $(SORT) > $$($1_BIN)/_the.$$($1_JARNAME)_contents_sorted && \
+      $$($1_JAR_CMD) --update $$($1_JAR_OPTIONS) --file $$@ @$$($1_BIN)/_the.$$($1_JARNAME)_contents_sorted $$(NEWLINE)
 
   # Use a slightly shorter name for logging, but with enough path to identify this jar.
   $1_NAME:=$$(subst $$(OUTPUTDIR)/,,$$($1_JAR))


### PR DESCRIPTION
JarArchive.gmk uses an un-sorted jar @\<file list\>, thus depending on exactly how that list gets ordered by relevant OS querys. Such queries can differ in order on different CPU architectures (Intel vs AMD).

This PR adds a "sort" to the jar @\<file list\> contents.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283315](https://bugs.openjdk.java.net/browse/JDK-8283315): jrt-fs.jar not always deterministically built


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to 897726be59d2908588169ca79ca8e5b3de3a89d2


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7852/head:pull/7852` \
`$ git checkout pull/7852`

Update a local copy of the PR: \
`$ git checkout pull/7852` \
`$ git pull https://git.openjdk.java.net/jdk pull/7852/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7852`

View PR using the GUI difftool: \
`$ git pr show -t 7852`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7852.diff">https://git.openjdk.java.net/jdk/pull/7852.diff</a>

</details>
