### PR TITLE
8283488: AArch64: Improve stack trace accuracy in hs log

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.hpp
@@ -172,4 +172,6 @@
 
   void set_sp_is_trusted() { _sp_is_trusted = true; }
 
+  static bool need_to_deduce_sender_sp(frame& sender);
+  static intptr_t* deduce_sender_sp(frame& frame);
 #endif // CPU_AARCH64_FRAME_AARCH64_HPP

--- a/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
@@ -176,7 +176,11 @@ frame os::fetch_compiled_frame_from_context(const void* ucVoid) {
 
 // JVM compiled with -fno-omit-frame-pointer, so RFP is saved on the stack.
 frame os::get_sender_for_C_frame(frame* fr) {
-  return frame(fr->link(), fr->link(), fr->sender_pc());
+  frame sender(fr->link(), fr->link(), fr->sender_pc());
+  if (frame::need_to_deduce_sender_sp(sender)) {
+    return frame(frame::deduce_sender_sp(*fr), fr->link(), fr->sender_pc());
+  }
+  return sender;
 }
 
 NOINLINE frame os::current_frame() {

--- a/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
@@ -146,7 +146,11 @@ frame os::fetch_compiled_frame_from_context(const void* ucVoid) {
 // By default, gcc always saves frame pointer rfp on this stack. This
 // may get turned off by -fomit-frame-pointer.
 frame os::get_sender_for_C_frame(frame* fr) {
-  return frame(fr->link(), fr->link(), fr->sender_pc());
+  frame sender(fr->link(), fr->link(), fr->sender_pc());
+  if (frame::need_to_deduce_sender_sp(sender)) {
+    return frame(frame::deduce_sender_sp(*fr), fr->link(), fr->sender_pc());
+  }
+  return sender;
 }
 
 NOINLINE frame os::current_frame() {


### PR DESCRIPTION
Hi team,

Could I have a review of this patch?

The native stack trace in hs log is not accurate sometime since we cannot get the accurate `sender sp`, and `sp` is the key to walk stack for compiled frames.

```
frame os::get_sender_for_C_frame(frame* fr) {
  return frame(fr->link(), fr->link(), fr->sender_pc());
}
```

JDK-8277948[1] solved the problem but the premise is that PreserveFramePointer needs to be enabled.

For x86 platform, we can get the `sender sp` by `fp + 2`, but it does not hold in Aarch64.

According to "Procedure Call Standard for the Arm® 64-bit Architecture (AArch64)[2]", section "6.2.3 The Frame Pointer" describes that the location of the frame record within a stack frame is not specified. Hence, I cannot get the `sender sp` by adding a constant to `fp`.

By the way, I found that in the executable I compiled on mac m1, like x86, the frame record is always at the bottom of the stack, but I didn't find a standard specification to prove it. If we can guarantee that this is the case, we can simplify the solution on the mac

This patch deduces the `sender sp` by decoding the native instructions, this solution is applicable to both Mac and Linux I think.

At present, I found that there are mainly three patterns as follows:

```
a)
  stp x29, x30, [sp, #-N]!
  mov x29, sp
  => sender sp = fp + N

b)
  sub sp, sp, #N1
  stp x29, x30, [sp, #N2]
  add x29, sp, #N2
  => sender sp = fp + (N1 - N2)

c)
  stp Xt1, Xt2, [sp, #-N1]! ; Xt1 is not x29, Xt2 is not x30
  stp x29, x30, [sp, #N2]
  add x29, sp, #N2
  => sender sp = fp + (N1 - N2)
```

In addition, special treatment is required for two cases, you can refer to the comments in the code.

To reduce the impact, deducing the `sender sp` is occurred only when a VM error is reported.

I'm not sure if this solution is acceptable as it is a bit tricky, any input is appreciated.

Worth mentioning, the stack trace may still not be accurate sometimes even if this patch is applied. One of the reasons is that `os::is_first_C_frame` will check the `sender fp`. Since `fp` is used as a general register in JIT(When PreserveFramePointer is diabled), it is usually not a reasonable `fp` value in the case of `jit code -> c code`, we may consider modifying the implementation of `os::is_first_C_frame` to apply this case.

[1] https://bugs.openjdk.java.net/browse/JDK-8277948
[2] https://github.com/ARM-software/abi-aa/blob/320a56971fdcba282b7001cf4b84abb4fd993131/aapcs64/aapcs64.rst#the-frame-pointer

Thanks,
Denghui

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8283488](https://bugs.openjdk.java.net/browse/JDK-8283488): AArch64: Improve stack trace accuracy in hs log


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7900/head:pull/7900` \
`$ git checkout pull/7900`

Update a local copy of the PR: \
`$ git checkout pull/7900` \
`$ git pull https://git.openjdk.java.net/jdk pull/7900/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7900`

View PR using the GUI difftool: \
`$ git pr show -t 7900`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7900.diff">https://git.openjdk.java.net/jdk/pull/7900.diff</a>

</details>
