### PR TITLE
8283717: vmTestbase/nsk/jdi/ThreadStartEvent/thread/thread001 failed due to SocketTimeoutException

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadStartEvent/thread/thread001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadStartEvent/thread/thread001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -151,6 +151,8 @@ public class thread001 {
             if (checkedRequest != null) {
                 log.display("Disabling event request");
                 checkedRequest.disable();
+                // need to resume all threds in case a stray ThreadStartEvent arrived
+                vm.resume();
             }
 
             // force debuggee to quit

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadStartEvent/thread/thread001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadStartEvent/thread/thread001.java
@@ -151,7 +151,7 @@ public class thread001 {
             if (checkedRequest != null) {
                 log.display("Disabling event request");
                 checkedRequest.disable();
-                // need to resume all threds in case a stray ThreadStartEvent arrived
+                // need to resume all threads in case a stray ThreadStartEvent arrived
                 vm.resume();
             }
 


### PR DESCRIPTION
In this test the debuggee creates a couple of threads, and the debugger checks to make sure it gets a ThreadStartEvent for each of these threads, plus one for the main debuggee thread. Once it has done this, it disables the ThreadStartRequest and sends a "quit" command to the debuggee. However, another ThreadStartEvent can arrive after the expected 3, and this will cause all debuggee threads to be suspended (since the ThreadStartRequest uses the SUSPEND_ALL). If this happens the debuggee cannot even read "quit" message and terminate, so the debugger times out waiting. The solution is to simply to an unconditional vm.resume() after disabling ThreadStartRequest.

Note this bug was observed in loom due to the creation of carrier threads, but it could potentially happen in jdk also since the jvm creates numerous threads on startup, and they can potentially be delayed a bit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283717](https://bugs.openjdk.java.net/browse/JDK-8283717): vmTestbase/nsk/jdi/ThreadStartEvent/thread/thread001 failed due to SocketTimeoutException


### Reviewers
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8003/head:pull/8003` \
`$ git checkout pull/8003`

Update a local copy of the PR: \
`$ git checkout pull/8003` \
`$ git pull https://git.openjdk.java.net/jdk pull/8003/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8003`

View PR using the GUI difftool: \
`$ git pr show -t 8003`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8003.diff">https://git.openjdk.java.net/jdk/pull/8003.diff</a>

</details>
