### PR TITLE
8283703: Add sealed modifier to java.awt.geom.Path2D

### DIFF
--- a/src/java.desktop/share/classes/java/awt/geom/Path2D.java
+++ b/src/java.desktop/share/classes/java/awt/geom/Path2D.java
@@ -70,7 +70,9 @@ import sun.awt.geom.Curve;
  * @author Jim Graham
  * @since 1.6
  */
-public abstract class Path2D implements Shape, Cloneable {
+public abstract sealed class Path2D implements Shape, Cloneable
+    permits Path2D.Double,
+            Path2D.Float   {
     /**
      * An even-odd winding rule for determining the interior of
      * a path.
@@ -191,7 +193,7 @@ public abstract class Path2D implements Shape, Cloneable {
      *
      * @since 1.6
      */
-    public static class Float extends Path2D implements Serializable {
+    public static non-sealed class Float extends Path2D implements Serializable {
         transient float[] floatCoords;
 
         /**
@@ -1093,7 +1095,7 @@ public abstract class Path2D implements Shape, Cloneable {
      *
      * @since 1.6
      */
-    public static class Double extends Path2D implements Serializable {
+    public static non-sealed class Double extends Path2D implements Serializable {
         transient double[] doubleCoords;
 
         /**


### PR DESCRIPTION
JDK 17 delivered JEP 409: Sealed Classes : https://openjdk.java.net/jeps/409
In essence this JEP allows a class to limit which classes can subclass it.

Path2D can be sealed because no code outside the package can sub-class it directly.

However the extant subclasses need to be made non-sealed as they can be sub-classed.

jtreg tests and JCK API tests pass.

CSR here : https://bugs.openjdk.java.net/browse/JDK-8284031

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8283703](https://bugs.openjdk.java.net/browse/JDK-8283703): Add sealed modifier to java.awt.geom.Path2D
 * [JDK-8284031](https://bugs.openjdk.java.net/browse/JDK-8284031): Add sealed modifier to java.awt.geom.Path2D (**CSR**)


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8048/head:pull/8048` \
`$ git checkout pull/8048`

Update a local copy of the PR: \
`$ git checkout pull/8048` \
`$ git pull https://git.openjdk.java.net/jdk pull/8048/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8048`

View PR using the GUI difftool: \
`$ git pr show -t 8048`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8048.diff">https://git.openjdk.java.net/jdk/pull/8048.diff</a>

</details>
