### PR TITLE
8283426: Fix 'exeption' typo

### DIFF
--- a/src/hotspot/os_cpu/linux_s390/os_linux_s390.cpp
+++ b/src/hotspot/os_cpu/linux_s390/os_linux_s390.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2016, 2019 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -304,7 +304,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
         CodeBlob* cb = CodeCache::find_blob_unsafe(pc);
         CompiledMethod* nm = (cb != NULL) ? cb->as_compiled_method_or_null() : NULL;
         if (nm != NULL && nm->has_unsafe_access()) {
-          // We don't really need a stub here! Just set the pending exeption and
+          // We don't really need a stub here! Just set the pending exception and
           // continue at the next instruction after the faulting read. Returning
           // garbage from this read is ok.
           thread->set_pending_unsafe_access_error();
@@ -329,7 +329,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
       } else if ((thread->thread_state() == _thread_in_vm ||
                   thread->thread_state() == _thread_in_native) &&
                  sig == SIGBUS && thread->doing_unsafe_access()) {
-        // We don't really need a stub here! Just set the pending exeption and
+        // We don't really need a stub here! Just set the pending exception and
         // continue at the next instruction after the faulting read. Returning
         // garbage from this read is ok.
         thread->set_pending_unsafe_access_error();

--- a/src/hotspot/os_cpu/windows_x86/assembler_windows_x86.cpp
+++ b/src/hotspot/os_cpu/windows_x86/assembler_windows_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ void MacroAssembler::int3() {
 // Warning: This mechanism assumes that we only attempt to get the
 //          thread when we are nested below a call wrapper.
 //
-// movl reg, fs:[0]                        Get exeception pointer
+// movl reg, fs:[0]                        Get exception pointer
 // movl reg, [reg + thread_ptr_offset]     Load thread
 //
 void MacroAssembler::get_thread(Register thread) {

--- a/src/hotspot/share/code/exceptionHandlerTable.cpp
+++ b/src/hotspot/share/code/exceptionHandlerTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ ExceptionHandlerTable::ExceptionHandlerTable(int initial_size) {
 ExceptionHandlerTable::ExceptionHandlerTable(const CompiledMethod* cm) {
   _table  = (HandlerTableEntry*)cm->handler_table_begin();
   _length = cm->handler_table_size() / sizeof(HandlerTableEntry);
-  _size   = 0; // no space allocated by ExeptionHandlerTable!
+  _size   = 0; // no space allocated by ExceptionHandlerTable!
 }
 
 

--- a/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
+++ b/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -132,7 +132,7 @@ static void handle_dcmd_result(outputStream* output,
   const bool startup = DCmd_Source_Internal == source;
   if (HAS_PENDING_EXCEPTION) {
     handle_pending_exception(output, startup, PENDING_EXCEPTION);
-    // Don't clear excption on startup, JVM should fail initialization.
+    // Don't clear exception on startup, JVM should fail initialization.
     if (!startup) {
       CLEAR_PENDING_EXCEPTION;
     }

--- a/src/java.base/share/classes/javax/crypto/Cipher.java
+++ b/src/java.base/share/classes/javax/crypto/Cipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1174,7 +1174,7 @@ public class Cipher {
     }
 
     // check if opmode is one of the defined constants
-    // throw InvalidParameterExeption if not
+    // throw InvalidParameterException if not
     private static void checkOpmode(int opmode) {
         if ((opmode < ENCRYPT_MODE) || (opmode > UNWRAP_MODE)) {
             throw new InvalidParameterException("Invalid operation mode");

--- a/src/java.base/share/classes/jdk/internal/misc/CDS.java
+++ b/src/java.base/share/classes/jdk/internal/misc/CDS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import jdk.internal.access.JavaLangInvokeAccess;
 import jdk.internal.access.SharedSecrets;
 
 public class CDS {
@@ -224,7 +223,7 @@ public class CDS {
                     prt.println(line);
                 }
             } catch (IOException e) {
-                throw new RuntimeException("IOExeption happens during drain stream to file " +
+                throw new RuntimeException("IOException happens during drain stream to file " +
                                            fileName + ": " + e.getMessage());
             }}).start();
         return fileName;

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformEmbeddedFrame.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformEmbeddedFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@ import sun.awt.CGraphicsDevice;
 import sun.java2d.SurfaceData;
 import sun.java2d.metal.MTLLayer;
 import sun.java2d.opengl.CGLLayer;
-import sun.lwawt.macosx.CFLayer;
 import sun.lwawt.LWWindowPeer;
 import sun.lwawt.PlatformWindow;
 import sun.util.logging.PlatformLogger;
@@ -199,7 +198,7 @@ public class CPlatformEmbeddedFrame implements PlatformWindow {
 
     /*
      * The method could not be implemented due to CALayer restrictions.
-     * The exeption enforce clients not to use it.
+     * The exception enforce clients not to use it.
      */
     @Override
     public boolean isUnderMouse() {

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformEmbeddedFrame.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformEmbeddedFrame.java
@@ -198,7 +198,7 @@ public class CPlatformEmbeddedFrame implements PlatformWindow {
 
     /*
      * The method could not be implemented due to CALayer restrictions.
-     * The exception enforce clients not to use it.
+     * The exception enforces clients not to use it.
      */
     @Override
     public boolean isUnderMouse() {

--- a/src/java.security.jgss/share/classes/sun/security/krb5/KrbCryptoException.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/KrbCryptoException.java
@@ -31,7 +31,7 @@
 package sun.security.krb5;
 
 /**
- * KrbCryptoExceptoin is a wrapper exception for exceptions thrown by JCE.
+ * KrbCryptoException is a wrapper exception for exceptions thrown by JCE.
  *
  * @author Yanni Zhang
  */
@@ -39,7 +39,7 @@ public class KrbCryptoException extends KrbException {
 
     private static final long serialVersionUID = -1657367919979982250L;
 
-    public KrbCryptoException (String s) {
+    public KrbCryptoException(String s) {
         super(s);
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/ownedMonitors/ownedmonitors001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -281,7 +281,7 @@ public class ownedmonitors001 {
                 Value value = debuggeeRef.getValue(field);
                 expMonitors.add((ObjectReference)value);
             } catch (Exception e) {
-                log3("Unexpected excption while getting ObjectReference for monitors");
+                log3("Unexpected exception while getting ObjectReference for monitors");
                 testExitCode = FAILED;
             }
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/EXCEPTION/exception001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/Event/EXCEPTION/exception001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -267,7 +267,7 @@ public class exception001 {
                                                         JDWP.SuspendPolicy.ALL);
         log.display("  ... breakpoint reached with threadID: " + testedThreadID);
 
-        // get excepion objectID value for static field
+        // get exception objectID value for static field
         log.display("Getting exception objectID from static field: " + EXCEPTION_FIELD_NAME);
         JDWP.Value value = debugee.getStaticFieldValue(testedClassID,  EXCEPTION_FIELD_NAME, JDWP.Tag.OBJECT);
         exceptionObjectID = ((Long)value.getValue()).longValue();

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/MlvmOOMTest.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/MlvmOOMTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,7 @@ public abstract class MlvmOOMTest extends MlvmTest {
 
     /**
      * Checks the OOME type is expected.
-     * Method just exits if OOME is expected and throws an exeption if not.
+     * Method just exits if OOME is expected and throws an exception if not.
      * @param oome thrown by {@link #eatMemory(List)}
      */
     protected abstract void checkOOME(OutOfMemoryError oome);

--- a/test/jaxp/javax/xml/jaxp/unittest/validation/Bug4987574.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/validation/Bug4987574.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ import org.testng.annotations.Test;
  * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
  * @run testng/othervm -DrunSecMngr=true -Djava.security.manager=allow validation.Bug4987574
  * @run testng/othervm validation.Bug4987574
- * @summary Test schemaFactory.newSchema doesn't throw NullPointerExceptio for empty schema.
+ * @summary Test schemaFactory.newSchema doesn't throw NullPointerException for empty schema.
  */
 @Listeners({jaxp.library.FilePolicy.class})
 public class Bug4987574 {

--- a/test/jdk/java/awt/Window/AlwaysOnTop/AutoTestOnTop.java
+++ b/test/jdk/java/awt/Window/AlwaysOnTop/AutoTestOnTop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -672,7 +672,7 @@ public class AutoTestOnTop {
         } catch (Exception e) {
             error("Test failed: stage#" + stageNum + "action #" + actNum + ": " + msgCase + ": " + msgAction +
                                ": setAlwaysOnTop(" + value + ") called at state " + msgVisibility +
-                               " threw exeption " + e);
+                               " threw exception " + e);
         }
     }
 
@@ -685,7 +685,7 @@ public class AutoTestOnTop {
         } catch (Exception e) {
             error("Test failed: stage #" + stageNum + ", action # " + actNum + ": " + msgCase + ": " + msgAction +
                                ": isAlwaysOnTop() called at state " + msgVisibility +
-                               " threw exeption " + e);
+                               " threw exception " + e);
         }
         return result;
     }

--- a/test/jdk/java/awt/dnd/ImageDecoratedDnDNegative/DnDSource.java
+++ b/test/jdk/java/awt/dnd/ImageDecoratedDnDNegative/DnDSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,7 +76,7 @@ class DnDSource extends Button implements Transferable,
      * a Drag gesture has been recognized
      */
     int iProblem = 0;
-    String[] problem = {"unready", "throw exeption", "good"};
+    String[] problem = {"unready", "throw exception", "good"};
     public void dragGestureRecognized(DragGestureEvent dge) {
         System.out.println("starting Drag");
         if( !DragSource.isDragImageSupported() ) {

--- a/test/jdk/java/lang/Throwable/StackTraceSerialization.java
+++ b/test/jdk/java/lang/Throwable/StackTraceSerialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,7 +126,7 @@ public class StackTraceSerialization {
      * Returns true if e1 and e2 have equal stack traces and their
      * causes are recursively equal (by the same definition) and their
      * suppressed exception information is equals.  Returns false or
-     * throws NullPointerExeption otherwise.
+     * throws NullPointerException otherwise.
      */
     private static boolean equal(Throwable t1, Throwable t2) {
         return t1==t2 ||

--- a/test/jdk/java/text/BreakIterator/Bug7104012.java
+++ b/test/jdk/java/text/BreakIterator/Bug7104012.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,7 @@ public class Bug7104012 {
         }
 
         if (err) {
-            throw new RuntimeException("Unexpected exeption.");
+            throw new RuntimeException("Unexpected exception.");
         }
     }
 

--- a/test/jdk/javax/sql/testng/test/rowset/serial/SerialJavaObjectTests.java
+++ b/test/jdk/javax/sql/testng/test/rowset/serial/SerialJavaObjectTests.java
@@ -43,7 +43,7 @@ public class SerialJavaObjectTests extends BaseTest {
     }
 
     /*
-     * Validate that an SerialException is thrown when the object specified
+     * Validate that a SerialException is thrown when the object specified
      * contains public static fields
      */
     @Test(expectedExceptions = SerialException.class, enabled = false)

--- a/test/jdk/javax/sql/testng/test/rowset/serial/SerialJavaObjectTests.java
+++ b/test/jdk/javax/sql/testng/test/rowset/serial/SerialJavaObjectTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ public class SerialJavaObjectTests extends BaseTest {
     }
 
     /*
-     * Validate that an SerialExcepion is thrown when the object specified
+     * Validate that an SerialException is thrown when the object specified
      * contains public static fields
      */
     @Test(expectedExceptions = SerialException.class, enabled = false)


### PR DESCRIPTION
Fix repeated typo `exeption`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283426](https://bugs.openjdk.java.net/browse/JDK-8283426): Fix 'exeption' typo


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**) ⚠️ Review applies to d93dde2582e70f9e5b02ae1568a3615d11037488
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to d93dde2582e70f9e5b02ae1568a3615d11037488
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to d93dde2582e70f9e5b02ae1568a3615d11037488
 * [Bradford Wetmore](https://openjdk.java.net/census#wetmore) (@bradfordwetmore - **Reviewer**) ⚠️ Review applies to d93dde2582e70f9e5b02ae1568a3615d11037488
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7879/head:pull/7879` \
`$ git checkout pull/7879`

Update a local copy of the PR: \
`$ git checkout pull/7879` \
`$ git pull https://git.openjdk.java.net/jdk pull/7879/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7879`

View PR using the GUI difftool: \
`$ git pr show -t 7879`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7879.diff">https://git.openjdk.java.net/jdk/pull/7879.diff</a>

</details>
