### PR TITLE
8283352: [CDS] SharedBaseAddress.java fails on x86_32

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/SharedBaseAddress.java
+++ b/test/hotspot/jtreg/runtime/cds/SharedBaseAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  * @summary Test variety of values for SharedBaseAddress, making sure
  *          VM handles normal values as well as edge values w/o a crash.
  * @requires vm.cds
+ * @requires vm.bits == 64
  * @library /test/lib
  * @run driver SharedBaseAddress 0
  */
@@ -37,6 +38,7 @@
  * @summary Test variety of values for SharedBaseAddress, making sure
  *          VM handles normal values as well as edge values w/o a crash.
  * @requires vm.cds
+ * @requires vm.bits == 64
  * @library /test/lib
  * @run driver SharedBaseAddress 1
  */

--- a/test/hotspot/jtreg/runtime/cds/SharedBaseAddress.java
+++ b/test/hotspot/jtreg/runtime/cds/SharedBaseAddress.java
@@ -27,7 +27,6 @@
  * @summary Test variety of values for SharedBaseAddress, making sure
  *          VM handles normal values as well as edge values w/o a crash.
  * @requires vm.cds
- * @requires vm.bits == 64
  * @library /test/lib
  * @run driver SharedBaseAddress 0
  */
@@ -38,7 +37,6 @@
  * @summary Test variety of values for SharedBaseAddress, making sure
  *          VM handles normal values as well as edge values w/o a crash.
  * @requires vm.cds
- * @requires vm.bits == 64
  * @library /test/lib
  * @run driver SharedBaseAddress 1
  */
