### PR TITLE
8283799: Collapse identical catch branches in jdk.hotspot.agent

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotAgent.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotAgent.java
@@ -477,12 +477,8 @@ public class HotSpotAgent {
             throw new DebuggerException("Cannot find alternate SA Debugger: '" + alternateName + "'");
         } catch (NoSuchMethodException nsme) {
             throw new DebuggerException("Alternate SA Debugger: '" + alternateName + "' has missing constructor.");
-        } catch (InstantiationException ie) {
-            throw new DebuggerException("Alternate SA Debugger: '" + alternateName + "' fails to initialise: ", ie);
-        } catch (IllegalAccessException iae) {
-            throw new DebuggerException("Alternate SA Debugger: '" + alternateName + "' fails to initialise: ", iae);
-        } catch (InvocationTargetException iae) {
-            throw new DebuggerException("Alternate SA Debugger: '" + alternateName + "' fails to initialise: ", iae);
+        } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
+            throw new DebuggerException("Alternate SA Debugger: '" + alternateName + "' fails to initialise: ", e);
         }
 
         System.err.println("Loaded alternate HotSpot SA Debugger: " + alternateName);

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/win32/coff/COFFFileParser.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/win32/coff/COFFFileParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,8 +76,6 @@ public class COFFFileParser {
       // a bug if there is one. (FIXME)
       //   buf.order(ByteOrder.nativeOrder());
       return parse(new MappedByteBufferDataSource(buf));
-    } catch (FileNotFoundException e) {
-      throw new COFFException(e);
     } catch (IOException e) {
       throw new COFFException(e);
     }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MemoryPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MemoryPanel.java
@@ -31,12 +31,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.math.*;
-import java.util.*;
 import javax.swing.*;
 import javax.swing.event.*;
 import javax.swing.table.*;
 import sun.jvm.hotspot.debugger.*;
-import sun.jvm.hotspot.ui.*;
 import sun.jvm.hotspot.utilities.PointerFinder;
 import sun.jvm.hotspot.utilities.PointerLocation;
 
