### PR TITLE
8284033: Leak XVisualInfo in getAllConfigs in awt_GraphicsEnv.c

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -579,7 +579,8 @@ cleanup:
        XFree (pVI8sg);
     if (n1sg != 0)
        XFree (pVI1sg);
-
+    if (nTrue != 0)
+       XFree (pVITrue);
     AWT_UNLOCK ();
 }
 


### PR DESCRIPTION
Please review this small patch to fix possibly leak of `pVITrue`.

Test:
- [x] jdk_awt

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284033](https://bugs.openjdk.java.net/browse/JDK-8284033): Leak XVisualInfo in getAllConfigs in awt_GraphicsEnv.c


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8050/head:pull/8050` \
`$ git checkout pull/8050`

Update a local copy of the PR: \
`$ git checkout pull/8050` \
`$ git pull https://git.openjdk.java.net/jdk pull/8050/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8050`

View PR using the GUI difftool: \
`$ git pr show -t 8050`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8050.diff">https://git.openjdk.java.net/jdk/pull/8050.diff</a>

</details>
