### PR TITLE
8283368: G1: Remove G1SegmentedArraySegment MEMFLAGS template parameter

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSetMemory.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.hpp
@@ -50,7 +50,7 @@ public:
   static const uint SlotAlignment = 8;
 
   G1CardSetAllocOptions(uint slot_size, uint initial_num_slots = MinimumNumSlots, uint max_num_slots = MaximumNumSlots) :
-    G1SegmentedArrayAllocOptions(align_up(slot_size, SlotAlignment), initial_num_slots, max_num_slots, SlotAlignment) {
+    G1SegmentedArrayAllocOptions(mtGCCardSet, slot_size, initial_num_slots, max_num_slots, SlotAlignment) {
   }
 
   virtual uint next_num_slots(uint prev_num_slots) const override {
@@ -58,16 +58,16 @@ public:
   }
 };
 
-typedef G1SegmentedArraySegment<mtGCCardSet> G1CardSetSegment;
+using G1CardSetSegment = G1SegmentedArraySegment;
 
-typedef G1SegmentedArrayFreeList<mtGCCardSet> G1CardSetFreeList;
+using G1CardSetFreeList = G1SegmentedArrayFreeList;
 
 // Arena-like allocator for (card set) heap memory objects.
 //
 // Allocation occurs from an internal free list of objects first. If the free list is
 // empty then tries to allocate from the G1SegmentedArray.
 class G1CardSetAllocator {
-  G1SegmentedArray<mtGCCardSet> _segmented_array;
+  G1SegmentedArray _segmented_array;
   FreeListAllocator _free_slots_list;
 
 public:
@@ -92,7 +92,7 @@ public:
   void print(outputStream* os);
 };
 
