### PR TITLE
8283411: InflaterInputStream holds on to a temporary byte array of 512 bytes

### DIFF
--- a/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,7 +203,7 @@ public class InflaterInputStream extends FilterInputStream {
         ensureOpen();
         int max = (int)Math.min(n, Integer.MAX_VALUE);
         int total = 0;
-        byte[] b = new byte[512];
+        byte[] b = new byte[Math.min(max, 512)];
         while (total < max) {
             int len = max - total;
             if (len > b.length) {

--- a/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
@@ -189,8 +189,6 @@ public class InflaterInputStream extends FilterInputStream {
         }
     }
 
-    private byte[] b = new byte[512];
-
     /**
      * Skips specified number of bytes of uncompressed data.
      * @param n the number of bytes to skip
@@ -205,6 +203,7 @@ public class InflaterInputStream extends FilterInputStream {
         ensureOpen();
         int max = (int)Math.min(n, Integer.MAX_VALUE);
         int total = 0;
+        byte[] b = new byte[512];
         while (total < max) {
             int len = max - total;
             if (len > b.length) {


### PR DESCRIPTION
Can I please get a review of this change which handles https://bugs.openjdk.java.net/browse/JDK-8283411?

The commit here moves the temporary byte array from being a member of the class to a local variable within the `skip` method which is the only place where it is used as a temporary buffer.

tier1, tier2, tier3 tests have been run successfully with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283411](https://bugs.openjdk.java.net/browse/JDK-8283411): InflaterInputStream holds on to a temporary byte array of 512 bytes


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to 6bc997fbaa65c32d5669ef0a076ae924747d0725
 * [Vyom Tewari](https://openjdk.java.net/census#vtewari) (@vyommani - Committer)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7875/head:pull/7875` \
`$ git checkout pull/7875`

Update a local copy of the PR: \
`$ git checkout pull/7875` \
`$ git pull https://git.openjdk.java.net/jdk pull/7875/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7875`

View PR using the GUI difftool: \
`$ git pr show -t 7875`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7875.diff">https://git.openjdk.java.net/jdk/pull/7875.diff</a>

</details>
