### PR TITLE
8283623: Create an automated regression test for JDK-4525475

### DIFF
--- a/test/jdk/javax/swing/JFileChooser/4525475/JFileChooserReadOnlyTest.java
+++ b/test/jdk/javax/swing/JFileChooser/4525475/JFileChooserReadOnlyTest.java
@@ -34,7 +34,6 @@ import javax.swing.UIManager;
 import javax.swing.UIManager.LookAndFeelInfo;
 import javax.swing.UnsupportedLookAndFeelException;
 
-
 import static javax.swing.UIManager.getInstalledLookAndFeels;
 
 /*

--- a/test/jdk/javax/swing/JFileChooser/4525475/JFileChooserReadOnlyTest.java
+++ b/test/jdk/javax/swing/JFileChooser/4525475/JFileChooserReadOnlyTest.java
@@ -71,12 +71,11 @@ public class JFileChooserReadOnlyTest {
                                (result ? "Passed" : "Failed") + " for " + laf);
 
             // Test2, Read/Write JFileChooser
-            /* Skipping Motif and Aqua L&Fs, because for Motif L&F, the 'New
-            Folder' button is not shown anywhere irrespective of what we set in
-            UI defaults in any platform and the Aqua L&F behaves similar to the
-            native FileChooser always, like for 'Open' dialog it will not show
-            the 'New Folder' button, but it will show the 'New Folder' button
-             for 'Save' dialog.
+            /* Skipping Motif and Aqua L&Fs
+               For Motif L&F, the 'New Folder' button is never shown.
+               The Aqua L&F behaves similar to the native FileChooser:
+                 the 'Open' dialog doesn't show the 'New Folder' button,
+                 but it shows the button for the 'Save' dialog.
              */
             if (!(laf.contains("Motif") || laf.contains("Aqua"))) {
                 SwingUtilities.invokeAndWait(

--- a/test/jdk/javax/swing/JFileChooser/4525475/JFileChooserReadOnlyTest.java
+++ b/test/jdk/javax/swing/JFileChooser/4525475/JFileChooserReadOnlyTest.java
@@ -113,8 +113,8 @@ public class JFileChooserReadOnlyTest {
             if (comp instanceof JButton) {
                 JButton b = (JButton) comp;
                 Action action = b.getAction();
-                if (action != null &&
-                    "New Folder".equals(action.getValue(Action.NAME))) {
+                if (action != null
+                    && "New Folder".equals(action.getValue(Action.NAME))) {
                     newFolderFound = true;
                     System.out.println(
                             "New Folder Button Found when readOnly = " +

--- a/test/jdk/javax/swing/JFileChooser/4525475/JFileChooserReadOnlyTest.java
+++ b/test/jdk/javax/swing/JFileChooser/4525475/JFileChooserReadOnlyTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Component;
+import java.awt.Container;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.swing.Action;
+import javax.swing.JButton;
+import javax.swing.JFileChooser;
+import javax.swing.UIManager;
+import javax.swing.UIManager.LookAndFeelInfo;
+import javax.swing.UnsupportedLookAndFeelException;
+
+import static javax.swing.UIManager.getInstalledLookAndFeels;
+
+/*
+ * @test
+ * @key headful
+ * @bug 4525475
+ * @summary This testcase tests JDK-4525475 bug fix, checks whether JFileChooser
+ *          allows modification to the file-system by way of the "New Folder"
+ *          button or not, ideally a read-only JFileChooser shouldn't allow it.
+ * @run main JFileChooserReadOnlyTest
+ */
+public class JFileChooserReadOnlyTest {
+
+    private static boolean result = true;
+    private static boolean newFolderFound = false;
+
+    public static void main(String[] args) {
+
+        List<String> lafs = Arrays.stream(getInstalledLookAndFeels())
+                                  .map(LookAndFeelInfo::getClassName)
+                                  .collect(Collectors.toList());
+        for (final String laf : lafs) {
+            if (!setLookAndFeel(laf)) {
+                continue;
+            }
+
+            // Test1, Read Only JFileChooser
+            boolean readOnly = true;
+            createAndTestCustomFileChooser(readOnly);
+            System.out.println("Its a Read Only JFileChooser " +
+                               (newFolderFound ? "but it has" :
+                                "and it doesn't have") +
+                               " a New Folder Button found" +
+                               ", So the Test1 " +
+                               (result ? "Passed" : "Failed") + " for " + laf);
+
+            // Test2, Read/Write JFileChooser
+            if (!(laf.contains("Motif") || laf.contains("Aqua"))) {
+                createAndTestCustomFileChooser(readOnly = false);
+                System.out.println("Its a not a Read Only JFileChooser " +
+                                   (newFolderFound ? "and it has" :
+                                    "but it doesn't have") +
+                                   " a New Folder Button" + ", So the Test2 " +
+                                   (result ? "Passed" : "Failed") + " for " +
+                                   laf);
+            }
+
+            if (result) {
+                System.out.println("Test Passed for " + laf);
+            } else {
+                throw new RuntimeException(
+                        "Test Failed, JFileChooser readOnly flag is not " +
+                        "working properly for " + laf);
+            }
+        }
+    }
+
+    private static void createAndTestCustomFileChooser(boolean readOnly) {
+        newFolderFound = false;
+        UIManager.put("FileChooser.readOnly", Boolean.valueOf(readOnly));
+        JFileChooser jfc = new JFileChooser();
+        checkNewFolderButton(jfc, readOnly);
+        result = readOnly ^ newFolderFound;
+    }
+
+    private static void checkNewFolderButton(Container c, boolean readOnly) {
+        int n = c.getComponentCount();
+        for (int i = 0; i < n; i++) {
+            if (newFolderFound) {
+                break;
+            }
+            Component comp = c.getComponent(i);
+            if (comp instanceof JButton) {
+                JButton b = (JButton) comp;
+                Action action = b.getAction();
+                if (action != null) {
+                    String name = (String) action.getValue(Action.NAME);
+                    if (name != null && name.equals("New Folder")) {
+                        newFolderFound = true;
+                        System.out.println(
+                                "New Folder Button Found when readOnly = " +
+                                readOnly);
+                    }
+                }
+            } else if (comp instanceof Container) {
+                checkNewFolderButton((Container) comp, readOnly);
+            }
+        }
+    }
+
+    private static boolean setLookAndFeel(String lafName) {
+        try {
+            UIManager.setLookAndFeel(lafName);
+        } catch (UnsupportedLookAndFeelException ignored) {
+            System.out.println("Ignoring Unsupported L&F: " + lafName);
+            return false;
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+        return true;
+    }
+
+}


### PR DESCRIPTION
Write a regression test for [JDK-4525475](https://bugs.openjdk.java.net/browse/JDK-4525475)

Issue:
JFileChooser allows modification to the file-system by way of the "New Folder"
button, and the ability to rename file/folder names. There is no method on
JFileChooser which indicates that this type of modification should not be
allowed within the given JFileChooser.

Testing:
1. Tested using Mach5(20 times per platform) in macos,linux and windows and got all pass.
2. Tested in original failed Java version and the fixed version;
Java 1.4.0 -> Test Failed.
$ j2sdk1.4.0/bin/java Bug4525475
LookAndFeel: com.sun.java.swing.plaf.windows.WindowsLookAndFeel
Name = Go Up, readOnly = true
Name = New Folder, readOnly = true
Its a Read Only JFileChooser and has a New Folder Button. So Test Failed.
Name = Go Up, readOnly = false
Name = New Folder, readOnly = false
Failed

Java 1.5.0 -> Test Passed.
$ jdk1.5.0/bin/java Bug4525475
LookAndFeel: com.sun.java.swing.plaf.windows.WindowsLookAndFeel
Name = Go Up, readOnly = true
Name = Go Up, readOnly = false
Name = New Folder, readOnly = false
Passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283623](https://bugs.openjdk.java.net/browse/JDK-8283623): Create an automated regression test for JDK-4525475


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7969/head:pull/7969` \
`$ git checkout pull/7969`

Update a local copy of the PR: \
`$ git checkout pull/7969` \
`$ git pull https://git.openjdk.java.net/jdk pull/7969/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7969`

View PR using the GUI difftool: \
`$ git pr show -t 7969`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7969.diff">https://git.openjdk.java.net/jdk/pull/7969.diff</a>

</details>
