### PR TITLE
8283603: Remove redundant qualifier in Windows specific Attach Operation

### DIFF
--- a/src/hotspot/os/windows/attachListener_windows.cpp
+++ b/src/hotspot/os/windows/attachListener_windows.cpp
@@ -154,7 +154,7 @@ class Win32AttachOperation: public AttachOperation {
   }
 
  public:
-  void Win32AttachOperation::complete(jint result, bufferedStream* result_stream);
+  void complete(jint result, bufferedStream* result_stream);
 };
 
 


### PR DESCRIPTION
Tested and compiled successfully with 2019 and 2022

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283603](https://bugs.openjdk.java.net/browse/JDK-8283603): Remove redundant qualifier in Windows specific Attach Operation


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7935/head:pull/7935` \
`$ git checkout pull/7935`

Update a local copy of the PR: \
`$ git checkout pull/7935` \
`$ git pull https://git.openjdk.java.net/jdk pull/7935/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7935`

View PR using the GUI difftool: \
`$ git pr show -t 7935`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7935.diff">https://git.openjdk.java.net/jdk/pull/7935.diff</a>

</details>
