### PR TITLE
8283717: vmTestbase/nsk/jdi/ThreadStartEvent/thread/thread001 failed due to SocketTimeoutException

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerFinder.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerFinder.java
@@ -87,6 +87,7 @@ public class PointerFinder {
     if (heap instanceof GenCollectedHeap) {
       GenCollectedHeap genheap = (GenCollectedHeap) heap;
       if (genheap.isIn(a)) {
+        loc.heap = heap;
         for (int i = 0; i < genheap.nGens(); i++) {
           Generation g = genheap.getGen(i);
           if (g.isIn(a)) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
@@ -107,7 +107,7 @@ public class PointerLocation {
   }
 
   public boolean isInHeap() {
-    return (heap != null || (gen != null));
+    return (heap != null);
   }
 
   public boolean isInNewGen() {
@@ -122,7 +122,6 @@ public class PointerLocation {
     return (!isInNewGen() && !isInOldGen());
   }
 
-  /** Only valid if isInHeap() */
   public Generation getGeneration() {
       return gen;
   }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
@@ -111,11 +111,11 @@ public class PointerLocation {
   }
 
   public boolean isInNewGen() {
-    return ((gen != null) && (gen == ((GenCollectedHeap)heap).getGen(0)));
+    return ((gen != null) && (gen.equals(((GenCollectedHeap)heap).getGen(0))));
   }
 
   public boolean isInOldGen() {
-    return ((gen != null) && (gen == ((GenCollectedHeap)heap).getGen(1)));
+    return ((gen != null) && (gen.equals(((GenCollectedHeap)heap).getGen(1))));
   }
 
   public boolean inOtherGen() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadStartEvent/thread/thread001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadStartEvent/thread/thread001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -151,6 +151,8 @@ public class thread001 {
             if (checkedRequest != null) {
                 log.display("Disabling event request");
                 checkedRequest.disable();
+                // need to resume all threds in case a stray ThreadStartEvent arrived
+                vm.resume();
             }
 
             // force debuggee to quit


### PR DESCRIPTION
In this test the debuggee creates a couple of threads, and the debugger checks to make sure it gets a ThreadStartEvent for each of these threads, plus one for the main debuggee thread. Once it has done this, it disables the ThreadStartRequest and sends a "quit" command to the debuggee. However, another ThreadStartEvent can arrive after the expected 3, and this will cause all debuggee threads to be suspended (since the ThreadStartRequest uses the SUSPEND_ALL). If this happens the debuggee cannot even read "quit" message and terminate, so the debugger times out waiting. The solution is to simply to an unconditional vm.resume() after disabling ThreadStartRequest.

Note this bug was observed in loom due to the creation of carrier threads, but it could potentially happen in jdk also since the jvm creates numerous threads on startup, and they can potentially be delayed a bit.