### PR TITLE
8283525: http://tools.ietf.org/html/* URLs return 404

### DIFF
--- a/src/java.base/share/classes/java/security/Key.java
+++ b/src/java.base/share/classes/java/security/Key.java
@@ -63,7 +63,7 @@ package java.security;
  * </pre>
  *
  * For more information, see
- * <a href="http://tools.ietf.org/html/rfc5280">RFC 5280:
+ * <a href="https://tools.ietf.org/html/rfc5280">RFC 5280:
  * Internet X.509 Public Key Infrastructure Certificate and CRL Profile</a>.
  *
  * <LI>A Format

--- a/src/java.base/share/classes/java/security/SecureRandom.java
+++ b/src/java.base/share/classes/java/security/SecureRandom.java
@@ -50,7 +50,7 @@ import sun.security.util.Debug;
  * Therefore any seed material passed to a {@code SecureRandom} object must be
  * unpredictable, and all {@code SecureRandom} output sequences must be
  * cryptographically strong, as described in
- * <a href="http://tools.ietf.org/html/rfc4086">
+ * <a href="https://tools.ietf.org/html/rfc4086">
  * <i>RFC 4086: Randomness Requirements for Security</i></a>.
  *
  * <p> Many {@code SecureRandom} implementations are in the form of a

--- a/src/java.base/share/classes/java/security/cert/CRLReason.java
+++ b/src/java.base/share/classes/java/security/cert/CRLReason.java
@@ -27,7 +27,7 @@ package java.security.cert;
 
 /**
  * The CRLReason enumeration specifies the reason that a certificate
- * is revoked, as defined in <a href="http://tools.ietf.org/html/rfc5280">
+ * is revoked, as defined in <a href="https://tools.ietf.org/html/rfc5280">
  * RFC 5280: Internet X.509 Public Key Infrastructure Certificate and CRL
  * Profile</a>.
  *

--- a/src/java.base/share/classes/java/security/cert/TrustAnchor.java
+++ b/src/java.base/share/classes/java/security/cert/TrustAnchor.java
@@ -84,7 +84,7 @@ public class TrustAnchor {
      * The name constraints are specified as a byte array. This byte array
      * should contain the DER encoded form of the name constraints, as they
      * would appear in the NameConstraints structure defined in
-     * <a href="http://tools.ietf.org/html/rfc5280">RFC 5280</a>
+     * <a href="https://tools.ietf.org/html/rfc5280">RFC 5280</a>
      * and X.509. The ASN.1 definition of this structure appears below.
      *
      * <pre>{@code

--- a/src/java.base/share/classes/java/security/cert/X509CRL.java
+++ b/src/java.base/share/classes/java/security/cert/X509CRL.java
@@ -66,7 +66,7 @@ import sun.security.util.SignatureUtil;
  * </pre>
  * <p>
  * More information can be found in
- * <a href="http://tools.ietf.org/html/rfc5280">RFC 5280: Internet X.509
+ * <a href="https://tools.ietf.org/html/rfc5280">RFC 5280: Internet X.509
  * Public Key Infrastructure Certificate and CRL Profile</a>.
  * <p>
  * The ASN.1 definition of {@code tbsCertList} is:

--- a/src/java.base/share/classes/java/security/cert/X509CRLSelector.java
+++ b/src/java.base/share/classes/java/security/cert/X509CRLSelector.java
@@ -53,7 +53,7 @@ import sun.security.x509.X500Name;
  * {@link CertStore#getCRLs CertStore.getCRLs} or some similar
  * method.
  * <p>
- * Please refer to <a href="http://tools.ietf.org/html/rfc5280">RFC 5280:
+ * Please refer to <a href="https://tools.ietf.org/html/rfc5280">RFC 5280:
  * Internet X.509 Public Key Infrastructure Certificate and CRL Profile</a>
  * for definitions of the X.509 CRL fields and extensions mentioned below.
  * <p>

--- a/src/java.base/share/classes/java/security/cert/X509CertSelector.java
+++ b/src/java.base/share/classes/java/security/cert/X509CertSelector.java
@@ -62,7 +62,7 @@ import sun.security.x509.*;
  * number. Other unique combinations include the issuer, subject,
  * subjectKeyIdentifier and/or the subjectPublicKey criteria.
  * <p>
- * Please refer to <a href="http://tools.ietf.org/html/rfc5280">RFC 5280:
+ * Please refer to <a href="https://tools.ietf.org/html/rfc5280">RFC 5280:
  * Internet X.509 Public Key Infrastructure Certificate and CRL Profile</a> for
  * definitions of the X.509 certificate extensions mentioned below.
  * <p>

--- a/src/java.base/share/classes/java/security/cert/X509Certificate.java
+++ b/src/java.base/share/classes/java/security/cert/X509Certificate.java
@@ -65,7 +65,7 @@ import sun.security.util.SignatureUtil;
  * CA such as a "root" CA.
  * <p>
  * More information can be found in
- * <a href="http://tools.ietf.org/html/rfc5280">RFC 5280: Internet X.509
+ * <a href="https://tools.ietf.org/html/rfc5280">RFC 5280: Internet X.509
  * Public Key Infrastructure Certificate and CRL Profile</a>.
  * <p>
  * The ASN.1 definition of {@code tbsCertificate} is:

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -75,8 +75,8 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * region, or culture.
  *
  * <p> The {@code Locale} class implements IETF BCP 47 which is composed of
- * <a href="http://tools.ietf.org/html/rfc4647">RFC 4647 "Matching of Language
- * Tags"</a> and <a href="http://tools.ietf.org/html/rfc5646">RFC 5646 "Tags
+ * <a href="https://tools.ietf.org/html/rfc4647">RFC 4647 "Matching of Language
+ * Tags"</a> and <a href="https://tools.ietf.org/html/rfc5646">RFC 5646 "Tags
  * for Identifying Languages"</a> with support for the LDML (UTS#35, "Unicode
  * Locale Data Markup Language") BCP 47-compatible extensions for locale data
  * exchange.
@@ -280,7 +280,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * locale matching documentation.
  *
  * <p>In order to do matching a user's preferred locales to a set of language
- * tags, <a href="http://tools.ietf.org/html/rfc4647">RFC 4647 Matching of
+ * tags, <a href="https://tools.ietf.org/html/rfc4647">RFC 4647 Matching of
  * Language Tags</a> defines two mechanisms: filtering and lookup.
  * <em>Filtering</em> is used to get all matching locales, whereas
  * <em>lookup</em> is to choose the best matching locale.
@@ -2853,7 +2853,7 @@ public final class Locale implements Cloneable, Serializable {
 
     /**
      * This enum provides constants to select a filtering mode for locale
-     * matching. Refer to <a href="http://tools.ietf.org/html/rfc4647">RFC 4647
+     * matching. Refer to <a href="https://tools.ietf.org/html/rfc4647">RFC 4647
      * Matching of Language Tags</a> for details.
      *
      * <p>As an example, think of two Language Priority Lists each of which
@@ -2989,7 +2989,7 @@ public final class Locale implements Cloneable, Serializable {
 
     /**
      * This class expresses a <em>Language Range</em> defined in
-     * <a href="http://tools.ietf.org/html/rfc4647">RFC 4647 Matching of
+     * <a href="https://tools.ietf.org/html/rfc4647">RFC 4647 Matching of
      * Language Tags</a>. A language range is an identifier which is used to
      * select language tag(s) meeting specific requirements by using the
      * mechanisms described in <a href="Locale.html#LocaleMatching">Locale
@@ -2998,7 +2998,7 @@ public final class Locale implements Cloneable, Serializable {
      *
      * <p>There are two types of language ranges: basic and extended. In RFC
      * 4647, the syntax of language ranges is expressed in
-     * <a href="http://tools.ietf.org/html/rfc4234">ABNF</a> as follows:
+     * <a href="https://tools.ietf.org/html/rfc4234">ABNF</a> as follows:
      * <blockquote>
      * <pre>
      *     basic-language-range    = (1*8ALPHA *("-" 1*8alphanum)) / "*"
@@ -3164,7 +3164,7 @@ public final class Locale implements Cloneable, Serializable {
          *
          * In a weighted list, each language range is given a weight value.
          * The weight value is identical to the "quality value" in
-         * <a href="http://tools.ietf.org/html/rfc2616">RFC 2616</a>, and it
+         * <a href="https://tools.ietf.org/html/rfc2616">RFC 2616</a>, and it
          * expresses how much the user prefers  the language. A weight value is
          * specified after a corresponding language range followed by
          * {@code ";q="}, and the default weight value is {@code MAX_WEIGHT}
@@ -3202,7 +3202,7 @@ public final class Locale implements Cloneable, Serializable {
          *
          * @param ranges a list of comma-separated language ranges or a list of
          *     language ranges in the form of the "Accept-Language" header
-         *     defined in <a href="http://tools.ietf.org/html/rfc2616">RFC
+         *     defined in <a href="https://tools.ietf.org/html/rfc2616">RFC
          *     2616</a>
          * @return a Language Priority List consisting of language ranges
          *     included in the given {@code ranges} and their equivalent
@@ -3223,7 +3223,7 @@ public final class Locale implements Cloneable, Serializable {
          *
          * @param ranges a list of comma-separated language ranges or a list
          *     of language ranges in the form of the "Accept-Language" header
-         *     defined in <a href="http://tools.ietf.org/html/rfc2616">RFC
+         *     defined in <a href="https://tools.ietf.org/html/rfc2616">RFC
          *     2616</a>
          * @param map a map containing information to customize language ranges
          * @return a Language Priority List with customization. The list is

--- a/src/java.base/share/classes/javax/crypto/spec/RC5ParameterSpec.java
+++ b/src/java.base/share/classes/javax/crypto/spec/RC5ParameterSpec.java
@@ -29,7 +29,7 @@ import java.security.spec.AlgorithmParameterSpec;
 
 /**
  * This class specifies the parameters used with the
- * <a href="http://tools.ietf.org/html/rfc2040"><i>RC5</i></a>
+ * <a href="https://tools.ietf.org/html/rfc2040"><i>RC5</i></a>
  * algorithm.
  *
  * <p> The parameters consist of a version number, a rounds count, a word

--- a/src/java.base/share/classes/javax/security/auth/x500/X500Principal.java
+++ b/src/java.base/share/classes/javax/security/auth/x500/X500Principal.java
@@ -41,13 +41,13 @@ import sun.security.util.*;
  * of the distinguished name, or by using the ASN.1 DER encoded byte
  * representation of the distinguished name.  The current specification
  * for the string representation of a distinguished name is defined in
- * <a href="http://tools.ietf.org/html/rfc2253">RFC 2253: Lightweight
+ * <a href="https://tools.ietf.org/html/rfc2253">RFC 2253: Lightweight
  * Directory Access Protocol (v3): UTF-8 String Representation of
  * Distinguished Names</a>. This class, however, accepts string formats from
- * both RFC 2253 and <a href="http://tools.ietf.org/html/rfc1779">RFC 1779:
+ * both RFC 2253 and <a href="https://tools.ietf.org/html/rfc1779">RFC 1779:
  * A String Representation of Distinguished Names</a>, and also recognizes
  * attribute type keywords whose OIDs (Object Identifiers) are defined in
- * <a href="http://tools.ietf.org/html/rfc5280">RFC 5280: Internet X.509
+ * <a href="https://tools.ietf.org/html/rfc5280">RFC 5280: Internet X.509
  * Public Key Infrastructure Certificate and CRL Profile</a>.
  *
  * <p> The string representation for this {@code X500Principal}

--- a/src/java.base/share/classes/javax/security/auth/x500/package-info.java
+++ b/src/java.base/share/classes/javax/security/auth/x500/package-info.java
@@ -31,15 +31,15 @@
  * <h2>Package Specification</h2>
  *
  * <ul>
- *   <li><a href="http://tools.ietf.org/html/rfc1779">
+ *   <li><a href="https://tools.ietf.org/html/rfc1779">
  *     RFC 1779: A String Representation of Distinguished Names</a></li>
- *   <li><a href="http://tools.ietf.org/html/rfc2253">
+ *   <li><a href="https://tools.ietf.org/html/rfc2253">
  *     RFC 2253: Lightweight Directory Access Protocol (v3):
  *     UTF-8 String Representation of Distinguished Names</a></li>
- *   <li><a href="http://tools.ietf.org/html/rfc5280">
+ *   <li><a href="https://tools.ietf.org/html/rfc5280">
  *     RFC 5280: Internet X.509 Public Key Infrastructure
  *     Certificate and Certificate Revocation List (CRL) Profile</a></li>
- *   <li><a href="http://tools.ietf.org/html/rfc4512">
+ *   <li><a href="https://tools.ietf.org/html/rfc4512">
  *     RFC 4512: Lightweight Directory Access Protocol (LDAP):
  *     Directory Information Models</a></li>
  * </ul>

--- a/src/java.base/share/classes/sun/security/pkcs/PKCS7.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS7.java
@@ -940,7 +940,7 @@ public class PKCS7 {
 
     /**
      * Examine the certificate for a Subject Information Access extension
-     * (<a href="http://tools.ietf.org/html/rfc5280">RFC 5280</a>).
+     * (<a href="https://tools.ietf.org/html/rfc5280">RFC 5280</a>).
      * The extension's {@code accessMethod} field should contain the object
      * identifier defined for timestamping: 1.3.6.1.5.5.7.48.3 and its
      * {@code accessLocation} field should contain an HTTP or HTTPS URL.

--- a/src/java.base/share/classes/sun/security/x509/AuthorityInfoAccessExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/AuthorityInfoAccessExtension.java
@@ -43,7 +43,7 @@ import sun.security.util.DerValue;
  * certificate that identifies the specific OCSP Responder to use when
  * performing on-line validation of that certificate.
  * <p>
- * This extension is defined in <a href="http://tools.ietf.org/html/rfc5280">
+ * This extension is defined in <a href="https://tools.ietf.org/html/rfc5280">
  * Internet X.509 PKI Certificate and Certificate Revocation List
  * (CRL) Profile</a>. The profile permits
  * the extension to be included in end-entity or CA certificates,

--- a/src/java.base/share/classes/sun/security/x509/DeltaCRLIndicatorExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/DeltaCRLIndicatorExtension.java
@@ -42,7 +42,7 @@ import java.math.BigInteger;
  *
  * <p>
  * The extension is defined in Section 5.2.4 of
- * <a href="http://tools.ietf.org/html/rfc5280">Internet X.509 PKI
+ * <a href="https://tools.ietf.org/html/rfc5280">Internet X.509 PKI
  * Certificate and Certificate Revocation List (CRL) Profile</a>.
  *
  * <p>

--- a/src/java.base/share/classes/sun/security/x509/FreshestCRLExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/FreshestCRLExtension.java
@@ -42,7 +42,7 @@ import sun.security.util.*;
  *
  * <p>
  * The extension is defined in Section 5.2.6 of
- * <a href="http://tools.ietf.org/html/rfc5280">Internet X.509 PKI
+ * <a href="https://tools.ietf.org/html/rfc5280">Internet X.509 PKI
  * Certificate and Certificate Revocation List (CRL) Profile</a>.
  *
  * <p>

--- a/src/java.base/share/classes/sun/security/x509/IssuingDistributionPointExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/IssuingDistributionPointExtension.java
@@ -46,7 +46,7 @@ import sun.security.util.DerValue;
  *
  * <p>
  * The extension is defined in Section 5.2.5 of
- * <a href="http://tools.ietf.org/html/rfc5280">Internet X.509 PKI
+ * <a href="https://tools.ietf.org/html/rfc5280">Internet X.509 PKI
  * Certificate and Certificate Revocation List (CRL) Profile</a>.
  *
  * <p>

--- a/src/java.base/share/classes/sun/security/x509/SubjectInfoAccessExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/SubjectInfoAccessExtension.java
@@ -48,7 +48,7 @@ import sun.security.util.DerValue;
  * included in end entity or CA certificates.  Conforming CAs MUST mark
  * this extension as non-critical.
  * <p>
- * This extension is defined in <a href="http://tools.ietf.org/html/rfc5280">
+ * This extension is defined in <a href="https://tools.ietf.org/html/rfc5280">
  * Internet X.509 PKI Certificate and Certificate Revocation List
  * (CRL) Profile</a>. The profile permits
  * the extension to be included in end-entity or CA certificates,

--- a/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
@@ -54,7 +54,7 @@ import sun.security.util.*;
  *     signature            BIT STRING  }
  * </pre>
  * More information can be found in
- * <a href="http://tools.ietf.org/html/rfc5280">RFC 5280: Internet X.509
+ * <a href="https://tools.ietf.org/html/rfc5280">RFC 5280: Internet X.509
  * Public Key Infrastructure Certificate and CRL Profile</a>.
  * <p>
  * The ASN.1 definition of <code>tbsCertList</code> is:

--- a/src/java.base/share/native/libzip/zlib/ChangeLog
+++ b/src/java.base/share/native/libzip/zlib/ChangeLog
@@ -304,7 +304,7 @@ Changes in 1.2.5.1 (10 Sep 2011)
 - Add dummy name before $(SHAREDLIBV) in Makefile [Bar-Lev, Bowler]
 - Delete line in configure that adds -L. libz.a to LDFLAGS [Weigelt]
 - Add debug records in assmebler code [Londer]
-- Update RFC references to use http://tools.ietf.org/html/... [Li]
+- Update RFC references to use https://tools.ietf.org/html/... [Li]
 - Add --archs option, use of libtool to configure for Mac OS X [Borstel]
 
 Changes in 1.2.5 (19 Apr 2010)

--- a/src/java.base/share/native/libzip/zlib/README
+++ b/src/java.base/share/native/libzip/zlib/README
@@ -3,7 +3,7 @@ ZLIB DATA COMPRESSION LIBRARY
 zlib 1.2.11 is a general purpose data compression library.  All the code is
 thread safe.  The data format used by the zlib library is described by RFCs
 (Request for Comments) 1950 to 1952 in the files
-http://tools.ietf.org/html/rfc1950 (zlib format), rfc1951 (deflate format) and
+https://tools.ietf.org/html/rfc1950 (zlib format), rfc1951 (deflate format) and
 rfc1952 (gzip format).
 
 All functions of the compression library are documented in the file zlib.h

--- a/src/java.base/share/native/libzip/zlib/deflate.c
+++ b/src/java.base/share/native/libzip/zlib/deflate.c
@@ -61,7 +61,7 @@
  *  REFERENCES
  *
  *      Deutsch, L.P.,"DEFLATE Compressed Data Format Specification".
- *      Available in http://tools.ietf.org/html/rfc1951
+ *      Available in https://tools.ietf.org/html/rfc1951
  *
  *      A description of the Rabin and Karp algorithm is given in the book
  *         "Algorithms" by R. Sedgewick, Addison-Wesley, p252.

--- a/src/java.base/share/native/libzip/zlib/zlib.h
+++ b/src/java.base/share/native/libzip/zlib/zlib.h
@@ -48,7 +48,7 @@
 
 
   The data format used by the zlib library is described by RFCs (Request for
-  Comments) 1950 to 1952 in the files http://tools.ietf.org/html/rfc1950
+  Comments) 1950 to 1952 in the files https://tools.ietf.org/html/rfc1950
   (zlib format), rfc1951 (deflate format) and rfc1952 (gzip format).
 */
 

