### PR TITLE
JDK-8283648: Improve the snippet "file not found" message.

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,7 @@ Please file a bug against the javadoc tool via the Java bug reporting page\n\
 (http://bugreport.java.com) after checking the Bug Database (http://bugs.java.com)\n\
 for duplicates. Include error messages and the following diagnostic in your report. Thank you.
 doclet.File_not_found=File not found: {0}
+doclet.snippet_file_not_found=file not found on source path or snippet path: {0}
 doclet.Copy_Overwrite_warning=File {0} not copied to {1} due to existing file with same name...
 doclet.Copy_Ignored_warning=File {0} not copied: invalid name
 doclet.Copy_snippet_to_clipboard=Copy

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SnippetTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SnippetTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -240,7 +240,7 @@ public class SnippetTaglet extends BaseTaglet {
 
             if (fileObject == null) {
                 // i.e. the file does not exist
-                throw new BadSnippetException(a, "doclet.File_not_found", v);
+                throw new BadSnippetException(a, "doclet.snippet_file_not_found", v);
             }
 
             try {

--- a/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1079,11 +1079,11 @@ public class TestSnippetTag extends SnippetTester {
         checkExit(Exit.ERROR);
         checkOutput(Output.OUT, true,
                     """
-                    A.java:4: error: File not found: %s""".formatted(fileName));
+                    A.java:4: error: file not found on source path or snippet path: %s""".formatted(fileName));
         checkOutput("pkg/A.html", true, """
                         <details class="invalid-tag">
                         <summary>invalid @snippet</summary>
-                        <pre>File not found: text.txt</pre>
+                        <pre>file not found on source path or snippet path: text.txt</pre>
                         </details>
                         """);
         checkNoCrashes();
@@ -1140,7 +1140,7 @@ public class TestSnippetTag extends SnippetTester {
         checkExit(Exit.ERROR);
         checkOutput(Output.OUT, true,
                     """
-                    A.java:4: error: File not found: %s""".formatted(fileName));
+                    A.java:4: error: file not found on source path or snippet path: %s""".formatted(fileName));
         checkNoCrashes();
     }
 
@@ -1869,7 +1869,7 @@ public class TestSnippetTag extends SnippetTester {
         checkExit(Exit.ERROR);
         checkOutput(Output.OUT, true,
                     """
-                    A.java:4: error: File not found: %s""".formatted(fileName));
+                    A.java:4: error: file not found on source path or snippet path: %s""".formatted(fileName));
         checkNoCrashes();
     }
 


### PR DESCRIPTION
Please review a (mostly) resource-file change to improve the message when the file for an external snippet cannot be found.

Previously, the code (re)used an existing resource, "File not found". This resource was used in conjunction with files specified on the command line, like a help file or a stylesheet file.   Thus, little extra context was needed.

For external snippets, the underlying problem is less overtly connected to anything specific on the command line, although the problem may be on the command line or related to info on the command line.  Thus, a new resource is created specifically for external snippet files, that hints at issues with (files on) the source path or snippet path.

The main snippet test is updated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283648](https://bugs.openjdk.java.net/browse/JDK-8283648): Improve the snippet "file not found" message.


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7951/head:pull/7951` \
`$ git checkout pull/7951`

Update a local copy of the PR: \
`$ git checkout pull/7951` \
`$ git pull https://git.openjdk.java.net/jdk pull/7951/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7951`

View PR using the GUI difftool: \
`$ git pr show -t 7951`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7951.diff">https://git.openjdk.java.net/jdk/pull/7951.diff</a>

</details>
