### PR TITLE
8283558: Parallel: Pass PSIsAliveClosure to ReferenceProcessor constructor

### DIFF
--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -758,7 +758,7 @@ void PSScavenge::initialize() {
                            ParallelGCThreads,          // mt processing degree
                            ParallelGCThreads,          // mt discovery degree
                            false,                      // concurrent_discovery
-                           NULL);                      // header provides liveness info
+                           &_is_alive_closure);        // header provides liveness info
 
   // Cache the cardtable
   _card_table = heap->card_table();


### PR DESCRIPTION
Simple change around non-strong ref discovery in young-gc ref-processing.

Test: tier1-6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283558](https://bugs.openjdk.java.net/browse/JDK-8283558): Parallel: Pass PSIsAliveClosure to ReferenceProcessor constructor


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7918/head:pull/7918` \
`$ git checkout pull/7918`

Update a local copy of the PR: \
`$ git checkout pull/7918` \
`$ git pull https://git.openjdk.java.net/jdk pull/7918/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7918`

View PR using the GUI difftool: \
`$ git pr show -t 7918`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7918.diff">https://git.openjdk.java.net/jdk/pull/7918.diff</a>

</details>
