### PR TITLE
8283725: Launching java with "-Xlog:gc*=trace,safepoint*=trace,class*=trace" crashes the JVM

### DIFF
--- a/src/hotspot/share/logging/logOutput.cpp
+++ b/src/hotspot/share/logging/logOutput.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -334,6 +334,11 @@ void LogOutput::update_config_string(const size_t on_level[LogLevel::Count]) {
 
     assert(n_deviates < deviating_tagsets, "deviating tag set array overflow");
     assert(prev_deviates > n_deviates, "number of deviating tag sets must never grow");
+
+    if (n_deviates == 1 && n_selections == 0) {
+      // we're done as we couldn't reduce things any further
+      break;
+    }
   }
   FREE_C_HEAP_ARRAY(LogTagSet*, deviates);
   FREE_C_HEAP_ARRAY(Selection, selections);


### PR DESCRIPTION
I think the loop termination condition in `LogOutput::update_config_string` is not quite correct. We process "deviating tagsets" until there are no more - tracking `n_deviants` and `n_selections`. However, we can reach the case where `n_deviants == 1` and there are no further selections possible - `add_selections` finds no more subsets for the given tagset. This causes the guarantee to fire as it expects to see selections as long as we still have deviations. We can fix this by adding a new check at the bottom of the loop:
```
    if (n_deviates == 1 && n_selections == 0) {
      // we're done as we couldn't reduce things any further
      break;
    }
```
I do not know what a "deviating tagset" means so it is unclear whether the bug is not checking for this "1 and 0" case, or whether the bug is that we got that final 0. Hopefully someone else may be able to expand on that.

Testing:
- tiers 1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283725](https://bugs.openjdk.java.net/browse/JDK-8283725): Launching java with "-Xlog:gc*=trace,safepoint*=trace,class*=trace" crashes the JVM


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7978/head:pull/7978` \
`$ git checkout pull/7978`

Update a local copy of the PR: \
`$ git checkout pull/7978` \
`$ git pull https://git.openjdk.java.net/jdk pull/7978/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7978`

View PR using the GUI difftool: \
`$ git pr show -t 7978`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7978.diff">https://git.openjdk.java.net/jdk/pull/7978.diff</a>

</details>
