### PR TITLE
8283494: Factor out calculation of actual number of XMM registers 

### DIFF
--- a/src/hotspot/cpu/x86/c1_FrameMap_x86.hpp
+++ b/src/hotspot/cpu/x86/c1_FrameMap_x86.hpp
@@ -152,8 +152,8 @@
     return range;
   }
 
-  static int get_num_caller_save_xmms(void) {
-    return XMMRegisterImpl::actual_num_xmm_registers();
+  static int get_num_caller_save_xmms() {
+    return XMMRegisterImpl::available_xmm_registers();
   }
 
   static int nof_caller_save_cpu_regs() { return adjust_reg_range(pd_nof_caller_save_cpu_regs_frame_map); }

--- a/src/hotspot/cpu/x86/c1_FrameMap_x86.hpp
+++ b/src/hotspot/cpu/x86/c1_FrameMap_x86.hpp
@@ -153,13 +153,7 @@
   }
 
   static int get_num_caller_save_xmms(void) {
-    int num_caller_save_xmm_regs = nof_caller_save_xmm_regs;
-#ifdef _LP64
-    if (UseAVX < 3) {
-      num_caller_save_xmm_regs = num_caller_save_xmm_regs / 2;
-    }
-#endif
-    return num_caller_save_xmm_regs;
+    return XMMRegisterImpl::actual_num_xmm_registers();
   }
 
   static int nof_caller_save_cpu_regs() { return adjust_reg_range(pd_nof_caller_save_cpu_regs_frame_map); }

