### PR TITLE
8284015: ProblemList containers/docker/TestJcmd.java on linux-x64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -105,7 +105,7 @@ runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
 
 applications/jcstress/copy.java 8229852 linux-all
 
-containers/docker/TestJcmd.java 8278102 linux-aarch64
+containers/docker/TestJcmd.java 8278102 linux-all
 
 #############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList containers/docker/TestJcmd.java on linux-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284015](https://bugs.openjdk.java.net/browse/JDK-8284015): ProblemList containers/docker/TestJcmd.java on linux-x64


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8042/head:pull/8042` \
`$ git checkout pull/8042`

Update a local copy of the PR: \
`$ git checkout pull/8042` \
`$ git pull https://git.openjdk.java.net/jdk pull/8042/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8042`

View PR using the GUI difftool: \
`$ git pr show -t 8042`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8042.diff">https://git.openjdk.java.net/jdk/pull/8042.diff</a>

</details>
