### PR TITLE
8283789: CompilerPhaseTypeHelper::to_bitmask should operate on uint64_t

### DIFF
--- a/src/hotspot/share/opto/phasetype.hpp
+++ b/src/hotspot/share/opto/phasetype.hpp
@@ -96,8 +96,8 @@ class CompilerPhaseTypeHelper {
   static const char* to_description(CompilerPhaseType cpt) {
     return phase_descriptions[cpt];
   }
-  static int to_bitmask(CompilerPhaseType cpt) {
-    return (1 << cpt);
+  static uint64_t to_bitmask(CompilerPhaseType cpt) {
+    return (UINT64_C(1) << cpt);
   }
 };
 


### PR DESCRIPTION
[JDK-8281505](https://bugs.openjdk.java.net/browse/JDK-8281505) added this helper method that operates on `uint64_t` masks, but it operates on `int`s. So it is subtly broken on 32-bit platforms, for example. SonarCloud complains about it: "The result of the left shift is undefined due to shifting by '32', which is greater or equal to the width of type 'int'"

Additional testing:
 - [x] Linux x86_64 fastdebug, `compiler/oracle` passes
 - [x] Linux x86_32 fastdebug, `compiler/oracle` passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283789](https://bugs.openjdk.java.net/browse/JDK-8283789): CompilerPhaseTypeHelper::to_bitmask should operate on uint64_t


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7994/head:pull/7994` \
`$ git checkout pull/7994`

Update a local copy of the PR: \
`$ git checkout pull/7994` \
`$ git pull https://git.openjdk.java.net/jdk pull/7994/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7994`

View PR using the GUI difftool: \
`$ git pr show -t 7994`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7994.diff">https://git.openjdk.java.net/jdk/pull/7994.diff</a>

</details>
