### PR TITLE
JDK-8283562: JDK-8282306 breaks gtests on zero

### DIFF
--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -868,7 +868,7 @@ TEST_VM(os, iso8601_time) {
 }
 
 TEST_VM(os, is_first_C_frame) {
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(ZERO)
   frame invalid_frame;
   EXPECT_TRUE(os::is_first_C_frame(&invalid_frame)); // the frame has zeroes for all values
 


### PR DESCRIPTION
Trivial workaround for zero.

[JDK-8282306](https://bugs.openjdk.java.net/browse/JDK-8282306) introduced os.is_first_C_frame_vm gtest, but that breaks on zero since the test relies on os::current_frame(), which on all zero platforms is almost empty.

As a workaround, I disable the test. A potential solution would be to use getcontext(3) in `os::current_frame()`, but lets just exclude the test for now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283562](https://bugs.openjdk.java.net/browse/JDK-8283562): JDK-8282306 breaks gtests on zero


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7920/head:pull/7920` \
`$ git checkout pull/7920`

Update a local copy of the PR: \
`$ git checkout pull/7920` \
`$ git pull https://git.openjdk.java.net/jdk pull/7920/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7920`

View PR using the GUI difftool: \
`$ git pr show -t 7920`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7920.diff">https://git.openjdk.java.net/jdk/pull/7920.diff</a>

</details>
