### PR TITLE
8282374: Java_sun_awt_X11_XlibWrapper_XSynchronize is wrong and unused

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/XlibWrapper.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XlibWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -523,13 +523,6 @@ static native String XSetLocaleModifiers(String modifier_list);
 
     static native void XChangeActivePointerGrab(long display, int mask,
                                                 long cursor, long time);
-
-    /*
-      int (*XSynchronize(Display *display, Bool onoff))();
-          display   Specifies the connection to the X server.
-          onoff     Specifies a Boolean value that indicates whether to enable or disable synchronization.
-     */
-    static native int XSynchronize(long display, boolean onoff);
 
     /**
      * Extracts an X event that can be processed in a secondary loop.

--- a/src/java.desktop/unix/native/libawt_xawt/xawt/XlibWrapper.c
+++ b/src/java.desktop/unix/native/libawt_xawt/xawt/XlibWrapper.c
@@ -2184,11 +2184,6 @@ Java_sun_awt_X11_XlibWrapper_copyLongArray(JNIEnv *env,
     }
 }
 
-JNIEXPORT jint JNICALL
-Java_sun_awt_X11_XlibWrapper_XSynchronize(JNIEnv *env, jclass clazz, jlong display, jboolean onoff)
-{
-    return (jint) XSynchronize((Display*)jlong_to_ptr(display), (onoff == JNI_TRUE ? True : False));
-}
 
 JNIEXPORT jboolean JNICALL
 Java_sun_awt_X11_XlibWrapper_XShapeQueryExtension


### PR DESCRIPTION
This fix simply removes unused `XSynchronize` method.

Alternatively its return type may be changed to `long`, but I think less code is better.

Testing is green.