### PR TITLE
JDK-8283668: Update IllegalFormatException to use sealed classes

### DIFF
--- a/src/java.base/share/classes/java/util/DuplicateFormatFlagsException.java
+++ b/src/java.base/share/classes/java/util/DuplicateFormatFlagsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ package java.util;
  *
  * @since 1.5
  */
-public class DuplicateFormatFlagsException extends IllegalFormatException {
+public non-sealed class DuplicateFormatFlagsException extends IllegalFormatException {
 
     @java.io.Serial
     private static final long serialVersionUID = 18890531L;

--- a/src/java.base/share/classes/java/util/FormatFlagsConversionMismatchException.java
+++ b/src/java.base/share/classes/java/util/FormatFlagsConversionMismatchException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ package java.util;
  *
  * @since 1.5
  */
-public class FormatFlagsConversionMismatchException
+public non-sealed class FormatFlagsConversionMismatchException
     extends IllegalFormatException
 {
     @java.io.Serial

--- a/src/java.base/share/classes/java/util/IllegalFormatArgumentIndexException.java
+++ b/src/java.base/share/classes/java/util/IllegalFormatArgumentIndexException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ package java.util;
  *
  * @since 16
  */
-class IllegalFormatArgumentIndexException extends IllegalFormatException {
+final class IllegalFormatArgumentIndexException extends IllegalFormatException {
 
     @java.io.Serial
     private static final long serialVersionUID = 4191767811181838112L;

--- a/src/java.base/share/classes/java/util/IllegalFormatCodePointException.java
+++ b/src/java.base/share/classes/java/util/IllegalFormatCodePointException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ package java.util;
  *
  * @since 1.5
  */
-public class IllegalFormatCodePointException extends IllegalFormatException {
+public non-sealed class IllegalFormatCodePointException extends IllegalFormatException {
 
     @java.io.Serial
     private static final long serialVersionUID = 19080630L;

--- a/src/java.base/share/classes/java/util/IllegalFormatConversionException.java
+++ b/src/java.base/share/classes/java/util/IllegalFormatConversionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ package java.util;
  *
  * @since 1.5
  */
-public class IllegalFormatConversionException extends IllegalFormatException {
+public non-sealed class IllegalFormatConversionException extends IllegalFormatException {
 
     @java.io.Serial
     private static final long serialVersionUID = 17000126L;

--- a/src/java.base/share/classes/java/util/IllegalFormatException.java
+++ b/src/java.base/share/classes/java/util/IllegalFormatException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,19 @@ package java.util;
  *
  * @since 1.5
  */
-public class IllegalFormatException extends IllegalArgumentException {
+public sealed class IllegalFormatException extends IllegalArgumentException
+    permits DuplicateFormatFlagsException,
+            FormatFlagsConversionMismatchException,
+            IllegalFormatArgumentIndexException,
+            IllegalFormatCodePointException,
+            IllegalFormatConversionException,
+            IllegalFormatFlagsException,
+            IllegalFormatPrecisionException,
+            IllegalFormatWidthException,
+            MissingFormatArgumentException,
+            MissingFormatWidthException,
+            UnknownFormatConversionException,
+            UnknownFormatFlagsException {
 
     @java.io.Serial
     private static final long serialVersionUID = 18830826L;

--- a/src/java.base/share/classes/java/util/IllegalFormatFlagsException.java
+++ b/src/java.base/share/classes/java/util/IllegalFormatFlagsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ package java.util;
  *
  * @since 1.5
  */
-public class IllegalFormatFlagsException extends IllegalFormatException {
+public non-sealed class IllegalFormatFlagsException extends IllegalFormatException {
 
     @java.io.Serial
     private static final long serialVersionUID = 790824L;

--- a/src/java.base/share/classes/java/util/IllegalFormatPrecisionException.java
+++ b/src/java.base/share/classes/java/util/IllegalFormatPrecisionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ package java.util;
  *
  * @since 1.5
  */
-public class IllegalFormatPrecisionException extends IllegalFormatException {
+public non-sealed class IllegalFormatPrecisionException extends IllegalFormatException {
 
     @java.io.Serial
     private static final long serialVersionUID = 18711008L;

--- a/src/java.base/share/classes/java/util/IllegalFormatWidthException.java
+++ b/src/java.base/share/classes/java/util/IllegalFormatWidthException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ package java.util;
  *
  * @since 1.5
  */
-public class IllegalFormatWidthException extends IllegalFormatException {
+public non-sealed class IllegalFormatWidthException extends IllegalFormatException {
 
     @java.io.Serial
     private static final long serialVersionUID = 16660902L;

--- a/src/java.base/share/classes/java/util/MissingFormatArgumentException.java
+++ b/src/java.base/share/classes/java/util/MissingFormatArgumentException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ package java.util;
  *
  * @since 1.5
  */
-public class MissingFormatArgumentException extends IllegalFormatException {
+public non-sealed class MissingFormatArgumentException extends IllegalFormatException {
 
     @java.io.Serial
     private static final long serialVersionUID = 19190115L;

--- a/src/java.base/share/classes/java/util/MissingFormatWidthException.java
+++ b/src/java.base/share/classes/java/util/MissingFormatWidthException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ package java.util;
  *
  * @since 1.5
  */
-public class MissingFormatWidthException extends IllegalFormatException {
+public non-sealed class MissingFormatWidthException extends IllegalFormatException {
 
     @java.io.Serial
     private static final long serialVersionUID = 15560123L;

--- a/src/java.base/share/classes/java/util/UnknownFormatConversionException.java
+++ b/src/java.base/share/classes/java/util/UnknownFormatConversionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ package java.util;
  *
  * @since 1.5
  */
-public class UnknownFormatConversionException extends IllegalFormatException {
+public non-sealed class UnknownFormatConversionException extends IllegalFormatException {
 
     @java.io.Serial
     private static final long serialVersionUID = 19060418L;

--- a/src/java.base/share/classes/java/util/UnknownFormatFlagsException.java
+++ b/src/java.base/share/classes/java/util/UnknownFormatFlagsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ package java.util;
  *
  * @since 1.5
  */
-public class UnknownFormatFlagsException extends IllegalFormatException {
+public non-sealed class UnknownFormatFlagsException extends IllegalFormatException {
 
     @java.io.Serial
     private static final long serialVersionUID = 19370506L;


### PR DESCRIPTION
Working down the list of candidates to be sealed, this time IllegalFormatException.

Please also review the companion CSR: https://bugs.openjdk.java.net/browse/JDK-8283669

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8283668](https://bugs.openjdk.java.net/browse/JDK-8283668): Update IllegalFormatException  to use sealed classes
 * [JDK-8283669](https://bugs.openjdk.java.net/browse/JDK-8283669): Update IllegalFormatException to use sealed classes (**CSR**)


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.java.net/census#jpai) (@jaikiran - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7950/head:pull/7950` \
`$ git checkout pull/7950`

Update a local copy of the PR: \
`$ git checkout pull/7950` \
`$ git pull https://git.openjdk.java.net/jdk pull/7950/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7950`

View PR using the GUI difftool: \
`$ git pr show -t 7950`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7950.diff">https://git.openjdk.java.net/jdk/pull/7950.diff</a>

</details>
