### PR TITLE
8282043: IGV: speed up schedule approximation

### DIFF
--- a/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/java/com/sun/hotspot/igv/servercompiler/ServerCompilerScheduler.java
+++ b/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/java/com/sun/hotspot/igv/servercompiler/ServerCompilerScheduler.java
@@ -91,8 +91,6 @@ public class ServerCompilerScheduler implements Scheduler {
     private Map<InputNode, Node> inputNodeToNode;
     private Vector<InputBlock> blocks;
     private Map<InputBlock, InputBlock> dominatorMap;
-    private Map<InputBlock, Integer> blockIndex;
-    private InputBlock[][] commonDominator;
     private static final Comparator<InputEdge> edgeComparator = new Comparator<InputEdge>() {
 
         @Override
@@ -230,14 +228,6 @@ public class ServerCompilerScheduler implements Scheduler {
                 block.addNode(n.inputNode.getId());
             }
         }
-
-        // Compute block index map for dominator computation.
-        int z = 0;
-        blockIndex = new HashMap<>(blocks.size());
-        for (InputBlock b : blocks) {
-            blockIndex.put(b, z);
-            z++;
-        }
     }
 
     private String getBlockName(InputNode n) {
@@ -276,7 +266,6 @@ public class ServerCompilerScheduler implements Scheduler {
             connectOrphansAndWidows();
             buildBlocks();
             buildDominators();
-            buildCommonDominators();
             scheduleLatest();
 
             InputBlock noBlock = null;
@@ -439,7 +428,7 @@ public class ServerCompilerScheduler implements Scheduler {
                                 if (block == null) {
                                     block = s.block;
                                 } else {
-                                    block = commonDominator[this.blockIndex.get(block)][blockIndex.get(s.block)];
+                                    block = getCommonDominator(block, s.block);
                                 }
                             }
                         }
@@ -505,18 +494,7 @@ public class ServerCompilerScheduler implements Scheduler {
         }
     }
 
-    public void buildCommonDominators() {
-        commonDominator = new InputBlock[this.blocks.size()][this.blocks.size()];
-        for (int i = 0; i < blocks.size(); i++) {
-            for (int j = 0; j < blocks.size(); j++) {
-                commonDominator[i][j] = getCommonDominator(i, j);
-            }
-        }
-    }
-
-    public InputBlock getCommonDominator(int a, int b) {
-        InputBlock ba = blocks.get(a);
-        InputBlock bb = blocks.get(b);
+    public InputBlock getCommonDominator(InputBlock ba, InputBlock bb) {
         if (ba == bb) {
             return ba;
         }


### PR DESCRIPTION
Schedule approximation for building the _clustered sea-of-nodes_ and _control-flow graph_ views is an expensive computation that can sometimes take as much time as computing the layout of the graph itself. This change removes the main bottleneck in schedule approximation by computing common dominators on-demand instead of pre-computing them.

Pre-computation of common dominators requires _(no. blocks)^2_ calls to `getCommonDominator()`. On-demand computation requires, in the worst case, _(no. Ideal nodes)^2_ calls, but in practice the number of calls is linear due to the sparseness of the Ideal graph, and the change speeds up scheduling by more than an order of magnitude (see details below).

#### Testing

##### Functionality

- Tested manually the approximated schedule on a small selection of graphs.

- Tested automatically that scheduling and viewing thousands of graphs in the _clustered sea-of-nodes_ and _control-flow graph_ views does not trigger any assertion failure (by instrumenting IGV to schedule and view graphs as they are loaded and running `java -Xcomp -XX:-TieredCompilation -XX:PrintIdealGraphLevel=4`).

##### Performance

 Measured the scheduling time for a selection of 100 large graphs (2511-7329 nodes). On average, this change speeds up scheduling by more than an order of magnitude (15x), where the largest improvements are seen on the largest graphs. The performance results are [attached](https://github.com/openjdk/jdk/files/8380091/performance-evaluation.ods) (note that each measurement in the sheet corresponds to the median of ten runs).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282043](https://bugs.openjdk.java.net/browse/JDK-8282043): IGV: speed up schedule approximation


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8037/head:pull/8037` \
`$ git checkout pull/8037`

Update a local copy of the PR: \
`$ git checkout pull/8037` \
`$ git pull https://git.openjdk.java.net/jdk pull/8037/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8037`

View PR using the GUI difftool: \
`$ git pr show -t 8037`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8037.diff">https://git.openjdk.java.net/jdk/pull/8037.diff</a>

</details>
