### PR TITLE
8283788: Remove unused VM_DeoptimizeAll::_dependee

### DIFF
--- a/src/hotspot/share/runtime/vmOperations.hpp
+++ b/src/hotspot/share/runtime/vmOperations.hpp
@@ -115,8 +115,6 @@ class VM_DeoptimizeFrame: public VM_Operation {
 
 #ifndef PRODUCT
 class VM_DeoptimizeAll: public VM_Operation {
- private:
-  Klass* _dependee;
  public:
   VM_DeoptimizeAll() {}
   VMOp_Type type() const                         { return VMOp_DeoptimizeAll; }


### PR DESCRIPTION
SonarCloud complains the `VM_DeoptimizeAll::_dependee` field is not initialized. In fact, it is not used at all and can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283788](https://bugs.openjdk.java.net/browse/JDK-8283788): Remove unused VM_DeoptimizeAll::_dependee


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7993/head:pull/7993` \
`$ git checkout pull/7993`

Update a local copy of the PR: \
`$ git checkout pull/7993` \
`$ git pull https://git.openjdk.java.net/jdk pull/7993/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7993`

View PR using the GUI difftool: \
`$ git pr show -t 7993`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7993.diff">https://git.openjdk.java.net/jdk/pull/7993.diff</a>

</details>
