### PR TITLE
8283626: AArch64: Set relocInfo::offset_unit to 4

### DIFF
--- a/src/hotspot/cpu/aarch64/relocInfo_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/relocInfo_aarch64.hpp
@@ -29,8 +29,8 @@
   // machine-dependent parts of class relocInfo
  private:
   enum {
-    // AArch64 instructions size is 4 bytes.
-    // Two lowest offset bits can always be discarded.
+    // AArch64 instructions are always 4 bytes long and 4-aligned, so
+    // the two lowest offset bits can always be discarded.
     offset_unit        =  4,
     // Must be at least 1 for RelocInfo::narrow_oop_in_const.
     format_width       =  1

--- a/src/hotspot/cpu/aarch64/relocInfo_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/relocInfo_aarch64.hpp
@@ -29,8 +29,9 @@
   // machine-dependent parts of class relocInfo
  private:
   enum {
-    // Relocations are byte-aligned.
-    offset_unit        =  1,
+    // AArch64 instructions size is 4 bytes.
+    // Two lowest offset bits can always be discarded.
+    offset_unit        =  4,
     // Must be at least 1 for RelocInfo::narrow_oop_in_const.
     format_width       =  1
   };


### PR DESCRIPTION
AArch64 instructions size is 4 bytes. Two lowest bits of `relocInfo` offsets can be discarded.
Tested with release and fastdebug builds:
- `gtest`: Passed.
- `tier1`...`tier4`: Passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283626](https://bugs.openjdk.java.net/browse/JDK-8283626): AArch64: Set relocInfo::offset_unit to 4


### Reviewers
 * [Volker Simonis](https://openjdk.java.net/census#simonis) (@simonis - **Reviewer**)
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7991/head:pull/7991` \
`$ git checkout pull/7991`

Update a local copy of the PR: \
`$ git checkout pull/7991` \
`$ git pull https://git.openjdk.java.net/jdk pull/7991/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7991`

View PR using the GUI difftool: \
`$ git pr show -t 7991`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7991.diff">https://git.openjdk.java.net/jdk/pull/7991.diff</a>

</details>
