### PR TITLE
8281469: aarch64: Improve interpreter stack banging

### DIFF
--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -1100,7 +1100,8 @@ void TemplateInterpreterGenerator::bang_stack_shadow_pages(bool native_call) {
   __ ldr(rscratch1, Address(rthread, JavaThread::shadow_zone_safe_limit()));
   __ cmp(sp, rscratch1);
   __ br(Assembler::LE, L_done);
-  __ str(sp, Address(rthread, JavaThread::shadow_zone_growth_watermark()));
+  __ mov(rscratch1, sp);
+  __ str(rscratch1, Address(rthread, JavaThread::shadow_zone_growth_watermark()));
 
   __ bind(L_done);
 }

--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -1088,7 +1088,7 @@ void TemplateInterpreterGenerator::bang_stack_shadow_pages(bool native_call) {
 
   __ ldr(rscratch1, Address(rthread, JavaThread::shadow_zone_growth_watermark()));
   __ cmp(sp, rscratch1);
-  __ br(Assembler::GT, L_done);
+  __ br(Assembler::HI, L_done);
 
   for (int p = 1; p <= n_shadow_pages; p++) {
     __ sub(rscratch2, sp, p*page_size);
@@ -1099,7 +1099,7 @@ void TemplateInterpreterGenerator::bang_stack_shadow_pages(bool native_call) {
   // Otherwise, the next time around the check above would pass the safe limit.
   __ ldr(rscratch1, Address(rthread, JavaThread::shadow_zone_safe_limit()));
   __ cmp(sp, rscratch1);
-  __ br(Assembler::LE, L_done);
+  __ br(Assembler::LS, L_done);
   __ mov(rscratch1, sp);
   __ str(rscratch1, Address(rthread, JavaThread::shadow_zone_growth_watermark()));
 

--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -1064,18 +1064,46 @@ address TemplateInterpreterGenerator::generate_CRC32C_updateBytes_entry(Abstract
 }
 
 void TemplateInterpreterGenerator::bang_stack_shadow_pages(bool native_call) {
-  // Bang each page in the shadow zone. We can't assume it's been done for
-  // an interpreter frame with greater than a page of locals, so each page
-  // needs to be checked.  Only true for non-native.
-  const int n_shadow_pages = (int)(StackOverflow::stack_shadow_zone_size() / os::vm_page_size());
-  const int start_page = native_call ? n_shadow_pages : 1;
+  // See more discussion in stackOverflow.hpp.
+
+  const int shadow_zone_size = checked_cast<int>(StackOverflow::stack_shadow_zone_size());
   const int page_size = os::vm_page_size();
-  for (int pages = start_page; pages <= n_shadow_pages ; pages++) {
-    __ sub(rscratch2, sp, pages*page_size);
+  const int n_shadow_pages = shadow_zone_size / page_size;
+
+#ifdef ASSERT
+  Label L_good_limit;
+  __ ldr(rscratch1, Address(rthread, JavaThread::shadow_zone_safe_limit()));
+  __ cbnz(rscratch1, L_good_limit);
+  __ stop("shadow zone safe limit is not initialized");
+  __ bind(L_good_limit);
+
+  Label L_good_watermark;
+  __ ldr(rscratch1, Address(rthread, JavaThread::shadow_zone_growth_watermark()));
+  __ cbnz(rscratch1, L_good_watermark);
+  __ stop("shadow zone growth watermark is not initialized");
+  __ bind(L_good_watermark);
+#endif
+
+  Label L_done;
+
+  __ ldr(rscratch1, Address(rthread, JavaThread::shadow_zone_growth_watermark()));
+  __ cmp(sp, rscratch1);
+  __ br(Assembler::GT, L_done);
+
+  for (int p = 1; p <= n_shadow_pages; p++) {
+    __ sub(rscratch2, sp, p*page_size);
     __ str(zr, Address(rscratch2));
   }
-}
 
+  // Record the new watermark, but only if the update is above the safe limit.
+  // Otherwise, the next time around the check above would pass the safe limit.
+  __ ldr(rscratch1, Address(rthread, JavaThread::shadow_zone_safe_limit()));
+  __ cmp(sp, rscratch1);
+  __ br(Assembler::LE, L_done);
+  __ str(sp, Address(rthread, JavaThread::shadow_zone_growth_watermark()));
+
+  __ bind(L_done);
+}
 
 // Interpreter stub for calling a native method. (asm interpreter)
 // This sets up a somewhat different looking stack for calling the


### PR DESCRIPTION
This is the AArch64 counterpart of X86 change: https://github.com/openjdk/jdk/commit/3a13425bc9088cbb6d95e1a46248d7eba27fb1a6.

Motivational performance improvements on Raspberry Pi 3:

```
 Performance counter stats for 'baseline/bin/java -version' (10 runs):

            476.96 msec task-clock                #    1.288 CPUs utilized            ( +-  0.11% )
               166      context-switches          #    0.348 K/sec                    ( +-  0.93% )
                 8      cpu-migrations            #    0.017 K/sec                    ( +-  9.33% )
             2,954      page-faults               #    0.006 M/sec                    ( +-  0.04% )
       560,690,251      cycles                    #    1.176 GHz                      ( +-  0.07% )
       239,068,958      instructions              #    0.43  insn per cycle           ( +-  0.04% )
        30,236,426      branches                  #   63.394 M/sec                    ( +-  0.05% )
         4,145,994      branch-misses             #   13.71% of all branches          ( +-  0.09% )

          0.370225 +- 0.000285 seconds time elapsed  ( +-  0.08% )

 Performance counter stats for 'patched/bin/java -version' (10 runs):

            456.01 msec task-clock                #    1.283 CPUs utilized            ( +-  0.12% )
               156      context-switches          #    0.341 K/sec                    ( +-  0.99% )
                 8      cpu-migrations            #    0.018 K/sec                    ( +-  4.30% )
             2,957      page-faults               #    0.006 M/sec                    ( +-  0.07% )
       536,970,476      cycles                    #    1.178 GHz                      ( +-  0.12% )
       236,527,954      instructions              #    0.44  insn per cycle           ( +-  0.04% )
        30,195,820      branches                  #   66.218 M/sec                    ( +-  0.04% )
         4,128,388      branch-misses             #   13.67% of all branches          ( +-  0.13% )

          0.355460 +- 0.000741 seconds time elapsed  ( +-  0.21% )
```

SPECjvm2008 with `-Xint`:

```
Compress: +54%
Serial: +56%
```

Additional testing:
 - [x] Linux aarch64 fastdebug, `tier1`
 - [x] Linux aarch64 fastdebug, `tier2`
 - [x] Ad-hoc benchmarks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281469](https://bugs.openjdk.java.net/browse/JDK-8281469): aarch64: Improve interpreter stack banging


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)
 * [Xin Liu](https://openjdk.java.net/census#xliu) (@navyxliu - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8001/head:pull/8001` \
`$ git checkout pull/8001`

Update a local copy of the PR: \
`$ git checkout pull/8001` \
`$ git pull https://git.openjdk.java.net/jdk pull/8001/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8001`

View PR using the GUI difftool: \
`$ git pr show -t 8001`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8001.diff">https://git.openjdk.java.net/jdk/pull/8001.diff</a>

</details>