--- a/src/java.desktop/share/classes/javax/imageio/plugins/tiff/FaxTIFFTagSet.java
+++ b/src/java.desktop/share/classes/javax/imageio/plugins/tiff/FaxTIFFTagSet.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 /**
  * A class representing the extra tags found in a
- * <a href="http://tools.ietf.org/html/rfc2306.html">TIFF-F</a> (RFC 2036) file.
+ * <a href="https://tools.ietf.org/html/rfc2306.html">TIFF-F</a> (RFC 2036) file.
  *
  * @since 9
  */

--- a/src/java.security.jgss/share/classes/org/ietf/jgss/GSSContext.java
+++ b/src/java.security.jgss/share/classes/org/ietf/jgss/GSSContext.java
@@ -101,7 +101,7 @@ import java.io.OutputStream;
  *
  * The stream-based methods of {@code GSSContext} have been deprecated in
  * Java SE 11. These methods have also been removed from
- * <a href="http://tools.ietf.org/html/rfc8353">
+ * <a href="https://tools.ietf.org/html/rfc8353">
  * RFC 8353: Generic Security Service API Version 2: Java Bindings Update</a>
  * for the following reasons (see section 11): "The overloaded methods of
  * GSSContext that use input and output streams as the means to convey

--- a/src/jdk.jartool/share/man/jarsigner.1
+++ b/src/jdk.jartool/share/man/jarsigner.1
@@ -766,7 +766,7 @@ The file can be a sequence of concatenated X.509 certificates, or a
 single PKCS#7 formatted data block, either in binary encoding format or
 in printable encoding format (also known as Base64 encoding) as defined
 by \f[B]Internet RFC 1421 Certificate Encoding Standard\f[R]
