### PR TITLE
8283681: Improve ZonedDateTime offset handling

### DIFF
--- a/src/java.base/share/classes/java/time/ZoneId.java
+++ b/src/java.base/share/classes/java/time/ZoneId.java
@@ -584,7 +584,7 @@ public abstract sealed class ZoneId implements Serializable permits ZoneOffset, 
         return this;
     }
 
-    /* package-private */ abstract ZoneOffset getOffset(long epochSecond);
+    /* package-private */ abstract ZoneOffset getOffset(long epochSecond, int nanoOfSecond);
 
     //-----------------------------------------------------------------------
     /**

--- a/src/java.base/share/classes/java/time/ZoneId.java
+++ b/src/java.base/share/classes/java/time/ZoneId.java
@@ -584,6 +584,8 @@ public abstract sealed class ZoneId implements Serializable permits ZoneOffset, 
         return this;
     }
 
+    /* package-private */ abstract ZoneOffset getOffset(long epochSecond);
+
     //-----------------------------------------------------------------------
     /**
      * Checks if this time-zone ID is equal to another time-zone ID.

--- a/src/java.base/share/classes/java/time/ZoneId.java
+++ b/src/java.base/share/classes/java/time/ZoneId.java
@@ -584,7 +584,10 @@ public abstract sealed class ZoneId implements Serializable permits ZoneOffset, 
         return this;
     }
 
-    /* package-private */ abstract ZoneOffset getOffset(long epochSecond, int nanoOfSecond);
+    /**
+     * Get the effective offset for an instant at the given epochSecond.
+     */
+    /* package-private */ abstract ZoneOffset getOffset(long epochSecond);
 
     //-----------------------------------------------------------------------
     /**

--- a/src/java.base/share/classes/java/time/ZoneOffset.java
+++ b/src/java.base/share/classes/java/time/ZoneOffset.java
@@ -508,7 +508,7 @@ public final class ZoneOffset
     }
 
     @Override
-    /* package-private */ ZoneOffset getOffset(long epochSecond) {
+    /* package-private */ ZoneOffset getOffset(long epochSecond, int nanoOfSecond) {
         return this;
     }
 

--- a/src/java.base/share/classes/java/time/ZoneOffset.java
+++ b/src/java.base/share/classes/java/time/ZoneOffset.java
@@ -507,6 +507,11 @@ public final class ZoneOffset
         return ZoneRules.of(this);
     }
 
+    @Override
+    /* package-private */ ZoneOffset getOffset(long epochSecond) {
+        return this;
+    }
+
     //-----------------------------------------------------------------------
     /**
      * Checks if the specified field is supported.

--- a/src/java.base/share/classes/java/time/ZoneOffset.java
+++ b/src/java.base/share/classes/java/time/ZoneOffset.java
@@ -86,6 +86,8 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import jdk.internal.vm.annotation.Stable;
+
 /**
  * A time-zone offset from Greenwich/UTC, such as {@code +02:00}.
  * <p>
@@ -168,6 +170,11 @@ public final class ZoneOffset
      * The string form of the time-zone offset.
      */
     private final transient String id;
+    /**
+     * The zone rules for an offset will always return this offset. Cache it for efficiency.
+     */
+    @Stable
+    private transient ZoneRules rules;
 
     //-----------------------------------------------------------------------
     /**
@@ -504,11 +511,20 @@ public final class ZoneOffset
      */
     @Override
     public ZoneRules getRules() {
-        return ZoneRules.of(this);
+        ZoneRules rules = this.rules;
+        if (rules == null) {
+            rules = this.rules = ZoneRules.of(this);
+        }
+        return rules;
     }
 
     @Override
