### PR TITLE
JDK-8283594: Improve docs of ElementScanner classes

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner14.java
@@ -44,7 +44,7 @@ import static javax.lang.model.SourceVersion.*;
  * parameters}, etc., as indicated in the individual method
  * specifications.  A subclass can control the order elements are
  * visited by overriding the <code>visit<i>Xyz</i></code> methods.
- * Note that clients of a scanner may get the desired behavior be
+ * Note that clients of a scanner may get the desired behavior by
  * invoking {@code v.scan(e, p)} rather than {@code v.visit(e, p)} on
  * the root objects of interest.
  *

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner14.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import static javax.lang.model.SourceVersion.*;
  * source version.
  *
  * The <code>visit<i>Xyz</i></code> methods in this
- * class scan their component elements by calling {@code scan} on
+ * class scan their component elements by calling {@link ElementScanner6#scan(Element, Object) scan} on
  * their {@linkplain Element#getEnclosedElements enclosed elements},
  * {@linkplain ExecutableElement#getParameters parameters}, etc., as
  * indicated in the individual method specifications.  A subclass can

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner14.java
@@ -37,15 +37,16 @@ import static javax.lang.model.SourceVersion.*;
  * appropriate for the {@link SourceVersion#RELEASE_14 RELEASE_14}
  * source version.
  *
- * The <code>visit<i>Xyz</i></code> methods in this
- * class scan their component elements by calling {@link ElementScanner6#scan(Element, Object) scan} on
- * their {@linkplain Element#getEnclosedElements enclosed elements},
- * {@linkplain ExecutableElement#getParameters parameters}, etc., as
- * indicated in the individual method specifications.  A subclass can
- * control the order elements are visited by overriding the
- * <code>visit<i>Xyz</i></code> methods.  Note that clients of a scanner
- * may get the desired behavior be invoking {@code v.scan(e, p)} rather
- * than {@code v.visit(e, p)} on the root objects of interest.
+ * The <code>visit<i>Xyz</i></code> methods in this class scan their
+ * component elements by calling {@link ElementScanner6#scan(Element,
+ * Object) scan} on their {@linkplain Element#getEnclosedElements
+ * enclosed elements}, {@linkplain ExecutableElement#getParameters
+ * parameters}, etc., as indicated in the individual method
+ * specifications.  A subclass can control the order elements are
+ * visited by overriding the <code>visit<i>Xyz</i></code> methods.
+ * Note that clients of a scanner may get the desired behavior be
+ * invoking {@code v.scan(e, p)} rather than {@code v.visit(e, p)} on
+ * the root objects of interest.
  *
  * <p>When a subclass overrides a <code>visit<i>Xyz</i></code> method, the
  * new method can cause the enclosed elements to be scanned in the

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner6.java
@@ -42,7 +42,7 @@ import static javax.lang.model.SourceVersion.*;
  * the individual method specifications.  A subclass can control the
  * order elements are visited by overriding the
  * <code>visit<i>Xyz</i></code> methods.  Note that clients of a
- * scanner may get the desired behavior be invoking {@code v.scan(e,
+ * scanner may get the desired behavior by invoking {@code v.scan(e,
  * p)} rather than {@code v.visit(e, p)} on the root objects of
  * interest.
  *

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner6.java
@@ -35,14 +35,16 @@ import static javax.lang.model.SourceVersion.*;
  * A scanning visitor of program elements with default behavior
  * appropriate for the {@link SourceVersion#RELEASE_6 RELEASE_6}
  * source version.  The <code>visit<i>Xyz</i></code> methods in this
- * class scan their component elements by calling {@link #scan(Element, P) scan} on
- * their {@linkplain Element#getEnclosedElements enclosed elements},
- * {@linkplain ExecutableElement#getParameters parameters}, etc., as
- * indicated in the individual method specifications.  A subclass can
- * control the order elements are visited by overriding the
- * <code>visit<i>Xyz</i></code> methods.  Note that clients of a scanner
- * may get the desired behavior be invoking {@code v.scan(e, p)} rather
- * than {@code v.visit(e, p)} on the root objects of interest.
+ * class scan their component elements by calling {@link
+ * #scan(Element, P) scan} on their {@linkplain
+ * Element#getEnclosedElements enclosed elements}, {@linkplain
+ * ExecutableElement#getParameters parameters}, etc., as indicated in
+ * the individual method specifications.  A subclass can control the
+ * order elements are visited by overriding the
+ * <code>visit<i>Xyz</i></code> methods.  Note that clients of a
+ * scanner may get the desired behavior be invoking {@code v.scan(e,
+ * p)} rather than {@code v.visit(e, p)} on the root objects of
+ * interest.
  *
  * <p>When a subclass overrides a <code>visit<i>Xyz</i></code> method, the
  * new method can cause the enclosed elements to be scanned in the

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner6.java
@@ -35,7 +35,7 @@ import static javax.lang.model.SourceVersion.*;
  * A scanning visitor of program elements with default behavior
  * appropriate for the {@link SourceVersion#RELEASE_6 RELEASE_6}
  * source version.  The <code>visit<i>Xyz</i></code> methods in this
- * class scan their component elements by calling {@code scan} on
+ * class scan their component elements by calling {@link #scan(Element, P) scan} on
  * their {@linkplain Element#getEnclosedElements enclosed elements},
  * {@linkplain ExecutableElement#getParameters parameters}, etc., as
  * indicated in the individual method specifications.  A subclass can

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import static javax.lang.model.SourceVersion.*;
  * A scanning visitor of program elements with default behavior
  * appropriate for the {@link SourceVersion#RELEASE_7 RELEASE_7}
  * source version.  The <code>visit<i>Xyz</i></code> methods in this
- * class scan their component elements by calling {@code scan} on
+ * class scan their component elements by calling {@link ElementScanner6#scan(Element, Object) scan} on
  * their {@linkplain Element#getEnclosedElements enclosed elements},
  * {@linkplain ExecutableElement#getParameters parameters}, etc., as
  * indicated in the individual method specifications.  A subclass can

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner7.java
@@ -42,7 +42,7 @@ import static javax.lang.model.SourceVersion.*;
  * the individual method specifications.  A subclass can control the
  * order elements are visited by overriding the
  * <code>visit<i>Xyz</i></code> methods.  Note that clients of a
- * scanner may get the desired behavior be invoking {@code v.scan(e,
+ * scanner may get the desired behavior by invoking {@code v.scan(e,
  * p)} rather than {@code v.visit(e, p)} on the root objects of
  * interest.
  *

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner7.java
@@ -35,14 +35,16 @@ import static javax.lang.model.SourceVersion.*;
  * A scanning visitor of program elements with default behavior
  * appropriate for the {@link SourceVersion#RELEASE_7 RELEASE_7}
  * source version.  The <code>visit<i>Xyz</i></code> methods in this
- * class scan their component elements by calling {@link ElementScanner6#scan(Element, Object) scan} on
- * their {@linkplain Element#getEnclosedElements enclosed elements},
- * {@linkplain ExecutableElement#getParameters parameters}, etc., as
- * indicated in the individual method specifications.  A subclass can
- * control the order elements are visited by overriding the
- * <code>visit<i>Xyz</i></code> methods.  Note that clients of a scanner
- * may get the desired behavior be invoking {@code v.scan(e, p)} rather
- * than {@code v.visit(e, p)} on the root objects of interest.
+ * class scan their component elements by calling {@link
+ * ElementScanner6#scan(Element, Object) scan} on their {@linkplain
+ * Element#getEnclosedElements enclosed elements}, {@linkplain
+ * ExecutableElement#getParameters parameters}, etc., as indicated in
+ * the individual method specifications.  A subclass can control the
+ * order elements are visited by overriding the
+ * <code>visit<i>Xyz</i></code> methods.  Note that clients of a
+ * scanner may get the desired behavior be invoking {@code v.scan(e,
+ * p)} rather than {@code v.visit(e, p)} on the root objects of
+ * interest.
  *
  * <p>When a subclass overrides a <code>visit<i>Xyz</i></code> method, the
  * new method can cause the enclosed elements to be scanned in the

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner8.java
@@ -42,7 +42,7 @@ import static javax.lang.model.SourceVersion.*;
  * the individual method specifications.  A subclass can control the
  * order elements are visited by overriding the
  * <code>visit<i>Xyz</i></code> methods.  Note that clients of a
- * scanner may get the desired behavior be invoking {@code v.scan(e,
+ * scanner may get the desired behavior by invoking {@code v.scan(e,
  * p)} rather than {@code v.visit(e, p)} on the root objects of
  * interest.
  *

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import static javax.lang.model.SourceVersion.*;
  * A scanning visitor of program elements with default behavior
  * appropriate for the {@link SourceVersion#RELEASE_8 RELEASE_8}
  * source version.  The <code>visit<i>Xyz</i></code> methods in this
- * class scan their component elements by calling {@code scan} on
+ * class scan their component elements by calling {@link ElementScanner6#scan(Element, Object) scan} on
  * their {@linkplain Element#getEnclosedElements enclosed elements},
  * {@linkplain ExecutableElement#getParameters parameters}, etc., as
  * indicated in the individual method specifications.  A subclass can

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner8.java
@@ -35,14 +35,16 @@ import static javax.lang.model.SourceVersion.*;
  * A scanning visitor of program elements with default behavior
  * appropriate for the {@link SourceVersion#RELEASE_8 RELEASE_8}
  * source version.  The <code>visit<i>Xyz</i></code> methods in this
- * class scan their component elements by calling {@link ElementScanner6#scan(Element, Object) scan} on
- * their {@linkplain Element#getEnclosedElements enclosed elements},
- * {@linkplain ExecutableElement#getParameters parameters}, etc., as
- * indicated in the individual method specifications.  A subclass can
- * control the order elements are visited by overriding the
- * <code>visit<i>Xyz</i></code> methods.  Note that clients of a scanner
- * may get the desired behavior be invoking {@code v.scan(e, p)} rather
- * than {@code v.visit(e, p)} on the root objects of interest.
+ * class scan their component elements by calling {@link
+ * ElementScanner6#scan(Element, Object) scan} on their {@linkplain
+ * Element#getEnclosedElements enclosed elements}, {@linkplain
+ * ExecutableElement#getParameters parameters}, etc., as indicated in
+ * the individual method specifications.  A subclass can control the
+ * order elements are visited by overriding the
+ * <code>visit<i>Xyz</i></code> methods.  Note that clients of a
+ * scanner may get the desired behavior be invoking {@code v.scan(e,
+ * p)} rather than {@code v.visit(e, p)} on the root objects of
+ * interest.
  *
  * <p>When a subclass overrides a <code>visit<i>Xyz</i></code> method, the
  * new method can cause the enclosed elements to be scanned in the

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner9.java
@@ -36,15 +36,16 @@ import static javax.lang.model.SourceVersion.*;
  * appropriate for source versions {@link SourceVersion#RELEASE_9
  * RELEASE_9} through {@link SourceVersion#RELEASE_14 RELEASE_14}.
  *
- * The <code>visit<i>Xyz</i></code> methods in this
- * class scan their component elements by calling {@link ElementScanner6#scan(Element, Object) scan} on
- * their {@linkplain Element#getEnclosedElements enclosed elements},
- * {@linkplain ExecutableElement#getParameters parameters}, etc., as
- * indicated in the individual method specifications.  A subclass can
- * control the order elements are visited by overriding the
- * <code>visit<i>Xyz</i></code> methods.  Note that clients of a scanner
- * may get the desired behavior be invoking {@code v.scan(e, p)} rather
- * than {@code v.visit(e, p)} on the root objects of interest.
+ * The <code>visit<i>Xyz</i></code> methods in this class scan their
+ * component elements by calling {@link ElementScanner6#scan(Element,
+ * Object) scan} on their {@linkplain Element#getEnclosedElements
+ * enclosed elements}, {@linkplain ExecutableElement#getParameters
+ * parameters}, etc., as indicated in the individual method
+ * specifications.  A subclass can control the order elements are
+ * visited by overriding the <code>visit<i>Xyz</i></code> methods.
+ * Note that clients of a scanner may get the desired behavior be
+ * invoking {@code v.scan(e, p)} rather than {@code v.visit(e, p)} on
+ * the root objects of interest.
  *
  * <p>When a subclass overrides a <code>visit<i>Xyz</i></code> method, the
  * new method can cause the enclosed elements to be scanned in the

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner9.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import static javax.lang.model.SourceVersion.*;
  * RELEASE_9} through {@link SourceVersion#RELEASE_14 RELEASE_14}.
  *
  * The <code>visit<i>Xyz</i></code> methods in this
- * class scan their component elements by calling {@code scan} on
+ * class scan their component elements by calling {@link ElementScanner6#scan(Element, Object) scan} on
  * their {@linkplain Element#getEnclosedElements enclosed elements},
  * {@linkplain ExecutableElement#getParameters parameters}, etc., as
  * indicated in the individual method specifications.  A subclass can

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner9.java
@@ -43,7 +43,7 @@ import static javax.lang.model.SourceVersion.*;
  * parameters}, etc., as indicated in the individual method
  * specifications.  A subclass can control the order elements are
  * visited by overriding the <code>visit<i>Xyz</i></code> methods.
- * Note that clients of a scanner may get the desired behavior be
+ * Note that clients of a scanner may get the desired behavior by
  * invoking {@code v.scan(e, p)} rather than {@code v.visit(e, p)} on
  * the root objects of interest.
  *


### PR DESCRIPTION
Simple update to add links. In the subclasses, the erasure of the parameter's type needs to be used for the link to be recognized as valid.

After getting reviews, I'll reflow the paragraphs before pushing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283594](https://bugs.openjdk.java.net/browse/JDK-8283594): Improve docs of ElementScanner classes


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to 035d7e40a0854e96fafdeb1a8813f0ba6f1dcc28


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7932/head:pull/7932` \
`$ git checkout pull/7932`

Update a local copy of the PR: \
`$ git checkout pull/7932` \
`$ git pull https://git.openjdk.java.net/jdk pull/7932/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7932`

View PR using the GUI difftool: \
`$ git pr show -t 7932`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7932.diff">https://git.openjdk.java.net/jdk/pull/7932.diff</a>

</details>
