### PR TITLE
8283790: G1: Remove redundant card/heap-address transition

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -117,13 +117,8 @@ private:
   // The region that owns this subregion.
   HeapRegion* _hr;
 
-  // Sets the entries
-  // corresponding to the cards starting at "start" and ending at "end"
-  // to point back to the card before "start": the interval [start, end)
-  // is right-open.
-  void set_remainder_to_point_to_start(HeapWord* start, HeapWord* end);
-  // Same as above, except that the args here are a card _index_ interval
-  // that is closed: [start_index, end_index]
+  // Sets the entries corresponding to the cards starting at "start" and ending
+  // at "end" to point back to the card before "start"; [start, end]
   void set_remainder_to_point_to_start_incl(size_t start, size_t end);
 
   inline size_t block_size(const HeapWord* p) const;


### PR DESCRIPTION
Simple change of removing some unnecessary code.

(Also checked the assembly in `release` build and these redundant transitions are *not* optimized away.)

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283790](https://bugs.openjdk.java.net/browse/JDK-8283790): G1: Remove redundant card/heap-address transition


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/7995/head:pull/7995` \
`$ git checkout pull/7995`

Update a local copy of the PR: \
`$ git checkout pull/7995` \
`$ git pull https://git.openjdk.java.net/jdk pull/7995/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7995`

View PR using the GUI difftool: \
`$ git pr show -t 7995`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/7995.diff">https://git.openjdk.java.net/jdk/pull/7995.diff</a>

</details>
