### PR TITLE
8283408: Fix a C2 crash when filling arrays with unsafe

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -4043,6 +4043,9 @@ bool PhaseIdealLoop::intrinsify_fill(IdealLoopTree* lpt) {
   }
   Node* from = new AddPNode(base, base, index);
   _igvn.register_new_node_with_optimizer(from);
+  // For normal array fills, C2 uses two AddP nodes for array element
+  // addressing. But for array fills with Unsafe call, there's only one
+  // AddP node adding an absolute offset, so we do a NULL check here.
   if (offset != NULL) {
     from = new AddPNode(base, from, offset);
     _igvn.register_new_node_with_optimizer(from);

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -4046,6 +4046,8 @@ bool PhaseIdealLoop::intrinsify_fill(IdealLoopTree* lpt) {
   // For normal array fills, C2 uses two AddP nodes for array element
   // addressing. But for array fills with Unsafe call, there's only one
   // AddP node adding an absolute offset, so we do a NULL check here.
+  assert(offset != NULL || C->has_unsafe_access(),
+         "Only array fills with unsafe have no extra offset");
   if (offset != NULL) {
     from = new AddPNode(base, from, offset);
     _igvn.register_new_node_with_optimizer(from);

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -4041,10 +4041,12 @@ bool PhaseIdealLoop::intrinsify_fill(IdealLoopTree* lpt) {
     index = new LShiftXNode(index, shift->in(2));
     _igvn.register_new_node_with_optimizer(index);
   }
-  index = new AddPNode(base, base, index);
-  _igvn.register_new_node_with_optimizer(index);
-  Node* from = new AddPNode(base, index, offset);
+  Node* from = new AddPNode(base, base, index);
   _igvn.register_new_node_with_optimizer(from);
+  if (offset != NULL) {
+    from = new AddPNode(base, from, offset);
+    _igvn.register_new_node_with_optimizer(from);
+  }
   // Compute the number of elements to copy
   Node* len = new SubINode(head->limit(), head->init_trip());
   _igvn.register_new_node_with_optimizer(len);

--- a/test/hotspot/jtreg/compiler/loopopts/FillArrayWithUnsafe.java
+++ b/test/hotspot/jtreg/compiler/loopopts/FillArrayWithUnsafe.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8283408
+ * @summary Fill a byte array with Java Unsafe API
+ * @run main/othervm -XX:+OptimizeFill compiler.loopopts.FillArrayWithUnsafe
+ */
+
+package compiler.loopopts;
+
+import java.lang.reflect.Field;
+
+import sun.misc.Unsafe;
+
+public class FillArrayWithUnsafe {
+
+    private static Unsafe unsafe;
+
+    public static void main(String[] args) throws Exception {
+        Class klass = Unsafe.class;
+        Field field = klass.getDeclaredField("theUnsafe");
+        field.setAccessible(true);
+        unsafe = (Unsafe) field.get(null);
+
+        byte[] buffer;
+        // Make sure method newByteArray is compiled by C2
+        for (int i = 0; i < 50000; i++) {
+            buffer = newByteArray(100, (byte) 0x80);
+        }
+    }
+
+    public static byte[] newByteArray(int size, byte val) {
+        byte[] arr = new byte[size];
+        int offset = unsafe.arrayBaseOffset(byte[].class);
+        for (int i = offset; i < offset + size; i++) {
+             unsafe.putByte(arr, i, val);
+        }
+        return arr;
+    }
+}
+


### PR DESCRIPTION
We recently found a segmentation fault issue in C2 compiler with some
code that uses Java Unsafe API to initialize an array in a loop. It can
be reproduced by below code snippet compiled by C2 on AArch64. It's also
reproducible on x86 with an additional VM option "-XX:+OptimizeFill".
```
  byte[] arr = new byte[size];
  int offset = unsafe.arrayBaseOffset(byte[].class);
  for (int i = offset; i < offset + size; i++) {
    unsafe.putByte(arr, i, val);
  }
```
This issue is caused by a NULL pointer in a C2 loop optimization phase
called intrinsify_fill. In this phase, array filling loop patterns are
recognized and replaced by some intrinsics. But filling operations with
Unsafe API call are not handled very well. From C2 mid-end's point of
view, a difference between an Unsafe call and a normal array access like
`arr[i] = val` is element addressing. For normal array accesses, C2 uses
two AddP nodes for computing an element's address - one for adding array
header size and another for adding the element's relative offset from
the header. But Unsafe calls may have only one AddP node for adding an
absolute offset of an element from the array base. In current code, the
intrinsify_fill phase creates an AddP node but with NULL input for above
case and eventually causes a segmentation fault.

In this patch, we add a check to allow one AddP node in array filling
patterns to be optional. After this fix, the case above can be optimized
by intrinsify_fill as well. We know that the Unsafe call is rarely used
in Java application code and developers should use it at their own risk.
But we still propose this fix because C2 crashes even Unsafe is used in
a correct way.

Jtreg hotspot::hotspot_all_no_apps, jdk::tier1~3 and langtools::tier1
are tested and no issue is found. We also create a new jtreg case within
this patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283408](https://bugs.openjdk.java.net/browse/JDK-8283408): Fix a C2 crash when filling arrays with unsafe


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**) ⚠️ Review applies to 040da679f7c8983731b1e52966a5efef15800891
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to 16ebef5713cd7b0f9f3bcdc76be537b7b300e336


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7884/head:pull/7884` \
`$ git checkout pull/7884`

Update a local copy of the PR: \
`$ git checkout pull/7884` \
`$ git pull https://git.openjdk.java.net/jdk pull/7884/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7884`

View PR using the GUI difftool: \
`$ git pr show -t 7884`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7884.diff">https://git.openjdk.java.net/jdk/pull/7884.diff</a>

</details>
