### PR TITLE
8283544: HttpClient GET method adds Content-Length: 0 header

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
@@ -302,15 +302,12 @@ class Http1Request {
         if (requestPublisher != null || !"GET".equals(request.method())) {
             if (contentLength == 0) {
                 systemHeadersBuilder.setHeader("Content-Length", "0");
-                System.err.println("in 1");
             } else if (contentLength > 0) {
                 systemHeadersBuilder.setHeader("Content-Length", Long.toString(contentLength));
                 streaming = false;
-                System.err.println("in 2");
             } else {
                 streaming = true;
                 systemHeadersBuilder.setHeader("Transfer-encoding", "chunked");
-                System.err.println("in 3");
             }
         }
         collectHeaders0(sb);

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
@@ -294,11 +294,15 @@ class Http1Request {
 
         // GET, HEAD and DELETE with no request body should not set the Content-Length header
         if (requestPublisher != null) {
+            contentLength = requestPublisher.contentLength();
             if (contentLength == 0) {
                 systemHeadersBuilder.setHeader("Content-Length", "0");
             } else if (contentLength > 0) {
                 systemHeadersBuilder.setHeader("Content-Length", Long.toString(contentLength));
                 streaming = false;
+            } else {
+                streaming = true;
+                systemHeadersBuilder.setHeader("Transfer-encoding", "chunked");
             }
         }
         collectHeaders0(sb);

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
@@ -298,8 +298,8 @@ class Http1Request {
             contentLength = requestPublisher.contentLength();
         }
 
-        // GET with no body should not set the Content-Length header
-        if (requestPublisher != null || !"GET".equals(request.method())) {
+        // GET, HEAD and DELETE with no request body should not set the Content-Length header
+        if (requestPublisher != null) {
             if (contentLength == 0) {
                 systemHeadersBuilder.setHeader("Content-Length", "0");
             } else if (contentLength > 0) {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
@@ -291,12 +291,6 @@ class Http1Request {
         if (uri != null) {
             systemHeadersBuilder.setHeader("Host", hostString());
         }
-        if (requestPublisher == null) {
-            // Not a user request, or maybe a method, e.g. GET, with no body.
-            contentLength = 0;
-        } else {
-            contentLength = requestPublisher.contentLength();
-        }
 
         // GET, HEAD and DELETE with no request body should not set the Content-Length header
         if (requestPublisher != null) {
@@ -305,9 +299,6 @@ class Http1Request {
             } else if (contentLength > 0) {
                 systemHeadersBuilder.setHeader("Content-Length", Long.toString(contentLength));
                 streaming = false;
-            } else {
-                streaming = true;
-                systemHeadersBuilder.setHeader("Transfer-encoding", "chunked");
             }
         }
         collectHeaders0(sb);

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -298,14 +298,20 @@ class Http1Request {
             contentLength = requestPublisher.contentLength();
         }
 
-        if (contentLength == 0) {
-            systemHeadersBuilder.setHeader("Content-Length", "0");
-        } else if (contentLength > 0) {
-            systemHeadersBuilder.setHeader("Content-Length", Long.toString(contentLength));
-            streaming = false;
-        } else {
-            streaming = true;
-            systemHeadersBuilder.setHeader("Transfer-encoding", "chunked");
+        // GET with no body should not set the Content-Length header
+        if (requestPublisher != null || !"GET".equals(request.method())) {
+            if (contentLength == 0) {
+                systemHeadersBuilder.setHeader("Content-Length", "0");
+                System.err.println("in 1");
+            } else if (contentLength > 0) {
+                systemHeadersBuilder.setHeader("Content-Length", Long.toString(contentLength));
+                streaming = false;
+                System.err.println("in 2");
+            } else {
+                streaming = true;
+                systemHeadersBuilder.setHeader("Transfer-encoding", "chunked");
+                System.err.println("in 3");
+            }
         }
         collectHeaders0(sb);
         String hs = sb.toString();

--- a/test/jdk/java/net/httpclient/ContentLengthHeaderTest.java
+++ b/test/jdk/java/net/httpclient/ContentLengthHeaderTest.java
@@ -40,6 +40,7 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.InetAddress;
@@ -179,7 +180,9 @@ public class ContentLengthHeaderTest {
     }
 
     public static void handleResponse(HttpExchange ex, String body, int rCode) throws IOException {
-        try (OutputStream os = ex.getResponseBody()) {
+        try (InputStream is = ex.getRequestBody();
+             OutputStream os = ex.getResponseBody()) {
+            is.readAllBytes();
             byte[] bytes = body.getBytes(UTF_8);
             ex.sendResponseHeaders(rCode, bytes.length);
             os.write(bytes);
@@ -199,7 +202,7 @@ public class ContentLengthHeaderTest {
                 handleResponse(exchange, "Request completed",200);
             } else {
                 String responseBody = exchange.getRequestMethod() + " request contained an unexpected " +
-                        "Content-length header.";
+                        "Content-length header of value: " + exchange.getRequestHeaders().getFirst("Content-length");
                 handleResponse(exchange, responseBody, 400);
             }
         }

--- a/test/jdk/java/net/httpclient/ContentLengthHeaderTest.java
+++ b/test/jdk/java/net/httpclient/ContentLengthHeaderTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Tests that a Content-length header is not sent for GET requests
+ *          that do not have a body. Also checks that the header is sent when
+ *          a body is present on the GET request.
+ * @bug 8283544
+ * @run testng/othervm ContentLengthHeaderTest
+ */
+
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+
+public class ContentLengthHeaderTest {
+
+    final String GET_NO_BODY_PATH = "/get_no_body";
+    final String GET_BODY_PATH = "/get_body";
+    static final String GET_BODY_STRING = "Get with body";
+
+    static HttpServer testContentLengthServer;
+    static PrintStream testLog = System.err;
+    static String responseString = "Test Response Body";
+
+    String testContentLenURI;
+
+    @BeforeTest
+    public void setup() throws IOException {
+        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
+        testContentLengthServer = HttpServer.create(sa, 0);
+
+        // Create handlers for tests that check for the presence of a Content-length header
+        testContentLengthServer.createContext(GET_NO_BODY_PATH, new NoContentLengthHandler());
+        testContentLengthServer.createContext(GET_BODY_PATH, new ContentLengthHandler());
+        testContentLenURI = "http://" + testContentLengthServer.getAddress().getHostString() +
+                             ":" + testContentLengthServer.getAddress().getPort();
+
+        testContentLengthServer.start();
+        testLog.println("Server up at address: " + testContentLengthServer.getAddress());
+        testLog.println("Request URI for Client: " + testContentLenURI);
+    }
+
+    @AfterTest
+    public void teardown() {
+        testContentLengthServer.stop(0);
+    }
+
+    @Test
+    // A GET request with no request body should have no Content-length header
+    public void getWithNoBody() throws IOException, InterruptedException {
+        HttpRequest req = HttpRequest.newBuilder()
+                .version(HTTP_1_1)
+                .GET()
+                .uri(URI.create(testContentLenURI + GET_NO_BODY_PATH))
+                .build();
+        HttpClient hc = HttpClient.newHttpClient();
+        hc.send(req, HttpResponse.BodyHandlers.ofString(UTF_8));
+    }
+
+    @Test
+    // A GET request with a request body should have a Content-length header
+    public void getWithBody() throws IOException, InterruptedException {
+        HttpRequest req = HttpRequest.newBuilder()
+                .version(HTTP_1_1)
+                .method("GET", HttpRequest.BodyPublishers.ofString(GET_BODY_STRING))
+                .uri(URI.create(testContentLenURI + GET_BODY_PATH))
+                .build();
+        HttpClient hc = HttpClient.newHttpClient();
+        hc.send(req, HttpResponse.BodyHandlers.ofString(UTF_8));
+    }
+
+    public static void handleResponse(HttpExchange ex) throws IOException {
+        // Meaningless response to finish off the exchange
+        try (OutputStream os = ex.getResponseBody()) {
+            byte[] bytes = responseString.getBytes(UTF_8);
+            ex.sendResponseHeaders(200, bytes.length);
+            os.write(bytes);
+        }
+    }
+
+    static class NoContentLengthHandler implements HttpHandler {
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            testLog.println("NoContentLengthHandler Received Headers: " + exchange.getRequestHeaders().entrySet());
+            String contentLength = exchange.getRequestHeaders().getFirst("Content-length");
+
+            // Check that content length was not set
+            assertNull(contentLength);
+            // Finish exchange with canned response
+            handleResponse(exchange);
+        }
+    }
+
+    static class ContentLengthHandler implements HttpHandler {
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            testLog.println("ContentLengthHandler Received Headers: " +
+                            exchange.getRequestHeaders().entrySet());
+            String contentLength = exchange.getRequestHeaders().getFirst("Content-length");
+
+            // Check that the Content-length is correctly set
+            assertNotNull(contentLength);
+            assertEquals(Integer.valueOf(contentLength), Integer.valueOf(GET_BODY_STRING.getBytes(UTF_8).length));
+            // Finish exchange with canned response
+            handleResponse(exchange);
+        }
+    }
+}

--- a/test/jdk/java/net/httpclient/ContentLengthHeaderTest.java
+++ b/test/jdk/java/net/httpclient/ContentLengthHeaderTest.java
@@ -45,6 +45,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.ProxySelector;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
@@ -66,6 +67,7 @@ public class ContentLengthHeaderTest {
     static HttpServer testContentLengthServer;
     static PrintStream testLog = System.err;
 
+    HttpClient hc;
     URI testContentLengthURI;
 
     @BeforeTest
@@ -85,6 +87,11 @@ public class ContentLengthHeaderTest {
         testContentLengthServer.start();
         testLog.println("Server up at address: " + testContentLengthServer.getAddress());
         testLog.println("Request URI for Client: " + testContentLengthURI);
+
+        hc = HttpClient.newBuilder()
+                .proxy(HttpClient.Builder.NO_PROXY)
+                .version(HTTP_1_1)
+                .build();
     }
 
     @AfterTest
@@ -102,7 +109,6 @@ public class ContentLengthHeaderTest {
                 .GET()
                 .uri(URI.create(testContentLengthURI + NO_BODY_PATH))
                 .build();
-        HttpClient hc = HttpClient.newHttpClient();
         HttpResponse<String> resp = hc.send(req, HttpResponse.BodyHandlers.ofString(UTF_8));
         assertEquals(resp.statusCode(), 200, resp.body());
     }
@@ -116,7 +122,6 @@ public class ContentLengthHeaderTest {
                 .method("GET", HttpRequest.BodyPublishers.ofString("GET Body"))
                 .uri(URI.create(testContentLengthURI + BODY_PATH))
                 .build();
-        HttpClient hc = HttpClient.newHttpClient();
         HttpResponse<String> resp = hc.send(req, HttpResponse.BodyHandlers.ofString(UTF_8));
         assertEquals(resp.statusCode(), 200, resp.body());
     }
@@ -130,7 +135,6 @@ public class ContentLengthHeaderTest {
                 .DELETE()
                 .uri(URI.create(testContentLengthURI + NO_BODY_PATH))
                 .build();
-        HttpClient hc = HttpClient.newHttpClient();
         HttpResponse<String> resp = hc.send(req, HttpResponse.BodyHandlers.ofString(UTF_8));
         assertEquals(resp.statusCode(), 200, resp.body());
     }
@@ -144,7 +148,6 @@ public class ContentLengthHeaderTest {
                 .method("DELETE", HttpRequest.BodyPublishers.ofString("DELETE Body"))
                 .uri(URI.create(testContentLengthURI + BODY_PATH))
                 .build();
-        HttpClient hc = HttpClient.newHttpClient();
         HttpResponse<String> resp = hc.send(req, HttpResponse.BodyHandlers.ofString(UTF_8));
         assertEquals(resp.statusCode(), 200, resp.body());
     }
@@ -158,7 +161,6 @@ public class ContentLengthHeaderTest {
                 .HEAD()
                 .uri(URI.create(testContentLengthURI + NO_BODY_PATH))
                 .build();
-        HttpClient hc = HttpClient.newHttpClient();
         HttpResponse<String> resp = hc.send(req, HttpResponse.BodyHandlers.ofString(UTF_8));
         assertEquals(resp.statusCode(), 200, resp.body());
     }
@@ -172,7 +174,6 @@ public class ContentLengthHeaderTest {
                 .method("HEAD", HttpRequest.BodyPublishers.ofString("HEAD Body"))
                 .uri(URI.create(testContentLengthURI + BODY_PATH))
                 .build();
-        HttpClient hc = HttpClient.newHttpClient();
         // Sending this request invokes sendResponseHeaders which emits a warning about including
         // a Content-length header with a HEAD request
         HttpResponse<String> resp = hc.send(req, HttpResponse.BodyHandlers.ofString(UTF_8));


### PR DESCRIPTION
**Issue**
When using the `HttpClient.send()` to send a GET request created using the `HttpRequest.newBuilder()`, a `Content-length: 0` header is set. This behaviour causes issues with many services as a body related header is usually not expected to be included with a GET request. 

**Solution**
`Http1Request.java` was modified so that when the request method is a GET, a `Content-length` header is not added to the request. However, if a developer chooses to include a body in a GET request (though it is generally considered bad practice), a `Content-length` header with the appropriate value will be added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8283544](https://bugs.openjdk.java.net/browse/JDK-8283544): HttpClient GET method adds Content-Length: 0 header


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.java.net/census#jpai) (@jaikiran - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8017/head:pull/8017` \
`$ git checkout pull/8017`

Update a local copy of the PR: \
`$ git checkout pull/8017` \
`$ git pull https://git.openjdk.java.net/jdk pull/8017/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8017`

View PR using the GUI difftool: \
`$ git pr show -t 8017`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8017.diff">https://git.openjdk.java.net/jdk/pull/8017.diff</a>

</details>
