### PR TITLE
JDK-8283674: Pad ObjectMonitor allocation size to cache line size

### DIFF
--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -232,6 +232,10 @@ OopStorage* ObjectMonitor::_oop_storage = NULL;
 //
 // * See also http://blogs.sun.com/dave
 
+void* ObjectMonitor::operator new (size_t size) throw() {
+  // Prevent libc allocator from accidentally placing OMs into the same cache line
+  return AllocateHeap(align_up(size, OM_CACHE_LINE_SIZE), mtObjectMonitor);
+}
 
 // Check that object() and set_object() are called from the right context:
 static void check_object_context() {

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -203,6 +203,8 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
 
   static int Knob_SpinLimit;
 
+  void* operator new (size_t size) throw();
+
   // TODO-FIXME: the "offset" routines should return a type of off_t instead of int ...
   // ByteSize would also be an appropriate type.
   static int header_offset_in_bytes()      { return offset_of(ObjectMonitor, _header); }


### PR DESCRIPTION
See discussion under [1].

Since the libc malloc allocator may place ObjectMonitor instances adjacent to each other, we should pad the size of ObjectMonitor to fill a whole cache line to prevent false sharing between adjacent OMs.

[1] https://mail.openjdk.java.net/pipermail/hotspot-runtime-dev/2022-March/054187.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8283674](https://bugs.openjdk.java.net/browse/JDK-8283674): Pad ObjectMonitor allocation size to cache line size


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7955/head:pull/7955` \
`$ git checkout pull/7955`

Update a local copy of the PR: \
`$ git checkout pull/7955` \
`$ git pull https://git.openjdk.java.net/jdk pull/7955/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7955`

View PR using the GUI difftool: \
`$ git pr show -t 7955`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7955.diff">https://git.openjdk.java.net/jdk/pull/7955.diff</a>

</details>
