### PR TITLE
8283417: Update java.nio buffers to use sealed classes

### DIFF
--- a/src/java.base/share/classes/java/nio/Buffer.java
+++ b/src/java.base/share/classes/java/nio/Buffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -191,7 +191,9 @@ import java.util.Spliterator;
  * @since 1.4
  */
 
-public abstract class Buffer {
+public abstract sealed class Buffer
+    permits ByteBuffer, CharBuffer, DoubleBuffer, FloatBuffer, IntBuffer,
+        LongBuffer, ShortBuffer {
     // Cached unsafe-access object
     static final Unsafe UNSAFE = Unsafe.getUnsafe();
 

--- a/src/java.base/share/classes/java/nio/ByteBufferAs-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/ByteBufferAs-X-Buffer.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,8 +31,16 @@ import java.util.Objects;
 import jdk.internal.access.foreign.MemorySegmentProxy;
 import jdk.internal.misc.Unsafe;
 
+#if[rw]
+sealed
+#else[rw]
+final
+#end[rw]
 class ByteBufferAs$Type$Buffer$RW$$BO$                  // package-private
     extends {#if[ro]?ByteBufferAs}$Type$Buffer{#if[ro]?$BO$}
+#if[rw]
+    permits ByteBufferAs$Type$BufferR$BO$
+#end[rw]
 {
 
 #if[rw]

--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,11 @@ import jdk.internal.ref.Cleaner;
 import sun.nio.ch.DirectBuffer;
 
 
+#if[rw]
+sealed
+#else[rw]
+final
+#end[rw]
 class Direct$Type$Buffer$RW$$BO$
 #if[rw]
     extends {#if[byte]?Mapped$Type$Buffer:$Type$Buffer}
@@ -44,6 +49,9 @@ class Direct$Type$Buffer$RW$$BO$
     extends Direct$Type$Buffer$BO$
 #end[rw]
     implements DirectBuffer
+#if[rw]
+    permits Direct$Type$BufferR$BO$
+#end[rw]
 {
 
 #if[rw]

--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -40,8 +40,16 @@ import jdk.internal.access.foreign.MemorySegmentProxy;
  * instance of this class rather than of the superclass.
 #end[rw]
  */
+#if[rw]
+sealed
+#else[rw]
+final
+#end[rw]
 class Heap$Type$Buffer$RW$
     extends {#if[ro]?Heap}$Type$Buffer
+#if[rw]
+    permits Heap$Type$BufferR
+#end[rw]
 {
 #if[rw]
     // Cached array base offset

--- a/src/java.base/share/classes/java/nio/MappedByteBuffer.java
+++ b/src/java.base/share/classes/java/nio/MappedByteBuffer.java
@@ -70,8 +70,9 @@ import jdk.internal.misc.Unsafe;
  * @since 1.4
  */
 
-public abstract class MappedByteBuffer
+public abstract sealed class MappedByteBuffer
     extends ByteBuffer
+    permits DirectByteBuffer
 {
 
     // This is a little bit backwards: By rights MappedByteBuffer should be a

--- a/src/java.base/share/classes/java/nio/StringCharBuffer.java
+++ b/src/java.base/share/classes/java/nio/StringCharBuffer.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 
 // ## If the sequence is a string, use reflection to share its array
 
-class StringCharBuffer                                  // package-private
+final class StringCharBuffer                                  // package-private
     extends CharBuffer
 {
     CharSequence str;

--- a/src/java.base/share/classes/java/nio/X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/X-Buffer.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -264,9 +264,19 @@ import jdk.internal.util.ArraysSupport;
  * @since 1.4
  */
 
-public abstract class $Type$Buffer
+public abstract sealed class $Type$Buffer
     extends Buffer
     implements Comparable<$Type$Buffer>{#if[char]?, Appendable, CharSequence, Readable}
+    permits
+#if[byte]
+    Heap$Type$Buffer, MappedByteBuffer
+#else[byte]
+#if[char]
+    StringCharBuffer,
+#end[char]
+    Heap$Type$Buffer, Direct$Type$BufferS, Direct$Type$BufferU,
+    ByteBufferAs$Type$BufferB, ByteBufferAs$Type$BufferL
+#end[byte]
 {
     // Cached array base offset
     private static final long ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset($type$[].class);


### PR DESCRIPTION
Seal subclassed buffer classes and make non-subclassed buffer classes final.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8283417](https://bugs.openjdk.java.net/browse/JDK-8283417): Update java.nio buffers to use sealed classes
 * [JDK-8283527](https://bugs.openjdk.java.net/browse/JDK-8283527): Update java.nio buffers to use sealed classes (**CSR**)


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7907/head:pull/7907` \
`$ git checkout pull/7907`

Update a local copy of the PR: \
`$ git checkout pull/7907` \
`$ git pull https://git.openjdk.java.net/jdk pull/7907/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7907`

View PR using the GUI difftool: \
`$ git pr show -t 7907`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7907.diff">https://git.openjdk.java.net/jdk/pull/7907.diff</a>

</details>
