### PR TITLE
8283215: [macos] Screen Magnifier: Getting java.awt.IllegalComponentStateException when menu item is selected 

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
@@ -469,6 +469,9 @@ class CAccessibility implements PropertyChangeListener {
     public static Accessible accessibilityHitTest(final Container parent, final float hitPointX, final float hitPointY) {
         return invokeAndWait(new Callable<Accessible>() {
             public Accessible call() throws Exception {
+                if (parent == null || !parent.isVisible()) {
+                    return null;
+                }
                 final Point p = parent.getLocationOnScreen();
 
                 // Make it into local coords

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
@@ -28,6 +28,7 @@ package sun.lwawt.macosx;
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dimension;
+import java.awt.IllegalComponentStateException;
 import java.awt.KeyboardFocusManager;
 import java.awt.Point;
 import java.awt.Window;
@@ -469,33 +470,37 @@ class CAccessibility implements PropertyChangeListener {
     public static Accessible accessibilityHitTest(final Container parent, final float hitPointX, final float hitPointY) {
         return invokeAndWait(new Callable<Accessible>() {
             public Accessible call() throws Exception {
-                if (parent == null || !parent.isVisible()) {
+                try {
+                    if (parent == null) {
+                        return null;
+                    }
+                    final Point p = parent.getLocationOnScreen();
+
+                    // Make it into local coords
+                    final Point localPoint = new Point((int) (hitPointX - p.getX()), (int) (hitPointY - p.getY()));
+
+                    final Component component = parent.findComponentAt(localPoint);
+                    if (component == null) return null;
+
+                    final AccessibleContext axContext = component.getAccessibleContext();
+                    if (axContext == null) return null;
+
+                    final AccessibleComponent axComponent = axContext.getAccessibleComponent();
+                    if (axComponent == null) return null;
+
+                    final int numChildren = axContext.getAccessibleChildrenCount();
+                    if (numChildren > 0) {
+                        // It has children, check to see which one is hit.
+                        final Point p2 = axComponent.getLocationOnScreen();
+                        final Point localP2 = new Point((int) (hitPointX - p2.getX()), (int) (hitPointY - p2.getY()));
+                        return CAccessible.getCAccessible(axComponent.getAccessibleAt(localP2));
+                    }
+
+                    if (!(component instanceof Accessible)) return null;
+                    return CAccessible.getCAccessible((Accessible) component);
+                } catch (IllegalComponentStateException ice) {
                     return null;
                 }
-                final Point p = parent.getLocationOnScreen();
-
-                // Make it into local coords
-                final Point localPoint = new Point((int)(hitPointX - p.getX()), (int)(hitPointY - p.getY()));
-
-                final Component component = parent.findComponentAt(localPoint);
-                if (component == null) return null;
-
-                final AccessibleContext axContext = component.getAccessibleContext();
-                if (axContext == null) return null;
-
-                final AccessibleComponent axComponent = axContext.getAccessibleComponent();
-                if (axComponent == null) return null;
-
-                final int numChildren = axContext.getAccessibleChildrenCount();
-                if (numChildren > 0) {
-                    // It has children, check to see which one is hit.
-                    final Point p2 = axComponent.getLocationOnScreen();
-                    final Point localP2 = new Point((int)(hitPointX - p2.getX()), (int)(hitPointY - p2.getY()));
-                    return CAccessible.getCAccessible(axComponent.getAccessibleAt(localP2));
-                }
-
-                if (!(component instanceof Accessible)) return null;
-                return CAccessible.getCAccessible((Accessible)component);
             }
         }, parent);
     }

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
@@ -470,37 +470,39 @@ class CAccessibility implements PropertyChangeListener {
     public static Accessible accessibilityHitTest(final Container parent, final float hitPointX, final float hitPointY) {
         return invokeAndWait(new Callable<Accessible>() {
             public Accessible call() throws Exception {
+                if (parent == null) {
+                    return null;
+                }
+
+                final Point p;
                 try {
-                    if (parent == null) {
-                        return null;
-                    }
-                    final Point p = parent.getLocationOnScreen();
-
-                    // Make it into local coords
-                    final Point localPoint = new Point((int) (hitPointX - p.getX()), (int) (hitPointY - p.getY()));
-
-                    final Component component = parent.findComponentAt(localPoint);
-                    if (component == null) return null;
-
-                    final AccessibleContext axContext = component.getAccessibleContext();
-                    if (axContext == null) return null;
-
-                    final AccessibleComponent axComponent = axContext.getAccessibleComponent();
-                    if (axComponent == null) return null;
-
-                    final int numChildren = axContext.getAccessibleChildrenCount();
-                    if (numChildren > 0) {
-                        // It has children, check to see which one is hit.
-                        final Point p2 = axComponent.getLocationOnScreen();
-                        final Point localP2 = new Point((int) (hitPointX - p2.getX()), (int) (hitPointY - p2.getY()));
-                        return CAccessible.getCAccessible(axComponent.getAccessibleAt(localP2));
-                    }
-
-                    if (!(component instanceof Accessible)) return null;
-                    return CAccessible.getCAccessible((Accessible) component);
+                    p = parent.getLocationOnScreen();
                 } catch (IllegalComponentStateException ice) {
                     return null;
                 }
+
+                // Make it into local coords
+                final Point localPoint = new Point((int)(hitPointX - p.getX()), (int)(hitPointY - p.getY()));
+
+                final Component component = parent.findComponentAt(localPoint);
+                if (component == null) return null;
+
+                final AccessibleContext axContext = component.getAccessibleContext();
+                if (axContext == null) return null;
+
+                final AccessibleComponent axComponent = axContext.getAccessibleComponent();
+                if (axComponent == null) return null;
+
+                final int numChildren = axContext.getAccessibleChildrenCount();
+                if (numChildren > 0) {
+                    // It has children, check to see which one is hit.
+                    final Point p2 = axComponent.getLocationOnScreen();
+                    final Point localP2 = new Point((int)(hitPointX - p2.getX()), (int)(hitPointY - p2.getY()));
+                    return CAccessible.getCAccessible(axComponent.getAccessibleAt(localP2));
+                }
+
+                if (!(component instanceof Accessible)) return null;
+                return CAccessible.getCAccessible((Accessible)component);
             }
         }, parent);
     }


### PR DESCRIPTION
Check parent component visibility status before asking it for its screen coordinates.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283215](https://bugs.openjdk.java.net/browse/JDK-8283215): [macos] Screen Magnifier: Getting java.awt.IllegalComponentStateException when menu item is selected


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8008/head:pull/8008` \
`$ git checkout pull/8008`

Update a local copy of the PR: \
`$ git checkout pull/8008` \
`$ git pull https://git.openjdk.java.net/jdk pull/8008/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8008`

View PR using the GUI difftool: \
`$ git pr show -t 8008`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8008.diff">https://git.openjdk.java.net/jdk/pull/8008.diff</a>

</details>
