### PR TITLE
8224977: [macos] On AquaLookAndFeel, Iconified JInternalFrame does not restore when Control + F5 is used.

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -720,7 +720,6 @@ javax/swing/text/DefaultCaret/HidingSelection/MultiSelectionTest.java 8213562 li
 javax/swing/JFileChooser/6798062/bug6798062.java 8146446 windows-all
 javax/swing/JComboBox/8182031/ComboPopupTest.java 8196465 linux-all,macosx-all
 javax/swing/JFileChooser/6738668/bug6738668.java 8194946 generic-all
-javax/swing/JInternalFrame/Test6325652.java 8224977 macosx-all
 javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all,linux-all
 javax/swing/PopupFactory/6276087/NonOpaquePopupMenuTest.java 8065099,8208565 macosx-all,linux-all
 javax/swing/dnd/8139050/NativeErrorsInTableDnD.java 8202765  macosx-all,linux-all

--- a/test/jdk/javax/swing/JInternalFrame/Test6325652.java
+++ b/test/jdk/javax/swing/JInternalFrame/Test6325652.java
@@ -25,6 +25,7 @@
  * @test
  * @key headful
  * @bug 6325652 8159152
+ * @requires (os.family != "mac")
  * @summary Tests keyboard shortcuts
  * @library ..
  */


### PR DESCRIPTION
test/jdk/javax/swing/JInternalFrame/Test6325652.java test was failing in macos in Aqua L&F due to nonsupport in macos of such shortcuts Ctrl+F5 to restore or Ctrl+F9 to iconify. Keyboard->Shortcut in macos System->Preference do not have these shortcut usage.
https://docs.oracle.com/javase/tutorial/uiswing/components/internalframe.html also does not talk of these shortcut support as standard.
So, removed this test from macos run.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8224977](https://bugs.openjdk.java.net/browse/JDK-8224977): [macos] On AquaLookAndFeel, Iconified JInternalFrame does not restore when Control + F5 is used.


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7985/head:pull/7985` \
`$ git checkout pull/7985`

Update a local copy of the PR: \
`$ git checkout pull/7985` \
`$ git pull https://git.openjdk.java.net/jdk pull/7985/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7985`

View PR using the GUI difftool: \
`$ git pr show -t 7985`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7985.diff">https://git.openjdk.java.net/jdk/pull/7985.diff</a>

</details>
