### PR TITLE
8283774: TestZoneOffset::test_immutable should ignore ZoneOffset::rules

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -742,7 +742,7 @@ java/awt/Robot/HiDPIScreenCapture/ScreenCaptureTest.java  8277816 macosx-aarch64
 java/awt/Robot/CheckCommonColors/CheckCommonColors.java 8277816 macosx-aarch64
 java/awt/ColorClass/AlphaColorTest.java 8277816 macosx-aarch64
 java/awt/AlphaComposite/WindowAlphaCompositeTest.java 8277816 macosx-aarch64
-	
+
 # macos12 failure
 javax/swing/JMenu/4515762/bug4515762.java 8276074 macosx-all
 
@@ -758,9 +758,6 @@ javax/swing/JTree/4908142/bug4908142.java 8278348 macosx-all
 ############################################################################
 
 # jdk_time
-
-java/time/test/java/time/TestZoneOffset.java                    8283716 generic-all
-
 
 ############################################################################
 

--- a/test/jdk/java/time/test/java/time/AbstractTest.java
+++ b/test/jdk/java/time/test/java/time/AbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/time/test/java/time/AbstractTest.java
+++ b/test/jdk/java/time/test/java/time/AbstractTest.java
@@ -66,6 +66,7 @@ import static org.testng.Assert.assertTrue;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.Set;
 
 /**
  * Base test class.
@@ -83,11 +84,15 @@ public abstract class AbstractTest {
     }
 
     protected static void assertImmutable(Class<?> cls) {
+        assertImmutable(cls, Set.of());
+    }
+
+    protected static void assertImmutable(Class<?> cls, Set<String> ignoreFields) {
         assertTrue(Modifier.isPublic(cls.getModifiers()));
         assertTrue(Modifier.isFinal(cls.getModifiers()));
         Field[] fields = cls.getDeclaredFields();
         for (Field field : fields) {
-            if (field.getName().contains("$") == false) {
+            if (!field.getName().contains("$") && !ignoreFields.contains(field.getName())) {
                 if (Modifier.isStatic(field.getModifiers())) {
                     assertTrue(Modifier.isFinal(field.getModifiers()), "Field:" + field.getName());
                 } else {

--- a/test/jdk/java/time/test/java/time/TestZoneOffset.java
+++ b/test/jdk/java/time/test/java/time/TestZoneOffset.java
@@ -61,6 +61,7 @@ package test.java.time;
 
 import static org.testng.Assert.assertSame;
 
+import java.util.Set;
 import java.time.ZoneOffset;
 
 import org.testng.annotations.Test;
@@ -73,7 +74,7 @@ public class TestZoneOffset extends AbstractTest {
 
     @Test
     public void test_immutable() {
-        assertImmutable(ZoneOffset.class);
+        assertImmutable(ZoneOffset.class, /* ignore field */ Set.of("rules"));
     }
 
     @Test

--- a/test/jdk/java/time/test/java/time/TestZoneOffset.java
+++ b/test/jdk/java/time/test/java/time/TestZoneOffset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
- Add capability to ignore fields explicitly when checking for immutability of classes in java.time
- Use this to avoid a test failure due the new `rules` cache in `ZoneOffset`
- Remove `TestZoneOffset` from problem list.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283774](https://bugs.openjdk.java.net/browse/JDK-8283774): TestZoneOffset::test_immutable should ignore ZoneOffset::rules


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to 44a8cc6b4a8ea2e27d1bd3268ed222abd2deead6
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to 44a8cc6b4a8ea2e27d1bd3268ed222abd2deead6


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7989/head:pull/7989` \
`$ git checkout pull/7989`

Update a local copy of the PR: \
`$ git checkout pull/7989` \
`$ git pull https://git.openjdk.java.net/jdk pull/7989/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7989`

View PR using the GUI difftool: \
`$ git pr show -t 7989`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7989.diff">https://git.openjdk.java.net/jdk/pull/7989.diff</a>

</details>
