### PR TITLE
8283543: indentation error at com.sun.tools.javac.comp.Enter::visitTopLevel

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
@@ -377,7 +377,7 @@ public class Enter extends JCTree.Visitor {
                 ClassSymbol c = syms.enterClass(tree.modle, name, tree.packge);
                 c.flatname = names.fromString(tree.packge + "." + name);
                 c.classfile = c.sourcefile = tree.sourcefile;
-            c.completer = Completer.NULL_COMPLETER;
+                c.completer = Completer.NULL_COMPLETER;
                 c.members_field = WriteableScope.create(c);
                 tree.packge.package_info = c;
                 tree.packge.sourcefile = tree.sourcefile;


### PR DESCRIPTION
Simple PR, fixing an indentation issue at com.sun.tools.javac.comp.Enter::visitTopLevel, the fix is a one liner,

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283543](https://bugs.openjdk.java.net/browse/JDK-8283543): indentation error at com.sun.tools.javac.comp.Enter::visitTopLevel


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7915/head:pull/7915` \
`$ git checkout pull/7915`

Update a local copy of the PR: \
`$ git checkout pull/7915` \
`$ git pull https://git.openjdk.java.net/jdk pull/7915/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7915`

View PR using the GUI difftool: \
`$ git pr show -t 7915`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7915.diff">https://git.openjdk.java.net/jdk/pull/7915.diff</a>

</details>
