### PR TITLE
8283782: Redundant verification of year in LocalDate::ofEpochDay

### DIFF
--- a/src/java.base/share/classes/java/time/LocalDate.java
+++ b/src/java.base/share/classes/java/time/LocalDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/time/LocalDate.java
+++ b/src/java.base/share/classes/java/time/LocalDate.java
@@ -367,9 +367,7 @@ public final class LocalDate
         int dom = marchDoy0 - (marchMonth0 * 306 + 5) / 10 + 1;
         yearEst += marchMonth0 / 10;
 
-        // check year now we are certain it is correct
-        int year = YEAR.checkValidIntValue(yearEst);
-        return new LocalDate(year, month, dom);
+        return new LocalDate((int)yearEst, month, dom);
     }
 
     //-----------------------------------------------------------------------

--- a/test/jdk/java/time/test/java/time/TestLocalDate.java
+++ b/test/jdk/java/time/test/java/time/TestLocalDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,9 +63,12 @@ import static java.time.temporal.ChronoField.YEAR;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
+import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.Month;
+import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.IsoFields;
 
@@ -417,6 +420,28 @@ public class TestLocalDate extends AbstractTest {
         for (long i = date_0000_01_01; i > -2000000; i--) {
             assertEquals(LocalDate.ofEpochDay(test.toEpochDay()), test);
             test = previous(test);
+        }
+    }
+
+    @Test
+    public void test_toEpochDay_edges() {
+        long minDay = ChronoField.EPOCH_DAY.range().getMinimum();
+        long maxDay = ChronoField.EPOCH_DAY.range().getMaximum();
+        for (int i = 0; i < 500; i++) {
+            assertEquals(LocalDate.ofEpochDay(minDay + i), LocalDate.MIN.plusDays(i));
+            assertEquals(LocalDate.ofEpochDay(maxDay - i), LocalDate.MAX.minusDays(i));
+            try {
+                LocalDate.ofEpochDay(minDay - 1 - i);
+                fail("Expected DateTimeException");
+            } catch (DateTimeException e) {
+                // expected
+            }
+            try {
+                LocalDate.ofEpochDay(maxDay + 1 + i);
+                fail("Expected DateTimeException");
+            } catch (DateTimeException e) {
+                // expected
+            }
         }
     }
 

--- a/test/jdk/java/time/test/java/time/TestLocalDate.java
+++ b/test/jdk/java/time/test/java/time/TestLocalDate.java
@@ -424,7 +424,7 @@ public class TestLocalDate extends AbstractTest {
     }
 
     @Test
-    public void test_toEpochDay_edges() {
+    public void test_ofEpochDay_edges() {
         long minDay = ChronoField.EPOCH_DAY.range().getMinimum();
         long maxDay = ChronoField.EPOCH_DAY.range().getMaximum();
         long minYear = ChronoField.YEAR.range().getMinimum();

--- a/test/jdk/java/time/test/java/time/TestLocalDate.java
+++ b/test/jdk/java/time/test/java/time/TestLocalDate.java
@@ -429,23 +429,24 @@ public class TestLocalDate extends AbstractTest {
         long maxDay = ChronoField.EPOCH_DAY.range().getMaximum();
         long minYear = ChronoField.YEAR.range().getMinimum();
         long maxYear = ChronoField.YEAR.range().getMinimum();
-        for (int i = 0; i < 500; i++) {
-            LocalDate minDate = LocalDate.ofEpochDay(minDay + i);
-            assertEquals(minDate, LocalDate.MIN.plusDays(i));
+        int[] offsets = new int[] { 0, 1, 2, 3, 28, 29, 30, 31, 32, 363, 364, 365, 366, 367 };
+        for (int offset : offsets) {
+            LocalDate minDate = LocalDate.ofEpochDay(minDay + offset);
+            assertEquals(minDate, LocalDate.MIN.plusDays(offset));
             assertTrue(ChronoField.YEAR.range().isValidValue(minDate.getYear()));
 
-            LocalDate maxDate = LocalDate.ofEpochDay(maxDay - i);
-            assertEquals(maxDate, LocalDate.MAX.minusDays(i));
+            LocalDate maxDate = LocalDate.ofEpochDay(maxDay - offset);
+            assertEquals(maxDate, LocalDate.MAX.minusDays(offset));
             assertTrue(ChronoField.YEAR.range().isValidValue(maxDate.getYear()));
 
             try {
-                LocalDate.ofEpochDay(minDay - 1 - i);
+                LocalDate.ofEpochDay(minDay - 1 - offset);
                 fail("Expected DateTimeException");
             } catch (DateTimeException e) {
                 // expected
             }
             try {
-                LocalDate.ofEpochDay(maxDay + 1 + i);
+                LocalDate.ofEpochDay(maxDay + 1 + offset);
                 fail("Expected DateTimeException");
             } catch (DateTimeException e) {
                 // expected

--- a/test/jdk/java/time/test/java/time/TestLocalDate.java
+++ b/test/jdk/java/time/test/java/time/TestLocalDate.java
@@ -427,9 +427,17 @@ public class TestLocalDate extends AbstractTest {
     public void test_toEpochDay_edges() {
         long minDay = ChronoField.EPOCH_DAY.range().getMinimum();
         long maxDay = ChronoField.EPOCH_DAY.range().getMaximum();
+        long minYear = ChronoField.YEAR.range().getMinimum();
+        long maxYear = ChronoField.YEAR.range().getMinimum();
         for (int i = 0; i < 500; i++) {
-            assertEquals(LocalDate.ofEpochDay(minDay + i), LocalDate.MIN.plusDays(i));
-            assertEquals(LocalDate.ofEpochDay(maxDay - i), LocalDate.MAX.minusDays(i));
+            LocalDate minDate = LocalDate.ofEpochDay(minDay + i);
+            assertEquals(minDate, LocalDate.MIN.plusDays(i));
+            assertTrue(ChronoField.YEAR.range().isValidValue(minDate.getYear()));
+
+            LocalDate maxDate = LocalDate.ofEpochDay(maxDay - i);
+            assertEquals(maxDate, LocalDate.MAX.minusDays(i));
+            assertTrue(ChronoField.YEAR.range().isValidValue(maxDate.getYear()));
+
             try {
                 LocalDate.ofEpochDay(minDay - 1 - i);
                 fail("Expected DateTimeException");


### PR DESCRIPTION
In `LocalDate::ofEpochDays` we validate the epoch day input, then we also validate the year derived from that value. This second validation is redundant since the minimum and maximum valid epoch day line up with the first and last day of the minimum and maximum valid year, respectively. This patch replace this redundant runtime validation with a test. 

This reduces code complexity (increasing chance for inlining to happen) and removes a couple of branches from generated code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283782](https://bugs.openjdk.java.net/browse/JDK-8283782): Redundant verification of year in LocalDate::ofEpochDay


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to 44a11aa7f55d8ce73224ab73a63a1e5705fb8bc7
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8014/head:pull/8014` \
`$ git checkout pull/8014`

Update a local copy of the PR: \
`$ git checkout pull/8014` \
`$ git pull https://git.openjdk.java.net/jdk pull/8014/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8014`

View PR using the GUI difftool: \
`$ git pr show -t 8014`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8014.diff">https://git.openjdk.java.net/jdk/pull/8014.diff</a>

</details>