-[http://tools.ietf.org/html/rfc1421].
+[https://tools.ietf.org/html/rfc1421].
 .RS
 .RE
 .TP

--- a/src/jdk.sctp/share/classes/com/sun/nio/sctp/Association.java
+++ b/src/jdk.sctp/share/classes/com/sun/nio/sctp/Association.java
@@ -39,7 +39,7 @@ package com.sun.nio.sctp;
  * shutdown. An association ID is not unique across multiple SCTP channels.
  * An Association's local and remote addresses may change if the SCTP
  * implementation supports <I>Dynamic Address Reconfiguration</I> as defined by
- * <A HREF="http://tools.ietf.org/html/rfc5061">RFC5061</A>, see the
+ * <A HREF="https://tools.ietf.org/html/rfc5061">RFC5061</A>, see the
  * {@code bindAddress} and {@code unbindAddress} methods of {@link SctpChannel},
  * {@link SctpServerChannel}, and {@link SctpMultiChannel}.
  *

--- a/src/jdk.sctp/share/classes/com/sun/nio/sctp/package-info.java
+++ b/src/jdk.sctp/share/classes/com/sun/nio/sctp/package-info.java
@@ -65,9 +65,9 @@
  * com.sun.nio.sctp.NotificationHandler notification handler}.
  *
  * <P> The SCTP protocol is defined by
- * <A HREF="http://tools.ietf.org/html/rfc4960">RFC4960</A>, and the optional
+ * <A HREF="https://tools.ietf.org/html/rfc4960">RFC4960</A>, and the optional
  * extension for <I>Dynamic Address Reconfiguration</I> is defined by
- * <A HREF="http://tools.ietf.org/html/rfc5061">RFC5061</A>.
+ * <A HREF="https://tools.ietf.org/html/rfc5061">RFC5061</A>.
  *
  * @since 1.7
  */

--- a/test/jdk/java/net/httpclient/http2/java.net.http/jdk/internal/net/http/hpack/DecoderTest.java
+++ b/test/jdk/java/net/httpclient/http2/java.net.http/jdk/internal/net/http/hpack/DecoderTest.java
@@ -44,7 +44,7 @@ import static jdk.internal.net.http.hpack.TestHelper.*;
 public final class DecoderTest {
 
     //
-    // http://tools.ietf.org/html/rfc7541#appendix-C.2.1
+    // https://tools.ietf.org/html/rfc7541#appendix-C.2.1
     //
     @Test
     public void example1() {
@@ -60,7 +60,7 @@ public final class DecoderTest {
     }
 
     //
-    // http://tools.ietf.org/html/rfc7541#appendix-C.2.2
+    // https://tools.ietf.org/html/rfc7541#appendix-C.2.2
     //
     @Test
     public void example2() {
@@ -72,7 +72,7 @@ public final class DecoderTest {
     }
 
     //
-    // http://tools.ietf.org/html/rfc7541#appendix-C.2.3
+    // https://tools.ietf.org/html/rfc7541#appendix-C.2.3
     //
     @Test
     public void example3() {
@@ -85,7 +85,7 @@ public final class DecoderTest {
     }
 
     //
-    // http://tools.ietf.org/html/rfc7541#appendix-C.2.4
+    // https://tools.ietf.org/html/rfc7541#appendix-C.2.4
     //
     @Test
     public void example4() {
@@ -97,7 +97,7 @@ public final class DecoderTest {
     }
 
     //
-    // http://tools.ietf.org/html/rfc7541#appendix-C.3
+    // https://tools.ietf.org/html/rfc7541#appendix-C.3
     //
     @Test
     public void example5() {
@@ -162,7 +162,7 @@ public final class DecoderTest {
     }
 
     //
-    // http://tools.ietf.org/html/rfc7541#appendix-C.4
+    // https://tools.ietf.org/html/rfc7541#appendix-C.4
     //
     @Test
     public void example6() {
@@ -209,7 +209,7 @@ public final class DecoderTest {
     }
 
     //
-    // http://tools.ietf.org/html/rfc7541#appendix-C.5
+    // https://tools.ietf.org/html/rfc7541#appendix-C.5
     //
     @Test
     public void example7() {
@@ -269,7 +269,7 @@ public final class DecoderTest {
     }
 
     //
-    // http://tools.ietf.org/html/rfc7541#appendix-C.6
+    // https://tools.ietf.org/html/rfc7541#appendix-C.6
     //
     @Test
     public void example8() {

--- a/test/jdk/java/net/httpclient/http2/java.net.http/jdk/internal/net/http/hpack/EncoderTest.java
+++ b/test/jdk/java/net/httpclient/http2/java.net.http/jdk/internal/net/http/hpack/EncoderTest.java
@@ -48,7 +48,7 @@ import static org.testng.Assert.assertTrue;
 public final class EncoderTest {
 
     //
-    // http://tools.ietf.org/html/rfc7541#appendix-C.2.1
+    // https://tools.ietf.org/html/rfc7541#appendix-C.2.1
     //
     @Test
     public void example1() {
@@ -69,7 +69,7 @@ public final class EncoderTest {
     }
 
     //
-    // http://tools.ietf.org/html/rfc7541#appendix-C.2.2
+    // https://tools.ietf.org/html/rfc7541#appendix-C.2.2
     //
     @Test
     public void example2() {
@@ -88,7 +88,7 @@ public final class EncoderTest {
     }
 
     //
-    // http://tools.ietf.org/html/rfc7541#appendix-C.2.3
+    // https://tools.ietf.org/html/rfc7541#appendix-C.2.3
     //
     @Test
     public void example3() {
@@ -108,7 +108,7 @@ public final class EncoderTest {
     }
 
     //
-    // http://tools.ietf.org/html/rfc7541#appendix-C.2.4
+    // https://tools.ietf.org/html/rfc7541#appendix-C.2.4
     //
     @Test
     public void example4() {
@@ -127,7 +127,7 @@ public final class EncoderTest {
     }
 
     //
-    // http://tools.ietf.org/html/rfc7541#appendix-C.3
+    // https://tools.ietf.org/html/rfc7541#appendix-C.3
     //
     @Test
     public void example5() {
@@ -261,7 +261,7 @@ public final class EncoderTest {
     }
 
     //
-    // http://tools.ietf.org/html/rfc7541#appendix-C.4
+    // https://tools.ietf.org/html/rfc7541#appendix-C.4
     //
     @Test
     public void example6() {
@@ -340,7 +340,7 @@ public final class EncoderTest {
     }
 
     //
-    // http://tools.ietf.org/html/rfc7541#appendix-C.5
+    // https://tools.ietf.org/html/rfc7541#appendix-C.5
     //
     @Test
     public void example7() {
@@ -432,7 +432,7 @@ public final class EncoderTest {
     }
 
     //
-    // http://tools.ietf.org/html/rfc7541#appendix-C.6
+    // https://tools.ietf.org/html/rfc7541#appendix-C.6
     //
     @Test
     public void example8() {

--- a/test/jdk/javax/naming/module/src/authz/org/example/authz/AuthzIdRequestControl.java
+++ b/test/jdk/javax/naming/module/src/authz/org/example/authz/AuthzIdRequestControl.java
@@ -24,7 +24,7 @@
 /**
  * This class implements the LDAPv3 Authorization Identity request control
  * as defined in
- * <a href="http://tools.ietf.org/html/rfc3829">RFC 3829</a>.
+ * <a href="https://tools.ietf.org/html/rfc3829">RFC 3829</a>.
  */
 
 package org.example.authz;

--- a/test/jdk/javax/naming/module/src/authz/org/example/authz/AuthzIdResponseControl.java
+++ b/test/jdk/javax/naming/module/src/authz/org/example/authz/AuthzIdResponseControl.java
@@ -24,7 +24,7 @@
 /**
  * This class implements the LDAPv3 Authorization Identity response control
  * as defined in
- * <a href="http://tools.ietf.org/html/rfc3829">RFC 3829</a>.
+ * <a href="https://tools.ietf.org/html/rfc3829">RFC 3829</a>.
  */
 
 package org.example.authz;


### PR DESCRIPTION
Hi folks,

Can you please review this small change to update javadoc links as my first contribution to the openJDK.

EDIT: Mach5 tests are green.

Reviewers: @coffeys

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283525](https://bugs.openjdk.java.net/browse/JDK-8283525): http://tools.ietf.org/html/* URLs return 404


### Reviewers
 * [Sean Coffey](https://openjdk.java.net/census#coffeys) (@coffeys - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7956/head:pull/7956` \
`$ git checkout pull/7956`

Update a local copy of the PR: \
`$ git checkout pull/7956` \
`$ git pull https://git.openjdk.java.net/jdk pull/7956/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7956`

View PR using the GUI difftool: \
`$ git pr show -t 7956`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7956.diff">https://git.openjdk.java.net/jdk/pull/7956.diff</a>

</details>
