### PR TITLE
8283642: JavaDoc of JFileChooser() need to be updated for default directory in Windows

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JFileChooser.java
+++ b/src/java.desktop/share/classes/javax/swing/JFileChooser.java
@@ -303,7 +303,7 @@ public class JFileChooser extends JComponent implements Accessible {
     /**
      * Constructs a <code>JFileChooser</code> pointing to the user's
      * default directory. This default depends on the operating system.
-     * It is typically the "My Documents" folder on Windows, and the
+     * It is typically the "Documents" folder on Windows, and the
      * user's home directory on Unix.
      */
     public JFileChooser() {
@@ -315,7 +315,7 @@ public class JFileChooser extends JComponent implements Accessible {
      * Passing in a <code>null</code>
      * string causes the file chooser to point to the user's default directory.
      * This default depends on the operating system. It is
-     * typically the "My Documents" folder on Windows, and the user's
+     * typically the "Documents" folder on Windows, and the user's
      * home directory on Unix.
      *
      * @param currentDirectoryPath  a <code>String</code> giving the path
@@ -330,7 +330,7 @@ public class JFileChooser extends JComponent implements Accessible {
      * as the path. Passing in a <code>null</code> file
      * causes the file chooser to point to the user's default directory.
      * This default depends on the operating system. It is
-     * typically the "My Documents" folder on Windows, and the user's
+     * typically the "Documents" folder on Windows, and the user's
      * home directory on Unix.
      *
      * @param currentDirectory  a <code>File</code> object specifying
@@ -570,7 +570,7 @@ public class JFileChooser extends JComponent implements Accessible {
      * Sets the current directory. Passing in <code>null</code> sets the
      * file chooser to point to the user's default directory.
      * This default depends on the operating system. It is
-     * typically the "My Documents" folder on Windows, and the user's
+     * typically the "Documents" folder on Windows, and the user's
      * home directory on Unix.
      *
      * If the file passed in as <code>currentDirectory</code> is not a


### PR DESCRIPTION
Default directory name has changed from "My Documents" to "Documents" in recent WIndows version, so javadoc needs to be updated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283642](https://bugs.openjdk.java.net/browse/JDK-8283642): JavaDoc of JFileChooser() need to be updated for default directory in Windows


### Reviewers
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7983/head:pull/7983` \
`$ git checkout pull/7983`

Update a local copy of the PR: \
`$ git checkout pull/7983` \
`$ git pull https://git.openjdk.java.net/jdk pull/7983/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7983`

View PR using the GUI difftool: \
`$ git pr show -t 7983`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7983.diff">https://git.openjdk.java.net/jdk/pull/7983.diff</a>

</details>
