### PR TITLE
8283323: libharfbuzz optimization level results in extreme build times

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -486,7 +486,8 @@ LIBFONTMANAGER_OPTIMIZATION := HIGHEST
 
 ifneq ($(filter $(TOOLCHAIN_TYPE), gcc clang), )
   # gcc (and to an extent clang) is particularly bad at optimizing these files,
-  # causing a massive spike in compile time.
+  # causing a massive spike in compile time. We don't care about these
+  # particular files anyway, so lower optimization level.
   BUILD_LIBFONTMANAGER_hb-subset.cc_OPTIMIZATION := SIZE
   BUILD_LIBFONTMANAGER_hb-subset-plan.cc_OPTIMIZATION := SIZE
 endif


### PR DESCRIPTION
[JDK-8247872](https://bugs.openjdk.java.net/browse/JDK-8247872) (upgrade HarfBuzz to 2.7.2) caused build time to go up with 24 seconds on my reference linux machine. This was one of the four culprits that caused a 25-30% build time regression over the last two years.

The problem here was that the new HarfBuzz code caught really bad behaviour from gcc when compiling with optimizations. The official HarfBuzz build does not use any -O flags at all for gcc, so presumably the HarfBuzz team is:

a) not thinking compiler optimization is important for the performance of this library, and
b) unaware that their code causes such a headache for gcc.

(Other compilers fare much better: visual studio makes no difference at all, and for clang just a small regression was observed.)

The current optimization level was introduced by [JDK-8255790](https://bugs.openjdk.java.net/browse/JDK-8255790), which were really about moving libharfbuzz compilation back into libfontmanager. I could find no comments/discussion relating to the change of optimization level, so I assume it was incidental, and just seemed good at the time.

This patch changes the optimization level to `SIZE` (which is the closest thing we have to no optimization level) on gcc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283323](https://bugs.openjdk.java.net/browse/JDK-8283323): libharfbuzz optimization level results in extreme build times


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to 20ab768fa49e6f25075014aa2dafa9698b168905
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7919/head:pull/7919` \
`$ git checkout pull/7919`

Update a local copy of the PR: \
`$ git checkout pull/7919` \
`$ git pull https://git.openjdk.java.net/jdk pull/7919/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7919`

View PR using the GUI difftool: \
`$ git pr show -t 7919`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7919.diff">https://git.openjdk.java.net/jdk/pull/7919.diff</a>

</details>
