### PR TITLE
8283842: TestZoneTextPrinterParser.test_roundTripAtOverlap fails: DateTimeParseException

### DIFF
--- a/test/jdk/java/time/test/java/time/format/TestZoneTextPrinterParser.java
+++ b/test/jdk/java/time/test/java/time/format/TestZoneTextPrinterParser.java
@@ -262,7 +262,7 @@ public class TestZoneTextPrinterParser extends AbstractTestPrinterParser {
 
     @Test(dataProvider="roundTripAtOverlap")
     public void test_roundTripAtOverlap(String pattern, String input) {
-        var dtf = DateTimeFormatter.ofPattern(pattern);
+        var dtf = DateTimeFormatter.ofPattern(pattern, Locale.US);
         assertEquals(dtf.format(ZonedDateTime.parse(input, dtf)), input);
         var lc = input.toLowerCase(Locale.ROOT);
         try {
@@ -270,7 +270,7 @@ public class TestZoneTextPrinterParser extends AbstractTestPrinterParser {
             fail("Should throw DateTimeParseException");
         } catch (DateTimeParseException ignore) {}
 
-        dtf = new DateTimeFormatterBuilder().parseCaseInsensitive().appendPattern(pattern).toFormatter();
+        dtf = new DateTimeFormatterBuilder().parseCaseInsensitive().appendPattern(pattern).toFormatter(Locale.US);
         assertEquals(dtf.format(ZonedDateTime.parse(input, dtf)), input);
         assertEquals(dtf.format(ZonedDateTime.parse(lc, dtf)), input);
     }


### PR DESCRIPTION
Fixes test failures caused by depending on the default locale. Specifying explicit `Locale.US` will do.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283842](https://bugs.openjdk.java.net/browse/JDK-8283842): TestZoneTextPrinterParser.test_roundTripAtOverlap fails: DateTimeParseException


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Stephen Colebourne](https://openjdk.java.net/census#scolebourne) (@jodastephen - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8045/head:pull/8045` \
`$ git checkout pull/8045`

Update a local copy of the PR: \
`$ git checkout pull/8045` \
`$ git pull https://git.openjdk.java.net/jdk pull/8045/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8045`

View PR using the GUI difftool: \
`$ git pr show -t 8045`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8045.diff">https://git.openjdk.java.net/jdk/pull/8045.diff</a>

</details>
