### PR TITLE
8282024: add EscapeAnalysis statistics under PrintOptoStatistics

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2176,7 +2176,6 @@ void Compile::Optimize() {
       if (failing())  return;
     }
     bool progress;
-
     do {
       ConnectionGraph::do_analysis(this, &igvn);
 
@@ -2207,7 +2206,6 @@ void Compile::Optimize() {
       // Try again if candidates exist and made progress
       // by removing some allocations and/or locks.
     } while (progress);
-
   }
 
   // Loop transforms on the ideal graph.  Range Check Elimination,

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2177,7 +2177,6 @@ void Compile::Optimize() {
     }
     bool progress;
 
-    NOT_PRODUCT(int total_scalar_replaced = 0;)
     do {
       ConnectionGraph::do_analysis(this, &igvn);
 
@@ -2197,7 +2196,6 @@ void Compile::Optimize() {
         mexp.eliminate_macro_nodes();
         igvn.set_delay_transform(false);
 
-        NOT_PRODUCT(total_scalar_replaced += mexp._local_scalar_replaced;)
         igvn.optimize();
         print_method(PHASE_ITER_GVN_AFTER_ELIMINATION, 2);
 
@@ -2210,11 +2208,6 @@ void Compile::Optimize() {
       // by removing some allocations and/or locks.
     } while (progress);
 
-#ifndef PRODUCT
-    Atomic::add(&ConnectionGraph::_no_escape_counter, _local_no_escape_ctr + total_scalar_replaced);
-    Atomic::add(&ConnectionGraph::_arg_escape_counter, _local_arg_escape_ctr);
-    Atomic::add(&ConnectionGraph::_global_escape_counter, _local_global_escape_ctr);
-#endif
   }
 
   // Loop transforms on the ideal graph.  Range Check Elimination,

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -676,6 +676,11 @@ class Compile : public Phase {
   Node*         expensive_node(int idx)   const { return _expensive_nodes.at(idx); }
 
   ConnectionGraph* congraph()                   { return _congraph;}
+#ifndef PRODUCT
+  int _local_no_escape_ctr;
+  int _local_arg_escape_ctr;
+  int _local_global_escape_ctr;
+#endif
   void set_congraph(ConnectionGraph* congraph)  { _congraph = congraph;}
   void add_macro_node(Node * n) {
     //assert(n->is_macro(), "must be a macro node");

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -676,11 +676,6 @@ class Compile : public Phase {
   Node*         expensive_node(int idx)   const { return _expensive_nodes.at(idx); }
 
   ConnectionGraph* congraph()                   { return _congraph;}
-#ifndef PRODUCT
-  int _local_no_escape_ctr;
-  int _local_arg_escape_ctr;
-  int _local_global_escape_ctr;
-#endif
   void set_congraph(ConnectionGraph* congraph)  { _congraph = congraph;}
   void add_macro_node(Node * n) {
     //assert(n->is_macro(), "must be a macro node");

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -3753,7 +3753,6 @@ void ConnectionGraph::dump(GrowableArray<PointsToNode*>& ptnodes_worklist) {
 }
 
 void ConnectionGraph::print_statistics() {
-  // EA stats might be slightly off since objects might be double counted due to iterative EA
   tty->print_cr("No escape = %d, Arg escape = %d, Global escape = %d", Atomic::load(&_no_escape_counter), Atomic::load(&_arg_escape_counter), Atomic::load(&_global_escape_counter));
 }
 

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -396,7 +396,7 @@ bool ConnectionGraph::compute_escape() {
       }
     }
   }
-  
+
   NOT_PRODUCT(escape_state_statistics(java_objects_worklist);)
   return has_non_escaping_obj;
 }

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -247,9 +247,7 @@ bool ConnectionGraph::compute_escape() {
 
   if (non_escaped_allocs_worklist.length() == 0) {
     _collecting = false;
-#ifndef PRODUCT
-    escape_state_statistics(java_objects_worklist);
-#endif
+    NOT_PRODUCT(escape_state_statistics(java_objects_worklist);)
     return false; // Nothing to do.
   }
   // Add final simple edges to graph.

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -3758,7 +3758,7 @@ void ConnectionGraph::print_statistics() {
 }
 
 void ConnectionGraph::escape_state_statistics(GrowableArray<JavaObjectNode*>& java_objects_worklist) {
-  if (!PrintOptoStatistics) {
+  if (!PrintOptoStatistics || (_invocation > 0)) { // Collect data only for the first invocation
     return;
   }
   for (int next = 0; next < java_objects_worklist.length(); ++next) {

--- a/src/hotspot/share/opto/escape.hpp
+++ b/src/hotspot/share/opto/escape.hpp
@@ -636,7 +636,13 @@ public:
   bool add_final_edges_unsafe_access(Node* n, uint opcode);
 
 #ifndef PRODUCT
+  static int _no_escape_counter;
+  static int _arg_escape_counter;
+  static int _global_escape_counter;
+  static long _time_elapsed;
   void dump(GrowableArray<PointsToNode*>& ptnodes_worklist);
+  static void print_statistics();
+  void escape_state_statistics(GrowableArray<JavaObjectNode*>& java_objects_worklist);
 #endif
 };
 

--- a/src/hotspot/share/opto/escape.hpp
+++ b/src/hotspot/share/opto/escape.hpp
@@ -639,10 +639,9 @@ public:
   static int _no_escape_counter;
   static int _arg_escape_counter;
   static int _global_escape_counter;
-  static long _time_elapsed;
   void dump(GrowableArray<PointsToNode*>& ptnodes_worklist);
   static void print_statistics();
-  void escape_state_statistics(GrowableArray<JavaObjectNode*>& java_objects_worklist);
+  static void escape_state_statistics(GrowableArray<JavaObjectNode*>& java_objects_worklist);
 #endif
 };
 

--- a/src/hotspot/share/opto/escape.hpp
+++ b/src/hotspot/share/opto/escape.hpp
@@ -641,7 +641,7 @@ public:
   static int _global_escape_counter;
   void dump(GrowableArray<PointsToNode*>& ptnodes_worklist);
   static void print_statistics();
-  static void escape_state_statistics(GrowableArray<JavaObjectNode*>& java_objects_worklist);
+  void escape_state_statistics(GrowableArray<JavaObjectNode*>& java_objects_worklist);
 #endif
 };
 

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2314,8 +2314,7 @@ void PhaseMacroExpand::expand_subtypecheck_node(SubTypeCheckNode *check) {
 void PhaseMacroExpand::eliminate_macro_nodes() {
   if (C->macro_count() == 0)
     return;
-    NOT_PRODUCT(int membar_before = count_MemBar();)
-
+  NOT_PRODUCT(int membar_before = count_MemBar();)
 
   // Before elimination may re-mark (change to Nested or NonEscObj)
   // all associated (same box and obj) lock and unlock nodes.

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2606,8 +2606,8 @@ void PhaseMacroExpand::print_statistics() {
 }
 
 int PhaseMacroExpand::count_MemBar() {
-  if(!PrintOptoStatistics) { 
-    return 0; 
+  if(!PrintOptoStatistics) {
+    return 0;
   }
   Unique_Node_List ideal_nodes;
   int total = 0;

--- a/src/hotspot/share/opto/macro.hpp
+++ b/src/hotspot/share/opto/macro.hpp
@@ -200,13 +200,23 @@ private:
   Node* make_arraycopy_load(ArrayCopyNode* ac, intptr_t offset, Node* ctl, Node* mem, BasicType ft, const Type *ftype, AllocateNode *alloc);
 
 public:
-  PhaseMacroExpand(PhaseIterGVN &igvn) : Phase(Macro_Expand), _igvn(igvn), _has_locks(false) {
+  PhaseMacroExpand(PhaseIterGVN &igvn) : Phase(Macro_Expand), _igvn(igvn), _has_locks(false) NOT_PRODUCT(COMMA _local_scalar_replaced(0)) {
     _igvn.set_delay_transform(true);
   }
   void eliminate_macro_nodes();
   bool expand_macro_nodes();
 
   PhaseIterGVN &igvn() const { return _igvn; }
+
+#ifndef PRODUCT
+    static int _objs_scalar_replaced_counter;
+    static int _monitor_objects_removed_counter;
+    static int _GC_barriers_removed_counter;
+    static int _memory_barriers_removed_counter;
+    int _local_scalar_replaced;
+    static void print_statistics();
+    int count_MemBar();
+#endif
 
   // Members accessed from BarrierSetC2
   void replace_node(Node* source, Node* target) { _igvn.replace_node(source, target); }

--- a/src/hotspot/share/opto/macro.hpp
+++ b/src/hotspot/share/opto/macro.hpp
@@ -200,7 +200,7 @@ private:
   Node* make_arraycopy_load(ArrayCopyNode* ac, intptr_t offset, Node* ctl, Node* mem, BasicType ft, const Type *ftype, AllocateNode *alloc);
 
 public:
-  PhaseMacroExpand(PhaseIterGVN &igvn) : Phase(Macro_Expand), _igvn(igvn), _has_locks(false) NOT_PRODUCT(COMMA _local_scalar_replaced(0)) {
+  PhaseMacroExpand(PhaseIterGVN &igvn) : Phase(Macro_Expand), _igvn(igvn), _has_locks(false) {
     _igvn.set_delay_transform(true);
   }
   void eliminate_macro_nodes();
@@ -213,7 +213,6 @@ public:
     static int _monitor_objects_removed_counter;
     static int _GC_barriers_removed_counter;
     static int _memory_barriers_removed_counter;
-    int _local_scalar_replaced;
     static void print_statistics();
     int count_MemBar();
 #endif

--- a/src/hotspot/share/opto/macro.hpp
+++ b/src/hotspot/share/opto/macro.hpp
@@ -214,7 +214,7 @@ public:
     static int _GC_barriers_removed_counter;
     static int _memory_barriers_removed_counter;
     static void print_statistics();
-    int count_MemBar();
+    int count_MemBar(Compile *C);
 #endif
 
   // Members accessed from BarrierSetC2

--- a/src/hotspot/share/opto/macro.hpp
+++ b/src/hotspot/share/opto/macro.hpp
@@ -214,7 +214,7 @@ public:
     static int _GC_barriers_removed_counter;
     static int _memory_barriers_removed_counter;
     static void print_statistics();
-    int count_MemBar(Compile *C);
+    static int count_MemBar(Compile *C);
 #endif
 
   // Members accessed from BarrierSetC2


### PR DESCRIPTION
Escape Analysis and Scalar Replacement statistics were added when the -XX:+PrintOptoStatistics flag is set. All code is placed in `#ifndef Product` block, so this code is only run when creating a debug build. Using renaissance benchmark I ran a few tests to confirm that numbers were printing correctly. Below is an example run:

```
No escape = 263, Arg escape = 87, Global escape = 1628
Objects scalar replaced = 193, Monitor objects removed = 32, GC barriers removed = 38, Memory barriers removed = 225
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282024](https://bugs.openjdk.java.net/browse/JDK-8282024): add EscapeAnalysis statistics under PrintOptoStatistics


### Reviewers
 * [Xin Liu](https://openjdk.java.net/census#xliu) (@navyxliu - Committer)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8019/head:pull/8019` \
`$ git checkout pull/8019`

Update a local copy of the PR: \
`$ git checkout pull/8019` \
`$ git pull https://git.openjdk.java.net/jdk pull/8019/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8019`

View PR using the GUI difftool: \
`$ git pr show -t 8019`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8019.diff">https://git.openjdk.java.net/jdk/pull/8019.diff</a>

</details>
