### PR TITLE
8283607: Rename KlassID to KlassKind

### DIFF
--- a/src/hotspot/share/memory/iterator.inline.hpp
+++ b/src/hotspot/share/memory/iterator.inline.hpp
@@ -174,7 +174,7 @@ void Devirtualizer::do_cld(OopClosureType* closure, ClassLoaderData* cld) {
 // It allows for a single call to do a multi-dispatch to an optimized version
 //   of oop_oop_iterate that statically know all these types:
 //   - OopClosureType    : static type give at call site
-//   - Klass*            : dynamic to static type through Klass::id() -> table index
+//   - Klass*            : dynamic to static type through Klass::kind() -> table index
 //   - UseCompressedOops : dynamic to static value determined once
 //
 // when users call obj->oop_iterate(&cl).
@@ -190,7 +190,7 @@ void Devirtualizer::do_cld(OopClosureType* closure, ClassLoaderData* cld) {
 //   used when calling do_oop.
 //
 // Klass* :
-//   A table mapping from *Klass::ID to function is setup. This happens once
+//   A table mapping from *Klass::Kind to function is setup. This happens once
 //   when the program starts, when the static _table instance is initialized for
 //   the OopOopIterateDispatch specialized with the OopClosureType.
 //
@@ -223,7 +223,7 @@ private:
 
     template <typename KlassType>
     void set_init_function() {
-      _function[KlassType::ID] = &init<KlassType>;
+      _function[KlassType::Kind] = &init<KlassType>;
     }
 
     template <typename KlassType>
@@ -232,20 +232,20 @@ private:
       // when functions pointers are updated.
       STATIC_ASSERT(sizeof(_function[0]) == sizeof(void*));
       if (UseCompressedOops) {
-        _function[KlassType::ID] = &oop_oop_iterate<KlassType, narrowOop>;
+        _function[KlassType::Kind] = &oop_oop_iterate<KlassType, narrowOop>;
       } else {
-        _function[KlassType::ID] = &oop_oop_iterate<KlassType, oop>;
+        _function[KlassType::Kind] = &oop_oop_iterate<KlassType, oop>;
       }
     }
 
     template <typename KlassType>
     void set_resolve_function_and_execute(OopClosureType* cl, oop obj, Klass* k) {
       set_resolve_function<KlassType>();
-      _function[KlassType::ID](cl, obj, k);
+      _function[KlassType::Kind](cl, obj, k);
     }
 
   public:
-    FunctionType _function[KLASS_ID_COUNT];
+    FunctionType _function[KLASS_KIND_COUNT];
 
     Table(){
       set_init_function<InstanceKlass>();
@@ -261,7 +261,7 @@ private:
 public:
 
   static FunctionType function(Klass* klass) {
-    return _table._function[klass->id()];
+    return _table._function[klass->kind()];
   }
 };
 
@@ -288,26 +288,26 @@ private:
 
     template <typename KlassType>
     void set_init_function() {
-      _function[KlassType::ID] = &init<KlassType>;
+      _function[KlassType::Kind] = &init<KlassType>;
     }
 
     template <typename KlassType>
     void set_resolve_function() {
       if (UseCompressedOops) {
-        _function[KlassType::ID] = &oop_oop_iterate_bounded<KlassType, narrowOop>;
+        _function[KlassType::Kind] = &oop_oop_iterate_bounded<KlassType, narrowOop>;
       } else {
-        _function[KlassType::ID] = &oop_oop_iterate_bounded<KlassType, oop>;
+        _function[KlassType::Kind] = &oop_oop_iterate_bounded<KlassType, oop>;
       }
     }
 
     template <typename KlassType>
     void set_resolve_function_and_execute(OopClosureType* cl, oop obj, Klass* k, MemRegion mr) {
       set_resolve_function<KlassType>();
-      _function[KlassType::ID](cl, obj, k, mr);
+      _function[KlassType::Kind](cl, obj, k, mr);
     }
 
   public:
-    FunctionType _function[KLASS_ID_COUNT];
+    FunctionType _function[KLASS_KIND_COUNT];
 
     Table(){
       set_init_function<InstanceKlass>();
@@ -323,7 +323,7 @@ private:
 public:
 
   static FunctionType function(Klass* klass) {
-    return _table._function[klass->id()];
+    return _table._function[klass->kind()];
   }
 };
 
@@ -350,26 +350,26 @@ private:
 
     template <typename KlassType>
     void set_init_function() {
-      _function[KlassType::ID] = &init<KlassType>;
+      _function[KlassType::Kind] = &init<KlassType>;
     }
 
     template <typename KlassType>
     void set_resolve_function() {
       if (UseCompressedOops) {
-        _function[KlassType::ID] = &oop_oop_iterate_backwards<KlassType, narrowOop>;
+        _function[KlassType::Kind] = &oop_oop_iterate_backwards<KlassType, narrowOop>;
       } else {
-        _function[KlassType::ID] = &oop_oop_iterate_backwards<KlassType, oop>;
+        _function[KlassType::Kind] = &oop_oop_iterate_backwards<KlassType, oop>;
       }
     }
 
     template <typename KlassType>
     void set_resolve_function_and_execute(OopClosureType* cl, oop obj, Klass* k) {
       set_resolve_function<KlassType>();
-      _function[KlassType::ID](cl, obj, k);
+      _function[KlassType::Kind](cl, obj, k);
     }
 
   public:
-    FunctionType _function[KLASS_ID_COUNT];
+    FunctionType _function[KLASS_KIND_COUNT];
 
     Table(){
       set_init_function<InstanceKlass>();
@@ -385,7 +385,7 @@ private:
 public:
 
   static FunctionType function(Klass* klass) {
-    return _table._function[klass->id()];
+    return _table._function[klass->kind()];
   }
 };
 

--- a/src/hotspot/share/oops/arrayKlass.cpp
+++ b/src/hotspot/share/oops/arrayKlass.cpp
@@ -83,8 +83,8 @@ Method* ArrayKlass::uncached_lookup_method(const Symbol* name,
   return super()->uncached_lookup_method(name, signature, OverpassLookupMode::skip, private_mode);
 }
 
-ArrayKlass::ArrayKlass(Symbol* name, KlassID id) :
-  Klass(id),
+ArrayKlass::ArrayKlass(Symbol* name, KlassKind kind) :
+  Klass(kind),
   _dimension(1),
   _higher_dimension(NULL),
   _lower_dimension(NULL) {

--- a/src/hotspot/share/oops/arrayKlass.hpp
+++ b/src/hotspot/share/oops/arrayKlass.hpp
@@ -45,7 +45,7 @@ class ArrayKlass: public Klass {
   // Constructors
   // The constructor with the Symbol argument does the real array
   // initialization, the other is a dummy
-  ArrayKlass(Symbol* name, KlassID id);
+  ArrayKlass(Symbol* name, KlassKind kind);
   ArrayKlass() { assert(DumpSharedSpaces || UseSharedSpaces, "only for cds"); }
 
  public:

--- a/src/hotspot/share/oops/instanceClassLoaderKlass.hpp
+++ b/src/hotspot/share/oops/instanceClassLoaderKlass.hpp
@@ -40,10 +40,10 @@ class InstanceClassLoaderKlass: public InstanceKlass {
   friend class VMStructs;
   friend class InstanceKlass;
 public:
-  static const KlassID ID = InstanceClassLoaderKlassID;
+  static const KlassKind Kind = InstanceClassLoaderKlassKind;
 
 private:
-  InstanceClassLoaderKlass(const ClassFileParser& parser) : InstanceKlass(parser, ID) {}
+  InstanceClassLoaderKlass(const ClassFileParser& parser) : InstanceKlass(parser, Kind) {}
 
 public:
   InstanceClassLoaderKlass() { assert(DumpSharedSpaces || UseSharedSpaces, "only for CDS"); }

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -485,8 +485,8 @@ Array<int>* InstanceKlass::create_new_default_vtable_indices(int len, TRAPS) {
   return vtable_indices;
 }
 
-InstanceKlass::InstanceKlass(const ClassFileParser& parser, KlassID id) :
-  Klass(id),
+InstanceKlass::InstanceKlass(const ClassFileParser& parser, KlassKind kind) :
+  Klass(kind),
   _nest_members(NULL),
   _nest_host(NULL),
   _permitted_subclasses(NULL),

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -133,10 +133,10 @@ class InstanceKlass: public Klass {
   friend class CompileReplay;
 
  public:
-  static const KlassID ID = InstanceKlassID;
+  static const KlassKind Kind = InstanceKlassKind;
 
  protected:
-  InstanceKlass(const ClassFileParser& parser, KlassID id = ID);
+  InstanceKlass(const ClassFileParser& parser, KlassKind kind = Kind);
 
  public:
   InstanceKlass() { assert(DumpSharedSpaces || UseSharedSpaces, "only for CDS"); }

--- a/src/hotspot/share/oops/instanceMirrorKlass.hpp
+++ b/src/hotspot/share/oops/instanceMirrorKlass.hpp
@@ -45,12 +45,12 @@ class InstanceMirrorKlass: public InstanceKlass {
   friend class InstanceKlass;
 
  public:
-  static const KlassID ID = InstanceMirrorKlassID;
+  static const KlassKind Kind = InstanceMirrorKlassKind;
 
  private:
   static int _offset_of_static_fields;
 
-  InstanceMirrorKlass(const ClassFileParser& parser) : InstanceKlass(parser, ID) {}
+  InstanceMirrorKlass(const ClassFileParser& parser) : InstanceKlass(parser, Kind) {}
 
  public:
   InstanceMirrorKlass() { assert(DumpSharedSpaces || UseSharedSpaces, "only for CDS"); }

--- a/src/hotspot/share/oops/instanceRefKlass.hpp
+++ b/src/hotspot/share/oops/instanceRefKlass.hpp
@@ -50,10 +50,10 @@ class ClassFileParser;
 class InstanceRefKlass: public InstanceKlass {
   friend class InstanceKlass;
  public:
-  static const KlassID ID = InstanceRefKlassID;
+  static const KlassKind ID = InstanceRefKlassKind;
 
  private:
-  InstanceRefKlass(const ClassFileParser& parser) : InstanceKlass(parser, ID) {}
+  InstanceRefKlass(const ClassFileParser& parser) : InstanceKlass(parser, Kind) {}
 
  public:
   InstanceRefKlass() { assert(DumpSharedSpaces || UseSharedSpaces, "only for CDS"); }

--- a/src/hotspot/share/oops/instanceRefKlass.hpp
+++ b/src/hotspot/share/oops/instanceRefKlass.hpp
@@ -50,7 +50,7 @@ class ClassFileParser;
 class InstanceRefKlass: public InstanceKlass {
   friend class InstanceKlass;
  public:
-  static const KlassKind ID = InstanceRefKlassKind;
+  static const KlassKind Kind = InstanceRefKlassKind;
 
  private:
   InstanceRefKlass(const ClassFileParser& parser) : InstanceKlass(parser, Kind) {}

--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -201,7 +201,7 @@ void* Klass::operator new(size_t size, ClassLoaderData* loader_data, size_t word
 // which zeros out memory - calloc equivalent.
 // The constructor is also used from CppVtableCloner,
 // which doesn't zero out the memory before calling the constructor.
-Klass::Klass(KlassID id) : _id(id),
+Klass::Klass(KlassKind kind) : _kind(kind),
                            _shared_class_path_index(-1) {
   CDS_ONLY(_shared_class_flags = 0;)
   CDS_JAVA_HEAP_ONLY(_archived_mirror_index = -1;)

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -37,17 +37,17 @@
 #include "jfr/support/jfrTraceIdExtension.hpp"
 #endif
 
-// Klass IDs for all subclasses of Klass
-enum KlassID {
-  InstanceKlassID,
-  InstanceRefKlassID,
-  InstanceMirrorKlassID,
-  InstanceClassLoaderKlassID,
-  TypeArrayKlassID,
-  ObjArrayKlassID
+// Klass Kinds for all subclasses of Klass
+enum KlassKind {
+  InstanceKlassKind,
+  InstanceRefKlassKind,
+  InstanceMirrorKlassKind,
+  InstanceClassLoaderKlassKind,
+  TypeArrayKlassKind,
+  ObjArrayKlassKind
 };
 
-const uint KLASS_ID_COUNT = 6;
+const uint KLASS_KIND_COUNT = ObjArrayKlassKind + 1;
 
 //
 // A Klass provides:
@@ -114,8 +114,10 @@ class Klass : public Metadata {
   // because it is frequently queried.
   jint        _layout_helper;
 
-  // Klass identifier used to implement devirtualized oop closure dispatching.
-  const KlassID _id;
+  // Klass kind used to resolve the runtime type of the instance.
+  //  - Used to implement devirtualized oop closure dispatching.
+  //  - Various type checking in the JVM
+  const KlassKind _kind;
 
   // Processed access flags, for use by Class.getModifiers.
   jint        _modifier_flags;
@@ -186,13 +188,13 @@ private:
 protected:
 
   // Constructor
-  Klass(KlassID id);
-  Klass() : _id(KlassID(-1)) { assert(DumpSharedSpaces || UseSharedSpaces, "only for cds"); }
+  Klass(KlassKind kind);
+  Klass() : _kind(KlassKind(-1)) { assert(DumpSharedSpaces || UseSharedSpaces, "only for cds"); }
 
   void* operator new(size_t size, ClassLoaderData* loader_data, size_t word_size, TRAPS) throw();
 
  public:
-  int id() { return _id; }
+  int kind() { return _kind; }
 
   enum class DefaultsLookupMode { find, skip };
   enum class OverpassLookupMode { find, skip };
@@ -615,15 +617,15 @@ protected:
  public:
   #endif
 
-  bool is_instance_klass()              const { return assert_same_query(_id <= InstanceClassLoaderKlassID, is_instance_klass_slow()); }
+  bool is_instance_klass()              const { return assert_same_query(_kind <= InstanceClassLoaderKlassKind, is_instance_klass_slow()); }
   // Other is anything that is not one of the more specialized kinds of InstanceKlass.
-  bool is_other_instance_klass()        const { return _id == InstanceKlassID; }
-  bool is_reference_instance_klass()    const { return _id == InstanceRefKlassID; }
-  bool is_mirror_instance_klass()       const { return _id == InstanceMirrorKlassID; }
-  bool is_class_loader_instance_klass() const { return _id == InstanceClassLoaderKlassID; }
-  bool is_array_klass()                 const { return assert_same_query( _id >= TypeArrayKlassID, is_array_klass_slow()); }
-  bool is_objArray_klass()              const { return assert_same_query( _id == ObjArrayKlassID,  is_objArray_klass_slow()); }
-  bool is_typeArray_klass()             const { return assert_same_query( _id == TypeArrayKlassID, is_typeArray_klass_slow()); }
+  bool is_other_instance_klass()        const { return _kind == InstanceKlassKind; }
+  bool is_reference_instance_klass()    const { return _kind == InstanceRefKlassKind; }
+  bool is_mirror_instance_klass()       const { return _kind == InstanceMirrorKlassKind; }
+  bool is_class_loader_instance_klass() const { return _kind == InstanceClassLoaderKlassKind; }
+  bool is_array_klass()                 const { return assert_same_query( _kind >= TypeArrayKlassKind, is_array_klass_slow()); }
+  bool is_objArray_klass()              const { return assert_same_query( _kind == ObjArrayKlassKind,  is_objArray_klass_slow()); }
+  bool is_typeArray_klass()             const { return assert_same_query( _kind == TypeArrayKlassKind, is_typeArray_klass_slow()); }
   #undef assert_same_query
 
   // Access flags

--- a/src/hotspot/share/oops/objArrayKlass.cpp
+++ b/src/hotspot/share/oops/objArrayKlass.cpp
@@ -136,7 +136,7 @@ ObjArrayKlass* ObjArrayKlass::allocate_objArray_klass(ClassLoaderData* loader_da
   return oak;
 }
 
-ObjArrayKlass::ObjArrayKlass(int n, Klass* element_klass, Symbol* name) : ArrayKlass(name, ID) {
+ObjArrayKlass::ObjArrayKlass(int n, Klass* element_klass, Symbol* name) : ArrayKlass(name, Kind) {
   set_dimension(n);
   set_element_klass(element_klass);
 

--- a/src/hotspot/share/oops/objArrayKlass.hpp
+++ b/src/hotspot/share/oops/objArrayKlass.hpp
@@ -37,7 +37,7 @@ class ObjArrayKlass : public ArrayKlass {
   friend class JVMCIVMStructs;
 
  public:
-  static const KlassID ID = ObjArrayKlassID;
+  static const KlassKind Kind = ObjArrayKlassKind;
 
  private:
   // If you add a new field that points to any metaspace object, you

--- a/src/hotspot/share/oops/typeArrayKlass.cpp
+++ b/src/hotspot/share/oops/typeArrayKlass.cpp
@@ -75,7 +75,7 @@ TypeArrayKlass* TypeArrayKlass::allocate(ClassLoaderData* loader_data, BasicType
   return new (loader_data, size, THREAD) TypeArrayKlass(type, name);
 }
 
-TypeArrayKlass::TypeArrayKlass(BasicType type, Symbol* name) : ArrayKlass(name, ID) {
+TypeArrayKlass::TypeArrayKlass(BasicType type, Symbol* name) : ArrayKlass(name, Kind) {
   set_layout_helper(array_layout_helper(type));
   assert(is_array_klass(), "sanity");
   assert(is_typeArray_klass(), "sanity");

--- a/src/hotspot/share/oops/typeArrayKlass.hpp
+++ b/src/hotspot/share/oops/typeArrayKlass.hpp
@@ -36,7 +36,7 @@ class TypeArrayKlass : public ArrayKlass {
   friend class VMStructs;
 
  public:
-  static const KlassID ID = TypeArrayKlassID;
+  static const KlassKind Kind = TypeArrayKlassKind;
 
  private:
   jint _max_length;            // maximum number of elements allowed in an array


### PR DESCRIPTION
During the review of JDK-8283574 / #7922 , it was brought up that the term ID to describe the "kind" of *Klass is misleading. Rename KlassID to KlassKind, and update names of variables of KlassID.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283607](https://bugs.openjdk.java.net/browse/JDK-8283607): Rename KlassID to KlassKind


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7936/head:pull/7936` \
`$ git checkout pull/7936`

Update a local copy of the PR: \
`$ git checkout pull/7936` \
`$ git pull https://git.openjdk.java.net/jdk pull/7936/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7936`

View PR using the GUI difftool: \
`$ git pr show -t 7936`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7936.diff">https://git.openjdk.java.net/jdk/pull/7936.diff</a>

</details>
