### PR TITLE
8283691: Classes in java.security still reference deprecated classes in spec

### DIFF
--- a/src/java.base/share/classes/java/security/Key.java
+++ b/src/java.base/share/classes/java/security/Key.java
@@ -93,8 +93,6 @@ package java.security;
  * @see KeyFactory
  * @see KeyRep
  * @see java.security.spec.KeySpec
- * @see Identity
- * @see Signer
  *
  * @author Benjamin Renaud
  * @since 1.1

--- a/src/java.base/share/classes/java/security/PrivateKey.java
+++ b/src/java.base/share/classes/java/security/PrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ package java.security;
  *
  * @see Key
  * @see PublicKey
- * @see Certificate
+ * @see java.security.cert.Certificate
  * @see Signature#initVerify
  * @see java.security.interfaces.DSAPrivateKey
  * @see java.security.interfaces.RSAPrivateKey

--- a/src/java.base/share/classes/java/security/PublicKey.java
+++ b/src/java.base/share/classes/java/security/PublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ package java.security;
  * @since 1.1
  * @see Key
  * @see PrivateKey
- * @see Certificate
+ * @see java.security.cert.Certificate
  * @see Signature#initVerify
  * @see java.security.interfaces.DSAPublicKey
  * @see java.security.interfaces.RSAPublicKey


### PR DESCRIPTION
Some spec cleanup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283691](https://bugs.openjdk.java.net/browse/JDK-8283691): Classes in java.security still reference deprecated classes in spec


### Reviewers
 * [Hai-May Chao](https://openjdk.java.net/census#hchao) (@haimaychao - Committer)
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)
 * [Bradford Wetmore](https://openjdk.java.net/census#wetmore) (@bradfordwetmore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7961/head:pull/7961` \
`$ git checkout pull/7961`

Update a local copy of the PR: \
`$ git checkout pull/7961` \
`$ git pull https://git.openjdk.java.net/jdk pull/7961/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7961`

View PR using the GUI difftool: \
`$ git pr show -t 7961`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7961.diff">https://git.openjdk.java.net/jdk/pull/7961.diff</a>

</details>
