### PR TITLE
8282943: Unused weird key in compiler.properties

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -1565,9 +1565,6 @@ compiler.misc.diamond.anonymous.methods.implicitly.override=\
 compiler.misc.source.unavailable=\
     (source unavailable)
 
-compiler.misc.base.membership=\
-    all your base class are belong to us
-
 # 0: string, 1: string, 2: boolean
 compiler.misc.x.print.processor.info=\
     Processor {0} matches {1} and returns {2}.

--- a/test/langtools/tools/javac/diags/examples.not-yet.txt
+++ b/test/langtools/tools/javac/diags/examples.not-yet.txt
@@ -57,7 +57,6 @@ compiler.misc.bad.runtime.invisible.param.annotations   # bad class file
 compiler.misc.bad.signature                             # bad class file
 compiler.misc.bad.requires.flag                         # bad class file
 compiler.misc.bad.type.annotation.value
-compiler.misc.base.membership                           # UNUSED
 compiler.misc.class.file.not.found                      # ClassReader
 compiler.misc.class.file.wrong.class
 compiler.misc.exception.message                         # uncommon completion failure based on a string


### PR DESCRIPTION
There is a weird key in `compiler.properties` in javac. This key is, to my knowledge, unused, so the proposal is to remove it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282943](https://bugs.openjdk.java.net/browse/JDK-8282943): Unused weird key in compiler.properties


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7929/head:pull/7929` \
`$ git checkout pull/7929`

Update a local copy of the PR: \
`$ git checkout pull/7929` \
`$ git pull https://git.openjdk.java.net/jdk pull/7929/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7929`

View PR using the GUI difftool: \
`$ git pr show -t 7929`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7929.diff">https://git.openjdk.java.net/jdk/pull/7929.diff</a>

</details>