-typedef G1SegmentedArrayFreePool<mtGCCardSet> G1CardSetFreePool;
+using G1CardSetFreePool = G1SegmentedArrayFreePool;
 
 class G1CardSetMemoryManager : public CHeapObj<mtGCCardSet> {
   G1CardSetConfiguration* _config;

--- a/src/hotspot/share/gc/g1/g1SegmentedArray.cpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArray.cpp
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+
+#include "gc/g1/g1SegmentedArray.inline.hpp"
+#include "memory/allocation.hpp"
+#include "runtime/atomic.hpp"
+#include "utilities/globalCounter.inline.hpp"
+
+G1SegmentedArraySegment::G1SegmentedArraySegment(uint slot_size, uint num_slots, G1SegmentedArraySegment* next, MEMFLAGS flag) :
+  _slot_size(slot_size),
+  _num_slots(num_slots),
+  _mem_flag(flag),
+  _next(next),
+  _next_allocate(0) {
+  _bottom = ((char*) this) + header_size();
+}
+
+G1SegmentedArraySegment* G1SegmentedArraySegment::create_segment(uint slot_size,
+                                                                 uint num_slots,
+                                                                 G1SegmentedArraySegment* next,
+                                                                 MEMFLAGS mem_flag) {
+  size_t block_size = size_in_bytes(slot_size, num_slots);
+  char* alloc_block = NEW_C_HEAP_ARRAY(char, block_size, mem_flag);
+  return new (alloc_block) G1SegmentedArraySegment(slot_size, num_slots, next, mem_flag);
+}
+
+void G1SegmentedArraySegment::delete_segment(G1SegmentedArraySegment* segment) {
+  segment->~G1SegmentedArraySegment();
+  FREE_C_HEAP_ARRAY(_mem_flag, segment);
+}
+
+void G1SegmentedArrayFreeList::bulk_add(G1SegmentedArraySegment& first,
+                                        G1SegmentedArraySegment& last,
+                                        size_t num,
+                                        size_t mem_size) {
+  _list.prepend(first, last);
+  Atomic::add(&_num_segments, num, memory_order_relaxed);
+  Atomic::add(&_mem_size, mem_size, memory_order_relaxed);
+}
+
+void G1SegmentedArrayFreeList::print_on(outputStream* out, const char* prefix) {
+  out->print_cr("%s: segments %zu size %zu",
+                prefix, Atomic::load(&_num_segments), Atomic::load(&_mem_size));
+}
+
+G1SegmentedArraySegment* G1SegmentedArrayFreeList::get_all(size_t& num_segments,
+                                                           size_t& mem_size) {
+  GlobalCounter::CriticalSection cs(Thread::current());
+
+  G1SegmentedArraySegment* result = _list.pop_all();
+  num_segments = Atomic::load(&_num_segments);
+  mem_size = Atomic::load(&_mem_size);
+
+  if (result != nullptr) {
+    Atomic::sub(&_num_segments, num_segments, memory_order_relaxed);
+    Atomic::sub(&_mem_size, mem_size, memory_order_relaxed);
+  }
+  return result;
+}
+
+void G1SegmentedArrayFreeList::free_all() {
+  size_t num_freed = 0;
+  size_t mem_size_freed = 0;
+  G1SegmentedArraySegment* cur;
+
+  while ((cur = _list.pop()) != nullptr) {
+    mem_size_freed += cur->mem_size();
+    num_freed++;
+    G1SegmentedArraySegment::delete_segment(cur);
+  }
+
+  Atomic::sub(&_num_segments, num_freed, memory_order_relaxed);
+  Atomic::sub(&_mem_size, mem_size_freed, memory_order_relaxed);
+}
+
+G1SegmentedArraySegment* G1SegmentedArray::create_new_segment(G1SegmentedArraySegment* const prev) {
+  // Take an existing segment if available.
+  G1SegmentedArraySegment* next = _free_segment_list->get();
+  if (next == nullptr) {
+    uint prev_num_slots = (prev != nullptr) ? prev->num_slots() : 0;
+    uint num_slots = _alloc_options->next_num_slots(prev_num_slots);
+
+    next = G1SegmentedArraySegment::create_segment(slot_size(), num_slots, prev, _alloc_options->mem_flag());
+    // next = new G1SegmentedArraySegment(slot_size(), num_slots, prev);
+  } else {
+    assert(slot_size() == next->slot_size() ,
+           "Mismatch %d != %d", slot_size(), next->slot_size());
+    next->reset(prev);
+  }
+
+  // Install it as current allocation segment.
+  G1SegmentedArraySegment* old = Atomic::cmpxchg(&_first, prev, next);
+  if (old != prev) {
+    // Somebody else installed the segment, use that one.
+    G1SegmentedArraySegment::delete_segment(next);
+    return old;
+  } else {
+    // Did we install the first segment in the list? If so, this is also the last.
+    if (prev == nullptr) {
+      _last = next;
+    }
+    // Successfully installed the segment into the list.
+    Atomic::inc(&_num_segments, memory_order_relaxed);
+    Atomic::add(&_mem_size, next->mem_size(), memory_order_relaxed);
+    Atomic::add(&_num_available_slots, next->num_slots(), memory_order_relaxed);
+    return next;
+  }
+}
+
+G1SegmentedArray::G1SegmentedArray(const G1SegmentedArrayAllocOptions* alloc_options,
+                                   G1SegmentedArrayFreeList* free_segment_list) :
+  _alloc_options(alloc_options),
+  _first(nullptr),
+  _last(nullptr),
+  _num_segments(0),
+  _mem_size(0),
+  _free_segment_list(free_segment_list),
+  _num_available_slots(0),
+  _num_allocated_slots(0) {
+  assert(_free_segment_list != nullptr, "precondition!");
+}
+
+G1SegmentedArray::~G1SegmentedArray() {
+  drop_all();
+}
+
+uint G1SegmentedArray::slot_size() const {
+  return _alloc_options->slot_size();
+}
+
+void G1SegmentedArray::drop_all() {
+  G1SegmentedArraySegment* cur = Atomic::load_acquire(&_first);
+
+  if (cur != nullptr) {
+    assert(_last != nullptr, "If there is at least one segment, there must be a last one.");
+
+    G1SegmentedArraySegment* first = cur;
+#ifdef ASSERT
+    // Check list consistency.
+    G1SegmentedArraySegment* last = cur;
+    uint num_segments = 0;
+    size_t mem_size = 0;
+    while (cur != nullptr) {
+      mem_size += cur->mem_size();
+      num_segments++;
+
+      G1SegmentedArraySegment* next = cur->next();
+      last = cur;
+      cur = next;
+    }
+#endif
+    assert(num_segments == _num_segments, "Segment count inconsistent %u %u", num_segments, _num_segments);
+    assert(mem_size == _mem_size, "Memory size inconsistent");
+    assert(last == _last, "Inconsistent last segment");
+
+    _free_segment_list->bulk_add(*first, *_last, _num_segments, _mem_size);
+  }
+
+  _first = nullptr;
+  _last = nullptr;
+  _num_segments = 0;
+  _mem_size = 0;
+  _num_available_slots = 0;
+  _num_allocated_slots = 0;
+}
+
+void* G1SegmentedArray::allocate() {
+  assert(slot_size() > 0, "instance size not set.");
+
+  G1SegmentedArraySegment* cur = Atomic::load_acquire(&_first);
+  if (cur == nullptr) {
+    cur = create_new_segment(cur);
+  }
+
+  while (true) {
+    void* slot = cur->get_new_slot();
+    if (slot != nullptr) {
+      Atomic::inc(&_num_allocated_slots, memory_order_relaxed);
+      guarantee(is_aligned(slot, _alloc_options->slot_alignment()),
+                "result " PTR_FORMAT " not aligned at %u", p2i(slot), _alloc_options->slot_alignment());
+      return slot;
+    }
+    // The segment is full. Next round.
+    assert(cur->is_full(), "must be");
+    cur = create_new_segment(cur);
+  }
+}
+
+uint G1SegmentedArray::num_segments() const {
+  return Atomic::load(&_num_segments);
+}
+
+#ifdef ASSERT
+class LengthClosure {
+  uint _total;
+public:
+  LengthClosure() : _total(0) {}
+  void do_segment(G1SegmentedArraySegment* segment, uint limit) {
+    _total += limit;
+  }
+  uint length() const {
+    return _total;
+  }
+};
+
+uint G1SegmentedArray::calculate_length() const {
+  LengthClosure closure;
+  iterate_segments(closure);
+  return closure.length();
+}
+#endif
+
+template <typename SegmentClosure>
+void G1SegmentedArray::iterate_segments(SegmentClosure& closure) const {
+  G1SegmentedArraySegment* cur = Atomic::load_acquire(&_first);
+
+  assert((cur != nullptr) == (_last != nullptr),
+         "If there is at least one segment, there must be a last one");
+
+  while (cur != nullptr) {
+    closure.do_segment(cur, cur->length());
+    cur = cur->next();
+  }
+}

--- a/src/hotspot/share/gc/g1/g1SegmentedArray.cpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArray.cpp
@@ -104,7 +104,6 @@ G1SegmentedArraySegment* G1SegmentedArray::create_new_segment(G1SegmentedArraySe
     uint num_slots = _alloc_options->next_num_slots(prev_num_slots);
 
     next = G1SegmentedArraySegment::create_segment(slot_size(), num_slots, prev, _alloc_options->mem_flag());
-    // next = new G1SegmentedArraySegment(slot_size(), num_slots, prev);
   } else {
     assert(slot_size() == next->slot_size() ,
            "Mismatch %d != %d", slot_size(), next->slot_size());

--- a/src/hotspot/share/gc/g1/g1SegmentedArray.hpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArray.hpp
@@ -113,7 +113,7 @@ class G1SegmentedArrayFreeList {
   static G1SegmentedArraySegment* volatile* next_ptr(G1SegmentedArraySegment& segment) {
     return segment.next_addr();
   }
-  typedef LockFreeStack<G1SegmentedArraySegment, &G1SegmentedArrayFreeList::next_ptr> SegmentStack;
+  using SegmentStack = LockFreeStack<G1SegmentedArraySegment, &G1SegmentedArrayFreeList::next_ptr>;
 
   SegmentStack _list;
 

--- a/src/hotspot/share/gc/g1/g1SegmentedArray.hpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArray.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Huawei Technologies Co. Ltd. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Huawei Technologies Co. Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,28 +28,38 @@
 
 #include "gc/shared/freeListAllocator.hpp"
 #include "memory/allocation.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "utilities/lockFreeStack.hpp"
 
 // A single segment/arena containing _num_slots blocks of memory of _slot_size.
 // G1SegmentedArraySegments can be linked together using a singly linked list.
-template<MEMFLAGS flag>
-class G1SegmentedArraySegment : public CHeapObj<flag> {
+class G1SegmentedArraySegment {
   const uint _slot_size;
   const uint _num_slots;
-
+  const MEMFLAGS _mem_flag;
   G1SegmentedArraySegment* volatile _next;
-
-  char* _segment;  // Actual data.
-
   // Index into the next free slot to allocate into. Full if equal (or larger)
   // to _num_slots (can be larger because we atomically increment this value and
   // check only afterwards if the allocation has been successful).
   uint volatile _next_allocate;
 
-public:
-  G1SegmentedArraySegment(uint slot_size, uint num_slots, G1SegmentedArraySegment* next);
-  ~G1SegmentedArraySegment();
+  char* _bottom;  // Actual data.
+  // Do not add class member variables beyond this point
 
+  static size_t header_size() { return align_up(offset_of(G1SegmentedArraySegment, _bottom), DEFAULT_CACHE_LINE_SIZE); }
+
+  static size_t payload_size(uint slot_size, uint num_slots) {
+    // The cast (size_t) is required to guard against overflow wrap around.
+    return (size_t)slot_size * num_slots;
+  }
+
+  size_t payload_size() const { return payload_size(_slot_size, _num_slots); }
+
+  NONCOPYABLE(G1SegmentedArraySegment);
+
+  G1SegmentedArraySegment(uint slot_size, uint num_slots, G1SegmentedArraySegment* next, MEMFLAGS flag);
+  ~G1SegmentedArraySegment() = default;
+public:
   G1SegmentedArraySegment* volatile* next_addr() { return &_next; }
 
   void* get_new_slot();
@@ -67,12 +77,12 @@ public:
     _next_allocate = 0;
     assert(next != this, " loop condition");
     set_next(next);
-    memset((void*)_segment, 0, (size_t)_num_slots * _slot_size);
+    memset((void*)_bottom, 0, payload_size());
   }
 
   uint slot_size() const { return _slot_size; }
 
-  size_t mem_size() const { return sizeof(*this) + (size_t)_num_slots * _slot_size; }
+  size_t mem_size() const { return header_size() + payload_size(); }
 
   uint length() const {
     // _next_allocate might grow larger than _num_slots in multi-thread environments
@@ -80,9 +90,16 @@ public:
     return MIN2(_next_allocate, _num_slots);
   }
 
+  static size_t size_in_bytes(uint slot_size, uint num_slots) {
+    return header_size() + payload_size(slot_size, num_slots);
+  }
+
+  static G1SegmentedArraySegment* create_segment(uint slot_size, uint num_slots, G1SegmentedArraySegment* next, MEMFLAGS mem_flag);
+  static void delete_segment(G1SegmentedArraySegment* segment);
+
   // Copies the (valid) contents of this segment into the destination.
   void copy_to(void* dest) const {
-    ::memcpy(dest, _segment, length() * _slot_size);
+    ::memcpy(dest, _bottom, length() * _slot_size);
   }
 
   bool is_full() const { return _next_allocate >= _num_slots; }
@@ -92,12 +109,11 @@ public:
 // to it and removal of segments is strictly separate, but every action may be
 // performed by multiple threads at the same time.
 // Counts and memory usage are current on a best-effort basis if accessed concurrently.
-template<MEMFLAGS flag>
 class G1SegmentedArrayFreeList {
-  static G1SegmentedArraySegment<flag>* volatile* next_ptr(G1SegmentedArraySegment<flag>& segment) {
+  static G1SegmentedArraySegment* volatile* next_ptr(G1SegmentedArraySegment& segment) {
     return segment.next_addr();
   }
-  typedef LockFreeStack<G1SegmentedArraySegment<flag>, &G1SegmentedArrayFreeList::next_ptr> SegmentStack;
+  typedef LockFreeStack<G1SegmentedArraySegment, &G1SegmentedArrayFreeList::next_ptr> SegmentStack;
 
   SegmentStack _list;
 
@@ -108,10 +124,10 @@ public:
   G1SegmentedArrayFreeList() : _list(), _num_segments(0), _mem_size(0) { }
   ~G1SegmentedArrayFreeList() { free_all(); }
 
-  void bulk_add(G1SegmentedArraySegment<flag>& first, G1SegmentedArraySegment<flag>& last, size_t num, size_t mem_size);
+  void bulk_add(G1SegmentedArraySegment& first, G1SegmentedArraySegment& last, size_t num, size_t mem_size);
 
-  G1SegmentedArraySegment<flag>* get();
-  G1SegmentedArraySegment<flag>* get_all(size_t& num_segments, size_t& mem_size);
+  G1SegmentedArraySegment* get();
+  G1SegmentedArraySegment* get_all(size_t& num_segments, size_t& mem_size);
 
   // Give back all memory to the OS.
   void free_all();
@@ -126,6 +142,7 @@ public:
 class G1SegmentedArrayAllocOptions {
 
 protected:
+  const MEMFLAGS _mem_flag;
   const uint _slot_size;
   const uint _initial_num_slots;
   // Defines a limit to the number of slots in the segment
@@ -133,8 +150,9 @@ protected:
   const uint _slot_alignment;
 
 public:
-  G1SegmentedArrayAllocOptions(uint slot_size, uint initial_num_slots, uint max_num_slots, uint alignment) :
-    _slot_size(slot_size),
+  G1SegmentedArrayAllocOptions(MEMFLAGS mem_flag, uint slot_size, uint initial_num_slots, uint max_num_slots, uint alignment) :
+    _mem_flag(mem_flag),
+    _slot_size(align_up(slot_size, alignment)),
     _initial_num_slots(initial_num_slots),
     _max_num_slots(max_num_slots),
     _slot_alignment(alignment) {
@@ -151,6 +169,8 @@ public:
   uint slot_size() const { return _slot_size; }
 
   uint slot_alignment() const { return _slot_alignment; }
+
+  MEMFLAGS mem_flag() const {return _mem_flag; }
 };
 
 // A segmented array where G1SegmentedArraySegment is the segment, and
@@ -181,30 +201,30 @@ public:
 // The class also manages a few counters for statistics using atomic operations.
 // Their values are only consistent within each other with extra global
 // synchronization.
-template <MEMFLAGS flag>
+
 class G1SegmentedArray : public FreeListConfig  {
   // G1SegmentedArrayAllocOptions provides parameters for allocation segment
   // sizing and expansion.
   const G1SegmentedArrayAllocOptions* _alloc_options;
 
-  G1SegmentedArraySegment<flag>* volatile _first;       // The (start of the) list of all segments.
-  G1SegmentedArraySegment<flag>* _last;                 // The last segment of the list of all segments.
-  volatile uint _num_segments;                          // Number of assigned segments to this allocator.
-  volatile size_t _mem_size;                            // Memory used by all segments.
+  G1SegmentedArraySegment* volatile _first;       // The (start of the) list of all segments.
+  G1SegmentedArraySegment* _last;                 // The last segment of the list of all segments.
+  volatile uint _num_segments;                    // Number of assigned segments to this allocator.
+  volatile size_t _mem_size;                      // Memory used by all segments.
 
-  G1SegmentedArrayFreeList<flag>* _free_segment_list;   // The global free segment list to
-                                                        // preferentially get new segments from.
+  G1SegmentedArrayFreeList* _free_segment_list;   // The global free segment list to preferentially
+                                                  // get new segments from.
 
   volatile uint _num_available_slots; // Number of slots available in all segments (allocated + free + pending + not yet used).
   volatile uint _num_allocated_slots; // Number of total slots allocated and in use.
 
 private:
-  inline G1SegmentedArraySegment<flag>* create_new_segment(G1SegmentedArraySegment<flag>* const prev);
+  inline G1SegmentedArraySegment* create_new_segment(G1SegmentedArraySegment* const prev);
 
   DEBUG_ONLY(uint calculate_length() const;)
 
 public:
-  const G1SegmentedArraySegment<flag>* first_array_segment() const { return Atomic::load(&_first); }
+  const G1SegmentedArraySegment* first_array_segment() const { return Atomic::load(&_first); }
 
   uint num_available_slots() const { return Atomic::load(&_num_available_slots); }
   uint num_allocated_slots() const {
@@ -213,10 +233,10 @@ public:
     return allocated;
   }
 
-  inline uint slot_size() const;
+  uint slot_size() const;
 
   G1SegmentedArray(const G1SegmentedArrayAllocOptions* alloc_options,
-                   G1SegmentedArrayFreeList<flag>* free_segment_list);
+                   G1SegmentedArrayFreeList* free_segment_list);
   ~G1SegmentedArray();
 
   // Deallocate all segments to the free segment list and reset this allocator. Must
@@ -228,7 +248,7 @@ public:
   // We do not deallocate individual slots
   inline void deallocate(void* node) override { ShouldNotReachHere(); }
 
-  inline uint num_segments() const;
+  uint num_segments() const;
 
   template<typename SegmentClosure>
   void iterate_segments(SegmentClosure& closure) const;

--- a/src/hotspot/share/gc/g1/g1SegmentedArrayFreeMemoryTask.cpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArrayFreeMemoryTask.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ bool G1SegmentedArrayFreeMemoryTask::calculate_return_infos(jlong deadline) {
   // Ignore the deadline in this step as it is very short.
 
   G1SegmentedArrayMemoryStats used = _total_used;
-  G1SegmentedArrayMemoryStats free = G1SegmentedArrayFreePool<mtGCCardSet>::free_list_sizes();
+  G1SegmentedArrayMemoryStats free = G1SegmentedArrayFreePool::free_list_sizes();
 
   _return_info = new G1ReturnMemoryProcessorSet(used.num_pools());
   for (uint i = 0; i < used.num_pools(); i++) {
@@ -68,7 +68,7 @@ bool G1SegmentedArrayFreeMemoryTask::calculate_return_infos(jlong deadline) {
     _return_info->append(new G1ReturnMemoryProcessor(return_to_vm_size));
   }
 
-  G1SegmentedArrayFreePool<mtGCCardSet>::update_unlink_processors(_return_info);
+  G1SegmentedArrayFreePool::update_unlink_processors(_return_info);
   return false;
 }
 

--- a/src/hotspot/share/gc/g1/g1SegmentedArrayFreeMemoryTask.hpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArrayFreeMemoryTask.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,8 +56,8 @@ class G1SegmentedArrayFreeMemoryTask : public G1ServiceTask {
   // Current total segmented array memory usage.
   G1SegmentedArrayMemoryStats _total_used;
 
-  typedef G1SegmentedArrayFreePool<mtGCCardSet>::G1ReturnMemoryProcessor G1ReturnMemoryProcessor;
-  typedef G1SegmentedArrayFreePool<mtGCCardSet>::G1ReturnMemoryProcessorSet G1ReturnMemoryProcessorSet;
+  using G1ReturnMemoryProcessor = G1SegmentedArrayFreePool::G1ReturnMemoryProcessor;
+  using G1ReturnMemoryProcessorSet = G1SegmentedArrayFreePool::G1ReturnMemoryProcessorSet;
 
   G1ReturnMemoryProcessorSet* _return_info;
 

--- a/src/hotspot/share/gc/g1/g1SegmentedArrayFreePool.hpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArrayFreePool.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,13 +56,12 @@ public:
 
 // A set of free lists holding freed segments for use by G1SegmentedArray,
 // e.g. G1CardSetAllocators::SegmentedArray
-template<MEMFLAGS flag>
 class G1SegmentedArrayFreePool {
   // The global free pool.
   static G1SegmentedArrayFreePool _freelist_pool;
 
   const uint _num_free_lists;
-  G1SegmentedArrayFreeList<flag>* _free_lists;
+  G1SegmentedArrayFreeList* _free_lists;
 
 public:
   static G1SegmentedArrayFreePool* free_list_pool() { return &_freelist_pool; }
@@ -76,7 +75,7 @@ public:
   explicit G1SegmentedArrayFreePool(uint num_free_lists);
   ~G1SegmentedArrayFreePool();
 
-  G1SegmentedArrayFreeList<flag>* free_list(uint i) {
+  G1SegmentedArrayFreeList* free_list(uint i) {
     assert(i < _num_free_lists, "must be");
     return &_free_lists[i];
   }
@@ -91,12 +90,11 @@ public:
 
 // Data structure containing current in-progress state for returning memory to the
 // operating system for a single G1SegmentedArrayFreeList.
-template<MEMFLAGS flag>
-class G1SegmentedArrayFreePool<flag>::G1ReturnMemoryProcessor : public CHeapObj<mtGC> {
-  G1SegmentedArrayFreeList<flag>* _source;
+class G1SegmentedArrayFreePool::G1ReturnMemoryProcessor : public CHeapObj<mtGC> {
+  G1SegmentedArrayFreeList* _source;
   size_t _return_to_vm_size;
 
-  G1SegmentedArraySegment<flag>* _first;
+  G1SegmentedArraySegment* _first;
   size_t _unlinked_bytes;
   size_t _num_unlinked;
 
@@ -108,7 +106,7 @@ public:
   // Updates the instance members about the given free list for
   // the purpose of giving back memory. Only necessary members are updated,
   // e.g. if there is nothing to return to the VM, do not set the source list.
-  void visit_free_list(G1SegmentedArrayFreeList<flag>* source);
+  void visit_free_list(G1SegmentedArrayFreeList* source);
 
   bool finished_return_to_vm() const { return _return_to_vm_size == 0; }
   bool finished_return_to_os() const { return _first == nullptr; }

--- a/src/hotspot/share/gc/g1/heapRegionRemSet.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,7 @@ HeapRegionRemSet::HeapRegionRemSet(HeapRegion* hr,
                                    G1CardSetConfiguration* config) :
   _m(Mutex::service - 1, FormatBuffer<128>("HeapRegionRemSet#%u_lock", hr->hrm_index())),
   _code_roots(),
-  _card_set_mm(config, G1SegmentedArrayFreePool<mtGCCardSet>::free_list_pool()),
+  _card_set_mm(config, G1SegmentedArrayFreePool::free_list_pool()),
   _card_set(config, &_card_set_mm),
   _hr(hr),
   _state(Untracked) { }


### PR DESCRIPTION
Hi all,

Please review this change to remove the MEMFLAGS template parameter for G1SegmentedArraySegment and make it a runtime configuration parameter. This reduces on the code bloat due to templating because many of the methods in G1SegmentedArraySegment are independent of the template parameter.

To achieve this we added factory methods for handling allocation and deallocation. Having the factory methods allows us to embed the array data with the G1SegmentedArraySegment struct thus limiting the allocation to a single allocation as well as the deallocation. One upside to this approach is that we limit the allocation and deallocation overheads. 

Thanks
Ivan

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283368](https://bugs.openjdk.java.net/browse/JDK-8283368): G1: Remove G1SegmentedArraySegment MEMFLAGS template parameter


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to ea77e81b2fe412447cf6a1153cf42e9835658c8f


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7891/head:pull/7891` \
`$ git checkout pull/7891`

Update a local copy of the PR: \
`$ git checkout pull/7891` \
`$ git pull https://git.openjdk.java.net/jdk pull/7891/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7891`

View PR using the GUI difftool: \
`$ git pr show -t 7891`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7891.diff">https://git.openjdk.java.net/jdk/pull/7891.diff</a>

</details>
