### PR TITLE
8283890: Changes in CFG file format break C1Visualizer

### DIFF
--- a/src/hotspot/share/c1/c1_CFGPrinter.cpp
+++ b/src/hotspot/share/c1/c1_CFGPrinter.cpp
@@ -244,13 +244,11 @@ void CFGPrinterOutput::print_block(BlockBegin* block) {
   output()->cr();
 
   output()->indent();
+  output()->print("successors ");
   if (block->end() != NULL) {
-    output()->print("successors ");
     for (i = 0; i < block->number_of_sux(); i++) {
       output()->print("\"B%d\" ", block->sux_at(i)->block_id());
     }
-  } else {
-    output()->print("(block has no end, cannot print successors)");
   }
   output()->cr();
 


### PR DESCRIPTION
Please review this small fix reverting a change in the format of the CFG log file which prevent those files from being loaded by the C1Visualizer tool.

Thank you,

Fred
