### PR TITLE
8282952: Thread::exit should be immune to Thread.stop

### DIFF
--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1388,7 +1388,6 @@ void JavaThread::exit(bool destroy_vm, ExitType exit_type) {
                               vmSymbols::exit_method_name(),
                               vmSymbols::void_method_signature(),
                               THREAD);
-      guarantee(java_lang_Thread::threadGroup(threadObj()) == NULL, "Must be");
       CLEAR_PENDING_EXCEPTION;
     }
 

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1376,8 +1376,8 @@ void JavaThread::exit(bool destroy_vm, ExitType exit_type) {
     if (!is_Compiler_thread()) {
       // We have finished executing user-defined Java code and now have to do the
       // implementation specific clean-up by calling Thread.exit(). We prevent any
-      // further asynchronous exceptions from being delivered to ensure the clean-up
-      // is not corrupted.
+      // asynchronous exceptions from being delivered while in Thread.exit()
+      // to ensure the clean-up is not corrupted.
       NoAsyncExceptionDeliveryMark _no_async(this);
 
       EXCEPTION_MARK;

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1613,11 +1613,10 @@ void JavaThread::check_and_handle_async_exceptions() {
     }
   }
 
-  if ((_suspend_flags & _async_delivery_disabled) != 0) {
-    log_info(exceptions)("Async exception delivery is disabled");
-  }
-
   if (!clear_async_exception_condition()) {
+    if ((_suspend_flags & _async_delivery_disabled) != 0) {
+      log_info(exceptions)("Async exception delivery is disabled");
+    }
     return;
   }
 

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1392,10 +1392,6 @@ void JavaThread::exit(bool destroy_vm, ExitType exit_type) {
       CLEAR_PENDING_EXCEPTION;
     }
 
-    if (this->has_async_exception_condition()) {
-      log_info(exceptions)("Pending async exception detected after Thread::exit");
-    }
-
     // notify JVMTI
     if (JvmtiExport::should_post_thread_life()) {
       JvmtiExport::post_thread_end(this);

--- a/src/hotspot/share/runtime/thread.inline.hpp
+++ b/src/hotspot/share/runtime/thread.inline.hpp
@@ -124,7 +124,9 @@ inline void JavaThread::clear_obj_deopt_flag() {
 
 inline bool JavaThread::clear_async_exception_condition() {
   bool ret = has_async_exception_condition();
-  clear_suspend_flag(_has_async_exception);
+  if (ret) {
+    clear_suspend_flag(_has_async_exception);
+  }
   return ret;
 }
 
@@ -136,6 +138,15 @@ inline void JavaThread::set_pending_async_exception(oop e) {
 inline void JavaThread::set_pending_unsafe_access_error() {
   set_suspend_flag(_has_async_exception);
   DEBUG_ONLY(_is_unsafe_access_error = true);
+}
+
+
+inline JavaThread::NoAsyncExceptionDeliveryMark::NoAsyncExceptionDeliveryMark(JavaThread *t) : _target(t) {
+  assert((_target->_suspend_flags & _async_delivery_disabled) == 0, "Nesting is not supported");
+  _target->set_suspend_flag(_async_delivery_disabled);
+}
+inline JavaThread::NoAsyncExceptionDeliveryMark::~NoAsyncExceptionDeliveryMark() {
+  _target->clear_suspend_flag(_async_delivery_disabled);
 }
 
 inline JavaThreadState JavaThread::thread_state() const    {


### PR DESCRIPTION
To allow Thread::exit to be immune from asynchronous exceptions causing corruption of state we introduce a simple async exception delivery deferral mechanism. Note that we still allow async exceptions to become the "pending async exception" so they are not lost (potentially desirable in other usecases), but we defer the delivery of that exception i.e when it is moved from being the "pending async exception" to being the "current pending exception" (which is the exception actually in the process of being propagated).

Testing:
 - runtime/Thread/StopAtExit.java combined with logging and debugging hooks to show that exceptions were being deferred
 - tiers 1-3

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282952](https://bugs.openjdk.java.net/browse/JDK-8282952): Thread::exit should be immune to Thread.stop


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Patricio Chilano Mateo](https://openjdk.java.net/census#pchilanomate) (@pchilano - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7886/head:pull/7886` \
`$ git checkout pull/7886`

Update a local copy of the PR: \
`$ git checkout pull/7886` \
`$ git pull https://git.openjdk.java.net/jdk pull/7886/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7886`

View PR using the GUI difftool: \
`$ git pr show -t 7886`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7886.diff">https://git.openjdk.java.net/jdk/pull/7886.diff</a>

</details>
