### PR TITLE
8283997: Unused argument in GraphKit::builtin_throw

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -526,7 +526,7 @@ void GraphKit::uncommon_trap_if_should_post_on_exceptions(Deoptimization::DeoptR
 }
 
 //------------------------------builtin_throw----------------------------------
-void GraphKit::builtin_throw(Deoptimization::DeoptReason reason, Node* arg) {
+void GraphKit::builtin_throw(Deoptimization::DeoptReason reason) {
   bool must_throw = true;
 
   // If this particular condition has not yet happened at this

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -266,12 +266,8 @@ class GraphKit : public Phase {
   JVMState* transfer_exceptions_into_jvms();
 
   // Helper to throw a built-in exception.
-  // Range checks take the offending index.
-  // Cast and array store checks take the offending class.
-  // Others do not take the optional argument.
-  // The JVMS must allow the bytecode to be re-executed
-  // via an uncommon trap.
-  void builtin_throw(Deoptimization::DeoptReason reason, Node* arg = NULL);
+  // The JVMS must allow the bytecode to be re-executed via an uncommon trap.
+  void builtin_throw(Deoptimization::DeoptReason reason);
 
   // Helper to check the JavaThread::_should_post_on_exceptions flag
   // and branch to an uncommon_trap if it is true (with the specified reason and must_throw)


### PR DESCRIPTION
Trivial fix that removes an unused argument and adjust a comment accordingly.

Thanks,
Tobias