### PR TITLE
8283332: G1: Stricter assertion in G1BlockOffsetTablePart::forward_to_block_containing_addr

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
@@ -140,7 +140,7 @@ inline HeapWord* G1BlockOffsetTablePart::forward_to_block_containing_addr(HeapWo
         "start of block must be an initialized object");
     n += block_size(q);
   }
-  assert(q <= n, "wrong order for q and addr");
+  assert(q <= addr, "wrong order for q and addr");
   assert(addr < n, "wrong order for addr and n");
   return q;
 }


### PR DESCRIPTION
Stricter assertion to match the assert message.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283332](https://bugs.openjdk.java.net/browse/JDK-8283332): G1: Stricter assertion in G1BlockOffsetTablePart::forward_to_block_containing_addr


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7856/head:pull/7856` \
`$ git checkout pull/7856`

Update a local copy of the PR: \
`$ git checkout pull/7856` \
`$ git pull https://git.openjdk.java.net/jdk pull/7856/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7856`

View PR using the GUI difftool: \
`$ git pr show -t 7856`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7856.diff">https://git.openjdk.java.net/jdk/pull/7856.diff</a>

</details>
