### PR TITLE
8284043: com/sun/jdi/MethodInvokeWithTraceOnTest.java failing with com.sun.jdi.ObjectCollectedException

### DIFF
--- a/test/jdk/com/sun/jdi/MethodInvokeWithTraceOnTest.java
+++ b/test/jdk/com/sun/jdi/MethodInvokeWithTraceOnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,6 +116,7 @@ public class MethodInvokeWithTraceOnTest extends TestScaffold {
         LocalVariable threadVar = frame.visibleVariableByName("thread");
         ThreadReference threadObj = (ThreadReference) frame.getValue(threadVar);
         StringReference stringObj = vm().mirrorOf("test string");
+        stringObj.disableCollection();
         int invokeOptions = getMethodInvokeOptions(be);
 
         testInstanceMethod1(thread, thisObj, stringObj, threadObj, invokeOptions);


### PR DESCRIPTION
Test is getting an `com.sun.jdi.ObjectCollectedException` during an invoke. The reason is because an allocated object is not being prevented from being gc'd:

```
         StringReference stringObj = vm().mirrorOf("test string");
        ...
        classType.invokeMethod(thread, printMethod, Collections.singletonList(stringObj), invokeOptions);
```

Need a `disableCollection()` on `stringObj` since threads are resumed during the invoke, allowing it to be collected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284043](https://bugs.openjdk.java.net/browse/JDK-8284043): com/sun/jdi/MethodInvokeWithTraceOnTest.java failing with com.sun.jdi.ObjectCollectedException


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8052/head:pull/8052` \
`$ git checkout pull/8052`

Update a local copy of the PR: \
`$ git checkout pull/8052` \
`$ git pull https://git.openjdk.java.net/jdk pull/8052/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8052`

View PR using the GUI difftool: \
`$ git pr show -t 8052`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8052.diff">https://git.openjdk.java.net/jdk/pull/8052.diff</a>

</details>
