### PR TITLE
8270090: C2: LCM may prioritize CheckCastPP nodes over projections

### DIFF
--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -1274,16 +1274,6 @@ void PhaseCFG::verify() const {
         Node* pred = block->get_node(j - 1);
         Node* parent = n->in(0);
         assert(parent != NULL, "projections must have a parent");
-        if (!(pred == parent || (pred->is_Proj() && pred->in(0) == parent))) {
-          tty->print("n: ");
-          n->dump();
-          tty->print("pred: ");
-          pred->dump();
-          tty->print("parent: ");
-          parent->dump();
-          tty->print_cr("block:");
-          block->dump();
-        }
         assert(pred == parent || (pred->is_Proj() && pred->in(0) == parent),
                "projections must follow their parents or other sibling projections");
       }

--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -1274,6 +1274,16 @@ void PhaseCFG::verify() const {
         Node* pred = block->get_node(j - 1);
         Node* parent = n->in(0);
         assert(parent != NULL, "projections must have a parent");
+        if (!(pred == parent || (pred->is_Proj() && pred->in(0) == parent))) {
+          tty->print("n: ");
+          n->dump();
+          tty->print("pred: ");
+          pred->dump();
+          tty->print("parent: ");
+          parent->dump();
+          tty->print_cr("block:");
+          block->dump();
+        }
         assert(pred == parent || (pred->is_Proj() && pred->in(0) == parent),
                "projections must follow their parents or other sibling projections");
       }

--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -528,11 +528,15 @@ Node* PhaseCFG::select(
     Node *n = worklist[i];      // Get Node on worklist
 
     int iop = n->is_Mach() ? n->as_Mach()->ideal_Opcode() : 0;
-    if( n->is_Proj() ||         // Projections always win
-        n->Opcode()== Op_Con || // So does constant 'Top'
-        iop == Op_CreateEx ||   // Create-exception must start block
-        iop == Op_CheckCastPP
-        ) {
+    if (n->is_Proj()) {         // Projections always win
+      worklist.map(i,worklist.pop());
+      return n;
+    }
+
+    // These nodes must be scheduled at the beginning of the block.
+    if (n->Opcode()== Op_Con ||
+        iop == Op_CreateEx ||
+        iop == Op_CheckCastPP) {
       worklist.map(i,worklist.pop());
       return n;
     }


### PR DESCRIPTION
This change breaks the tie between top-priority nodes (CreateEx, projections, constants, and CheckCastPP) in LCM, when the node to be scheduled next is selected. The change assigns the highest priority to CreateEx (which must be scheduled at the beginning of its block, right after Phi and Parm nodes), followed by projections (which must be scheduled right after their parents), followed by constant and CheckCastPP nodes (which are given equal priority to preserve the current behavior), followed by the remaining lower-priority nodes.

The proposed prioritization prevents CheckCastPP from being incorrectly scheduled between a node and its projection. See the [bug description](https://bugs.openjdk.java.net/browse/JDK-8270090) for more details.

As a side-benefit, the proposed change removes the need of manipulating the ready list order for scheduling of CreateEx nodes correctly.

#### Testing

##### Functionality

- Original failure on linux-arm (see results [here](https://pici.beachhub.io/#/JDK-8270090/20220325-103958) and [here](https://pici.beachhub.io/#/JDK-8270090-jacoco/20220325-131740), thanks to Marc Hoffmann for setting up a test environment).
- hs-tier1-5 (windows-x64, linux-x64, linux-aarch64, and macosx-x64; release and debug mode).
- hs-tier1-3 (windows-x64, linux-x64, linux-aarch64, and macosx-x64; debug mode) with `-XX:+StressLCM` and `-XX:+StressGCM` (5 different seeds).

Note that the change does not include a regression test, since the failure only seems to be reproducible in ARM32 and I do not have access to this platform. If anyone wants to extract an ARM32 regression test out of the original failure, please let me know and I would be happy to add it to the change.

##### Performance

Tested performance on a set of standard benchmark suites (DaCapo, SPECjbb2015, SPECjvm2008, ...) and on windows-x64, linux-x64, linux-aarch64, and macosx-x64. No significant regression was observed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270090](https://bugs.openjdk.java.net/browse/JDK-8270090): C2: LCM may prioritize CheckCastPP nodes over projections


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7988/head:pull/7988` \
`$ git checkout pull/7988`

Update a local copy of the PR: \
`$ git checkout pull/7988` \
`$ git pull https://git.openjdk.java.net/jdk pull/7988/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7988`

View PR using the GUI difftool: \
`$ git pr show -t 7988`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7988.diff">https://git.openjdk.java.net/jdk/pull/7988.diff</a>

</details>