@@ -219,8 +217,7 @@ public class MemoryPanel extends JPanel {
               String str = (String)t.getTransferData(DataFlavor.stringFlavor);
               handleImport(c, str);
               return true;
-            } catch (UnsupportedFlavorException ufe) {
-            } catch (IOException ioe) {
+            } catch (UnsupportedFlavorException | IOException e) {
             }
           }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/tree/CTypeTreeNodeAdapter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/tree/CTypeTreeNodeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -132,11 +132,7 @@ public class CTypeTreeNodeAdapter extends FieldTreeNodeAdapter {
         try {
           Oop oop = VM.getVM().getObjectHeap().newOop(handle);
           return new OopTreeNodeAdapter(oop, cf, getTreeTableMode());
-        } catch (AddressException e) {
-          return new BadAddressTreeNodeAdapter(handle,
-                                           new CTypeFieldIdentifier(type, f),
-                                           getTreeTableMode());
-        } catch (UnknownOopException e) {
+        } catch (AddressException | UnknownOopException e) {
           return new BadAddressTreeNodeAdapter(handle,
                                            new CTypeFieldIdentifier(type, f),
                                            getTreeTableMode());

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/tree/MetadataTreeNodeAdapter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/tree/MetadataTreeNodeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -153,9 +153,7 @@ public class MetadataTreeNodeAdapter extends FieldTreeNodeAdapter {
       if (curField == index) {
         try {
           child = new MetadataTreeNodeAdapter(field.getValue(getObj()), field.getID(), getTreeTableMode());
-        } catch (AddressException e) {
-          child = new BadAddressTreeNodeAdapter(getObj().getAddress().getAddressAt(field.getOffset()), field, getTreeTableMode());
-        } catch (UnknownOopException e) {
+        } catch (AddressException | UnknownOopException e) {
           child = new BadAddressTreeNodeAdapter(getObj().getAddress().getAddressAt(field.getOffset()), field, getTreeTableMode());
         }
       }
@@ -166,9 +164,7 @@ public class MetadataTreeNodeAdapter extends FieldTreeNodeAdapter {
       if (curField == index) {
         try {
           child = new OopTreeNodeAdapter(field.getValue(getObj()), field.getID(), getTreeTableMode());
-        } catch (AddressException e) {
-          child = new BadAddressTreeNodeAdapter(field.getValueAsOopHandle(getObj()), field, getTreeTableMode());
-        } catch (UnknownOopException e) {
+        } catch (AddressException | UnknownOopException e) {
           child = new BadAddressTreeNodeAdapter(field.getValueAsOopHandle(getObj()), field, getTreeTableMode());
         }
       }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/tree/OopTreeNodeAdapter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/tree/OopTreeNodeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -160,9 +160,7 @@ public class OopTreeNodeAdapter extends FieldTreeNodeAdapter {
       if (curField == index) {
         try {
           child = new MetadataTreeNodeAdapter(field.getValue(getObj()), field.getID(), getTreeTableMode());
-        } catch (AddressException e) {
-          child = new BadAddressTreeNodeAdapter(getObj().getHandle().getAddressAt(field.getOffset()), field, getTreeTableMode());
-        } catch (UnknownOopException e) {
+        } catch (AddressException | UnknownOopException e) {
           child = new BadAddressTreeNodeAdapter(getObj().getHandle().getAddressAt(field.getOffset()), field, getTreeTableMode());
         }
       }
@@ -173,9 +171,7 @@ public class OopTreeNodeAdapter extends FieldTreeNodeAdapter {
       if (curField == index) {
         try {
           child = new OopTreeNodeAdapter(field.getValue(getObj()), field.getID(), getTreeTableMode());
-        } catch (AddressException e) {
-          child = new BadAddressTreeNodeAdapter(field.getValueAsOopHandle(getObj()), field, getTreeTableMode());
-        } catch (UnknownOopException e) {
+        } catch (AddressException | UnknownOopException e) {
           child = new BadAddressTreeNodeAdapter(field.getValueAsOopHandle(getObj()), field, getTreeTableMode());
         }
       }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/ReversePtrsAnalysis.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/ReversePtrsAnalysis.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@ import sun.jvm.hotspot.gc.shared.*;
 import sun.jvm.hotspot.memory.*;
 import sun.jvm.hotspot.oops.*;
 import sun.jvm.hotspot.runtime.*;
-import sun.jvm.hotspot.utilities.*;
 
 /** For a set of known roots, descends recursively into the object
     graph, for each object recording those objects (and their fields)
@@ -259,9 +258,6 @@ public class ReversePtrsAnalysis {
       }
     } catch (EmptyStackException e) {
       // Done
-    } catch (NullPointerException e) {
-      System.err.println("ReversePtrs: WARNING: " + e +
-        " during traversal");
     } catch (Exception e) {
       System.err.println("ReversePtrs: WARNING: " + e +
         " during traversal");

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/RobustOopDeterminator.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/RobustOopDeterminator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,15 +24,10 @@
 
 package sun.jvm.hotspot.utilities;
 
-import java.util.*;
 import sun.jvm.hotspot.debugger.*;
-import sun.jvm.hotspot.memory.*;
 import sun.jvm.hotspot.oops.Metadata;
-import sun.jvm.hotspot.oops.Klass;
 import sun.jvm.hotspot.runtime.*;
 import sun.jvm.hotspot.types.*;
-import sun.jvm.hotspot.utilities.Observable;
-import sun.jvm.hotspot.utilities.Observer;
 
 /** This class determines to the best of its ability, and in a
     reasonably robust fashion, whether a given pointer is an intact
@@ -77,9 +72,7 @@ public class RobustOopDeterminator {
         Metadata.instantiateWrapperFor(klassField.getValue(oop));
       }
       return true;
-    } catch (AddressException e) {
-      return false;
-    } catch (WrongTypeException e) {
+    } catch (AddressException | WrongTypeException e) {
       return false;
     }
   }


### PR DESCRIPTION
Let's take advantage of Java 7 languate feature - "Catching Multiple Exception Types".
It simplifies code. Reduce duplication.
Found by IntelliJ IDEA inspection `Identical 'catch' branches in 'try' statement`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283799](https://bugs.openjdk.java.net/browse/JDK-8283799): Collapse identical catch branches in jdk.hotspot.agent


### Reviewers
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7973/head:pull/7973` \
`$ git checkout pull/7973`

Update a local copy of the PR: \
`$ git checkout pull/7973` \
`$ git pull https://git.openjdk.java.net/jdk pull/7973/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7973`

View PR using the GUI difftool: \
`$ git pr show -t 7973`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7973.diff">https://git.openjdk.java.net/jdk/pull/7973.diff</a>

</details>
