### PR TITLE
8283784: java_lang_String::as_platform_dependent_str stores to oop in native state

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -456,12 +456,14 @@ char* java_lang_String::as_platform_dependent_str(Handle java_string, TRAPS) {
   char *native_platform_string;
   { JavaThread* thread = THREAD;
     jstring js = (jstring) JNIHandles::make_local(thread, java_string());
-    bool is_copy;
-    HandleMark hm(thread);
-    ThreadToNativeFromVM ttn(thread);
-    JNIEnv *env = thread->jni_environment();
-    native_platform_string = (_to_platform_string_fn)(env, js, &is_copy);
-    assert(is_copy == JNI_TRUE, "is_copy value changed");
+    {
+      bool is_copy;
+      HandleMark hm(thread);
+      ThreadToNativeFromVM ttn(thread);
+      JNIEnv *env = thread->jni_environment();
+      native_platform_string = (_to_platform_string_fn)(env, js, &is_copy);
+      assert(is_copy == JNI_TRUE, "is_copy value changed");
+    }
     JNIHandles::destroy_local(js);
   }
   return native_platform_string;


### PR DESCRIPTION
Please review this trivial fix that introduces a new block scope so that `JNIHandles::destroy_local` is called once we are back in VM, and so no longer safepoint-safe.

Testing: tiers 1-3 as sanity test

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8283784](https://bugs.openjdk.java.net/browse/JDK-8283784): java_lang_String::as_platform_dependent_str stores to oop in native state


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8030/head:pull/8030` \
`$ git checkout pull/8030`

Update a local copy of the PR: \
`$ git checkout pull/8030` \
`$ git pull https://git.openjdk.java.net/jdk pull/8030/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8030`

View PR using the GUI difftool: \
`$ git pr show -t 8030`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8030.diff">https://git.openjdk.java.net/jdk/pull/8030.diff</a>

</details>