-    /* package-private */ ZoneOffset getOffset(long epochSecond, int nanoOfSecond) {
+    public ZoneId normalized() {
+        return this;
+    }
+
+    @Override
+    /* package-private */ ZoneOffset getOffset(long epochSecond) {
         return this;
     }
 

--- a/src/java.base/share/classes/java/time/ZoneRegion.java
+++ b/src/java.base/share/classes/java/time/ZoneRegion.java
@@ -178,6 +178,11 @@ final class ZoneRegion extends ZoneId implements Serializable {
         return (rules != null ? rules : ZoneRulesProvider.getRules(id, false));
     }
 
+    @Override
+    /* package-private */ ZoneOffset getOffset(long epochSecond) {
+        return getRules().getOffset(Instant.ofEpochSecond(epochSecond));
+    }
+
     //-----------------------------------------------------------------------
     /**
      * Writes the object using a

--- a/src/java.base/share/classes/java/time/ZoneRegion.java
+++ b/src/java.base/share/classes/java/time/ZoneRegion.java
@@ -179,8 +179,8 @@ final class ZoneRegion extends ZoneId implements Serializable {
     }
 
     @Override
-    /* package-private */ ZoneOffset getOffset(long epochSecond) {
-        return getRules().getOffset(Instant.ofEpochSecond(epochSecond));
+    /* package-private */ ZoneOffset getOffset(long epochSecond, int nanoOfSecond) {
+        return getRules().getOffset(Instant.ofEpochSecond(epochSecond, nanoOfSecond));
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/ZoneRegion.java
+++ b/src/java.base/share/classes/java/time/ZoneRegion.java
@@ -179,8 +179,8 @@ final class ZoneRegion extends ZoneId implements Serializable {
     }
 
     @Override
-    /* package-private */ ZoneOffset getOffset(long epochSecond, int nanoOfSecond) {
-        return getRules().getOffset(Instant.ofEpochSecond(epochSecond, nanoOfSecond));
+    /* package-private */ ZoneOffset getOffset(long epochSecond) {
+        return getRules().getOffset(Instant.ofEpochSecond(epochSecond));
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/ZonedDateTime.java
+++ b/src/java.base/share/classes/java/time/ZonedDateTime.java
@@ -452,9 +452,7 @@ public final class ZonedDateTime
      * @throws DateTimeException if the result exceeds the supported range
      */
     private static ZonedDateTime create(long epochSecond, int nanoOfSecond, ZoneId zone) {
-        ZoneRules rules = zone.getRules();
-        Instant instant = Instant.ofEpochSecond(epochSecond, nanoOfSecond);  // TODO: rules should be queryable by epochSeconds
-        ZoneOffset offset = rules.getOffset(instant);
+        ZoneOffset offset = zone.getOffset(epochSecond);
         LocalDateTime ldt = LocalDateTime.ofEpochSecond(epochSecond, nanoOfSecond, offset);
         return new ZonedDateTime(ldt, offset, zone);
     }

--- a/src/java.base/share/classes/java/time/ZonedDateTime.java
+++ b/src/java.base/share/classes/java/time/ZonedDateTime.java
@@ -452,7 +452,7 @@ public final class ZonedDateTime
      * @throws DateTimeException if the result exceeds the supported range
      */
     private static ZonedDateTime create(long epochSecond, int nanoOfSecond, ZoneId zone) {
-        ZoneOffset offset = zone.getOffset(epochSecond);
+        ZoneOffset offset = zone.getOffset(epochSecond, nanoOfSecond);
         LocalDateTime ldt = LocalDateTime.ofEpochSecond(epochSecond, nanoOfSecond, offset);
         return new ZonedDateTime(ldt, offset, zone);
     }

--- a/src/java.base/share/classes/java/time/ZonedDateTime.java
+++ b/src/java.base/share/classes/java/time/ZonedDateTime.java
@@ -452,7 +452,9 @@ public final class ZonedDateTime
      * @throws DateTimeException if the result exceeds the supported range
      */
     private static ZonedDateTime create(long epochSecond, int nanoOfSecond, ZoneId zone) {
-        ZoneOffset offset = zone.getOffset(epochSecond, nanoOfSecond);
+        // nanoOfSecond is in a range that'll not affect epochSecond, validated
+        // by LocalDateTime.ofEpochSecond
+        ZoneOffset offset = zone.getOffset(epochSecond);
         LocalDateTime ldt = LocalDateTime.ofEpochSecond(epochSecond, nanoOfSecond, offset);
         return new ZonedDateTime(ldt, offset, zone);
     }

--- a/test/micro/org/openjdk/bench/java/time/GetYearBench.java
+++ b/test/micro/org/openjdk/bench/java/time/GetYearBench.java
@@ -110,4 +110,12 @@ public class GetYearBench {
         }
         return YEARS;
     }
+
+    @Benchmark
+    public int[] getYearFromMillisZoneRegionNormalized() {
+        for (int i = 0; i < YEARS.length; i++) {
+            YEARS[i] = Instant.ofEpochMilli(INSTANT_MILLIS[i]).atZone(UTC.toZoneId().normalized()).getYear();
+        }
+        return YEARS;
+    }
 }

--- a/test/micro/org/openjdk/bench/java/time/GetYearBench.java
+++ b/test/micro/org/openjdk/bench/java/time/GetYearBench.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.time;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
+import java.util.Locale;
+import java.util.Random;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Tests the JITs ability to remove allocations from expressions
+ * like {@code Instant.ofEpochMilli(value).atZone(ZoneOffset.UTC).getYear()}
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
+@State(Scope.Benchmark)
+public class GetYearBench {
+
+    private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+
+    private static final TimeZone LONDON = TimeZone.getTimeZone("Europe/London");
+
+    private static final long[] INSTANT_MILLIS = createInstants();
+
+    private static final int[] YEARS = new int[INSTANTS.length];
+
+    private static long[] createInstants() {
+        // Various instants during the same day
+        final Instant loInstant = Instant.EPOCH.plus(Duration.ofDays(365*50)); // 2020-01-01
+        final Instant hiInstant = loInstant.plus(Duration.ofDays(1));
+        final long maxOffsetNanos = Duration.between(loInstant, hiInstant).toNanos();
+        final Random random = new Random(0);
+        return IntStream
+                .range(0, 1_000)
+                .mapToObj(ignored -> {
+                    final long offsetNanos = (long) Math.floor(random.nextDouble() * maxOffsetNanos);
+                    return loInstant.plus(offsetNanos, ChronoUnit.NANOS);
+                })
+                .mapToLong(instant -> instant.toEpochMilli())
+                .toArray();
+    }
+
+    @Benchmark
+    public int[] getYearFromMillis() {
+        for (int i = 0; i < YEARS.length; i++) {
+            YEARS[i] = Instant.ofEpochMilli(INSTANT_MILLIS[i]).atZone(ZoneOffset.UTC).getYear();
+        }
+        return YEARS;
+    }
+
+    @Benchmark
+    public int[] getYearFromMillisZoneIdUTC() {
+        for (int i = 0; i < YEARS.length; i++) {
+            YEARS[i] = Instant.ofEpochMilli(INSTANT_MILLIS[i]).atZone(UTC.toZoneId()).getYear();
+        }
+        return YEARS;
+    }
+
+    @Benchmark
+    public int[] getYearFromMillisZoneIdLondon() {
+        for (int i = 0; i < YEARS.length; i++) {
+            YEARS[i] = Instant.ofEpochMilli(INSTANT_MILLIS[i]).atZone(LONDON.toZoneId()).getYear();
+        }
+        return YEARS;
+    }
+}

--- a/test/micro/org/openjdk/bench/java/time/GetYearBench.java
+++ b/test/micro/org/openjdk/bench/java/time/GetYearBench.java
@@ -67,7 +67,7 @@ public class GetYearBench {
 
     private static final long[] INSTANT_MILLIS = createInstants();
 
-    private static final int[] YEARS = new int[INSTANTS.length];
+    private static final int[] YEARS = new int[INSTANT_MILLIS.length];
 
     private static long[] createInstants() {
         // Various instants during the same day
@@ -86,7 +86,7 @@ public class GetYearBench {
     }
 
     @Benchmark
-    public int[] getYearFromMillis() {
+    public int[] getYearFromMillisZoneOffset() {
         for (int i = 0; i < YEARS.length; i++) {
             YEARS[i] = Instant.ofEpochMilli(INSTANT_MILLIS[i]).atZone(ZoneOffset.UTC).getYear();
         }
@@ -94,7 +94,7 @@ public class GetYearBench {
     }
 
     @Benchmark
-    public int[] getYearFromMillisZoneIdUTC() {
+    public int[] getYearFromMillisZoneRegionUTC() {
         for (int i = 0; i < YEARS.length; i++) {
             YEARS[i] = Instant.ofEpochMilli(INSTANT_MILLIS[i]).atZone(UTC.toZoneId()).getYear();
         }
@@ -102,7 +102,7 @@ public class GetYearBench {
     }
 
     @Benchmark
-    public int[] getYearFromMillisZoneIdLondon() {
+    public int[] getYearFromMillisZoneRegion() {
         for (int i = 0; i < YEARS.length; i++) {
             YEARS[i] = Instant.ofEpochMilli(INSTANT_MILLIS[i]).atZone(LONDON.toZoneId()).getYear();
         }


### PR DESCRIPTION
Richard Startin prompted me to have a look at a case where java.time underperforms relative to joda time (https://twitter.com/richardstartin/status/1506975932271190017). 

It seems the java.time test of his suffer from heavy allocations due ZoneOffset::getRules allocating a new ZoneRules object every time and escape analysis failing to do the thing in his test. The patch here adds a simple specialization so that when creating ZonedDateTimes using a ZoneOffset we don't query the rules at all. This removes the risk of extra allocations and slightly speeds up ZonedDateTime creation for both ZoneOffset (+14%) and ZoneRegion (+5%) even when EA works like it should (the case in the here provided microbenchmark).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283681](https://bugs.openjdk.java.net/browse/JDK-8283681): Improve ZonedDateTime offset handling


### Reviewers
 * [Stephen Colebourne](https://openjdk.java.net/census#scolebourne) (@jodastephen - Author)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7957/head:pull/7957` \
`$ git checkout pull/7957`

Update a local copy of the PR: \
`$ git checkout pull/7957` \
`$ git pull https://git.openjdk.java.net/jdk pull/7957/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7957`

View PR using the GUI difftool: \
`$ git pr show -t 7957`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7957.diff">https://git.openjdk.java.net/jdk/pull/7957.diff</a>

</details>
