### PR TITLE
8283335: Add exists/isDirectory/isRegularFile(Path path, LinkOption... options) methods to FileSystemProvider

### DIFF
--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -80,7 +80,7 @@ import java.util.stream.StreamSupport;
 import jdk.internal.util.ArraysSupport;
 import sun.nio.ch.FileChannelImpl;
 import sun.nio.cs.UTF_8;
-import sun.nio.fs.AbstractFileSystemProvider;
+
 
 /**
  * This class consists exclusively of static methods that operate on files,
@@ -1596,7 +1596,7 @@ public final class Files {
         byte[] buffer1 = new byte[BUFFER_SIZE];
         byte[] buffer2 = new byte[BUFFER_SIZE];
         try (InputStream in1 = Files.newInputStream(path);
-             InputStream in2 = Files.newInputStream(path2);) {
+             InputStream in2 = Files.newInputStream(path2)) {
             long totalRead = 0;
             while (true) {
                 int nRead1 = in1.readNBytes(buffer1, 0, BUFFER_SIZE);
@@ -2312,17 +2312,7 @@ public final class Files {
      *          method denies read access to the file.
      */
     public static boolean isDirectory(Path path, LinkOption... options) {
-        if (options.length == 0) {
-            FileSystemProvider provider = provider(path);
-            if (provider instanceof AbstractFileSystemProvider)
-                return ((AbstractFileSystemProvider)provider).isDirectory(path);
-        }
-
-        try {
-            return readAttributes(path, BasicFileAttributes.class, options).isDirectory();
-        } catch (IOException ioe) {
-            return false;
-        }
+        return provider(path).isDirectory(path, options);
     }
 
     /**
@@ -2355,17 +2345,7 @@ public final class Files {
      *          method denies read access to the file.
      */
     public static boolean isRegularFile(Path path, LinkOption... options) {
-        if (options.length == 0) {
-            FileSystemProvider provider = provider(path);
-            if (provider instanceof AbstractFileSystemProvider)
-                return ((AbstractFileSystemProvider)provider).isRegularFile(path);
-        }
-
-        try {
-            return readAttributes(path, BasicFileAttributes.class, options).isRegularFile();
-        } catch (IOException ioe) {
-            return false;
-        }
+        return provider(path).isRegularFile(path, options);
     }
 
     /**
@@ -2517,27 +2497,7 @@ public final class Files {
      * @see FileSystemProvider#checkAccess
      */
     public static boolean exists(Path path, LinkOption... options) {
-        if (options.length == 0) {
-            FileSystemProvider provider = provider(path);
-            if (provider instanceof AbstractFileSystemProvider)
-                return ((AbstractFileSystemProvider)provider).exists(path);
-        }
-
-        try {
-            if (followLinks(options)) {
-                provider(path).checkAccess(path);
-            } else {
-                // attempt to read attributes without following links
-                readAttributes(path, BasicFileAttributes.class,
-                               LinkOption.NOFOLLOW_LINKS);
-            }
-            // file exists
-            return true;
-        } catch (IOException x) {
-            // does not exist or unable to determine if file exists
-            return false;
-        }
-
+        return provider(path).exists(path, options);
     }
 
     /**

--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -666,6 +666,16 @@ class ZipFileSystem extends FileSystem {
         try {
             IndexNode n = getInode(path);
             return n != null && n.isDir();
+        } finally {
+            endRead();
+        }
+    }
+
+    boolean isRegularFile(byte[] path) {
+        beginRead();
+        try {
+            IndexNode n = getInode(path);
+            return n != null && !(n.isDir());
         } finally {
             endRead();
         }

--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipPath.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -901,8 +901,16 @@ final class ZipPath implements Path {
         }
     }
 
-    private boolean exists() {
+    boolean exists() {
         return zfs.exists(getResolvedPath());
+    }
+
+    boolean isDirectory() {
+        return zfs.isDirectory(getResolvedPath());
+    }
+
+    boolean isRegularFile() {
+        return zfs.isRegularFile(getResolvedPath());
     }
 
     OutputStream newOutputStream(OpenOption... options) throws IOException


### PR DESCRIPTION
Hi all,

Please review this patch which adds the following methods to FileSystemProvider:

- public boolean exists(Path path, LinkOption... options); 
- public boolean isDirectory(Path path, LinkOption... options); 
- public boolean isRegularFile(Path path, LinkOption... options); 

This change allows for providers to optimize these methods when the file's attributes are not needed.

Mach5 tiers 1 - 3 are run clean with this change

Best,
Lance

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8283335](https://bugs.openjdk.org/browse/JDK-8283335)

### Issues
 * [JDK-8283335](https://bugs.openjdk.org/browse/JDK-8283335): Add exists and readAttributesIfExists methods to FileSystemProvider ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is not open.
 * [JDK-8283336](https://bugs.openjdk.org/browse/JDK-8283336): Add exists and readAttributesIfExists methods to  FileSystemProvider (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/7870/head:pull/7870` \
`$ git checkout pull/7870`

Update a local copy of the PR: \
`$ git checkout pull/7870` \
`$ git pull https://git.openjdk.org/jdk pull/7870/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7870`

View PR using the GUI difftool: \
`$ git pr show -t 7870`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/7870.diff">https://git.openjdk.org/jdk/pull/7870.diff</a>

</details>