@@ -72,68 +70,79 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 public class SharedBaseAddress {
 
-    // shared base address test table
-    private static final String[] testTable = {
-        "1g", "8g", "64g","512g", "4t",
-        "32t", "128t", "0",
+    // shared base address test table for {32, 64}bit VM
+    private static final String[] testTableShared = {
+        "1g", "0",
         "1", "64k", "64M",
+        "0xfff80000",         // archive top wraps around 32-bit address space
+        "0xffffffff",         // archive bottom wraps around 32-bit address space -- due to align_up()
+        "0"                   // always let OS pick the base address at runtime (ASLR for CDS archive)
+    };
+
+    // shared base address test table for 64bit VM only
+    private static final String[] testTable64 = {
+        "8g", "64g","512g", "4t",
+        "32t", "128t",
         "0x800001000",        // Default base address + 1 page - probably valid but unaligned to metaspace alignment, see JDK 8247522
         "0xfffffffffff00000", // archive top wraps around 64-bit address space
-        "0xfff80000",         // archive top wraps around 32-bit address space
         "0xffffffffffffffff", // archive bottom wraps around 64-bit address space -- due to align_up()
-        "0xffffffff",         // archive bottom wraps around 32-bit address space -- due to align_up()
         "0x00007ffffff00000", // end of archive will go past the end of user space on linux/x64
-        "0x500000000",        // (20g) below 32g at a 4g aligned address, but cannot be expressed with a logical
+        "0x500000000"         // (20g) below 32g at a 4g aligned address, but cannot be expressed with a logical
                               //    immediate on aarch64 (0x5_0000_0000) (see JDK-8265705)
-        "0",                  // always let OS pick the base address at runtime (ASLR for CDS archive)
     };
 
     // failed pattern
     private static String failedPattern = "os::release_memory\\(0x[0-9a-fA-F]*,\\s[0-9]*\\)\\sfailed";
 
     public static void main(String[] args) throws Exception {
-        int mid = testTable.length / 2;
-        int start = args[0].equals("0") ? 0 : mid;
-        int end   = args[0].equals("0") ? mid : testTable.length;
-        boolean provoke = (args.length > 1 && args[1].equals("provoke"));
+        String[] testTable = testTableShared;
+        int iter = 0;
+        do {
+            int mid = testTable.length / 2;
+            int start = args[0].equals("0") ? 0 : mid;
+            int end   = args[0].equals("0") ? mid : testTable.length;
+            boolean provoke = (args.length > 1 && args[1].equals("provoke"));
 
-        // provoke == true: we want to increase the chance that mapping the generated archive at the designated base
-        // succeeds, to test Klass pointer encoding at that weird location. We do this by sizing heap + class space
-        // small, and by switching off compressed oops.
+            // provoke == true: we want to increase the chance that mapping the generated archive at the designated base
+            // succeeds, to test Klass pointer encoding at that weird location. We do this by sizing heap + class space
+            // small, and by switching off compressed oops.
 
-        // provoke == false:  we just go with default parameters. This is more of a test of
-        // CDS' ability to recover if mapping at runtime fails.
-        for (int i = start; i < end; i++) {
-            String testEntry = testTable[i];
-            String filename = "SharedBaseAddress-base" + testEntry + ".jsa";
-            System.out.println("sharedBaseAddress = " + testEntry);
-            CDSOptions opts = (new CDSOptions())
-                        .setArchiveName(filename)
-                        .addPrefix("-XX:SharedBaseAddress=" + testEntry)
-                        .addPrefix("-Xlog:cds=debug")
-                        .addPrefix("-Xlog:cds+reloc=debug")
-                        .addPrefix("-Xlog:nmt=debug")
-                        .addPrefix("-Xlog:os=debug")
-                        .addPrefix("-Xlog:gc+metaspace")
-                        .addPrefix("-XX:NativeMemoryTracking=detail");
+            // provoke == false:  we just go with default parameters. This is more of a test of
+            // CDS' ability to recover if mapping at runtime fails.
+            for (int i = start; i < end; i++) {
+                String testEntry = testTable[i];
+                String filename = "SharedBaseAddress-base" + testEntry + ".jsa";
+                System.out.println("sharedBaseAddress = " + testEntry);
+                CDSOptions opts = (new CDSOptions())
+                            .setArchiveName(filename)
+                            .addPrefix("-XX:SharedBaseAddress=" + testEntry)
+                            .addPrefix("-Xlog:cds=debug")
+                            .addPrefix("-Xlog:cds+reloc=debug")
+                            .addPrefix("-Xlog:nmt=debug")
+                            .addPrefix("-Xlog:os=debug")
+                            .addPrefix("-Xlog:gc+metaspace")
+                            .addPrefix("-XX:NativeMemoryTracking=detail");
 
-            if (provoke) {
-                opts.addPrefix("-Xmx128m")
-                    .addPrefix("-XX:CompressedClassSpaceSize=32m")
-                    .addPrefix("-XX:-UseCompressedOops");
+                if (provoke) {
+                    opts.addPrefix("-Xmx128m")
+                        .addPrefix("-XX:CompressedClassSpaceSize=32m")
+                        .addPrefix("-XX:-UseCompressedOops");
+                }
+                if (Platform.isDebugBuild()) {
+                    // Make VM start faster in debug build with large heap.
+                    opts.addPrefix("-XX:-ZapUnusedHeapArea");
+                }
+
+                CDSTestUtils.createArchiveAndCheck(opts);
+                OutputAnalyzer out = CDSTestUtils.runWithArchiveAndCheck(opts);
+                if (testEntry.equals("0")) {
+                    out.shouldContain("Archive(s) were created with -XX:SharedBaseAddress=0. Always map at os-selected address.")
+                       .shouldContain("Try to map archive(s) at an alternative address")
+                       .shouldNotMatch(failedPattern);
+                }
             }
-            if (Platform.isDebugBuild()) {
-                // Make VM start faster in debug build with large heap.
-                opts.addPrefix("-XX:-ZapUnusedHeapArea");
-            }
-
-            CDSTestUtils.createArchiveAndCheck(opts);
-            OutputAnalyzer out = CDSTestUtils.runWithArchiveAndCheck(opts);
-            if (testEntry.equals("0")) {
-                out.shouldContain("Archive(s) were created with -XX:SharedBaseAddress=0. Always map at os-selected address.")
-                   .shouldContain("Try to map archive(s) at an alternative address")
-                   .shouldNotMatch(failedPattern);
-            }
-        }
+            iter++;
+            testTable = testTable64;
+        } while (iter < 2 && Platform.is64bit());
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/SharedBaseAddress.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/SharedBaseAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
  *          making sure VM handles normal values as well as edge values
  *          w/o a crash.
  * @requires vm.cds
+ * @requires vm.bits == 64
  * @library /test/lib
  * @compile test-classes/Hello.java
  * @run main/timeout=240 SharedBaseAddress

--- a/test/hotspot/jtreg/runtime/cds/appcds/SharedBaseAddress.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/SharedBaseAddress.java
@@ -50,26 +50,28 @@ public class SharedBaseAddress {
         "0x800001000"  // Default base address + 1 page - probably valid but unaligned to metaspace alignment, see JDK 8247522
     };
 
-    public static void main(String[] args) throws Exception {
+    public static void test(String[] testTable) throws Exception {
         String appJar = JarBuilder.getOrCreateHelloJar();
-        String[] testTable = testTableShared;
-        int iter = 0;
-        do {
-            for (String testEntry : testTable) {
-                System.out.println("sharedBaseAddress = " + testEntry);
 
-                // Note: some platforms may restrict valid values for SharedBaseAddress; the VM should print
-                // a warning and use the default value instead. Similar, ASLR may prevent the given address
-                // from being used; this too should handled gracefully by using the default base address.
-                OutputAnalyzer dumpOutput = TestCommon.dump(
-                    appJar, new String[] {"Hello"}, "-XX:SharedBaseAddress=" + testEntry);
-                TestCommon.checkDump(dumpOutput, "Loading classes to share");
+        for (String testEntry : testTable) {
+            System.out.println("sharedBaseAddress = " + testEntry);
 
-                OutputAnalyzer execOutput = TestCommon.exec(appJar, "Hello");
-                TestCommon.checkExec(execOutput, "Hello World");
-            }
-            iter++;
-            testTable = testTable64;
-        } while (iter < 2 && Platform.is64bit());
+            // Note: some platforms may restrict valid values for SharedBaseAddress; the VM should print
+            // a warning and use the default value instead. Similar, ASLR may prevent the given address
+            // from being used; this too should handled gracefully by using the default base address.
+            OutputAnalyzer dumpOutput = TestCommon.dump(
+                appJar, new String[] {"Hello"}, "-XX:SharedBaseAddress=" + testEntry);
+            TestCommon.checkDump(dumpOutput, "Loading classes to share");
+
+            OutputAnalyzer execOutput = TestCommon.exec(appJar, "Hello");
+            TestCommon.checkExec(execOutput, "Hello World");
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        test(testTableShared);
+        if (Platform.is64bit()) {
+            test(testTable64);
+        }
     }
 }


### PR DESCRIPTION
Hi all, 

Three cds tests fail on x86_32 due to incorrect VM testing parameters.
```
runtime/cds/appcds/SharedBaseAddress.java
runtime/cds/SharedBaseAddress.java#id1
runtime/cds/SharedBaseAddress.java#id0
```

Here is part of the failing log.
```
[STDERR]
Improperly specified VM option 'SharedBaseAddress=8g'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.


[STDERR]
Improperly specified VM option 'SharedBaseAddress=0x800001000'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

The fix just excludes them for 32-bit VMs.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283352](https://bugs.openjdk.java.net/browse/JDK-8283352): [CDS] SharedBaseAddress.java fails on x86_32


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to f4c74e8170c6dbba0439f199710dc723fd31c568
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7863/head:pull/7863` \
`$ git checkout pull/7863`

Update a local copy of the PR: \
`$ git checkout pull/7863` \
`$ git pull https://git.openjdk.java.net/jdk pull/7863/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7863`

View PR using the GUI difftool: \
`$ git pr show -t 7863`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7863.diff">https://git.openjdk.java.net/jdk/pull/7863.diff</a>

</details>
