### PR TITLE
8283641: Large value for CompileThresholdScaling causes assert

### DIFF
--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -127,7 +127,14 @@ intx CompilerConfig::scaled_compile_threshold(intx threshold, double scale) {
   if (scale == 1.0 || scale < 0.0) {
     return threshold;
   } else {
-    return (intx)(threshold * scale);
+    double v = threshold * scale;
+    if (v > max_intx) {
+      return max_intx;
+    } else if (v < min_intx) {
+      return min_intx;
+    } else {
+      return (intx)(v);
+    }
   }
 }
 

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -124,14 +124,14 @@ intx CompilerConfig::scaled_freq_log(intx freq_log) {
 // Returns threshold scaled with the value of scale.
 // If scale < 0.0, threshold is returned without scaling.
 intx CompilerConfig::scaled_compile_threshold(intx threshold, double scale) {
+  assert(threshold >= 0, "must be");
   if (scale == 1.0 || scale < 0.0) {
     return threshold;
   } else {
     double v = threshold * scale;
+    assert(v >= 0, "must be");
     if (v > max_intx) {
       return max_intx;
-    } else if (v < min_intx) {
-      return min_intx;
     } else {
       return (intx)(v);
     }


### PR DESCRIPTION
Please review this trivial fix that checks for overflow of `(intx)(threshold * scale)`

Before:
```
$ java -XX:CompileThresholdScaling=12345678901234567890.0 -version
...
# Internal Error (/jdk/open/src/hotspot/share/utilities/powerOfTwo.hpp:54), pid=4147940, tid=4147941
# assert(value > T(0)) failed: value must be > 0
```

After:

```
$ java -XX:CompileThresholdScaling=12345678901234567890.0 -version
intx Tier0InvokeNotifyFreqLog=32 is outside the allowed range [ 0 ... 30 ]
...
OnStackReplacePercentage cannot be validated because CompileThreshold value is invalid
CompileThreshold (9223372036854775807) must be between 0 and 1073741823
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

Tested with tiers 1-2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283641](https://bugs.openjdk.java.net/browse/JDK-8283641): Large value for CompileThresholdScaling causes assert


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7944/head:pull/7944` \
`$ git checkout pull/7944`

Update a local copy of the PR: \
`$ git checkout pull/7944` \
`$ git pull https://git.openjdk.java.net/jdk pull/7944/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7944`

View PR using the GUI difftool: \
`$ git pr show -t 7944`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7944.diff">https://git.openjdk.java.net/jdk/pull/7944.diff</a>

</details>
