### PR TITLE
8282149: Some -Xlint keys are missing in javac man page

### DIFF
--- a/src/jdk.compiler/share/man/javac.1
+++ b/src/jdk.compiler/share/man/javac.1
@@ -778,6 +778,8 @@ switch statement to the next.
 \f[CB]finally\f[R]: Warns about \f[CB]finally\f[R] clauses that do not
 terminate normally.
 .IP \[bu] 2
+\f[CB]missing\-explicit\-ctor\f[R]: Warns about missing explicit constructors in public and protected classes in exported packages.
+.IP \[bu] 2
 \f[CB]module\f[R]: Warns about the module system\-related issues.
 .IP \[bu] 2
 \f[CB]opens\f[R]: Warns about the issues related to module opens.
@@ -813,6 +815,14 @@ element.
 .IP \[bu] 2
 \f[CB]static\f[R]: Warns about the accessing a static member using an
 instance.
+.IP \[bu] 2
+\f[CB]strictfp\f[R]: Warns about unnecessary use of the strictfp modifier.
+.IP \[bu] 2
+\f[CB]synchronization\f[R]: Warns about synchronization attempts on instances of value\-based classes
+.IP \[bu] 2
+\f[CB]text\-blocks\f[R]: Warns about inconsistent white space characters in text block indentation.
+.IP \[bu] 2
+\f[CB]preview\f[R]: Warns about use of preview language features.
 .IP \[bu] 2
 \f[CB]try\f[R]: Warns about the issues relating to the use of try blocks (
 that is, try\-with\-resources).

--- a/src/jdk.compiler/share/man/javac.1
+++ b/src/jdk.compiler/share/man/javac.1
@@ -818,7 +818,7 @@ instance.
 .IP \[bu] 2
 \f[CB]strictfp\f[R]: Warns about unnecessary use of the strictfp modifier.
 .IP \[bu] 2
-\f[CB]synchronization\f[R]: Warns about synchronization attempts on instances of value\-based classes
+\f[CB]synchronization\f[R]: Warns about synchronization attempts on instances of value\-based classes.
 .IP \[bu] 2
 \f[CB]text\-blocks\f[R]: Warns about inconsistent white space characters in text block indentation.
 .IP \[bu] 2


### PR DESCRIPTION
Adds all the XLint options that were noted as missing in the man page by the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8282149](https://bugs.openjdk.java.net/browse/JDK-8282149): Some -Xlint keys are missing in javac man page


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7971/head:pull/7971` \
`$ git checkout pull/7971`

Update a local copy of the PR: \
`$ git checkout pull/7971` \
`$ git pull https://git.openjdk.java.net/jdk pull/7971/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7971`

View PR using the GUI difftool: \
`$ git pr show -t 7971`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7971.diff">https://git.openjdk.java.net/jdk/pull/7971.diff</a>

</details>
