### PR TITLE
JDK-8259072: access flags inside local class are allowed for source levels previous to 16

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -1231,7 +1231,15 @@ public class Check {
                 implicit |= sym.owner.flags_field & STRICTFP;
             break;
         case TYP:
-            if (sym.owner.kind.matches(KindSelector.VAL_MTH) ||
+            if (!allowRecords && sym.isDirectlyOrIndirectlyLocal()) {
+                mask = LocalClassFlags;
+                if (((flags & ENUM) != 0 || (flags & RECORD) != 0)) {
+                    if (sym.owner.kind == TYP) {
+                        log.error(pos, Errors.StaticDeclarationNotAllowedInInnerClasses);
+                    }
+                }
+            }
+            else if(sym.owner.kind.matches(KindSelector.VAL_MTH) ||
                     (sym.isDirectlyOrIndirectlyLocal() && (flags & ANNOTATION) != 0)) {
                 boolean implicitlyStatic = !sym.isAnonymous() &&
                         ((flags & RECORD) != 0 || (flags & ENUM) != 0 || (flags & INTERFACE) != 0);

--- a/test/langtools/tools/javac/InterfaceInInner.out
+++ b/test/langtools/tools/javac/InterfaceInInner.out
@@ -1,4 +1,4 @@
 - compiler.warn.source.no.system.modules.path: 15
-InterfaceInInner.java:13:13: compiler.err.icls.cant.have.static.decl: foo
+InterfaceInInner.java:13:13: compiler.err.intf.not.allowed.here
 1 error
 1 warning

--- a/test/langtools/tools/javac/T8259072.java
+++ b/test/langtools/tools/javac/T8259072.java
@@ -1,0 +1,57 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8259072
+ * @summary access flags inside local class are allowed for source levels previous to 16
+ * @compile/fail/ref=T8259072.out -XDrawDiagnostics -source 15 T8259072.java
+ */
+
+// Add all three variants + public, protected, or private
+public class T8259072 {
+    private void PriA1() {
+        class Foo {
+            private class Test {}
+        }
+    }
+
+    class PriA2 {
+        public PriA2 check() {
+            return new PriA2() { private class STRENGTH{}; };
+        }
+    }
+
+    class PriA3 {
+        Object o = new Object() { private class STRENGTH{}; };
+    }
+
+    private void PubA1() {
+        class Foo {
+            public class Test {}
+        }
+    }
+
+    class PubA2 {
+        public PubA2 check() {
+            return new PubA2() { public class STRENGTH{}; };
+        }
+    }
+
+    class PubA3 {
+        Object o = new Object() { public class STRENGTH{}; };
+    }
+
+    private void ProA1() {
+        class Foo {
+            protected class Test {}
+        }
+    }
+
+    class ProA2 {
+        public ProA2 check() {
+            return new ProA2() { protected class STRENGTH{}; };
+        }
+    }
+
+    class ProA3 {
+        Object o = new Object() { protected class STRENGTH{}; };
+    }
+}

--- a/test/langtools/tools/javac/T8259072.out
+++ b/test/langtools/tools/javac/T8259072.out
@@ -1,0 +1,12 @@
+- compiler.warn.source.no.system.modules.path: 15
+T8259072.java:12:21: compiler.err.mod.not.allowed.here: private
+T8259072.java:18:42: compiler.err.mod.not.allowed.here: private
+T8259072.java:23:43: compiler.err.mod.not.allowed.here: private
+T8259072.java:28:20: compiler.err.mod.not.allowed.here: public
+T8259072.java:34:41: compiler.err.mod.not.allowed.here: public
+T8259072.java:39:42: compiler.err.mod.not.allowed.here: public
+T8259072.java:44:23: compiler.err.mod.not.allowed.here: protected
+T8259072.java:50:44: compiler.err.mod.not.allowed.here: protected
+T8259072.java:55:45: compiler.err.mod.not.allowed.here: protected
+9 errors
+1 warning


### PR DESCRIPTION
Restores behaviour of local classes for source level previous to 16.

Essentially, for {protected, private, public} local classes, `checkFlags` is adjusted to match the control flow of 15. One error also adjusted/affected via this change.

 However, this does not restore the behaviour on current versions since the spec is not clear, yet. Will investigate further before marking this PR ready for review,.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8259072](https://bugs.openjdk.java.net/browse/JDK-8259072): access flags inside local class are allowed for source levels previous to 16


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7869/head:pull/7869` \
`$ git checkout pull/7869`

Update a local copy of the PR: \
`$ git checkout pull/7869` \
`$ git pull https://git.openjdk.java.net/jdk pull/7869/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7869`

View PR using the GUI difftool: \
`$ git pr show -t 7869`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7869.diff">https://git.openjdk.java.net/jdk/pull/7869.diff</a>

</details>
