### PR TITLE
8283447: Remove unused LIR_Assembler::_bs 

### DIFF
--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@
 #include "c1/c1_ValueStack.hpp"
 #include "ci/ciInstance.hpp"
 #include "compiler/oopMap.hpp"
-#include "gc/shared/barrierSet.hpp"
 #include "runtime/os.hpp"
 #include "runtime/vm_version.hpp"
 
@@ -104,7 +103,6 @@ PatchingStub::PatchID LIR_Assembler::patching_id(CodeEmitInfo* info) {
 
 LIR_Assembler::LIR_Assembler(Compilation* c):
    _masm(c->masm())
- , _bs(BarrierSet::barrier_set())
  , _compilation(c)
  , _frame_map(c->frame_map())
  , _current_block(NULL)

--- a/src/hotspot/share/c1/c1_LIRAssembler.hpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,13 +32,11 @@
 
 class Compilation;
 class ScopeValue;
-class BarrierSet;
 
 class LIR_Assembler: public CompilationResourceObj {
  private:
   C1_MacroAssembler* _masm;
   CodeStubList*      _slow_case_stubs;
-  BarrierSet*        _bs;
 
   Compilation*       _compilation;
   FrameMap*          _frame_map;


### PR DESCRIPTION
Hi,

  can I have reviews for this trivial removal of the unused `LIR_Assembler::_bs ` member?

Test: gha, local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283447](https://bugs.openjdk.java.net/browse/JDK-8283447): Remove unused LIR_Assembler::_bs


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7887/head:pull/7887` \
`$ git checkout pull/7887`

Update a local copy of the PR: \
`$ git checkout pull/7887` \
`$ git pull https://git.openjdk.java.net/jdk pull/7887/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7887`

View PR using the GUI difftool: \
`$ git pr show -t 7887`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7887.diff">https://git.openjdk.java.net/jdk/pull/7887.diff</a>

</details>
