### PR TITLE
5087440: java.io bulk read(...) end-of-stream return value descriptions ambiguous

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInput.java
+++ b/src/java.base/share/classes/java/io/ObjectInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,8 +62,9 @@ public interface ObjectInput extends DataInput, AutoCloseable {
      * Reads into an array of bytes.  This method will
      * block until some input is available.
      * @param   b the buffer into which the data is read
-     * @return  the actual number of bytes read, -1 is
-     *          returned when the end of the stream is reached.
+     * @return  the total number of bytes read into the buffer, or
+     *          {@code -1} if there is no more data because the end of
+     *          the stream has been reached.
      * @throws  IOException If an I/O error has occurred.
      */
     public int read(byte[] b) throws IOException;
@@ -74,8 +75,9 @@ public interface ObjectInput extends DataInput, AutoCloseable {
      * @param   b the buffer into which the data is read
      * @param   off the start offset of the data
      * @param   len the maximum number of bytes read
-     * @return  the actual number of bytes read, -1 is
-     *          returned when the end of the stream is reached.
+     * @return  the total number of bytes read into the buffer, or
+     *          {@code -1} if there is no more data because the end of
+     *          the stream has been reached.
      * @throws  IOException If an I/O error has occurred.
      */
     public int read(byte[] b, int off, int len) throws IOException;

--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -1031,8 +1031,9 @@ public class ObjectInputStream
      * @param   buf the buffer into which the data is read
      * @param   off the start offset in the destination array {@code buf}
      * @param   len the maximum number of bytes read
-     * @return  the actual number of bytes read, -1 is returned when the end of
-     *          the stream is reached.
+     * @return  the total number of bytes read into the buffer, or
+     *          {@code -1} if there is no more data because the end of
+     *          the stream has been reached.
      * @throws  NullPointerException if {@code buf} is {@code null}.
      * @throws  IndexOutOfBoundsException if {@code off} is negative,
      *          {@code len} is negative, or {@code len} is greater than

--- a/src/java.base/share/classes/java/io/SequenceInputStream.java
+++ b/src/java.base/share/classes/java/io/SequenceInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -177,7 +177,9 @@ public class SequenceInputStream extends InputStream {
      * @param      off   the start offset in array {@code b}
      *                   at which the data is written.
      * @param      len   the maximum number of bytes read.
-     * @return     int   the number of bytes read.
+     * @return     the total number of bytes read into the buffer, or
+     *             {@code -1} if there is no more data because the end of
+     *             the stream has been reached.
      * @throws     NullPointerException If {@code b} is {@code null}.
      * @throws     IndexOutOfBoundsException If {@code off} is negative,
      *             {@code len} is negative, or {@code len} is

--- a/src/java.base/share/classes/java/io/SequenceInputStream.java
+++ b/src/java.base/share/classes/java/io/SequenceInputStream.java
@@ -179,7 +179,7 @@ public class SequenceInputStream extends InputStream {
      * @param      len   the maximum number of bytes read.
      * @return     the total number of bytes read into the buffer, or
      *             {@code -1} if there is no more data because the end of
-     *             the stream has been reached.
+     *             the last contained stream has been reached.
      * @throws     NullPointerException If {@code b} is {@code null}.
      * @throws     IndexOutOfBoundsException If {@code off} is negative,
      *             {@code len} is negative, or {@code len} is


### PR DESCRIPTION
Minimal version of possible fixes: make the bulk read `@return` verbiage consistent in the `java.io` package.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-5087440](https://bugs.openjdk.java.net/browse/JDK-5087440): java.io bulk read(...) end-of-stream return value descriptions ambiguous
 * [JDK-8284022](https://bugs.openjdk.java.net/browse/JDK-8284022): java.io bulk read(...) end-of-stream return value descriptions ambiguous (**CSR**)


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to 3de7caa83e08916063d2c450e7b4861b8ccd432e


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8044/head:pull/8044` \
`$ git checkout pull/8044`

Update a local copy of the PR: \
`$ git checkout pull/8044` \
`$ git pull https://git.openjdk.java.net/jdk pull/8044/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8044`

View PR using the GUI difftool: \
`$ git pr show -t 8044`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8044.diff">https://git.openjdk.java.net/jdk/pull/8044.diff</a>

</details>
