### PR TITLE
    8281853  serviceability/sa/ClhsdbThreadContext.java failed with NullPointerException: Cannot invoke "sun.jvm.hotspot.gc.shared.GenCollectedHeap.getGen(int)" because "this.heap" is null

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerFinder.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerFinder.java
@@ -87,6 +87,7 @@ public class PointerFinder {
     if (heap instanceof GenCollectedHeap) {
       GenCollectedHeap genheap = (GenCollectedHeap) heap;
       if (genheap.isIn(a)) {
+        loc.heap = heap;
         for (int i = 0; i < genheap.nGens(); i++) {
           Generation g = genheap.getGen(i);
           if (g.isIn(a)) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
@@ -107,7 +107,7 @@ public class PointerLocation {
   }
 
   public boolean isInHeap() {
-    return (heap != null || (gen != null));
+    return (heap != null);
   }
 
   public boolean isInNewGen() {
@@ -122,7 +122,6 @@ public class PointerLocation {
     return (!isInNewGen() && !isInOldGen());
   }
 
-  /** Only valid if isInHeap() */
   public Generation getGeneration() {
       return gen;
   }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
@@ -111,11 +111,11 @@ public class PointerLocation {
   }
 
   public boolean isInNewGen() {
-    return ((gen != null) && (gen == ((GenCollectedHeap)heap).getGen(0)));
+    return ((gen != null) && (gen.equals(((GenCollectedHeap)heap).getGen(0))));
   }
 
   public boolean isInOldGen() {
-    return ((gen != null) && (gen == ((GenCollectedHeap)heap).getGen(1)));
+    return ((gen != null) && (gen.equals(((GenCollectedHeap)heap).getGen(1))));
   }
 
   public boolean inOtherGen() {


### PR DESCRIPTION
`isInNewGen()` is throwing an NPE because "heap" is null:

```
  public boolean isInNewGen() {
    return ((gen != null) && (gen == ((GenCollectedHeap)heap).getGen(0)));
  }
```

The call came from here:

```
    } else if (isInHeap()) {
      if (isInTLAB()) {
        tty.print("In thread-local allocation buffer for thread (");
        getTLABThread().printThreadInfoOn(tty);
        tty.print(") ");
        getTLAB().printOn(tty); // includes "\n"
      } else {
        if (isInNewGen()) {
          tty.print("In new generation ");
        } else if (isInOldGen()) {
          tty.print("In old generation ");
        } else {
          tty.print("In unknown section of Java heap");
        }
        if (getGeneration() != null) {
          getGeneration().printOn(tty); // does not include "\n"
        }
        tty.println();
      }
```

`isInHeap()` returns true if either "heap" or "gen" is non-null. If "gen" is non-null and "heap" is null, it is not safe to call `isInNewGen()`. Yet you can see from the code above that when `isInNewGen()` is called, the only guarantee is that  "heap" or "gen" is non-null, not both, and it turns out that `PointerFinder.find()` only sets "gen" when the ptr is found to be in a generation of the heap. It does not set "heap". So the logic in `PointerFinder.find()` is not in agreement with the logic in `PointerLocation.printOn()` w.r.t. to the setting up and meaning of the "gen" and "heap" fields.

The solution is pretty straight forward. Always set "heap" when the ptr is in the heap, even if it is in a generation (in which case "gen" is also set) or in a tlab (in which case "tlab" is also set). `isInHeap()` no longer requires that "gen" also be set, just "heap".

I also noticed that the printlns in the following were not being triggered:

```
        if (isInNewGen()) {
          tty.print("In new generation ");
        } else if (isInOldGen()) {
          tty.print("In old generation ");
        } else {
```

This was true even though "gen" was set and was indeed either pointing to the new gen or old gen. It turns out that the following returns a newly created Generation object:

`   ((GenCollectedHeap)heap).getGen(0)`

For this reason `equals()` must be used to compare them, not ==. The `VMObject.equals()` method is what ends up being called, and it compares the address associated with the underlying `VMObject`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281853](https://bugs.openjdk.java.net/browse/JDK-8281853): serviceability/sa/ClhsdbThreadContext.java failed with NullPointerException: Cannot invoke "sun.jvm.hotspot.gc.shared.GenCollectedHeap.getGen(int)" because "this.heap" is null


### Reviewers
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7873/head:pull/7873` \
`$ git checkout pull/7873`

Update a local copy of the PR: \
`$ git checkout pull/7873` \
`$ git pull https://git.openjdk.java.net/jdk pull/7873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7873`

View PR using the GUI difftool: \
`$ git pr show -t 7873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7873.diff">https://git.openjdk.java.net/jdk/pull/7873.diff</a>

</details>
