### PR TITLE
8283493: Create an automated regression test for RFE 4231298

### DIFF
--- a/test/jdk/javax/swing/JComboBox/4231298/JComboBoxPrototypeDisplayValueTest.java
+++ b/test/jdk/javax/swing/JComboBox/4231298/JComboBoxPrototypeDisplayValueTest.java
@@ -1,0 +1,201 @@
+/*This test has been modified per scott's mail dated 07th March 03
+ * Scott wrote:
+ *
+ *I don't think any timing is necessary to test this. The key thing to
+ *test for is how often the renderer is called for.
+ *
+ *If I were writing a test for this I would do the following:
+ *
+ *Create a custom renderer that has a counter indicating how many times
+ *it has been configured. Configure a JComboBox with this renderer, set
+ *the prototype display value and ask for the preferred size. The custom
+ *renderer should be called only once.
+ *
+ * Accordingly this test has been rewritten to check how many times the
+ * getListCellRendererComponent method is called in the custom renderer
+ * with setPrototypeDisplayValue(true). It should be called only once.
+ */
+/*
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Robot;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Vector;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.ListCellRenderer;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UIManager.LookAndFeelInfo;
+import javax.swing.UnsupportedLookAndFeelException;
+
+import static javax.swing.UIManager.getInstalledLookAndFeels;
+
+/*
+ * @test
+ * @key headful
+ * @bug 4231298
+ * @summary This testcase tests the RFE 4231298 request, JComboBox Custom
+ *          Renderer should not be called for non displaying elements if
+ *          setPrototypeDisplayValue() has been invoked.
+ * @run main JComboBoxPrototypeDisplayValueTest
+ */
+public class JComboBoxPrototypeDisplayValueTest {
+
+    private static Robot robot;
+    private static JFrame frame;
+    private static JComboBox buttonComboBox;
+    private static volatile int count;
+
+    public static void main(String[] args) throws Exception {
+        robot = new Robot();
+        robot.setAutoWaitForIdle(true);
+        robot.setAutoDelay(200);
+        List<String> lafs = Arrays.stream(getInstalledLookAndFeels())
+                                  .map(LookAndFeelInfo::getClassName)
+                                  .collect(Collectors.toList());
+        for (final String laf : lafs) {
+            try {
+                count = 0;
+                AtomicBoolean lafSetSuccess = new AtomicBoolean(false);
+                SwingUtilities.invokeAndWait(() -> {
+                    lafSetSuccess.set(setLookAndFeel(laf));
+                    if (lafSetSuccess.get()) {
+                        createUI();
+                    }
+                });
+                if (!lafSetSuccess.get()) {
+                    continue;
+                }
+                robot.waitForIdle();
+
+                SwingUtilities
+                        .invokeAndWait(() -> buttonComboBox.getPreferredSize());
+
+                robot.waitForIdle();
+                if (count > 6) {
+                    System.out.println("Test Failed");
+                    throw new RuntimeException(
+                            "Custom Renderer got called " + count + " times, " +
+                            "even after calling setPrototypeDisplayValue(), " +
+                            "but the expected maximum is 6 times for " + laf);
+                } else {
+                    System.out.println("Test Passed for " + laf);
+                }
+            } finally {
+                SwingUtilities.invokeAndWait(
+                        JComboBoxPrototypeDisplayValueTest::disposeFrame);
+            }
+        }
+    }
+
+    public static void createUI() {
+        Vector data = new Vector(IntStream.rangeClosed(1, 100).boxed()
+                                          .map(i -> new JButton("" + i))
+                                          .collect(Collectors.toList()));
+        buttonComboBox = new JComboBox(data);
+        ButtonRenderer renderer = new ButtonRenderer();
+        buttonComboBox.setRenderer(renderer);
+        buttonComboBox.setMaximumRowCount(25);
+
+        // New method introduced in Java 1.4
+        buttonComboBox.setPrototypeDisplayValue(new JButton("111111111"));
+
+        frame = new JFrame();
+        JPanel panel = new JPanel();
+        panel.add(buttonComboBox);
+        frame.getContentPane().add(panel);
+        frame.setSize(200, 100);
+        frame.setLocationRelativeTo(null);
+        frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+        frame.setVisible(true);
+    }
+
+    private static boolean setLookAndFeel(String lafName) {
+        try {
+            UIManager.setLookAndFeel(lafName);
+        } catch (UnsupportedLookAndFeelException ignored) {
+            System.out.println("Ignoring Unsupported L&F: " + lafName);
+            return false;
+        } catch (ClassNotFoundException | InstantiationException
+                | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+        return true;
+    }
+
+    private static void disposeFrame() {
+        if (frame != null) {
+            frame.dispose();
+            frame = null;
+        }
+    }
+
+    /**
+     * Custom ListCellRenderer used for the drop down portion and the text
+     * portion of the ComboBox.
+     */
+    private static class ButtonRenderer implements ListCellRenderer {
+        private final Color selectedBackground;
+        private final Color selectedForeground;
+        private final Color background;
+        private final Color foreground;
+
+        public ButtonRenderer() {
+            selectedBackground = Color.BLUE;
+            selectedForeground = Color.YELLOW;
+            background = Color.GRAY;
+            foreground = Color.RED;
+        }
+
+        public Component getListCellRendererComponent(JList list, Object value,
+                                                      int index,
+                                                      boolean isSelected,
+                                                      boolean cellHasFocus) {
+            JButton button = (JButton) value;
+            System.out.println(
+                    "getListCellRendererComponent index = " + index + ", " +
+                    "isSelected = " + isSelected + ", cellHasFocus = " +
+                    cellHasFocus);
+
+            button.setBackground(isSelected ? selectedBackground : background);
+            button.setForeground(isSelected ? selectedForeground : foreground);
+
+            count++;
+            System.out.println("Value of the Counter is " + count);
+
+            return button;
+        }
+
+    }
+
+}

--- a/test/jdk/javax/swing/JComboBox/4231298/JComboBoxPrototypeDisplayValueTest.java
+++ b/test/jdk/javax/swing/JComboBox/4231298/JComboBoxPrototypeDisplayValueTest.java
@@ -1,20 +1,3 @@
-/*This test has been modified per scott's mail dated 07th March 03
- * Scott wrote:
- *
- *I don't think any timing is necessary to test this. The key thing to
- *test for is how often the renderer is called for.
- *
- *If I were writing a test for this I would do the following:
- *
- *Create a custom renderer that has a counter indicating how many times
- *it has been configured. Configure a JComboBox with this renderer, set
- *the prototype display value and ask for the preferred size. The custom
- *renderer should be called only once.
- *
- * Accordingly this test has been rewritten to check how many times the
- * getListCellRendererComponent method is called in the custom renderer
- * with setPrototypeDisplayValue(true). It should be called only once.
- */
 /*
  * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.


### PR DESCRIPTION
Create a regression test for [JDK-4231298](https://bugs.openjdk.java.net/browse/JDK-4231298)
Issue:
When a JComboBox first drops down, the renderer is called for
every element in the list, even those elements that will not
actually be drawn on the screen.

Fix:
Introduced new API to JComboBox: get/setPrototypeDisplayValue(). This API allows the UI to calculate the display size using this prototype value rather than iterated over a large list of items. See RFE 4289100 which also addresses this problem.

Testing:
1. Tested in Mach5, 10 times per platform(macos,linux and windows) and got all pass.

2. Tested in JDK 1.3.0 and JDK 1.4.0 and the results are given below.
Java 1.3.0 -> Test Failed.
$ jdk1.3/bin/java JComboBoxPrototypeTest
getListCellRendererComponent index = -1, isSelected = false, cellHasFocus = false
Value of the Counter is 1
....
getListCellRendererComponent index = -1, isSelected = false, cellHasFocus = false
Value of the Counter is 101
Test Failed
java.lang.RuntimeException: Custom Renderer got called 101 times, expected is maximum 6 times
        at JComboBoxPrototypeTestOld.main(JComboBoxPrototypeTest.java:107)

Java 1.4.0(added a call to setPrototypeDisplayValue()) -> Test Passed.
$ j2sdk1.4.0/bin/java JComboBoxPrototypeTest
getListCellRendererComponent index = -1, isSelected = false, cellHasFocus = false
Value of the Counter is 1
getListCellRendererComponent index = -1, isSelected = false, cellHasFocus = false
Value of the Counter is 2
getListCellRendererComponent index = -1, isSelected = false, cellHasFocus = false
Value of the Counter is 3
Test Passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283493](https://bugs.openjdk.java.net/browse/JDK-8283493): Create an automated regression test for RFE 4231298


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7905/head:pull/7905` \
`$ git checkout pull/7905`

Update a local copy of the PR: \
`$ git checkout pull/7905` \
`$ git pull https://git.openjdk.java.net/jdk pull/7905/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7905`

View PR using the GUI difftool: \
`$ git pr show -t 7905`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7905.diff">https://git.openjdk.java.net/jdk/pull/7905.diff</a>

</details>
