### PR TITLE
8283772: Make sun.net.dns.ResolverConfiguration sealed

### DIFF
--- a/src/java.base/share/classes/sun/net/dns/ResolverConfiguration.java
+++ b/src/java.base/share/classes/sun/net/dns/ResolverConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import java.util.List;
  * @since 1.4
  */
 
-public abstract class ResolverConfiguration {
+public sealed abstract class ResolverConfiguration permits ResolverConfigurationImpl {
 
     private static final Object lock = new Object();
 

--- a/src/java.base/unix/classes/sun/net/dns/ResolverConfigurationImpl.java
+++ b/src/java.base/unix/classes/sun/net/dns/ResolverConfigurationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import java.io.IOException;
  * and Linux.
  */
 
-public class ResolverConfigurationImpl
+public final class ResolverConfigurationImpl
     extends ResolverConfiguration
 {
     // Lock helds whilst loading configuration or checking

--- a/src/java.base/windows/classes/sun/net/dns/ResolverConfigurationImpl.java
+++ b/src/java.base/windows/classes/sun/net/dns/ResolverConfigurationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
  * An implementation of sun.net.ResolverConfiguration for Windows.
  */
 
-public class ResolverConfigurationImpl
+public final class ResolverConfigurationImpl
     extends ResolverConfiguration
 {
     // Lock held whilst loading configuration or checking


### PR DESCRIPTION
The following fix seals `sun.net.dns.ResolverConfiguration` abstract class.
`sun.net.dns.ResolverConfigurationImpl` is the only permitted subclass which has two O/S specific implementations: for `Windows` and `Unix` architectures. Both of them are marked as `final`.

Testing: `jdk-tier1`, `jdk-tier2`, `jdk-tier3` and `java.naming` JCK tests show no failures with the change.