### PR TITLE
8283665: Two Jarsigner tests needs to be updated with JDK-8267319

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/CheckAlgParams.java
+++ b/test/jdk/sun/security/tools/jarsigner/CheckAlgParams.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8277474
+ * @bug 8277474 8283665
  * @summary jarsigner -verify should check if the algorithm parameters of
  *          its signature algorithm use disabled or legacy algorithms
  * @library /test/lib
@@ -56,29 +56,29 @@ public class CheckAlgParams {
                 .shouldHaveExitValue(0);
 
         Files.writeString(Files.createFile(Paths.get(JAVA_SECURITY_FILE)),
-                "jdk.jar.disabledAlgorithms=SHA256\n" +
+                "jdk.jar.disabledAlgorithms=SHA384\n" +
                 "jdk.security.legacyAlgorithms=\n");
 
         SecurityTools.jarsigner("-verify signeda.jar " +
                 "-J-Djava.security.properties=" +
                 JAVA_SECURITY_FILE +
                 " -keystore ks -storepass changeit -verbose -debug")
-                .shouldMatch("Digest algorithm: SHA-256.*(disabled)")
-                .shouldMatch("Signature algorithm: RSASSA-PSS using PSSParameterSpec.*hashAlgorithm=SHA-256.*(disabled)")
+                .shouldMatch("Digest algorithm: SHA-384.*(disabled)")
+                .shouldMatch("Signature algorithm: RSASSA-PSS using PSSParameterSpec.*hashAlgorithm=SHA-384.*(disabled)")
                 .shouldContain("The jar will be treated as unsigned")
                 .shouldHaveExitValue(0);
 
         Files.deleteIfExists(Paths.get(JAVA_SECURITY_FILE));
         Files.writeString(Files.createFile(Paths.get(JAVA_SECURITY_FILE)),
                 "jdk.jar.disabledAlgorithms=\n" +
-                "jdk.security.legacyAlgorithms=SHA256\n");
+                "jdk.security.legacyAlgorithms=SHA384\n");
 
         SecurityTools.jarsigner("-verify signeda.jar " +
                 "-J-Djava.security.properties=" +
                 JAVA_SECURITY_FILE +
                 " -keystore ks -storepass changeit -verbose -debug")
-                .shouldMatch("Digest algorithm: SHA-256.*(weak)")
-                .shouldMatch("Signature algorithm: RSASSA-PSS using PSSParameterSpec.*hashAlgorithm=SHA-256.*(weak)")
+                .shouldMatch("Digest algorithm: SHA-384.*(weak)")
+                .shouldMatch("Signature algorithm: RSASSA-PSS using PSSParameterSpec.*hashAlgorithm=SHA-384.*(weak)")
                 .shouldNotContain("The jar will be treated as unsigned")
                 .shouldHaveExitValue(0);
     }

--- a/test/jdk/sun/security/tools/jarsigner/DisableCurveTest.java
+++ b/test/jdk/sun/security/tools/jarsigner/DisableCurveTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8282633
+ * @bug 8282633 8283665
  * @summary jarsigner should display the named curve to better explain why
  *          an EC key is disabled or will be disabled.
  * @library /test/lib
@@ -42,7 +42,7 @@ public class DisableCurveTest {
 
     public static void main(String[] args) throws Exception{
         SecurityTools.keytool("-keystore ks -storepass changeit " +
-                "-genkeypair -keyalg EC -alias ca -dname CN=CA " +
+                "-genkeypair -keyalg EC -keysize 256 -alias ca -dname CN=CA " +
                 "-ext bc:c")
                 .shouldHaveExitValue(0);
 
@@ -58,7 +58,7 @@ public class DisableCurveTest {
                 JAVA_SECURITY_FILE +
                 " a.jar ca")
                 .shouldContain(">>> Signer")
-                .shouldContain("Signature algorithm: SHA256withECDSA, 256-bit EC (secp256r1) key (disabled)")
+                .shouldContain("Signature algorithm: SHA384withECDSA, 256-bit EC (secp256r1) key (disabled)")
                 .shouldContain("Warning:")
                 .shouldContain("The EC (secp256r1) signing key has a keysize of 256 which is considered a security risk and is disabled")
                 .shouldHaveExitValue(0);
@@ -68,7 +68,7 @@ public class DisableCurveTest {
                 JAVA_SECURITY_FILE +
                 " -keystore ks -storepass changeit -verbose -debug")
                 .shouldContain("- Signed by")
-                .shouldContain("Signature algorithm: SHA256withECDSA, 256-bit EC (secp256r1) key (disabled)")
+                .shouldContain("Signature algorithm: SHA384withECDSA, 256-bit EC (secp256r1) key (disabled)")
                 .shouldContain("WARNING: The jar will be treated as unsigned")
                 .shouldHaveExitValue(0);
 
@@ -82,7 +82,7 @@ public class DisableCurveTest {
                 JAVA_SECURITY_FILE +
                 " a.jar ca")
                 .shouldContain(">>> Signer")
-                .shouldContain("Signature algorithm: SHA256withECDSA, 256-bit EC (secp256r1) key (weak)")
+                .shouldContain("Signature algorithm: SHA384withECDSA, 256-bit EC (secp256r1) key (weak)")
                 .shouldContain("Warning:")
                 .shouldContain("The EC (secp256r1) signing key has a keysize of 256 which is considered a security risk. This key size will be disabled in a future update")
                 .shouldHaveExitValue(0);
@@ -92,7 +92,7 @@ public class DisableCurveTest {
                 JAVA_SECURITY_FILE +
                 " -keystore ks -storepass changeit -verbose -debug")
                 .shouldContain("- Signed by")
-                .shouldContain("Signature algorithm: SHA256withECDSA, 256-bit EC (secp256r1) key (weak)")
+                .shouldContain("Signature algorithm: SHA384withECDSA, 256-bit EC (secp256r1) key (weak)")
                 .shouldContain("jar verified")
                 .shouldContain("The EC (secp256r1) signing key has a keysize of 256 which is considered a security risk. This key size will be disabled in a future update")
                 .shouldHaveExitValue(0);


### PR DESCRIPTION
Max, can you please help review this fix? It updates the two jarsigner tests which are added to the main trunk during the code review of JDK-8267319.

Mach5 run succeeds.
Thanks,
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283665](https://bugs.openjdk.java.net/browse/JDK-8283665): Two Jarsigner tests needs to be updated with JDK-8267319


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Anthony Scarpino](https://openjdk.java.net/census#ascarpino) (@ascarpino - **Reviewer**)
 * [Hai-May Chao](https://openjdk.java.net/census#hchao) (@haimaychao - Committer)
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7952/head:pull/7952` \
`$ git checkout pull/7952`

Update a local copy of the PR: \
`$ git checkout pull/7952` \
`$ git pull https://git.openjdk.java.net/jdk pull/7952/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7952`

View PR using the GUI difftool: \
`$ git pr show -t 7952`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7952.diff">https://git.openjdk.java.net/jdk/pull/7952.diff</a>

</details>
