### PR TITLE
8283794: CCE in XRTextRenderer.drawGlyphList and XRMaskFill.MaskFill

### DIFF
--- a/src/java.desktop/macosx/classes/sun/java2d/metal/MTLMaskFill.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/metal/MTLMaskFill.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,8 @@
  */
 package sun.java2d.metal;
 
-import sun.java2d.InvalidPipeException;
 import sun.java2d.SunGraphics2D;
+import sun.java2d.SurfaceData;
 import sun.java2d.loops.CompositeType;
 import sun.java2d.loops.GraphicsPrimitive;
 import sun.java2d.loops.GraphicsPrimitiveMgr;
@@ -70,13 +70,8 @@ class MTLMaskFill extends BufferedMaskFill {
     protected void validateContext(SunGraphics2D sg2d,
                                    Composite comp, int ctxflags)
     {
-        MTLSurfaceData dstData;
-        try {
-            dstData = (MTLSurfaceData) sg2d.surfaceData;
-        } catch (ClassCastException e) {
-            throw new InvalidPipeException("wrong surface data type: " +
-                    sg2d.surfaceData);
-        }
+        MTLSurfaceData dstData = SurfaceData.convertTo(MTLSurfaceData.class,
+                                                       sg2d.surfaceData);
 
         MTLContext.validateContext(dstData, dstData,
                 sg2d.getCompClip(), comp,

--- a/src/java.desktop/macosx/classes/sun/java2d/metal/MTLRenderer.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/metal/MTLRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,8 @@
 
 package sun.java2d.metal;
 
-import sun.java2d.InvalidPipeException;
 import sun.java2d.SunGraphics2D;
+import sun.java2d.SurfaceData;
 import sun.java2d.loops.GraphicsPrimitive;
 import sun.java2d.pipe.BufferedRenderPipe;
 import sun.java2d.pipe.ParallelogramPipe;
@@ -49,12 +49,8 @@ class MTLRenderer extends BufferedRenderPipe {
         int ctxflags =
                 sg2d.paint.getTransparency() == Transparency.OPAQUE ?
                         MTLContext.SRC_IS_OPAQUE : MTLContext.NO_CONTEXT_FLAGS;
-        MTLSurfaceData dstData;
-        try {
-            dstData = (MTLSurfaceData)sg2d.surfaceData;
-        } catch (ClassCastException e) {
-            throw new InvalidPipeException("wrong surface data type: " + sg2d.surfaceData);
-        }
+        MTLSurfaceData dstData = SurfaceData.convertTo(MTLSurfaceData.class,
+                                                       sg2d.surfaceData);
         MTLContext.validateContext(dstData, dstData,
                 sg2d.getCompClip(), sg2d.composite,
                 null, sg2d.paint, sg2d, ctxflags);
@@ -63,12 +59,8 @@ class MTLRenderer extends BufferedRenderPipe {
     @Override
     protected void validateContextAA(SunGraphics2D sg2d) {
         int ctxflags = MTLContext.NO_CONTEXT_FLAGS;
-        MTLSurfaceData dstData;
-        try {
-            dstData = (MTLSurfaceData)sg2d.surfaceData;
-        } catch (ClassCastException e) {
-            throw new InvalidPipeException("wrong surface data type: " + sg2d.surfaceData);
-        }
+        MTLSurfaceData dstData = SurfaceData.convertTo(MTLSurfaceData.class,
+                                                       sg2d.surfaceData);
         MTLContext.validateContext(dstData, dstData,
                 sg2d.getCompClip(), sg2d.composite,
                 null, sg2d.paint, sg2d, ctxflags);
@@ -82,12 +74,8 @@ class MTLRenderer extends BufferedRenderPipe {
             int ctxflags =
                     sg2d.surfaceData.getTransparency() == Transparency.OPAQUE ?
                             MTLContext.SRC_IS_OPAQUE : MTLContext.NO_CONTEXT_FLAGS;
-            MTLSurfaceData dstData;
-            try {
-                dstData = (MTLSurfaceData)sg2d.surfaceData;
-            } catch (ClassCastException e) {
-                throw new InvalidPipeException("wrong surface data type: " + sg2d.surfaceData);
-            }
+            MTLSurfaceData dstData = SurfaceData.convertTo(MTLSurfaceData.class,
+                                                           sg2d.surfaceData);
             MTLContext.validateContext(dstData, dstData,
                     sg2d.getCompClip(), sg2d.composite,
                     null, null, null, ctxflags);

--- a/src/java.desktop/share/classes/sun/java2d/SurfaceData.java
+++ b/src/java.desktop/share/classes/sun/java2d/SurfaceData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1090,5 +1090,16 @@ public abstract class SurfaceData
      */
     public double getDefaultScaleY() {
         return 1;
+    }
+
+    /**
+     * Converts surfaceData to the particular subclass or throws InvalidPipeException
+     */
+    public static <T> T convertTo(Class<T> surfaceDataClass, SurfaceData surfaceData) {
+        try {
+            return surfaceDataClass.cast(surfaceData);
+        } catch(ClassCastException e) {
+            throw new InvalidPipeException("wrong surface data type: " + surfaceData);
+        }
     }
 }

--- a/src/java.desktop/share/classes/sun/java2d/opengl/OGLMaskFill.java
+++ b/src/java.desktop/share/classes/sun/java2d/opengl/OGLMaskFill.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,8 @@
 package sun.java2d.opengl;
 
 import java.awt.Composite;
-import sun.java2d.InvalidPipeException;
 import sun.java2d.SunGraphics2D;
+import sun.java2d.SurfaceData;
 import sun.java2d.loops.GraphicsPrimitive;
 import sun.java2d.loops.GraphicsPrimitiveMgr;
 import sun.java2d.loops.CompositeType;
@@ -68,13 +68,8 @@ class OGLMaskFill extends BufferedMaskFill {
     protected void validateContext(SunGraphics2D sg2d,
                                    Composite comp, int ctxflags)
     {
-        OGLSurfaceData dstData;
-        try {
-            dstData = (OGLSurfaceData) sg2d.surfaceData;
-        } catch (ClassCastException e) {
-            throw new InvalidPipeException("wrong surface data type: " +
-                                           sg2d.surfaceData);
-        }
+        OGLSurfaceData dstData = SurfaceData.convertTo(OGLSurfaceData.class,
+                                                       sg2d.surfaceData);
 
         OGLContext.validateContext(dstData, dstData,
                                    sg2d.getCompClip(), comp,

--- a/src/java.desktop/share/classes/sun/java2d/opengl/OGLRenderer.java
+++ b/src/java.desktop/share/classes/sun/java2d/opengl/OGLRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,8 @@ package sun.java2d.opengl;
 
 import java.awt.Transparency;
 import java.awt.geom.Path2D;
-import sun.java2d.InvalidPipeException;
 import sun.java2d.SunGraphics2D;
+import sun.java2d.SurfaceData;
 import sun.java2d.loops.GraphicsPrimitive;
 import sun.java2d.pipe.BufferedRenderPipe;
 import sun.java2d.pipe.ParallelogramPipe;
@@ -47,12 +47,8 @@ class OGLRenderer extends BufferedRenderPipe {
         int ctxflags =
             sg2d.paint.getTransparency() == Transparency.OPAQUE ?
                 OGLContext.SRC_IS_OPAQUE : OGLContext.NO_CONTEXT_FLAGS;
-        OGLSurfaceData dstData;
-        try {
-            dstData = (OGLSurfaceData)sg2d.surfaceData;
-        } catch (ClassCastException e) {
-            throw new InvalidPipeException("wrong surface data type: " + sg2d.surfaceData);
-        }
+        OGLSurfaceData dstData = SurfaceData.convertTo(OGLSurfaceData.class,
+                                                       sg2d.surfaceData);
         OGLContext.validateContext(dstData, dstData,
                                    sg2d.getCompClip(), sg2d.composite,
                                    null, sg2d.paint, sg2d, ctxflags);
@@ -61,12 +57,8 @@ class OGLRenderer extends BufferedRenderPipe {
     @Override
     protected void validateContextAA(SunGraphics2D sg2d) {
         int ctxflags = OGLContext.NO_CONTEXT_FLAGS;
-        OGLSurfaceData dstData;
-        try {
-            dstData = (OGLSurfaceData)sg2d.surfaceData;
-        } catch (ClassCastException e) {
-            throw new InvalidPipeException("wrong surface data type: " + sg2d.surfaceData);
-        }
+        OGLSurfaceData dstData = SurfaceData.convertTo(OGLSurfaceData.class,
+                                                       sg2d.surfaceData);
         OGLContext.validateContext(dstData, dstData,
                                    sg2d.getCompClip(), sg2d.composite,
                                    null, sg2d.paint, sg2d, ctxflags);
@@ -80,12 +72,8 @@ class OGLRenderer extends BufferedRenderPipe {
             int ctxflags =
                 sg2d.surfaceData.getTransparency() == Transparency.OPAQUE ?
                     OGLContext.SRC_IS_OPAQUE : OGLContext.NO_CONTEXT_FLAGS;
-            OGLSurfaceData dstData;
-            try {
-                dstData = (OGLSurfaceData)sg2d.surfaceData;
-            } catch (ClassCastException e) {
-                throw new InvalidPipeException("wrong surface data type: " + sg2d.surfaceData);
-            }
+            OGLSurfaceData dstData = SurfaceData.convertTo(OGLSurfaceData.class,
+                                                           sg2d.surfaceData);
             OGLContext.validateContext(dstData, dstData,
                                        sg2d.getCompClip(), sg2d.composite,
                                        null, null, null, ctxflags);

--- a/src/java.desktop/unix/classes/sun/font/XRTextRenderer.java
+++ b/src/java.desktop/unix/classes/sun/font/XRTextRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package sun.font;
 
 import sun.awt.*;
+import sun.java2d.InvalidPipeException;
 import sun.java2d.SunGraphics2D;
 import sun.java2d.pipe.GlyphListPipe;
 import sun.java2d.xr.*;
@@ -61,8 +62,12 @@ public class XRTextRenderer extends GlyphListPipe {
 
         try {
             SunToolkit.awtLock();
-
-            XRSurfaceData x11sd = (XRSurfaceData) sg2d.surfaceData;
+            XRSurfaceData x11sd;
+            try {
+                x11sd = (XRSurfaceData) sg2d.surfaceData;
+            } catch (ClassCastException e) {
+                throw new InvalidPipeException("wrong surface data type: " + sg2d.surfaceData);
+            }
             x11sd.validateAsDestination(null, sg2d.getCompClip());
             x11sd.maskBuffer.validateCompositeState(sg2d.composite, sg2d.transform, sg2d.paint, sg2d);
 

--- a/src/java.desktop/unix/classes/sun/font/XRTextRenderer.java
+++ b/src/java.desktop/unix/classes/sun/font/XRTextRenderer.java
@@ -26,8 +26,8 @@
 package sun.font;
 
 import sun.awt.*;
-import sun.java2d.InvalidPipeException;
 import sun.java2d.SunGraphics2D;
+import sun.java2d.SurfaceData;
 import sun.java2d.pipe.GlyphListPipe;
 import sun.java2d.xr.*;
 
@@ -62,12 +62,7 @@ public class XRTextRenderer extends GlyphListPipe {
 
         try {
             SunToolkit.awtLock();
-            XRSurfaceData x11sd;
-            try {
-                x11sd = (XRSurfaceData) sg2d.surfaceData;
-            } catch (ClassCastException e) {
-                throw new InvalidPipeException("wrong surface data type: " + sg2d.surfaceData);
-            }
+            XRSurfaceData x11sd = SurfaceData.convertTo(XRSurfaceData.class, sg2d.surfaceData);
             x11sd.validateAsDestination(null, sg2d.getCompClip());
             x11sd.maskBuffer.validateCompositeState(sg2d.composite, sg2d.transform, sg2d.paint, sg2d);
 

--- a/src/java.desktop/unix/classes/sun/java2d/xr/XRMaskFill.java
+++ b/src/java.desktop/unix/classes/sun/java2d/xr/XRMaskFill.java
@@ -99,12 +99,7 @@ public class XRMaskFill extends MaskFill {
         try {
             SunToolkit.awtLock();
 
-            XRSurfaceData x11sd;
-            try {
-                x11sd = (XRSurfaceData) sData;
-            } catch (ClassCastException e) {
-                throw new InvalidPipeException("wrong surface data type: " + sData);
-            }
+            XRSurfaceData x11sd = SurfaceData.convertTo(XRSurfaceData.class, sData);
             x11sd.validateAsDestination(null, sg2d.getCompClip());
 
             XRCompositeManager maskBuffer = x11sd.maskBuffer;

--- a/src/java.desktop/unix/classes/sun/java2d/xr/XRMaskFill.java
+++ b/src/java.desktop/unix/classes/sun/java2d/xr/XRMaskFill.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,7 +99,12 @@ public class XRMaskFill extends MaskFill {
         try {
             SunToolkit.awtLock();
 
-            XRSurfaceData x11sd = (XRSurfaceData) sData;
+            XRSurfaceData x11sd;
+            try {
+                x11sd = (XRSurfaceData) sData;
+            } catch (ClassCastException e) {
+                throw new InvalidPipeException("wrong surface data type: " + sData);
+            }
             x11sd.validateAsDestination(null, sg2d.getCompClip());
 
             XRCompositeManager maskBuffer = x11sd.maskBuffer;

--- a/src/java.desktop/unix/classes/sun/java2d/xr/XRRenderer.java
+++ b/src/java.desktop/unix/classes/sun/java2d/xr/XRRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,8 +28,8 @@ package sun.java2d.xr;
 import java.awt.*;
 import java.awt.geom.*;
 import sun.awt.SunToolkit;
-import sun.java2d.InvalidPipeException;
 import sun.java2d.SunGraphics2D;
+import sun.java2d.SurfaceData;
 import sun.java2d.loops.*;
 import sun.java2d.pipe.Region;
 import sun.java2d.pipe.PixelDrawPipe;
@@ -70,12 +70,8 @@ public class XRRenderer implements PixelDrawPipe, PixelFillPipe, ShapeDrawPipe {
      * destination context.
      */
     private void validateSurface(SunGraphics2D sg2d) {
-        XRSurfaceData xrsd;
-        try {
-            xrsd = (XRSurfaceData) sg2d.surfaceData;
-        } catch (ClassCastException e) {
-            throw new InvalidPipeException("wrong surface data type: " + sg2d.surfaceData);
-        }
+        XRSurfaceData xrsd = SurfaceData.convertTo(XRSurfaceData.class,
+                                                   sg2d.surfaceData);
         xrsd.validateAsDestination(sg2d, sg2d.getCompClip());
         xrsd.maskBuffer.validateCompositeState(sg2d.composite, sg2d.transform,
                                                sg2d.paint, sg2d);

--- a/src/java.desktop/windows/classes/sun/java2d/d3d/D3DMaskFill.java
+++ b/src/java.desktop/windows/classes/sun/java2d/d3d/D3DMaskFill.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,8 @@
 package sun.java2d.d3d;
 
 import java.awt.Composite;
-import sun.java2d.InvalidPipeException;
 import sun.java2d.SunGraphics2D;
+import sun.java2d.SurfaceData;
 import sun.java2d.loops.GraphicsPrimitive;
 import sun.java2d.loops.GraphicsPrimitiveMgr;
 import sun.java2d.loops.CompositeType;
@@ -68,13 +68,8 @@ class D3DMaskFill extends BufferedMaskFill {
     protected void validateContext(SunGraphics2D sg2d,
                                    Composite comp, int ctxflags)
     {
-        D3DSurfaceData dstData;
-        try {
-            dstData = (D3DSurfaceData) sg2d.surfaceData;
-        } catch (ClassCastException e) {
-            throw new InvalidPipeException("wrong surface data type: " +
-                                           sg2d.surfaceData);
-        }
+        D3DSurfaceData dstData = SurfaceData.convertTo(D3DSurfaceData.class,
+                                                       sg2d.surfaceData);
         D3DContext.validateContext(dstData, dstData,
                                    sg2d.getCompClip(), comp,
                                    null, sg2d.paint, sg2d, ctxflags);

--- a/src/java.desktop/windows/classes/sun/java2d/d3d/D3DRenderer.java
+++ b/src/java.desktop/windows/classes/sun/java2d/d3d/D3DRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,8 @@ package sun.java2d.d3d;
 
 import java.awt.Transparency;
 import java.awt.geom.Path2D;
-import sun.java2d.InvalidPipeException;
 import sun.java2d.SunGraphics2D;
+import sun.java2d.SurfaceData;
 import sun.java2d.loops.GraphicsPrimitive;
 import sun.java2d.pipe.BufferedRenderPipe;
 import sun.java2d.pipe.RenderQueue;
@@ -47,12 +47,8 @@ class D3DRenderer extends BufferedRenderPipe {
         int ctxflags =
             sg2d.paint.getTransparency() == Transparency.OPAQUE ?
                 D3DContext.SRC_IS_OPAQUE : D3DContext.NO_CONTEXT_FLAGS;
-        D3DSurfaceData dstData;
-        try {
-            dstData = (D3DSurfaceData)sg2d.surfaceData;
-        } catch (ClassCastException e) {
-            throw new InvalidPipeException("wrong surface data type: " + sg2d.surfaceData);
-        }
+        D3DSurfaceData dstData = SurfaceData.convertTo(D3DSurfaceData.class,
+                                                       sg2d.surfaceData);
         D3DContext.validateContext(dstData, dstData,
                                    sg2d.getCompClip(), sg2d.composite,
                                    null, sg2d.paint, sg2d, ctxflags);
@@ -61,12 +57,8 @@ class D3DRenderer extends BufferedRenderPipe {
     @Override
     protected void validateContextAA(SunGraphics2D sg2d) {
         int ctxflags = D3DContext.NO_CONTEXT_FLAGS;
-        D3DSurfaceData dstData;
-        try {
-            dstData = (D3DSurfaceData)sg2d.surfaceData;
-        } catch (ClassCastException e) {
-            throw new InvalidPipeException("wrong surface data type: " + sg2d.surfaceData);
-        }
+        D3DSurfaceData dstData = SurfaceData.convertTo(D3DSurfaceData.class,
+                                                       sg2d.surfaceData);
         D3DContext.validateContext(dstData, dstData,
                                    sg2d.getCompClip(), sg2d.composite,
                                    null, sg2d.paint, sg2d, ctxflags);
@@ -80,12 +72,8 @@ class D3DRenderer extends BufferedRenderPipe {
             int ctxflags =
                 sg2d.surfaceData.getTransparency() == Transparency.OPAQUE ?
                     D3DContext.SRC_IS_OPAQUE : D3DContext.NO_CONTEXT_FLAGS;
-            D3DSurfaceData dstData;
-            try {
-                dstData = (D3DSurfaceData)sg2d.surfaceData;
-            } catch (ClassCastException e) {
-                throw new InvalidPipeException("wrong surface data type: " + sg2d.surfaceData);
-            }
+            D3DSurfaceData dstData = SurfaceData.convertTo(D3DSurfaceData.class,
+                                                           sg2d.surfaceData);
             D3DContext.validateContext(dstData, dstData,
                                        sg2d.getCompClip(), sg2d.composite,
                                        null, null, null, ctxflags);

--- a/src/java.desktop/windows/classes/sun/java2d/windows/GDIRenderer.java
+++ b/src/java.desktop/windows/classes/sun/java2d/windows/GDIRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -292,12 +292,8 @@ public class GDIRenderer implements
     // method that could be filled by the doShape method more quickly.
     public void doFillSpans(SunGraphics2D sg2d, SpanIterator si) {
         int[] box = new int[4];
-        GDIWindowSurfaceData sd;
-        try {
-            sd = (GDIWindowSurfaceData)sg2d.surfaceData;
-        } catch (ClassCastException e) {
-            throw new InvalidPipeException("wrong surface data type: " + sg2d.surfaceData);
-        }
+        GDIWindowSurfaceData sd = SurfaceData.convertTo(GDIWindowSurfaceData.class,
+                                                        sg2d.surfaceData);
         Region clip = sg2d.getCompClip();
         Composite comp = sg2d.composite;
         int eargb = sg2d.eargb;

--- a/test/jdk/sun/java2d/ClassCastExceptionForInvalidSurface.java
+++ b/test/jdk/sun/java2d/ClassCastExceptionForInvalidSurface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016,2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ import static java.awt.image.BufferedImage.TYPE_INT_ARGB;
 /**
  * @test
  * @key headful
- * @bug 8158072 7172749
+ * @bug 8158072 7172749 8283794
  */
 public final class ClassCastExceptionForInvalidSurface {
 

--- a/test/jdk/sun/java2d/ClassCastExceptionForInvalidSurface.java
+++ b/test/jdk/sun/java2d/ClassCastExceptionForInvalidSurface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016,2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Throwing InvalidPipeException for incompatible surfaces

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283794](https://bugs.openjdk.java.net/browse/JDK-8283794): CCE in XRTextRenderer.drawGlyphList and XRMaskFill.MaskFill


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to d9a132efe331ec0c00ae6b4bf87da9ac34e45420
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8015/head:pull/8015` \
`$ git checkout pull/8015`

Update a local copy of the PR: \
`$ git checkout pull/8015` \
`$ git pull https://git.openjdk.java.net/jdk pull/8015/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8015`

View PR using the GUI difftool: \
`$ git pr show -t 8015`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8015.diff">https://git.openjdk.java.net/jdk/pull/8015.diff</a>

</details>
