### PR TITLE
8283470: Update java.lang.invoke.VarHandle to use sealed classes

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ import java.util.function.BiFunction;
  * (using the method handle combinator API) and then repackaging the adapted method handles into a new, indirect
  * var handle.
  */
-/* package */ class IndirectVarHandle extends VarHandle {
+/* package */ final class IndirectVarHandle extends VarHandle {
 
     @Stable
     private final MethodHandle[] handleMap = new MethodHandle[AccessMode.COUNT];

--- a/src/java.base/share/classes/java/lang/invoke/MemoryAccessVarHandleBase.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemoryAccessVarHandleBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,15 @@ package java.lang.invoke;
 /**
  * Base class for memory access var handle implementations.
  */
-abstract class MemoryAccessVarHandleBase extends VarHandle {
+abstract sealed class MemoryAccessVarHandleBase extends VarHandle permits
+        MemoryAccessVarHandleByteHelper,
+        MemoryAccessVarHandleCharHelper,
+        MemoryAccessVarHandleDoubleHelper,
+        MemoryAccessVarHandleFloatHelper,
+        MemoryAccessVarHandleIntHelper,
+        MemoryAccessVarHandleLongHelper,
+        MemoryAccessVarHandleShortHelper
+{
 
     /** endianness **/
     final boolean be;

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,15 +31,10 @@ import java.lang.constant.ConstantDesc;
 import java.lang.constant.ConstantDescs;
 import java.lang.constant.DirectMethodHandleDesc;
 import java.lang.constant.DynamicConstantDesc;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 
-import jdk.internal.util.Preconditions;
 import jdk.internal.vm.annotation.DontInline;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
@@ -476,7 +471,41 @@ import static java.lang.invoke.MethodHandleStatics.UNSAFE;
  * @see MethodType
  * @since 9
  */
-public abstract class VarHandle implements Constable {
+public abstract sealed class VarHandle implements Constable
+     permits IndirectVarHandle, MemoryAccessVarHandleBase,
+             VarHandleByteArrayAsChars.ByteArrayViewVarHandle,
+             VarHandleByteArrayAsDoubles.ByteArrayViewVarHandle,
+             VarHandleByteArrayAsFloats.ByteArrayViewVarHandle,
+             VarHandleByteArrayAsInts.ByteArrayViewVarHandle,
+             VarHandleByteArrayAsLongs.ByteArrayViewVarHandle,
+             VarHandleByteArrayAsShorts.ByteArrayViewVarHandle,
+             VarHandleBooleans.Array,
+             VarHandleBooleans.FieldInstanceReadOnly,
+             VarHandleBooleans.FieldStaticReadOnly,
+             VarHandleBytes.Array,
+             VarHandleBytes.FieldInstanceReadOnly,
+             VarHandleBytes.FieldStaticReadOnly,
+             VarHandleChars.Array,
+             VarHandleChars.FieldInstanceReadOnly,
+             VarHandleChars.FieldStaticReadOnly,
+             VarHandleDoubles.Array,
+             VarHandleDoubles.FieldInstanceReadOnly,
+             VarHandleDoubles.FieldStaticReadOnly,
+             VarHandleFloats.Array,
+             VarHandleFloats.FieldInstanceReadOnly,
+             VarHandleFloats.FieldStaticReadOnly,
+             VarHandleInts.Array,
+             VarHandleInts.FieldInstanceReadOnly,
+             VarHandleInts.FieldStaticReadOnly,
+             VarHandleLongs.Array,
+             VarHandleLongs.FieldInstanceReadOnly,
+             VarHandleLongs.FieldStaticReadOnly,
+             VarHandleReferences.Array,
+             VarHandleReferences.FieldInstanceReadOnly,
+             VarHandleReferences.FieldStaticReadOnly,
+             VarHandleShorts.Array,
+             VarHandleShorts.FieldInstanceReadOnly,
+             VarHandleShorts.FieldStaticReadOnly {
     final VarForm vform;
     final boolean exact;
 

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import static java.lang.invoke.MethodHandleStatics.UNSAFE;
 
 final class VarHandle$Type$s {
 
-    static class FieldInstanceReadOnly extends VarHandle {
+    static sealed class FieldInstanceReadOnly extends VarHandle {
         final long fieldOffset;
         final Class<?> receiverType;
 #if[Object]
@@ -381,7 +381,7 @@ final class VarHandle$Type$s {
     }
 
 
-    static class FieldStaticReadOnly extends VarHandle {
+    static sealed class FieldStaticReadOnly extends VarHandle {
         final Object base;
         final long fieldOffset;
 #if[Object]

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandleByteArrayView.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandleByteArrayView.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
 #end[floatingPoint]
 
 
-    private static abstract class ByteArrayViewVarHandle extends VarHandle {
+    static abstract sealed class ByteArrayViewVarHandle extends VarHandle {
         final boolean be;
 
         ByteArrayViewVarHandle(VarForm form, boolean be, boolean exact) {


### PR DESCRIPTION
This patch changes VarHandle and its implementation hierarchy to use sealed classes.  All VarHandle permitted classes are package-private and either final or sealed abstract classes.

Please also review the CSR: https://bugs.openjdk.java.net/browse/JDK-8283540

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8283470](https://bugs.openjdk.java.net/browse/JDK-8283470): Update java.lang.invoke.VarHandle to use sealed classes
 * [JDK-8283540](https://bugs.openjdk.java.net/browse/JDK-8283540): Update java.lang.invoke.VarHandle to use sealed classes (**CSR**)


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7926/head:pull/7926` \
`$ git checkout pull/7926`

Update a local copy of the PR: \
`$ git checkout pull/7926` \
`$ git pull https://git.openjdk.java.net/jdk pull/7926/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7926`

View PR using the GUI difftool: \
`$ git pr show -t 7926`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7926.diff">https://git.openjdk.java.net/jdk/pull/7926.diff</a>

</details>
