### PR TITLE
[PATCH] Avoid loops which always call return

### DIFF
--- a/src/java.base/share/classes/java/util/jar/JarVerifier.java
+++ b/src/java.base/share/classes/java/util/jar/JarVerifier.java
@@ -721,7 +721,7 @@ class JarVerifier {
                         return true;
                     }
                 }
-                while (enum2.hasMoreElements()) {
+                if (enum2.hasMoreElements()) {
                     name = enum2.nextElement();
                     return true;
                 }
@@ -767,7 +767,7 @@ class JarVerifier {
                 if (signers == null) {
                     signers = Collections.enumeration(map.keySet());
                 }
-                while (signers.hasMoreElements()) {
+                if (signers.hasMoreElements()) {
                     String name = signers.nextElement();
                     entry = jar.newEntry(name);
                     return true;

--- a/src/java.base/windows/classes/sun/nio/ch/WindowsSelectorImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/WindowsSelectorImpl.java
@@ -246,20 +246,18 @@ class WindowsSelectorImpl extends SelectorImpl {
         // redundant. If yes, it returns true, notifying the thread
         // that it should exit.
         private synchronized boolean waitForStart(SelectThread thread) {
-            while (true) {
-                while (runsCounter == thread.lastRun) {
-                    try {
-                        startLock.wait();
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                    }
+            while (runsCounter == thread.lastRun) {
+                try {
+                    startLock.wait();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
                 }
-                if (thread.isZombie()) { // redundant thread
-                    return true; // will cause run() to exit.
-                } else {
-                    thread.lastRun = runsCounter; // update lastRun
-                    return false; //   will cause run() to poll.
-                }
+            }
+            if (thread.isZombie()) { // redundant thread
+                return true; // will cause run() to exit.
+            } else {
+                thread.lastRun = runsCounter; // update lastRun
+                return false; //   will cause run() to poll.
             }
         }
     }

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/PAData.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/PAData.java
@@ -219,7 +219,7 @@ public class PAData {
             }
         }
         if (d != null) {
-            while (d.data.available() > 0) {
+            if (d.data.available() > 0) {
                 DerValue value = d.data.getDerValue();
                 ETypeInfo tmp = new ETypeInfo(value);
                 return tmp.getEType();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -2299,7 +2299,7 @@ public class LambdaToMethod extends TreeTranslator {
              */
             boolean interfaceParameterIsIntersectionOrUnionType() {
                 List<Type> tl = tree.getDescriptorType(types).getParameterTypes();
-                for (; tl.nonEmpty(); tl = tl.tail) {
+                if (tl.nonEmpty()) {
                     Type pt = tl.head;
                     return isIntersectionOrUnionType(pt);
                 }


### PR DESCRIPTION
Loops which execute only single iteration are confusing.
I propose to cleanup them and replace with plain `if` where possible.
Detected by IntelliJ IDEA's inspection `Loop statement that does not loop`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7880/head:pull/7880` \
`$ git checkout pull/7880`

Update a local copy of the PR: \
`$ git checkout pull/7880` \
`$ git pull https://git.openjdk.java.net/jdk pull/7880/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7880`

View PR using the GUI difftool: \
`$ git pr show -t 7880`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7880.diff">https://git.openjdk.java.net/jdk/pull/7880.diff</a>

</details>
