### PR TITLE
8283325: US_ASCII decoder relies on String.decodeASCII being exhaustive

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -1032,6 +1032,12 @@ public final class String
     /* package-private */
     static int decodeASCII(byte[] sa, int sp, char[] da, int dp, int len) {
         int count = StringCoding.countPositives(sa, sp, len);
+        while (count < len) {
+            if (sa[sp + count] < 0) {
+                break;
+            }
+            count++;
+        }
         StringLatin1.inflate(sa, sp, da, dp, count);
         return count;
     }

--- a/test/jdk/java/nio/charset/CharsetDecoder/ASCIIDecode.java
+++ b/test/jdk/java/nio/charset/CharsetDecoder/ASCIIDecode.java
@@ -36,7 +36,12 @@ public class ASCIIDecode {
     public static void main(String[] args) throws Exception {
         final Charset ascii = Charset.forName("US-ASCII");
         final CharsetDecoder decoder = ascii.newDecoder();
+
         byte[] ba = new byte[] { 0x60, 0x60, 0x60, (byte)0xFF };
+
+        // Repeat enough times to test that interpreter and JIT:ed versions
+        // behave the same (without the patch for 8283325 this fails within
+        // 50 000 iterations on the system used for verification)
         for (int i = 0; i < 100_000; i++) {
             ByteBuffer bb = ByteBuffer.wrap(ba);
             char[] ca = new char[4];
@@ -45,7 +50,6 @@ public class ASCIIDecode {
             if (ca[0] != 0x60 || ca[1] != 0x60 || ca[2] != 0x60) {
                 throw new RuntimeException("Unexpected output on iteration " + i);
             }
-            Arrays.fill(ca, (char)0);
         }
     }
 }

--- a/test/jdk/java/nio/charset/CharsetDecoder/ASCIIDecode.java
+++ b/test/jdk/java/nio/charset/CharsetDecoder/ASCIIDecode.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8283325
+ * @summary Ensure that decoding to ASCII from a stream with a non-ASCII
+ *          character correctly decodes up until the byte in error.
+ */
+
+import java.nio.*;
+import java.nio.charset.*;
+import java.util.Arrays;
+
+public class ASCIIDecode {
+
+    public static void main(String[] args) throws Exception {
+        final Charset ascii = Charset.forName("US-ASCII");
+        final CharsetDecoder decoder = ascii.newDecoder();
+        byte[] ba = new byte[] { 0x60, 0x60, 0x60, (byte)0xFF };
+        for (int i = 0; i < 100_000; i++) {
+            ByteBuffer bb = ByteBuffer.wrap(ba);
+            char[] ca = new char[4];
+            CharBuffer cb = CharBuffer.wrap(ca);
+            CoderResult buf = decoder.decode(bb, cb, true);
+            if (ca[0] != 0x60 || ca[1] != 0x60 || ca[2] != 0x60) {
+                throw new RuntimeException("Unexpected output on iteration " + i);
+            }
+            Arrays.fill(ca, (char)0);
+        }
+    }
+}


### PR DESCRIPTION
Adjust `String.decodeASCII` to deal with the possibility that `StringCoding.countPositives` can return a value less than the exact number of leading positive bytes. This is the likely cause of a number of intermittent but somewhat common errors on aarch64 tests in our CI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283325](https://bugs.openjdk.java.net/browse/JDK-8283325): US_ASCII decoder relies on String.decodeASCII being exhaustive


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7855/head:pull/7855` \
`$ git checkout pull/7855`

Update a local copy of the PR: \
`$ git checkout pull/7855` \
`$ git pull https://git.openjdk.java.net/jdk pull/7855/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7855`

View PR using the GUI difftool: \
`$ git pr show -t 7855`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7855.diff">https://git.openjdk.java.net/jdk/pull/7855.diff</a>

</details>
