### PR TITLE
8283701: Add final or sealed modifier to appropriate java.awt.color ICC_Profile API classes

### DIFF
--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -83,7 +83,9 @@ import sun.java2d.cmm.ProfileDeferralInfo;
  *
  * @see ICC_ColorSpace
  */
-public class ICC_Profile implements Serializable {
+public sealed class ICC_Profile implements Serializable
+    permits ICC_ProfileGray,
+            ICC_ProfileRGB {
 
     /**
      * Use serialVersionUID from JDK 1.2 for interoperability.

--- a/src/java.desktop/share/classes/java/awt/color/ICC_ProfileGray.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_ProfileGray.java
@@ -65,7 +65,7 @@ import sun.java2d.cmm.ProfileDeferralInfo;
  * The inverse transform is done by converting the PCS Y components to device
  * Gray via the inverse of the grayTRC.
  */
-public class ICC_ProfileGray extends ICC_Profile {
+public final class ICC_ProfileGray extends ICC_Profile {
 
     /**
      * Use serialVersionUID from JDK 1.2 for interoperability.

--- a/src/java.desktop/share/classes/java/awt/color/ICC_ProfileRGB.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_ProfileRGB.java
@@ -80,7 +80,7 @@ import sun.java2d.cmm.ProfileDeferralInfo;
  * RGB components through the inverse of the above 3x3 matrix, and then
  * converting linear RGB to device RGB through inverses of the TRCs.
  */
-public class ICC_ProfileRGB extends ICC_Profile {
+public final class ICC_ProfileRGB extends ICC_Profile {
 
     /**
      * Use serialVersionUID from JDK 1.2 for interoperability.


### PR DESCRIPTION
This PR is similar to https://git.openjdk.java.net/jdk/pull/7998 but addresses some Java 2D API color related classes.

ICC_Profile can be made sealed, and the two extant sub-classes can be made final.

All regression and JCK tests have passed

CSR is here https://bugs.openjdk.java.net/browse/JDK-8283891

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8283701](https://bugs.openjdk.java.net/browse/JDK-8283701): Add final or sealed modifier to appropriate java.awt.color ICC_Profile API classes
 * [JDK-8283891](https://bugs.openjdk.java.net/browse/JDK-8283891): Add final or sealed modifier to appropriate java.awt.color ICC_Profile API classes (**CSR**)


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8021/head:pull/8021` \
`$ git checkout pull/8021`

Update a local copy of the PR: \
`$ git checkout pull/8021` \
`$ git pull https://git.openjdk.java.net/jdk pull/8021/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8021`

View PR using the GUI difftool: \
`$ git pr show -t 8021`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8021.diff">https://git.openjdk.java.net/jdk/pull/8021.diff</a>

</details>
