### PR TITLE
8283574: Use Klass::_id for type checks in the C++ code

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
@@ -138,7 +138,7 @@ inline void G1FullGCMarker::follow_object(oop obj) {
   } else {
     obj->oop_iterate(mark_closure());
     if (VerifyDuringGC) {
-      if (obj->is_instance() && InstanceKlass::cast(obj->klass())->is_reference_instance_klass()) {
+      if (obj->is_instanceRef()) {
         return;
       }
       _verify_closure.set_containing_obj(obj);

--- a/src/hotspot/share/oops/instanceClassLoaderKlass.hpp
+++ b/src/hotspot/share/oops/instanceClassLoaderKlass.hpp
@@ -43,7 +43,7 @@ public:
   static const KlassID ID = InstanceClassLoaderKlassID;
 
 private:
-  InstanceClassLoaderKlass(const ClassFileParser& parser) : InstanceKlass(parser, InstanceKlass::_kind_class_loader, ID) {}
+  InstanceClassLoaderKlass(const ClassFileParser& parser) : InstanceKlass(parser, ID) {}
 
 public:
   InstanceClassLoaderKlass() { assert(DumpSharedSpaces || UseSharedSpaces, "only for CDS"); }

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -442,13 +442,12 @@ InstanceKlass* InstanceKlass::allocate_instance_klass(const ClassFileParser& par
     if (class_name == vmSymbols::java_lang_Class()) {
       // mirror
       ik = new (loader_data, size, THREAD) InstanceMirrorKlass(parser);
-    }
-    else if (is_class_loader(class_name, parser)) {
+    } else if (is_class_loader(class_name, parser)) {
       // class loader
       ik = new (loader_data, size, THREAD) InstanceClassLoaderKlass(parser);
     } else {
       // normal
-      ik = new (loader_data, size, THREAD) InstanceKlass(parser, InstanceKlass::_kind_other);
+      ik = new (loader_data, size, THREAD) InstanceKlass(parser);
     }
   } else {
     // reference
@@ -486,7 +485,7 @@ Array<int>* InstanceKlass::create_new_default_vtable_indices(int len, TRAPS) {
   return vtable_indices;
 }
 
-InstanceKlass::InstanceKlass(const ClassFileParser& parser, unsigned kind, KlassID id) :
+InstanceKlass::InstanceKlass(const ClassFileParser& parser, KlassID id) :
   Klass(id),
   _nest_members(NULL),
   _nest_host(NULL),
@@ -501,7 +500,6 @@ InstanceKlass::InstanceKlass(const ClassFileParser& parser, unsigned kind, Klass
   _init_thread(NULL)
 {
   set_vtable_length(parser.vtable_size());
-  set_kind(kind);
   set_access_flags(parser.access_flags());
   if (parser.is_hidden()) set_is_hidden();
   set_layout_helper(Klass::instance_layout_helper(parser.layout_size(),

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -136,7 +136,7 @@ class InstanceKlass: public Klass {
   static const KlassID ID = InstanceKlassID;
 
  protected:
-  InstanceKlass(const ClassFileParser& parser, unsigned kind, KlassID id = ID);
+  InstanceKlass(const ClassFileParser& parser, KlassID id = ID);
 
  public:
   InstanceKlass() { assert(DumpSharedSpaces || UseSharedSpaces, "only for CDS"); }
@@ -229,15 +229,7 @@ class InstanceKlass: public Klass {
   // _idnum_allocated_count.
   u1              _init_state;              // state of class
 
-  // This can be used to quickly discriminate among the four kinds of
-  // InstanceKlass. This should be an enum (?)
-  static const unsigned _kind_other        = 0; // concrete InstanceKlass
-  static const unsigned _kind_reference    = 1; // InstanceRefKlass
-  static const unsigned _kind_class_loader = 2; // InstanceClassLoaderKlass
-  static const unsigned _kind_mirror       = 3; // InstanceMirrorKlass
-
   u1              _reference_type;                // reference type
-  u1              _kind;                          // kind of InstanceKlass
 
   enum {
     _misc_rewritten                           = 1 << 0,  // methods rewritten.
@@ -787,24 +779,8 @@ public:
   void set_has_resolved_methods() {
     _access_flags.set_has_resolved_methods();
   }
-private:
-
-  void set_kind(unsigned kind) {
-    _kind = (u1)kind;
-  }
-
-  bool is_kind(unsigned desired) const {
-    return _kind == (u1)desired;
-  }
 
 public:
-
-  // Other is anything that is not one of the more specialized kinds of InstanceKlass.
-  bool is_other_instance_klass() const        { return is_kind(_kind_other); }
-  bool is_reference_instance_klass() const    { return is_kind(_kind_reference); }
-  bool is_mirror_instance_klass() const       { return is_kind(_kind_mirror); }
-  bool is_class_loader_instance_klass() const { return is_kind(_kind_class_loader); }
-
 #if INCLUDE_JVMTI
 
   void init_previous_versions() {

--- a/src/hotspot/share/oops/instanceMirrorKlass.hpp
+++ b/src/hotspot/share/oops/instanceMirrorKlass.hpp
@@ -50,7 +50,7 @@ class InstanceMirrorKlass: public InstanceKlass {
  private:
   static int _offset_of_static_fields;
 
-  InstanceMirrorKlass(const ClassFileParser& parser) : InstanceKlass(parser, InstanceKlass::_kind_mirror, ID) {}
+  InstanceMirrorKlass(const ClassFileParser& parser) : InstanceKlass(parser, ID) {}
 
  public:
   InstanceMirrorKlass() { assert(DumpSharedSpaces || UseSharedSpaces, "only for CDS"); }
@@ -60,7 +60,7 @@ class InstanceMirrorKlass: public InstanceKlass {
   }
 
   static const InstanceMirrorKlass* cast(const Klass* k) {
-    assert(InstanceKlass::cast(k)->is_mirror_instance_klass(), "cast to InstanceMirrorKlass");
+    assert(k->is_mirror_instance_klass(), "cast to InstanceMirrorKlass");
     return static_cast<const InstanceMirrorKlass*>(k);
   }
 

--- a/src/hotspot/share/oops/instanceRefKlass.cpp
+++ b/src/hotspot/share/oops/instanceRefKlass.cpp
@@ -87,7 +87,6 @@ void InstanceRefKlass::oop_verify_on(oop obj, outputStream* st) {
   oop next = java_lang_ref_Reference::next(obj);
   if (next != NULL) {
     guarantee(oopDesc::is_oop(next), "next field should be an oop");
-    guarantee(next->is_instance(), "next field should be an instance");
-    guarantee(InstanceKlass::cast(next->klass())->is_reference_instance_klass(), "next field verify failed");
+    guarantee(next->is_instanceRef(), "next field verify failed");
   }
 }

--- a/src/hotspot/share/oops/instanceRefKlass.hpp
+++ b/src/hotspot/share/oops/instanceRefKlass.hpp
@@ -53,7 +53,7 @@ class InstanceRefKlass: public InstanceKlass {
   static const KlassID ID = InstanceRefKlassID;
 
  private:
-  InstanceRefKlass(const ClassFileParser& parser) : InstanceKlass(parser, InstanceKlass::_kind_reference, ID) {}
+  InstanceRefKlass(const ClassFileParser& parser) : InstanceKlass(parser, ID) {}
 
  public:
   InstanceRefKlass() { assert(DumpSharedSpaces || UseSharedSpaces, "only for CDS"); }

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -614,18 +614,16 @@ protected:
   }
  public:
   #endif
-  inline  bool is_instance_klass()            const { return assert_same_query(
-                                                      layout_helper_is_instance(layout_helper()),
-                                                      is_instance_klass_slow()); }
-  inline  bool is_array_klass()               const { return assert_same_query(
-                                                    layout_helper_is_array(layout_helper()),
-                                                    is_array_klass_slow()); }
-  inline  bool is_objArray_klass()            const { return assert_same_query(
-                                                    layout_helper_is_objArray(layout_helper()),
-                                                    is_objArray_klass_slow()); }
-  inline  bool is_typeArray_klass()           const { return assert_same_query(
-                                                    layout_helper_is_typeArray(layout_helper()),
-                                                    is_typeArray_klass_slow()); }
+
+  bool is_instance_klass()              const { return assert_same_query(_id <= InstanceClassLoaderKlassID, is_instance_klass_slow()); }
+  // Other is anything that is not one of the more specialized kinds of InstanceKlass.
+  bool is_other_instance_klass()        const { return _id == InstanceKlassID; }
+  bool is_reference_instance_klass()    const { return _id == InstanceRefKlassID; }
+  bool is_mirror_instance_klass()       const { return _id == InstanceMirrorKlassID; }
+  bool is_class_loader_instance_klass() const { return _id == InstanceClassLoaderKlassID; }
+  bool is_array_klass()                 const { return assert_same_query( _id >= TypeArrayKlassID, is_array_klass_slow()); }
+  bool is_objArray_klass()              const { return assert_same_query( _id == ObjArrayKlassID,  is_objArray_klass_slow()); }
+  bool is_typeArray_klass()             const { return assert_same_query( _id == TypeArrayKlassID, is_typeArray_klass_slow()); }
   #undef assert_same_query
 
   // Access flags

--- a/src/hotspot/share/oops/oop.cpp
+++ b/src/hotspot/share/oops/oop.cpp
@@ -134,10 +134,11 @@ void VerifyOopClosure::do_oop(oop* p)       { VerifyOopClosure::do_oop_work(p); 
 void VerifyOopClosure::do_oop(narrowOop* p) { VerifyOopClosure::do_oop_work(p); }
 
 // type test operations that doesn't require inclusion of oop.inline.hpp.
-bool oopDesc::is_instance_noinline()          const { return is_instance();            }
-bool oopDesc::is_array_noinline()             const { return is_array();               }
-bool oopDesc::is_objArray_noinline()          const { return is_objArray();            }
-bool oopDesc::is_typeArray_noinline()         const { return is_typeArray();           }
+bool oopDesc::is_instance_noinline()    const { return is_instance();    }
+bool oopDesc::is_instanceRef_noinline() const { return is_instanceRef(); }
+bool oopDesc::is_array_noinline()       const { return is_array();       }
+bool oopDesc::is_objArray_noinline()    const { return is_objArray();    }
+bool oopDesc::is_typeArray_noinline()   const { return is_typeArray();   }
 
 bool oopDesc::has_klass_gap() {
   // Only has a klass gap when compressed class pointers are used.

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -107,16 +107,18 @@ class oopDesc {
   inline size_t size_given_klass(Klass* klass);
 
   // type test operations (inlined in oop.inline.hpp)
-  inline bool is_instance()            const;
-  inline bool is_array()               const;
-  inline bool is_objArray()            const;
-  inline bool is_typeArray()           const;
+  inline bool is_instance()    const;
+  inline bool is_instanceRef() const;
+  inline bool is_array()       const;
+  inline bool is_objArray()    const;
+  inline bool is_typeArray()   const;
 
   // type test operations that don't require inclusion of oop.inline.hpp.
-  bool is_instance_noinline()          const;
-  bool is_array_noinline()             const;
-  bool is_objArray_noinline()          const;
-  bool is_typeArray_noinline()         const;
+  bool is_instance_noinline()    const;
+  bool is_instanceRef_noinline() const;
+  bool is_array_noinline()       const;
+  bool is_objArray_noinline()    const;
+  bool is_typeArray_noinline()   const;
 
  protected:
   inline oop        as_oop() const { return const_cast<oopDesc*>(this); }

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -195,10 +195,11 @@ size_t oopDesc::size_given_klass(Klass* klass)  {
   return s;
 }
 
-bool oopDesc::is_instance()  const { return klass()->is_instance_klass();  }
-bool oopDesc::is_array()     const { return klass()->is_array_klass();     }
-bool oopDesc::is_objArray()  const { return klass()->is_objArray_klass();  }
-bool oopDesc::is_typeArray() const { return klass()->is_typeArray_klass(); }
+bool oopDesc::is_instance()    const { return klass()->is_instance_klass();           }
+bool oopDesc::is_instanceRef() const { return klass()->is_reference_instance_klass(); }
+bool oopDesc::is_array()       const { return klass()->is_array_klass();              }
+bool oopDesc::is_objArray()    const { return klass()->is_objArray_klass();           }
+bool oopDesc::is_typeArray()   const { return klass()->is_typeArray_klass();          }
 
 template<typename T>
 T*       oopDesc::field_addr(int offset)     const { return reinterpret_cast<T*>(cast_from_oop<intptr_t>(as_oop()) + offset); }


### PR DESCRIPTION
We have at least three ways to check the type of a given Klass*:
1) Using the Klass::_id field
2) Using the layout helper
3) Using the InstanceKlass::_kind field

The Klass::_id field was something that was added when we rewrote the oop_oop_iterate dispatch mechanism, but the other mechanisms where left in place.

The current Loom code uses both (2) and (3) every time a the code checks if an object is of type InstanceStackChunkKlass. In the Loom repository I intend to reduce that check to be a single test against the (1) field. To keep the code unified, and simpler, I changed all C++ Klass type checks to use (1).

I propose that we upstream this change to the mainline, to slightly reduce the Loom diff.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283574](https://bugs.openjdk.java.net/browse/JDK-8283574): Use Klass::_id for type checks in the C++ code


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7922/head:pull/7922` \
`$ git checkout pull/7922`

Update a local copy of the PR: \
`$ git checkout pull/7922` \
`$ git pull https://git.openjdk.java.net/jdk pull/7922/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7922`

View PR using the GUI difftool: \
`$ git pr show -t 7922`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7922.diff">https://git.openjdk.java.net/jdk/pull/7922.diff</a>

</details>
