### PR TITLE
8283737: riscv: MacroAssembler::stop() should emit fixed-length instruction sequence

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -2795,7 +2795,7 @@ public:
   }
 
   INSN(beq, c_beqz, _beq);
-  INSN(bne, c_beqz, _bne);
+  INSN(bne, c_bnez, _bne);
 
 #undef INSN
 

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -2795,7 +2795,7 @@ public:
   }
 
   INSN(beq, c_beqz, _beq);
-  INSN(bne, c_bnez, _bne);
+  INSN(bne, c_beqz, _bne);
 
 #undef INSN
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -532,8 +532,8 @@ void MacroAssembler::stop(const char* msg) {
   address ip = pc();
   pusha();
   // The length of the instruction sequence emitted should be independent
-  // of the values of msg and ip so that size of mach node for scratch emit
-  // and normal emit.
+  // of the values of msg and ip so that the size of mach nodes for scratch
+  // emit and normal emit matches.
   mv(c_rarg0, (address)msg);
   mv(c_rarg1, (address)ip);
   mv(c_rarg2, sp);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -529,10 +529,11 @@ void MacroAssembler::resolve_jobject(Register value, Register thread, Register t
 }
 
 void MacroAssembler::stop(const char* msg) {
-  // these shall generate fixed-length instruction sequences
-  // because machnode size of scratch_emit() and emit() should match
   address ip = pc();
   pusha();
+  // The length of the instruction sequence emitted should be independent
+  // of the values of msg and ip so that size of mach node for scratch emit
+  // and normal emit.
   mv(c_rarg0, (address)msg);
   mv(c_rarg1, (address)ip);
   mv(c_rarg2, sp);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -529,10 +529,12 @@ void MacroAssembler::resolve_jobject(Register value, Register thread, Register t
 }
 
 void MacroAssembler::stop(const char* msg) {
+  // these shall generate fixed-length instruction sequences
+  // because machnode size of scratch_emit() and emit() should match
   address ip = pc();
   pusha();
-  li(c_rarg0, (uintptr_t)(address)msg);
-  li(c_rarg1, (uintptr_t)(address)ip);
+  mv(c_rarg0, (address)msg);
+  mv(c_rarg1, (address)ip);
   mv(c_rarg2, sp);
   mv(c_rarg3, CAST_FROM_FN_PTR(address, MacroAssembler::debug64));
   jalr(c_rarg3);


### PR DESCRIPTION
Hi team,

Could I have a review of this simple patch? -

`PhaseOutput::fill_buffer` detects if the real size of a node matches (<=) the size of it in scratch_emit(). The call chain for MacroAssembler::stop() is:

```
MachEpilogNode::emit
    -> reserved_stack_check()
         -> should_not_reach_here()
              -> stop(const char *msg)
```

`li()` on RISCV could generate 1~6 instructions, and the msg argument could be an on-stack buffer; `stop()` also uses `__ pc()` that could also be different in `scratch_emit()` and `emit()`. They both have the potential issue here so the size generated in `MacroAssembler::stop()` needs to be a fixed value.

Could be reproduced in the fastdebug build by adding one line:

```
// Die now.
instruct ShouldNotReachHere() %{
  match(Halt);
  ins_cost(BRANCH_COST);
  format %{ "#@ShouldNotReachHere" %}
  ins_encode %{
    Assembler::CompressibleRegion cr(&_masm);
    if (is_reachable()) {
      __ halt();
+     __ unimplemented("this is an on-stack char literal");  // assertion fail at 'assert(false, "wrong size of mach node");'
    }
  %}
  ins_pipe(pipe_class_default);
%}
```

Tests passed in hotspot tier1 & jdk tier1 without new errors found.

Thanks,
Xiaolin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283737](https://bugs.openjdk.java.net/browse/JDK-8283737): riscv: MacroAssembler::stop() should emit fixed-length instruction sequence


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - Committer) ⚠️ Review applies to 1106943de57d87b636dc9185b1c1893055573ebf
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7982/head:pull/7982` \
`$ git checkout pull/7982`

Update a local copy of the PR: \
`$ git checkout pull/7982` \
`$ git pull https://git.openjdk.java.net/jdk pull/7982/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7982`

View PR using the GUI difftool: \
`$ git pr show -t 7982`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7982.diff">https://git.openjdk.java.net/jdk/pull/7982.diff</a>

</details>
