### PR TITLE
8283787: C1: Remove unused ArrayStoreExceptionStub::_info

### DIFF
--- a/src/hotspot/share/c1/c1_CodeStubs.hpp
+++ b/src/hotspot/share/c1/c1_CodeStubs.hpp
@@ -513,9 +513,6 @@ class SimpleExceptionStub: public CodeStub {
 
 
 class ArrayStoreExceptionStub: public SimpleExceptionStub {
- private:
-  CodeEmitInfo* _info;
-
  public:
   ArrayStoreExceptionStub(LIR_Opr obj, CodeEmitInfo* info): SimpleExceptionStub(Runtime1::throw_array_store_exception_id, obj, info) {}
 #ifndef PRODUCT


### PR DESCRIPTION
SonarCloud complains `ArrayStoreExceptionStub::_info` field is not initialized. It is not actually used, and the incoming `CodeEmitInfo*` gets passed to superclass instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283787](https://bugs.openjdk.java.net/browse/JDK-8283787): C1: Remove unused ArrayStoreExceptionStub::_info


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7992/head:pull/7992` \
`$ git checkout pull/7992`

Update a local copy of the PR: \
`$ git checkout pull/7992` \
`$ git pull https://git.openjdk.java.net/jdk pull/7992/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7992`

View PR using the GUI difftool: \
`$ git pr show -t 7992`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7992.diff">https://git.openjdk.java.net/jdk/pull/7992.diff</a>

</details>
