### PR TITLE
8283353: compiler/c2/cr6865031/Test.java and compiler/runtime/Test6826736.java fails on x86_32

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/cr6865031/Test.java
+++ b/test/hotspot/jtreg/compiler/c2/cr6865031/Test.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2009 Goldman Sachs International.  All Rights Reserved.
+ * Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +28,7 @@
  * @bug 6865031
  * @summary Application gives bad result (throws bad exception) with compressed oops
  *
+ * @requires vm.bits == 64
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops
  *      -XX:HeapBaseMinAddress=32g -XX:-LoopUnswitching
  *      -XX:CompileCommand=inline,compiler.c2.cr6865031.AbstractMemoryEfficientList::equals

--- a/test/hotspot/jtreg/compiler/runtime/Test6826736.java
+++ b/test/hotspot/jtreg/compiler/runtime/Test6826736.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @bug 6826736
  * @summary CMS: core dump with -XX:+UseCompressedOops
  *
+ * @requires vm.bits == 64
  * @run main/othervm/timeout=600 -XX:+IgnoreUnrecognizedVMOptions -Xbatch
  *      -XX:+ScavengeALot -XX:+UseCompressedOops -XX:HeapBaseMinAddress=32g
  *      -XX:CompileThreshold=100 -XX:-BlockLayoutRotateLoops


### PR DESCRIPTION
Hi all,

Fail due to improperly specified VM option 'HeapBaseMinAddress=32g' on x86_32.

```
STDERR:
Improperly specified VM option 'HeapBaseMinAddress=32g'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

The fix just excludes them for 32-bit VMs.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283353](https://bugs.openjdk.java.net/browse/JDK-8283353): compiler/c2/cr6865031/Test.java and compiler/runtime/Test6826736.java fails on x86_32


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7864/head:pull/7864` \
`$ git checkout pull/7864`

Update a local copy of the PR: \
`$ git checkout pull/7864` \
`$ git pull https://git.openjdk.java.net/jdk pull/7864/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7864`

View PR using the GUI difftool: \
`$ git pr show -t 7864`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7864.diff">https://git.openjdk.java.net/jdk/pull/7864.diff</a>

</details>
