### PR TITLE
[PATCH] Remove redundant 'new String' calls after concatenation

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5MechFactory.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5MechFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5MechFactory.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5MechFactory.java
@@ -146,8 +146,7 @@ public final class Krb5MechFactory implements MechanismFactory {
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
             String realm = (name.getKrb5PrincipalName()).getRealmAsString();
-            String tgsPrincipal =
-                new String("krbtgt/" + realm + '@' + realm);
+            String tgsPrincipal = "krbtgt/" + realm + '@' + realm;
             ServicePermission perm =
                 new ServicePermission(tgsPrincipal, "initiate");
             try {

--- a/src/java.security.jgss/share/classes/sun/security/krb5/EncryptionKey.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/EncryptionKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.security.jgss/share/classes/sun/security/krb5/EncryptionKey.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/EncryptionKey.java
@@ -497,13 +497,13 @@ public class EncryptionKey
     }
 
     public String toString() {
-        return new String("EncryptionKey: keyType=" + keyType
-                          + " kvno=" + kvno
-                          + " keyValue (hex dump)="
-                          + (keyValue == null || keyValue.length == 0 ?
-                        " Empty Key" : '\n'
-                        + Krb5.hexDumper.encodeBuffer(keyValue)
-                        + '\n'));
+        return "EncryptionKey: keyType=" + keyType
+                + " kvno=" + kvno
+                + " keyValue (hex dump)="
+                + (keyValue == null || keyValue.length == 0 ?
+                " Empty Key" : '\n'
+                + Krb5.hexDumper.encodeBuffer(keyValue)
+                + '\n');
     }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -2054,7 +2054,7 @@ public class LambdaToMethod extends TreeTranslator {
                         };
                         break;
                     case CAPTURED_OUTER_THIS:
-                        Name name = names.fromString(new String(sym.flatName().toString().replace('.', '$') + names.dollarThis));
+                        Name name = names.fromString(sym.flatName().toString().replace('.', '$') + names.dollarThis);
                         ret = new VarSymbol(SYNTHETIC | FINAL | PARAMETER, name, types.erasure(sym.type), translatedSym) {
                             @Override
                             public Symbol baseSymbol() {


### PR DESCRIPTION
Result of string concatenation is a newly created String object. There is no need it wrap it in another 'new String' call.
Such calls are confusing and produce warnings in IDE. Without them code is easier to read. 