### PR TITLE
8283994: Make Xerces DatatypeException stackless

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/DatatypeException.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/DatatypeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -107,5 +107,11 @@ public class DatatypeException extends Exception {
         }
 
         return msg;
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        // This is an internal exception; the stack trace is irrelevant.
+        return this;
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/DatatypeException.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/DatatypeException.java
@@ -35,7 +35,7 @@ import jdk.xml.internal.SecuritySupport;
  *
  * @author Sandy Gao, IBM
  *
- * @LastModified: Oct 2021
+ * @LastModified: Mar 2022
  */
 public class DatatypeException extends Exception {
 


### PR DESCRIPTION
See bug report for more details. This change improves SPECjvm2008:xml.validation for about +3%:

```
 baseline: 298.353 ± 1.008  ops/min
 patched:  309.912 ± 1.347  ops/min
```
Of course, the real improvements might be even higher, as exception might be thrown from much deeper call hierarchy.

Additional testing:
 - [x] Linux x86_64 fastdebug, `jaxp_all`
 - [x] Linux x86_64 fastdebug, `javax/xml`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283994](https://bugs.openjdk.java.net/browse/JDK-8283994): Make Xerces DatatypeException stackless


### Reviewers
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to 399a4ad722f1ca1a131722d725d07191ff02bb26
 * [Jaikiran Pai](https://openjdk.java.net/census#jpai) (@jaikiran - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8036/head:pull/8036` \
`$ git checkout pull/8036`

Update a local copy of the PR: \
`$ git checkout pull/8036` \
`$ git pull https://git.openjdk.java.net/jdk pull/8036/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8036`

View PR using the GUI difftool: \
`$ git pr show -t 8036`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8036.diff">https://git.openjdk.java.net/jdk/pull/8036.diff</a>

</details>
