### PR TITLE
Reduce algorithm decomposer set lookups

### DIFF
--- a/src/java.base/share/classes/sun/security/util/AlgorithmDecomposer.java
+++ b/src/java.base/share/classes/sun/security/util/AlgorithmDecomposer.java
@@ -109,11 +109,9 @@ public class AlgorithmDecomposer {
         }
 
         for (Map.Entry<String, String> e : DECOMPOSED_DIGEST_NAMES.entrySet()) {
-            if (elements.contains(e.getValue()) &&
-                    !elements.contains(e.getKey())) {
+            if (elements.contains(e.getValue())) {
                 elements.add(e.getKey());
-            } else if (elements.contains(e.getKey()) &&
-                    !elements.contains(e.getValue())) {
+            } else if (elements.contains(e.getKey())) {
                 elements.add(e.getValue());
             }
         }
@@ -156,11 +154,8 @@ public class AlgorithmDecomposer {
         }
 
         for (Map.Entry<String, String> e : DECOMPOSED_DIGEST_NAMES.entrySet()) {
-            if (elements.contains(e.getKey())) {
-                if (!elements.contains(e.getValue())) {
-                    elements.add(e.getValue());
-                }
-                elements.remove(e.getKey());
+            if (elements.remove(e.getKey())) {
+                elements.add(e.getValue());
             }
         }
 


### PR DESCRIPTION
Please consider this minor optimization to reduce algorithm decomposer set lookups that occur during TLS handshaking. Using the `AlgorithmConstraintsPermits.permits` microbenchmark from https://github.com/openjdk/jdk/pull/4424 I see ~1% improvement for TLS 1.3

#### Baseline
```
Benchmark                            (algorithm)  Mode  Cnt    Score   Error  Units
AlgorithmConstraintsPermits.permits        SSLv3  avgt   25   32.149 ± 0.834  ns/op
AlgorithmConstraintsPermits.permits          DES  avgt   25   41.492 ± 2.161  ns/op
AlgorithmConstraintsPermits.permits         NULL  avgt   25   41.636 ± 2.161  ns/op
AlgorithmConstraintsPermits.permits       TLS1.3  avgt   25  344.877 ± 4.757  ns/op
```


#### After
```
Benchmark                            (algorithm)  Mode  Cnt    Score   Error  Units
AlgorithmConstraintsPermits.permits        SSLv3  avgt   25   32.991 ± 0.576  ns/op
AlgorithmConstraintsPermits.permits          DES  avgt   25   41.689 ± 2.216  ns/op
AlgorithmConstraintsPermits.permits         NULL  avgt   25   40.098 ± 2.334  ns/op
AlgorithmConstraintsPermits.permits       TLS1.3  avgt   25  340.829 ± 3.651  ns/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8051/head:pull/8051` \
`$ git checkout pull/8051`

Update a local copy of the PR: \
`$ git checkout pull/8051` \
`$ git pull https://git.openjdk.java.net/jdk pull/8051/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8051`

View PR using the GUI difftool: \
`$ git pr show -t 8051`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8051.diff">https://git.openjdk.java.net/jdk/pull/8051.diff</a>

</details>
