### PR TITLE
8283727: P11KeyGenerator has import statement with two semicolons after JDK-8267319

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyGenerator.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyGenerator.java
@@ -30,7 +30,7 @@ import java.security.spec.AlgorithmParameterSpec;
 
 import javax.crypto.*;
 
-import sun.security.util.SecurityProviderConstants;;
+import sun.security.util.SecurityProviderConstants;
 import static sun.security.pkcs11.TemplateManager.*;
 import sun.security.pkcs11.wrapper.*;
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;


### PR DESCRIPTION
Remove double semicolon

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283727](https://bugs.openjdk.java.net/browse/JDK-8283727): P11KeyGenerator has import statement with two semicolons after JDK-8267319


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7976/head:pull/7976` \
`$ git checkout pull/7976`

Update a local copy of the PR: \
`$ git checkout pull/7976` \
`$ git pull https://git.openjdk.java.net/jdk pull/7976/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7976`

View PR using the GUI difftool: \
`$ git pr show -t 7976`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7976.diff">https://git.openjdk.java.net/jdk/pull/7976.diff</a>

</details>
