### PR TITLE
8283800: Simplify String.indexOf/lastIndexOf calls

### DIFF
--- a/src/java.base/share/classes/java/util/UUID.java
+++ b/src/java.base/share/classes/java/util/UUID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -264,7 +264,7 @@ public final class UUID implements java.io.Serializable, Comparable<UUID> {
             throw new IllegalArgumentException("UUID string too large");
         }
 
-        int dash1 = name.indexOf('-', 0);
+        int dash1 = name.indexOf('-');
         int dash2 = name.indexOf('-', dash1 + 1);
         int dash3 = name.indexOf('-', dash2 + 1);
         int dash4 = name.indexOf('-', dash3 + 1);

--- a/src/java.base/share/classes/sun/security/util/PropertyExpander.java
+++ b/src/java.base/share/classes/sun/security/util/PropertyExpander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public class PropertyExpander {
         if (value == null)
             return null;
 
-        int p = value.indexOf("${", 0);
+        int p = value.indexOf("${");
 
         // no special characters
         if (p == -1) return value;

--- a/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
+++ b/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
     private static final long serialVersionUID = 7205873507486557157L;
 
     /**
-     * The object identitifer being used for this algorithm.
+     * The object identifier being used for this algorithm.
      */
     private ObjectIdentifier algid;
 
@@ -584,7 +584,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
                 String upperCaseAlias = alias.toUpperCase(Locale.ENGLISH);
                 int index;
                 if (upperCaseAlias.startsWith("ALG.ALIAS") &&
-                    (index = upperCaseAlias.indexOf("OID.", 0)) != -1) {
+                    (index = upperCaseAlias.indexOf("OID.")) != -1) {
                     index += "OID.".length();
                     if (index == alias.length()) {
                         // invalid alias entry

--- a/src/java.base/share/classes/sun/security/x509/DNSName.java
+++ b/src/java.base/share/classes/sun/security/x509/DNSName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,7 +100,7 @@ public class DNSName implements GeneralNameInterface {
                 if (alphaDigits.indexOf(name.charAt(startIndex)) < 0) {
                     // Checking to make sure the wildcard only appears in the first component,
                     // and it has to be at least 3-char long with the form of *.[alphaDigit]
-                    if ((name.length() < 3) || (name.indexOf('*', 0) != 0) ||
+                    if ((name.length() < 3) || (name.indexOf('*') != 0) ||
                         (name.charAt(startIndex+1) != '.') ||
                         (alphaDigits.indexOf(name.charAt(startIndex+2)) < 0))
                         throw new IOException("DNSName components must begin with a letter, digit, "

--- a/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5NameElement.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5NameElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public class Krb5NameElement
     /**
      * Instantiates a new Krb5NameElement object. Internally it stores the
      * information provided by the input parameters so that they may later
-     * be used for output when a printable representaion of this name is
+     * be used for output when a printable representation of this name is
      * needed in GSS-API format rather than in Kerberos format.
      *
      */
@@ -158,7 +158,7 @@ public class Krb5NameElement
 
         // Look for @ as in service@host
         // Assumes host name will not have an escaped '@'
-        int separatorPos = gssNameStr.lastIndexOf('@', gssNameStr.length());
+        int separatorPos = gssNameStr.lastIndexOf('@');
 
         // Not really a separator if it is escaped. Then this is just part
         // of the principal name or service name

--- a/src/jdk.jconsole/share/classes/sun/tools/jconsole/AboutDialog.java
+++ b/src/jdk.jconsole/share/classes/sun/tools/jconsole/AboutDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -194,7 +194,7 @@ public class AboutDialog extends InternalDialog {
             Highlighter hilite = helpLink.getHighlighter();
             Document doc = helpLink.getDocument();
             String text = doc.getText(0, doc.getLength());
-            int pos = text.indexOf(urlStr, 0);
+            int pos = text.indexOf(urlStr);
             hilite.addHighlight(pos, pos + urlStr.length(), new HighlightPainter());
         } catch (BadLocationException e) {
             // ignore


### PR DESCRIPTION
In a few places String.indexOf/lastIndexOf methods are called with default parameter for index: `0` for `indexOf`, length() for `lastIndexOf`.
I propose to cleanup such calls. It makes code a bit easier to read. In case of `indexOf` it even could be faster, as there is separate intrinsic for `indexOf` call without index argument.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283800](https://bugs.openjdk.java.net/browse/JDK-8283800): Simplify String.indexOf/lastIndexOf calls


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7877/head:pull/7877` \
`$ git checkout pull/7877`

Update a local copy of the PR: \
`$ git checkout pull/7877` \
`$ git pull https://git.openjdk.java.net/jdk pull/7877/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7877`

View PR using the GUI difftool: \
`$ git pr show -t 7877`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7877.diff">https://git.openjdk.java.net/jdk/pull/7877.diff</a>

</details>
