### PR TITLE
8283349 : Robustness improvements to java/util/prefs/AddNodeChangeListener.jar

### DIFF
--- a/test/jdk/java/util/prefs/AddNodeChangeListener.java
+++ b/test/jdk/java/util/prefs/AddNodeChangeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,75 +34,88 @@ import java.util.prefs.*;
 public class AddNodeChangeListener {
 
     private static final int SLEEP_ITRS = 10;
+    private static final String N2_STR = "N2";
     private static boolean failed = false;
     private static Preferences userRoot, N2;
     private static NodeChangeListenerAdd ncla;
 
     public static void main(String[] args)
              throws BackingStoreException, InterruptedException {
-        userRoot = Preferences.userRoot();
-        ncla = new NodeChangeListenerAdd();
-        userRoot.addNodeChangeListener(ncla);
-        //Should initiate a node added event
-        addNode();
-        // Should not initiate a node added event
-        addNode();
-        //Should initate a child removed event
-        removeNode();
+        try {
+            userRoot = Preferences.userRoot();
+            // Make sure test node is not present before test
+            clearPrefs();
 
-        if (failed) {
-            throw new RuntimeException("Failed");
+            ncla = new NodeChangeListenerAdd();
+            userRoot.addNodeChangeListener(ncla);
+            //Should initiate a node added event
+            addNode();
+            // Should not initiate a node added event
+            addNode();
+            //Should initate a child removed event
+            removeNode();
+
+            if (failed) {
+                throw new RuntimeException("Failed");
+            }
+        } finally {
+            // Make sure test node is not present after the test
+            clearPrefs();
         }
     }
 
     private static void addNode()
             throws BackingStoreException, InterruptedException {
-        N2 = userRoot.node("N2");
+        N2 = userRoot.node(N2_STR);
         userRoot.flush();
-        int passItr = -1;
-
-        for (int i = 0; i < SLEEP_ITRS; i++) {
-            System.out.print("addNode sleep iteration " + i + "...");
-            Thread.sleep(3000);
-            System.out.println("done.");
-            if (ncla.getAddNumber() == 1) {
-                passItr = i;
-                break;
-            }
-        }
-        checkPassItr(passItr, "addNode()");
+        checkAndSleep(1, "addNode");
     }
 
     private static void removeNode()
             throws BackingStoreException, InterruptedException {
         N2.removeNode();
         userRoot.flush();
-        int passItr = -1;
+        checkAndSleep(0, "removeNode");
+    }
 
+    /* Check for the expected value in the listener (1 after addNode(), 0 after removeNode()).
+     * Sleep a few extra times in a loop, if needed, for debugging purposes, to
+     * see if the event gets delivered late.
+     */
+    private static void checkAndSleep(int expectedListenerVal, String methodName) throws InterruptedException {
+        int expectedItr = -1; // iteration in which the expected value was retrieved from the listener, or -1 if never
         for (int i = 0; i < SLEEP_ITRS; i++) {
-            System.out.print("removeNode sleep iteration " + i + "...");
+            System.out.print(methodName + " sleep iteration " + i + "...");
             Thread.sleep(3000);
             System.out.println("done.");
-            if (ncla.getAddNumber() == 0) {
-                passItr = i;
+            if (ncla.getAddNumber() == expectedListenerVal) {
+                expectedItr = i;
                 break;
             }
         }
-        checkPassItr(passItr, "removeNode()");
-    }
 
-    /* If the listener wasn't notified on iteration 0, throw a RuntimeException
-     * with some contextual information
-     */
-    private static void checkPassItr(int itr, String methodName) {
-        if (itr == 0) {
+        if (expectedItr == 0) {
             System.out.println(methodName + " test passed");
         } else {
             failed = true;
-            if (itr == -1) {
-                throw new RuntimeException("Failed in " + methodName + " - change listener never notified");
+            if (expectedItr == -1) {
+                System.out.println("Failed in " + methodName + " - change listener never notified");
             } else {
-                throw new RuntimeException("Failed in " + methodName + " - listener notified on iteration " + itr);
+                System.out.println("Failed in " + methodName + " - listener notified on iteration " + expectedItr);
+            }
+        }
+    }
+
+    /* Check if the node already exists in userRoot, and remove it if so. */
+    private static void clearPrefs() throws BackingStoreException {
+        if (userRoot.nodeExists(N2_STR)) {
+            System.out.println("Node " + N2_STR + " already/still exists; clearing");
+            Preferences clearNode = userRoot.node(N2_STR);
+            userRoot.flush();
+            clearNode.removeNode();
+            userRoot.flush();
+            if (userRoot.nodeExists(N2_STR)) {
+                throw new RuntimeException("Unable to clear pre-existing node");
             }
         }
     }

--- a/test/jdk/java/util/prefs/AddNodeChangeListener.java
+++ b/test/jdk/java/util/prefs/AddNodeChangeListener.java
@@ -115,7 +115,7 @@ public class AddNodeChangeListener {
             clearNode.removeNode();
             userRoot.flush();
             if (userRoot.nodeExists(N2_STR)) {
-                throw new RuntimeException("Unable to clear pre-existing node");
+                throw new RuntimeException("Unable to clear pre-existing node." + (failed ? " Also, the test failed" : ""));
             }
         }
     }


### PR DESCRIPTION
Please review this change to the java/util/prefs/AddNodeChangeListener.jar test.

Although the test specifies "-Djava.util.prefs.userRoot=." to ensure a fresh Preferences on each test run, MacOS does not seem to honor this, and still stores prefs in Library/.

This test has long suffered intermittent failures. 8255031 added some debugging code; as of that change, the test fails fast as soon as an expected change event is not received. In particular, if the expected event is not received for adding the node, the test exits without removing the node. In this way, on Mac, the node can get "stuck" in the preferences of the machine. Future runs on the machine will already have the node, no node added change event will be generated (because the node was already there), the test will continue to fail without removing the node, etc. This matches observations on some CI machines.  

This change ensures that:
* the test node is not present before the test
* the test runs to completion, including removing the test node
* the test node is not left behind after the test

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283349](https://bugs.openjdk.java.net/browse/JDK-8283349): Robustness improvements to java/util/prefs/AddNodeChangeListener.jar


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to 71ab1f17e59d45a6899be1abe20a792813311a9f
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to 71ab1f17e59d45a6899be1abe20a792813311a9f
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7908/head:pull/7908` \
`$ git checkout pull/7908`

Update a local copy of the PR: \
`$ git checkout pull/7908` \
`$ git pull https://git.openjdk.java.net/jdk pull/7908/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7908`

View PR using the GUI difftool: \
`$ git pr show -t 7908`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7908.diff">https://git.openjdk.java.net/jdk/pull/7908.diff</a>

</details>
