### PR TITLE
JDK-8273115: CountedLoopEndNode::stride_con crash in debug build with -XX:+TraceLoopOpts

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -3924,11 +3924,21 @@ void IdealLoopTree::dump_head() const {
       tty->print("%d),", cl->limit()->get_int());
     else
       tty->print("int),");
-    int stride_con  = cl->stride_con();
-    if (stride_con > 0) tty->print("+");
-    tty->print("%d", stride_con);
 
-    tty->print(" (%0.f iters) ", cl->profile_trip_cnt());
+    if (cl->stride_is_con()) {
+      int stride_con  = cl->stride_con();
+      if (stride_con > 0) tty->print("+");
+      tty->print("%d", stride_con);
+    } else {
+      tty->print("int");
+    }
+
+    float trip_cnt = cl->profile_trip_cnt();
+    if (trip_cnt >= 0.0 && trip_cnt != (float)max_jint) {
+      tty->print(" (%0.f iters) ", cl->profile_trip_cnt());
+    } else {
+      tty->print(" (COUNT_UNKNOWN) ");
+    }
 
     if (cl->is_pre_loop ()) tty->print(" pre" );
     if (cl->is_main_loop()) tty->print(" main");

--- a/test/hotspot/jtreg/compiler/loopopts/TestTraceLoopOptsStride.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestTraceLoopOptsStride.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8273115
+ * @requires vm.debug == true & vm.compiler2.enabled
+ * @summary CountedLoopEndNode::stride_con should not crash with -XX:+TraceLoopOpts
+ * @run main/othervm  -XX:+TraceLoopOpts -Xcomp -XX:-TieredCompilation
+ * -XX:CompileOnly=compiler.loopopts.TestTraceLoopOptsStride.main compiler.loopopts.TestTraceLoopOptsStride
+ */
+
+package compiler.loopopts;
+
+public class TestTraceLoopOptsStride {
+    static int y;
+    static int[] A = new int[1];
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10; i+=2) {
+            int k;
+            int j;
+            for (j = 1; (j += 3) < 5; ) {
+                A[0] = 0;
+                for (k = j; k < 5; k++) {
+                    y++;
+                }
+            }
+            y = j;
+        }
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/loopopts/TestTraceLoopOptsStride.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestTraceLoopOptsStride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8273115
  * @requires vm.debug == true & vm.compiler2.enabled
  * @summary CountedLoopEndNode::stride_con should not crash with -XX:+TraceLoopOpts
- * @run main/othervm  -XX:+TraceLoopOpts -Xcomp -XX:-TieredCompilation
+ * @run main/othervm -XX:+TraceLoopOpts -Xcomp -XX:-TieredCompilation
  * -XX:CompileOnly=compiler.loopopts.TestTraceLoopOptsStride.main compiler.loopopts.TestTraceLoopOptsStride
  */
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8273115](https://bugs.openjdk.java.net/browse/JDK-8273115): CountedLoopEndNode::stride_con crash in debug build with -XX:+TraceLoopOpts


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7941/head:pull/7941` \
`$ git checkout pull/7941`

Update a local copy of the PR: \
`$ git checkout pull/7941` \
`$ git pull https://git.openjdk.java.net/jdk pull/7941/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7941`

View PR using the GUI difftool: \
`$ git pr show -t 7941`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7941.diff">https://git.openjdk.java.net/jdk/pull/7941.diff</a>

</details>
