### PR TITLE
8283683: Make ThreadLocalRandom a final class

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
@@ -93,7 +93,7 @@ import jdk.internal.misc.VM;
         i = 64, j = 0, k = 0,
         equidistribution = 1
 )
-public class ThreadLocalRandom extends Random {
+public final class ThreadLocalRandom extends Random {
     /*
      * This class implements the java.util.Random API (and subclasses
      * Random) using a single static instance that accesses 64 bits of


### PR DESCRIPTION
Can I please get a review of this change which marks the `ThreadLocalRandom` class as `final`? Related JBS issue https://bugs.openjdk.java.net/browse/JDK-8283683.

A CSR has been filed too https://bugs.openjdk.java.net/browse/JDK-8283688.

tier1, tier2 and tier3 tests have been run with this change and no related failures have been noticed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8283683](https://bugs.openjdk.java.net/browse/JDK-8283683): Make ThreadLocalRandom a final class
 * [JDK-8283688](https://bugs.openjdk.java.net/browse/JDK-8283688): Make ThreadLocalRandom a final class (**CSR**)


### Reviewers
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7958/head:pull/7958` \
`$ git checkout pull/7958`

Update a local copy of the PR: \
`$ git checkout pull/7958` \
`$ git pull https://git.openjdk.java.net/jdk pull/7958/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7958`

View PR using the GUI difftool: \
`$ git pr show -t 7958`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7958.diff">https://git.openjdk.java.net/jdk/pull/7958.diff</a>

</details>
