### PR TITLE
8283457: [macos] libpng build failures with Xcode13.3

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -742,7 +742,7 @@ ifeq ($(ENABLE_HEADLESS_ONLY), false)
           maybe-uninitialized shift-negative-value implicit-fallthrough \
           unused-function, \
       DISABLED_WARNINGS_clang := incompatible-pointer-types sign-compare \
-          deprecated-declarations, \
+          deprecated-declarations null-pointer-subtraction, \
       DISABLED_WARNINGS_microsoft := 4018 4244 4267, \
       LDFLAGS := $(LDFLAGS_JDKLIB) \
           $(call SET_SHARED_LIBRARY_ORIGIN), \


### PR DESCRIPTION
Disable a warning from the Xcode 13.3 clang compiler when compiling libpng, which is used by libsplashscreen.

Policy is not to change the upstream code locally unless it is also changed in the same way upstream.
We could consider reporting it upstream but libpng releases are very infrequent.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283457](https://bugs.openjdk.java.net/browse/JDK-8283457): [macos] libpng build failures with Xcode13.3


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7911/head:pull/7911` \
`$ git checkout pull/7911`

Update a local copy of the PR: \
`$ git checkout pull/7911` \
`$ git pull https://git.openjdk.java.net/jdk pull/7911/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7911`

View PR using the GUI difftool: \
`$ git pr show -t 7911`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7911.diff">https://git.openjdk.java.net/jdk/pull/7911.diff</a>

</details>
