### PR TITLE
JDK-8283497: [windows] print TMP and TEMP in hs_err and VM.info

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -115,7 +115,7 @@ static const char* env_list[] = {
   "DYLD_INSERT_LIBRARIES",
 
   // defined on Windows
-  "OS", "PROCESSOR_IDENTIFIER", "_ALT_JAVA_HOME_DIR",
+  "OS", "PROCESSOR_IDENTIFIER", "_ALT_JAVA_HOME_DIR", "TMP", "TEMP",
 
   (const char *)0
 };


### PR DESCRIPTION
Trivial change to add TMP and TEMP - important e.g. to analyze problems with jdk.attach - to the list of environment variables we print into hs-err files and jcmd VM.info.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283497](https://bugs.openjdk.java.net/browse/JDK-8283497): [windows] print TMP and TEMP in hs_err and VM.info


### Reviewers
 * [Yasumasa Suenaga](https://openjdk.java.net/census#ysuenaga) (@YaSuenag - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7901/head:pull/7901` \
`$ git checkout pull/7901`

Update a local copy of the PR: \
`$ git checkout pull/7901` \
`$ git pull https://git.openjdk.java.net/jdk pull/7901/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7901`

View PR using the GUI difftool: \
`$ git pr show -t 7901`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7901.diff">https://git.openjdk.java.net/jdk/pull/7901.diff</a>

</details>
