### PR TITLE
8283889: Fix Typo in open/src/java.sql/share/classes/java/sql/package-info.java

### DIFF
--- a/src/java.sql/share/classes/java/sql/package-info.java
+++ b/src/java.sql/share/classes/java/sql/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -334,7 +334,7 @@
  *
  * <ul>
  *   <li><a href="http://docs.oracle.com/javase/tutorial/jdbc/basics/index.html">
- *           Lesson:JDBC Basics(The Javaxx Tutorials &gt; JDBC Database Access)</a>
+ *           Lesson:JDBC Basics(The Java Tutorials &gt; JDBC Database Access)</a>
  *
  *  <li>&ldquo;<i>JDBC API Tutorial and Reference, Third Edition</i>&rdquo;
  * </ul>


### PR DESCRIPTION
Hi all,

Please review this trivial fix which addresses a typo in src/java.sql/share/classes/java/sql/package-info.java

make docs is clean and I am also running mach5 tier1 as an extra sanity check so there are no surprises when the patch is pushed

Best
Lance

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283889](https://bugs.openjdk.java.net/browse/JDK-8283889): Fix Typo in open/src/java.sql/share/classes/java/sql/package-info.java


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8020/head:pull/8020` \
`$ git checkout pull/8020`

Update a local copy of the PR: \
`$ git checkout pull/8020` \
`$ git pull https://git.openjdk.java.net/jdk pull/8020/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8020`

View PR using the GUI difftool: \
`$ git pr show -t 8020`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8020.diff">https://git.openjdk.java.net/jdk/pull/8020.diff</a>

</details>
