### PR TITLE
8283929: GHA: Add riscv64 build config

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -425,6 +425,7 @@ jobs:
           - hs arm build only
           - hs s390x build only
           - hs ppc64le build only
+          - hs riscv64 build only
         include:
           - flavor: hs x64 build only
             flags: --enable-debug --disable-precompiled-headers
@@ -451,6 +452,10 @@ jobs:
             flags: --enable-debug --disable-precompiled-headers
             debian-arch: ppc64el
             gnu-arch: powerpc64le
+          - flavor: hs riscv64 build only
+            flags: --enable-debug --disable-precompiled-headers
+            debian-arch: riscv64
+            gnu-arch: riscv64
 
     env:
       JDK_VERSION: "${{ needs.prerequisites.outputs.jdk_version }}"

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -437,23 +437,28 @@ jobs:
             flags: --with-debug-level=optimized --disable-precompiled-headers
           - flavor: hs aarch64 build only
             flags: --enable-debug --disable-precompiled-headers
+            debian-distro: buster
             debian-arch: arm64
             gnu-arch: aarch64
           - flavor: hs arm build only
             flags: --enable-debug --disable-precompiled-headers
+            debian-distro: buster
             debian-arch: armhf
             gnu-arch: arm
             gnu-flavor: eabihf
           - flavor: hs s390x build only
             flags: --enable-debug --disable-precompiled-headers
+            debian-distro: buster
             debian-arch: s390x
             gnu-arch: s390x
           - flavor: hs ppc64le build only
             flags: --enable-debug --disable-precompiled-headers
+            debian-distro: buster
             debian-arch: ppc64el
             gnu-arch: powerpc64le
           - flavor: hs riscv64 build only
             flags: --enable-debug --disable-precompiled-headers
+            debian-distro: bullseye
             debian-arch: riscv64
             gnu-arch: riscv64
 
@@ -543,7 +548,7 @@ jobs:
           --verbose
           --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev
           --resolve-deps
-          buster
+          ${{ matrix.debian-distro }}
           ~/sysroot-${{ matrix.debian-arch }}
           http://httpredir.debian.org/debian/
         if: matrix.debian-arch != '' && steps.cache-sysroot.outputs.cache-hit != 'true'

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -437,28 +437,28 @@ jobs:
             flags: --with-debug-level=optimized --disable-precompiled-headers
           - flavor: hs aarch64 build only
             flags: --enable-debug --disable-precompiled-headers
-            debian-distro: buster
+            debian-release: buster
             debian-arch: arm64
             gnu-arch: aarch64
           - flavor: hs arm build only
             flags: --enable-debug --disable-precompiled-headers
-            debian-distro: buster
+            debian-release: buster
             debian-arch: armhf
             gnu-arch: arm
             gnu-flavor: eabihf
           - flavor: hs s390x build only
             flags: --enable-debug --disable-precompiled-headers
-            debian-distro: buster
+            debian-release: buster
             debian-arch: s390x
             gnu-arch: s390x
           - flavor: hs ppc64le build only
             flags: --enable-debug --disable-precompiled-headers
-            debian-distro: buster
+            debian-release: buster
             debian-arch: ppc64el
             gnu-arch: powerpc64le
           - flavor: hs riscv64 build only
             flags: --enable-debug --disable-precompiled-headers
-            debian-distro: bullseye
+            debian-release: bullseye
             debian-arch: riscv64
             gnu-arch: riscv64
 
@@ -548,7 +548,7 @@ jobs:
           --verbose
           --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev
           --resolve-deps
-          ${{ matrix.debian-distro }}
+          ${{ matrix.debian-release }}
           ~/sysroot-${{ matrix.debian-arch }}
           http://httpredir.debian.org/debian/
         if: matrix.debian-arch != '' && steps.cache-sysroot.outputs.cache-hit != 'true'


### PR DESCRIPTION
WIP.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8283929](https://bugs.openjdk.java.net/browse/JDK-8283929): GHA: Add riscv64 build config


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8033/head:pull/8033` \
`$ git checkout pull/8033`

Update a local copy of the PR: \
`$ git checkout pull/8033` \
`$ git pull https://git.openjdk.java.net/jdk pull/8033/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8033`

View PR using the GUI difftool: \
`$ git pr show -t 8033`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8033.diff">https://git.openjdk.java.net/jdk/pull/8033.diff</a>

</details>
