### PR TITLE
8254935: Deprecate the PSSParameterSpec(int) constructor

### DIFF
--- a/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
+++ b/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  * as defined in the
  * <a href="https://tools.ietf.org/rfc/rfc8017.txt">PKCS#1 v2.2</a> standard.
  *
- * <p>Its ASN.1 definition in PKCS#1 standard is described below:
+ * <p>Its ASN.1 definition in the PKCS#1 standard is described below:
  * <pre>
  * RSASSA-PSS-params ::= SEQUENCE {
  *   hashAlgorithm      [0] HashAlgorithm      DEFAULT sha1,
@@ -175,10 +175,10 @@ public class PSSParameterSpec implements AlgorithmParameterSpec {
      * @throws    IllegalArgumentException if {@code saltLen} is
      *         less than 0
      * @deprecated This constructor uses the default values defined in
-     *         the ASN.1 encoding in the PKCS#1 standard except for the
-     *         salt length. These default values may become obsolete as
-     *         time progresses. Thus, it is recommended to explicitly
-     *         specify all desired parameter values with
+     *         the ASN.1 encoding in PKCS#1 except for the salt length.
+     *         These default values may become obsolete as time progresses.
+     *         Thus, it is recommended to explicitly specify all desired
+     *         parameter values with
      *         {@link #PSSParameterSpec(String, String, AlgorithmParameterSpec, int, int) PSSParameterSpec}.
      */
     @Deprecated(since="19")

--- a/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
+++ b/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
@@ -28,11 +28,11 @@ package java.security.spec;
 import java.util.Objects;
 
 /**
- * This class specifies a parameter spec for RSASSA-PSS signature scheme,
+ * This class specifies a parameter spec for the RSASSA-PSS signature scheme,
  * as defined in the
  * <a href="https://tools.ietf.org/rfc/rfc8017.txt">PKCS#1 v2.2</a> standard.
  *
- * <p>Its ASN.1 definition in the PKCS#1 standard is described below:
+ * <p>Its ASN.1 definition in the PKCS #1 standard is described below:
  * <pre>
  * RSASSA-PSS-params ::= SEQUENCE {
  *   hashAlgorithm      [0] HashAlgorithm      DEFAULT sha1,
@@ -88,7 +88,7 @@ public class PSSParameterSpec implements AlgorithmParameterSpec {
     private final int trailerField;
 
     /**
-     * The {@code TrailerFieldBC} constant as defined in PKCS#1
+     * The {@code TrailerFieldBC} constant as defined in the PKCS #1 standard.
      *
      * @since 11
      */
@@ -96,10 +96,13 @@ public class PSSParameterSpec implements AlgorithmParameterSpec {
 
     /**
      * The PSS parameter set with all default values
-     * @deprecated This field uses the default values defined in the ASN.1
-     *         encoding in PKCS#1 which may become obsolete as time progresses.
-     *         Thus, it is recommended to create a new {@code PSSParameterSpec}
-     *         with the desired parameter values using
+     * @deprecated This field uses the default values defined in the PKCS #1
+     *         standard. Some of these defaults are no longer recommended due
+     *         to advances in cryptanalysis -- see the
+     *         <a href="https://tools.ietf.org/rfc/rfc8017.txt">PKCS#1 v2.2</a>
+     *         standard for more details. Thus, it is recommended to create
+     *         a new {@code PSSParameterSpec} with the desired parameter values
+     *         using
      *         {@link #PSSParameterSpec(String, String, AlgorithmParameterSpec, int, int) PSSParameterSpec}.
      *
      * @since 1.5
@@ -126,7 +129,7 @@ public class PSSParameterSpec implements AlgorithmParameterSpec {
      * @param mgfSpec      the parameters for the mask generation function.
      *         If null is specified, null will be returned by
      *         getMGFParameters().
-     * @param saltLen      the length of salt
+     * @param saltLen      the length of salt in bytes
      * @param trailerField the value of the trailer field
      * @throws    NullPointerException if {@code mdName}, or {@code mgfName}
      *         is null
@@ -157,17 +160,18 @@ public class PSSParameterSpec implements AlgorithmParameterSpec {
     /**
      * Creates a new {@code PSSParameterSpec}
      * using the specified salt length and other default values as
-     * defined in PKCS#1.
+     * defined in the PKCS #1 standard.
      *
-     * @param saltLen the length of salt in bytes to be used in PKCS#1
-     *         PSS encoding
+     * @param saltLen the length of salt in bytes
      * @throws    IllegalArgumentException if {@code saltLen} is
      *         less than 0
      * @deprecated This constructor uses the default values defined in
-     *         the ASN.1 encoding in PKCS#1 except for the salt length.
-     *         These default values may become obsolete as time progresses.
-     *         Thus, it is recommended to explicitly specify all desired
-     *         parameter values with
+     *         the PKCS #1 standard except for the salt length. Some of these
+     *         defaults are no longer recommended due to advances in
+     *         cryptanalysis -- see the
+     *         <a href="https://tools.ietf.org/rfc/rfc8017.txt">PKCS#1 v2.2</a>
+     *         standard for more details. Thus, it is recommended to explicitly
+     *         specify all desired parameter values with
      *         {@link #PSSParameterSpec(String, String, AlgorithmParameterSpec, int, int) PSSParameterSpec}.
      */
     @Deprecated(since="19")

--- a/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
+++ b/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,6 +71,11 @@ import java.util.Objects;
  *     SaltLength   -- 20
  *     TrailerField -- 1
  *
+ * <p>Its values are based on the default values in the ASN.1 encoding
+ * from PKCS#1 standard and may become obsolete as time progresses.
+ * Please do not rely on PSSParameterSpec.DEFAULT unless these values are
+ * really what you want to use.
+ *
  * @see MGF1ParameterSpec
  * @see AlgorithmParameterSpec
  * @see java.security.Signature
@@ -102,9 +107,15 @@ public class PSSParameterSpec implements AlgorithmParameterSpec {
 
     /**
      * The PSS parameter set with all default values
+     * @deprecated The default values defined in the ASN.1 encoding in
+     *         PKCS#1 may become obsolete as time progresses. Thus, it is
+     *         recommended to explicitly specify all desired parameter
+     *         values with
+     *         {@link #PSSParameterSpec(String, String, AlgorithmParameterSpec, int, int) PSSParameterSpec}.
      *
      * @since 1.5
      */
+    @Deprecated(since="19", forRemoval=true)
     public static final PSSParameterSpec DEFAULT = new PSSParameterSpec
         ("SHA-1", "MGF1", MGF1ParameterSpec.SHA1, 20, TRAILER_FIELD_BC);
 
@@ -163,7 +174,14 @@ public class PSSParameterSpec implements AlgorithmParameterSpec {
      *         PSS encoding
      * @throws    IllegalArgumentException if {@code saltLen} is
      *         less than 0
+     * @deprecated This constructor uses the default values as defined in
+     *         ASN.1 encoding in PKCS#1 except for the salt length. These
+     *         default values may become obsolete as time progresses.
+     *         Thus, it is recommended to explicitly specify all desired
+     *         parameter values with
+     *         {@link #PSSParameterSpec(String, String, AlgorithmParameterSpec, int, int) PSSParameterSpec}.
      */
+    @Deprecated(since="19", forRemoval=true)
     public PSSParameterSpec(int saltLen) {
         this("SHA-1", "MGF1", MGF1ParameterSpec.SHA1, saltLen, TRAILER_FIELD_BC);
     }

--- a/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
+++ b/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
@@ -107,15 +107,15 @@ public class PSSParameterSpec implements AlgorithmParameterSpec {
 
     /**
      * The PSS parameter set with all default values
-     * @deprecated The default values defined in the ASN.1 encoding in
-     *         PKCS#1 may become obsolete as time progresses. Thus, it is
-     *         recommended to explicitly specify all desired parameter
-     *         values with
+     * @deprecated This field uses the default values defined in the ASN.1
+     *         encoding in PKCS#1 which may become obsolete as time progresses.
+     *         Thus, it is recommended to create a new PSSParameterSpec object
+     *         with the desired parameter values using
      *         {@link #PSSParameterSpec(String, String, AlgorithmParameterSpec, int, int) PSSParameterSpec}.
      *
      * @since 1.5
      */
-    @Deprecated(since="19", forRemoval=true)
+    @Deprecated(since="19")
     public static final PSSParameterSpec DEFAULT = new PSSParameterSpec
         ("SHA-1", "MGF1", MGF1ParameterSpec.SHA1, 20, TRAILER_FIELD_BC);
 
@@ -175,13 +175,13 @@ public class PSSParameterSpec implements AlgorithmParameterSpec {
      * @throws    IllegalArgumentException if {@code saltLen} is
      *         less than 0
      * @deprecated This constructor uses the default values as defined in
-     *         ASN.1 encoding in PKCS#1 except for the salt length. These
+     *         the ASN.1 encoding in PKCS#1 except for the salt length. These
      *         default values may become obsolete as time progresses.
      *         Thus, it is recommended to explicitly specify all desired
      *         parameter values with
      *         {@link #PSSParameterSpec(String, String, AlgorithmParameterSpec, int, int) PSSParameterSpec}.
      */
-    @Deprecated(since="19", forRemoval=true)
+    @Deprecated(since="19")
     public PSSParameterSpec(int saltLen) {
         this("SHA-1", "MGF1", MGF1ParameterSpec.SHA1, saltLen, TRAILER_FIELD_BC);
     }

--- a/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
+++ b/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
@@ -95,7 +95,7 @@ public class PSSParameterSpec implements AlgorithmParameterSpec {
     public static final int TRAILER_FIELD_BC = 1;
 
     /**
-     * The PSS parameter set with all default values
+     * The PSS parameter set with all default values.
      * @deprecated This field uses the default values defined in the PKCS #1
      *         standard. Some of these defaults are no longer recommended due
      *         to advances in cryptanalysis -- see the
@@ -103,7 +103,7 @@ public class PSSParameterSpec implements AlgorithmParameterSpec {
      *         standard for more details. Thus, it is recommended to create
      *         a new {@code PSSParameterSpec} with the desired parameter values
      *         using
-     *         {@link #PSSParameterSpec(String, String, AlgorithmParameterSpec, int, int) PSSParameterSpec}.
+     *         {@link #PSSParameterSpec(String, String, AlgorithmParameterSpec, int, int)} constructor.
      *
      * @since 1.5
      */
@@ -172,7 +172,7 @@ public class PSSParameterSpec implements AlgorithmParameterSpec {
      *         <a href="https://tools.ietf.org/rfc/rfc8017.txt">PKCS#1 v2.2</a>
      *         standard for more details. Thus, it is recommended to explicitly
      *         specify all desired parameter values with
-     *         {@link #PSSParameterSpec(String, String, AlgorithmParameterSpec, int, int) PSSParameterSpec}.
+     *         {@link #PSSParameterSpec(String, String, AlgorithmParameterSpec, int, int)} constructor.
      */
     @Deprecated(since="19")
     public PSSParameterSpec(int saltLen) {

--- a/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
+++ b/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
@@ -102,7 +102,7 @@ public class PSSParameterSpec implements AlgorithmParameterSpec {
      *         <a href="https://tools.ietf.org/rfc/rfc8017.txt">PKCS#1 v2.2</a>
      *         standard for more details. Thus, it is recommended to create
      *         a new {@code PSSParameterSpec} with the desired parameter values
-     *         using
+     *         using the
      *         {@link #PSSParameterSpec(String, String, AlgorithmParameterSpec, int, int)} constructor.
      *
      * @since 1.5
@@ -171,7 +171,7 @@ public class PSSParameterSpec implements AlgorithmParameterSpec {
      *         cryptanalysis -- see the
      *         <a href="https://tools.ietf.org/rfc/rfc8017.txt">PKCS#1 v2.2</a>
      *         standard for more details. Thus, it is recommended to explicitly
-     *         specify all desired parameter values with
+     *         specify all desired parameter values with the
      *         {@link #PSSParameterSpec(String, String, AlgorithmParameterSpec, int, int)} constructor.
      */
     @Deprecated(since="19")

--- a/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
+++ b/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
@@ -64,17 +64,17 @@ import java.util.Objects;
  *   ...  -- Allows for future expansion --
  * }
  * </pre>
- * <p>Note: the PSSParameterSpec.DEFAULT uses the following:
+ * <p>Note: the {@code PSSParameterSpec.DEFAULT} uses the following:
  *     message digest  -- "SHA-1"
  *     mask generation function (mgf) -- "MGF1"
  *     parameters for mgf -- MGF1ParameterSpec.SHA1
  *     SaltLength   -- 20
  *     TrailerField -- 1
  *
- * <p>Its values are based on the default values in the ASN.1 encoding
- * from PKCS#1 standard and may become obsolete as time progresses.
- * Please do not rely on PSSParameterSpec.DEFAULT unless these values are
- * really what you want to use.
+ * <p>Its values are based on the default values defined in the ASN.1 encoding
+ * from the PKCS#1 standard and may become obsolete as time progresses.
+ * Please do not rely on {@code PSSParameterSpec.DEFAULT} unless these
+ * values are really what you want to use.
  *
  * @see MGF1ParameterSpec
  * @see AlgorithmParameterSpec
@@ -109,8 +109,8 @@ public class PSSParameterSpec implements AlgorithmParameterSpec {
      * The PSS parameter set with all default values
      * @deprecated This field uses the default values defined in the ASN.1
      *         encoding in PKCS#1 which may become obsolete as time progresses.
-     *         Thus, it is recommended to create a new PSSParameterSpec object
-     *         with the desired parameter values using
+     *         Thus, it is recommended to create a new {@code PSSParameterSpec}
+     *         object with the desired parameter values using
      *         {@link #PSSParameterSpec(String, String, AlgorithmParameterSpec, int, int) PSSParameterSpec}.
      *
      * @since 1.5

--- a/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
+++ b/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
@@ -64,17 +64,6 @@ import java.util.Objects;
  *   ...  -- Allows for future expansion --
  * }
  * </pre>
- * <p>Note: the {@code PSSParameterSpec.DEFAULT} uses the following:
- *     message digest  -- "SHA-1"
- *     mask generation function (mgf) -- "MGF1"
- *     parameters for mgf -- MGF1ParameterSpec.SHA1
- *     SaltLength   -- 20
- *     TrailerField -- 1
- *
- * <p>Its values are based on the default values defined in the ASN.1 encoding
- * from the PKCS#1 standard and may become obsolete as time progresses.
- * Please do not rely on {@code PSSParameterSpec.DEFAULT} unless these
- * values are really what you want to use.
  *
  * @see MGF1ParameterSpec
  * @see AlgorithmParameterSpec
@@ -110,7 +99,7 @@ public class PSSParameterSpec implements AlgorithmParameterSpec {
      * @deprecated This field uses the default values defined in the ASN.1
      *         encoding in PKCS#1 which may become obsolete as time progresses.
      *         Thus, it is recommended to create a new {@code PSSParameterSpec}
-     *         object with the desired parameter values using
+     *         with the desired parameter values using
      *         {@link #PSSParameterSpec(String, String, AlgorithmParameterSpec, int, int) PSSParameterSpec}.
      *
      * @since 1.5

--- a/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
+++ b/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
@@ -174,11 +174,11 @@ public class PSSParameterSpec implements AlgorithmParameterSpec {
      *         PSS encoding
      * @throws    IllegalArgumentException if {@code saltLen} is
      *         less than 0
-     * @deprecated This constructor uses the default values as defined in
-     *         the ASN.1 encoding in PKCS#1 except for the salt length. These
-     *         default values may become obsolete as time progresses.
-     *         Thus, it is recommended to explicitly specify all desired
-     *         parameter values with
+     * @deprecated This constructor uses the default values defined in
+     *         the ASN.1 encoding in the PKCS#1 standard except for the
+     *         salt length. These default values may become obsolete as
+     *         time progresses. Thus, it is recommended to explicitly
+     *         specify all desired parameter values with
      *         {@link #PSSParameterSpec(String, String, AlgorithmParameterSpec, int, int) PSSParameterSpec}.
      */
     @Deprecated(since="19")

--- a/src/java.base/share/classes/sun/security/rsa/PSSParameters.java
+++ b/src/java.base/share/classes/sun/security/rsa/PSSParameters.java
@@ -80,8 +80,8 @@ public final class PSSParameters extends AlgorithmParametersSpi {
 
     @Override
     protected void engineInit(byte[] encoded) throws IOException {
-        // first initialize with the ASN.1 DEFAULT defined in PKCS#1 v2.2
-        // since the encoding bytes may not define all fields
+        // first initialize with the ASN.1 DEFAULT values defined in PKCS #1
+        // v2.2 since the encoding bytes may not define all fields
         String mdName = "SHA-1";
         MGF1ParameterSpec mgfSpec = MGF1ParameterSpec.SHA1;
         int saltLength = 20;

--- a/src/java.base/share/classes/sun/security/rsa/PSSParameters.java
+++ b/src/java.base/share/classes/sun/security/rsa/PSSParameters.java
@@ -34,7 +34,6 @@ import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.InvalidParameterSpecException;
 import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.PSSParameterSpec;
-import static java.security.spec.PSSParameterSpec.DEFAULT;
 
 /**
  * This class implements the PSS parameters used with the RSA
@@ -81,12 +80,12 @@ public final class PSSParameters extends AlgorithmParametersSpi {
 
     @Override
     protected void engineInit(byte[] encoded) throws IOException {
-        // first initialize with the DEFAULT values before
-        // retrieving from the encoding bytes
-        String mdName = DEFAULT.getDigestAlgorithm();
-        MGF1ParameterSpec mgfSpec = (MGF1ParameterSpec) DEFAULT.getMGFParameters();
-        int saltLength = DEFAULT.getSaltLength();
-        int trailerField = DEFAULT.getTrailerField();
+        // first initialize with the ASN.1 DEFAULT defined in PKCS#1 v2.2
+        // since the encoding bytes may not define all fields
+        String mdName = "SHA-1";
+        MGF1ParameterSpec mgfSpec = MGF1ParameterSpec.SHA1;
+        int saltLength = 20;
+        int trailerField = PSSParameterSpec.TRAILER_FIELD_BC;
 
         DerInputStream der = new DerInputStream(encoded);
         DerValue[] datum = der.getSequence(4);


### PR DESCRIPTION
Can someone help review this update to the PSSParameterSpec class regarding the constructor with int argument and the DEFAULT static field? Just added @Deprecate javadoc tag and caution about their usage as suggested in the bug record.

A CSR will be filed once the wording changes are reviewed.

Thanks,
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8254935](https://bugs.openjdk.java.net/browse/JDK-8254935): Deprecate the PSSParameterSpec(int) constructor
 * [JDK-8283650](https://bugs.openjdk.java.net/browse/JDK-8283650): Deprecate the PSSParameterSpec(int) constructor and DEFAULT static field (**CSR**)


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**) ⚠️ Review applies to 26e31a640cdf69dcd1fe538723f33a0e26886fef


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7913/head:pull/7913` \
`$ git checkout pull/7913`

Update a local copy of the PR: \
`$ git checkout pull/7913` \
`$ git pull https://git.openjdk.java.net/jdk pull/7913/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7913`

View PR using the GUI difftool: \
`$ git pr show -t 7913`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7913.diff">https://git.openjdk.java.net/jdk/pull/7913.diff</a>

</details>
