### PR TITLE
8283337: Posix signal handler modification warning triggering incorrectly

### DIFF
--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -1244,8 +1244,10 @@ void set_signal_handler(int sig, bool do_check = true) {
   }
 #endif
 
-  // Save handler setup for later checking
-  vm_handlers.set(sig, &sigAct);
+  // Save handler setup for possible later checking
+  if (do_check) {
+    vm_handlers.set(sig, &sigAct);
+  }
   do_check_signal_periodically[sig] = do_check;
 
   int ret = sigaction(sig, &sigAct, &oldAct);


### PR DESCRIPTION
PosixSignals::print_signal_handler() is incorrectly detecting a changed signal handler.  The signal handler for SIGBREAK/SIGQUIT is now set in src/hotspot/os/posix/signals_posix.cpp with the bool parameter do_check set to false.

set_signal_handler should only store a handler in vm_handlers when do_check is true.

However I don't see a simple way of getting a valid warning for the SIGQUIT handler, if it is added later when os::initialize_jdk_signal_support() calls os::signal().

If only signals added directly by src/hotspot/os/posix/signals_posix.cpp have the warning for a handler changing, then we never had a warning for SIGQUIT, so just this simple change is needed to remove the bogus warning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283337](https://bugs.openjdk.java.net/browse/JDK-8283337): Posix signal handler modification warning triggering incorrectly


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7858/head:pull/7858` \
`$ git checkout pull/7858`

Update a local copy of the PR: \
`$ git checkout pull/7858` \
`$ git pull https://git.openjdk.java.net/jdk pull/7858/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7858`

View PR using the GUI difftool: \
`$ git pr show -t 7858`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7858.diff">https://git.openjdk.java.net/jdk/pull/7858.diff</a>

</details>
