### PR TITLE
8283245: Create a test for JDK-4670319

### DIFF
--- a/test/jdk/javax/accessibility/4670319/AccessibleJTrePCESourceTest.java
+++ b/test/jdk/javax/accessibility/4670319/AccessibleJTrePCESourceTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key headful
+ * @bug 4670319
+ * @summary AccessibleJTree should fire a PropertyChangeEvent using a AccessibleJTreeNode as source.
+ * @run main AccessibleJTrePCESourceTest
+ */
+
+import java.awt.Robot;
+import java.beans.PropertyChangeEvent;
+import java.util.ArrayList;
+
+import javax.swing.JFrame;
+import javax.swing.JTree;
+import javax.swing.SwingUtilities;
+
+public class AccessibleJTrePCESourceTest {
+    private static JTree jTree;
+    private static JFrame jFrame;
+
+    private static ArrayList<PropertyChangeEvent> eventsList = new ArrayList<PropertyChangeEvent>();
+
+    private static void doTest() throws Exception {
+        try {
+            SwingUtilities.invokeAndWait(() -> createGUI());
+            Robot robot = new Robot();
+            robot.setAutoDelay(500);
+            robot.waitForIdle();
+
+            expand(1);
+            robot.waitForIdle();
+            collapse(1);
+            robot.waitForIdle();
+            expand(2);
+            robot.waitForIdle();
+            collapse(2);
+            robot.waitForIdle();
+        } finally {
+            SwingUtilities.invokeAndWait(() -> jFrame.dispose());
+        }
+    }
+
+    public static void expand(int row) throws Exception {
+        SwingUtilities.invokeAndWait(() -> jTree.expandRow(row));
+    }
+
+    public static void collapse(int row) throws Exception {
+        SwingUtilities.invokeAndWait(() -> jTree.collapseRow(row));
+    }
+
+    private static void createGUI() {
+        jTree = new JTree();
+        jFrame = new JFrame();
+
+        jFrame.add(jTree);
+
+        jTree.getAccessibleContext().addPropertyChangeListener(event -> {
+            if (event.getNewValue() != null) {
+                eventsList.add(event);
+            }
+        });
+
+        jFrame.setSize(200, 200);
+        jFrame.getContentPane().add(jTree);
+        jFrame.setVisible(true);
+    }
+
+    public static void main(String args[]) throws Exception {
+        doTest();
+
+        for (int i = 0; i < eventsList.size(); i++) {
+            PropertyChangeEvent obj = eventsList.get(i);
+            String state = obj.getNewValue().toString();
+
+            if ((state.equals("expanded") || state.equals("collapsed"))
+                && (obj.getPropertyName().toString()).equals("AccessibleState")) {
+                if (!(obj.getSource().getClass().getName())
+                    .equals("javax.swing.JTree$AccessibleJTree$AccessibleJTreeNode")) {
+                    throw new RuntimeException("Test Failed: When tree node is " + state
+                        + ", PropertyChangeEventSource is " + obj.getSource().getClass().getName());
+                }
+            }
+        }
+        System.out.println(
+            "Test Passed: When tree node is expanded/collapsed, PropertyChangeEventSource is the Node");
+    }
+}
+

--- a/test/jdk/javax/accessibility/4670319/AccessibleJTreePCESourceTest.java
+++ b/test/jdk/javax/accessibility/4670319/AccessibleJTreePCESourceTest.java
@@ -108,6 +108,8 @@ public class AccessibleJTreePCESourceTest {
             }
         }
         System.out.println(
-            "Test Passed: When tree node is expanded/collapsed, PropertyChangeEventSource is the Node");
+            "Test Passed: When tree node is expanded/collapsed, "
+            + "PropertyChangeEventSource is the Node");
     }
 }
+

--- a/test/jdk/javax/accessibility/4670319/AccessibleJTreePCESourceTest.java
+++ b/test/jdk/javax/accessibility/4670319/AccessibleJTreePCESourceTest.java
@@ -25,8 +25,9 @@
  * @test
  * @key headful
  * @bug 4670319
