### PR TITLE
8284014 Menu items with submenus in JPopupMEnu are not spoken on macOS

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
@@ -173,7 +173,7 @@ class CAccessible extends CFRetainedResource implements Accessible {
                             menuClosed(ptr);
                         }
                     } else if (thisRole == AccessibleRole.MENU_ITEM ||
-                            ((parentRole == AccessibleRole.POPUP_MENU) && (thisRole == AccessibleRole.MENU))) {
+                            (thisRole == AccessibleRole.MENU)) {
                         if ( newValue != null &&
                                 ((AccessibleState)newValue) == AccessibleState.FOCUSED ) {
                             menuItemSelected(ptr);

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
@@ -172,7 +172,8 @@ class CAccessible extends CFRetainedResource implements Accessible {
                                 ((AccessibleState)oldValue) == AccessibleState.VISIBLE ) {
                             menuClosed(ptr);
                         }
-                    } else if (thisRole == AccessibleRole.MENU_ITEM) {
+                    } else if (thisRole == AccessibleRole.MENU_ITEM ||
+                            ((parentRole == AccessibleRole.POPUP_MENU) && (thisRole == AccessibleRole.MENU))) {
                         if ( newValue != null &&
                                 ((AccessibleState)newValue) == AccessibleState.FOCUSED ) {
                             menuItemSelected(ptr);
@@ -199,7 +200,6 @@ class CAccessible extends CFRetainedResource implements Accessible {
             }
         }
     }
-
 
     static Accessible getSwingAccessible(final Accessible a) {
         return (a instanceof CAccessible) ? ((CAccessible)a).accessible : a;

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -126,7 +126,7 @@ static jobject sAccessibilityClass = NULL;
     /*
      * Here we should keep all the mapping between the accessibility roles and implementing classes
      */
-    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:51];
+    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:50];
 
     [rolesMap setObject:@"ButtonAccessibility" forKey:@"pushbutton"];
     [rolesMap setObject:@"ImageAccessibility" forKey:@"icon"];
@@ -158,7 +158,6 @@ static jobject sAccessibilityClass = NULL;
     [rolesMap setObject:@"TableAccessibility" forKey:@"table"];
     [rolesMap setObject:@"MenuBarAccessibility" forKey:@"menubar"];
     [rolesMap setObject:@"MenuAccessibility" forKey:@"menu"];
-    [rolesMap setObject:@"MenuItemAccessibility" forKey:@"menuitem"];
     [rolesMap setObject:@"MenuAccessibility" forKey:@"popupmenu"];
     [rolesMap setObject:@"ProgressIndicatorAccessibility" forKey:@"progressbar"];
 
@@ -186,7 +185,8 @@ static jobject sAccessibilityClass = NULL;
     [rolesMap setObject:IgnoreClassName forKey:@"viewport"];
     [rolesMap setObject:IgnoreClassName forKey:@"window"];
 
-    rowRolesMapForParent = [[NSMutableDictionary alloc] initWithCapacity:2];
+    rowRolesMapForParent = [[NSMutableDictionary alloc] initWithCapacity:3];
+    [rowRolesMapForParent setObject:@"MenuItemAccessibility" forKey:@"MenuAccessibility"];
 
     [rowRolesMapForParent setObject:@"ListRowAccessibility" forKey:@"ListAccessibility"];
     [rowRolesMapForParent setObject:@"OutlineRowAccessibility" forKey:@"OutlineAccessibility"];

--- a/test/jdk/java/awt/a11y/AccessibleJPopupMenuTest.java
+++ b/test/jdk/java/awt/a11y/AccessibleJPopupMenuTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, JetBrains s.r.o.. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test implementation of NSAccessibilityMenu and NSAccessibilityMenuItem roles peer
+ * @author Artem.Semenov@jetbrains.com
+ * @run main/manual AccessibleJPopupMenuTest
+ * @requires (os.family == "mac")
+ */
+
+import javax.swing.JButton;
+import javax.swing.JMenu;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.SwingUtilities;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.util.concurrent.CountDownLatch;
+
+public class AccessibleJPopupMenuTest extends AccessibleComponentTest {
+
+    @Override
+    public CountDownLatch createCountDownLatch() {
+        return new CountDownLatch(1);
+    }
+
+
+    private static JPopupMenu createPopup() {
+        JPopupMenu popup = new JPopupMenu("MENU");
+        popup.add("One");
+        popup.add("Two");
+        popup.add("Three");
+        popup.addSeparator();
+        JMenu menu = new JMenu("For submenu");
+        menu.add("subOne");
+        menu.add("subTwo");
+        menu.add("subThree");
+        popup.add(menu);
+        return popup;
+    }
+
+    public void createTest() {
+        INSTRUCTIONS = "INSTRUCTIONS:\n"
+                + "Check a11y of JPopupMenu.\n\n"
+                + "Turn screen reader on, and Tab to the show button and press space.\n"
+                + "Press the up and down arrow buttons to move through the menu, and open submenu.\n\n"
+                + "If you can hear popup menu items tab further and press PASS, otherwise press FAIL.\n";
+
+        JPanel frame = new JPanel();
+
+        JButton button = new JButton("show");
+        button.setPreferredSize(new Dimension(100, 35));
+
+        button.addActionListener(new ActionListener() {
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                createPopup().show(button, button.getX(), button.getY());
+            }
+        });
+
+        frame.setLayout(new FlowLayout());
+        frame.add(button);
+        exceptionString = "Accessible JPopupMenu test failed!";
+        super.createUI(frame, "Accessible JPopupMenu test");
+    }
+
+    public static void main(String[] args) throws Exception {
+        AccessibleJPopupMenuTest a11yTest = new AccessibleJPopupMenuTest();
+
+        CountDownLatch countDownLatch = a11yTest.createCountDownLatch();
+        SwingUtilities.invokeLater(a11yTest::createTest);
+        countDownLatch.await();
+
+        if (!testResult) {
+            throw new RuntimeException(a11yTest.exceptionString);
+        }
+    }
+}


### PR DESCRIPTION
If the JPopupMenu has menu items with submenus, those items are not spoken by VoiceOver.

@forantar @azuev-java please review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284014](https://bugs.openjdk.java.net/browse/JDK-8284014): Menu items with submenus in JPopupMenu are not spoken on macOS


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Anton Tarasov](https://openjdk.java.net/census#ant) (@forantar - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8043/head:pull/8043` \
`$ git checkout pull/8043`

Update a local copy of the PR: \
`$ git checkout pull/8043` \
`$ git pull https://git.openjdk.java.net/jdk pull/8043/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8043`

View PR using the GUI difftool: \
`$ git pr show -t 8043`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8043.diff">https://git.openjdk.java.net/jdk/pull/8043.diff</a>

</details>
