### PR TITLE
JDK-8283320: Error message for Windows libraries always points to --with-msvcr-dll no matter the actual file name

### DIFF
--- a/make/autoconf/toolchain_microsoft.m4
+++ b/make/autoconf/toolchain_microsoft.m4
@@ -481,6 +481,7 @@ AC_DEFUN([TOOLCHAIN_CHECK_POSSIBLE_MSVC_DLL],
 AC_DEFUN([TOOLCHAIN_SETUP_MSVC_DLL],
 [
   DLL_NAME="$1"
+  DLL_HELP="$2"
   MSVC_DLL=
 
   if test "x$OPENJDK_TARGET_CPU" = xx86; then
@@ -565,7 +566,7 @@ AC_DEFUN([TOOLCHAIN_SETUP_MSVC_DLL],
   if test "x$MSVC_DLL" = x; then
     AC_MSG_CHECKING([for $DLL_NAME])
     AC_MSG_RESULT([no])
-    AC_MSG_ERROR([Could not find $DLL_NAME. Please specify using --with-msvcr-dll.])
+    AC_MSG_ERROR([Could not find $DLL_NAME. Please specify using ${DLL_HELP}.])
   fi
 ])
 
@@ -588,7 +589,7 @@ AC_DEFUN([TOOLCHAIN_SETUP_VS_RUNTIME_DLLS],
     fi
     MSVCR_DLL="$MSVC_DLL"
   else
-    TOOLCHAIN_SETUP_MSVC_DLL([${MSVCR_NAME}])
+    TOOLCHAIN_SETUP_MSVC_DLL([${MSVCR_NAME}], [--with-msvcr-dll])
     MSVCR_DLL="$MSVC_DLL"
   fi
   AC_SUBST(MSVCR_DLL)
@@ -611,7 +612,7 @@ AC_DEFUN([TOOLCHAIN_SETUP_VS_RUNTIME_DLLS],
       fi
       MSVCP_DLL="$MSVC_DLL"
     else
-      TOOLCHAIN_SETUP_MSVC_DLL([${MSVCP_NAME}])
+      TOOLCHAIN_SETUP_MSVC_DLL([${MSVCP_NAME}], [--with-msvcp-dll])
       MSVCP_DLL="$MSVC_DLL"
     fi
     AC_SUBST(MSVCP_DLL)
@@ -636,7 +637,7 @@ AC_DEFUN([TOOLCHAIN_SETUP_VS_RUNTIME_DLLS],
       fi
       VCRUNTIME_1_DLL="$MSVC_DLL"
     else
-      TOOLCHAIN_SETUP_MSVC_DLL([${VCRUNTIME_1_NAME}])
+      TOOLCHAIN_SETUP_MSVC_DLL([${VCRUNTIME_1_NAME}], [--with-vcruntime-1-dll])
       VCRUNTIME_1_DLL="$MSVC_DLL"
     fi
   fi


### PR DESCRIPTION
TOOLCHAIN_SETUP_MSVC_DLL always points to --with-msvcr-dll if it couldn't find the requested file, even if the dll being searched for was msvcp.dll for instance. This small patch fixes the potentially confusing advice to point to the correct options

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283320](https://bugs.openjdk.java.net/browse/JDK-8283320): Error message for Windows libraries always points to --with-msvcr-dll no matter the actual file name


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7853/head:pull/7853` \
`$ git checkout pull/7853`

Update a local copy of the PR: \
`$ git checkout pull/7853` \
`$ git pull https://git.openjdk.java.net/jdk pull/7853/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7853`

View PR using the GUI difftool: \
`$ git pr show -t 7853`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7853.diff">https://git.openjdk.java.net/jdk/pull/7853.diff</a>

</details>