--- a/src/hotspot/cpu/x86/c1_LinearScan_x86.hpp
+++ b/src/hotspot/cpu/x86/c1_LinearScan_x86.hpp
@@ -101,12 +101,7 @@ inline void LinearScan::pd_add_temps(LIR_Op* op) {
 // Implementation of LinearScanWalker
 
 inline bool LinearScanWalker::pd_init_regs_for_alloc(Interval* cur) {
-  int last_xmm_reg = pd_last_xmm_reg;
-#ifdef _LP64
-  if (UseAVX < 3) {
-    last_xmm_reg = pd_first_xmm_reg + (pd_nof_xmm_regs_frame_map / 2) - 1;
-  }
-#endif
+  int last_xmm_reg = pd_first_xmm_reg + XMMRegisterImpl::available_xmm_registers() - 1;
   if (allocator()->gen()->is_vreg_flag_set(cur->reg_num(), LIRGenerator::byte_reg)) {
     assert(cur->type() != T_FLOAT && cur->type() != T_DOUBLE, "cpu regs only");
     _first_reg = pd_first_byte_reg;

--- a/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
@@ -369,12 +369,7 @@ static OopMap* generate_oop_map(StubAssembler* sasm, int num_rt_args,
   map->set_callee_saved(VMRegImpl::stack2reg(r15H_off + num_rt_args), r15->as_VMReg()->next());
 #endif // _LP64
 
-  int xmm_bypass_limit = FrameMap::nof_xmm_regs;
-#ifdef _LP64
-  if (UseAVX < 3) {
-    xmm_bypass_limit = xmm_bypass_limit / 2;
-  }
-#endif
+  int xmm_bypass_limit = FrameMap::get_num_caller_save_xmms();
 
   if (save_fpu_registers) {
 #ifndef _LP64
@@ -487,13 +482,8 @@ void C1_MacroAssembler::save_live_registers_no_oop_map(bool save_fpu_registers) 
       // so always save them as doubles.
       // note that float values are _not_ converted automatically, so for float values
       // the second word contains only garbage data.
-      int xmm_bypass_limit = FrameMap::nof_xmm_regs;
+      int xmm_bypass_limit = FrameMap::get_num_caller_save_xmms();
       int offset = 0;
-#ifdef _LP64
-      if (UseAVX < 3) {
-        xmm_bypass_limit = xmm_bypass_limit / 2;
-      }
-#endif
       for (int n = 0; n < xmm_bypass_limit; n++) {
         XMMRegister xmm_name = as_XMMRegister(n);
         __ movdbl(Address(rsp, xmm_regs_as_doubles_off * VMRegImpl::stack_slot_size + offset), xmm_name);
@@ -513,10 +503,7 @@ static void restore_fpu(C1_MacroAssembler* sasm, bool restore_fpu_registers) {
 #ifdef _LP64
   if (restore_fpu_registers) {
     // restore XMM registers
-    int xmm_bypass_limit = FrameMap::nof_xmm_regs;
-    if (UseAVX < 3) {
-      xmm_bypass_limit = xmm_bypass_limit / 2;
-    }
+    int xmm_bypass_limit = get_num_caller_save_xmms();
     int offset = 0;
     for (int n = 0; n < xmm_bypass_limit; n++) {
       XMMRegister xmm_name = as_XMMRegister(n);

--- a/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
@@ -25,6 +25,7 @@
 #include "precompiled.hpp"
 #include "asm/assembler.hpp"
 #include "c1/c1_Defs.hpp"
+#include "c1/c1_FrameMap.hpp"
 #include "c1/c1_MacroAssembler.hpp"
 #include "c1/c1_Runtime1.hpp"
 #include "ci/ciUtilities.hpp"
@@ -503,7 +504,7 @@ static void restore_fpu(C1_MacroAssembler* sasm, bool restore_fpu_registers) {
 #ifdef _LP64
   if (restore_fpu_registers) {
     // restore XMM registers
-    int xmm_bypass_limit = get_num_caller_save_xmms();
+    int xmm_bypass_limit = FrameMap::get_num_caller_save_xmms();
     int offset = 0;
     for (int n = 0; n < xmm_bypass_limit; n++) {
       XMMRegister xmm_name = as_XMMRegister(n);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -26,7 +26,6 @@
 #include "jvm.h"
 #include "asm/assembler.hpp"
 #include "asm/assembler.inline.hpp"
-#include "c1/c1_FrameMap.hpp"
 #include "compiler/compiler_globals.hpp"
 #include "compiler/disassembler.hpp"
 #include "gc/shared/barrierSet.hpp"
@@ -3593,15 +3592,19 @@ RegSet MacroAssembler::call_clobbered_gp_registers() {
   return regs;
 }
 
+static uint get_num_xmm_registers() {
+  return XMMRegisterImpl::actual_num_xmm_registers();
+}
+
 XMMRegSet MacroAssembler::call_clobbered_xmm_registers() {
 #if defined(WINDOWS) && defined(_LP64)
   XMMRegSet result = XMMRegSet::range(xmm0, xmm5);
-  if (FrameMap::get_num_caller_save_xmms() > 16) {
-     result += XMMRegSet::range(xmm16, as_XMMRegister(FrameMap::get_num_caller_save_xmms() - 1));
+  if (get_num_xmm_registers() > 16) {
+     result += XMMRegSet::range(xmm16, as_XMMRegister(get_num_xmm_registers() - 1));
   }
   return result;
 #else
-  return XMMRegSet::range(xmm0, as_XMMRegister(FrameMap::get_num_caller_save_xmms() - 1));
+  return XMMRegSet::range(xmm0, as_XMMRegister(get_num_xmm_registers() - 1));
 #endif
 }
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -3592,19 +3592,16 @@ RegSet MacroAssembler::call_clobbered_gp_registers() {
   return regs;
 }
 
-static uint get_num_xmm_registers() {
-  return XMMRegisterImpl::actual_num_xmm_registers();
-}
-
 XMMRegSet MacroAssembler::call_clobbered_xmm_registers() {
+  int num_xmm_registers = XMMRegisterImpl::available_xmm_registers();
 #if defined(WINDOWS) && defined(_LP64)
   XMMRegSet result = XMMRegSet::range(xmm0, xmm5);
-  if (get_num_xmm_registers() > 16) {
-     result += XMMRegSet::range(xmm16, as_XMMRegister(get_num_xmm_registers() - 1));
+  if (num_xmm_registers > 16) {
+     result += XMMRegSet::range(xmm16, as_XMMRegister(num_xmm_registers - 1));
   }
   return result;
 #else
-  return XMMRegSet::range(xmm0, as_XMMRegister(get_num_xmm_registers() - 1));
+  return XMMRegSet::range(xmm0, as_XMMRegister(num_xmm_registers - 1));
 #endif
 }
 

--- a/src/hotspot/cpu/x86/register_x86.cpp
+++ b/src/hotspot/cpu/x86/register_x86.cpp
@@ -94,6 +94,14 @@ const char* XMMRegisterImpl::sub_word_name(int i) const {
   return is_valid() ? names[encoding() * 8 + i] : "xnoreg";
 }
 
+uint XMMRegisterImpl::actual_num_xmm_registers() {
+  uint num_xmm_regs = XMMRegisterImpl::number_of_registers;
+  if (UseAVX < 3) {
+    num_xmm_regs /= 2;
+  }
+  return num_xmm_regs;
+}
+
 const char* KRegisterImpl::name() const {
   const char* names[number_of_registers] = {
     "k0", "k1", "k2", "k3", "k4", "k5", "k6", "k7"

--- a/src/hotspot/cpu/x86/register_x86.cpp
+++ b/src/hotspot/cpu/x86/register_x86.cpp
@@ -23,7 +23,9 @@
  */
 
 #include "precompiled.hpp"
+
 #include "register_x86.hpp"
+#include "runtime/globals.hpp"
 
 #ifndef AMD64
 const int ConcreteRegisterImpl::max_gpr = RegisterImpl::number_of_registers;
@@ -94,11 +96,13 @@ const char* XMMRegisterImpl::sub_word_name(int i) const {
   return is_valid() ? names[encoding() * 8 + i] : "xnoreg";
 }
 
-uint XMMRegisterImpl::actual_num_xmm_registers() {
-  uint num_xmm_regs = XMMRegisterImpl::number_of_registers;
+int XMMRegisterImpl::available_xmm_registers() {
+  int num_xmm_regs = XMMRegisterImpl::number_of_registers;
+#ifdef _LP64
   if (UseAVX < 3) {
     num_xmm_regs /= 2;
   }
+#endif
   return num_xmm_regs;
 }
 

--- a/src/hotspot/cpu/x86/register_x86.hpp
+++ b/src/hotspot/cpu/x86/register_x86.hpp
@@ -163,6 +163,8 @@ class XMMRegisterImpl: public AbstractRegisterImpl {
   bool  is_valid() const                          { return 0 <= (intptr_t)this && (intptr_t)this < number_of_registers; }
   const char* name() const;
   const char* sub_word_name(int offset) const;
+
+  static uint actual_num_xmm_registers();
 };
 
 

--- a/src/hotspot/cpu/x86/register_x86.hpp
+++ b/src/hotspot/cpu/x86/register_x86.hpp
@@ -164,7 +164,9 @@ class XMMRegisterImpl: public AbstractRegisterImpl {
   const char* name() const;
   const char* sub_word_name(int offset) const;
 
-  static uint actual_num_xmm_registers();
+  // Actually available XMM registers for use, depending on actual CPU capabilities
+  // and flags.
+  static int available_xmm_registers();
 };
 
 

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -174,7 +174,7 @@ PRAGMA_DIAG_PUSH
 PRAGMA_NONNULL_IGNORED
 OopMap* RegisterSaver::save_live_registers(MacroAssembler* masm, int additional_frame_words, int* total_frame_words, bool save_vectors) {
   int off = 0;
-  int num_xmm_regs = XMMRegisterImpl::actual_num_xmm_registers();
+  int num_xmm_regs = XMMRegisterImpl::available_xmm_registers();
 #if COMPILER2_OR_JVMCI
   if (save_vectors && UseAVX == 0) {
     save_vectors = false; // vectors larger than 16 byte long are supported only with AVX
@@ -364,7 +364,7 @@ OopMap* RegisterSaver::save_live_registers(MacroAssembler* masm, int additional_
 PRAGMA_DIAG_POP
 
 void RegisterSaver::restore_live_registers(MacroAssembler* masm, bool restore_vectors) {
-  int num_xmm_regs = XMMRegisterImpl::actual_num_xmm_registers();
+  int num_xmm_regs = XMMRegisterImpl::available_xmm_registers();
   if (frame::arg_reg_save_area_bytes != 0) {
     // Pop arg register save area
     __ addptr(rsp, frame::arg_reg_save_area_bytes);

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -174,10 +174,7 @@ PRAGMA_DIAG_PUSH
 PRAGMA_NONNULL_IGNORED
 OopMap* RegisterSaver::save_live_registers(MacroAssembler* masm, int additional_frame_words, int* total_frame_words, bool save_vectors) {
   int off = 0;
-  int num_xmm_regs = XMMRegisterImpl::number_of_registers;
-  if (UseAVX < 3) {
-    num_xmm_regs = num_xmm_regs/2;
-  }
+  int num_xmm_regs = XMMRegisterImpl::actual_num_xmm_registers();
 #if COMPILER2_OR_JVMCI
   if (save_vectors && UseAVX == 0) {
     save_vectors = false; // vectors larger than 16 byte long are supported only with AVX
@@ -367,10 +364,7 @@ OopMap* RegisterSaver::save_live_registers(MacroAssembler* masm, int additional_
 PRAGMA_DIAG_POP
 
 void RegisterSaver::restore_live_registers(MacroAssembler* masm, bool restore_vectors) {
-  int num_xmm_regs = XMMRegisterImpl::number_of_registers;
-  if (UseAVX < 3) {
-    num_xmm_regs = num_xmm_regs/2;
-  }
+  int num_xmm_regs = XMMRegisterImpl::actual_num_xmm_registers();
   if (frame::arg_reg_save_area_bytes != 0) {
     // Pop arg register save area
     __ addptr(rsp, frame::arg_reg_save_area_bytes);

--- a/src/hotspot/cpu/x86/vmreg_x86.hpp
+++ b/src/hotspot/cpu/x86/vmreg_x86.hpp
@@ -25,7 +25,7 @@
 #ifndef CPU_X86_VMREG_X86_HPP
 #define CPU_X86_VMREG_X86_HPP
 
-
+#include "register_x86.hpp"
 
 inline bool is_Register() {
   return (unsigned int) value() < (unsigned int) ConcreteRegisterImpl::max_gpr;
@@ -36,14 +36,8 @@ inline bool is_FloatRegister() {
 }
 
 inline bool is_XMMRegister() {
-  int uarch_max_xmm = ConcreteRegisterImpl::max_xmm;
-
-#ifdef _LP64
-  if (UseAVX < 3) {
-    int half_xmm = (XMMRegisterImpl::max_slots_per_register * XMMRegisterImpl::number_of_registers) / 2;
-    uarch_max_xmm -= half_xmm;
-  }
-#endif
+  int uarch_max_xmm = ConcreteRegisterImpl::max_fpr +
+    (XMMRegisterImpl::max_slots_per_register * XMMRegisterImpl::available_xmm_registers());
 
   return (value() >= ConcreteRegisterImpl::max_fpr && value() < uarch_max_xmm);
 }


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that factors out calculation of the actually available number of XMM registers on a given processor/given command line options into a method and reuse that as much as possible?

This relates to this code snippet:
```
      int xmm_bypass_limit = FrameMap::nof_xmm_regs;
#ifdef _LP64
      if (UseAVX < 3) {
        xmm_bypass_limit = xmm_bypass_limit / 2;
      }
#endif
```

Also, there is already the method `FrameMap::get_num_caller_save_xmms()` that has been updated to use that new method `XMMRegisterImpl::available_xmm_registers()`; further I tried to appropriately use `FrameMap::get_num_caller_save_xmms` in the places where either would work. Please have a look in particular about that.

I did not change strange to me variable names like `xmm_bypass_limit` above as they probably make some sense to somebody as it's used quite often.

This also fixes a compilation error without configuring C1 introduced with [JDK-8283327](https://bugs.openjdk.java.net/browse/JDK-8283327).

Testing: tier1-5 (all but linux-aarch64 done), gha, local compilation with `configure --with-features=-compiler1`.

Thanks,
  Thomas