### PR TITLE
8282648: Weaken the InflaterInputStream specification in order to allow faster Zip implementations

### DIFF
--- a/src/java.base/share/classes/java/net/URLConnection.java
+++ b/src/java.base/share/classes/java/net/URLConnection.java
@@ -840,6 +840,13 @@ public abstract class URLConnection {
      * returned input stream if the read timeout expires before data
      * is available for read.
      *
+     * @apiNote The {@code InputStream} returned by this method can wrap
+     * an {@link java.util.zip.InflaterInputStream InflaterInputStream}
+     * which leaves the contents of the output buffer beyond the
+     * last inflated byte undefined after a read operation (see {@link
+     * java.util.zip.InflaterInputStream#read(byte[], int, int)
+     * InflaterInputStream.read(byte[], int, int)}).
+     *
      * @return     an input stream that reads from this open connection.
      * @throws     IOException              if an I/O error occurs while
      *               creating the input stream.

--- a/src/java.base/share/classes/java/net/URLConnection.java
+++ b/src/java.base/share/classes/java/net/URLConnection.java
@@ -840,12 +840,11 @@ public abstract class URLConnection {
      * returned input stream if the read timeout expires before data
      * is available for read.
      *
-     * @apiNote The {@code InputStream} returned by this method can wrap
-     * an {@link java.util.zip.InflaterInputStream InflaterInputStream}
-     * which leaves the contents of the output buffer beyond the
-     * last inflated byte undefined after a read operation (see {@link
-     * java.util.zip.InflaterInputStream#read(byte[], int, int)
-     * InflaterInputStream.read(byte[], int, int)}).
+     * @apiNote The {@code InputStream} returned by this method can wrap an
+     * {@link java.util.zip.InflaterInputStream InflaterInputStream}, whose
+     * {@link java.util.zip.InflaterInputStream#read(byte[], int, int)
+     * read(byte[], int, int)} method can modify any element of the output
+     * buffer.
      *
      * @return     an input stream that reads from this open connection.
      * @throws     IOException              if an I/O error occurs while

--- a/src/java.base/share/classes/java/util/jar/JarFile.java
+++ b/src/java.base/share/classes/java/util/jar/JarFile.java
@@ -822,6 +822,13 @@ public class JarFile extends ZipFile {
     /**
      * Returns an input stream for reading the contents of the specified
      * zip file entry.
+     *
+     * @apiNote This method can return an {@link java.util.zip.InflaterInputStream
+     * InflaterInputStream} which leaves the contents of the output buffer beyond
+     * the last inflated byte undefined after a read operation (see {@link
+     * java.util.zip.InflaterInputStream#read(byte[], int, int)
+     * InflaterInputStream.read(byte[], int, int)}).
+     *
      * @param ze the zip file entry
      * @return an input stream for reading the contents of the specified
      *         zip file entry or null if the zip file entry does not exist

--- a/src/java.base/share/classes/java/util/jar/JarFile.java
+++ b/src/java.base/share/classes/java/util/jar/JarFile.java
@@ -823,11 +823,11 @@ public class JarFile extends ZipFile {
      * Returns an input stream for reading the contents of the specified
      * zip file entry.
      *
-     * @apiNote This method can return an {@link java.util.zip.InflaterInputStream
-     * InflaterInputStream} which leaves the contents of the output buffer beyond
-     * the last inflated byte undefined after a read operation (see {@link
-     * java.util.zip.InflaterInputStream#read(byte[], int, int)
-     * InflaterInputStream.read(byte[], int, int)}).
+     * @apiNote The {@code InputStream} returned by this method can wrap an
+     * {@link java.util.zip.InflaterInputStream InflaterInputStream}, whose
+     * {@link java.util.zip.InflaterInputStream#read(byte[], int, int)
+     * read(byte[], int, int)} method can modify any element of the output
+     * buffer.
      *
      * @param ze the zip file entry
      * @return an input stream for reading the contents of the specified

--- a/src/java.base/share/classes/java/util/jar/JarInputStream.java
+++ b/src/java.base/share/classes/java/util/jar/JarInputStream.java
@@ -167,7 +167,7 @@ public class JarInputStream extends ZipInputStream {
     }
 
     /**
-     * Reads from the current ZIP entry into an array of bytes, returning the number of
+     * Reads from the current JAR entry into an array of bytes, returning the number of
      * inflated bytes. If {@code len} is not zero, the method blocks until some input is
      * available; otherwise, no bytes are read and {@code 0} is returned.
      * <p>

--- a/src/java.base/share/classes/java/util/jar/JarInputStream.java
+++ b/src/java.base/share/classes/java/util/jar/JarInputStream.java
@@ -171,13 +171,16 @@ public class JarInputStream extends ZipInputStream {
      * inflated bytes. If {@code len} is not zero, the method blocks until some input is
      * available; otherwise, no bytes are read and {@code 0} is returned.
      * <p>
-     * If the current entry is compressed and <i>n</i> denotes a nonzero number of inflated
-     * bytes to return, then {@code b[off]} trough {@code b[off+}<i>n</i>{@code -1]} will
-     * contain the uncompressed data. The elements {@code b[off+}<i>n</i>{@code ]} through
-     * {@code b[off+}<i>len</i>{@code -1]} are undefined (an implementation is free to
-     * change them during the inflate operation). If the return value is -1 or an exception
-     * is thrown, then the content of {@code b[off]} to {@code b[off+}<i>len</i>{@code -1]}
-     * is undefined.
+     * If the current entry is compressed and this method returns a nonzero
+     * integer <i>n</i> then {@code buf[off]}
+     * through {@code buf[off+}<i>n</i>{@code -1]} contain the uncompressed
+     * data.  The content of elements {@code buf[off+}<i>n</i>{@code ]} through
+     * {@code buf[off+}<i>len</i>{@code -1]} is undefined, contrary to the
+     * specification of the {@link java.io.InputStream InputStream} superclass,
+     * so an implementation is free to modify these elements during the inflate
+     * operation. If this method returns {@code -1} or throws an exception then
+     * the content of {@code buf[off]} through {@code buf[off+}<i>len</i>{@code
+     * -1]} is undefined.
      * <p>
      * If verification has been enabled, any invalid signature
      * on the current entry will be reported at some point before the

--- a/src/java.base/share/classes/java/util/jar/JarInputStream.java
+++ b/src/java.base/share/classes/java/util/jar/JarInputStream.java
@@ -167,10 +167,18 @@ public class JarInputStream extends ZipInputStream {
     }
 
     /**
-     * Reads from the current JAR file entry into an array of bytes.
-     * If {@code len} is not zero, the method
-     * blocks until some input is available; otherwise, no
-     * bytes are read and {@code 0} is returned.
+     * Reads from the current ZIP entry into an array of bytes, returning the number of
+     * inflated bytes. If {@code len} is not zero, the method blocks until some input is
+     * available; otherwise, no bytes are read and {@code 0} is returned.
+     * <p>
+     * If the current entry is compressed and <i>n</i> denotes a nonzero number of inflated
+     * bytes to return, then {@code b[off]} trough {@code b[off+}<i>n</i>{@code -1]} will
+     * contain the uncompressed data. The elements {@code b[off+}<i>n</i>{@code ]} through
+     * {@code b[off+}<i>len</i>{@code -1]} are undefined (an implementation is free to
+     * change them during the inflate operation). If the return value is -1 or an exception
+     * is thrown, then the content of {@code b[off]} to {@code b[off+}<i>len</i>{@code -1]}
+     * is undefined.
+     * <p>
      * If verification has been enabled, any invalid signature
      * on the current entry will be reported at some point before the
      * end of the entry is reached.

--- a/src/java.base/share/classes/java/util/zip/GZIPInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/GZIPInputStream.java
@@ -95,6 +95,14 @@ public class GZIPInputStream extends InflaterInputStream {
      * Reads uncompressed data into an array of bytes. If {@code len} is not
      * zero, the method will block until some input can be decompressed; otherwise,
      * no bytes are read and {@code 0} is returned.
+     * <p>
+     * If <i>n</i> denotes the returned number of inflated bytes then {@code buf[off]}
+     * trough {@code buf[off+}<i>n</i>{@code -1]} will contain the uncompressed data. The
+     * elements {@code buf[off+}<i>n</i>{@code ]} through {@code buf[off+}<i>len</i>{@code -1]}
+     * are undefined and an implementation is free to change them during the inflate
+     * operation. If the return value is -1 or an exception is thrown the whole
+     * content of {@code buf} is undefined.
+     *
      * @param buf the buffer into which the data is read
      * @param off the start offset in the destination array {@code b}
      * @param len the maximum number of bytes read

--- a/src/java.base/share/classes/java/util/zip/GZIPInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/GZIPInputStream.java
@@ -96,17 +96,20 @@ public class GZIPInputStream extends InflaterInputStream {
      * bytes. If {@code len} is not zero, the method will block until some input can be
      * decompressed; otherwise, no bytes are read and {@code 0} is returned.
      * <p>
-     * If <i>n</i> denotes a nonzero number of inflated bytes to return, then {@code buf[off]}
-     * through {@code buf[off+}<i>n</i>{@code -1]} will contain the uncompressed data. The
-     * elements {@code buf[off+}<i>n</i>{@code ]} through {@code buf[off+}<i>len</i>{@code -1]}
-     * are undefined (an implementation is free to change them during the inflate
-     * operation). If the return value is -1 or an exception is thrown, then the content of
-     * {@code buf[off]} to {@code buf[off+}<i>len</i>{@code -1]} is undefined.
+     * If this method returns a nonzero integer <i>n</i> then {@code buf[off]}
+     * through {@code buf[off+}<i>n</i>{@code -1]} contain the uncompressed
+     * data.  The content of elements {@code buf[off+}<i>n</i>{@code ]} through
+     * {@code buf[off+}<i>len</i>{@code -1]} is undefined, contrary to the
+     * specification of the {@link java.io.InputStream InputStream} superclass,
+     * so an implementation is free to modify these elements during the inflate
+     * operation. If this method returns {@code -1} or throws an exception then
+     * the content of {@code buf[off]} through {@code buf[off+}<i>len</i>{@code
+     * -1]} is undefined.
      *
      * @param buf the buffer into which the data is read
      * @param off the start offset in the destination array {@code buf}
      * @param len the maximum number of bytes read
-     * @return  the actual number of inflated bytes, or -1 if the end of the
+     * @return  the actual number of bytes inflated, or -1 if the end of the
      *          compressed input stream is reached
      *
      * @throws     NullPointerException If {@code buf} is {@code null}.

--- a/src/java.base/share/classes/java/util/zip/GZIPInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/GZIPInputStream.java
@@ -96,12 +96,12 @@ public class GZIPInputStream extends InflaterInputStream {
      * zero, the method will block until some input can be decompressed; otherwise,
      * no bytes are read and {@code 0} is returned.
      * <p>
-     * If <i>n</i> denotes the returned number of inflated bytes then {@code buf[off]}
+     * If <i>n</i> denotes the returned number of inflated bytes, then {@code buf[off]}
      * through {@code buf[off+}<i>n</i>{@code -1]} will contain the uncompressed data. The
      * elements {@code buf[off+}<i>n</i>{@code ]} through {@code buf[off+}<i>len</i>{@code -1]}
      * are undefined (an implementation is free to change them during the inflate
-     * operation). If the return value is -1 or an exception is thrown then {@code buf[off]}
-     * to {@code buf[off+}<i>len</i>{@code -1]} is undefined.
+     * operation). If the return value is -1 or an exception is thrown, then the content of
+     * {@code buf[off]} to {@code buf[off+}<i>len</i>{@code -1]} is undefined.
      *
      * @param buf the buffer into which the data is read
      * @param off the start offset in the destination array {@code buf}

--- a/src/java.base/share/classes/java/util/zip/GZIPInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/GZIPInputStream.java
@@ -92,11 +92,11 @@ public class GZIPInputStream extends InflaterInputStream {
     }
 
     /**
-     * Reads uncompressed data into an array of bytes. If {@code len} is not
-     * zero, the method will block until some input can be decompressed; otherwise,
-     * no bytes are read and {@code 0} is returned.
+     * Reads uncompressed data into an array of bytes, returning the number of inflated
+     * bytes. If {@code len} is not zero, the method will block until some input can be
+     * decompressed; otherwise, no bytes are read and {@code 0} is returned.
      * <p>
-     * If <i>n</i> denotes the returned number of inflated bytes, then {@code buf[off]}
+     * If <i>n</i> denotes a nonzero number of inflated bytes to return, then {@code buf[off]}
      * through {@code buf[off+}<i>n</i>{@code -1]} will contain the uncompressed data. The
      * elements {@code buf[off+}<i>n</i>{@code ]} through {@code buf[off+}<i>len</i>{@code -1]}
      * are undefined (an implementation is free to change them during the inflate

--- a/src/java.base/share/classes/java/util/zip/GZIPInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/GZIPInputStream.java
@@ -99,14 +99,14 @@ public class GZIPInputStream extends InflaterInputStream {
      * If <i>n</i> denotes the returned number of inflated bytes then {@code buf[off]}
      * through {@code buf[off+}<i>n</i>{@code -1]} will contain the uncompressed data. The
      * elements {@code buf[off+}<i>n</i>{@code ]} through {@code buf[off+}<i>len</i>{@code -1]}
-     * are undefined and an implementation is free to change them during the inflate
-     * operation. If the return value is -1 or an exception is thrown the whole
-     * content of {@code buf} is undefined.
+     * are undefined (an implementation is free to change them during the inflate
+     * operation). If the return value is -1 or an exception is thrown then {@code buf[off]}
+     * to {@code buf[off+}<i>len</i>{@code -1]} is undefined.
      *
      * @param buf the buffer into which the data is read
      * @param off the start offset in the destination array {@code buf}
      * @param len the maximum number of bytes read
-     * @return  the actual number of bytes read, or -1 if the end of the
+     * @return  the actual number of inflated bytes, or -1 if the end of the
      *          compressed input stream is reached
      *
      * @throws     NullPointerException If {@code buf} is {@code null}.

--- a/src/java.base/share/classes/java/util/zip/GZIPInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/GZIPInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,14 +97,14 @@ public class GZIPInputStream extends InflaterInputStream {
      * no bytes are read and {@code 0} is returned.
      * <p>
      * If <i>n</i> denotes the returned number of inflated bytes then {@code buf[off]}
-     * trough {@code buf[off+}<i>n</i>{@code -1]} will contain the uncompressed data. The
+     * through {@code buf[off+}<i>n</i>{@code -1]} will contain the uncompressed data. The
      * elements {@code buf[off+}<i>n</i>{@code ]} through {@code buf[off+}<i>len</i>{@code -1]}
      * are undefined and an implementation is free to change them during the inflate
      * operation. If the return value is -1 or an exception is thrown the whole
      * content of {@code buf} is undefined.
      *
      * @param buf the buffer into which the data is read
-     * @param off the start offset in the destination array {@code b}
+     * @param off the start offset in the destination array {@code buf}
      * @param len the maximum number of bytes read
      * @return  the actual number of bytes read, or -1 if the end of the
      *          compressed input stream is reached

--- a/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
@@ -129,7 +129,7 @@ public class InflaterInputStream extends FilterInputStream {
      * no bytes are read and {@code 0} is returned.
      * <p>
      * If <i>n</i> denotes the returned number of inflated bytes then {@code b[off]}
-     * trough {@code b[off+}<i>n</i>{@code -1]} will contain the uncompressed data. The
+     * through {@code b[off+}<i>n</i>{@code -1]} will contain the uncompressed data. The
      * elements {@code b[off+}<i>n</i>{@code ]} through {@code b[off+}<i>len</i>{@code -1]}
      * are undefined and an implementation is free to change them during the inflate
      * operation. If the return value is -1 or an exception is thrown the whole

--- a/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
@@ -128,12 +128,12 @@ public class InflaterInputStream extends FilterInputStream {
      * zero, the method will block until some input can be decompressed; otherwise,
      * no bytes are read and {@code 0} is returned.
      * <p>
-     * If <i>n</i> denotes the returned number of inflated bytes then {@code b[off]}
+     * If <i>n</i> denotes the returned number of inflated bytes, then {@code b[off]}
      * through {@code b[off+}<i>n</i>{@code -1]} will contain the uncompressed data. The
      * elements {@code b[off+}<i>n</i>{@code ]} through {@code b[off+}<i>len</i>{@code -1]}
      * are undefined (an implementation is free to change them during the inflate
-     * operation). If the return value is -1 or an exception is thrown then {@code b[off]}
-     * to {@code b[off+}<i>len</i>{@code -1]} is undefined.
+     * operation). If the return value is -1 or an exception is thrown, then the content of
+     * {@code b[off]} to {@code b[off+}<i>len</i>{@code -1]} is undefined.
      *
      * @param b the buffer into which the data is read
      * @param off the start offset in the destination array {@code b}

--- a/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
@@ -124,11 +124,11 @@ public class InflaterInputStream extends FilterInputStream {
     }
 
     /**
-     * Reads uncompressed data into an array of bytes. If {@code len} is not
-     * zero, the method will block until some input can be decompressed; otherwise,
-     * no bytes are read and {@code 0} is returned.
+     * Reads uncompressed data into an array of bytes, returning the number of inflated
+     * bytes. If {@code len} is not zero, the method will block until some input can be
+     * decompressed; otherwise, no bytes are read and {@code 0} is returned.
      * <p>
-     * If <i>n</i> denotes the returned number of inflated bytes, then {@code b[off]}
+     * If <i>n</i> denotes a nonzero number of inflated bytes to return, then {@code b[off]}
      * through {@code b[off+}<i>n</i>{@code -1]} will contain the uncompressed data. The
      * elements {@code b[off+}<i>n</i>{@code ]} through {@code b[off+}<i>len</i>{@code -1]}
      * are undefined (an implementation is free to change them during the inflate

--- a/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
@@ -127,10 +127,15 @@ public class InflaterInputStream extends FilterInputStream {
      * Reads uncompressed data into an array of bytes. If {@code len} is not
      * zero, the method will block until some input can be decompressed; otherwise,
      * no bytes are read and {@code 0} is returned.
+     *
+     * Unlike the {@link InputStream#read(byte[],int,int) overridden method}
+     * of {@code InputStream}, this method might write more bytes than the returned
+     * number of inflated bytes into the buffer {@code b}.
+     *
      * @param b the buffer into which the data is read
      * @param off the start offset in the destination array {@code b}
      * @param len the maximum number of bytes read
-     * @return the actual number of bytes read, or -1 if the end of the
+     * @return the actual number of bytes inflated into {@code b}, or -1 if the end of the
      *         compressed input is reached or a preset dictionary is needed
      * @throws     NullPointerException If {@code b} is {@code null}.
      * @throws     IndexOutOfBoundsException If {@code off} is negative,

--- a/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
@@ -128,14 +128,19 @@ public class InflaterInputStream extends FilterInputStream {
      * zero, the method will block until some input can be decompressed; otherwise,
      * no bytes are read and {@code 0} is returned.
      *
-     * Unlike the {@link InputStream#read(byte[],int,int) overridden method}
-     * of {@code InputStream}, this method might write more bytes than the returned
-     * number of inflated bytes into the buffer {@code b}.
+     * <p>Unlike the {@link InputStream#read(byte[],int,int) overridden method}
+     * of {@code InputStream}, this method might write some additional bytes beyond the
+     * last uncompressed byte. If <i>n</i> denotes the returned number of inflated bytes
+     * than {@code b[off]} trough {@code b[off+}<i>n</i>{@code -1]} will contain the
+     * uncompressed data while the elements {@code b[off+}<i>n</i>{@code ]} through
+     * {@code b[off+}<i>len</i>{@code -1]} are undefined and their value may or may not have
+     * been changed by the inflate operation. If the return value <i>n</i> is -1 the whole
+     * content of {@code b[off]} to {@code b[off+len-1]} will be undefined.
      *
      * @param b the buffer into which the data is read
      * @param off the start offset in the destination array {@code b}
      * @param len the maximum number of bytes read
-     * @return the actual number of bytes inflated into {@code b}, or -1 if the end of the
+     * @return the actual number of inflated bytes, or -1 if the end of the
      *         compressed input is reached or a preset dictionary is needed
      * @throws     NullPointerException If {@code b} is {@code null}.
      * @throws     IndexOutOfBoundsException If {@code off} is negative,

--- a/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
@@ -127,15 +127,13 @@ public class InflaterInputStream extends FilterInputStream {
      * Reads uncompressed data into an array of bytes. If {@code len} is not
      * zero, the method will block until some input can be decompressed; otherwise,
      * no bytes are read and {@code 0} is returned.
-     *
-     * <p>Unlike the {@link InputStream#read(byte[],int,int) overridden method}
-     * of {@code InputStream}, this method might write some additional bytes beyond the
-     * last uncompressed byte. If <i>n</i> denotes the returned number of inflated bytes
-     * than {@code b[off]} trough {@code b[off+}<i>n</i>{@code -1]} will contain the
-     * uncompressed data while the elements {@code b[off+}<i>n</i>{@code ]} through
-     * {@code b[off+}<i>len</i>{@code -1]} are undefined and their value may or may not have
-     * been changed by the inflate operation. If the return value <i>n</i> is -1 the whole
-     * content of {@code b[off]} to {@code b[off+len-1]} will be undefined.
+     * <p>
+     * If <i>n</i> denotes the returned number of inflated bytes then {@code b[off]}
+     * trough {@code b[off+}<i>n</i>{@code -1]} will contain the uncompressed data. The
+     * elements {@code b[off+}<i>n</i>{@code ]} through {@code b[off+}<i>len</i>{@code -1]}
+     * are undefined and an implementation is free to change them during the inflate
+     * operation. If the return value is -1 or an exception is thrown the whole
+     * content of {@code b} is undefined.
      *
      * @param b the buffer into which the data is read
      * @param off the start offset in the destination array {@code b}

--- a/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
@@ -128,17 +128,20 @@ public class InflaterInputStream extends FilterInputStream {
      * bytes. If {@code len} is not zero, the method will block until some input can be
      * decompressed; otherwise, no bytes are read and {@code 0} is returned.
      * <p>
-     * If <i>n</i> denotes a nonzero number of inflated bytes to return, then {@code b[off]}
-     * through {@code b[off+}<i>n</i>{@code -1]} will contain the uncompressed data. The
-     * elements {@code b[off+}<i>n</i>{@code ]} through {@code b[off+}<i>len</i>{@code -1]}
-     * are undefined (an implementation is free to change them during the inflate
-     * operation). If the return value is -1 or an exception is thrown, then the content of
-     * {@code b[off]} to {@code b[off+}<i>len</i>{@code -1]} is undefined.
+     * If this method returns a nonzero integer <i>n</i> then {@code buf[off]}
+     * through {@code buf[off+}<i>n</i>{@code -1]} contain the uncompressed
+     * data.  The content of elements {@code buf[off+}<i>n</i>{@code ]} through
+     * {@code buf[off+}<i>len</i>{@code -1]} is undefined, contrary to the
+     * specification of the {@link java.io.InputStream InputStream} superclass,
+     * so an implementation is free to modify these elements during the inflate
+     * operation. If this method returns {@code -1} or throws an exception then
+     * the content of {@code buf[off]} through {@code buf[off+}<i>len</i>{@code
+     * -1]} is undefined.
      *
      * @param b the buffer into which the data is read
      * @param off the start offset in the destination array {@code b}
      * @param len the maximum number of bytes read
-     * @return the actual number of inflated bytes, or -1 if the end of the
+     * @return the actual number of bytes inflated, or -1 if the end of the
      *         compressed input is reached or a preset dictionary is needed
      * @throws     NullPointerException If {@code b} is {@code null}.
      * @throws     IndexOutOfBoundsException If {@code off} is negative,

--- a/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
@@ -131,9 +131,9 @@ public class InflaterInputStream extends FilterInputStream {
      * If <i>n</i> denotes the returned number of inflated bytes then {@code b[off]}
      * through {@code b[off+}<i>n</i>{@code -1]} will contain the uncompressed data. The
      * elements {@code b[off+}<i>n</i>{@code ]} through {@code b[off+}<i>len</i>{@code -1]}
-     * are undefined and an implementation is free to change them during the inflate
-     * operation. If the return value is -1 or an exception is thrown the whole
-     * content of {@code b} is undefined.
+     * are undefined (an implementation is free to change them during the inflate
+     * operation). If the return value is -1 or an exception is thrown then {@code b[off]}
+     * to {@code b[off+}<i>len</i>{@code -1]} is undefined.
      *
      * @param b the buffer into which the data is read
      * @param off the start offset in the destination array {@code b}

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -343,9 +343,6 @@ public class ZipFile implements ZipConstants, Closeable {
      * Closing this ZIP file will, in turn, close all input streams that
      * have been returned by invocations of this method.
      *
-     * @implNote This implementation returns an instance of
-     * {@link java.util.zip.InflaterInputStream}.
-     *
      * @param entry the zip file entry
      * @return the input stream for reading the contents of the specified
      * zip file entry or null if the zip file entry does not exist

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -343,6 +343,12 @@ public class ZipFile implements ZipConstants, Closeable {
      * Closing this ZIP file will, in turn, close all input streams that
      * have been returned by invocations of this method.
      *
+     * @apiNote This method can return an {@link java.util.zip.InflaterInputStream
+     * InflaterInputStream} which leaves the contents of the output buffer beyond
+     * the last inflated byte undefined after a read operation (see {@link
+     * java.util.zip.InflaterInputStream#read(byte[], int, int)
+     * InflaterInputStream.read(byte[], int, int)}).
+     *
      * @param entry the zip file entry
      * @return the input stream for reading the contents of the specified
      * zip file entry or null if the zip file entry does not exist

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -343,7 +343,7 @@ public class ZipFile implements ZipConstants, Closeable {
      * Closing this ZIP file will, in turn, close all input streams that
      * have been returned by invocations of this method.
      *
-     * @implNote In the JDK implementation this method returns an
+     * @implNote This implementation returns an instance of
      * {@link java.util.zip.InflaterInputStream}.
      *
      * @param entry the zip file entry

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -343,11 +343,11 @@ public class ZipFile implements ZipConstants, Closeable {
      * Closing this ZIP file will, in turn, close all input streams that
      * have been returned by invocations of this method.
      *
-     * @apiNote This method can return an {@link java.util.zip.InflaterInputStream
-     * InflaterInputStream} which leaves the contents of the output buffer beyond
-     * the last inflated byte undefined after a read operation (see {@link
-     * java.util.zip.InflaterInputStream#read(byte[], int, int)
-     * InflaterInputStream.read(byte[], int, int)}).
+     * @apiNote The {@code InputStream} returned by this method can wrap an
+     * {@link java.util.zip.InflaterInputStream InflaterInputStream}, whose
+     * {@link java.util.zip.InflaterInputStream#read(byte[], int, int)
+     * read(byte[], int, int)} method can modify any element of the output
+     * buffer.
      *
      * @param entry the zip file entry
      * @return the input stream for reading the contents of the specified

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -343,6 +343,9 @@ public class ZipFile implements ZipConstants, Closeable {
      * Closing this ZIP file will, in turn, close all input streams that
      * have been returned by invocations of this method.
      *
+     * @implNote In the JDK implementation this method returns an
+     * {@link java.util.zip.InflaterInputStream}.
+     *
      * @param entry the zip file entry
      * @return the input stream for reading the contents of the specified
      * zip file entry or null if the zip file entry does not exist

--- a/src/java.base/share/classes/java/util/zip/ZipInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipInputStream.java
@@ -169,6 +169,14 @@ public class ZipInputStream extends InflaterInputStream implements ZipConstants 
      * If {@code len} is not zero, the method
      * blocks until some input is available; otherwise, no
      * bytes are read and {@code 0} is returned.
+     * <p>
+     * If <i>n</i> denotes the returned number of inflated bytes then {@code b[off]}
+     * trough {@code b[off+}<i>n</i>{@code -1]} will contain the uncompressed data. The
+     * elements {@code b[off+}<i>n</i>{@code ]} through {@code b[off+}<i>len</i>{@code -1]}
+     * are undefined and an implementation is free to change them during the inflate
+     * operation. If the return value is -1 or an exception is thrown the whole
+     * content of {@code b} is undefined.
+     *
      * @param b the buffer into which the data is read
      * @param off the start offset in the destination array {@code b}
      * @param len the maximum number of bytes read

--- a/src/java.base/share/classes/java/util/zip/ZipInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipInputStream.java
@@ -171,11 +171,12 @@ public class ZipInputStream extends InflaterInputStream implements ZipConstants 
      * bytes are read and {@code 0} is returned.
      * <p>
      * If the current entry is compressed and <i>n</i> denotes the returned number of
-     * inflated bytes then {@code b[off]} trough {@code b[off+}<i>n</i>{@code -1]} will
+     * inflated bytes, then {@code b[off]} trough {@code b[off+}<i>n</i>{@code -1]} will
      * contain the uncompressed data. The elements {@code b[off+}<i>n</i>{@code ]} through
      * {@code b[off+}<i>len</i>{@code -1]} are undefined (an implementation is free to
      * change them during the inflate operation). If the return value is -1 or an exception
-     * is thrown then {@code b[off]} to {@code b[off+}<i>len</i>{@code -1]} is undefined.
+     * is thrown, then the content of {@code b[off]} to {@code b[off+}<i>len</i>{@code -1]}
+     * is undefined.
      *
      * @param b the buffer into which the data is read
      * @param off the start offset in the destination array {@code b}

--- a/src/java.base/share/classes/java/util/zip/ZipInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipInputStream.java
@@ -169,13 +169,16 @@ public class ZipInputStream extends InflaterInputStream implements ZipConstants 
      * inflated bytes. If {@code len} is not zero, the method blocks until some input is
      * available; otherwise, no bytes are read and {@code 0} is returned.
      * <p>
-     * If the current entry is compressed and <i>n</i> denotes a nonzero number of inflated
-     * bytes to return, then {@code b[off]} trough {@code b[off+}<i>n</i>{@code -1]} will
-     * contain the uncompressed data. The elements {@code b[off+}<i>n</i>{@code ]} through
-     * {@code b[off+}<i>len</i>{@code -1]} are undefined (an implementation is free to
-     * change them during the inflate operation). If the return value is -1 or an exception
-     * is thrown, then the content of {@code b[off]} to {@code b[off+}<i>len</i>{@code -1]}
-     * is undefined.
+     * If the current entry is compressed and this method returns a nonzero
+     * integer <i>n</i> then {@code buf[off]}
+     * through {@code buf[off+}<i>n</i>{@code -1]} contain the uncompressed
+     * data.  The content of elements {@code buf[off+}<i>n</i>{@code ]} through
+     * {@code buf[off+}<i>len</i>{@code -1]} is undefined, contrary to the
+     * specification of the {@link java.io.InputStream InputStream} superclass,
+     * so an implementation is free to modify these elements during the inflate
+     * operation. If this method returns {@code -1} or throws an exception then
+     * the content of {@code buf[off]} through {@code buf[off+}<i>len</i>{@code
+     * -1]} is undefined.
      *
      * @param b the buffer into which the data is read
      * @param off the start offset in the destination array {@code b}

--- a/src/java.base/share/classes/java/util/zip/ZipInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipInputStream.java
@@ -180,7 +180,7 @@ public class ZipInputStream extends InflaterInputStream implements ZipConstants 
      * @param b the buffer into which the data is read
      * @param off the start offset in the destination array {@code b}
      * @param len the maximum number of bytes read
-     * @return the actual number of inflated bytes, or -1 if the end of the
+     * @return the actual number of bytes read, or -1 if the end of the
      *         entry is reached
      * @throws     NullPointerException if {@code b} is {@code null}.
      * @throws     IndexOutOfBoundsException if {@code off} is negative,

--- a/src/java.base/share/classes/java/util/zip/ZipInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipInputStream.java
@@ -173,14 +173,14 @@ public class ZipInputStream extends InflaterInputStream implements ZipConstants 
      * If the current entry is compressed and <i>n</i> denotes the returned number of
      * inflated bytes then {@code b[off]} trough {@code b[off+}<i>n</i>{@code -1]} will
      * contain the uncompressed data. The elements {@code b[off+}<i>n</i>{@code ]} through
-     * {@code b[off+}<i>len</i>{@code -1]} are undefined and an implementation is free to
-     * change them during the inflate operation. If the return value is -1 or an exception
-     * is thrown the whole content of {@code b} is undefined.
+     * {@code b[off+}<i>len</i>{@code -1]} are undefined (an implementation is free to
+     * change them during the inflate operation). If the return value is -1 or an exception
+     * is thrown then {@code b[off]} to {@code b[off+}<i>len</i>{@code -1]} is undefined.
      *
      * @param b the buffer into which the data is read
      * @param off the start offset in the destination array {@code b}
      * @param len the maximum number of bytes read
-     * @return the actual number of bytes read, or -1 if the end of the
+     * @return the actual number of inflated bytes, or -1 if the end of the
      *         entry is reached
      * @throws     NullPointerException if {@code b} is {@code null}.
      * @throws     IndexOutOfBoundsException if {@code off} is negative,

--- a/src/java.base/share/classes/java/util/zip/ZipInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipInputStream.java
@@ -165,13 +165,12 @@ public class ZipInputStream extends InflaterInputStream implements ZipConstants 
     }
 
     /**
-     * Reads from the current ZIP entry into an array of bytes.
-     * If {@code len} is not zero, the method
-     * blocks until some input is available; otherwise, no
-     * bytes are read and {@code 0} is returned.
+     * Reads from the current ZIP entry into an array of bytes, returning the number of
+     * inflated bytes. If {@code len} is not zero, the method blocks until some input is
+     * available; otherwise, no bytes are read and {@code 0} is returned.
      * <p>
-     * If the current entry is compressed and <i>n</i> denotes the returned number of
-     * inflated bytes, then {@code b[off]} trough {@code b[off+}<i>n</i>{@code -1]} will
+     * If the current entry is compressed and <i>n</i> denotes a nonzero number of inflated
+     * bytes to return, then {@code b[off]} trough {@code b[off+}<i>n</i>{@code -1]} will
      * contain the uncompressed data. The elements {@code b[off+}<i>n</i>{@code ]} through
      * {@code b[off+}<i>len</i>{@code -1]} are undefined (an implementation is free to
      * change them during the inflate operation). If the return value is -1 or an exception

--- a/src/java.base/share/classes/java/util/zip/ZipInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,12 +170,12 @@ public class ZipInputStream extends InflaterInputStream implements ZipConstants 
      * blocks until some input is available; otherwise, no
      * bytes are read and {@code 0} is returned.
      * <p>
-     * If <i>n</i> denotes the returned number of inflated bytes then {@code b[off]}
-     * trough {@code b[off+}<i>n</i>{@code -1]} will contain the uncompressed data. The
-     * elements {@code b[off+}<i>n</i>{@code ]} through {@code b[off+}<i>len</i>{@code -1]}
-     * are undefined and an implementation is free to change them during the inflate
-     * operation. If the return value is -1 or an exception is thrown the whole
-     * content of {@code b} is undefined.
+     * If the current entry is compressed and <i>n</i> denotes the returned number of
+     * inflated bytes then {@code b[off]} trough {@code b[off+}<i>n</i>{@code -1]} will
+     * contain the uncompressed data. The elements {@code b[off+}<i>n</i>{@code ]} through
+     * {@code b[off+}<i>len</i>{@code -1]} are undefined and an implementation is free to
+     * change them during the inflate operation. If the return value is -1 or an exception
+     * is thrown the whole content of {@code b} is undefined.
      *
      * @param b the buffer into which the data is read
      * @param off the start offset in the destination array {@code b}


### PR DESCRIPTION
Add an API note to `InflaterInputStream::read(byte[] b, int off, int len)` to highlight that it might  write more bytes than the returned number of inflated bytes into the buffer `b`.

The superclass `java.io.InputStream` specifies that `read(byte[] b, int off, int len)` will leave the content beyond the last read byte in the read buffer `b` unaffected. However, the overridden `read` method in `InflaterInputStream` passes the read buffer `b` to `Inflater::inflate(byte[] b, int off, int len)` which doesn't provide this guarantee. Depending on implementation details, `Inflater::inflate` might write more than the returned number of inflated bytes into the buffer `b`.

### TL;DR

`java.util.zip.Inflater` is the Java wrapper class for zlib's inflater functionality. `Inflater::inflate(byte[] output, int off, int len)` currently calls zlib's native `inflate(..)` function and passes the address of `output[off]` and `len` to it via JNI.

The specification of zlib's `inflate(..)` function (i.e. the [API documentation in the original zlib implementation](https://github.com/madler/zlib/blob/cacf7f1d4e3d44d871b605da3b647f07d718623f/zlib.h#L400)) doesn't give any guarantees with regard to usage of the output buffer. It only states that upon completion the function will return the number of bytes that have been written (i.e. "inflated") into the output buffer.

The original zlib implementation only wrote as many bytes into the output buffer as it inflated. However, this is not a hard requirement and newer, more performant implementations of the zlib library like [zlib-chromium](https://chromium.googlesource.com/chromium/src/third_party/zlib/) or [zlib-cloudflare](https://github.com/cloudflare/zlib) can use more bytes of the output buffer than they actually inflate as a scratch buffer. See https://github.com/simonis/zlib-chromium for a more detailed description of their approach and its performance benefit.

These new zlib versions can still be used transparently from Java (e.g. by putting them into the `LD_LIBRARY_PATH` or by using `LD_PRELOAD`), because they still fully comply to specification of `Inflater::inflate(..)`. However, we might run into problems when using the `Inflater` functionality from the `InflaterInputStream` class. `InflaterInputStream` is derived from from `InputStream` and as such, its `read(byte[] b, int off, int len)` method is quite constrained. It specifically specifies that if *k* bytes have been read, then "these bytes will be stored in elements `b[off]` through `b[off+`*k*`-1]`, leaving elements `b[off+`*k*`]` through `b[off+len-1]` **unaffected**". But `InflaterInputStream::read(byte[] b, int off, int len)` (which is constrained by `InputStream::read(..)`'s specification) calls `Inflater::inflate(byte[] b, int off, int len)` and directly passes its output buffer down to the native zlib `inflate(..)` method which is free to change the bytes beyond `b[off+`*k*`]` (where *k* is the number of inflated bytes).

From a practical point of view, I don't see this as a big problem, because callers of `InflaterInputStream::read(byte[] b, int off, int len)` can never know how many bytes will be written into the output buffer `b` (and in fact its content can always be completely overwritten). It therefore makes no sense to depend on any data there being untouched after the call. Also, having used zlib-cloudflare productively for about two years, we haven't seen real-world issues because of this behavior yet. However, from a specification point of view it is easy to artificially construct a program which violates `InflaterInputStream::read(..)`'s postcondition if using one of the alterantive zlib implementations. A recently integrated JTreg test (test/jdk/jdk/nio/zipfs/ZipFSOutputStreamTest.java) "unintentionally" fails with zlib-chromium but can fixed easily to run with alternative implementations as well (see [JDK-8283756](https://bugs.openjdk.java.net/browse/JDK-8283756)).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8282648](https://bugs.openjdk.org/browse/JDK-8282648): Weaken the InflaterInputStream specification in order to allow faster Zip implementations
 * [JDK-8283758](https://bugs.openjdk.org/browse/JDK-8283758): Weaken the InflaterInputStream specification in order to allow faster Zip implementations (**CSR**)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [d82c7526](https://git.openjdk.org/jdk/pull/7986/files/d82c75267a76d3538465de17f4f7ffd2962dd563)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [c9b60404](https://git.openjdk.org/jdk/pull/7986/files/c9b60404b39241d46ec32c86d35839a9f7a9659d)
 * [Mark Reinhold](https://openjdk.org/census#mr) (@mbreinhold - **Reviewer**) ⚠️ Review applies to [d82c7526](https://git.openjdk.org/jdk/pull/7986/files/d82c75267a76d3538465de17f4f7ffd2962dd563)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/7986/head:pull/7986` \
`$ git checkout pull/7986`

Update a local copy of the PR: \
`$ git checkout pull/7986` \
`$ git pull https://git.openjdk.org/jdk pull/7986/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7986`

View PR using the GUI difftool: \
`$ git pr show -t 7986`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/7986.diff">https://git.openjdk.org/jdk/pull/7986.diff</a>

</details>
