### PR TITLE
8283437: Refactor imageio classes javadoc to use @throws instead of @exception

### DIFF
--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/bmp/BMPImageReader.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/bmp/BMPImageReader.java
@@ -254,11 +254,11 @@ public class BMPImageReader extends ImageReader implements BMPConstants {
     /**
      * Process the image header.
      *
-     * @exception IllegalStateException if source stream is not set.
+     * @throws IllegalStateException if source stream is not set.
      *
-     * @exception IOException if image stream is corrupted.
+     * @throws IOException if image stream is corrupted.
      *
-     * @exception IllegalArgumentException if the image stream does not contain
+     * @throws IllegalArgumentException if the image stream does not contain
      *             a BMP image, or if a sample model instance to describe the
      *             image can not be created.
      */

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/common/BogusColorSpace.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/common/BogusColorSpace.java
@@ -38,7 +38,7 @@ public class BogusColorSpace extends ColorSpace {
      *
      * @param numComponents The number of components in the
      * {@code ColorSpace}.
-     * @exception IllegalArgumentException if {@code numComponents}
+     * @throws IllegalArgumentException if {@code numComponents}
      * is less than 1.
      */
     private static int getType(int numComponents) {
@@ -66,7 +66,7 @@ public class BogusColorSpace extends ColorSpace {
      *
      * @param numComponents The number of components in the
      * {@code ColorSpace}.
-     * @exception IllegalArgumentException if {@code numComponents}
+     * @throws IllegalArgumentException if {@code numComponents}
      * is less than 1.
      */
     public BogusColorSpace(int numComponents) {

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/common/LZWCompressor.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/common/LZWCompressor.java
@@ -65,7 +65,7 @@ public class LZWCompressor {
      * @param out destination for compressed data
      * @param codeSize the initial code size for the LZW compressor
      * @param TIFF flag indicating that TIFF lzw fudge needs to be applied
-     * @exception IOException if underlying output stream error
+     * @throws IOException if underlying output stream error
      **/
     public LZWCompressor(ImageOutputStream out, int codeSize, boolean TIFF)
         throws IOException
@@ -90,7 +90,7 @@ public class LZWCompressor {
 
     /**
      * @param buf data to be compressed to output stream
-     * @exception IOException if underlying output stream error
+     * @throws IOException if underlying output stream error
      **/
     public void compress(byte[] buf, int offset, int length)
         throws IOException

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/common/LZWCompressor.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/common/LZWCompressor.java
@@ -129,7 +129,7 @@ public class LZWCompressor {
      * Indicate to compressor that no more data to go so write out
      * any remaining buffered data.
      *
-     * @exception IOException if underlying output stream error
+     * @throws IOException if underlying output stream error
      */
     public void flush() throws IOException {
         if (prefix != -1) {

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/common/PaletteBuilder.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/common/PaletteBuilder.java
@@ -77,10 +77,10 @@ public class PaletteBuilder {
      * Result image then is an approximation constructed by octree
      * quantization method.
      *
-     * @exception IllegalArgumentException if {@code src} is
+     * @throws IllegalArgumentException if {@code src} is
      * {@code null}.
      *
-     * @exception UnsupportedOperationException if implemented method
+     * @throws UnsupportedOperationException if implemented method
      * is unable to create approximation of {@code src}
      * and {@code canCreatePalette} returns {@code false}.
      *
@@ -98,10 +98,10 @@ public class PaletteBuilder {
      * {@code img}. If number of colors in the given image exceeds
      * maximum palette size closest colors would be merged.
      *
-     * @exception IllegalArgumentException if {@code img} is
+     * @throws IllegalArgumentException if {@code img} is
      * {@code null}.
      *
-     * @exception UnsupportedOperationException if implemented method
+     * @throws UnsupportedOperationException if implemented method
      * is unable to create approximation of {@code img}
      * and {@code canCreatePalette} returns {@code false}.
      *
@@ -124,7 +124,7 @@ public class PaletteBuilder {
      * @return {@code true} if the {@code PaletteBuilder}
      * is likely to be able to create palette for this image type.
      *
-     * @exception IllegalArgumentException if {@code type}
+     * @throws IllegalArgumentException if {@code type}
      * is {@code null}.
      */
     public static boolean canCreatePalette(ImageTypeSpecifier type) {
@@ -144,7 +144,7 @@ public class PaletteBuilder {
      * @return {@code true} if the {@code PaletteBuilder}
      * is likely to be able to create palette for this image type.
      *
-     * @exception IllegalArgumentException if {@code image}
+     * @throws IllegalArgumentException if {@code image}
      * is {@code null}.
      */
     public static boolean canCreatePalette(RenderedImage image) {

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JPEGImageReader.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JPEGImageReader.java
@@ -487,9 +487,9 @@ public class JPEGImageReader extends ImageReader {
     /**
      * Sets the input stream to the start of the requested image.
      * <pre>
-     * @exception IllegalStateException if the input source has not been
+     * @throws IllegalStateException if the input source has not been
      * set.
-     * @exception IndexOutOfBoundsException if the supplied index is
+     * @throws IndexOutOfBoundsException if the supplied index is
      * out of bounds.
      * </pre>
      */

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/png/PNGImageWriter.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/png/PNGImageWriter.java
@@ -322,7 +322,7 @@ final class PNGImageWriteParam extends ImageWriteParam {
      * <p> The default implementation resets the compression quality
      * to <code>0.5F</code>.
      *
-     * @exception IllegalStateException if the compression mode is not
+     * @throws IllegalStateException if the compression mode is not
      * <code>MODE_EXPLICIT</code>.
      */
     @Override

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFDecompressor.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFDecompressor.java
@@ -2373,7 +2373,7 @@ public abstract class TIFFDecompressor {
      * and instead override the {@code decodeRaw} and/or
      * {@code getRawImageType} methods.
      *
-     * @exception IOException if an error occurs in
+     * @throws IOException if an error occurs in
      * {@code decodeRaw}.
      */
     public void decode() throws IOException {

--- a/src/java.desktop/share/classes/javax/imageio/IIOImage.java
+++ b/src/java.desktop/share/classes/javax/imageio/IIOImage.java
@@ -99,7 +99,7 @@ public class IIOImage {
      * @param metadata an {@code IIOMetadata} object, or
      * {@code null}.
      *
-     * @exception IllegalArgumentException if {@code image} is
+     * @throws IllegalArgumentException if {@code image} is
      * {@code null}.
      */
     public IIOImage(RenderedImage image,
@@ -127,7 +127,7 @@ public class IIOImage {
      * @param metadata an {@code IIOMetadata} object, or
      * {@code null}.
      *
-     * @exception IllegalArgumentException if {@code raster} is
+     * @throws IllegalArgumentException if {@code raster} is
      * {@code null}.
      */
     public IIOImage(Raster raster,
@@ -163,7 +163,7 @@ public class IIOImage {
      *
      * @param image a {@code RenderedImage}.
      *
-     * @exception IllegalArgumentException if {@code image} is
+     * @throws IllegalArgumentException if {@code image} is
      * {@code null}.
      *
      * @see #getRenderedImage
@@ -213,7 +213,7 @@ public class IIOImage {
      *
      * @param raster a {@code Raster}.
      *
-     * @exception IllegalArgumentException if {@code raster} is
+     * @throws IllegalArgumentException if {@code raster} is
      * {@code null}.
      *
      * @see #getRaster
@@ -245,9 +245,9 @@ public class IIOImage {
      *
      * @return a thumbnail image, as a {@code BufferedImage}.
      *
-     * @exception IndexOutOfBoundsException if the supplied index is
+     * @throws IndexOutOfBoundsException if the supplied index is
      * negative or larger than the largest valid index.
-     * @exception ClassCastException if a
+     * @throws ClassCastException if a
      * non-{@code BufferedImage} object is encountered in the
      * list of thumbnails at the given index.
      *

--- a/src/java.desktop/share/classes/javax/imageio/IIOParam.java
+++ b/src/java.desktop/share/classes/javax/imageio/IIOParam.java
@@ -162,15 +162,15 @@ public abstract class IIOParam {
      * @param sourceRegion a {@code Rectangle} specifying the
      * source region of interest, or {@code null}.
      *
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      * {@code sourceRegion} is non-{@code null} and either
      * {@code sourceRegion.x} or {@code sourceRegion.y} is
      * negative.
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      * {@code sourceRegion} is non-{@code null} and either
      * {@code sourceRegion.width} or
      * {@code sourceRegion.height} is negative or 0.
-     * @exception IllegalStateException if subsampling is such that
+     * @throws IllegalStateException if subsampling is such that
      * this region will have a subsampled width or height of zero.
      *
      * @see #getSourceRegion
@@ -290,10 +290,10 @@ public abstract class IIOParam {
      * within the region, or within the image if no region is set.
      * @param subsamplingYOffset the horizontal offset of the first subsample
      * within the region, or within the image if no region is set.
-     * @exception IllegalArgumentException if either period is
+     * @throws IllegalArgumentException if either period is
      * negative or 0, or if either grid offset is negative or greater than
      * the corresponding period.
-     * @exception IllegalStateException if the source region is such that
+     * @throws IllegalStateException if the source region is such that
      * the subsampled output would contain no pixels.
      */
     public void setSourceSubsampling(int sourceXSubsampling,
@@ -413,7 +413,7 @@ public abstract class IIOParam {
      * @param sourceBands an array of integer band indices to be
      * used.
      *
-     * @exception IllegalArgumentException if {@code sourceBands}
+     * @throws IllegalArgumentException if {@code sourceBands}
      * contains a negative or duplicate value.
      *
      * @see #getSourceBands
@@ -537,7 +537,7 @@ public abstract class IIOParam {
      * @param destinationOffset the offset in the destination, as a
      * {@code Point}.
      *
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      * {@code destinationOffset} is {@code null}.
      *
      * @see #getDestinationOffset
@@ -658,7 +658,7 @@ public abstract class IIOParam {
      *
      * @return {@code true} if the controller completed normally.
      *
-     * @exception IllegalStateException if there is no controller
+     * @throws IllegalStateException if there is no controller
      * currently installed.
      *
      * @see IIOParamController

--- a/src/java.desktop/share/classes/javax/imageio/IIOParamController.java
+++ b/src/java.desktop/share/classes/javax/imageio/IIOParamController.java
@@ -111,7 +111,7 @@ public interface IIOParamController {
      * @return {@code true} if the {@code IIOParam} has been
      * modified, {@code false} otherwise.
      *
-     * @exception IllegalArgumentException if {@code param} is
+     * @throws IllegalArgumentException if {@code param} is
      * {@code null} or is not an instance of the correct class.
      */
     boolean activate(IIOParam param);

--- a/src/java.desktop/share/classes/javax/imageio/ImageIO.java
+++ b/src/java.desktop/share/classes/javax/imageio/ImageIO.java
@@ -277,9 +277,9 @@ public final class ImageIO {
      *
      * @see File#createTempFile(String, String, File)
      *
-     * @exception SecurityException if the security manager denies
+     * @throws SecurityException if the security manager denies
      * access to the directory.
-     * @exception IllegalArgumentException if {@code cacheDir} is
+     * @throws IllegalArgumentException if {@code cacheDir} is
      * non-{@code null} but is not a directory.
      *
      * @see #getCacheDirectory
@@ -326,9 +326,9 @@ public final class ImageIO {
      *
      * @return an {@code ImageInputStream}, or {@code null}.
      *
-     * @exception IllegalArgumentException if {@code input}
+     * @throws IllegalArgumentException if {@code input}
      * is {@code null}.
-     * @exception IOException if a cache file is needed but cannot be
+     * @throws IOException if a cache file is needed but cannot be
      * created.
      *
      * @see javax.imageio.spi.ImageInputStreamSpi
@@ -388,9 +388,9 @@ public final class ImageIO {
      * @return an {@code ImageOutputStream}, or
      * {@code null}.
      *
-     * @exception IllegalArgumentException if {@code output} is
+     * @throws IllegalArgumentException if {@code output} is
      * {@code null}.
-     * @exception IOException if a cache file is needed but cannot be
+     * @throws IOException if a cache file is needed but cannot be
      * created.
      *
      * @see javax.imageio.spi.ImageOutputStreamSpi
@@ -637,7 +637,7 @@ public final class ImageIO {
      *
      * @return an {@code Iterator} containing {@code ImageReader}s.
      *
-     * @exception IllegalArgumentException if {@code input} is
+     * @throws IllegalArgumentException if {@code input} is
      * {@code null}.
      *
      * @see javax.imageio.spi.ImageReaderSpi#canDecodeInput
@@ -697,7 +697,7 @@ public final class ImageIO {
      * @return an {@code Iterator} containing
      * {@code ImageReader}s.
      *
-     * @exception IllegalArgumentException if {@code formatName}
+     * @throws IllegalArgumentException if {@code formatName}
      * is {@code null}.
      *
      * @see javax.imageio.spi.ImageReaderSpi#getFormatNames
@@ -732,7 +732,7 @@ public final class ImageIO {
      * @return an {@code Iterator} containing
      * {@code ImageReader}s.
      *
-     * @exception IllegalArgumentException if {@code fileSuffix}
+     * @throws IllegalArgumentException if {@code fileSuffix}
      * is {@code null}.
      *
      * @see javax.imageio.spi.ImageReaderSpi#getFileSuffixes
@@ -767,7 +767,7 @@ public final class ImageIO {
      * @return an {@code Iterator} containing
      * {@code ImageReader}s.
      *
-     * @exception IllegalArgumentException if {@code MIMEType} is
+     * @throws IllegalArgumentException if {@code MIMEType} is
      * {@code null}.
      *
      * @see javax.imageio.spi.ImageReaderSpi#getMIMETypes
@@ -880,7 +880,7 @@ public final class ImageIO {
      * @return an {@code Iterator} containing
      * {@code ImageWriter}s.
      *
-     * @exception IllegalArgumentException if {@code formatName} is
+     * @throws IllegalArgumentException if {@code formatName} is
      * {@code null}.
      *
      * @see javax.imageio.spi.ImageWriterSpi#getFormatNames
@@ -914,7 +914,7 @@ public final class ImageIO {
      *
      * @return an {@code Iterator} containing {@code ImageWriter}s.
      *
-     * @exception IllegalArgumentException if {@code fileSuffix} is
+     * @throws IllegalArgumentException if {@code fileSuffix} is
      * {@code null}.
      *
      * @see javax.imageio.spi.ImageWriterSpi#getFileSuffixes
@@ -948,7 +948,7 @@ public final class ImageIO {
      *
      * @return an {@code Iterator} containing {@code ImageWriter}s.
      *
-     * @exception IllegalArgumentException if {@code MIMEType} is
+     * @throws IllegalArgumentException if {@code MIMEType} is
      * {@code null}.
      *
      * @see javax.imageio.spi.ImageWriterSpi#getMIMETypes
@@ -995,7 +995,7 @@ public final class ImageIO {
      *
      * @return an {@code ImageWriter}, or null.
      *
-     * @exception IllegalArgumentException if {@code reader} is
+     * @throws IllegalArgumentException if {@code reader} is
      * {@code null}.
      *
      * @see #getImageReader(ImageWriter)
@@ -1075,7 +1075,7 @@ public final class ImageIO {
      *
      * @return an {@code ImageReader}, or null.
      *
-     * @exception IllegalArgumentException if {@code writer} is
+     * @throws IllegalArgumentException if {@code writer} is
      * {@code null}.
      *
      * @see #getImageWriter(ImageReader)
@@ -1151,7 +1151,7 @@ public final class ImageIO {
      *
      * @return an {@code Iterator} containing {@code ImageWriter}s.
      *
-     * @exception IllegalArgumentException if any parameter is
+     * @throws IllegalArgumentException if any parameter is
      * {@code null}.
      *
      * @see javax.imageio.spi.ImageWriterSpi#canEncodeImage(ImageTypeSpecifier)
@@ -1238,7 +1238,7 @@ public final class ImageIO {
      * @return an {@code Iterator} containing
      * {@code ImageTranscoder}s.
      *
-     * @exception IllegalArgumentException if {@code reader} or
+     * @throws IllegalArgumentException if {@code reader} or
      * {@code writer} is {@code null}.
      */
     public static Iterator<ImageTranscoder>
@@ -1295,9 +1295,9 @@ public final class ImageIO {
      * @return a {@code BufferedImage} containing the decoded
      * contents of the input, or {@code null}.
      *
-     * @exception IllegalArgumentException if {@code input} is
+     * @throws IllegalArgumentException if {@code input} is
      * {@code null}.
-     * @exception IOException if an error occurs during reading or when not
+     * @throws IOException if an error occurs during reading or when not
      * able to create required ImageInputStream.
      */
     public static BufferedImage read(File input) throws IOException {
@@ -1346,9 +1346,9 @@ public final class ImageIO {
      * @return a {@code BufferedImage} containing the decoded
      * contents of the input, or {@code null}.
      *
-     * @exception IllegalArgumentException if {@code input} is
+     * @throws IllegalArgumentException if {@code input} is
      * {@code null}.
-     * @exception IOException if an error occurs during reading or when not
+     * @throws IOException if an error occurs during reading or when not
      * able to create required ImageInputStream.
      */
     public static BufferedImage read(InputStream input) throws IOException {
@@ -1390,9 +1390,9 @@ public final class ImageIO {
      * @return a {@code BufferedImage} containing the decoded
      * contents of the input, or {@code null}.
      *
-     * @exception IllegalArgumentException if {@code input} is
+     * @throws IllegalArgumentException if {@code input} is
      * {@code null}.
-     * @exception IOException if an error occurs during reading or when not
+     * @throws IOException if an error occurs during reading or when not
      * able to create required ImageInputStream.
      */
     public static BufferedImage read(URL input) throws IOException {
@@ -1443,9 +1443,9 @@ public final class ImageIO {
      * @return a {@code BufferedImage} containing the decoded
      * contents of the input, or {@code null}.
      *
-     * @exception IllegalArgumentException if {@code stream} is
+     * @throws IllegalArgumentException if {@code stream} is
      * {@code null}.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      */
     public static BufferedImage read(ImageInputStream stream)
         throws IOException {
@@ -1489,9 +1489,9 @@ public final class ImageIO {
      *
      * @return {@code false} if no appropriate writer is found.
      *
-     * @exception IllegalArgumentException if any parameter is
+     * @throws IllegalArgumentException if any parameter is
      * {@code null}.
-     * @exception IOException if an error occurs during writing.
+     * @throws IOException if an error occurs during writing.
      */
     public static boolean write(RenderedImage im,
                                 String formatName,
@@ -1522,9 +1522,9 @@ public final class ImageIO {
      *
      * @return {@code false} if no appropriate writer is found.
      *
-     * @exception IllegalArgumentException if any parameter is
+     * @throws IllegalArgumentException if any parameter is
      * {@code null}.
-     * @exception IOException if an error occurs during writing or when not
+     * @throws IOException if an error occurs during writing or when not
      * able to create required ImageOutputStream.
      */
     public static boolean write(RenderedImage im,
@@ -1570,9 +1570,9 @@ public final class ImageIO {
      *
      * @return {@code false} if no appropriate writer is found.
      *
-     * @exception IllegalArgumentException if any parameter is
+     * @throws IllegalArgumentException if any parameter is
      * {@code null}.
-     * @exception IOException if an error occurs during writing or when not
+     * @throws IOException if an error occurs during writing or when not
      * able to create required ImageOutputStream.
      */
     public static boolean write(RenderedImage im,

--- a/src/java.desktop/share/classes/javax/imageio/ImageReadParam.java
+++ b/src/java.desktop/share/classes/javax/imageio/ImageReadParam.java
@@ -272,7 +272,7 @@ public class ImageReadParam extends IIOParam {
      * @param destinationBands an array of integer band indices to be
      * used.
      *
-     * @exception IllegalArgumentException if {@code destinationBands}
+     * @throws IllegalArgumentException if {@code destinationBands}
      * contains a negative or duplicate value.
      *
      * @see #getDestinationBands
@@ -360,9 +360,9 @@ public class ImageReadParam extends IIOParam {
      * @param size a {@code Dimension} indicating the desired
      * width and height.
      *
-     * @exception IllegalArgumentException if either the width or the
+     * @throws IllegalArgumentException if either the width or the
      * height is negative or 0.
-     * @exception UnsupportedOperationException if image resizing
+     * @throws UnsupportedOperationException if image resizing
      * is not supported by this plug-in.
      *
      * @see #getSourceRenderSize
@@ -433,7 +433,7 @@ public class ImageReadParam extends IIOParam {
      * @param minPass the index of the first pass to be decoded.
      * @param numPasses the maximum number of passes to be decoded.
      *
-     * @exception IllegalArgumentException if {@code minPass} is
+     * @throws IllegalArgumentException if {@code minPass} is
      * negative, {@code numPasses} is negative or 0, or
      * {@code numPasses} is smaller than
      * {@code Integer.MAX_VALUE} but

--- a/src/java.desktop/share/classes/javax/imageio/ImageReader.java
+++ b/src/java.desktop/share/classes/javax/imageio/ImageReader.java
@@ -196,7 +196,7 @@ public abstract class ImageReader {
      * provider, or which desire a different naming policy should
      * override this method.
      *
-     * @exception IOException if an error occurs reading the
+     * @throws IOException if an error occurs reading the
      * information from the input source.
      *
      * @return the format name, as a {@code String}.
@@ -276,7 +276,7 @@ public abstract class ImageReader {
      * @param ignoreMetadata if {@code true}, metadata
      * may be ignored during reads.
      *
-     * @exception IllegalArgumentException if {@code input} is
+     * @throws IllegalArgumentException if {@code input} is
      * not an instance of one of the classes returned by the
      * originating service provider's {@code getInputTypes}
      * method, or is not an {@code ImageInputStream}.
@@ -343,7 +343,7 @@ public abstract class ImageReader {
      * @param seekForwardOnly if {@code true}, images and metadata
      * may only be read in ascending order from this input source.
      *
-     * @exception IllegalArgumentException if {@code input} is
+     * @throws IllegalArgumentException if {@code input} is
      * not an instance of one of the classes returned by the
      * originating service provider's {@code getInputTypes}
      * method, or is not an {@code ImageInputStream}.
@@ -369,7 +369,7 @@ public abstract class ImageReader {
      * @param input the {@code ImageInputStream} or other
      * {@code Object} to use for future decoding.
      *
-     * @exception IllegalArgumentException if {@code input} is
+     * @throws IllegalArgumentException if {@code input} is
      * not an instance of one of the classes returned by the
      * originating service provider's {@code getInputTypes}
      * method, or is not an {@code ImageInputStream}.
@@ -470,7 +470,7 @@ public abstract class ImageReader {
      * @param locale the desired {@code Locale}, or
      * {@code null}.
      *
-     * @exception IllegalArgumentException if {@code locale} is
+     * @throws IllegalArgumentException if {@code locale} is
      * non-{@code null} but is not one of the values returned by
      * {@code getAvailableLocales}.
      *
@@ -538,10 +538,10 @@ public abstract class ImageReader {
      * {@code -1} if {@code allowSearch} is
      * {@code false} and a search would be required.
      *
-     * @exception IllegalStateException if the input source has not been set,
+     * @throws IllegalStateException if the input source has not been set,
      * or if the input has been specified with {@code seekForwardOnly}
      * set to {@code true}.
-     * @exception IOException if an error occurs reading the
+     * @throws IOException if an error occurs reading the
      * information from the input source.
      *
      * @see #setInput
@@ -559,10 +559,10 @@ public abstract class ImageReader {
      *
      * @return the width of the image, as an {@code int}.
      *
-     * @exception IllegalStateException if the input source has not been set.
-     * @exception IndexOutOfBoundsException if the supplied index is
+     * @throws IllegalStateException if the input source has not been set.
+     * @throws IndexOutOfBoundsException if the supplied index is
      * out of bounds.
-     * @exception IOException if an error occurs reading the width
+     * @throws IOException if an error occurs reading the width
      * information from the input source.
      */
     public abstract int getWidth(int imageIndex) throws IOException;
@@ -578,10 +578,10 @@ public abstract class ImageReader {
      *
      * @return the height of the image, as an {@code int}.
      *
-     * @exception IllegalStateException if the input source has not been set.
-     * @exception IndexOutOfBoundsException if the supplied index is
+     * @throws IllegalStateException if the input source has not been set.
+     * @throws IndexOutOfBoundsException if the supplied index is
      * out of bounds.
-     * @exception IOException if an error occurs reading the height
+     * @throws IOException if an error occurs reading the height
      * information from the input source.
      */
     public abstract int getHeight(int imageIndex) throws IOException;
@@ -617,12 +617,12 @@ public abstract class ImageReader {
      * @return {@code true} if reading a region of interest of
      * the given image is likely to be efficient.
      *
-     * @exception IllegalStateException if an input source is required
+     * @throws IllegalStateException if an input source is required
      * to determine the return value, but none has been set.
-     * @exception IndexOutOfBoundsException if an image must be
+     * @throws IndexOutOfBoundsException if an image must be
      * accessed to determine the return value, but the supplied index
      * is out of bounds.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      */
     public boolean isRandomAccessEasy(int imageIndex) throws IOException {
         return false;
@@ -644,10 +644,10 @@ public abstract class ImageReader {
      * @return a {@code float} indicating the aspect ratio of the
      * given image.
      *
-     * @exception IllegalStateException if the input source has not been set.
-     * @exception IndexOutOfBoundsException if the supplied index is
+     * @throws IllegalStateException if the input source has not been set.
+     * @throws IndexOutOfBoundsException if the supplied index is
      * out of bounds.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      */
     public float getAspectRatio(int imageIndex) throws IOException {
         return (float)getWidth(imageIndex)/getHeight(imageIndex);
@@ -669,10 +669,10 @@ public abstract class ImageReader {
      *
      * @return an {@code ImageTypeSpecifier}.
      *
-     * @exception IllegalStateException if the input source has not been set.
-     * @exception IndexOutOfBoundsException if the supplied index is
+     * @throws IllegalStateException if the input source has not been set.
+     * @throws IndexOutOfBoundsException if the supplied index is
      * out of bounds.
-     * @exception IOException if an error occurs reading the format
+     * @throws IOException if an error occurs reading the format
      * information from the input source.
      */
     public ImageTypeSpecifier getRawImageType(int imageIndex)
@@ -699,10 +699,10 @@ public abstract class ImageReader {
      * {@code ImageTypeSpecifier} representing suggested image
      * types for decoding the current given image.
      *
-     * @exception IllegalStateException if the input source has not been set.
-     * @exception IndexOutOfBoundsException if the supplied index is
+     * @throws IllegalStateException if the input source has not been set.
+     * @throws IndexOutOfBoundsException if the supplied index is
      * out of bounds.
-     * @exception IOException if an error occurs reading the format
+     * @throws IOException if an error occurs reading the format
      * information from the input source.
      *
      * @see ImageReadParam#setDestination(BufferedImage)
@@ -739,7 +739,7 @@ public abstract class ImageReader {
      *
      * @return an {@code IIOMetadata} object, or {@code null}.
      *
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      */
     public abstract IIOMetadata getStreamMetadata() throws IOException;
 
@@ -778,11 +778,11 @@ public abstract class ImageReader {
      *
      * @return an {@code IIOMetadata} object, or {@code null}.
      *
-     * @exception IllegalArgumentException if {@code formatName}
+     * @throws IllegalArgumentException if {@code formatName}
      * is {@code null}.
-     * @exception IllegalArgumentException if {@code nodeNames}
+     * @throws IllegalArgumentException if {@code nodeNames}
      * is {@code null}.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      */
     public IIOMetadata getStreamMetadata(String formatName,
                                          Set<String> nodeNames)
@@ -839,11 +839,11 @@ public abstract class ImageReader {
      * @return an {@code IIOMetadata} object, or
      * {@code null}.
      *
-     * @exception IllegalStateException if the input source has not been
+     * @throws IllegalStateException if the input source has not been
      * set.
-     * @exception IndexOutOfBoundsException if the supplied index is
+     * @throws IndexOutOfBoundsException if the supplied index is
      * out of bounds.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      */
     public abstract IIOMetadata getImageMetadata(int imageIndex)
         throws IOException;
@@ -885,15 +885,15 @@ public abstract class ImageReader {
      *
      * @return an {@code IIOMetadata} object, or {@code null}.
      *
-     * @exception IllegalStateException if the input source has not been
+     * @throws IllegalStateException if the input source has not been
      * set.
-     * @exception IndexOutOfBoundsException if the supplied index is
+     * @throws IndexOutOfBoundsException if the supplied index is
      * out of bounds.
-     * @exception IllegalArgumentException if {@code formatName}
+     * @throws IllegalArgumentException if {@code formatName}
      * is {@code null}.
-     * @exception IllegalArgumentException if {@code nodeNames}
+     * @throws IllegalArgumentException if {@code nodeNames}
      * is {@code null}.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      */
     public IIOMetadata getImageMetadata(int imageIndex,
                                         String formatName,
@@ -928,11 +928,11 @@ public abstract class ImageReader {
      * @return the desired portion of the image as a
      * {@code BufferedImage}.
      *
-     * @exception IllegalStateException if the input source has not been
+     * @throws IllegalStateException if the input source has not been
      * set.
-     * @exception IndexOutOfBoundsException if the supplied index is
+     * @throws IndexOutOfBoundsException if the supplied index is
      * out of bounds.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      */
     public BufferedImage read(int imageIndex) throws IOException {
         return read(imageIndex, null);
@@ -980,18 +980,18 @@ public abstract class ImageReader {
      * @return the desired portion of the image as a
      * {@code BufferedImage}.
      *
-     * @exception IllegalStateException if the input source has not been
+     * @throws IllegalStateException if the input source has not been
      * set.
-     * @exception IndexOutOfBoundsException if the supplied index is
+     * @throws IndexOutOfBoundsException if the supplied index is
      * out of bounds.
-     * @exception IllegalArgumentException if the set of source and
+     * @throws IllegalArgumentException if the set of source and
      * destination bands specified by
      * {@code param.getSourceBands} and
      * {@code param.getDestinationBands} differ in length or
      * include indices that are out of bounds.
-     * @exception IllegalArgumentException if the resulting image would
+     * @throws IllegalArgumentException if the resulting image would
      * have a width or height less than 1.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      */
     public abstract BufferedImage read(int imageIndex, ImageReadParam param)
         throws IOException;
@@ -1043,18 +1043,18 @@ public abstract class ImageReader {
      * of the image, a set of thumbnails, and associated image
      * metadata.
      *
-     * @exception IllegalStateException if the input source has not been
+     * @throws IllegalStateException if the input source has not been
      * set.
-     * @exception IndexOutOfBoundsException if the supplied index is
+     * @throws IndexOutOfBoundsException if the supplied index is
      * out of bounds.
-     * @exception IllegalArgumentException if the set of source and
+     * @throws IllegalArgumentException if the set of source and
      * destination bands specified by
      * {@code param.getSourceBands} and
      * {@code param.getDestinationBands} differ in length or
      * include indices that are out of bounds.
-     * @exception IllegalArgumentException if the resulting image
+     * @throws IllegalArgumentException if the resulting image
      * would have a width or height less than 1.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      */
     public IIOImage readAll(int imageIndex, ImageReadParam param)
         throws IOException {
@@ -1134,19 +1134,19 @@ public abstract class ImageReader {
      * @return an {@code Iterator} representing the
      * contents of the input source as {@code IIOImage}s.
      *
-     * @exception IllegalStateException if the input source has not been
+     * @throws IllegalStateException if the input source has not been
      * set.
-     * @exception IllegalArgumentException if any
+     * @throws IllegalArgumentException if any
      * non-{@code null} element of {@code params} is not an
      * {@code ImageReadParam}.
-     * @exception IllegalArgumentException if the set of source and
+     * @throws IllegalArgumentException if the set of source and
      * destination bands specified by
      * {@code param.getSourceBands} and
      * {@code param.getDestinationBands} differ in length or
      * include indices that are out of bounds.
-     * @exception IllegalArgumentException if a resulting image would
+     * @throws IllegalArgumentException if a resulting image would
      * have a width or height less than 1.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      *
      * @see ImageReadParam
      * @see IIOImage
@@ -1267,13 +1267,13 @@ public abstract class ImageReader {
      * @return the desired portion of the image as a
      * {@code Raster}.
      *
-     * @exception UnsupportedOperationException if this plug-in does not
+     * @throws UnsupportedOperationException if this plug-in does not
      * support reading raw {@code Raster}s.
-     * @exception IllegalStateException if the input source has not been
+     * @throws IllegalStateException if the input source has not been
      * set.
-     * @exception IndexOutOfBoundsException if the supplied index is
+     * @throws IndexOutOfBoundsException if the supplied index is
      * out of bounds.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      *
      * @see #canReadRaster
      * @see #read
@@ -1310,12 +1310,12 @@ public abstract class ImageReader {
      *
      * @return {@code true} if the image is tiled.
      *
-     * @exception IllegalStateException if an input source is required
+     * @throws IllegalStateException if an input source is required
      * to determine the return value, but none has been set.
-     * @exception IndexOutOfBoundsException if an image must be
+     * @throws IndexOutOfBoundsException if an image must be
      * accessed to determine the return value, but the supplied index
      * is out of bounds.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      */
     public boolean isImageTiled(int imageIndex) throws IOException {
         return false;
@@ -1333,10 +1333,10 @@ public abstract class ImageReader {
      *
      * @param imageIndex the index of the image to be queried.
      *
-     * @exception IllegalStateException if the input source has not been set.
-     * @exception IndexOutOfBoundsException if the supplied index is
+     * @throws IllegalStateException if the input source has not been set.
+     * @throws IndexOutOfBoundsException if the supplied index is
      * out of bounds.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      */
     public int getTileWidth(int imageIndex) throws IOException {
         return getWidth(imageIndex);
@@ -1354,10 +1354,10 @@ public abstract class ImageReader {
      *
      * @param imageIndex the index of the image to be queried.
      *
-     * @exception IllegalStateException if the input source has not been set.
-     * @exception IndexOutOfBoundsException if the supplied index is
+     * @throws IllegalStateException if the input source has not been set.
+     * @throws IndexOutOfBoundsException if the supplied index is
      * out of bounds.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      */
     public int getTileHeight(int imageIndex) throws IOException {
         return getHeight(imageIndex);
@@ -1382,12 +1382,12 @@ public abstract class ImageReader {
      *
      * @param imageIndex the index of the image to be queried.
      *
-     * @exception IllegalStateException if an input source is required
+     * @throws IllegalStateException if an input source is required
      * to determine the return value, but none has been set.
-     * @exception IndexOutOfBoundsException if an image must be
+     * @throws IndexOutOfBoundsException if an image must be
      * accessed to determine the return value, but the supplied index
      * is out of bounds.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      */
     public int getTileGridXOffset(int imageIndex) throws IOException {
         return 0;
@@ -1412,12 +1412,12 @@ public abstract class ImageReader {
      *
      * @param imageIndex the index of the image to be queried.
      *
-     * @exception IllegalStateException if an input source is required
+     * @throws IllegalStateException if an input source is required
      * to determine the return value, but none has been set.
-     * @exception IndexOutOfBoundsException if an image must be
+     * @throws IndexOutOfBoundsException if an image must be
      * accessed to determine the return value, but the supplied index
      * is out of bounds.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      */
     public int getTileGridYOffset(int imageIndex) throws IOException {
         return 0;
@@ -1455,13 +1455,13 @@ public abstract class ImageReader {
      *
      * @return the tile as a {@code BufferedImage}.
      *
-     * @exception IllegalStateException if the input source has not been
+     * @throws IllegalStateException if the input source has not been
      * set.
-     * @exception IndexOutOfBoundsException if {@code imageIndex}
+     * @throws IndexOutOfBoundsException if {@code imageIndex}
      * is out of bounds.
-     * @exception IllegalArgumentException if the tile indices are
+     * @throws IllegalArgumentException if the tile indices are
      * out of bounds.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      */
     public BufferedImage readTile(int imageIndex,
                                   int tileX, int tileY) throws IOException {
@@ -1495,15 +1495,15 @@ public abstract class ImageReader {
      *
      * @return the tile as a {@code Raster}.
      *
-     * @exception UnsupportedOperationException if this plug-in does not
+     * @throws UnsupportedOperationException if this plug-in does not
      * support reading raw {@code Raster}s.
-     * @exception IllegalArgumentException if the tile indices are
+     * @throws IllegalArgumentException if the tile indices are
      * out of bounds.
-     * @exception IllegalStateException if the input source has not been
+     * @throws IllegalStateException if the input source has not been
      * set.
-     * @exception IndexOutOfBoundsException if {@code imageIndex}
+     * @throws IndexOutOfBoundsException if {@code imageIndex}
      * is out of bounds.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      *
      * @see #readTile
      * @see #readRaster
@@ -1554,18 +1554,18 @@ public abstract class ImageReader {
      * @return a {@code RenderedImage} object providing a view of
      * the image.
      *
-     * @exception IllegalStateException if the input source has not been
+     * @throws IllegalStateException if the input source has not been
      * set.
-     * @exception IndexOutOfBoundsException if the supplied index is
+     * @throws IndexOutOfBoundsException if the supplied index is
      * out of bounds.
-     * @exception IllegalArgumentException if the set of source and
+     * @throws IllegalArgumentException if the set of source and
      * destination bands specified by
      * {@code param.getSourceBands} and
      * {@code param.getDestinationBands} differ in length or
      * include indices that are out of bounds.
-     * @exception IllegalArgumentException if the resulting image
+     * @throws IllegalArgumentException if the resulting image
      * would have a width or height less than 1.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      */
     public RenderedImage readAsRenderedImage(int imageIndex,
                                              ImageReadParam param)
@@ -1611,11 +1611,11 @@ public abstract class ImageReader {
      *
      * @return {@code true} if the given image has thumbnails.
      *
-     * @exception IllegalStateException if the reader supports
+     * @throws IllegalStateException if the reader supports
      * thumbnails but the input source has not been set.
-     * @exception IndexOutOfBoundsException if the reader supports
+     * @throws IndexOutOfBoundsException if the reader supports
      * thumbnails but {@code imageIndex} is out of bounds.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      */
     public boolean hasThumbnails(int imageIndex) throws IOException {
         return getNumThumbnails(imageIndex) > 0;
@@ -1637,11 +1637,11 @@ public abstract class ImageReader {
      * @return the number of thumbnails associated with the given
      * image.
      *
-     * @exception IllegalStateException if the reader supports
+     * @throws IllegalStateException if the reader supports
      * thumbnails but the input source has not been set.
-     * @exception IndexOutOfBoundsException if the reader supports
+     * @throws IndexOutOfBoundsException if the reader supports
      * thumbnails but {@code imageIndex} is out of bounds.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      */
     public int getNumThumbnails(int imageIndex)
         throws IOException {
@@ -1669,12 +1669,12 @@ public abstract class ImageReader {
      *
      * @return the width of the desired thumbnail as an {@code int}.
      *
-     * @exception UnsupportedOperationException if thumbnails are not
+     * @throws UnsupportedOperationException if thumbnails are not
      * supported.
-     * @exception IllegalStateException if the input source has not been set.
-     * @exception IndexOutOfBoundsException if either of the supplied
+     * @throws IllegalStateException if the input source has not been set.
+     * @throws IndexOutOfBoundsException if either of the supplied
      * indices are out of bounds.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      */
     public int getThumbnailWidth(int imageIndex, int thumbnailIndex)
         throws IOException {
@@ -1702,12 +1702,12 @@ public abstract class ImageReader {
      *
      * @return the height of the desired thumbnail as an {@code int}.
      *
-     * @exception UnsupportedOperationException if thumbnails are not
+     * @throws UnsupportedOperationException if thumbnails are not
      * supported.
-     * @exception IllegalStateException if the input source has not been set.
-     * @exception IndexOutOfBoundsException if either of the supplied
+     * @throws IllegalStateException if the input source has not been set.
+     * @throws IndexOutOfBoundsException if either of the supplied
      * indices are out of bounds.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      */
     public int getThumbnailHeight(int imageIndex, int thumbnailIndex)
         throws IOException {
@@ -1738,12 +1738,12 @@ public abstract class ImageReader {
      *
      * @return the desired thumbnail as a {@code BufferedImage}.
      *
-     * @exception UnsupportedOperationException if thumbnails are not
+     * @throws UnsupportedOperationException if thumbnails are not
      * supported.
-     * @exception IllegalStateException if the input source has not been set.
-     * @exception IndexOutOfBoundsException if either of the supplied
+     * @throws IllegalStateException if the input source has not been set.
+     * @throws IndexOutOfBoundsException if either of the supplied
      * indices are out of bounds.
-     * @exception IOException if an error occurs during reading.
+     * @throws IOException if an error occurs during reading.
      */
     public BufferedImage readThumbnail(int imageIndex,
                                        int thumbnailIndex)
@@ -2388,7 +2388,7 @@ public abstract class ImageReader {
      *
      * @param warning the warning message to send.
      *
-     * @exception IllegalArgumentException if {@code warning}
+     * @throws IllegalArgumentException if {@code warning}
      * is {@code null}.
      */
     protected void processWarningOccurred(String warning) {
@@ -2420,15 +2420,15 @@ public abstract class ImageReader {
      * @param keyword the keyword used to index the warning message
      * within the set of {@code ResourceBundle}s.
      *
-     * @exception IllegalArgumentException if {@code baseName}
+     * @throws IllegalArgumentException if {@code baseName}
      * is {@code null}.
-     * @exception IllegalArgumentException if {@code keyword}
+     * @throws IllegalArgumentException if {@code keyword}
      * is {@code null}.
-     * @exception IllegalArgumentException if no appropriate
+     * @throws IllegalArgumentException if no appropriate
      * {@code ResourceBundle} may be located.
-     * @exception IllegalArgumentException if the named resource is
+     * @throws IllegalArgumentException if the named resource is
      * not found in the located {@code ResourceBundle}.
-     * @exception IllegalArgumentException if the object retrieved
+     * @throws IllegalArgumentException if the object retrieved
      * from the {@code ResourceBundle} is not a
      * {@code String}.
      */
@@ -2594,11 +2594,11 @@ public abstract class ImageReader {
      * the source region of interest.
      * @param destRegion a {@code Rectangle} that will be filled with
      * the destination region of interest.
-     * @exception IllegalArgumentException if {@code srcRegion}
+     * @throws IllegalArgumentException if {@code srcRegion}
      * is {@code null}.
-     * @exception IllegalArgumentException if {@code dstRegion}
+     * @throws IllegalArgumentException if {@code dstRegion}
      * is {@code null}.
-     * @exception IllegalArgumentException if the resulting source or
+     * @throws IllegalArgumentException if the resulting source or
      * destination region is empty.
      */
     protected static void computeRegions(ImageReadParam param,
@@ -2720,7 +2720,7 @@ public abstract class ImageReader {
      * @param numDstBands the number of bands in the destination image
      * being written.
      *
-     * @exception IllegalArgumentException if {@code param}
+     * @throws IllegalArgumentException if {@code param}
      * contains an invalid specification of a source and/or
      * destination band subset.
      */
@@ -2797,15 +2797,15 @@ public abstract class ImageReader {
      * @return the {@code BufferedImage} to which decoded pixel
      * data should be written.
      *
-     * @exception IIOException if the {@code ImageTypeSpecifier}
+     * @throws IIOException if the {@code ImageTypeSpecifier}
      * specified by {@code param} does not match any of the legal
      * ones from {@code imageTypes}.
-     * @exception IllegalArgumentException if {@code imageTypes}
+     * @throws IllegalArgumentException if {@code imageTypes}
      * is {@code null} or empty, or if an object not of type
      * {@code ImageTypeSpecifier} is retrieved from it.
-     * @exception IllegalArgumentException if the resulting image would
+     * @throws IllegalArgumentException if the resulting image would
      * have a width or height less than 1.
-     * @exception IllegalArgumentException if the product of
+     * @throws IllegalArgumentException if the product of
      * {@code width} and {@code height} is greater than
      * {@code Integer.MAX_VALUE}.
      */

--- a/src/java.desktop/share/classes/javax/imageio/ImageTranscoder.java
+++ b/src/java.desktop/share/classes/javax/imageio/ImageTranscoder.java
@@ -109,7 +109,7 @@ public interface ImageTranscoder {
      * {@code null} if the plug-in does not provide metadata
      * encoding capabilities.
      *
-     * @exception IllegalArgumentException if {@code inData} is
+     * @throws IllegalArgumentException if {@code inData} is
      * {@code null}.
      */
     IIOMetadata convertStreamMetadata(IIOMetadata inData,
@@ -142,7 +142,7 @@ public interface ImageTranscoder {
      * or {@code null} if the plug-in does not provide
      * metadata encoding capabilities.
      *
-     * @exception IllegalArgumentException if either of
+     * @throws IllegalArgumentException if either of
      * {@code inData} or {@code imageType} is
      * {@code null}.
      */

--- a/src/java.desktop/share/classes/javax/imageio/ImageTypeSpecifier.java
+++ b/src/java.desktop/share/classes/javax/imageio/ImageTypeSpecifier.java
@@ -90,9 +90,9 @@ public class ImageTypeSpecifier {
      * @param colorModel a {@code ColorModel}.
      * @param sampleModel a {@code SampleModel}.
      *
-     * @exception IllegalArgumentException if either parameter is
+     * @throws IllegalArgumentException if either parameter is
      * {@code null}.
-     * @exception IllegalArgumentException if {@code sampleModel}
+     * @throws IllegalArgumentException if {@code sampleModel}
      * is not compatible with {@code colorModel}.
      */
     public ImageTypeSpecifier(ColorModel colorModel, SampleModel sampleModel) {
@@ -120,7 +120,7 @@ public class ImageTypeSpecifier {
      *
      * @param image a {@code RenderedImage}.
      *
-     * @exception IllegalArgumentException if the argument is
+     * @throws IllegalArgumentException if the argument is
      * {@code null}.
      */
     public ImageTypeSpecifier(RenderedImage image) {
@@ -208,13 +208,13 @@ public class ImageTypeSpecifier {
      * @return an {@code ImageTypeSpecifier} with the desired
      * characteristics.
      *
-     * @exception IllegalArgumentException if {@code colorSpace}
+     * @throws IllegalArgumentException if {@code colorSpace}
      * is {@code null}.
-     * @exception IllegalArgumentException if {@code colorSpace}
+     * @throws IllegalArgumentException if {@code colorSpace}
      * is not of type {@code TYPE_RGB}.
-     * @exception IllegalArgumentException if no mask has at least 1
+     * @throws IllegalArgumentException if no mask has at least 1
      * bit set.
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      * {@code transferType} if not one of
      * {@code DataBuffer.TYPE_BYTE},
      * {@code DataBuffer.TYPE_USHORT}, or
@@ -375,13 +375,13 @@ public class ImageTypeSpecifier {
      * @return an {@code ImageTypeSpecifier} with the desired
      * characteristics.
      *
-     * @exception IllegalArgumentException if {@code colorSpace}
+     * @throws IllegalArgumentException if {@code colorSpace}
      * is {@code null}.
-     * @exception IllegalArgumentException if {@code bandOffsets}
+     * @throws IllegalArgumentException if {@code bandOffsets}
      * is {@code null}.
-     * @exception IllegalArgumentException if {@code dataType} is
+     * @throws IllegalArgumentException if {@code dataType} is
      * not one of the legal {@code DataBuffer.TYPE_*} constants.
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      * {@code bandOffsets.length} does not equal the number of
      * color space components, plus 1 if {@code hasAlpha} is
      * {@code true}.
@@ -525,19 +525,19 @@ public class ImageTypeSpecifier {
      * @return an {@code ImageTypeSpecifier} with the desired
      * characteristics.
      *
-     * @exception IllegalArgumentException if {@code colorSpace}
+     * @throws IllegalArgumentException if {@code colorSpace}
      * is {@code null}.
-     * @exception IllegalArgumentException if {@code bankIndices}
+     * @throws IllegalArgumentException if {@code bankIndices}
      * is {@code null}.
-     * @exception IllegalArgumentException if {@code bandOffsets}
+     * @throws IllegalArgumentException if {@code bandOffsets}
      * is {@code null}.
-     * @exception IllegalArgumentException if the lengths of
+     * @throws IllegalArgumentException if the lengths of
      * {@code bankIndices} and {@code bandOffsets} differ.
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      * {@code bandOffsets.length} does not equal the number of
      * color space components, plus 1 if {@code hasAlpha} is
      * {@code true}.
-     * @exception IllegalArgumentException if {@code dataType} is
+     * @throws IllegalArgumentException if {@code dataType} is
      * not one of the legal {@code DataBuffer.TYPE_*} constants.
      */
     public static ImageTypeSpecifier
@@ -661,13 +661,13 @@ public class ImageTypeSpecifier {
      * @return an {@code ImageTypeSpecifier} with the desired
      * characteristics.
      *
-     * @exception IllegalArgumentException if {@code bits} is
+     * @throws IllegalArgumentException if {@code bits} is
      * not one of 1, 2, 4, 8, or 16.
-     * @exception IllegalArgumentException if {@code dataType} is
+     * @throws IllegalArgumentException if {@code dataType} is
      * not one of {@code DataBuffer.TYPE_BYTE},
      * {@code DataBuffer.TYPE_SHORT}, or
      * {@code DataBuffer.TYPE_USHORT}.
-     * @exception IllegalArgumentException if {@code bits} is
+     * @throws IllegalArgumentException if {@code bits} is
      * larger than the bit size of the given {@code dataType}.
      */
     public static ImageTypeSpecifier
@@ -697,13 +697,13 @@ public class ImageTypeSpecifier {
      * @return an {@code ImageTypeSpecifier} with the desired
      * characteristics.
      *
-     * @exception IllegalArgumentException if {@code bits} is
+     * @throws IllegalArgumentException if {@code bits} is
      * not one of 1, 2, 4, 8, or 16.
-     * @exception IllegalArgumentException if {@code dataType} is
+     * @throws IllegalArgumentException if {@code dataType} is
      * not one of {@code DataBuffer.TYPE_BYTE},
      * {@code DataBuffer.TYPE_SHORT}, or
      * {@code DataBuffer.TYPE_USHORT}.
-     * @exception IllegalArgumentException if {@code bits} is
+     * @throws IllegalArgumentException if {@code bits} is
      * larger than the bit size of the given {@code dataType}.
      */
     public static ImageTypeSpecifier
@@ -822,23 +822,23 @@ public class ImageTypeSpecifier {
      * @return an {@code ImageTypeSpecifier} with the desired
      * characteristics.
      *
-     * @exception IllegalArgumentException if {@code redLUT} is
+     * @throws IllegalArgumentException if {@code redLUT} is
      * {@code null}.
-     * @exception IllegalArgumentException if {@code greenLUT} is
+     * @throws IllegalArgumentException if {@code greenLUT} is
      * {@code null}.
-     * @exception IllegalArgumentException if {@code blueLUT} is
+     * @throws IllegalArgumentException if {@code blueLUT} is
      * {@code null}.
-     * @exception IllegalArgumentException if {@code bits} is
+     * @throws IllegalArgumentException if {@code bits} is
      * not one of 1, 2, 4, 8, or 16.
-     * @exception IllegalArgumentException if the
+     * @throws IllegalArgumentException if the
      * non-{@code null} LUT parameters do not have lengths of
      * exactly {@code 1 << bits}.
-     * @exception IllegalArgumentException if {@code dataType} is
+     * @throws IllegalArgumentException if {@code dataType} is
      * not one of {@code DataBuffer.TYPE_BYTE},
      * {@code DataBuffer.TYPE_SHORT},
      * {@code DataBuffer.TYPE_USHORT},
      * or {@code DataBuffer.TYPE_INT}.
-     * @exception IllegalArgumentException if {@code bits} is
+     * @throws IllegalArgumentException if {@code bits} is
      * larger than the bit size of the given {@code dataType}.
      */
     public static ImageTypeSpecifier
@@ -867,7 +867,7 @@ public class ImageTypeSpecifier {
      * @return an {@code ImageTypeSpecifier} with the desired
      * characteristics.
      *
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      * {@code bufferedImageType} is not one of the standard
      * types, or is equal to {@code TYPE_CUSTOM}.
      *
@@ -908,7 +908,7 @@ public class ImageTypeSpecifier {
      * @return an {@code ImageTypeSpecifier} with the desired
      * characteristics.
      *
-     * @exception IllegalArgumentException if {@code image} is
+     * @throws IllegalArgumentException if {@code image} is
      * {@code null}.
      */
     public static
@@ -985,7 +985,7 @@ public class ImageTypeSpecifier {
      *
      * @return an int specifying a number of bits.
      *
-     * @exception IllegalArgumentException if {@code band} is
+     * @throws IllegalArgumentException if {@code band} is
      * negative or greater than the largest band index.
      */
     public int getBitsPerBand(int band) {
@@ -1017,9 +1017,9 @@ public class ImageTypeSpecifier {
      *
      * @return a {@code SampleModel} with the given dimensions.
      *
-     * @exception IllegalArgumentException if either {@code width} or
+     * @throws IllegalArgumentException if either {@code width} or
      * {@code height} are negative or zero.
-     * @exception IllegalArgumentException if the product of
+     * @throws IllegalArgumentException if the product of
      * {@code width} and {@code height} is greater than
      * {@code Integer.MAX_VALUE}
      */
@@ -1051,9 +1051,9 @@ public class ImageTypeSpecifier {
      *
      * @return a new {@code BufferedImage}
      *
-     * @exception IllegalArgumentException if either {@code width} or
+     * @throws IllegalArgumentException if either {@code width} or
      * {@code height} are negative or zero.
-     * @exception IllegalArgumentException if the product of
+     * @throws IllegalArgumentException if the product of
      * {@code width} and {@code height} is greater than
      * {@code Integer.MAX_VALUE}, or if the number of array
      * elements needed to store the image is greater than

--- a/src/java.desktop/share/classes/javax/imageio/ImageWriteParam.java
+++ b/src/java.desktop/share/classes/javax/imageio/ImageWriteParam.java
@@ -474,9 +474,9 @@ public class ImageWriteParam extends IIOParam {
      *
      * @param mode The mode to use for tiling.
      *
-     * @exception UnsupportedOperationException if
+     * @throws UnsupportedOperationException if
      * {@code canWriteTiles} returns {@code false}.
-     * @exception IllegalArgumentException if {@code mode} is not
+     * @throws IllegalArgumentException if {@code mode} is not
      * one of the modes listed above.
      *
      * @see #setTiling
@@ -501,7 +501,7 @@ public class ImageWriteParam extends IIOParam {
      *
      * @return the current tiling mode.
      *
-     * @exception UnsupportedOperationException if
+     * @throws UnsupportedOperationException if
      * {@code canWriteTiles} returns {@code false}.
      *
      * @see #setTilingMode
@@ -530,7 +530,7 @@ public class ImageWriteParam extends IIOParam {
      * <p> If no array is specified on the constructor, but tiling is
      * allowed, then this method returns {@code null}.
      *
-     * @exception UnsupportedOperationException if the plug-in does
+     * @throws UnsupportedOperationException if the plug-in does
      * not support tiling.
      *
      * @return an array of {@code Dimension}s with an even length
@@ -559,16 +559,16 @@ public class ImageWriteParam extends IIOParam {
      * @param tileGridXOffset the horizontal offset of the tile grid.
      * @param tileGridYOffset the vertical offset of the tile grid.
      *
-     * @exception UnsupportedOperationException if the plug-in does not
+     * @throws UnsupportedOperationException if the plug-in does not
      * support tiling.
-     * @exception IllegalStateException if the tiling mode is not
+     * @throws IllegalStateException if the tiling mode is not
      * {@code MODE_EXPLICIT}.
-     * @exception UnsupportedOperationException if the plug-in does not
+     * @throws UnsupportedOperationException if the plug-in does not
      * support grid offsets, and the grid offsets are not both zero.
-     * @exception IllegalArgumentException if the tile size is not
+     * @throws IllegalArgumentException if the tile size is not
      * within one of the allowable ranges returned by
      * {@code getPreferredTileSizes}.
-     * @exception IllegalArgumentException if {@code tileWidth}
+     * @throws IllegalArgumentException if {@code tileWidth}
      * or {@code tileHeight} is less than or equal to 0.
      *
      * @see #canWriteTiles
@@ -630,9 +630,9 @@ public class ImageWriteParam extends IIOParam {
      * {@code tileGridXOffset}, and
      * {@code tileGridYOffset} to {@code 0}.
      *
-     * @exception UnsupportedOperationException if the plug-in does not
+     * @throws UnsupportedOperationException if the plug-in does not
      * support tiling.
-     * @exception IllegalStateException if the tiling mode is not
+     * @throws IllegalStateException if the tiling mode is not
      * {@code MODE_EXPLICIT}.
      *
      * @see #setTiling(int, int, int, int)
@@ -658,11 +658,11 @@ public class ImageWriteParam extends IIOParam {
      *
      * @return the tile width to be used for encoding.
      *
-     * @exception UnsupportedOperationException if the plug-in does not
+     * @throws UnsupportedOperationException if the plug-in does not
      * support tiling.
-     * @exception IllegalStateException if the tiling mode is not
+     * @throws IllegalStateException if the tiling mode is not
      * {@code MODE_EXPLICIT}.
-     * @exception IllegalStateException if the tiling parameters have
+     * @throws IllegalStateException if the tiling parameters have
      * not been set.
      *
      * @see #setTiling(int, int, int, int)
@@ -688,11 +688,11 @@ public class ImageWriteParam extends IIOParam {
      *
      * @return the tile height to be used for encoding.
      *
-     * @exception UnsupportedOperationException if the plug-in does not
+     * @throws UnsupportedOperationException if the plug-in does not
      * support tiling.
-     * @exception IllegalStateException if the tiling mode is not
+     * @throws IllegalStateException if the tiling mode is not
      * {@code MODE_EXPLICIT}.
-     * @exception IllegalStateException if the tiling parameters have
+     * @throws IllegalStateException if the tiling parameters have
      * not been set.
      *
      * @see #setTiling(int, int, int, int)
@@ -718,11 +718,11 @@ public class ImageWriteParam extends IIOParam {
      *
      * @return the tile grid X offset to be used for encoding.
      *
-     * @exception UnsupportedOperationException if the plug-in does not
+     * @throws UnsupportedOperationException if the plug-in does not
      * support tiling.
-     * @exception IllegalStateException if the tiling mode is not
+     * @throws IllegalStateException if the tiling mode is not
      * {@code MODE_EXPLICIT}.
-     * @exception IllegalStateException if the tiling parameters have
+     * @throws IllegalStateException if the tiling parameters have
      * not been set.
      *
      * @see #setTiling(int, int, int, int)
@@ -748,11 +748,11 @@ public class ImageWriteParam extends IIOParam {
      *
      * @return the tile grid Y offset to be used for encoding.
      *
-     * @exception UnsupportedOperationException if the plug-in does not
+     * @throws UnsupportedOperationException if the plug-in does not
      * support tiling.
-     * @exception IllegalStateException if the tiling mode is not
+     * @throws IllegalStateException if the tiling mode is not
      * {@code MODE_EXPLICIT}.
-     * @exception IllegalStateException if the tiling parameters have
+     * @throws IllegalStateException if the tiling parameters have
      * not been set.
      *
      * @see #setTiling(int, int, int, int)
@@ -818,9 +818,9 @@ public class ImageWriteParam extends IIOParam {
      * @param mode The mode for setting progression in the output
      * stream.
      *
-     * @exception UnsupportedOperationException if the writer does not
+     * @throws UnsupportedOperationException if the writer does not
      * support progressive encoding.
-     * @exception IllegalArgumentException if {@code mode} is not
+     * @throws IllegalArgumentException if {@code mode} is not
      * one of the modes listed above.
      *
      * @see #getProgressiveMode
@@ -846,7 +846,7 @@ public class ImageWriteParam extends IIOParam {
      *
      * @return the current mode for progressive encoding.
      *
-     * @exception UnsupportedOperationException if the writer does not
+     * @throws UnsupportedOperationException if the writer does not
      * support progressive encoding.
      *
      * @see #setProgressiveMode
@@ -902,9 +902,9 @@ public class ImageWriteParam extends IIOParam {
      * @param mode The mode for setting compression in the output
      * stream.
      *
-     * @exception UnsupportedOperationException if the writer does not
+     * @throws UnsupportedOperationException if the writer does not
      * support compression, or does not support the requested mode.
-     * @exception IllegalArgumentException if {@code mode} is not
+     * @throws IllegalArgumentException if {@code mode} is not
      * one of the modes listed above.
      *
      * @see #getCompressionMode
@@ -929,7 +929,7 @@ public class ImageWriteParam extends IIOParam {
      *
      * @return the current compression mode.
      *
-     * @exception UnsupportedOperationException if the writer does not
+     * @throws UnsupportedOperationException if the writer does not
      * support compression.
      *
      * @see #setCompressionMode
@@ -965,7 +965,7 @@ public class ImageWriteParam extends IIOParam {
      * (non-localized) names of available compression types, or
      * {@code null}.
      *
-     * @exception UnsupportedOperationException if the writer does not
+     * @throws UnsupportedOperationException if the writer does not
      * support compression.
      */
     public String[] getCompressionTypes() {
@@ -998,13 +998,13 @@ public class ImageWriteParam extends IIOParam {
      * by {@code getCompressionTypes}, or {@code null} to
      * remove any previous setting.
      *
-     * @exception UnsupportedOperationException if the writer does not
+     * @throws UnsupportedOperationException if the writer does not
      * support compression.
-     * @exception IllegalStateException if the compression mode is not
+     * @throws IllegalStateException if the compression mode is not
      * {@code MODE_EXPLICIT}.
-     * @exception UnsupportedOperationException if there are no
+     * @throws UnsupportedOperationException if there are no
      * settable compression types.
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      * {@code compressionType} is non-{@code null} but is not
      * one of the values returned by {@code getCompressionTypes}.
      *
@@ -1059,9 +1059,9 @@ public class ImageWriteParam extends IIOParam {
      * @return the current compression type as a {@code String},
      * or {@code null} if no type is set.
      *
-     * @exception UnsupportedOperationException if the writer does not
+     * @throws UnsupportedOperationException if the writer does not
      * support compression.
-     * @exception IllegalStateException if the compression mode is not
+     * @throws IllegalStateException if the compression mode is not
      * {@code MODE_EXPLICIT}.
      *
      * @see #setCompressionType
@@ -1086,9 +1086,9 @@ public class ImageWriteParam extends IIOParam {
      * instance variable {@code compressionQuality} to
      * {@code 1.0F}.
      *
-     * @exception UnsupportedOperationException if the plug-in does not
+     * @throws UnsupportedOperationException if the plug-in does not
      * support compression.
-     * @exception IllegalStateException if the compression mode is not
+     * @throws IllegalStateException if the compression mode is not
      * {@code MODE_EXPLICIT}.
      *
      * @see #setCompressionType
@@ -1122,11 +1122,11 @@ public class ImageWriteParam extends IIOParam {
      * @return a {@code String} containing a localized version of
      * the name of the current compression type.
      *
-     * @exception UnsupportedOperationException if the writer does not
+     * @throws UnsupportedOperationException if the writer does not
      * support compression.
-     * @exception IllegalStateException if the compression mode is not
+     * @throws IllegalStateException if the compression mode is not
      * {@code MODE_EXPLICIT}.
-     * @exception IllegalStateException if no compression type is set.
+     * @throws IllegalStateException if no compression type is set.
      */
     public String getLocalizedCompressionTypeName() {
         if (!canWriteCompressed()) {
@@ -1162,11 +1162,11 @@ public class ImageWriteParam extends IIOParam {
      * @return {@code true} if the current compression type is
      * lossless.
      *
-     * @exception UnsupportedOperationException if the writer does not
+     * @throws UnsupportedOperationException if the writer does not
      * support compression.
-     * @exception IllegalStateException if the compression mode is not
+     * @throws IllegalStateException if the compression mode is not
      * {@code MODE_EXPLICIT}.
-     * @exception IllegalStateException if the set of legal
+     * @throws IllegalStateException if the set of legal
      * compression types is non-{@code null} and the current
      * compression type is {@code null}.
      */
@@ -1218,14 +1218,14 @@ public class ImageWriteParam extends IIOParam {
      * @param quality a {@code float} between {@code 0} and
      * {@code 1} indicating the desired quality level.
      *
-     * @exception UnsupportedOperationException if the writer does not
+     * @throws UnsupportedOperationException if the writer does not
      * support compression.
-     * @exception IllegalStateException if the compression mode is not
+     * @throws IllegalStateException if the compression mode is not
      * {@code MODE_EXPLICIT}.
-     * @exception IllegalStateException if the set of legal
+     * @throws IllegalStateException if the set of legal
      * compression types is non-{@code null} and the current
      * compression type is {@code null}.
-     * @exception IllegalArgumentException if {@code quality} is
+     * @throws IllegalArgumentException if {@code quality} is
      * not between {@code 0} and {@code 1}, inclusive.
      *
      * @see #getCompressionQuality
@@ -1264,11 +1264,11 @@ public class ImageWriteParam extends IIOParam {
      *
      * @return the current compression quality setting.
      *
-     * @exception UnsupportedOperationException if the writer does not
+     * @throws UnsupportedOperationException if the writer does not
      * support compression.
-     * @exception IllegalStateException if the compression mode is not
+     * @throws IllegalStateException if the compression mode is not
      * {@code MODE_EXPLICIT}.
-     * @exception IllegalStateException if the set of legal
+     * @throws IllegalStateException if the set of legal
      * compression types is non-{@code null} and the current
      * compression type is {@code null}.
      *
@@ -1317,14 +1317,14 @@ public class ImageWriteParam extends IIOParam {
      * @return an estimate of the compressed bit rate, or
      * {@code -1.0F} if no estimate is available.
      *
-     * @exception UnsupportedOperationException if the writer does not
+     * @throws UnsupportedOperationException if the writer does not
      * support compression.
-     * @exception IllegalStateException if the compression mode is not
+     * @throws IllegalStateException if the compression mode is not
      * {@code MODE_EXPLICIT}.
-     * @exception IllegalStateException if the set of legal
+     * @throws IllegalStateException if the set of legal
      * compression types is non-{@code null} and the current
      * compression type is {@code null}.
-     * @exception IllegalArgumentException if {@code quality} is
+     * @throws IllegalArgumentException if {@code quality} is
      * not between {@code 0} and {@code 1}, inclusive.
      */
     public float getBitRate(float quality) {
@@ -1389,11 +1389,11 @@ public class ImageWriteParam extends IIOParam {
      * @return an array of {@code String}s containing localized
      * descriptions of the compression quality levels.
      *
-     * @exception UnsupportedOperationException if the writer does not
+     * @throws UnsupportedOperationException if the writer does not
      * support compression.
-     * @exception IllegalStateException if the compression mode is not
+     * @throws IllegalStateException if the compression mode is not
      * {@code MODE_EXPLICIT}.
-     * @exception IllegalStateException if the set of legal
+     * @throws IllegalStateException if the set of legal
      * compression types is non-{@code null} and the current
      * compression type is {@code null}.
      *
@@ -1442,11 +1442,11 @@ public class ImageWriteParam extends IIOParam {
      * by the {@code String}s from
      * {@code getCompressionQualityDescriptions}.
      *
-     * @exception UnsupportedOperationException if the writer does not
+     * @throws UnsupportedOperationException if the writer does not
      * support compression.
-     * @exception IllegalStateException if the compression mode is not
+     * @throws IllegalStateException if the compression mode is not
      * {@code MODE_EXPLICIT}.
-     * @exception IllegalStateException if the set of legal
+     * @throws IllegalStateException if the set of legal
      * compression types is non-{@code null} and the current
      * compression type is {@code null}.
      *

--- a/src/java.desktop/share/classes/javax/imageio/ImageWriter.java
+++ b/src/java.desktop/share/classes/javax/imageio/ImageWriter.java
@@ -194,7 +194,7 @@ public abstract class ImageWriter implements ImageTranscoder {
      * @param output the {@code ImageOutputStream} or other
      * {@code Object} to use for future writing.
      *
-     * @exception IllegalArgumentException if {@code output} is
+     * @throws IllegalArgumentException if {@code output} is
      * not an instance of one of the classes returned by the
      * originating service provider's {@code getOutputTypes}
      * method.
@@ -276,7 +276,7 @@ public abstract class ImageWriter implements ImageTranscoder {
      * @param locale the desired {@code Locale}, or
      * {@code null}.
      *
-     * @exception IllegalArgumentException if {@code locale} is
+     * @throws IllegalArgumentException if {@code locale} is
      * non-{@code null} but is not one of the values returned by
      * {@code getAvailableLocales}.
      *
@@ -561,14 +561,14 @@ public abstract class ImageWriter implements ImageTranscoder {
      * {@code null} to use a default
      * {@code ImageWriteParam}.
      *
-     * @exception IllegalStateException if the output has not
+     * @throws IllegalStateException if the output has not
      * been set.
-     * @exception UnsupportedOperationException if {@code image}
+     * @throws UnsupportedOperationException if {@code image}
      * contains a {@code Raster} and {@code canWriteRasters}
      * returns {@code false}.
-     * @exception IllegalArgumentException if {@code image} is
+     * @throws IllegalArgumentException if {@code image} is
      * {@code null}.
-     * @exception IOException if an error occurs during writing.
+     * @throws IOException if an error occurs during writing.
      */
     public abstract void write(IIOMetadata streamMetadata,
                                IIOImage image,
@@ -582,14 +582,14 @@ public abstract class ImageWriter implements ImageTranscoder {
      * @param image an {@code IIOImage} object containing an
      * image, thumbnails, and metadata to be written.
      *
-     * @exception IllegalStateException if the output has not
+     * @throws IllegalStateException if the output has not
      * been set.
-     * @exception IllegalArgumentException if {@code image} is
+     * @throws IllegalArgumentException if {@code image} is
      * {@code null}.
-     * @exception UnsupportedOperationException if {@code image}
+     * @throws UnsupportedOperationException if {@code image}
      * contains a {@code Raster} and {@code canWriteRasters}
      * returns {@code false}.
-     * @exception IOException if an error occurs during writing.
+     * @throws IOException if an error occurs during writing.
      */
     public void write(IIOImage image) throws IOException {
         write(null, image, null);
@@ -603,11 +603,11 @@ public abstract class ImageWriter implements ImageTranscoder {
      *
      * @param image a {@code RenderedImage} to be written.
      *
-     * @exception IllegalStateException if the output has not
+     * @throws IllegalStateException if the output has not
      * been set.
-     * @exception IllegalArgumentException if {@code image} is
+     * @throws IllegalArgumentException if {@code image} is
      * {@code null}.
-     * @exception IOException if an error occurs during writing.
+     * @throws IOException if an error occurs during writing.
      */
     public void write(RenderedImage image) throws IOException {
         write(null, new IIOImage(image, null, null), null);
@@ -671,11 +671,11 @@ public abstract class ImageWriter implements ImageTranscoder {
      *
      * @param streamMetadata A stream metadata object, or {@code null}.
      *
-     * @exception IllegalStateException if the output has not
+     * @throws IllegalStateException if the output has not
      * been set.
-     * @exception UnsupportedOperationException if
+     * @throws UnsupportedOperationException if
      * {@code canWriteSequence} returns {@code false}.
-     * @exception IOException if an error occurs writing the stream
+     * @throws IOException if an error occurs writing the stream
      * metadata.
      */
     public void prepareWriteSequence(IIOMetadata streamMetadata)
@@ -732,16 +732,16 @@ public abstract class ImageWriter implements ImageTranscoder {
      * {@code null} to use a default
      * {@code ImageWriteParam}.
      *
-     * @exception IllegalStateException if the output has not
+     * @throws IllegalStateException if the output has not
      * been set, or {@code prepareWriteSequence} has not been called.
-     * @exception UnsupportedOperationException if
+     * @throws UnsupportedOperationException if
      * {@code canWriteSequence} returns {@code false}.
-     * @exception IllegalArgumentException if {@code image} is
+     * @throws IllegalArgumentException if {@code image} is
      * {@code null}.
-     * @exception UnsupportedOperationException if {@code image}
+     * @throws UnsupportedOperationException if {@code image}
      * contains a {@code Raster} and {@code canWriteRasters}
      * returns {@code false}.
-     * @exception IOException if an error occurs during writing.
+     * @throws IOException if an error occurs during writing.
      */
     public void writeToSequence(IIOImage image, ImageWriteParam param)
         throws IOException {
@@ -767,11 +767,11 @@ public abstract class ImageWriter implements ImageTranscoder {
      * {@code null}, and otherwise throws an
      * {@code UnsupportedOperationException}.
      *
-     * @exception IllegalStateException if the output has not
+     * @throws IllegalStateException if the output has not
      * been set, or {@code prepareWriteSequence} has not been called.
-     * @exception UnsupportedOperationException if
+     * @throws UnsupportedOperationException if
      * {@code canWriteSequence} returns {@code false}.
-     * @exception IOException if an error occurs during writing.
+     * @throws IOException if an error occurs during writing.
      */
     public void endWriteSequence() throws IOException {
         unsupported();
@@ -790,9 +790,9 @@ public abstract class ImageWriter implements ImageTranscoder {
      * @return {@code true} if replacement of stream metadata is
      * allowed.
      *
-     * @exception IllegalStateException if the output has not
+     * @throws IllegalStateException if the output has not
      * been set.
-     * @exception IOException if an I/O error occurs during the query.
+     * @throws IOException if an I/O error occurs during the query.
      */
     public boolean canReplaceStreamMetadata() throws IOException {
         if (getOutput() == null) {
@@ -821,12 +821,12 @@ public abstract class ImageWriter implements ImageTranscoder {
      * @param streamMetadata an {@code IIOMetadata} object representing
      * stream metadata, or {@code null} to use default values.
      *
-     * @exception IllegalStateException if the output has not
+     * @throws IllegalStateException if the output has not
      * been set.
-     * @exception UnsupportedOperationException if the
+     * @throws UnsupportedOperationException if the
      * {@code canReplaceStreamMetadata} returns
      * {@code false}.  modes do not include
-     * @exception IOException if an error occurs during writing.
+     * @throws IOException if an error occurs during writing.
      */
     public void replaceStreamMetadata(IIOMetadata streamMetadata)
         throws IOException {
@@ -856,13 +856,13 @@ public abstract class ImageWriter implements ImageTranscoder {
      * @return {@code true} if the image metadata of the given
      * image can be replaced.
      *
-     * @exception IllegalStateException if the output has not
+     * @throws IllegalStateException if the output has not
      * been set.
-     * @exception IndexOutOfBoundsException if the writer supports
+     * @throws IndexOutOfBoundsException if the writer supports
      * image metadata replacement in general, but
      * {@code imageIndex} is less than 0 or greater than the
      * largest available index.
-     * @exception IOException if an I/O error occurs during the query.
+     * @throws IOException if an I/O error occurs during the query.
      */
     public boolean canReplaceImageMetadata(int imageIndex)
         throws IOException {
@@ -889,14 +889,14 @@ public abstract class ImageWriter implements ImageTranscoder {
      * @param imageMetadata an {@code IIOMetadata} object
      * representing image metadata, or {@code null}.
      *
-     * @exception IllegalStateException if the output has not been
+     * @throws IllegalStateException if the output has not been
      * set.
-     * @exception UnsupportedOperationException if
+     * @throws UnsupportedOperationException if
      * {@code canReplaceImageMetadata} returns
      * {@code false}.
-     * @exception IndexOutOfBoundsException if {@code imageIndex}
+     * @throws IndexOutOfBoundsException if {@code imageIndex}
      * is less than 0 or greater than the largest available index.
-     * @exception IOException if an error occurs during writing.
+     * @throws IOException if an error occurs during writing.
      */
     public void replaceImageMetadata(int imageIndex,
                                      IIOMetadata imageMetadata)
@@ -929,12 +929,12 @@ public abstract class ImageWriter implements ImageTranscoder {
      * @return {@code true} if an image may be inserted at the
      * given index.
      *
-     * @exception IllegalStateException if the output has not
+     * @throws IllegalStateException if the output has not
      * been set.
-     * @exception IndexOutOfBoundsException if the writer supports
+     * @throws IndexOutOfBoundsException if the writer supports
      * image insertion in general, but {@code imageIndex} is less
      * than -1 or greater than the largest available index.
-     * @exception IOException if an I/O error occurs during the query.
+     * @throws IOException if an I/O error occurs during the query.
      */
     public boolean canInsertImage(int imageIndex) throws IOException {
         if (getOutput() == null) {
@@ -978,18 +978,18 @@ public abstract class ImageWriter implements ImageTranscoder {
      * {@code null} to use a default
      * {@code ImageWriteParam}.
      *
-     * @exception IllegalStateException if the output has not
+     * @throws IllegalStateException if the output has not
      * been set.
-     * @exception UnsupportedOperationException if
+     * @throws UnsupportedOperationException if
      * {@code canInsertImage(imageIndex)} returns {@code false}.
-     * @exception IllegalArgumentException if {@code image} is
+     * @throws IllegalArgumentException if {@code image} is
      * {@code null}.
-     * @exception IndexOutOfBoundsException if {@code imageIndex}
+     * @throws IndexOutOfBoundsException if {@code imageIndex}
      * is less than -1 or greater than the largest available index.
-     * @exception UnsupportedOperationException if {@code image}
+     * @throws UnsupportedOperationException if {@code image}
      * contains a {@code Raster} and {@code canWriteRasters}
      * returns {@code false}.
-     * @exception IOException if an error occurs during writing.
+     * @throws IOException if an error occurs during writing.
      */
     public void writeInsert(int imageIndex,
                             IIOImage image,
@@ -1019,12 +1019,12 @@ public abstract class ImageWriter implements ImageTranscoder {
      * @return {@code true} if it is possible to remove the given
      * image.
      *
-     * @exception IllegalStateException if the output has not
+     * @throws IllegalStateException if the output has not
      * been set.
-     * @exception IndexOutOfBoundsException if the writer supports
+     * @throws IndexOutOfBoundsException if the writer supports
      * image removal in general, but {@code imageIndex} is less
      * than 0 or greater than the largest available index.
-     * @exception IOException if an I/O error occurs during the
+     * @throws IOException if an I/O error occurs during the
      * query.
      */
     public boolean canRemoveImage(int imageIndex) throws IOException {
@@ -1050,13 +1050,13 @@ public abstract class ImageWriter implements ImageTranscoder {
      *
      * @param imageIndex the index of the image to be removed.
      *
-     * @exception IllegalStateException if the output has not
+     * @throws IllegalStateException if the output has not
      * been set.
-     * @exception UnsupportedOperationException if
+     * @throws UnsupportedOperationException if
      * {@code canRemoveImage(imageIndex)} returns {@code false}.
-     * @exception IndexOutOfBoundsException if {@code imageIndex}
+     * @throws IndexOutOfBoundsException if {@code imageIndex}
      * is less than 0 or greater than the largest available index.
-     * @exception IOException if an I/O error occurs during the
+     * @throws IOException if an I/O error occurs during the
      * removal.
      */
     public void removeImage(int imageIndex) throws IOException {
@@ -1082,9 +1082,9 @@ public abstract class ImageWriter implements ImageTranscoder {
      * @return {@code true} if the writing of complete image
      * stream with contents to be defined later is supported.
      *
-     * @exception IllegalStateException if the output has not been
+     * @throws IllegalStateException if the output has not been
      * set.
-     * @exception IOException if an I/O error occurs during the
+     * @throws IOException if an I/O error occurs during the
      * query.
      */
     public boolean canWriteEmpty() throws IOException {
@@ -1144,23 +1144,23 @@ public abstract class ImageWriter implements ImageTranscoder {
      * {@code null} to use a default
      * {@code ImageWriteParam}.
      *
-     * @exception IllegalStateException if the output has not
+     * @throws IllegalStateException if the output has not
      * been set.
-     * @exception UnsupportedOperationException if
+     * @throws UnsupportedOperationException if
      * {@code canWriteEmpty} returns {@code false}.
-     * @exception IllegalStateException if a previous call to
+     * @throws IllegalStateException if a previous call to
      * {@code prepareWriteEmpty} has been made without a
      * corresponding call to {@code endWriteEmpty}.
-     * @exception IllegalStateException if a previous call to
+     * @throws IllegalStateException if a previous call to
      * {@code prepareInsertEmpty} has been made without a
      * corresponding call to {@code endInsertEmpty}.
-     * @exception IllegalArgumentException if {@code imageType}
+     * @throws IllegalArgumentException if {@code imageType}
      * is {@code null} or {@code thumbnails} contains
      * {@code null} references or objects other than
      * {@code BufferedImage}s.
-     * @exception IllegalArgumentException if width or height are less
+     * @throws IllegalArgumentException if width or height are less
      * than 1.
-     * @exception IOException if an I/O error occurs during writing.
+     * @throws IOException if an I/O error occurs during writing.
      */
     public void prepareWriteEmpty(IIOMetadata streamMetadata,
                                   ImageTypeSpecifier imageType,
@@ -1183,21 +1183,21 @@ public abstract class ImageWriter implements ImageTranscoder {
      * {@code null}, and otherwise throws an
      * {@code UnsupportedOperationException}.
      *
-     * @exception IllegalStateException if the output has not
+     * @throws IllegalStateException if the output has not
      * been set.
-     * @exception UnsupportedOperationException if
+     * @throws UnsupportedOperationException if
      * {@code canWriteEmpty(imageIndex)} returns
      * {@code false}.
-     * @exception IllegalStateException if a previous call to
+     * @throws IllegalStateException if a previous call to
      * {@code prepareWriteEmpty} without a corresponding call to
      * {@code endWriteEmpty} has not been made.
-     * @exception IllegalStateException if a previous call to
+     * @throws IllegalStateException if a previous call to
      * {@code prepareInsertEmpty} without a corresponding call to
      * {@code endInsertEmpty} has been made.
-     * @exception IllegalStateException if a call to
+     * @throws IllegalStateException if a call to
      * {@code prepareReiplacePixels} has been made without a
      * matching call to {@code endReplacePixels}.
-     * @exception IOException if an I/O error occurs during writing.
+     * @throws IOException if an I/O error occurs during writing.
      */
     public void endWriteEmpty() throws IOException {
         if (getOutput() == null) {
@@ -1231,12 +1231,12 @@ public abstract class ImageWriter implements ImageTranscoder {
      * @return {@code true} if an empty image may be inserted at
      * the given index.
      *
-     * @exception IllegalStateException if the output has not been
+     * @throws IllegalStateException if the output has not been
      * set.
-     * @exception IndexOutOfBoundsException if the writer supports
+     * @throws IndexOutOfBoundsException if the writer supports
      * empty image insertion in general, but {@code imageIndex}
      * is less than -1 or greater than the largest available index.
-     * @exception IOException if an I/O error occurs during the
+     * @throws IOException if an I/O error occurs during the
      * query.
      */
     public boolean canInsertEmpty(int imageIndex) throws IOException {
@@ -1301,26 +1301,26 @@ public abstract class ImageWriter implements ImageTranscoder {
      * {@code null} to use a default
      * {@code ImageWriteParam}.
      *
-     * @exception IllegalStateException if the output has not
+     * @throws IllegalStateException if the output has not
      * been set.
-     * @exception UnsupportedOperationException if
+     * @throws UnsupportedOperationException if
      * {@code canInsertEmpty(imageIndex)} returns
      * {@code false}.
-     * @exception IndexOutOfBoundsException if {@code imageIndex}
+     * @throws IndexOutOfBoundsException if {@code imageIndex}
      * is less than -1 or greater than the largest available index.
-     * @exception IllegalStateException if a previous call to
+     * @throws IllegalStateException if a previous call to
      * {@code prepareInsertEmpty} has been made without a
      * corresponding call to {@code endInsertEmpty}.
-     * @exception IllegalStateException if a previous call to
+     * @throws IllegalStateException if a previous call to
      * {@code prepareWriteEmpty} has been made without a
      * corresponding call to {@code endWriteEmpty}.
-     * @exception IllegalArgumentException if {@code imageType}
+     * @throws IllegalArgumentException if {@code imageType}
      * is {@code null} or {@code thumbnails} contains
      * {@code null} references or objects other than
      * {@code BufferedImage}s.
-     * @exception IllegalArgumentException if width or height are less
+     * @throws IllegalArgumentException if width or height are less
      * than 1.
-     * @exception IOException if an I/O error occurs during writing.
+     * @throws IOException if an I/O error occurs during writing.
      */
     public void prepareInsertEmpty(int imageIndex,
                                    ImageTypeSpecifier imageType,
@@ -1340,21 +1340,21 @@ public abstract class ImageWriter implements ImageTranscoder {
      * {@code null}, and otherwise throws an
      * {@code UnsupportedOperationException}.
      *
-     * @exception IllegalStateException if the output has not
+     * @throws IllegalStateException if the output has not
      * been set.
-     * @exception UnsupportedOperationException if
+     * @throws UnsupportedOperationException if
      * {@code canInsertEmpty(imageIndex)} returns
      * {@code false}.
-     * @exception IllegalStateException if a previous call to
+     * @throws IllegalStateException if a previous call to
      * {@code prepareInsertEmpty} without a corresponding call to
      * {@code endInsertEmpty} has not been made.
-     * @exception IllegalStateException if a previous call to
+     * @throws IllegalStateException if a previous call to
      * {@code prepareWriteEmpty} without a corresponding call to
      * {@code endWriteEmpty} has been made.
-     * @exception IllegalStateException if a call to
+     * @throws IllegalStateException if a call to
      * {@code prepareReplacePixels} has been made without a
      * matching call to {@code endReplacePixels}.
-     * @exception IOException if an I/O error occurs during writing.
+     * @throws IOException if an I/O error occurs during writing.
      */
     public void endInsertEmpty() throws IOException {
         unsupported();
@@ -1382,12 +1382,12 @@ public abstract class ImageWriter implements ImageTranscoder {
      * @return {@code true} if the pixels of the given
      * image can be replaced.
      *
-     * @exception IllegalStateException if the output has not been
+     * @throws IllegalStateException if the output has not been
      * set.
-     * @exception IndexOutOfBoundsException if the writer supports
+     * @throws IndexOutOfBoundsException if the writer supports
      * pixel replacement in general, but {@code imageIndex} is
      * less than 0 or greater than the largest available index.
-     * @exception IOException if an I/O error occurs during the query.
+     * @throws IOException if an I/O error occurs during the query.
      */
     public boolean canReplacePixels(int imageIndex) throws IOException {
         if (getOutput() == null) {
@@ -1415,20 +1415,20 @@ public abstract class ImageWriter implements ImageTranscoder {
      * @param region a {@code Rectangle} that will be used to clip
      * future pixel regions.
      *
-     * @exception IllegalStateException if the output has not
+     * @throws IllegalStateException if the output has not
      * been set.
-     * @exception UnsupportedOperationException if
+     * @throws UnsupportedOperationException if
      * {@code canReplacePixels(imageIndex)} returns
      * {@code false}.
-     * @exception IndexOutOfBoundsException if {@code imageIndex}
+     * @throws IndexOutOfBoundsException if {@code imageIndex}
      * is less than 0 or greater than the largest available index.
-     * @exception IllegalStateException if there is a previous call to
+     * @throws IllegalStateException if there is a previous call to
      * {@code prepareReplacePixels} without a matching call to
      * {@code endReplacePixels} (<i>i.e.</i>, nesting is not
      * allowed).
-     * @exception IllegalArgumentException if {@code region} is
+     * @throws IllegalArgumentException if {@code region} is
      * {@code null} or has a width or height less than 1.
-     * @exception IOException if an I/O error occurs during the
+     * @throws IOException if an I/O error occurs during the
      * preparation.
      */
     public void prepareReplacePixels(int imageIndex,
@@ -1471,22 +1471,22 @@ public abstract class ImageWriter implements ImageTranscoder {
      * {@code null} to use a default
      * {@code ImageWriteParam}.
      *
-     * @exception IllegalStateException if the output has not
+     * @throws IllegalStateException if the output has not
      * been set.
-     * @exception UnsupportedOperationException if
+     * @throws UnsupportedOperationException if
      * {@code canReplacePixels(imageIndex)} returns
      * {@code false}.
-     * @exception IllegalStateException if there is no previous call to
+     * @throws IllegalStateException if there is no previous call to
      * {@code prepareReplacePixels} without a matching call to
      * {@code endReplacePixels}.
-     * @exception IllegalArgumentException if any of the following are true:
+     * @throws IllegalArgumentException if any of the following are true:
      * <ul>
      * <li> {@code image} is {@code null}.
      * <li> the intersected region does not contain at least one pixel.
      * <li> the layout of {@code image} does not match, or this
      * writer cannot convert it to, the existing image layout.
      * </ul>
-     * @exception IOException if an I/O error occurs during writing.
+     * @throws IOException if an I/O error occurs during writing.
      */
     public void replacePixels(RenderedImage image, ImageWriteParam param)
         throws IOException {
@@ -1529,24 +1529,24 @@ public abstract class ImageWriter implements ImageTranscoder {
      * {@code null} to use a default
      * {@code ImageWriteParam}.
      *
-     * @exception IllegalStateException if the output has not
+     * @throws IllegalStateException if the output has not
      * been set.
-     * @exception UnsupportedOperationException if
+     * @throws UnsupportedOperationException if
      * {@code canReplacePixels(imageIndex)} returns
      * {@code false}.
-     * @exception IllegalStateException if there is no previous call to
+     * @throws IllegalStateException if there is no previous call to
      * {@code prepareReplacePixels} without a matching call to
      * {@code endReplacePixels}.
-     * @exception UnsupportedOperationException if
+     * @throws UnsupportedOperationException if
      * {@code canWriteRasters} returns {@code false}.
-     * @exception IllegalArgumentException if any of the following are true:
+     * @throws IllegalArgumentException if any of the following are true:
      * <ul>
      * <li> {@code raster} is {@code null}.
      * <li> the intersected region does not contain at least one pixel.
      * <li> the layout of {@code raster} does not match, or this
      * writer cannot convert it to, the existing image layout.
      * </ul>
-     * @exception IOException if an I/O error occurs during writing.
+     * @throws IOException if an I/O error occurs during writing.
      */
     public void replacePixels(Raster raster, ImageWriteParam param)
         throws IOException {
@@ -1565,15 +1565,15 @@ public abstract class ImageWriter implements ImageTranscoder {
      * {@code null}, and otherwise throws an
      * {@code UnsupportedOperationException}.
      *
-     * @exception IllegalStateException if the output has not
+     * @throws IllegalStateException if the output has not
      * been set.
-     * @exception UnsupportedOperationException if
+     * @throws UnsupportedOperationException if
      * {@code canReplacePixels(imageIndex)} returns
      * {@code false}.
-     * @exception IllegalStateException if there is no previous call
+     * @throws IllegalStateException if there is no previous call
      * to {@code prepareReplacePixels} without a matching call to
      * {@code endReplacePixels}.
-     * @exception IOException if an I/O error occurs during writing.
+     * @throws IOException if an I/O error occurs during writing.
      */
     public void endReplacePixels() throws IOException {
         unsupported();
@@ -1886,7 +1886,7 @@ public abstract class ImageWriter implements ImageTranscoder {
      * occurred.
      * @param warning the warning message.
      *
-     * @exception IllegalArgumentException if {@code warning}
+     * @throws IllegalArgumentException if {@code warning}
      * is {@code null}.
      */
     protected void processWarningOccurred(int imageIndex,
@@ -1921,15 +1921,15 @@ public abstract class ImageWriter implements ImageTranscoder {
      * @param keyword the keyword used to index the warning message
      * within the set of {@code ResourceBundle}s.
      *
-     * @exception IllegalArgumentException if {@code baseName}
+     * @throws IllegalArgumentException if {@code baseName}
      * is {@code null}.
-     * @exception IllegalArgumentException if {@code keyword}
+     * @throws IllegalArgumentException if {@code keyword}
      * is {@code null}.
-     * @exception IllegalArgumentException if no appropriate
+     * @throws IllegalArgumentException if no appropriate
      * {@code ResourceBundle} may be located.
-     * @exception IllegalArgumentException if the named resource is
+     * @throws IllegalArgumentException if the named resource is
      * not found in the located {@code ResourceBundle}.
-     * @exception IllegalArgumentException if the object retrieved
+     * @throws IllegalArgumentException if the object retrieved
      * from the {@code ResourceBundle} is not a
      * {@code String}.
      */

--- a/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadata.java
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadata.java
@@ -165,9 +165,9 @@ public abstract class IIOMetadata {
      * indicating the class names of any additional formats supported by
      * this object, or {@code null} if there are none.
      *
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      * {@code extraMetadataFormatNames} has length 0.
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      * {@code extraMetadataFormatNames} and
      * {@code extraMetadataFormatClassNames} are neither both
      * {@code null}, nor of the same length.
@@ -368,10 +368,10 @@ public abstract class IIOMetadata {
      *
      * @return an {@code IIOMetadataFormat} object.
      *
-     * @exception IllegalArgumentException if {@code formatName}
+     * @throws IllegalArgumentException if {@code formatName}
      * is {@code null} or is not one of the names recognized by
      * the plug-in.
-     * @exception IllegalStateException if the class corresponding to
+     * @throws IllegalStateException if the class corresponding to
      * the format name cannot be loaded.
      */
     public IIOMetadataFormat getMetadataFormat(String formatName) {
@@ -452,7 +452,7 @@ public abstract class IIOMetadata {
      * @return an XML DOM {@code Node} object forming the
      * root of a tree.
      *
-     * @exception IllegalArgumentException if {@code formatName}
+     * @throws IllegalArgumentException if {@code formatName}
      * is {@code null} or is not one of the names returned by
      * {@code getMetadataFormatNames}.
      *
@@ -481,13 +481,13 @@ public abstract class IIOMetadata {
      * @param root an XML DOM {@code Node} object forming the
      * root of a tree.
      *
-     * @exception IllegalStateException if this object is read-only.
-     * @exception IllegalArgumentException if {@code formatName}
+     * @throws IllegalStateException if this object is read-only.
+     * @throws IllegalArgumentException if {@code formatName}
      * is {@code null} or is not one of the names returned by
      * {@code getMetadataFormatNames}.
-     * @exception IllegalArgumentException if {@code root} is
+     * @throws IllegalArgumentException if {@code root} is
      * {@code null}.
-     * @exception IIOInvalidTreeException if the tree cannot be parsed
+     * @throws IIOInvalidTreeException if the tree cannot be parsed
      * successfully using the rules of the given format.
      *
      * @see #getMetadataFormatNames
@@ -731,13 +731,13 @@ public abstract class IIOMetadata {
      * @param root an XML DOM {@code Node} object forming the
      * root of a tree.
      *
-     * @exception IllegalStateException if this object is read-only.
-     * @exception IllegalArgumentException if {@code formatName}
+     * @throws IllegalStateException if this object is read-only.
+     * @throws IllegalArgumentException if {@code formatName}
      * is {@code null} or is not one of the names returned by
      * {@code getMetadataFormatNames}.
-     * @exception IllegalArgumentException if {@code root} is
+     * @throws IllegalArgumentException if {@code root} is
      * {@code null}.
-     * @exception IIOInvalidTreeException if the tree cannot be parsed
+     * @throws IIOInvalidTreeException if the tree cannot be parsed
      * successfully using the rules of the given format.
      *
      * @see #getMetadataFormatNames
@@ -757,7 +757,7 @@ public abstract class IIOMetadata {
      * Note that there are many possible default values, depending on
      * how the object was created.
      *
-     * @exception IllegalStateException if this object is read-only.
+     * @throws IllegalStateException if this object is read-only.
      *
      * @see javax.imageio.ImageReader#getStreamMetadata
      * @see javax.imageio.ImageReader#getImageMetadata
@@ -873,7 +873,7 @@ public abstract class IIOMetadata {
      *
      * @return {@code true} if the controller completed normally.
      *
-     * @exception IllegalStateException if there is no controller
+     * @throws IllegalStateException if there is no controller
      * currently installed.
      *
      * @see IIOMetadataController

--- a/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadataController.java
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadataController.java
@@ -79,7 +79,7 @@ public interface IIOMetadataController {
      * @return {@code true} if the {@code IIOMetadata} has been
      * modified, {@code false} otherwise.
      *
-     * @exception IllegalArgumentException if {@code metadata} is
+     * @throws IllegalArgumentException if {@code metadata} is
      * {@code null} or is not an instance of the correct class.
      */
     boolean activate(IIOMetadata metadata);

--- a/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadataFormat.java
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadataFormat.java
@@ -319,10 +319,10 @@ public interface IIOMetadataFormat {
      *
      * @return an {@code int}.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null} or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if the named element does
+     * @throws IllegalArgumentException if the named element does
      * not have a child policy of {@code CHILD_POLICY_REPEAT}.
      */
     int getElementMinChildren(String elementName);
@@ -339,10 +339,10 @@ public interface IIOMetadataFormat {
      *
      * @return an {@code int}.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null} or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if the named element does
+     * @throws IllegalArgumentException if the named element does
      * not have a child policy of {@code CHILD_POLICY_REPEAT}.
      */
     int getElementMaxChildren(String elementName);
@@ -362,7 +362,7 @@ public interface IIOMetadataFormat {
      *
      * @return the element description.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null}, or is not a legal element name for this format.
      */
     String getElementDescription(String elementName, Locale locale);
@@ -378,7 +378,7 @@ public interface IIOMetadataFormat {
      *
      * @return one of the {@code CHILD_POLICY_*} constants.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null} or is not a legal element name for this
      * format.
      */
@@ -394,7 +394,7 @@ public interface IIOMetadataFormat {
      *
      * @return an array of {@code String}s, or null.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null} or is not a legal element name for this
      * format.
      */
@@ -410,7 +410,7 @@ public interface IIOMetadataFormat {
      *
      * @return an array of {@code String}s.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null} or is not a legal element name for this
      * format.
      */
@@ -428,10 +428,10 @@ public interface IIOMetadataFormat {
      *
      * @return one of the {@code VALUE_*} constants.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null} or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if {@code attrName} is
+     * @throws IllegalArgumentException if {@code attrName} is
      * {@code null} or is not a legal attribute name for this
      * element.
      */
@@ -450,10 +450,10 @@ public interface IIOMetadataFormat {
      *
      * @return one of the {@code DATATYPE_*} constants.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null} or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if {@code attrName} is
+     * @throws IllegalArgumentException if {@code attrName} is
      * {@code null} or is not a legal attribute name for this
      * element.
      */
@@ -468,10 +468,10 @@ public interface IIOMetadataFormat {
      *
      * @return {@code true} if the attribute must be present.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null} or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if {@code attrName} is
+     * @throws IllegalArgumentException if {@code attrName} is
      * {@code null} or is not a legal attribute name for this
      * element.
      */
@@ -489,10 +489,10 @@ public interface IIOMetadataFormat {
      * @return a {@code String} containing the default value, or
      * {@code null}.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null} or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if {@code attrName} is
+     * @throws IllegalArgumentException if {@code attrName} is
      * {@code null} or is not a legal attribute name for this
      * element.
      */
@@ -510,13 +510,13 @@ public interface IIOMetadataFormat {
      *
      * @return an array of {@code String}s.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null} or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if {@code attrName} is
+     * @throws IllegalArgumentException if {@code attrName} is
      * {@code null} or is not a legal attribute name for this
      * element.
-     * @exception IllegalArgumentException if the given attribute is
+     * @throws IllegalArgumentException if the given attribute is
      * not defined as an enumeration.
      */
     String[] getAttributeEnumerations(String elementName, String attrName);
@@ -537,13 +537,13 @@ public interface IIOMetadataFormat {
      * @return a {@code String} containing the smallest legal
      * value for the attribute.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null} or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if {@code attrName} is
+     * @throws IllegalArgumentException if {@code attrName} is
      * {@code null} or is not a legal attribute name for this
      * element.
-     * @exception IllegalArgumentException if the given attribute is
+     * @throws IllegalArgumentException if the given attribute is
      * not defined as a range.
      */
     String getAttributeMinValue(String elementName, String attrName);
@@ -565,13 +565,13 @@ public interface IIOMetadataFormat {
      * @return a {@code String} containing the largest legal
      * value for the attribute.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null} or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if {@code attrName} is
+     * @throws IllegalArgumentException if {@code attrName} is
      * {@code null} or is not a legal attribute name for this
      * element.
-     * @exception IllegalArgumentException if the given attribute is
+     * @throws IllegalArgumentException if the given attribute is
      * not defined as a range.
      */
     String getAttributeMaxValue(String elementName, String attrName);
@@ -590,13 +590,13 @@ public interface IIOMetadataFormat {
      * @return the smallest legal number of list items for the
      * attribute.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null} or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if {@code attrName} is
+     * @throws IllegalArgumentException if {@code attrName} is
      * {@code null} or is not a legal attribute name for this
      * element.
-     * @exception IllegalArgumentException if the given attribute is
+     * @throws IllegalArgumentException if the given attribute is
      * not defined as a list.
      */
     int getAttributeListMinLength(String elementName, String attrName);
@@ -617,13 +617,13 @@ public interface IIOMetadataFormat {
      * @return the largest legal number of list items for the
      * attribute.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null} or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if {@code attrName} is
+     * @throws IllegalArgumentException if {@code attrName} is
      * {@code null} or is not a legal attribute name for this
      * element.
-     * @exception IllegalArgumentException if the given attribute is
+     * @throws IllegalArgumentException if the given attribute is
      * not defined as a list.
      */
     int getAttributeListMaxLength(String elementName, String attrName);
@@ -644,9 +644,9 @@ public interface IIOMetadataFormat {
      *
      * @return the attribute description.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null}, or is not a legal element name for this format.
-     * @exception IllegalArgumentException if {@code attrName} is
+     * @throws IllegalArgumentException if {@code attrName} is
      * {@code null} or is not a legal attribute name for this
      * element.
      */
@@ -671,7 +671,7 @@ public interface IIOMetadataFormat {
      *
      * @return one of the {@code VALUE_*} constants.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null} or is not a legal element name for this
      * format.
      *
@@ -696,10 +696,10 @@ public interface IIOMetadataFormat {
      *
      * @return a {@code Class} object.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null} or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if the named element cannot
+     * @throws IllegalArgumentException if the named element cannot
      * contain an object value (<i>i.e.</i>, if
      * {@code getObjectValueType(elementName) == VALUE_NONE}).
      */
@@ -714,10 +714,10 @@ public interface IIOMetadataFormat {
      *
      * @return an {@code Object}.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null} or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if the named element cannot
+     * @throws IllegalArgumentException if the named element cannot
      * contain an object value (<i>i.e.</i>, if
      * {@code getObjectValueType(elementName) == VALUE_NONE}).
      */
@@ -739,13 +739,13 @@ public interface IIOMetadataFormat {
      *
      * @return an array of {@code Object}s.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null} or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if the named element cannot
+     * @throws IllegalArgumentException if the named element cannot
      * contain an object value (<i>i.e.</i>, if
      * {@code getObjectValueType(elementName) == VALUE_NONE}).
-     * @exception IllegalArgumentException if the {@code Object}
+     * @throws IllegalArgumentException if the {@code Object}
      * is not defined as an enumeration.
      */
     Object[] getObjectEnumerations(String elementName);
@@ -762,13 +762,13 @@ public interface IIOMetadataFormat {
      *
      * @return the smallest legal value for the attribute.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null} or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if the named element cannot
+     * @throws IllegalArgumentException if the named element cannot
      * contain an object value (<i>i.e.</i>, if
      * {@code getObjectValueType(elementName) == VALUE_NONE}).
-     * @exception IllegalArgumentException if the {@code Object}
+     * @throws IllegalArgumentException if the {@code Object}
      * is not defined as a range.
      */
     Comparable<?> getObjectMinValue(String elementName);
@@ -785,13 +785,13 @@ public interface IIOMetadataFormat {
      *
      * @param elementName the name of the element being queried.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null} or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if the named element cannot
+     * @throws IllegalArgumentException if the named element cannot
      * contain an object value (<i>i.e.</i>, if
      * {@code getObjectValueType(elementName) == VALUE_NONE}).
-     * @exception IllegalArgumentException if the {@code Object}
+     * @throws IllegalArgumentException if the {@code Object}
      * is not defined as a range.
      */
     Comparable<?> getObjectMaxValue(String elementName);
@@ -808,13 +808,13 @@ public interface IIOMetadataFormat {
      * @return the smallest valid array length for the
      * {@code Object} reference.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null} or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if the named element cannot
+     * @throws IllegalArgumentException if the named element cannot
      * contain an object value (<i>i.e.</i>, if
      * {@code getObjectValueType(elementName) == VALUE_NONE}).
-     * @exception IllegalArgumentException if the {@code Object} is not
+     * @throws IllegalArgumentException if the {@code Object} is not
      * an array.
      */
     int getObjectArrayMinLength(String elementName);
@@ -832,13 +832,13 @@ public interface IIOMetadataFormat {
      * @return the largest valid array length for the
      * {@code Object} reference.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null} or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if the named element cannot
+     * @throws IllegalArgumentException if the named element cannot
      * contain an object value (<i>i.e.</i>, if
      * {@code getObjectValueType(elementName) == VALUE_NONE}).
-     * @exception IllegalArgumentException if the {@code Object} is not
+     * @throws IllegalArgumentException if the {@code Object} is not
      * an array.
      */
     int getObjectArrayMaxLength(String elementName);

--- a/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadataFormatImpl.java
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadataFormatImpl.java
@@ -160,9 +160,9 @@ public abstract class IIOMetadataFormatImpl implements IIOMetadataFormat {
      * @param childPolicy one of the {@code CHILD_POLICY_*} constants,
      * other than {@code CHILD_POLICY_REPEAT}.
      *
-     * @exception IllegalArgumentException if {@code rootName} is
+     * @throws IllegalArgumentException if {@code rootName} is
      * {@code null}.
-     * @exception IllegalArgumentException if {@code childPolicy} is
+     * @throws IllegalArgumentException if {@code childPolicy} is
      * not one of the predefined constants.
      */
     public IIOMetadataFormatImpl(String rootName,
@@ -196,9 +196,9 @@ public abstract class IIOMetadataFormatImpl implements IIOMetadataFormat {
      * @param minChildren the minimum number of children of the node.
      * @param maxChildren the maximum number of children of the node.
      *
-     * @exception IllegalArgumentException if {@code rootName} is
+     * @throws IllegalArgumentException if {@code rootName} is
      * {@code null}.
-     * @exception IllegalArgumentException if {@code minChildren}
+     * @throws IllegalArgumentException if {@code minChildren}
      * is negative or larger than {@code maxChildren}.
      */
     public IIOMetadataFormatImpl(String rootName,
@@ -236,7 +236,7 @@ public abstract class IIOMetadataFormatImpl implements IIOMetadataFormat {
      * @param resourceBaseName a {@code String} containing the new
      * base name.
      *
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      * {@code resourceBaseName} is {@code null}.
      *
      * @see #getResourceBaseName
@@ -307,10 +307,10 @@ public abstract class IIOMetadataFormatImpl implements IIOMetadataFormat {
      * constants, other than {@code CHILD_POLICY_REPEAT},
      * indicating the child policy of the new element.
      *
-     * @exception IllegalArgumentException if {@code parentName}
+     * @throws IllegalArgumentException if {@code parentName}
      * is {@code null}, or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if {@code childPolicy}
+     * @throws IllegalArgumentException if {@code childPolicy}
      * is not one of the predefined constants.
      */
     protected void addElement(String elementName,
@@ -344,10 +344,10 @@ public abstract class IIOMetadataFormatImpl implements IIOMetadataFormat {
      * @param minChildren the minimum number of children of the node.
      * @param maxChildren the maximum number of children of the node.
      *
-     * @exception IllegalArgumentException if {@code parentName}
+     * @throws IllegalArgumentException if {@code parentName}
      * is {@code null}, or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if {@code minChildren}
+     * @throws IllegalArgumentException if {@code minChildren}
      * is negative or larger than {@code maxChildren}.
      */
     protected void addElement(String elementName,
@@ -383,10 +383,10 @@ public abstract class IIOMetadataFormatImpl implements IIOMetadataFormat {
      * @param elementName the name of the element to be added as a
      * child.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null}, or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if {@code parentName}
+     * @throws IllegalArgumentException if {@code parentName}
      * is {@code null}, or is not a legal element name for this
      * format.
      */
@@ -429,12 +429,12 @@ public abstract class IIOMetadataFormatImpl implements IIOMetadataFormat {
      * @param defaultValue the default value for the attribute, or
      * {@code null}.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null}, or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if {@code attrName} is
+     * @throws IllegalArgumentException if {@code attrName} is
      * {@code null}.
-     * @exception IllegalArgumentException if {@code dataType} is
+     * @throws IllegalArgumentException if {@code dataType} is
      * not one of the predefined constants.
      */
     protected void addAttribute(String elementName,
@@ -476,19 +476,19 @@ public abstract class IIOMetadataFormatImpl implements IIOMetadataFormat {
      * {@code String}s containing the legal values for the
      * attribute.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null}, or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if {@code attrName} is
+     * @throws IllegalArgumentException if {@code attrName} is
      * {@code null}.
-     * @exception IllegalArgumentException if {@code dataType} is
+     * @throws IllegalArgumentException if {@code dataType} is
      * not one of the predefined constants.
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      * {@code enumeratedValues} is {@code null}.
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      * {@code enumeratedValues} does not contain at least one
      * entry.
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      * {@code enumeratedValues} contains an element that is not a
      * {@code String} or is {@code null}.
      */
@@ -556,12 +556,12 @@ public abstract class IIOMetadataFormatImpl implements IIOMetadataFormat {
      * @param maxInclusive {@code true} if {@code maxValue}
      * is inclusive.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null}, or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if {@code attrName} is
+     * @throws IllegalArgumentException if {@code attrName} is
      * {@code null}.
-     * @exception IllegalArgumentException if {@code dataType} is
+     * @throws IllegalArgumentException if {@code dataType} is
      * not one of the predefined constants.
      */
     protected void addAttribute(String elementName,
@@ -612,14 +612,14 @@ public abstract class IIOMetadataFormatImpl implements IIOMetadataFormat {
      * @param listMinLength the smallest legal number of list items.
      * @param listMaxLength the largest legal number of list items.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null}, or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if {@code attrName} is
+     * @throws IllegalArgumentException if {@code attrName} is
      * {@code null}.
-     * @exception IllegalArgumentException if {@code dataType} is
+     * @throws IllegalArgumentException if {@code dataType} is
      * not one of the predefined constants.
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      * {@code listMinLength} is negative or larger than
      * {@code listMaxLength}.
      */
@@ -666,10 +666,10 @@ public abstract class IIOMetadataFormatImpl implements IIOMetadataFormat {
      * {@code boolean}, ignored if {@code hasDefaultValue}
      * is {@code false}.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null}, or is not a legal element name for this
      * format.
-     * @exception IllegalArgumentException if {@code attrName} is
+     * @throws IllegalArgumentException if {@code attrName} is
      * {@code null}.
      */
     protected void addBooleanAttribute(String elementName,
@@ -700,7 +700,7 @@ public abstract class IIOMetadataFormatImpl implements IIOMetadataFormat {
      * @param elementName the name of the element.
      * @param attrName the name of the attribute being removed.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null}, or is not a legal element name for this format.
      */
     protected void removeAttribute(String elementName, String attrName) {
@@ -726,7 +726,7 @@ public abstract class IIOMetadataFormatImpl implements IIOMetadataFormat {
      * {@code Object} reference, or {@code null}.
      * @param <T> the type of the object.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null}, or is not a legal element name for this format.
      */
     protected <T> void addObjectValue(String elementName,
@@ -763,14 +763,14 @@ public abstract class IIOMetadataFormatImpl implements IIOMetadataFormat {
      * object reference.
      * @param <T> the type of the object.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null}, or is not a legal element name for this format.
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      * {@code enumeratedValues} is {@code null}.
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      * {@code enumeratedValues} does not contain at least one
      * entry.
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      * {@code enumeratedValues} contains an element that is not
      * an instance of the class type denoted by {@code classType}
      * or is {@code null}.
@@ -833,7 +833,7 @@ public abstract class IIOMetadataFormatImpl implements IIOMetadataFormat {
      * is inclusive.
      * @param <T> the type of the object.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null}, or is not a legal element name for this
      * format.
      */
@@ -880,7 +880,7 @@ public abstract class IIOMetadataFormatImpl implements IIOMetadataFormat {
      * @param arrayMinLength the smallest legal length for the array.
      * @param arrayMaxLength the largest legal length for the array.
      *
-     * @exception IllegalArgumentException if {@code elementName} is
+     * @throws IllegalArgumentException if {@code elementName} is
      * not a legal element name for this format.
      */
     protected void addObjectValue(String elementName,
@@ -903,7 +903,7 @@ public abstract class IIOMetadataFormatImpl implements IIOMetadataFormat {
      *
      * @param elementName the name of the element.
      *
-     * @exception IllegalArgumentException if {@code elementName} is
+     * @throws IllegalArgumentException if {@code elementName} is
      * not a legal element name for this format.
      */
     protected void removeObjectValue(String elementName) {
@@ -990,7 +990,7 @@ public abstract class IIOMetadataFormatImpl implements IIOMetadataFormat {
      *
      * @return the element description.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null}, or is not a legal element name for this format.
      *
      * @see #setResourceBaseName
@@ -1130,9 +1130,9 @@ public abstract class IIOMetadataFormatImpl implements IIOMetadataFormat {
      *
      * @return the attribute description.
      *
-     * @exception IllegalArgumentException if {@code elementName}
+     * @throws IllegalArgumentException if {@code elementName}
      * is {@code null}, or is not a legal element name for this format.
-     * @exception IllegalArgumentException if {@code attrName} is
+     * @throws IllegalArgumentException if {@code attrName} is
      * {@code null} or is not a legal attribute name for this
      * element.
      *

--- a/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadataNode.java
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadataNode.java
@@ -464,7 +464,7 @@ public class IIOMetadataNode implements Element, NodeList {
      *
      * @return the node being inserted.
      *
-     * @exception IllegalArgumentException if {@code newChild} is
+     * @throws IllegalArgumentException if {@code newChild} is
      * {@code null}.
      */
     public Node insertBefore(Node newChild,
@@ -522,7 +522,7 @@ public class IIOMetadataNode implements Element, NodeList {
      *
      * @return the node replaced.
      *
-     * @exception IllegalArgumentException if {@code newChild} is
+     * @throws IllegalArgumentException if {@code newChild} is
      * {@code null}.
      */
     public Node replaceChild(Node newChild,
@@ -573,7 +573,7 @@ public class IIOMetadataNode implements Element, NodeList {
      *
      * @return the node removed.
      *
-     * @exception IllegalArgumentException if {@code oldChild} is
+     * @throws IllegalArgumentException if {@code oldChild} is
      * {@code null}.
      */
     public Node removeChild(Node oldChild) {
@@ -617,7 +617,7 @@ public class IIOMetadataNode implements Element, NodeList {
      *
      * @return the node added.
      *
-     * @exception IllegalArgumentException if {@code newChild} is
+     * @throws IllegalArgumentException if {@code newChild} is
      * {@code null}.
      */
     public Node appendChild(Node newChild) {

--- a/src/java.desktop/share/classes/javax/imageio/plugins/jpeg/JPEGImageReadParam.java
+++ b/src/java.desktop/share/classes/javax/imageio/plugins/jpeg/JPEGImageReadParam.java
@@ -113,7 +113,7 @@ public class JPEGImageReadParam extends ImageReadParam {
      * @param DCHuffmanTables an array of Huffman table objects.
      * @param ACHuffmanTables an array of Huffman table objects.
      *
-     * @exception IllegalArgumentException if any of the arguments
+     * @throws IllegalArgumentException if any of the arguments
      * is {@code null}, has more than 4 elements, or if the
      * numbers of DC and AC tables differ.
      *

--- a/src/java.desktop/share/classes/javax/imageio/plugins/jpeg/JPEGImageWriteParam.java
+++ b/src/java.desktop/share/classes/javax/imageio/plugins/jpeg/JPEGImageWriteParam.java
@@ -130,7 +130,7 @@ public class JPEGImageWriteParam extends ImageWriteParam {
      * <p> The default implementation resets the compression quality
      * to {@code 0.75F}.
      *
-     * @exception IllegalStateException if the compression mode is not
+     * @throws IllegalStateException if the compression mode is not
      * {@code MODE_EXPLICIT}.
      */
     public void unsetCompression() {
@@ -147,7 +147,7 @@ public class JPEGImageWriteParam extends ImageWriteParam {
      *
      * @return {@code false}.
      *
-     * @exception IllegalStateException if the compression mode is not
+     * @throws IllegalStateException if the compression mode is not
      * {@code MODE_EXPLICIT}.
      */
     public boolean isCompressionLossless() {
@@ -204,7 +204,7 @@ public class JPEGImageWriteParam extends ImageWriteParam {
      * @param DCHuffmanTables An array of Huffman table objects.
      * @param ACHuffmanTables An array of Huffman table objects.
      *
-     * @exception IllegalArgumentException if any of the arguments
+     * @throws IllegalArgumentException if any of the arguments
      * is {@code null} or has more than 4 elements, or if the
      * numbers of DC and AC tables differ.
      *

--- a/src/java.desktop/share/classes/javax/imageio/spi/IIOServiceProvider.java
+++ b/src/java.desktop/share/classes/javax/imageio/spi/IIOServiceProvider.java
@@ -65,9 +65,9 @@ public abstract class IIOServiceProvider implements RegisterableService {
      * @param vendorName the vendor name.
      * @param version a version identifier.
      *
-     * @exception IllegalArgumentException if {@code vendorName}
+     * @throws IllegalArgumentException if {@code vendorName}
      * is {@code null}.
-     * @exception IllegalArgumentException if {@code version}
+     * @throws IllegalArgumentException if {@code version}
      * is {@code null}.
      */
     public IIOServiceProvider(String vendorName,

--- a/src/java.desktop/share/classes/javax/imageio/spi/ImageInputStreamSpi.java
+++ b/src/java.desktop/share/classes/javax/imageio/spi/ImageInputStreamSpi.java
@@ -79,9 +79,9 @@ public abstract class ImageInputStreamSpi extends IIOServiceProvider {
      * legal object type for use by the
      * {@code createInputStreamInstance} method.
      *
-     * @exception IllegalArgumentException if {@code vendorName}
+     * @throws IllegalArgumentException if {@code vendorName}
      * is {@code null}.
-     * @exception IllegalArgumentException if {@code version}
+     * @throws IllegalArgumentException if {@code version}
      * is {@code null}.
      */
     public ImageInputStreamSpi(String vendorName,
@@ -159,12 +159,12 @@ public abstract class ImageInputStreamSpi extends IIOServiceProvider {
      *
      * @return an {@code ImageInputStream} instance.
      *
-     * @exception IllegalArgumentException if {@code input} is
+     * @throws IllegalArgumentException if {@code input} is
      * not an instance of the correct class or is {@code null}.
-     * @exception IllegalArgumentException if a cache file is needed
+     * @throws IllegalArgumentException if a cache file is needed
      * but {@code cacheDir} is non-{@code null} and is not a
      * directory.
-     * @exception IOException if a cache file is needed but cannot be
+     * @throws IOException if a cache file is needed but cannot be
      * created.
      *
      * @see #getInputClass
@@ -187,9 +187,9 @@ public abstract class ImageInputStreamSpi extends IIOServiceProvider {
      *
      * @return an {@code ImageInputStream} instance.
      *
-     * @exception IllegalArgumentException if {@code input} is
+     * @throws IllegalArgumentException if {@code input} is
      * not an instance of the correct class or is {@code null}.
-     * @exception IOException if a cache file is needed but cannot be
+     * @throws IOException if a cache file is needed but cannot be
      * created.
      *
      * @see #getInputClass()

--- a/src/java.desktop/share/classes/javax/imageio/spi/ImageOutputStreamSpi.java
+++ b/src/java.desktop/share/classes/javax/imageio/spi/ImageOutputStreamSpi.java
@@ -80,9 +80,9 @@ public abstract class ImageOutputStreamSpi extends IIOServiceProvider {
      * legal object type for use by the
      * {@code createOutputStreamInstance} method.
      *
-     * @exception IllegalArgumentException if {@code vendorName}
+     * @throws IllegalArgumentException if {@code vendorName}
      * is {@code null}.
-     * @exception IllegalArgumentException if {@code version}
+     * @throws IllegalArgumentException if {@code version}
      * is {@code null}.
     */
     public ImageOutputStreamSpi(String vendorName,
@@ -159,12 +159,12 @@ public abstract class ImageOutputStreamSpi extends IIOServiceProvider {
      *
      * @return an {@code ImageOutputStream} instance.
      *
-     * @exception IllegalArgumentException if {@code output} is
+     * @throws IllegalArgumentException if {@code output} is
      * not an instance of the correct class or is {@code null}.
-     * @exception IllegalArgumentException if a cache file is needed,
+     * @throws IllegalArgumentException if a cache file is needed,
      * but {@code cacheDir} is non-{@code null} and is not a
      * directory.
-     * @exception IOException if a cache file is needed but cannot be
+     * @throws IOException if a cache file is needed but cannot be
      * created.
      *
      * @see #getOutputClass
@@ -186,9 +186,9 @@ public abstract class ImageOutputStreamSpi extends IIOServiceProvider {
      *
      * @return an {@code ImageOutputStream} instance.
      *
-     * @exception IllegalArgumentException if {@code output} is
+     * @throws IllegalArgumentException if {@code output} is
      * not an instance of the correct class or is {@code null}.
-     * @exception IOException if a cache file is needed but cannot be
+     * @throws IOException if a cache file is needed but cannot be
      * created.
      *
      * @see #getOutputClass()

--- a/src/java.desktop/share/classes/javax/imageio/spi/ImageReaderSpi.java
+++ b/src/java.desktop/share/classes/javax/imageio/spi/ImageReaderSpi.java
@@ -180,15 +180,15 @@ public abstract class ImageReaderSpi extends ImageReaderWriterSpi {
      * {@code getImageMetadataFormat}.  An array of length
      * 0 is normalized to {@code null}.
      *
-     * @exception IllegalArgumentException if {@code vendorName}
+     * @throws IllegalArgumentException if {@code vendorName}
      * is {@code null}.
-     * @exception IllegalArgumentException if {@code version}
+     * @throws IllegalArgumentException if {@code version}
      * is {@code null}.
-     * @exception IllegalArgumentException if {@code names}
+     * @throws IllegalArgumentException if {@code names}
      * is {@code null} or has length 0.
-     * @exception IllegalArgumentException if {@code readerClassName}
+     * @throws IllegalArgumentException if {@code readerClassName}
      * is {@code null}.
-     * @exception IllegalArgumentException if {@code inputTypes}
+     * @throws IllegalArgumentException if {@code inputTypes}
      * is {@code null} or has length 0.
      */
     public ImageReaderSpi(String vendorName,
@@ -294,9 +294,9 @@ public abstract class ImageReaderSpi extends ImageReaderWriterSpi {
      * @return {@code true} if it is likely that this stream can
      * be decoded.
      *
-     * @exception IllegalArgumentException if {@code source} is
+     * @throws IllegalArgumentException if {@code source} is
      * {@code null}.
-     * @exception IOException if an I/O error occurs while reading the
+     * @throws IOException if an I/O error occurs while reading the
      * stream.
      */
     public abstract boolean canDecodeInput(Object source) throws IOException;
@@ -312,7 +312,7 @@ public abstract class ImageReaderSpi extends ImageReaderWriterSpi {
      *
      * @return an {@code ImageReader} instance.
      *
-     * @exception IOException if an error occurs during loading,
+     * @throws IOException if an error occurs during loading,
      * or initialization of the reader class, or during instantiation
      * or initialization of the reader object.
      */
@@ -338,9 +338,9 @@ public abstract class ImageReaderSpi extends ImageReaderWriterSpi {
      *
      * @return an {@code ImageReader} instance.
      *
-     * @exception IOException if the attempt to instantiate
+     * @throws IOException if the attempt to instantiate
      * the reader fails.
-     * @exception IllegalArgumentException if the
+     * @throws IllegalArgumentException if the
      * {@code ImageReader}'s constructor throws an
      * {@code IllegalArgumentException} to indicate that the
      * extension object is unsuitable.
@@ -362,7 +362,7 @@ public abstract class ImageReaderSpi extends ImageReaderWriterSpi {
      *
      * @return {@code true} if {@code reader} is recognized.
      *
-     * @exception IllegalArgumentException if {@code reader} is
+     * @throws IllegalArgumentException if {@code reader} is
      * {@code null}.
      */
     public boolean isOwnReader(ImageReader reader) {

--- a/src/java.desktop/share/classes/javax/imageio/spi/ImageReaderWriterSpi.java
+++ b/src/java.desktop/share/classes/javax/imageio/spi/ImageReaderWriterSpi.java
@@ -199,13 +199,13 @@ public abstract class ImageReaderWriterSpi extends IIOServiceProvider {
      * {@code getImageMetadataFormat}.  An array of length
      * 0 is normalized to {@code null}.
      *
-     * @exception IllegalArgumentException if {@code vendorName}
+     * @throws IllegalArgumentException if {@code vendorName}
      * is {@code null}.
-     * @exception IllegalArgumentException if {@code version}
+     * @throws IllegalArgumentException if {@code version}
      * is {@code null}.
-     * @exception IllegalArgumentException if {@code names}
+     * @throws IllegalArgumentException if {@code names}
      * is {@code null} or has length 0.
-     * @exception IllegalArgumentException if {@code pluginClassName}
+     * @throws IllegalArgumentException if {@code pluginClassName}
      * is {@code null}.
      */
     public ImageReaderWriterSpi(String vendorName,
@@ -518,7 +518,7 @@ public abstract class ImageReaderWriterSpi extends IIOServiceProvider {
      *
      * @return an {@code IIOMetadataFormat} object.
      *
-     * @exception IllegalArgumentException if {@code formatName}
+     * @throws IllegalArgumentException if {@code formatName}
      * is {@code null} or is not a supported name.
      */
     public IIOMetadataFormat getStreamMetadataFormat(String formatName) {
@@ -542,7 +542,7 @@ public abstract class ImageReaderWriterSpi extends IIOServiceProvider {
      *
      * @return an {@code IIOMetadataFormat} object.
      *
-     * @exception IllegalArgumentException if {@code formatName}
+     * @throws IllegalArgumentException if {@code formatName}
      * is {@code null} or is not a supported name.
      */
     public IIOMetadataFormat getImageMetadataFormat(String formatName) {

--- a/src/java.desktop/share/classes/javax/imageio/spi/ImageWriterSpi.java
+++ b/src/java.desktop/share/classes/javax/imageio/spi/ImageWriterSpi.java
@@ -181,15 +181,15 @@ public abstract class ImageWriterSpi extends ImageReaderWriterSpi {
      * {@code getImageMetadataFormat}.  An array of length
      * 0 is normalized to {@code null}.
      *
-     * @exception IllegalArgumentException if {@code vendorName}
+     * @throws IllegalArgumentException if {@code vendorName}
      * is {@code null}.
-     * @exception IllegalArgumentException if {@code version}
+     * @throws IllegalArgumentException if {@code version}
      * is {@code null}.
-     * @exception IllegalArgumentException if {@code names}
+     * @throws IllegalArgumentException if {@code names}
      * is {@code null} or has length 0.
-     * @exception IllegalArgumentException if {@code writerClassName}
+     * @throws IllegalArgumentException if {@code writerClassName}
      * is {@code null}.
-     * @exception IllegalArgumentException if {@code outputTypes}
+     * @throws IllegalArgumentException if {@code outputTypes}
      * is {@code null} or has length 0.
      */
     public ImageWriterSpi(String vendorName,
@@ -304,7 +304,7 @@ public abstract class ImageWriterSpi extends ImageReaderWriterSpi {
      * @return {@code true} if this writer is likely to be able
      * to encode images with the given layout.
      *
-     * @exception IllegalArgumentException if {@code type}
+     * @throws IllegalArgumentException if {@code type}
      * is {@code null}.
      */
     public abstract boolean canEncodeImage(ImageTypeSpecifier type);
@@ -325,7 +325,7 @@ public abstract class ImageWriterSpi extends ImageReaderWriterSpi {
      * @return {@code true} if this writer is likely to be able
      * to encode this image.
      *
-     * @exception IllegalArgumentException if {@code im}
+     * @throws IllegalArgumentException if {@code im}
      * is {@code null}.
      */
     public boolean canEncodeImage(RenderedImage im) {
@@ -343,7 +343,7 @@ public abstract class ImageWriterSpi extends ImageReaderWriterSpi {
      *
      * @return an {@code ImageWriter} instance.
      *
-     * @exception IOException if an error occurs during loading,
+     * @throws IOException if an error occurs during loading,
      * or initialization of the writer class, or during instantiation
      * or initialization of the writer object.
      */
@@ -369,9 +369,9 @@ public abstract class ImageWriterSpi extends ImageReaderWriterSpi {
      *
      * @return an {@code ImageWriter} instance.
      *
-     * @exception IOException if the attempt to instantiate
+     * @throws IOException if the attempt to instantiate
      * the writer fails.
-     * @exception IllegalArgumentException if the
+     * @throws IllegalArgumentException if the
      * {@code ImageWriter}'s constructor throws an
      * {@code IllegalArgumentException} to indicate that the
      * extension object is unsuitable.
@@ -388,7 +388,7 @@ public abstract class ImageWriterSpi extends ImageReaderWriterSpi {
      *
      * @return {@code true} if {@code writer} is recognized
      *
-     * @exception IllegalArgumentException if {@code writer} is
+     * @throws IllegalArgumentException if {@code writer} is
      * {@code null}.
      */
     public boolean isOwnWriter(ImageWriter writer) {

--- a/src/java.desktop/share/classes/javax/imageio/spi/ServiceRegistry.java
+++ b/src/java.desktop/share/classes/javax/imageio/spi/ServiceRegistry.java
@@ -104,7 +104,7 @@ public class ServiceRegistry {
      * @param categories an {@code Iterator} containing
      * {@code Class} objects to be used to define categories.
      *
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      * {@code categories} is {@code null}, or if
      * one of the categories is not an allowed service type.
      */
@@ -157,7 +157,7 @@ public class ServiceRegistry {
      * file violates the specified format or if a provider class
      * cannot be found and instantiated.
      *
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      * {@code providerClass} is {@code null}, or if it is
      * not one of the allowed service types.
      */
@@ -196,7 +196,7 @@ public class ServiceRegistry {
      * file violates the specified format or if a provider class
      * cannot be found and instantiated.
      *
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      * {@code providerClass} is {@code null}, or if it is
      * not one of the allowed service types.
      */
@@ -254,11 +254,11 @@ public class ServiceRegistry {
      * @return true if no provider of the same class was previously
      * registered in the same category category.
      *
-     * @exception IllegalArgumentException if {@code provider} is
+     * @throws IllegalArgumentException if {@code provider} is
      * {@code null}.
-     * @exception IllegalArgumentException if there is no category
+     * @throws IllegalArgumentException if there is no category
      * corresponding to {@code category}.
-     * @exception ClassCastException if provider does not implement
+     * @throws ClassCastException if provider does not implement
      * the {@code Class} defined by {@code category}.
      */
     public <T> boolean registerServiceProvider(T provider,
@@ -292,7 +292,7 @@ public class ServiceRegistry {
      *
      * @param provider the service provider object to be registered.
      *
-     * @exception IllegalArgumentException if
+     * @throws IllegalArgumentException if
      * {@code provider} is {@code null}.
      */
     public void registerServiceProvider(Object provider) {
@@ -323,7 +323,7 @@ public class ServiceRegistry {
      * @param providers an Iterator containing service provider
      * objects to be registered.
      *
-     * @exception IllegalArgumentException if {@code providers}
+     * @throws IllegalArgumentException if {@code providers}
      * is {@code null} or contains a {@code null} entry.
      */
     public void registerServiceProviders(Iterator<?> providers) {
@@ -357,11 +357,11 @@ public class ServiceRegistry {
      * registered in the same category category,
      * {@code false} otherwise.
      *
-     * @exception IllegalArgumentException if {@code provider} is
+     * @throws IllegalArgumentException if {@code provider} is
      * {@code null}.
-     * @exception IllegalArgumentException if there is no category
+     * @throws IllegalArgumentException if there is no category
      * corresponding to {@code category}.
-     * @exception ClassCastException if provider does not implement
+     * @throws ClassCastException if provider does not implement
      * the class defined by {@code category}.
      */
     public <T> boolean deregisterServiceProvider(T provider,
@@ -385,7 +385,7 @@ public class ServiceRegistry {
      *
      * @param provider the service provider object to be deregistered.
      *
-     * @exception IllegalArgumentException if {@code provider} is
+     * @throws IllegalArgumentException if {@code provider} is
      * {@code null}.
      */
     public void deregisterServiceProvider(Object provider) {
@@ -408,7 +408,7 @@ public class ServiceRegistry {
      * @return {@code true} if the given provider has been
      * registered.
      *
-     * @exception IllegalArgumentException if {@code provider} is
+     * @throws IllegalArgumentException if {@code provider} is
      * {@code null}.
      */
     public boolean contains(Object provider) {
@@ -444,7 +444,7 @@ public class ServiceRegistry {
      * @return an {@code Iterator} containing service provider
      * objects from the given category, possibly in order.
      *
-     * @exception IllegalArgumentException if there is no category
+     * @throws IllegalArgumentException if there is no category
      * corresponding to {@code category}.
      */
     public <T> Iterator<T> getServiceProviders(Class<T> category,
@@ -502,7 +502,7 @@ public class ServiceRegistry {
      * @return an {@code Iterator} containing service provider
      * objects from the given category, possibly in order.
      *
-     * @exception IllegalArgumentException if there is no category
+     * @throws IllegalArgumentException if there is no category
      * corresponding to {@code category}.
      */
     public <T> Iterator<T> getServiceProviders(Class<T> category,
@@ -531,7 +531,7 @@ public class ServiceRegistry {
      * desired {@code Class} type, or {@code null} is none is
      * present.
      *
-     * @exception IllegalArgumentException if {@code providerClass} is
+     * @throws IllegalArgumentException if {@code providerClass} is
      * {@code null}.
      */
     public <T> T getServiceProviderByClass(Class<T> providerClass) {
@@ -573,9 +573,9 @@ public class ServiceRegistry {
      * @return {@code true} if a previously unset ordering
      * was established.
      *
-     * @exception IllegalArgumentException if either provider is
+     * @throws IllegalArgumentException if either provider is
      * {@code null} or they are the same object.
-     * @exception IllegalArgumentException if there is no category
+     * @throws IllegalArgumentException if there is no category
      * corresponding to {@code category}.
      */
     public <T> boolean setOrdering(Class<T> category,
@@ -619,9 +619,9 @@ public class ServiceRegistry {
      * @return {@code true} if a previously set ordering was
      * disestablished.
      *
-     * @exception IllegalArgumentException if either provider is
+     * @throws IllegalArgumentException if either provider is
      * {@code null} or they are the same object.
-     * @exception IllegalArgumentException if there is no category
+     * @throws IllegalArgumentException if there is no category
      * corresponding to {@code category}.
      */
     public <T> boolean unsetOrdering(Class<T> category,
@@ -650,7 +650,7 @@ public class ServiceRegistry {
      *
      * @param category the category to be emptied.
      *
-     * @exception IllegalArgumentException if there is no category
+     * @throws IllegalArgumentException if there is no category
      * corresponding to {@code category}.
      */
     public void deregisterAll(Class<?> category) {
@@ -677,7 +677,7 @@ public class ServiceRegistry {
      * currently registered service providers.  This method should not
      * be called from application code.
      *
-     * @exception Throwable if an error occurs during superclass
+     * @throws Throwable if an error occurs during superclass
      * finalization.
      *
      * @deprecated Finalization has been deprecated for removal.  See

--- a/src/java.desktop/share/classes/javax/imageio/stream/FileCacheImageInputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/FileCacheImageInputStream.java
@@ -83,9 +83,9 @@ public class FileCacheImageInputStream extends ImageInputStreamImpl {
      * cache file should be created, or {@code null} to use the
      * system directory.
      *
-     * @exception IllegalArgumentException if {@code stream} is
+     * @throws IllegalArgumentException if {@code stream} is
      * {@code null}.
-     * @exception IllegalArgumentException if {@code cacheDir} is
+     * @throws IllegalArgumentException if {@code cacheDir} is
      * non-{@code null} but is not a directory.
      * @throws IOException if a cache file cannot be created.
      */

--- a/src/java.desktop/share/classes/javax/imageio/stream/FileCacheImageOutputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/FileCacheImageOutputStream.java
@@ -69,11 +69,11 @@ public class FileCacheImageOutputStream extends ImageOutputStreamImpl {
      * cache file should be created, or {@code null} to use the
      * system directory.
      *
-     * @exception IllegalArgumentException if {@code stream}
+     * @throws IllegalArgumentException if {@code stream}
      * is {@code null}.
-     * @exception IllegalArgumentException if {@code cacheDir} is
+     * @throws IllegalArgumentException if {@code cacheDir} is
      * non-{@code null} but is not a directory.
-     * @exception IOException if a cache file cannot be created.
+     * @throws IOException if a cache file cannot be created.
      */
     public FileCacheImageOutputStream(OutputStream stream, File cacheDir)
         throws IOException {
@@ -159,9 +159,9 @@ public class FileCacheImageOutputStream extends ImageOutputStreamImpl {
      * performed.  The file length will not be increased until a write
      * is performed.
      *
-     * @exception IndexOutOfBoundsException if {@code pos} is smaller
+     * @throws IndexOutOfBoundsException if {@code pos} is smaller
      * than the flushed position.
-     * @exception IOException if any other I/O error occurs.
+     * @throws IOException if any other I/O error occurs.
      */
     public void seek(long pos) throws IOException {
         checkClosed();
@@ -223,7 +223,7 @@ public class FileCacheImageOutputStream extends ImageOutputStreamImpl {
      * is closed and removed.  The destination {@code OutputStream}
      * is not closed.
      *
-     * @exception IOException if an error occurs.
+     * @throws IOException if an error occurs.
      */
     public void close() throws IOException {
         maxStreamPos = cache.length();

--- a/src/java.desktop/share/classes/javax/imageio/stream/FileImageInputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/FileImageInputStream.java
@@ -60,13 +60,13 @@ public class FileImageInputStream extends ImageInputStreamImpl {
      *
      * @param f a {@code File} to read from.
      *
-     * @exception IllegalArgumentException if {@code f} is
+     * @throws IllegalArgumentException if {@code f} is
      * {@code null}.
-     * @exception SecurityException if a security manager exists
+     * @throws SecurityException if a security manager exists
      * and does not allow read access to the file.
-     * @exception FileNotFoundException if {@code f} is a
+     * @throws FileNotFoundException if {@code f} is a
      * directory or cannot be opened for reading for any other reason.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     public FileImageInputStream(File f)
         throws FileNotFoundException, IOException {
@@ -83,7 +83,7 @@ public class FileImageInputStream extends ImageInputStreamImpl {
      *
      * @param raf a {@code RandomAccessFile} to read from.
      *
-     * @exception IllegalArgumentException if {@code raf} is
+     * @throws IllegalArgumentException if {@code raf} is
      * {@code null}.
      */
     public FileImageInputStream(RandomAccessFile raf) {

--- a/src/java.desktop/share/classes/javax/imageio/stream/FileImageOutputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/FileImageOutputStream.java
@@ -55,14 +55,14 @@ public class FileImageOutputStream extends ImageOutputStreamImpl {
      *
      * @param f a {@code File} to write to.
      *
-     * @exception IllegalArgumentException if {@code f} is
+     * @throws IllegalArgumentException if {@code f} is
      * {@code null}.
-     * @exception SecurityException if a security manager exists
+     * @throws SecurityException if a security manager exists
      * and does not allow write access to the file.
-     * @exception FileNotFoundException if {@code f} does not denote
+     * @throws FileNotFoundException if {@code f} does not denote
      * a regular file or it cannot be opened for reading and writing for any
      * other reason.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     public FileImageOutputStream(File f)
         throws FileNotFoundException, IOException {
@@ -75,7 +75,7 @@ public class FileImageOutputStream extends ImageOutputStreamImpl {
      *
      * @param raf a {@code RandomAccessFile} to write to.
      *
-     * @exception IllegalArgumentException if {@code raf} is
+     * @throws IllegalArgumentException if {@code raf} is
      * {@code null}.
      */
     public FileImageOutputStream(RandomAccessFile raf) {
@@ -141,9 +141,9 @@ public class FileImageOutputStream extends ImageOutputStreamImpl {
      * performed.  The file length will not be increased until a write
      * is performed.
      *
-     * @exception IndexOutOfBoundsException if {@code pos} is smaller
+     * @throws IndexOutOfBoundsException if {@code pos} is smaller
      * than the flushed position.
-     * @exception IOException if any other I/O error occurs.
+     * @throws IOException if any other I/O error occurs.
      */
     public void seek(long pos) throws IOException {
         checkClosed();

--- a/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStream.java
@@ -100,7 +100,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      * @return a byte value from the stream, as an int, or -1 to
      * indicate EOF.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     int read() throws IOException;
 
@@ -118,10 +118,10 @@ public interface ImageInputStream extends DataInput, Closeable {
      * @return the number of bytes actually read, or {@code -1}
      * to indicate EOF.
      *
-     * @exception NullPointerException if {@code b} is
+     * @throws NullPointerException if {@code b} is
      * {@code null}.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     int read(byte[] b) throws IOException;
 
@@ -142,12 +142,12 @@ public interface ImageInputStream extends DataInput, Closeable {
      * @return the number of bytes actually read, or {@code -1}
      * to indicate EOF.
      *
-     * @exception NullPointerException if {@code b} is
+     * @throws NullPointerException if {@code b} is
      * {@code null}.
-     * @exception IndexOutOfBoundsException if {@code off} is
+     * @throws IndexOutOfBoundsException if {@code off} is
      * negative, {@code len} is negative, or {@code off + len}
      * is greater than {@code b.length}.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     int read(byte[] b, int off, int len) throws IOException;
 
@@ -164,12 +164,12 @@ public interface ImageInputStream extends DataInput, Closeable {
      * @param buf an IIOByteBuffer object to be modified.
      * @param len the maximum number of {@code byte}s to read.
      *
-     * @exception IndexOutOfBoundsException if {@code len} is
+     * @throws IndexOutOfBoundsException if {@code len} is
      * negative.
-     * @exception NullPointerException if {@code buf} is
+     * @throws NullPointerException if {@code buf} is
      * {@code null}.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void readBytes(IIOByteBuffer buf, int len) throws IOException;
 
@@ -183,8 +183,8 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @return a boolean value from the stream.
      *
-     * @exception java.io.EOFException if the end of the stream is reached.
-     * @exception IOException if an I/O error occurs.
+     * @throws java.io.EOFException if the end of the stream is reached.
+     * @throws IOException if an I/O error occurs.
      */
     boolean readBoolean() throws IOException;
 
@@ -201,8 +201,8 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @return a signed byte value from the stream.
      *
-     * @exception java.io.EOFException if the end of the stream is reached.
-     * @exception IOException if an I/O error occurs.
+     * @throws java.io.EOFException if the end of the stream is reached.
+     * @throws IOException if an I/O error occurs.
      */
     byte readByte() throws IOException;
 
@@ -225,8 +225,8 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @return an unsigned byte value from the stream.
      *
-     * @exception java.io.EOFException if the end of the stream is reached.
-     * @exception IOException if an I/O error occurs.
+     * @throws java.io.EOFException if the end of the stream is reached.
+     * @throws IOException if an I/O error occurs.
      */
     int readUnsignedByte() throws IOException;
 
@@ -240,9 +240,9 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @return a signed short value from the stream.
      *
-     * @exception java.io.EOFException if the stream reaches the end before
+     * @throws java.io.EOFException if the stream reaches the end before
      * reading all the bytes.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      *
      * @see #getByteOrder
      */
@@ -261,9 +261,9 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @return an unsigned short value from the stream, as an int.
      *
-     * @exception java.io.EOFException if the stream reaches the end before
+     * @throws java.io.EOFException if the stream reaches the end before
      * reading all the bytes.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      *
      * @see #getByteOrder
      */
@@ -278,9 +278,9 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @return an unsigned char value from the stream.
      *
-     * @exception java.io.EOFException if the stream reaches the end before
+     * @throws java.io.EOFException if the stream reaches the end before
      * reading all the bytes.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      *
      * @see #readUnsignedShort
      */
@@ -296,9 +296,9 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @return a signed int value from the stream.
      *
-     * @exception java.io.EOFException if the stream reaches the end before
+     * @throws java.io.EOFException if the stream reaches the end before
      * reading all the bytes.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      *
      * @see #getByteOrder
      */
@@ -316,9 +316,9 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @return an unsigned int value from the stream, as a long.
      *
-     * @exception java.io.EOFException if the stream reaches the end before
+     * @throws java.io.EOFException if the stream reaches the end before
      * reading all the bytes.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      *
      * @see #getByteOrder
      */
@@ -334,9 +334,9 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @return a signed long value from the stream.
      *
-     * @exception java.io.EOFException if the stream reaches the end before
+     * @throws java.io.EOFException if the stream reaches the end before
      * reading all the bytes.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      *
      * @see #getByteOrder
      */
@@ -352,9 +352,9 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @return a float value from the stream.
      *
-     * @exception java.io.EOFException if the stream reaches the end before
+     * @throws java.io.EOFException if the stream reaches the end before
      * reading all the bytes.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      *
      * @see #getByteOrder
      */
@@ -370,9 +370,9 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @return a double value from the stream.
      *
-     * @exception java.io.EOFException if the stream reaches the end before
+     * @throws java.io.EOFException if the stream reaches the end before
      * reading all the bytes.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      *
      * @see #getByteOrder
      */
@@ -408,7 +408,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @return a String containing a line of text from the stream.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     String readLine() throws IOException;
 
@@ -488,11 +488,11 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @return a String read from the stream.
      *
-     * @exception  java.io.EOFException  if this stream reaches the end
+     * @throws  java.io.EOFException  if this stream reaches the end
      * before reading all the bytes.
-     * @exception  java.io.UTFDataFormatException if the bytes do not represent
+     * @throws  java.io.UTFDataFormatException if the bytes do not represent
      * a valid modified UTF-8 encoding of a string.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     String readUTF() throws IOException;
 
@@ -509,14 +509,14 @@ public interface ImageInputStream extends DataInput, Closeable {
      * @param off the starting position within {@code b} to write to.
      * @param len the maximum number of {@code byte}s to read.
      *
-     * @exception IndexOutOfBoundsException if {@code off} is
+     * @throws IndexOutOfBoundsException if {@code off} is
      * negative, {@code len} is negative, or {@code off + len}
      * is greater than {@code b.length}.
-     * @exception NullPointerException if {@code b} is
+     * @throws NullPointerException if {@code b} is
      * {@code null}.
-     * @exception java.io.EOFException if the stream reaches the end before
+     * @throws java.io.EOFException if the stream reaches the end before
      * reading all the bytes.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void readFully(byte[] b, int off, int len) throws IOException;
 
@@ -531,11 +531,11 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @param b an array of {@code byte}s.
      *
-     * @exception NullPointerException if {@code b} is
+     * @throws NullPointerException if {@code b} is
      * {@code null}.
-     * @exception java.io.EOFException if the stream reaches the end before
+     * @throws java.io.EOFException if the stream reaches the end before
      * reading all the bytes.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void readFully(byte[] b) throws IOException;
 
@@ -553,14 +553,14 @@ public interface ImageInputStream extends DataInput, Closeable {
      * @param off the starting position within {@code s} to write to.
      * @param len the maximum number of {@code short}s to read.
      *
-     * @exception IndexOutOfBoundsException if {@code off} is
+     * @throws IndexOutOfBoundsException if {@code off} is
      * negative, {@code len} is negative, or {@code off + len}
      * is greater than {@code s.length}.
-     * @exception NullPointerException if {@code s} is
+     * @throws NullPointerException if {@code s} is
      * {@code null}.
-     * @exception java.io.EOFException if the stream reaches the end before
+     * @throws java.io.EOFException if the stream reaches the end before
      * reading all the bytes.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void readFully(short[] s, int off, int len) throws IOException;
 
@@ -578,14 +578,14 @@ public interface ImageInputStream extends DataInput, Closeable {
      * @param off the starting position within {@code c} to write to.
      * @param len the maximum number of {@code char}s to read.
      *
-     * @exception IndexOutOfBoundsException if {@code off} is
+     * @throws IndexOutOfBoundsException if {@code off} is
      * negative, {@code len} is negative, or {@code off + len}
      * is greater than {@code c.length}.
-     * @exception NullPointerException if {@code c} is
+     * @throws NullPointerException if {@code c} is
      * {@code null}.
-     * @exception java.io.EOFException if the stream reaches the end before
+     * @throws java.io.EOFException if the stream reaches the end before
      * reading all the bytes.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void readFully(char[] c, int off, int len) throws IOException;
 
@@ -603,14 +603,14 @@ public interface ImageInputStream extends DataInput, Closeable {
      * @param off the starting position within {@code i} to write to.
      * @param len the maximum number of {@code int}s to read.
      *
-     * @exception IndexOutOfBoundsException if {@code off} is
+     * @throws IndexOutOfBoundsException if {@code off} is
      * negative, {@code len} is negative, or {@code off + len}
      * is greater than {@code i.length}.
-     * @exception NullPointerException if {@code i} is
+     * @throws NullPointerException if {@code i} is
      * {@code null}.
-     * @exception java.io.EOFException if the stream reaches the end before
+     * @throws java.io.EOFException if the stream reaches the end before
      * reading all the bytes.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void readFully(int[] i, int off, int len) throws IOException;
 
@@ -628,14 +628,14 @@ public interface ImageInputStream extends DataInput, Closeable {
      * @param off the starting position within {@code l} to write to.
      * @param len the maximum number of {@code long}s to read.
      *
-     * @exception IndexOutOfBoundsException if {@code off} is
+     * @throws IndexOutOfBoundsException if {@code off} is
      * negative, {@code len} is negative, or {@code off + len}
      * is greater than {@code l.length}.
-     * @exception NullPointerException if {@code l} is
+     * @throws NullPointerException if {@code l} is
      * {@code null}.
-     * @exception java.io.EOFException if the stream reaches the end before
+     * @throws java.io.EOFException if the stream reaches the end before
      * reading all the bytes.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void readFully(long[] l, int off, int len) throws IOException;
 
@@ -653,14 +653,14 @@ public interface ImageInputStream extends DataInput, Closeable {
      * @param off the starting position within {@code f} to write to.
      * @param len the maximum number of {@code float}s to read.
      *
-     * @exception IndexOutOfBoundsException if {@code off} is
+     * @throws IndexOutOfBoundsException if {@code off} is
      * negative, {@code len} is negative, or {@code off + len}
      * is greater than {@code f.length}.
-     * @exception NullPointerException if {@code f} is
+     * @throws NullPointerException if {@code f} is
      * {@code null}.
-     * @exception java.io.EOFException if the stream reaches the end before
+     * @throws java.io.EOFException if the stream reaches the end before
      * reading all the bytes.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void readFully(float[] f, int off, int len) throws IOException;
 
@@ -678,14 +678,14 @@ public interface ImageInputStream extends DataInput, Closeable {
      * @param off the starting position within {@code d} to write to.
      * @param len the maximum number of {@code double}s to read.
      *
-     * @exception IndexOutOfBoundsException if {@code off} is
+     * @throws IndexOutOfBoundsException if {@code off} is
      * negative, {@code len} is negative, or {@code off + len}
      * is greater than {@code d.length}.
-     * @exception NullPointerException if {@code d} is
+     * @throws NullPointerException if {@code d} is
      * {@code null}.
-     * @exception java.io.EOFException if the stream reaches the end before
+     * @throws java.io.EOFException if the stream reaches the end before
      * reading all the bytes.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void readFully(double[] d, int off, int len) throws IOException;
 
@@ -695,7 +695,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @return a long containing the position of the stream.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     long getStreamPosition() throws IOException;
 
@@ -714,7 +714,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      * @return an {@code int} containing the bit offset between
      * 0 and 7, inclusive.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      *
      * @see #setBitOffset
      */
@@ -731,9 +731,9 @@ public interface ImageInputStream extends DataInput, Closeable {
      * @param bitOffset the desired offset, as an {@code int}
      * between 0 and 7, inclusive.
      *
-     * @exception IllegalArgumentException if {@code bitOffset}
+     * @throws IllegalArgumentException if {@code bitOffset}
      * is not between 0 and 7, inclusive.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      *
      * @see #getBitOffset
      */
@@ -748,9 +748,9 @@ public interface ImageInputStream extends DataInput, Closeable {
      * @return an {@code int} containing the value {@code 0}
      * or {@code 1}.
      *
-     * @exception java.io.EOFException if the stream reaches the end before
+     * @throws java.io.EOFException if the stream reaches the end before
      * reading all the bits.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     int readBit() throws IOException;
 
@@ -788,11 +788,11 @@ public interface ImageInputStream extends DataInput, Closeable {
      * @return the bitstring, as a {@code long} with the last bit
      * read stored in the least significant bit.
      *
-     * @exception IllegalArgumentException if {@code numBits}
+     * @throws IllegalArgumentException if {@code numBits}
      * is not between 0 and 64, inclusive.
-     * @exception java.io.EOFException if the stream reaches the end before
+     * @throws java.io.EOFException if the stream reaches the end before
      * reading all the bits.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     long readBits(int numBits) throws IOException;
 
@@ -803,7 +803,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      * @return a {@code long} containing the length of the
      * stream, if known, or else {@code -1}.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     long length() throws IOException;
 
@@ -820,7 +820,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      *
      * @return an {@code int} representing the number of bytes skipped.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     int skipBytes(int n) throws IOException;
 
@@ -835,7 +835,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      * @return a {@code long} representing the number of bytes
      * skipped.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     long skipBytes(long n) throws IOException;
 
@@ -855,9 +855,9 @@ public interface ImageInputStream extends DataInput, Closeable {
      * @param pos a {@code long} containing the desired file
      * pointer position.
      *
-     * @exception IndexOutOfBoundsException if {@code pos} is smaller
+     * @throws IndexOutOfBoundsException if {@code pos} is smaller
      * than the flushed position.
-     * @exception IOException if any other I/O error occurs.
+     * @throws IOException if any other I/O error occurs.
      */
     void seek(long pos) throws IOException;
 
@@ -897,7 +897,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      * <p> An {@code IOException} will be thrown if the previous
      * marked position lies in the discarded portion of the stream.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void reset() throws IOException;
 
@@ -915,10 +915,10 @@ public interface ImageInputStream extends DataInput, Closeable {
      * @param pos a {@code long} containing the length of the
      * stream prefix that may be flushed.
      *
-     * @exception IndexOutOfBoundsException if {@code pos} lies
+     * @throws IndexOutOfBoundsException if {@code pos} lies
      * in the flushed portion of the stream or past the current stream
      * position.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void flushBefore(long pos) throws IOException;
 
@@ -927,7 +927,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      * stream position.  Equivalent to
      * {@code flushBefore(getStreamPosition())}.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void flush() throws IOException;
 
@@ -993,7 +993,7 @@ public interface ImageInputStream extends DataInput, Closeable {
      * this interface to release resources associated with the stream
      * such as memory, disk space, or file descriptors.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void close() throws IOException;
 }

--- a/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStreamImpl.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/ImageInputStreamImpl.java
@@ -103,7 +103,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
      * Subclasses may call this method from any of their methods that
      * require the stream not to be closed.
      *
-     * @exception IOException if the stream is closed.
+     * @throws IOException if the stream is closed.
      */
     protected final void checkClosed() throws IOException {
         if (isClosed) {
@@ -134,7 +134,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
      * @return the value of the next byte in the stream, or {@code -1}
      * if EOF is reached.
      *
-     * @exception IOException if the stream has been closed.
+     * @throws IOException if the stream has been closed.
      */
     public abstract int read() throws IOException;
 
@@ -147,9 +147,9 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
      * @return the number of bytes actually read, or {@code -1}
      * to indicate EOF.
      *
-     * @exception NullPointerException if {@code b} is
+     * @throws NullPointerException if {@code b} is
      * {@code null}.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     public int read(byte[] b) throws IOException {
         return read(b, 0, b.length);
@@ -175,12 +175,12 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
      * @return the number of bytes actually read, or {@code -1}
      * to indicate EOF.
      *
-     * @exception IndexOutOfBoundsException if {@code off} is
+     * @throws IndexOutOfBoundsException if {@code off} is
      * negative, {@code len} is negative, or {@code off + len}
      * is greater than {@code b.length}.
-     * @exception NullPointerException if {@code b} is
+     * @throws NullPointerException if {@code b} is
      * {@code null}.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     public abstract int read(byte[] b, int off, int len) throws IOException;
 
@@ -729,7 +729,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
      * @return an {@code int} representing the number of bytes
      * skipped.
      *
-     * @exception IOException if {@code getStreamPosition}
+     * @throws IOException if {@code getStreamPosition}
      * throws an {@code IOException} when computing either
      * the starting or ending position.
      */
@@ -750,7 +750,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
      * @return a {@code long} representing the number of bytes
      * skipped.
      *
-     * @exception IOException if {@code getStreamPosition}
+     * @throws IOException if {@code getStreamPosition}
      * throws an {@code IOException} when computing either
      * the starting or ending position.
      */
@@ -791,7 +791,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
      * <p> An {@code IOException} will be thrown if the previous
      * marked position lies in the discarded portion of the stream.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     public void reset() throws IOException {
         if (markByteStack.empty()) {
@@ -865,7 +865,7 @@ public abstract class ImageInputStreamImpl implements ImageInputStream {
      * source.  This method should not be called from application
      * code.
      *
-     * @exception Throwable if an error occurs during superclass
+     * @throws Throwable if an error occurs during superclass
      * finalization.
      *
      * @deprecated Finalization has been deprecated for removal.  See

--- a/src/java.desktop/share/classes/javax/imageio/stream/ImageOutputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/ImageOutputStream.java
@@ -66,7 +66,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * @param b an {@code int} whose lower 8 bits are to be
      * written.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void write(int b) throws IOException;
 
@@ -83,9 +83,9 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      *
      * @param b an array of {@code byte}s to be written.
      *
-     * @exception NullPointerException if {@code b} is
+     * @throws NullPointerException if {@code b} is
      * {@code null}.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void write(byte[] b) throws IOException;
 
@@ -107,12 +107,12 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * @param off the start offset in the data.
      * @param len the number of {@code byte}s to write.
      *
-     * @exception IndexOutOfBoundsException if {@code off} is
+     * @throws IndexOutOfBoundsException if {@code off} is
      * negative, {@code len} is negative, or {@code off + len}
      * is greater than {@code b.length}.
-     * @exception NullPointerException if {@code b} is
+     * @throws NullPointerException if {@code b} is
      * {@code null}.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void write(byte[] b, int off, int len) throws IOException;
 
@@ -129,7 +129,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      *
      * @param v the {@code boolean} to be written.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void writeBoolean(boolean v) throws IOException;
 
@@ -147,7 +147,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * @param v an {@code int} containing the byte value to be
      * written.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void writeByte(int v) throws IOException;
 
@@ -177,7 +177,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * @param v an {@code int} containing the short value to be
      * written.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void writeShort(int v) throws IOException;
 
@@ -187,7 +187,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * @param v an {@code int} containing the char (unsigned
      * short) value to be written.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      *
      * @see #writeShort(int)
      */
@@ -222,7 +222,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * @param v an {@code int} containing the value to be
      * written.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void writeInt(int v) throws IOException;
 
@@ -263,7 +263,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * @param v a {@code long} containing the value to be
      * written.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void writeLong(long v) throws IOException;
 
@@ -283,7 +283,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * @param v a {@code float} containing the value to be
      * written.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void writeFloat(float v) throws IOException;
 
@@ -304,7 +304,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * @param v a {@code double} containing the value to be
      * written.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void writeDouble(double v) throws IOException;
 
@@ -330,9 +330,9 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * @param s a {@code String} containing the value to be
      * written.
      *
-     * @exception NullPointerException if {@code s} is
+     * @throws NullPointerException if {@code s} is
      * {@code null}.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void writeBytes(String s) throws IOException;
 
@@ -358,9 +358,9 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * @param s a {@code String} containing the value to be
      * written.
      *
-     * @exception NullPointerException if {@code s} is
+     * @throws NullPointerException if {@code s} is
      * {@code null}.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void writeChars(String s) throws IOException;
 
@@ -427,11 +427,11 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * @param s a {@code String} containing the value to be
      * written.
      *
-     * @exception NullPointerException if {@code s} is
+     * @throws NullPointerException if {@code s} is
      * {@code null}.
-     * @exception java.io.UTFDataFormatException if the modified UTF-8
+     * @throws java.io.UTFDataFormatException if the modified UTF-8
      * representation of {@code s} requires more than 65536 bytes.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void writeUTF(String s) throws IOException;
 
@@ -452,12 +452,12 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * @param off the start offset in the data.
      * @param len the number of {@code short}s to write.
      *
-     * @exception IndexOutOfBoundsException if {@code off} is
+     * @throws IndexOutOfBoundsException if {@code off} is
      * negative, {@code len} is negative, or {@code off + len}
      * is greater than {@code s.length}.
-     * @exception NullPointerException if {@code s} is
+     * @throws NullPointerException if {@code s} is
      * {@code null}.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void writeShorts(short[] s, int off, int len) throws IOException;
 
@@ -478,12 +478,12 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * @param off the start offset in the data.
      * @param len the number of {@code char}s to write.
      *
-     * @exception IndexOutOfBoundsException if {@code off} is
+     * @throws IndexOutOfBoundsException if {@code off} is
      * negative, {@code len} is negative, or {@code off + len}
      * is greater than {@code c.length}.
-     * @exception NullPointerException if {@code c} is
+     * @throws NullPointerException if {@code c} is
      * {@code null}.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void writeChars(char[] c, int off, int len) throws IOException;
 
@@ -504,12 +504,12 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * @param off the start offset in the data.
      * @param len the number of {@code int}s to write.
      *
-     * @exception IndexOutOfBoundsException if {@code off} is
+     * @throws IndexOutOfBoundsException if {@code off} is
      * negative, {@code len} is negative, or {@code off + len}
      * is greater than {@code i.length}.
-     * @exception NullPointerException if {@code i} is
+     * @throws NullPointerException if {@code i} is
      * {@code null}.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void writeInts(int[] i, int off, int len) throws IOException;
 
@@ -530,12 +530,12 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * @param off the start offset in the data.
      * @param len the number of {@code long}s to write.
      *
-     * @exception IndexOutOfBoundsException if {@code off} is
+     * @throws IndexOutOfBoundsException if {@code off} is
      * negative, {@code len} is negative, or {@code off + len}
      * is greater than {@code l.length}.
-     * @exception NullPointerException if {@code l} is
+     * @throws NullPointerException if {@code l} is
      * {@code null}.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void writeLongs(long[] l, int off, int len) throws IOException;
 
@@ -556,12 +556,12 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * @param off the start offset in the data.
      * @param len the number of {@code float}s to write.
      *
-     * @exception IndexOutOfBoundsException if {@code off} is
+     * @throws IndexOutOfBoundsException if {@code off} is
      * negative, {@code len} is negative, or {@code off + len}
      * is greater than {@code f.length}.
-     * @exception NullPointerException if {@code f} is
+     * @throws NullPointerException if {@code f} is
      * {@code null}.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void writeFloats(float[] f, int off, int len) throws IOException;
 
@@ -582,12 +582,12 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * @param off the start offset in the data.
      * @param len the number of {@code double}s to write.
      *
-     * @exception IndexOutOfBoundsException if {@code off} is
+     * @throws IndexOutOfBoundsException if {@code off} is
      * negative, {@code len} is negative, or {@code off + len}
      * is greater than {@code d.length}.
-     * @exception NullPointerException if {@code d} is
+     * @throws NullPointerException if {@code d} is
      * {@code null}.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void writeDoubles(double[] d, int off, int len) throws IOException;
 
@@ -606,7 +606,7 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * @param bit an {@code int} whose least significant bit
      * is to be written to the stream.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void writeBit(int bit) throws IOException;
 
@@ -637,9 +637,9 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      *
      * @param numBits an {@code int} between 0 and 64, inclusive.
      *
-     * @exception IllegalArgumentException if {@code numBits} is
+     * @throws IllegalArgumentException if {@code numBits} is
      * not between 0 and 64, inclusive.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void writeBits(long bits, int numBits) throws IOException;
 
@@ -653,10 +653,10 @@ public interface ImageOutputStream extends ImageInputStream, DataOutput {
      * @param pos a {@code long} containing the length of the
      * stream prefix that may be flushed to the destination.
      *
-     * @exception IndexOutOfBoundsException if {@code pos} lies
+     * @throws IndexOutOfBoundsException if {@code pos} lies
      * in the flushed portion of the stream or past the current stream
      * position.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     void flushBefore(long pos) throws IOException;
 }

--- a/src/java.desktop/share/classes/javax/imageio/stream/ImageOutputStreamImpl.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/ImageOutputStreamImpl.java
@@ -484,7 +484,7 @@ public abstract class ImageOutputStreamImpl
      * beginning of the {@code write(int)} and
      * {@code write(byte[], int, int)} methods.
      *
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     protected final void flushBits() throws IOException {
         checkClosed();

--- a/src/java.desktop/share/classes/javax/imageio/stream/MemoryCache.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/MemoryCache.java
@@ -141,7 +141,7 @@ class MemoryCache {
      * not dispose of any blocks containing bytes written.  To dispose
      * blocks, use {@link #disposeBefore disposeBefore()}.
      *
-     * @exception IndexOutOfBoundsException if any portion of
+     * @throws IndexOutOfBoundsException if any portion of
      * the requested data is not in the cache (including if {@code pos}
      * is in a block already disposed), or if either {@code pos} or
      * {@code len} is < 0.
@@ -207,8 +207,8 @@ class MemoryCache {
      * @param len the number of bytes to be written.
      * @param pos the cache position at which to begin writing.
      *
-     * @exception NullPointerException if {@code b} is {@code null}.
-     * @exception IndexOutOfBoundsException if {@code off},
+     * @throws NullPointerException if {@code b} is {@code null}.
+     * @throws IndexOutOfBoundsException if {@code off},
      * {@code len}, or {@code pos} are negative,
      * or if {@code off+len > b.length}.
      * @throws IOException if there is an I/O error while writing to the cache
@@ -254,7 +254,7 @@ class MemoryCache {
      * will be written.
      * @param pos the cache position at which to begin writing.
      *
-     * @exception IndexOutOfBoundsException if {@code pos} is negative.
+     * @throws IndexOutOfBoundsException if {@code pos} is negative.
      * @throws IOException if there is an I/O error while writing to the cache
      */
     public void write(int b, long pos) throws IOException {
@@ -309,8 +309,8 @@ class MemoryCache {
      * at cache position {@code pos}, into the array
      * {@code b} at offset {@code off}.
      *
-     * @exception NullPointerException if b is {@code null}
-     * @exception IndexOutOfBoundsException if {@code off},
+     * @throws NullPointerException if b is {@code null}
+     * @throws IndexOutOfBoundsException if {@code off},
      * {@code len} or {@code pos} are negative or if
      * {@code off + len > b.length} or if any portion of the
      * requested data is not in the cache (including if
@@ -349,7 +349,7 @@ class MemoryCache {
      * Free the blocks up to the position {@code pos}.
      * The byte at {@code pos} remains available.
      *
-     * @exception IndexOutOfBoundsException if {@code pos}
+     * @throws IndexOutOfBoundsException if {@code pos}
      * is in a block that has already been disposed.
      */
     public void disposeBefore(long pos) {

--- a/src/java.desktop/share/classes/javax/imageio/stream/MemoryCacheImageInputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/MemoryCacheImageInputStream.java
@@ -61,7 +61,7 @@ public class MemoryCacheImageInputStream extends ImageInputStreamImpl {
      *
      * @param stream an {@code InputStream} to read from.
      *
-     * @exception IllegalArgumentException if {@code stream} is
+     * @throws IllegalArgumentException if {@code stream} is
      * {@code null}.
      */
     public MemoryCacheImageInputStream(InputStream stream) {

--- a/src/java.desktop/share/classes/javax/imageio/stream/MemoryCacheImageOutputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/MemoryCacheImageOutputStream.java
@@ -51,7 +51,7 @@ public class MemoryCacheImageOutputStream extends ImageOutputStreamImpl {
      *
      * @param stream an {@code OutputStream} to write to.
      *
-     * @exception IllegalArgumentException if {@code stream} is
+     * @throws IllegalArgumentException if {@code stream} is
      * {@code null}.
      */
     public MemoryCacheImageOutputStream(OutputStream stream) {

--- a/src/java.desktop/share/classes/sun/awt/image/ByteBandedRaster.java
+++ b/src/java.desktop/share/classes/sun/awt/image/ByteBandedRaster.java
@@ -634,7 +634,7 @@ public class ByteBandedRaster extends SunWritableRaster {
      * @param x0              Translated X origin of the subraster.
      * @param y0              Translated Y origin of the subraster.
      * @param bandList        Array of band indices.
-     * @exception RasterFormatException
+     * @throws RasterFormatException
      *            if the specified bounding box is outside of the parent raster.
      */
     public WritableRaster createWritableChild (int x, int y,
@@ -689,7 +689,7 @@ public class ByteBandedRaster extends SunWritableRaster {
      * @param x0              Translated X origin of the subraster.
      * @param y0              Translated Y origin of the subraster.
      * @param bandList        Array of band indices.
-     * @exception RasterFormatException
+     * @throws RasterFormatException
      *            if the specified bounding box is outside of the parent raster.
      */
     public Raster createChild (int x, int y,

--- a/src/java.desktop/share/classes/sun/awt/image/ByteComponentRaster.java
+++ b/src/java.desktop/share/classes/sun/awt/image/ByteComponentRaster.java
@@ -759,7 +759,7 @@ public class ByteComponentRaster extends SunWritableRaster {
      * @param x0              Translated X origin of the subraster.
      * @param y0              Translated Y origin of the subraster.
      * @param bandList        Array of band indices.
-     * @exception RasterFormatException
+     * @throws RasterFormatException
      *            if the specified bounding box is outside of the parent raster.
      */
     public Raster createChild(int x, int y,
@@ -788,7 +788,7 @@ public class ByteComponentRaster extends SunWritableRaster {
      * @param x0              Translated X origin of the subraster.
      * @param y0              Translated Y origin of the subraster.
      * @param bandList        Array of band indices.
-     * @exception RasterFormatException
+     * @throws RasterFormatException
      *            if the specified bounding box is outside of the parent Raster.
      */
     public WritableRaster createWritableChild(int x, int y,

--- a/src/java.desktop/share/classes/sun/awt/image/ByteInterleavedRaster.java
+++ b/src/java.desktop/share/classes/sun/awt/image/ByteInterleavedRaster.java
@@ -1195,7 +1195,7 @@ public class ByteInterleavedRaster extends ByteComponentRaster {
      * @param x0              Translated X origin of the subraster.
      * @param y0              Translated Y origin of the subraster.
      * @param bandList        Array of band indices.
-     * @exception RasterFormatException
+     * @throws RasterFormatException
      *            if the specified bounding box is outside of the parent raster.
      */
     public Raster createChild(int x, int y,
@@ -1224,7 +1224,7 @@ public class ByteInterleavedRaster extends ByteComponentRaster {
      * @param x0              Translated X origin of the subraster.
      * @param y0              Translated Y origin of the subraster.
      * @param bandList        Array of band indices.
-     * @exception RasterFormatException
+     * @throws RasterFormatException
      *            if the specified bounding box is outside of the parent Raster.
      */
     public WritableRaster createWritableChild(int x, int y,

--- a/src/java.desktop/share/classes/sun/awt/image/BytePackedRaster.java
+++ b/src/java.desktop/share/classes/sun/awt/image/BytePackedRaster.java
@@ -143,7 +143,7 @@ public class BytePackedRaster extends SunWritableRaster {
      * @param origin          The Point that specifies the origin.
      * @param parent          The parent (if any) of this raster.
      *
-     * @exception RasterFormatException if the parameters do not conform
+     * @throws RasterFormatException if the parameters do not conform
      * to requirements of this Raster type.
      */
     public BytePackedRaster(SampleModel sampleModel,
@@ -1258,7 +1258,7 @@ public class BytePackedRaster extends SunWritableRaster {
      * @param x0              Translated X origin of the subraster.
      * @param y0              Translated Y origin of the subraster.
      * @param bandList        Array of band indices.
-     * @exception RasterFormatException
+     * @throws RasterFormatException
      *            if the specified bounding box is outside of the parent raster.
      */
     public Raster createChild(int x, int y,
@@ -1286,7 +1286,7 @@ public class BytePackedRaster extends SunWritableRaster {
      * @param x0              Translated X origin of the subraster.
      * @param y0              Translated Y origin of the subraster.
      * @param bandList        Array of band indices.
-     * @exception RasterFormatException
+     * @throws RasterFormatException
      *            if the specified bounding box is outside of the parent Raster.
      */
     public WritableRaster createWritableChild(int x, int y,

--- a/src/java.desktop/share/classes/sun/awt/image/IntegerComponentRaster.java
+++ b/src/java.desktop/share/classes/sun/awt/image/IntegerComponentRaster.java
@@ -535,7 +535,7 @@ public class IntegerComponentRaster extends SunWritableRaster {
      * @param x0              Translated X origin of the subraster.
      * @param y0              Translated Y origin of the subraster.
      * @param bandList        Array of band indices.
-     * @exception RasterFormatException
+     * @throws RasterFormatException
      *            if the specified bounding box is outside of the parent raster.
      */
     public WritableRaster createWritableChild (int x, int y,
@@ -589,7 +589,7 @@ public class IntegerComponentRaster extends SunWritableRaster {
      * @param x0              Translated X origin of the subRaster.
      * @param y0              Translated Y origin of the subRaster.
      * @param bandList        Array of band indices.
-     * @exception RasterFormatException
+     * @throws RasterFormatException
      *            if the specified bounding box is outside of the parent raster.
      */
     public Raster createChild (int x, int y,

--- a/src/java.desktop/share/classes/sun/awt/image/IntegerInterleavedRaster.java
+++ b/src/java.desktop/share/classes/sun/awt/image/IntegerInterleavedRaster.java
@@ -447,7 +447,7 @@ public class IntegerInterleavedRaster extends IntegerComponentRaster {
      * @param x0              Translated X origin of the subraster.
      * @param y0              Translated Y origin of the subraster.
      * @param bandList        Array of band indices.
-     * @exception RasterFormatException
+     * @throws RasterFormatException
      *            if the specified bounding box is outside of the parent raster.
      */
     public WritableRaster createWritableChild (int x, int y,
@@ -501,7 +501,7 @@ public class IntegerInterleavedRaster extends IntegerComponentRaster {
      * @param x0              Translated X origin of the subRaster.
      * @param y0              Translated Y origin of the subRaster.
      * @param bandList        Array of band indices.
-     * @exception RasterFormatException
+     * @throws RasterFormatException
      *            if the specified bounding box is outside of the parent raster.
      */
     public Raster createChild (int x, int y,

--- a/src/java.desktop/share/classes/sun/awt/image/ShortBandedRaster.java
+++ b/src/java.desktop/share/classes/sun/awt/image/ShortBandedRaster.java
@@ -633,7 +633,7 @@ public class ShortBandedRaster extends SunWritableRaster {
      * @param x0              Translated X origin of the subraster.
      * @param y0              Translated Y origin of the subraster.
      * @param bandList        Array of band indices.
-     * @exception RasterFormatException
+     * @throws RasterFormatException
      *            if the specified bounding box is outside of the parent Raster.
      */
     public WritableRaster createWritableChild(int x, int y,
@@ -689,7 +689,7 @@ public class ShortBandedRaster extends SunWritableRaster {
      * @param x0              Translated X origin of the subraster.
      * @param y0              Translated Y origin of the subraster.
      * @param bandList        Array of band indices.
-     * @exception RasterFormatException
+     * @throws RasterFormatException
      *            if the specified bounding box is outside of the parent raster.
      */
     public Raster createChild (int x, int y,

--- a/src/java.desktop/share/classes/sun/awt/image/ShortComponentRaster.java
+++ b/src/java.desktop/share/classes/sun/awt/image/ShortComponentRaster.java
@@ -693,7 +693,7 @@ public class ShortComponentRaster extends SunWritableRaster {
      * @param x0              Translated X origin of the subraster.
      * @param y0              Translated Y origin of the subraster.
      * @param bandList        Array of band indices.
-     * @exception RasterFormatException
+     * @throws RasterFormatException
      *            if the specified bounding box is outside of the parent raster.
      */
     public Raster createChild (int x, int y,
@@ -722,7 +722,7 @@ public class ShortComponentRaster extends SunWritableRaster {
      * @param x0              Translated X origin of the subraster.
      * @param y0              Translated Y origin of the subraster.
      * @param bandList        Array of band indices.
-     * @exception RasterFormatException
+     * @throws RasterFormatException
      *            if the specified bounding box is outside of the parent Raster.
      */
     public WritableRaster createWritableChild(int x, int y,

--- a/src/java.desktop/share/classes/sun/awt/image/ShortInterleavedRaster.java
+++ b/src/java.desktop/share/classes/sun/awt/image/ShortInterleavedRaster.java
@@ -666,7 +666,7 @@ public class ShortInterleavedRaster extends ShortComponentRaster {
      * @param x0              Translated X origin of the subraster.
      * @param y0              Translated Y origin of the subraster.
      * @param bandList        Array of band indices.
-     * @exception RasterFormatException
+     * @throws RasterFormatException
      *            if the specified bounding box is outside of the parent raster.
      */
     public Raster createChild (int x, int y,
@@ -695,7 +695,7 @@ public class ShortInterleavedRaster extends ShortComponentRaster {
      * @param x0              Translated X origin of the subraster.
      * @param y0              Translated Y origin of the subraster.
      * @param bandList        Array of band indices.
-     * @exception RasterFormatException
+     * @throws RasterFormatException
      *            if the specified bounding box is outside of the parent Raster.
      */
     public WritableRaster createWritableChild(int x, int y,


### PR DESCRIPTION
Prevailing JDK coding practices use "@throws" rather than "@exception".
Refactor existing imageio classes javadoc to use @throws

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283437](https://bugs.openjdk.java.net/browse/JDK-8283437): Refactor imageio classes javadoc to use @throws instead of @exception


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7885/head:pull/7885` \
`$ git checkout pull/7885`

Update a local copy of the PR: \
`$ git checkout pull/7885` \
`$ git pull https://git.openjdk.java.net/jdk pull/7885/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7885`

View PR using the GUI difftool: \
`$ git pr show -t 7885`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7885.diff">https://git.openjdk.java.net/jdk/pull/7885.diff</a>

</details>
