### PR TITLE
8283513: Parallel: Skip the card marking in PSRootsClosure

### DIFF
--- a/src/hotspot/share/gc/parallel/psScavenge.hpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.hpp
@@ -135,6 +135,10 @@ class PSScavenge: AllStatic {
   inline static bool is_obj_in_young(HeapWord* o) {
     return o >= _young_generation_boundary;
   }
+
+  static bool is_obj_in_to_space(oop o) {
+    return ParallelScavengeHeap::young_gen()->to_space()->contains(o);
+  }
 };
 
 #endif // SHARE_GC_PARALLEL_PSSCAVENGE_HPP


### PR DESCRIPTION
This PR consists of two commits:

1. Skip card marking in `PSRootsClosure`
2. Make in-heap `oop*` a precondition of `copy_and_push_safe_barrier`

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283513](https://bugs.openjdk.java.net/browse/JDK-8283513): Parallel: Skip the card marking in PSRootsClosure


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7903/head:pull/7903` \
`$ git checkout pull/7903`

Update a local copy of the PR: \
`$ git checkout pull/7903` \
`$ git pull https://git.openjdk.java.net/jdk pull/7903/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7903`

View PR using the GUI difftool: \
`$ git pr show -t 7903`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7903.diff">https://git.openjdk.java.net/jdk/pull/7903.diff</a>

</details>
