### PR TITLE
8283756: (zipfs) ZipFSOutputStreamTest.testOutputStream should only check inflated bytes

### DIFF
--- a/test/jdk/jdk/nio/zipfs/ZipFSOutputStreamTest.java
+++ b/test/jdk/jdk/nio/zipfs/ZipFSOutputStreamTest.java
@@ -117,7 +117,7 @@ public class ZipFSOutputStreamTest {
                     while ((numRead = is.read(buf)) != -1) {
                         totalRead += numRead;
                         // verify the content
-                        Assert.assertEquals(Arrays.mismatch(buf, chunk), -1,
+                        Assert.assertEquals(Arrays.mismatch(buf, 0, numRead, chunk, 0, numRead), -1,
                                 "Unexpected content in " + entryPath);
                     }
                     System.out.println("Read entry " + entryPath + " of bytes " + totalRead


### PR DESCRIPTION
The test `ZipFSOutputStreamTest` deflates content into a zip file system and subsequently inflates the deflated files and checks their content against the original data.

The content consists of a data stream of bytes with the value `42`.

The check currently compares the temporary inflation buffer with the original source buffer, no matter how many bytes were inflated into the inflation buffer. This can lead to problems with alternative zlib implementations which sometimes write beyond the last inflated byte (see [JDK-8282648](https://bugs.openjdk.java.net/browse/JDK-8282648) for more details).

The fix is trivial. Only compare as many bytes as have been inflated against the original content.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283756](https://bugs.openjdk.java.net/browse/JDK-8283756): (zipfs) ZipFSOutputStreamTest.testOutputStream should only check inflated bytes


### Reviewers
 * [Jaikiran Pai](https://openjdk.java.net/census#jpai) (@jaikiran - Committer) ⚠️ Review applies to 6f121a227379aeee4d59f495cc6231f720390a20
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to 6f121a227379aeee4d59f495cc6231f720390a20
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7984/head:pull/7984` \
`$ git checkout pull/7984`

Update a local copy of the PR: \
`$ git checkout pull/7984` \
`$ git pull https://git.openjdk.java.net/jdk pull/7984/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7984`

View PR using the GUI difftool: \
`$ git pr show -t 7984`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7984.diff">https://git.openjdk.java.net/jdk/pull/7984.diff</a>

</details>
