### PR TITLE
8283608: Refactor 2d, beans classes javadoc to use @throws instead of @exception

### DIFF
--- a/src/java.desktop/share/classes/com/sun/media/sound/AiffFileReader.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/AiffFileReader.java
@@ -172,7 +172,7 @@ public final class AiffFileReader extends SunFileReader {
      * Extended precision IEEE floating-point conversion routine.
      * @argument DataInputStream
      * @return double
-     * @exception IOException
+     * @throws IOException
      */
     private double read_ieee_extended(DataInputStream dis) throws IOException {
 

--- a/src/java.desktop/share/classes/com/sun/media/sound/AiffFileWriter.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/AiffFileWriter.java
@@ -392,7 +392,7 @@ public final class AiffFileWriter extends SunFileWriter {
      * Extended precision IEEE floating-point conversion routine.
      * @argument DataOutputStream
      * @argument double
-     * @exception IOException
+     * @throws IOException
      */
     private void write_ieee_extended(DataOutputStream dos, float f) throws IOException {
         /* The special cases NaN, Infinity and Zero are ignored, since

--- a/src/java.desktop/share/classes/com/sun/media/sound/SunFileReader.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/SunFileReader.java
@@ -164,7 +164,7 @@ abstract class SunFileReader extends AudioFileReader {
      * Protected helper method to read 64 bits and changing the order of
      * each bytes.
      * @return 32 bits swapped value.
-     * @exception IOException
+     * @throws IOException
      */
     final int rllong(DataInputStream dis) throws IOException {
 
@@ -206,7 +206,7 @@ abstract class SunFileReader extends AudioFileReader {
      * rlshort
      * Protected helper method to read 16 bits value. Swap high with low byte.
      * @return the swapped value.
-     * @exception IOException
+     * @throws IOException
      */
     final short rlshort(DataInputStream dis)  throws IOException {
 

--- a/src/java.desktop/share/classes/com/sun/media/sound/SunFileWriter.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/SunFileWriter.java
@@ -70,7 +70,7 @@ abstract class SunFileWriter extends AudioFileWriter {
      * Protected helper method to read 64 bits and changing the order of
      * each bytes.
      * @return 32 bits swapped value.
-     * @exception IOException
+     * @throws IOException
      */
     final int rllong(DataInputStream dis) throws IOException {
 
@@ -112,7 +112,7 @@ abstract class SunFileWriter extends AudioFileWriter {
      * rlshort
      * Protected helper method to read 16 bits value. Swap high with low byte.
      * @return the swapped value.
-     * @exception IOException
+     * @throws IOException
      */
     final short rlshort(DataInputStream dis)  throws IOException {
 

--- a/src/java.desktop/share/classes/java/beans/Beans.java
+++ b/src/java.desktop/share/classes/java/beans/Beans.java
@@ -75,9 +75,9 @@ public class Beans {
      * @param     beanName    the name of the bean within the class-loader.
      *                        For example "sun.beanbox.foobah"
      *
-     * @exception ClassNotFoundException if the class of a serialized
+     * @throws ClassNotFoundException if the class of a serialized
      *              object could not be found.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
 
     public static Object instantiate(ClassLoader cls, String beanName) throws IOException, ClassNotFoundException {
@@ -97,9 +97,9 @@ public class Beans {
      *                        For example "sun.beanbox.foobah"
      * @param     beanContext The BeanContext in which to nest the new bean
      *
-     * @exception ClassNotFoundException if the class of a serialized
+     * @throws ClassNotFoundException if the class of a serialized
      *              object could not be found.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      * @since 1.2
      */
     @SuppressWarnings("deprecation")
@@ -156,9 +156,9 @@ public class Beans {
      * @param     beanContext The BeanContext in which to nest the new bean
      * @param     initializer The AppletInitializer for the new bean
      *
-     * @exception ClassNotFoundException if the class of a serialized
+     * @throws ClassNotFoundException if the class of a serialized
      *              object could not be found.
-     * @exception IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      * @since 1.2
      *
      * @deprecated It is recommended to use
@@ -432,7 +432,7 @@ public class Beans {
      * method is called. This could result in a SecurityException.
      *
      * @param isDesignTime  True if we're in an application builder tool.
-     * @exception  SecurityException  if a security manager exists and its
+     * @throws  SecurityException  if a security manager exists and its
      *             {@code checkPropertiesAccess} method doesn't allow setting
      *              of system properties.
      * @see SecurityManager#checkPropertiesAccess
@@ -459,7 +459,7 @@ public class Beans {
      * method is called. This could result in a SecurityException.
      *
      * @param isGuiAvailable  True if GUI interaction is available.
-     * @exception  SecurityException  if a security manager exists and its
+     * @throws  SecurityException  if a security manager exists and its
      *             {@code checkPropertiesAccess} method doesn't allow setting
      *              of system properties.
      * @see SecurityManager#checkPropertiesAccess

--- a/src/java.desktop/share/classes/java/beans/EventSetDescriptor.java
+++ b/src/java.desktop/share/classes/java/beans/EventSetDescriptor.java
@@ -69,7 +69,7 @@ public class EventSetDescriptor extends FeatureDescriptor {
      *          will get delivered to.
      * @param listenerMethodName  The method that will get called when the event gets
      *          delivered to its target listener interface.
-     * @exception IntrospectionException if an exception occurs during
+     * @throws IntrospectionException if an exception occurs during
      *              introspection.
      */
     public EventSetDescriptor(Class<?> sourceClass, String eventSetName,
@@ -114,7 +114,7 @@ public class EventSetDescriptor extends FeatureDescriptor {
      *          that can be used to register an event listener object.
      * @param removeListenerMethodName  The name of the method on the event source
      *          that can be used to de-register an event listener object.
-     * @exception IntrospectionException if an exception occurs during
+     * @throws IntrospectionException if an exception occurs during
      *              introspection.
      */
     public EventSetDescriptor(Class<?> sourceClass,
@@ -146,7 +146,7 @@ public class EventSetDescriptor extends FeatureDescriptor {
      *          that can be used to de-register an event listener object.
      * @param getListenerMethodName The method on the event source that
      *          can be used to access the array of event listener objects.
-     * @exception IntrospectionException if an exception occurs during
+     * @throws IntrospectionException if an exception occurs during
      *              introspection.
      * @since 1.4
      */
@@ -210,7 +210,7 @@ public class EventSetDescriptor extends FeatureDescriptor {
      *          that can be used to register an event listener object.
      * @param removeListenerMethod  The method on the event source
      *          that can be used to de-register an event listener object.
-     * @exception IntrospectionException if an exception occurs during
+     * @throws IntrospectionException if an exception occurs during
      *              introspection.
      */
     public EventSetDescriptor(String eventSetName,
@@ -237,7 +237,7 @@ public class EventSetDescriptor extends FeatureDescriptor {
      *          that can be used to de-register an event listener object.
      * @param getListenerMethod The method on the event source
      *          that can be used to access the array of event listener objects.
-     * @exception IntrospectionException if an exception occurs during
+     * @throws IntrospectionException if an exception occurs during
      *              introspection.
      * @since 1.4
      */
@@ -280,7 +280,7 @@ public class EventSetDescriptor extends FeatureDescriptor {
      *          that can be used to register an event listener object.
      * @param removeListenerMethod  The method on the event source
      *          that can be used to de-register an event listener object.
-     * @exception IntrospectionException if an exception occurs during
+     * @throws IntrospectionException if an exception occurs during
      *              introspection.
      */
     public EventSetDescriptor(String eventSetName,

--- a/src/java.desktop/share/classes/java/beans/IndexedPropertyDescriptor.java
+++ b/src/java.desktop/share/classes/java/beans/IndexedPropertyDescriptor.java
@@ -63,7 +63,7 @@ public class IndexedPropertyDescriptor extends PropertyDescriptor {
      *
      * @param propertyName The programmatic name of the property.
      * @param beanClass The Class object for the target bean.
-     * @exception IntrospectionException if an exception occurs during
+     * @throws IntrospectionException if an exception occurs during
      *              introspection.
      */
     public IndexedPropertyDescriptor(String propertyName, Class<?> beanClass)
@@ -94,7 +94,7 @@ public class IndexedPropertyDescriptor extends PropertyDescriptor {
      * @param indexedWriteMethodName The name of the method used for writing
      *          an indexed property value.
      *          May be null if the property is read-only.
-     * @exception IntrospectionException if an exception occurs during
+     * @throws IntrospectionException if an exception occurs during
      *              introspection.
      */
     public IndexedPropertyDescriptor(String propertyName, Class<?> beanClass,
@@ -129,7 +129,7 @@ public class IndexedPropertyDescriptor extends PropertyDescriptor {
      *          May be null if the property is write-only.
      * @param indexedWriteMethod The method used for writing an indexed property value.
      *          May be null if the property is read-only.
-     * @exception IntrospectionException if an exception occurs during
+     * @throws IntrospectionException if an exception occurs during
      *              introspection.
      */
     public IndexedPropertyDescriptor(String propertyName, Method readMethod, Method writeMethod,

--- a/src/java.desktop/share/classes/java/beans/Introspector.java
+++ b/src/java.desktop/share/classes/java/beans/Introspector.java
@@ -178,7 +178,7 @@ public class Introspector {
      *
      * @param beanClass  The bean class to be analyzed.
      * @return  A BeanInfo object describing the target bean.
-     * @exception IntrospectionException if an exception occurs during
+     * @throws IntrospectionException if an exception occurs during
      *              introspection.
      * @see #flushCaches
      * @see #flushFromCaches
@@ -216,7 +216,7 @@ public class Introspector {
      *           associated with the specified beanClass or any of its
      *           parent classes.
      * @return  A BeanInfo object describing the target bean.
-     * @exception IntrospectionException if an exception occurs during
+     * @throws IntrospectionException if an exception occurs during
      *              introspection.
      * @since 1.2
      */
@@ -237,7 +237,7 @@ public class Introspector {
      * @param stopClass The baseclass at which to stop the analysis.  Any
      *    methods/properties/events in the stopClass or in its baseclasses
      *    will be ignored in the analysis.
-     * @exception IntrospectionException if an exception occurs during
+     * @throws IntrospectionException if an exception occurs during
      *              introspection.
      */
     public static BeanInfo getBeanInfo(Class<?> beanClass, Class<?> stopClass)
@@ -269,7 +269,7 @@ public class Introspector {
      * @param stopClass  the parent class at which to stop the analysis
      * @param flags      flags to control the introspection
      * @return a BeanInfo object describing the target bean
-     * @exception IntrospectionException if an exception occurs during introspection
+     * @throws IntrospectionException if an exception occurs during introspection
      *
      * @since 1.7
      */
@@ -339,7 +339,7 @@ public class Introspector {
      * method is called. This could result in a SecurityException.
      *
      * @param path  Array of package names.
-     * @exception  SecurityException  if a security manager exists and its
+     * @throws  SecurityException  if a security manager exists and its
      *             {@code checkPropertiesAccess} method doesn't allow setting
      *              of system properties.
      * @see SecurityManager#checkPropertiesAccess

--- a/src/java.desktop/share/classes/java/beans/PropertyDescriptor.java
+++ b/src/java.desktop/share/classes/java/beans/PropertyDescriptor.java
@@ -66,7 +66,7 @@ public class PropertyDescriptor extends FeatureDescriptor {
      * @param propertyName The programmatic name of the property.
      * @param beanClass The Class object for the target bean.  For
      *          example sun.beans.OurButton.class.
-     * @exception IntrospectionException if an exception occurs during
+     * @throws IntrospectionException if an exception occurs during
      *              introspection.
      */
     public PropertyDescriptor(String propertyName, Class<?> beanClass)
@@ -87,7 +87,7 @@ public class PropertyDescriptor extends FeatureDescriptor {
      *           value.  May be null if the property is write-only.
      * @param writeMethodName The name of the method used for writing the property
      *           value.  May be null if the property is read-only.
-     * @exception IntrospectionException if an exception occurs during
+     * @throws IntrospectionException if an exception occurs during
      *              introspection.
      */
     public PropertyDescriptor(String propertyName, Class<?> beanClass,
@@ -129,7 +129,7 @@ public class PropertyDescriptor extends FeatureDescriptor {
      *          May be null if the property is write-only.
      * @param writeMethod The method used for writing the property value.
      *          May be null if the property is read-only.
-     * @exception IntrospectionException if an exception occurs during
+     * @throws IntrospectionException if an exception occurs during
      *              introspection.
      */
     public PropertyDescriptor(String propertyName, Method readMethod, Method writeMethod)

--- a/src/java.desktop/share/classes/java/beans/PropertyEditorManager.java
+++ b/src/java.desktop/share/classes/java/beans/PropertyEditorManager.java
@@ -118,7 +118,7 @@ public class PropertyEditorManager {
      * method is called. This could result in a SecurityException.
      *
      * @param path  Array of package names.
-     * @exception  SecurityException  if a security manager exists and its
+     * @throws  SecurityException  if a security manager exists and its
      *             {@code checkPropertiesAccess} method doesn't allow setting
      *              of system properties.
      * @see SecurityManager#checkPropertiesAccess

--- a/src/java.desktop/share/classes/java/beans/VetoableChangeListener.java
+++ b/src/java.desktop/share/classes/java/beans/VetoableChangeListener.java
@@ -37,7 +37,7 @@ public interface VetoableChangeListener extends java.util.EventListener {
      *
      * @param     evt a {@code PropertyChangeEvent} object describing the
      *                event source and the property that has changed.
-     * @exception PropertyVetoException if the recipient wishes the property
+     * @throws PropertyVetoException if the recipient wishes the property
      *              change to be rolled back.
      */
     void vetoableChange(PropertyChangeEvent evt)

--- a/src/java.desktop/share/classes/java/beans/VetoableChangeListenerProxy.java
+++ b/src/java.desktop/share/classes/java/beans/VetoableChangeListenerProxy.java
@@ -66,7 +66,7 @@ public class VetoableChangeListenerProxy
     *
     * @param event  the property change event
     *
-    * @exception PropertyVetoException if the recipient wishes the property
+    * @throws PropertyVetoException if the recipient wishes the property
     *                                  change to be rolled back
     */
     public void vetoableChange(PropertyChangeEvent event) throws PropertyVetoException{

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextMembershipEvent.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextMembershipEvent.java
@@ -81,7 +81,7 @@ public class BeanContextMembershipEvent extends BeanContextEvent {
      *
      * @param bc        The BeanContext source
      * @param changes   The Children effected
-     * @exception       NullPointerException if changes associated with this
+     * @throws       NullPointerException if changes associated with this
      *                  event are null.
      */
 

--- a/src/java.desktop/share/classes/sun/awt/AppContext.java
+++ b/src/java.desktop/share/classes/sun/awt/AppContext.java
@@ -391,7 +391,7 @@ public final class AppContext {
      * This method must be called from a Thread which is not contained
      * within this AppContext.
      *
-     * @exception  IllegalThreadStateException  if the current thread is
+     * @throws  IllegalThreadStateException  if the current thread is
      *                                    contained within this AppContext
      * @since      1.2
      */
@@ -660,7 +660,7 @@ public final class AppContext {
      * @param      value   the value.
      * @return     the previous value of the specified key in this
      *             AppContext, or {@code null} if it did not have one.
-     * @exception  NullPointerException  if the key or value is
+     * @throws  NullPointerException  if the key or value is
      *               {@code null}.
      * @see     #get(Object)
      * @since   1.2

--- a/src/java.desktop/share/classes/sun/awt/im/InputContext.java
+++ b/src/java.desktop/share/classes/sun/awt/im/InputContext.java
@@ -133,7 +133,7 @@ public class InputContext extends java.awt.im.InputContext
 
     /**
      * @see java.awt.im.InputContext#selectInputMethod
-     * @exception NullPointerException when the locale is null.
+     * @throws NullPointerException when the locale is null.
      */
     public synchronized boolean selectInputMethod(Locale locale) {
         if (locale == null) {
@@ -206,7 +206,7 @@ public class InputContext extends java.awt.im.InputContext
     /**
      * @see java.awt.im.InputContext#reconvert
      * @since 1.3
-     * @exception UnsupportedOperationException when input method is null
+     * @throws UnsupportedOperationException when input method is null
      */
     public synchronized void reconvert() {
         InputMethod inputMethod = getInputMethod();
@@ -610,7 +610,7 @@ public class InputContext extends java.awt.im.InputContext
 
     /**
      * @see java.awt.im.InputContext#removeNotify
-     * @exception NullPointerException when the component is null.
+     * @throws NullPointerException when the component is null.
      */
     public synchronized void removeNotify(Component component) {
         if (component == null) {
@@ -662,7 +662,7 @@ public class InputContext extends java.awt.im.InputContext
 
     /**
      * @see java.awt.im.InputContext#dispose
-     * @exception IllegalStateException when the currentClientComponent is not null
+     * @throws IllegalStateException when the currentClientComponent is not null
      */
     public synchronized void dispose() {
         if (currentClientComponent != null) {
@@ -723,7 +723,7 @@ public class InputContext extends java.awt.im.InputContext
 
     /**
      * @see java.awt.im.InputContext#setCompositionEnabled(boolean)
-     * @exception UnsupportedOperationException when input method is null
+     * @throws UnsupportedOperationException when input method is null
      */
     public void setCompositionEnabled(boolean enable) {
         InputMethod inputMethod = getInputMethod();
@@ -736,7 +736,7 @@ public class InputContext extends java.awt.im.InputContext
 
     /**
      * @see java.awt.im.InputContext#isCompositionEnabled
-     * @exception UnsupportedOperationException when input method is null
+     * @throws UnsupportedOperationException when input method is null
      */
     public boolean isCompositionEnabled() {
         InputMethod inputMethod = getInputMethod();
@@ -749,7 +749,7 @@ public class InputContext extends java.awt.im.InputContext
 
     /**
      * @return a string with information about the current input method.
-     * @exception UnsupportedOperationException when input method is null
+     * @throws UnsupportedOperationException when input method is null
      */
     public String getInputMethodInfo() {
         InputMethod inputMethod = getInputMethod();

--- a/src/java.desktop/share/classes/sun/awt/im/InputMethodAdapter.java
+++ b/src/java.desktop/share/classes/sun/awt/im/InputMethodAdapter.java
@@ -93,7 +93,7 @@ public abstract class InputMethodAdapter implements InputMethod {
     /**
      * Starts reconvertion. An implementing host adapter has to override
      * this method if it can support reconvert().
-     * @exception UnsupportedOperationException when the adapter does not override
+     * @throws UnsupportedOperationException when the adapter does not override
      * the method.
      */
     public void reconvert() {

--- a/src/java.desktop/share/classes/sun/awt/shell/ShellFolder.java
+++ b/src/java.desktop/share/classes/sun/awt/shell/ShellFolder.java
@@ -259,7 +259,6 @@ public abstract class ShellFolder extends File {
         if (file instanceof ShellFolder) {
             return (ShellFolder)file;
         }
-System.out.println("File " + file + " path " + file.getPath());
         if (!Files.exists(Paths.get(file.getPath()), LinkOption.NOFOLLOW_LINKS)) {
             throw new FileNotFoundException();
         }

--- a/src/java.desktop/share/classes/sun/awt/shell/ShellFolder.java
+++ b/src/java.desktop/share/classes/sun/awt/shell/ShellFolder.java
@@ -253,13 +253,13 @@ public abstract class ShellFolder extends File {
 
     /**
      * Return a shell folder from a file object
-     * @exception FileNotFoundException if file does not exist
+     * @throws FileNotFoundException if file does not exist
      */
     public static ShellFolder getShellFolder(File file) throws FileNotFoundException {
         if (file instanceof ShellFolder) {
             return (ShellFolder)file;
         }
-
+System.out.println("File " + file + " path " + file.getPath());
         if (!Files.exists(Paths.get(file.getPath()), LinkOption.NOFOLLOW_LINKS)) {
             throw new FileNotFoundException();
         }

--- a/src/java.desktop/share/classes/sun/awt/util/IdentityArrayList.java
+++ b/src/java.desktop/share/classes/sun/awt/util/IdentityArrayList.java
@@ -113,7 +113,7 @@ public class IdentityArrayList<E> extends AbstractList<E>
      * Constructs an empty list with the specified initial capacity.
      *
      * @param   initialCapacity   the initial capacity of the list
-     * @exception IllegalArgumentException if the specified initial capacity
+     * @throws IllegalArgumentException if the specified initial capacity
      *            is negative
      */
     public IdentityArrayList(int initialCapacity) {

--- a/src/java.desktop/share/classes/sun/java2d/SunGraphics2D.java
+++ b/src/java.desktop/share/classes/sun/java2d/SunGraphics2D.java
@@ -409,7 +409,7 @@ public final class SunGraphics2D
      * drawback of the workaround is that the resulting
      * clip and device origin cannot be "enforced".
      *
-     * @exception IllegalStateException If the Graphics
+     * @throws IllegalStateException If the Graphics
      * to be constrained has a complex transform.
      */
     @Override

--- a/src/java.desktop/share/classes/sun/print/PSPrinterJob.java
+++ b/src/java.desktop/share/classes/sun/print/PSPrinterJob.java
@@ -418,7 +418,7 @@ public class PSPrinterJob extends RasterPrinterJob {
      * print job interactively.
      * @return false if the user cancels the dialog and
      *         true otherwise.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */

--- a/src/java.desktop/share/classes/sun/print/PrintJob2D.java
+++ b/src/java.desktop/share/classes/sun/print/PrintJob2D.java
@@ -966,7 +966,7 @@ public class PrintJob2D extends PrintJob implements Printable, Runnable {
      * @return PAGE_EXISTS if the page is rendered successfully
      *         or NO_SUCH_PAGE if {@code pageIndex} specifies a
      *         non-existent page.
-     * @exception java.awt.print.PrinterException
+     * @throws java.awt.print.PrinterException
      *         thrown when the print job is terminated.
      */
     public int print(Graphics graphics, PageFormat pageFormat, int pageIndex)

--- a/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
+++ b/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
@@ -714,7 +714,7 @@ public abstract class RasterPrinterJob extends PrinterJob {
      *            is cancelled, or a new PageFormat object containing
      *            the format indicated by the user if the dialog is
      *            acknowledged
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @since     1.2
@@ -947,7 +947,7 @@ public abstract class RasterPrinterJob extends PrinterJob {
      *
      * @param attributes to store changed properties.
      * @return false if the user cancels the dialog and true otherwise.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -1100,7 +1100,7 @@ public abstract class RasterPrinterJob extends PrinterJob {
      * print job interactively.
      * @return false if the user cancels the dialog and
      *         true otherwise.
-     * @exception HeadlessException if GraphicsEnvironment.isHeadless()
+     * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
      * @see java.awt.GraphicsEnvironment#isHeadless
      */
@@ -1183,7 +1183,7 @@ public abstract class RasterPrinterJob extends PrinterJob {
      * for the number of pages as well as the PageFormat and
      * Printable for each page.
      * @param document The document to be printed. It may not be null.
-     * @exception NullPointerException the Pageable passed in was null.
+     * @throws NullPointerException the Pageable passed in was null.
      * @see PageFormat
      * @see Printable
      */
@@ -1477,7 +1477,7 @@ public abstract class RasterPrinterJob extends PrinterJob {
 
     /**
      * Prints a set of pages.
-     * @exception java.awt.print.PrinterException an error in the print system
+     * @throws java.awt.print.PrinterException an error in the print system
      *                                          caused the job to be aborted
      * @see java.awt.print.Book
      * @see java.awt.print.Pageable


### PR DESCRIPTION
Prevailing JDK coding practices use "@throws" rather than "@exception".
Need to refactor remaining 2d, beans,sound classes to use @throws

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283608](https://bugs.openjdk.java.net/browse/JDK-8283608): Refactor 2d, beans classes javadoc to use @throws instead of @exception


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7937/head:pull/7937` \
`$ git checkout pull/7937`

Update a local copy of the PR: \
`$ git checkout pull/7937` \
`$ git pull https://git.openjdk.java.net/jdk pull/7937/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7937`

View PR using the GUI difftool: \
`$ git pr show -t 7937`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7937.diff">https://git.openjdk.java.net/jdk/pull/7937.diff</a>

</details>
