### PR TITLE
8283365: G1: Remove duplicate assertions in HeapRegion::oops_on_memregion_seq_iterate_careful

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -329,16 +329,6 @@ HeapWord* HeapRegion::oops_on_memregion_seq_iterate_careful(MemRegion mr,
   // Find the obj that extends onto mr.start().
   HeapWord* cur = block_start(start);
 
-#ifdef ASSERT
-  {
-    assert(cur <= start,
-           "cur: " PTR_FORMAT ", start: " PTR_FORMAT, p2i(cur), p2i(start));
-    HeapWord* next = cur + block_size(cur);
-    assert(start < next,
-           "start: " PTR_FORMAT ", next: " PTR_FORMAT, p2i(start), p2i(next));
-  }
-#endif
-
   const G1CMBitMap* const bitmap = g1h->concurrent_mark()->prev_mark_bitmap();
   while (true) {
     oop obj = cast_to_oop(cur);


### PR DESCRIPTION
Simple change of removing duplicate assertions.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283365](https://bugs.openjdk.java.net/browse/JDK-8283365): G1: Remove duplicate assertions in HeapRegion::oops_on_memregion_seq_iterate_careful


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7866/head:pull/7866` \
`$ git checkout pull/7866`

Update a local copy of the PR: \
`$ git checkout pull/7866` \
`$ git pull https://git.openjdk.java.net/jdk pull/7866/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7866`

View PR using the GUI difftool: \
`$ git pr show -t 7866`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7866.diff">https://git.openjdk.java.net/jdk/pull/7866.diff</a>

</details>
