### PR TITLE
8283456: Make CompiledICHolder::live_count/live_not_claimed_count debug only

### DIFF
--- a/src/hotspot/share/oops/compiledICHolder.cpp
+++ b/src/hotspot/share/oops/compiledICHolder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,10 @@
 #include "oops/compiledICHolder.hpp"
 #include "runtime/atomic.hpp"
 
+#ifdef ASSERT
 volatile int CompiledICHolder::_live_count;
 volatile int CompiledICHolder::_live_not_claimed_count;
-
+#endif
 
 CompiledICHolder::CompiledICHolder(Metadata* metadata, Klass* klass, bool is_method)
   : _holder_metadata(metadata), _holder_klass(klass), _is_metadata_method(is_method) {

--- a/src/hotspot/share/oops/compiledICHolder.hpp
+++ b/src/hotspot/share/oops/compiledICHolder.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,9 +44,11 @@
 class CompiledICHolder : public CHeapObj<mtCompiler> {
   friend class VMStructs;
  private:
+#ifdef ASSERT
   static volatile int _live_count; // allocated
   static volatile int _live_not_claimed_count; // allocated but not yet in use so not
                                                // reachable by iterating over nmethods
+#endif
 
   Metadata* _holder_metadata;
   Klass*    _holder_klass;    // to avoid name conflict with oopDesc::_klass
@@ -58,8 +60,10 @@ class CompiledICHolder : public CHeapObj<mtCompiler> {
   CompiledICHolder(Metadata* metadata, Klass* klass, bool is_method = true);
   ~CompiledICHolder() NOT_DEBUG_RETURN;
 
+#ifdef ASSERT
   static int live_count() { return _live_count; }
   static int live_not_claimed_count() { return _live_not_claimed_count; }
+#endif
 
   // accessors
   Klass*    holder_klass()  const     { return _holder_klass; }


### PR DESCRIPTION
Please review this trivial patch to make `CompiledICHolder::live_count/live_not_claimed_count` debug only, since they are only updated/used in debug only code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283456](https://bugs.openjdk.java.net/browse/JDK-8283456): Make CompiledICHolder::live_count/live_not_claimed_count debug only


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7890/head:pull/7890` \
`$ git checkout pull/7890`

Update a local copy of the PR: \
`$ git checkout pull/7890` \
`$ git pull https://git.openjdk.java.net/jdk pull/7890/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7890`

View PR using the GUI difftool: \
`$ git pr show -t 7890`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7890.diff">https://git.openjdk.java.net/jdk/pull/7890.diff</a>

</details>
