### PR TITLE
8283801: Cleanup confusing String.toString calls

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacFiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacFiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,6 @@ import static javax.tools.StandardLocation.CLASS_OUTPUT;
 import com.sun.tools.javac.code.Lint;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.ModuleSymbol;
-import com.sun.tools.javac.code.Symbol.TypeSymbol;
 import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.comp.Modules;
 import com.sun.tools.javac.model.JavacElements;
@@ -63,10 +62,8 @@ import com.sun.tools.javac.util.*;
 import com.sun.tools.javac.util.DefinedBy.Api;
 
 import static com.sun.tools.javac.code.Lint.LintCategory.PROCESSING;
-import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.PackageSymbol;
 import com.sun.tools.javac.main.Option;
-import java.util.stream.Collectors;
 
 /**
  * The FilerImplementation class must maintain a number of
@@ -547,12 +544,11 @@ public class JavacFiler implements Filer, Closeable {
 
         locationCheck(location);
 
-        String strPkg = pkg.toString();
-        if (strPkg.length() > 0)
-            checkName(strPkg);
+        if (pkg.length() > 0)
+            checkName(pkg);
 
         FileObject fileObject =
-            fileManager.getFileForOutputForOriginatingFiles(location, strPkg,
+            fileManager.getFileForOutputForOriginatingFiles(location, pkg,
                                                             relativeName.toString(), originatingFiles(originatingElements));
         checkFileReopening(fileObject, true);
 

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/TypeAnnotation.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/TypeAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ public class TypeAnnotation {
     @Override
     public String toString() {
         try {
-            return "@" + constant_pool.getUTF8Value(annotation.type_index).toString().substring(1) +
+            return "@" + constant_pool.getUTF8Value(annotation.type_index).substring(1) +
                     " pos: " + position.toString();
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/LocalVariableTypeTableWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/LocalVariableTypeTableWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -125,7 +125,7 @@ public class LocalVariableTypeTableWriter extends  InstructionDetailWriter {
                     print(" // ");
                     Descriptor d = new Signature(entry.signature_index);
                     try {
-                        print(d.getFieldType(constant_pool).toString().replace("/", "."));
+                        print(d.getFieldType(constant_pool).replace("/", "."));
                     } catch (InvalidDescriptor e) {
                         print(report(e));
                     } catch (ConstantPoolException e) {

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Platform.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,7 +70,7 @@ enum Platform {UNKNOWN, WINDOWS, LINUX, MAC;
             platform = Platform.UNKNOWN;
         }
 
-        String version = System.getProperty("os.version").toString();
+        String version = System.getProperty("os.version");
         String[] parts = version.split(Pattern.quote("."));
 
         if (parts.length > 0) {


### PR DESCRIPTION
String.toString() calls doesn't make much sense. Only one place, where it could be used - to generate NPE. But in a few places of JDK codebase it's called, even when NPE will happen anyway.
I propose to cleanup such places.
Found by IntelliJ IDEA inspection `Redundant 'String' operation`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283801](https://bugs.openjdk.java.net/browse/JDK-8283801): Cleanup confusing String.toString calls


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7878/head:pull/7878` \
`$ git checkout pull/7878`

Update a local copy of the PR: \
`$ git checkout pull/7878` \
`$ git pull https://git.openjdk.java.net/jdk pull/7878/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7878`

View PR using the GUI difftool: \
`$ git pr show -t 7878`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7878.diff">https://git.openjdk.java.net/jdk/pull/7878.diff</a>

</details>
