### PR TITLE
8283555: G1: Concurrent mark accesses uninitialized BOT of closed archive regions

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -2330,6 +2330,10 @@ void FileMapInfo::fixup_mapped_heap_regions() {
            "Null closed_heap_regions array with non-zero count");
     G1CollectedHeap::heap()->fill_archive_regions(closed_heap_regions,
                                                   num_closed_heap_regions);
+    // G1 marking uses the BOT for object chunking; for this reason we need to
+    // initialize the BOT for these regions.
+    G1CollectedHeap::heap()->populate_archive_regions_bot_part(closed_heap_regions,
+                                                               num_closed_heap_regions);
   }
 
   // do the same for mapped open archive heap regions
@@ -2342,11 +2346,6 @@ void FileMapInfo::fixup_mapped_heap_regions() {
     // fast G1BlockOffsetTablePart::block_start operations for any given address
     // within the open archive regions when trying to find start of an object
     // (e.g. during card table scanning).
-    //
-    // This is only needed for open archive regions but not the closed archive
-    // regions, because objects in closed archive regions never reference objects
-    // outside the closed archive regions and they are immutable. So we never
-    // need their BOT during garbage collection.
     G1CollectedHeap::heap()->populate_archive_regions_bot_part(open_heap_regions,
                                                                num_open_heap_regions);
   }

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -2330,8 +2330,9 @@ void FileMapInfo::fixup_mapped_heap_regions() {
            "Null closed_heap_regions array with non-zero count");
     G1CollectedHeap::heap()->fill_archive_regions(closed_heap_regions,
                                                   num_closed_heap_regions);
-    // G1 marking uses the BOT for object chunking; for this reason we need to
-    // initialize the BOT for these regions.
+    // G1 marking uses the BOT for object chunking during marking in
+    // G1CMObjArrayProcessor::process_slice(); for this reason we need to
+    // initialize the BOT for closed archive regions too.
     G1CollectedHeap::heap()->populate_archive_regions_bot_part(closed_heap_regions,
                                                                num_closed_heap_regions);
   }


### PR DESCRIPTION
Hi all,

  please review this change that fixes crashes occurring in the Loom repo because of missing initialization in the BOT of closed archive regions. This is a bug here too, just typically not occurring.

So during marking through the closed archive regions (for statistics mainly) it can happen that there are objects in these closed archive regions that are split into chunks. To get the start of the object that contains this chunk, we use the BOT.

Since it is not initialized for the closed archive regions G1 crashes as that call returns garbage.

The fix is to not only initialize open archive regions, but also closed archive regions.

The problem started with [JDK-8264908](https://bugs.openjdk.java.net/browse/JDK-8264908) which means that there will be a JDK 18 backport.

Testing: failing test with Loom, GHA

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283555](https://bugs.openjdk.java.net/browse/JDK-8283555): G1: Concurrent mark accesses uninitialized BOT of closed archive regions


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to ddc51e03057c33288389027431bb5d1acc56d495
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7923/head:pull/7923` \
`$ git checkout pull/7923`

Update a local copy of the PR: \
`$ git checkout pull/7923` \
`$ git pull https://git.openjdk.java.net/jdk pull/7923/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7923`

View PR using the GUI difftool: \
`$ git pr show -t 7923`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7923.diff">https://git.openjdk.java.net/jdk/pull/7923.diff</a>

</details>
