### PR TITLE
8281222: ciTypeFlow::profiled_count fails "assert(0 <= i && i < _len) failed: illegal index"

### DIFF
--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -2460,7 +2460,7 @@ int ciTypeFlow::profiled_count(ciTypeFlow::Loop* loop) {
     return 0;
   }
   ciTypeFlow::Block* tail = loop->tail();
-  if (tail->control() == -1) {
+  if (tail->control() == -1 || tail->has_trap()) {
     return 0;
   }
 


### PR DESCRIPTION
This failed in Project Loom with a specific version of TestNG. 

The root cause is that the block that is considered tail doesn't have any _successors, but a couple of _exception "successors".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281222](https://bugs.openjdk.java.net/browse/JDK-8281222): ciTypeFlow::profiled_count fails "assert(0 <= i && i < _len) failed: illegal index"


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7892/head:pull/7892` \
`$ git checkout pull/7892`

Update a local copy of the PR: \
`$ git checkout pull/7892` \
`$ git pull https://git.openjdk.java.net/jdk pull/7892/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7892`

View PR using the GUI difftool: \
`$ git pr show -t 7892`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7892.diff">https://git.openjdk.java.net/jdk/pull/7892.diff</a>

</details>
