### PR TITLE
8283999: Update JMH devkit to 1.35

### DIFF
--- a/make/devkit/createJMHBundle.sh
+++ b/make/devkit/createJMHBundle.sh
@@ -26,7 +26,7 @@
 # Create a bundle in the build directory, containing what's needed to
 # build and run JMH microbenchmarks from the OpenJDK build.
 
-JMH_VERSION=1.34
+JMH_VERSION=1.35
 COMMONS_MATH3_VERSION=3.2
 JOPT_SIMPLE_VERSION=4.6
 


### PR DESCRIPTION
JMH 1.35 is released, so we can bump the devkit too.

Additional testing:
 - [x] JMH devkit creation
 - [x] Sample benchmarks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283999](https://bugs.openjdk.java.net/browse/JDK-8283999): Update JMH devkit to 1.35


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8040/head:pull/8040` \
`$ git checkout pull/8040`

Update a local copy of the PR: \
`$ git checkout pull/8040` \
`$ git pull https://git.openjdk.java.net/jdk pull/8040/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8040`

View PR using the GUI difftool: \
`$ git pr show -t 8040`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8040.diff">https://git.openjdk.java.net/jdk/pull/8040.diff</a>

</details>
