### PR TITLE
8283937: riscv: RVC: Fix c_beqz to c_bnez

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -2795,7 +2795,7 @@ public:
   }
 
   INSN(beq, c_beqz, _beq);
-  INSN(bne, c_beqz, _bne);
+  INSN(bne, c_bnez, _bne);
 
 #undef INSN
 


### PR DESCRIPTION
Hi team,

As the appointment (mentioned in #7982 ), submit another PR for reviews.

This patch fixes a typo introduced in [JDK-8278994](https://bugs.openjdk.java.net/browse/JDK-8278994): `c_bnez` is mistakenly written to `c_beqz`, though not used until now, needing a fix for future usage.

Thanks,
Xiaolin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283937](https://bugs.openjdk.java.net/browse/JDK-8283937): riscv: RVC: Fix c_beqz to c_bnez


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8034/head:pull/8034` \
`$ git checkout pull/8034`

Update a local copy of the PR: \
`$ git checkout pull/8034` \
`$ git pull https://git.openjdk.java.net/jdk pull/8034/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8034`

View PR using the GUI difftool: \
`$ git pr show -t 8034`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8034.diff">https://git.openjdk.java.net/jdk/pull/8034.diff</a>

</details>
