### PR TITLE
8163327: Remove 3DES from the default enabled cipher suites list

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/CipherSuite.java
+++ b/src/java.base/share/classes/sun/security/ssl/CipherSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,9 +54,9 @@ enum CipherSuite {
     //    changed later, see below).
     // 2. Prefer forward secrecy cipher suites.
     // 3. Prefer the stronger bulk cipher, in the order of AES_256(GCM),
-    //    AES_128(GCM), AES_256, AES_128, 3DES-EDE.
+    //    AES_128(GCM), AES_256, AES_128.
     // 4. Prefer the stronger MAC algorithm, in the order of SHA384,
-    //    SHA256, SHA, MD5.
+    //    SHA256, SHA.
     // 5. Prefer the better performance of key exchange and digital
     //    signature algorithm, in the order of ECDHE-ECDSA, ECDHE-RSA,
     //    DHE-RSA, DHE-DSS, ECDH-ECDSA, ECDH-RSA, RSA.
@@ -327,41 +327,6 @@ enum CipherSuite {
             ProtocolVersion.PROTOCOLS_TO_12,
             K_RSA, B_AES_128, M_SHA, H_SHA256),
 
-    // 3DES_EDE, forward secrecy.
-    TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA(
-            0xC008, true, "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA", "",
-            ProtocolVersion.PROTOCOLS_TO_12,
-            K_ECDHE_ECDSA, B_3DES, M_SHA, H_SHA256),
-    TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA(
-            0xC012, true, "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA", "",
-            ProtocolVersion.PROTOCOLS_TO_12,
-            K_ECDHE_RSA, B_3DES, M_SHA, H_SHA256),
-    SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA(
-            0x0016, true, "SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA",
-                          "TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA",
-            ProtocolVersion.PROTOCOLS_TO_12,
-            K_DHE_RSA, B_3DES, M_SHA, H_SHA256),
-    SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA(
-            0x0013, true, "SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA",
-                          "TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA",
-            ProtocolVersion.PROTOCOLS_TO_12,
-            K_DHE_DSS, B_3DES, M_SHA, H_SHA256),
-
-    // 3DES_EDE, not forward secrecy.
-    TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA(
-            0xC003, true, "TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA", "",
-            ProtocolVersion.PROTOCOLS_TO_12,
-            K_ECDH_ECDSA, B_3DES, M_SHA, H_SHA256),
-    TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA(
-            0xC00D, true, "TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA", "",
-            ProtocolVersion.PROTOCOLS_TO_12,
-            K_ECDH_RSA, B_3DES, M_SHA, H_SHA256),
-    SSL_RSA_WITH_3DES_EDE_CBC_SHA(
-            0x000A, true, "SSL_RSA_WITH_3DES_EDE_CBC_SHA",
-                          "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
-            ProtocolVersion.PROTOCOLS_TO_12,
-            K_RSA, B_3DES, M_SHA, H_SHA256),
-
     // Renegotiation protection request Signalling Cipher Suite Value (SCSV).
     TLS_EMPTY_RENEGOTIATION_INFO_SCSV(        //  RFC 5746, TLS 1.2 and prior
             0x00FF, true, "TLS_EMPTY_RENEGOTIATION_INFO_SCSV", "",
@@ -422,6 +387,41 @@ enum CipherSuite {
                            "TLS_DH_anon_WITH_3DES_EDE_CBC_SHA",
             ProtocolVersion.PROTOCOLS_TO_12,
             K_DH_ANON, B_3DES, M_SHA, H_SHA256),
+
+    // 3DES_EDE, forward secrecy.
+    TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA(
+            0xC008, false, "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA", "",
+            ProtocolVersion.PROTOCOLS_TO_12,
+            K_ECDHE_ECDSA, B_3DES, M_SHA, H_SHA256),
+    TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA(
+            0xC012, false, "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA", "",
+            ProtocolVersion.PROTOCOLS_TO_12,
+            K_ECDHE_RSA, B_3DES, M_SHA, H_SHA256),
+    SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA(
+            0x0016, false, "SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA",
+                           "TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA",
+            ProtocolVersion.PROTOCOLS_TO_12,
+            K_DHE_RSA, B_3DES, M_SHA, H_SHA256),
+    SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA(
+            0x0013, false, "SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA",
+                           "TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA",
+            ProtocolVersion.PROTOCOLS_TO_12,
+            K_DHE_DSS, B_3DES, M_SHA, H_SHA256),
+
+    // 3DES_EDE, not forward secrecy.
+    TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA(
+            0xC003, false, "TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA", "",
+            ProtocolVersion.PROTOCOLS_TO_12,
+            K_ECDH_ECDSA, B_3DES, M_SHA, H_SHA256),
+    TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA(
+            0xC00D, false, "TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA", "",
+            ProtocolVersion.PROTOCOLS_TO_12,
+            K_ECDH_RSA, B_3DES, M_SHA, H_SHA256),
+    SSL_RSA_WITH_3DES_EDE_CBC_SHA(
+            0x000A, false, "SSL_RSA_WITH_3DES_EDE_CBC_SHA",
+                           "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+            ProtocolVersion.PROTOCOLS_TO_12,
+            K_RSA, B_3DES, M_SHA, H_SHA256),
 
     // RC4
     TLS_ECDHE_ECDSA_WITH_RC4_128_SHA(

--- a/src/java.base/share/classes/sun/security/ssl/CipherSuite.java
+++ b/src/java.base/share/classes/sun/security/ssl/CipherSuite.java
@@ -378,15 +378,6 @@ enum CipherSuite {
             0x0034, false, "TLS_DH_anon_WITH_AES_128_CBC_SHA", "",
             ProtocolVersion.PROTOCOLS_TO_12,
             K_DH_ANON, B_AES_128, M_SHA, H_SHA256),
-    TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA(
-            0xC017, false, "TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA", "",
-            ProtocolVersion.PROTOCOLS_TO_12,
-            K_ECDH_ANON, B_3DES, M_SHA, H_SHA256),
-    SSL_DH_anon_WITH_3DES_EDE_CBC_SHA(
-            0x001B, false, "SSL_DH_anon_WITH_3DES_EDE_CBC_SHA",
-                           "TLS_DH_anon_WITH_3DES_EDE_CBC_SHA",
-            ProtocolVersion.PROTOCOLS_TO_12,
-            K_DH_ANON, B_3DES, M_SHA, H_SHA256),
 
     // 3DES_EDE, forward secrecy.
     TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA(
@@ -422,6 +413,15 @@ enum CipherSuite {
                            "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
             ProtocolVersion.PROTOCOLS_TO_12,
             K_RSA, B_3DES, M_SHA, H_SHA256),
+    TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA(
+            0xC017, false, "TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA", "",
+            ProtocolVersion.PROTOCOLS_TO_12,
+            K_ECDH_ANON, B_3DES, M_SHA, H_SHA256),
+    SSL_DH_anon_WITH_3DES_EDE_CBC_SHA(
+            0x001B, false, "SSL_DH_anon_WITH_3DES_EDE_CBC_SHA",
+                           "TLS_DH_anon_WITH_3DES_EDE_CBC_SHA",
+            ProtocolVersion.PROTOCOLS_TO_12,
+            K_DH_ANON, B_3DES, M_SHA, H_SHA256),
 
     // RC4
     TLS_ECDHE_ECDSA_WITH_RC4_128_SHA(

--- a/test/jdk/javax/net/ssl/DTLS/CipherSuite.java
+++ b/test/jdk/javax/net/ssl/DTLS/CipherSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,6 +51,9 @@
 
 import javax.net.ssl.SSLEngine;
 import java.security.Security;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Test common DTLS cipher suites.
@@ -59,10 +62,12 @@ public class CipherSuite extends DTLSOverDatagram {
 
     // use the specific cipher suite
     volatile static String cipherSuite;
+    private static boolean reenable;
 
     public static void main(String[] args) throws Exception {
         if (args.length > 1 && "re-enable".equals(args[1])) {
             Security.setProperty("jdk.tls.disabledAlgorithms", "");
+            reenable = true;
         }
 
         cipherSuite = args[0];
@@ -77,6 +82,11 @@ public class CipherSuite extends DTLSOverDatagram {
 
         if (isClient) {
             engine.setEnabledCipherSuites(new String[]{cipherSuite});
+        } else if (reenable) {
+            List<String> cipherSuites =
+                new ArrayList(Arrays.asList(engine.getEnabledCipherSuites()));
+            cipherSuites.add(cipherSuite);
+            engine.setEnabledCipherSuites(cipherSuites.toArray(new String[0]));
         }
 
         return engine;

--- a/test/jdk/javax/net/ssl/ciphersuites/DisabledAlgorithms.java
+++ b/test/jdk/javax/net/ssl/ciphersuites/DisabledAlgorithms.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8076221 8211883
+ * @bug 8076221 8211883 8163327
  * @summary Check if weak cipher suites are disabled
  * @modules jdk.crypto.ec
  * @run main/othervm DisabledAlgorithms default
@@ -60,9 +60,10 @@ public class DisabledAlgorithms {
             System.getProperty("test.src", "./") + "/" + pathToStores +
                 "/" + trustStoreFile;
 
-    // supported RC4, NULL, and anon cipher suites
+    // supported 3DES, DES, RC4, NULL, and anon cipher suites
     // it does not contain KRB5 cipher suites because they need a KDC
-    private static final String[] rc4_null_anon_ciphersuites = new String[] {
+    private static final String[] desede_des_rc4_null_anon_ciphersuites
+        = new String[] {
         "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
         "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
         "SSL_RSA_WITH_RC4_128_SHA",
@@ -90,11 +91,25 @@ public class DisabledAlgorithms {
         "TLS_DH_anon_WITH_AES_256_CBC_SHA",
         "TLS_DH_anon_WITH_AES_256_CBC_SHA256",
         "TLS_DH_anon_WITH_AES_256_GCM_SHA384",
+        "SSL_RSA_WITH_DES_CBC_SHA",
+        "SSL_DHE_RSA_WITH_DES_CBC_SHA",
+        "SSL_DHE_DSS_WITH_DES_CBC_SHA",
+        "SSL_RSA_EXPORT_WITH_DES40_CBC_SHA",
+        "SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA",
+        "SSL_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA",
+        "SSL_RSA_EXPORT_WITH_RC4_40_MD5",
         "TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA",
         "TLS_ECDH_anon_WITH_AES_128_CBC_SHA",
         "TLS_ECDH_anon_WITH_AES_256_CBC_SHA",
         "TLS_ECDH_anon_WITH_NULL_SHA",
-        "TLS_ECDH_anon_WITH_RC4_128_SHA"
+        "TLS_ECDH_anon_WITH_RC4_128_SHA",
+        "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA",
+        "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",
+        "SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA",
+        "SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA",
+        "TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA",
+        "TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA",
+        "SSL_RSA_WITH_3DES_EDE_CBC_SHA"
     };
 
     public static void main(String[] args) throws Exception {
@@ -113,19 +128,25 @@ public class DisabledAlgorithms {
                 System.out.println("jdk.tls.disabledAlgorithms = "
                         + Security.getProperty("jdk.tls.disabledAlgorithms"));
 
-                // check if RC4, NULL, and anon cipher suites
+                // check if 3DES, DES, RC4, NULL, and anon cipher suites
                 // can't be used by default
-                checkFailure(rc4_null_anon_ciphersuites);
+                checkFailure(desede_des_rc4_null_anon_ciphersuites);
                 break;
             case "empty":
                 // reset jdk.tls.disabledAlgorithms
                 Security.setProperty("jdk.tls.disabledAlgorithms", "");
                 System.out.println("jdk.tls.disabledAlgorithms = "
                         + Security.getProperty("jdk.tls.disabledAlgorithms"));
+                // reset jdk.certpath.disabledAlgorithms. This is necessary
+                // to allow the RSA_EXPORT suites to pass which use an RSA 512
+                // bit key which violates the default certpath constraints.
+                Security.setProperty("jdk.certpath.disabledAlgorithms", "");
+                System.out.println("jdk.certpath.disabledAlgorithms = "
+                    + Security.getProperty("jdk.certpath.disabledAlgorithms"));
 
-                // check if RC4, NULL, and anon cipher suites can be used
-                // if jdk.tls.disabledAlgorithms is empty
-                checkSuccess(rc4_null_anon_ciphersuites);
+                // check if 3DES, DES, RC4, NULL, and anon cipher suites
+                // can be used if jdk.{tls,certpath}.disabledAlgorithms is empty
+                checkSuccess(desede_des_rc4_null_anon_ciphersuites);
                 break;
             default:
                 throw new RuntimeException("Wrong parameter: " + args[0]);

--- a/test/jdk/sun/security/ssl/CipherSuite/NoDesRC4DesEdeCiphSuite.java
+++ b/test/jdk/sun/security/ssl/CipherSuite/NoDesRC4DesEdeCiphSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,9 @@
 
 /*
  * @test
- * @bug 8208350
- * @summary Disable all DES cipher suites
- * @run main/othervm NoDesRC4CiphSuite
+ * @bug 8208350 8163327
+ * @summary Disable all DES, RC4, and 3DES/DesEde cipher suites
+ * @run main/othervm NoDesRC4DesEdeCiphSuite
  */
 
 /*
@@ -43,7 +43,7 @@ import java.util.List;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-public class NoDesRC4CiphSuite {
+public class NoDesRC4DesEdeCiphSuite {
 
     private static final boolean DEBUG = false;
 
@@ -80,6 +80,18 @@ public class NoDesRC4CiphSuite {
         "SSL_RSA_EXPORT_WITH_RC4_40_MD5",
         "SSL_DH_anon_EXPORT_WITH_RC4_40_MD5"
     };
+    private static final List<Integer> DESEDE_CS_LIST = Arrays.asList(
+        0xC008, 0xC012, 0x0016, 0x0013, 0xC003, 0xC00D, 0x000A
+    );
+    private static final String[] DESEDE_CS_LIST_NAMES = new String[] {
+        "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA",
+        "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",
+        "SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA",
+        "SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA",
+        "TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA",
+        "TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA",
+        "SSL_RSA_WITH_3DES_EDE_CBC_SHA"
+    };
 
     private static final ByteBuffer CLIOUTBUF =
             ByteBuffer.wrap("Client Side".getBytes());
@@ -98,6 +110,11 @@ public class NoDesRC4CiphSuite {
         allGood &= testDefaultCase(RC4_CS_LIST);
         allGood &= testEngAddDisabled(RC4_CS_LIST_NAMES, RC4_CS_LIST);
         allGood &= testEngOnlyDisabled(RC4_CS_LIST_NAMES);
+
+        // Disabled 3DES tests
+        allGood &= testDefaultCase(DESEDE_CS_LIST);
+        allGood &= testEngAddDisabled(DESEDE_CS_LIST_NAMES, DESEDE_CS_LIST);
+        allGood &= testEngOnlyDisabled(DESEDE_CS_LIST_NAMES);
 
         if (allGood) {
             System.err.println("All tests passed");


### PR DESCRIPTION
This fix removes obsolete and deprecated 3DES cipher suites from the default enabled cipher suites list of the SunJSSE provider implementation. 

Note that 3DES suites are already disabled by default via the `jdk.tls.disabledAlgorithms` security property.  This change goes one step further and provides an extra level of defense by making them unavailable by default.  See the CSR for more details: https://bugs.openjdk.java.net/browse/JDK-8283450

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8163327](https://bugs.openjdk.java.net/browse/JDK-8163327): Remove 3DES from the default enabled cipher suites list
 * [JDK-8283450](https://bugs.openjdk.java.net/browse/JDK-8283450): Remove 3DES from the default enabled cipher suites list (**CSR**)


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7894/head:pull/7894` \
`$ git checkout pull/7894`

Update a local copy of the PR: \
`$ git checkout pull/7894` \
`$ git pull https://git.openjdk.java.net/jdk pull/7894/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7894`

View PR using the GUI difftool: \
`$ git pr show -t 7894`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7894.diff">https://git.openjdk.java.net/jdk/pull/7894.diff</a>

</details>
