### PR TITLE
8283575: Check for GNU time fails for version >1.7

### DIFF
--- a/make/autoconf/basic_tools.m4
+++ b/make/autoconf/basic_tools.m4
@@ -348,7 +348,7 @@ AC_DEFUN_ONCE([BASIC_SETUP_COMPLEX_TOOLS],
   UTIL_LOOKUP_PROGS(DTRACE, dtrace, $PATH:/usr/sbin)
   UTIL_LOOKUP_PROGS(PATCH, gpatch patch)
   # Check if it's GNU time
-  IS_GNU_TIME=`$TIME --version 2>&1 | $GREP 'GNU [[Tt]]ime'`
+  [ IS_GNU_TIME=`$TIME --version 2>&1 | $GREP 'GNU [Tt]ime'` ]
   if test "x$IS_GNU_TIME" != x; then
     IS_GNU_TIME=yes
   else

--- a/make/autoconf/basic_tools.m4
+++ b/make/autoconf/basic_tools.m4
@@ -348,7 +348,7 @@ AC_DEFUN_ONCE([BASIC_SETUP_COMPLEX_TOOLS],
   UTIL_LOOKUP_PROGS(DTRACE, dtrace, $PATH:/usr/sbin)
   UTIL_LOOKUP_PROGS(PATCH, gpatch patch)
   # Check if it's GNU time
-  IS_GNU_TIME=`$TIME --version 2>&1 | $GREP 'GNU time'`
+  IS_GNU_TIME=`$TIME --version 2>&1 | $GREP 'GNU [[Tt]]ime'`
   if test "x$IS_GNU_TIME" != x; then
     IS_GNU_TIME=yes
   else


### PR DESCRIPTION
The version output of GNU time changed from "GNU time" to "GNU Time" in version 1.8. We need to update our check for identifying GNU time to handle this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283575](https://bugs.openjdk.java.net/browse/JDK-8283575): Check for GNU time fails for version >1.7


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to 2cf533f01f98605a29e6483fa8b528b936b7101e
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7925/head:pull/7925` \
`$ git checkout pull/7925`

Update a local copy of the PR: \
`$ git checkout pull/7925` \
`$ git pull https://git.openjdk.java.net/jdk pull/7925/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7925`

View PR using the GUI difftool: \
`$ git pr show -t 7925`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7925.diff">https://git.openjdk.java.net/jdk/pull/7925.diff</a>

</details>
