### PR TITLE
8283996: Reduce cost of year and month calculations

### DIFF
--- a/src/java.base/share/classes/java/time/LocalDate.java
+++ b/src/java.base/share/classes/java/time/LocalDate.java
@@ -363,9 +363,14 @@ public final class LocalDate
 
         // convert march-based values back to january-based
         int marchMonth0 = (marchDoy0 * 5 + 2) / 153;
-        int month = (marchMonth0 + 2) % 12 + 1;
+        int month = marchMonth0 + 3;
+        if (month > 12) {
+            month -= 12;
+        }
         int dom = marchDoy0 - (marchMonth0 * 306 + 5) / 10 + 1;
-        yearEst += marchMonth0 / 10;
+        if (marchDoy0 >= 306) {
+            yearEst++;
+        }
 
         return new LocalDate((int)yearEst, month, dom);
     }

--- a/src/java.base/share/classes/java/time/zone/ZoneRules.java
+++ b/src/java.base/share/classes/java/time/zone/ZoneRules.java
@@ -974,11 +974,11 @@ public final class ZoneRules implements Serializable {
             doyEst = zeroDay - (365 * yearEst + yearEst / 4 - yearEst / 100 + yearEst / 400);
         }
         yearEst += adjust;  // reset any negative year
-        int marchDoy0 = (int) doyEst;
 
-        // convert march-based values back to january-based
-        int marchMonth0 = (marchDoy0 * 5 + 2) / 153;
-        yearEst += marchMonth0 / 10;
+        // convert march-based values back to january-based, adjust year
+        if (doyEst >= 306) {
+            yearEst++;
+        }
 
         // Cap to the max value
         return (int)Math.min(yearEst, Year.MAX_VALUE);


### PR DESCRIPTION
A few integer divisions and multiplications can be replaced with test + addition, leading to a decent speed-up on java.time microbenchmarks such as `GetYearBench`. Numbers from my local x86 workstation, seeing similar speed-up on aarch64 and other x86 setups.

Baseline:
```
Benchmark                                            Mode  Cnt   Score   Error   Units
GetYearBench.getYearFromMillisZoneOffset            thrpt   15  18.492 ± 0.017  ops/ms
GetYearBench.getYearFromMillisZoneRegion            thrpt   15   6.121 ± 0.135  ops/ms
GetYearBench.getYearFromMillisZoneRegionNormalized  thrpt   15  18.936 ± 0.012  ops/ms
GetYearBench.getYearFromMillisZoneRegionUTC         thrpt   15   9.283 ± 0.222  ops/ms
```
Patched:
```
Benchmark                                            Mode  Cnt   Score   Error   Units
GetYearBench.getYearFromMillisZoneOffset            thrpt   15  20.931 ± 0.013  ops/ms
GetYearBench.getYearFromMillisZoneRegion            thrpt   15   6.858 ± 0.167  ops/ms
GetYearBench.getYearFromMillisZoneRegionNormalized  thrpt   15  20.923 ± 0.017  ops/ms
GetYearBench.getYearFromMillisZoneRegionUTC         thrpt   15  10.028 ± 0.182  ops/ms
```

Testing: java.time tests locally, CI tier1+2 ongoing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283996](https://bugs.openjdk.java.net/browse/JDK-8283996): Reduce cost of year and month calculations


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Stephen Colebourne](https://openjdk.java.net/census#scolebourne) (@jodastephen - Author)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8039/head:pull/8039` \
`$ git checkout pull/8039`

Update a local copy of the PR: \
`$ git checkout pull/8039` \
`$ git pull https://git.openjdk.java.net/jdk pull/8039/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8039`

View PR using the GUI difftool: \
`$ git pr show -t 8039`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8039.diff">https://git.openjdk.java.net/jdk/pull/8039.diff</a>

</details>
