### PR TITLE
8283692: Add PrintIdealPhase that includes block scheduling

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -548,7 +548,13 @@ void Compile::print_ideal_ir(const char* phase_name) {
                is_osr_compilation() ? " compile_kind='osr'" : "",
                phase_name);
   }
-  root()->dump(9999);
+  if (_output == nullptr) {
+    root()->dump(9999);
+  } else {
+    // Dump the node blockwise if we have a scheduling
+    _output->print_scheduling();
+  }
+
   if (xtty != NULL) {
     xtty->tail("ideal");
   }
@@ -624,7 +630,8 @@ Compile::Compile( ciEnv* ci_env, ciMethod* target, int osr_bci,
                   _replay_inline_data(NULL),
                   _java_calls(0),
                   _inner_loops(0),
-                  _interpreter_frame_size(0)
+                  _interpreter_frame_size(0),
+                  _output(NULL)
 #ifndef PRODUCT
                   , _in_dump_cnt(0)
 #endif
@@ -898,6 +905,7 @@ Compile::Compile( ciEnv* ci_env,
     _java_calls(0),
     _inner_loops(0),
     _interpreter_frame_size(0),
+    _output(NULL),
 #ifndef PRODUCT
     _in_dump_cnt(0),
 #endif

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -324,6 +324,8 @@ void PhaseOutput::perform_mach_node_analysis() {
   bs->late_barrier_analysis();
 
   pd_perform_mach_node_analysis();
+
+  C->print_method(CompilerPhaseType::PHASE_MACHANALYSIS, 4);
 }
 
 // Convert Nodes to instruction bits and pass off to the VM
@@ -2117,19 +2119,26 @@ void PhaseOutput::ScheduleAndBundle() {
 #ifndef PRODUCT
   if (C->trace_opto_output()) {
     tty->print("\n---- After ScheduleAndBundle ----\n");
-    for (uint i = 0; i < C->cfg()->number_of_blocks(); i++) {
-      tty->print("\nBB#%03d:\n", i);
-      Block* block = C->cfg()->get_block(i);
-      for (uint j = 0; j < block->number_of_nodes(); j++) {
-        Node* n = block->get_node(j);
-        OptoReg::Name reg = C->regalloc()->get_reg_first(n);
-        tty->print(" %-6s ", reg >= 0 && reg < REG_COUNT ? Matcher::regName[reg] : "");
-        n->dump();
-      }
-    }
+    print_scheduling();
   }
 #endif
 }
+
+#ifndef PRODUCT
+// Separated out so that it can be called directly from debugger
+void PhaseOutput::print_scheduling() {
+  for (uint i = 0; i < C->cfg()->number_of_blocks(); i++) {
+    tty->print("\nBB#%03d:\n", i);
+    Block* block = C->cfg()->get_block(i);
+    for (uint j = 0; j < block->number_of_nodes(); j++) {
+      Node* n = block->get_node(j);
+      OptoReg::Name reg = C->regalloc()->get_reg_first(n);
+      tty->print(" %-6s ", reg >= 0 && reg < REG_COUNT ? Matcher::regName[reg] : "");
+      n->dump();
+    }
+  }
+}
+#endif
 
 // See if this node fits into the present instruction bundle
 bool Scheduling::NodeFitsInBundle(Node *n) {

--- a/src/hotspot/share/opto/output.hpp
+++ b/src/hotspot/share/opto/output.hpp
@@ -263,6 +263,7 @@ public:
   void BuildOopMaps();
 
 #ifndef PRODUCT
+  void print_scheduling();
   static void print_statistics();
 #endif
 };

--- a/src/hotspot/share/opto/phasetype.hpp
+++ b/src/hotspot/share/opto/phasetype.hpp
@@ -57,6 +57,7 @@
   flags(AFTER_BEAUTIFY_LOOPS,         "After beautify loops") \
   flags(BEFORE_MATCHING,              "Before matching") \
   flags(MATCHING,                     "After matching") \
+  flags(MACHANALYSIS,                 "After mach analysis") \
   flags(INCREMENTAL_INLINE,           "Incremental Inline") \
   flags(INCREMENTAL_INLINE_STEP,      "Incremental Inline Step") \
   flags(INCREMENTAL_INLINE_CLEANUP,   "Incremental Inline Cleanup") \


### PR DESCRIPTION
Hi,

This patch adds:
1) A new method Output::print_scheduling() that encapsulates the ir node printing on blocks
2) Modifying print_ideal_ir to use the print_scheduling() when there is a scheduling available
3) A new compiler phase MACH_ANALYSIS after the mach dependent optimizations.

Motivation:
This is used by the IR-test framework when testing optimizations on mach-nodes, and is a requirement to be able to test peephole-optimizations (because peephole-removed nodes are only removed from the scheduling, not from the graph.)

Having a method for print_scheduling() is also very useful when debugging.

Please review,
Nils Eliasson

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283692](https://bugs.openjdk.java.net/browse/JDK-8283692): Add PrintIdealPhase that includes block scheduling


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7960/head:pull/7960` \
`$ git checkout pull/7960`

Update a local copy of the PR: \
`$ git checkout pull/7960` \
`$ git pull https://git.openjdk.java.net/jdk pull/7960/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7960`

View PR using the GUI difftool: \
`$ git pr show -t 7960`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7960.diff">https://git.openjdk.java.net/jdk/pull/7960.diff</a>

</details>