- * @summary AccessibleJTree should fire a PropertyChangeEvent using a AccessibleJTreeNode as source.
- * @run main AccessibleJTrePCESourceTest
+ * @summary AccessibleJTree should fire a PropertyChangeEvent
+ * using a AccessibleJTreeNode as source.
+ * @run main AccessibleJTreePCESourceTest
  */
 
 import java.awt.Robot;
@@ -37,17 +38,17 @@ import javax.swing.JFrame;
 import javax.swing.JTree;
 import javax.swing.SwingUtilities;
 
-public class AccessibleJTrePCESourceTest {
+public class AccessibleJTreePCESourceTest {
     private static JTree jTree;
     private static JFrame jFrame;
 
-    private static ArrayList<PropertyChangeEvent> eventsList = new ArrayList<PropertyChangeEvent>();
+    private static ArrayList<PropertyChangeEvent> eventsList =
+        new ArrayList<PropertyChangeEvent>();
 
     private static void doTest() throws Exception {
         try {
             SwingUtilities.invokeAndWait(() -> createGUI());
             Robot robot = new Robot();
-            robot.setAutoDelay(500);
             robot.waitForIdle();
 
             expand(1);
@@ -96,11 +97,13 @@ public class AccessibleJTrePCESourceTest {
             String state = obj.getNewValue().toString();
 
             if ((state.equals("expanded") || state.equals("collapsed"))
-                && (obj.getPropertyName().toString()).equals("AccessibleState")) {
-                if (!(obj.getSource().getClass().getName())
-                    .equals("javax.swing.JTree$AccessibleJTree$AccessibleJTreeNode")) {
-                    throw new RuntimeException("Test Failed: When tree node is " + state
-                        + ", PropertyChangeEventSource is " + obj.getSource().getClass().getName());
+                && (obj.getPropertyName().toString())
+                .equals("AccessibleState")) {
+                if (!(obj.getSource().getClass().getName()).equals(
+                    "javax.swing.JTree$AccessibleJTree$AccessibleJTreeNode")) {
+                    throw new RuntimeException("Test Failed: When tree node is "
+                        + state + ", PropertyChangeEventSource is "
+                        + obj.getSource().getClass().getName());
                 }
             }
         }
@@ -108,4 +111,3 @@ public class AccessibleJTrePCESourceTest {
             "Test Passed: When tree node is expanded/collapsed, PropertyChangeEventSource is the Node");
     }
 }
-


### PR DESCRIPTION
Write an automated regression test for  JDK-4670319

Issue
When a JTree node is expanded or collapsed, an Accessibility PropertyChange event is fired with the old state of "collapsed" and new state of "expanded" (or vice versa). The problem is that the source of the event is the AccessibeJTree, and not the AccessibleJTreeNode. This means that an assistive technology listening to this event is unable to report to the user what node was expanded/collapsed.

Fix
Fix for [JDK-4670319](https://bugs.openjdk.java.net/browse/JDK-4670319) addresses the above issue.  When tree node is expanded/collapsed, PropertyChangeEventSource is the Node.
This review is for a test for validating the above issue.

This review is for migrating tests from a closed test suite to open.

Testing:
The test ran successfully on Mach5 with multiple runs (30) on windows-x64, linux-x64 and macos-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283245](https://bugs.openjdk.java.net/browse/JDK-8283245): Create a test for JDK-4670319


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8012/head:pull/8012` \
`$ git checkout pull/8012`

Update a local copy of the PR: \
`$ git checkout pull/8012` \
`$ git pull https://git.openjdk.java.net/jdk pull/8012/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8012`

View PR using the GUI difftool: \
`$ git pr show -t 8012`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8012.diff">https://git.openjdk.java.net/jdk/pull/8012.diff</a>

</details>
