### PR TITLE
8284071: Collapse identical catch branches in jdk.console

### DIFF
--- a/src/jdk.jconsole/share/classes/sun/tools/jconsole/JConsole.java
+++ b/src/jdk.jconsole/share/classes/sun/tools/jconsole/JConsole.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -483,9 +483,7 @@ public class JConsole extends JFrame
             public void run() {
                 try {
                     addProxyClient(ProxyClient.getProxyClient(lvm), tile);
-                } catch (final SecurityException ex) {
-                    failed(ex, null, null, null);
-                } catch (final IOException ex) {
+                } catch (final SecurityException | IOException ex) {
                     failed(ex, null, null, null);
                 }
             }
@@ -502,11 +500,7 @@ public class JConsole extends JFrame
                 try {
                     addProxyClient(ProxyClient.getProxyClient(url, userName, password),
                                    tile);
-                } catch (final MalformedURLException ex) {
-                    failed(ex, url, userName, password);
-                } catch (final SecurityException ex) {
-                    failed(ex, url, userName, password);
-                } catch (final IOException ex) {
+                } catch (final IOException | SecurityException ex) {
                     failed(ex, url, userName, password);
                 }
             }

--- a/src/jdk.jconsole/share/classes/sun/tools/jconsole/MaximizableInternalFrame.java
+++ b/src/jdk.jconsole/share/classes/sun/tools/jconsole/MaximizableInternalFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -239,15 +239,7 @@ public class MaximizableInternalFrame extends JInternalFrame {
                     UIManager.put(key,
                                   new MDIButtonIcon(UIManager.getIcon(key)));
                 }
-            } catch (ClassNotFoundException ex) {
-                if (JConsole.debug) {
-                    ex.printStackTrace();
-                }
-            } catch (NoSuchFieldException ex) {
-                if (JConsole.debug) {
-                    ex.printStackTrace();
-                }
-            } catch (IllegalAccessException ex) {
+            } catch (ClassNotFoundException | IllegalAccessException | NoSuchFieldException ex) {
                 if (JConsole.debug) {
                     ex.printStackTrace();
                 }

--- a/src/jdk.jconsole/share/classes/sun/tools/jconsole/ProxyClient.java
+++ b/src/jdk.jconsole/share/classes/sun/tools/jconsole/ProxyClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -608,11 +608,7 @@ public class ProxyClient implements JConsoleContext {
                 try {
                     MBeanInfo info = server.getMBeanInfo(o);
                     result.put(o, info);
-                } catch (IntrospectionException e) {
-                    // TODO: should log the error
-                } catch (InstanceNotFoundException e) {
-                    // TODO: should log the error
-                } catch (ReflectionException e) {
+                } catch (IntrospectionException | ReflectionException | InstanceNotFoundException e) {
                     // TODO: should log the error
                 }
             }

--- a/src/jdk.jconsole/share/classes/sun/tools/jconsole/SummaryTab.java
+++ b/src/jdk.jconsole/share/classes/sun/tools/jconsole/SummaryTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -302,13 +302,7 @@ class SummaryTab extends Tab {
                        4);
                 append(endTable);
             }
-        } catch (IOException e) {
-            if (JConsole.isDebug()) {
-                e.printStackTrace();
-            }
-            proxyClient.markAsDead();
-            return null;
-        } catch (UndeclaredThrowableException e) {
+        } catch (IOException | UndeclaredThrowableException e) {
             if (JConsole.isDebug()) {
                 e.printStackTrace();
             }

--- a/src/jdk.jconsole/share/classes/sun/tools/jconsole/ThreadTab.java
+++ b/src/jdk.jconsole/share/classes/sun/tools/jconsole/ThreadTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -216,9 +216,7 @@ class ThreadTab extends Tab implements ActionListener, DocumentListener, ListSel
                     }
                     timeStamp = System.currentTimeMillis();
                     return true;
-                } catch (IOException e) {
-                    return false;
-                } catch (UndeclaredThrowableException e) {
+                } catch (IOException | UndeclaredThrowableException e) {
                     return false;
                 }
             }
@@ -426,9 +424,7 @@ class ThreadTab extends Tab implements ActionListener, DocumentListener, ListSel
                                         }
                                     });
                                     sleep(30 * 1000);
-                                } catch (InterruptedException ex) {
-                                    // Ignore
-                                } catch (InvocationTargetException ex) {
+                                } catch (InterruptedException | InvocationTargetException ex) {
                                     // Ignore
                                 }
                                 SwingUtilities.invokeLater(new Runnable() {


### PR DESCRIPTION
Let's take advantage of Java 7 language feature - "Catching Multiple Exception Types".
It simplifies code. Reduces duplication.
Found by IntelliJ IDEA inspection Identical 'catch' branches in 'try' statement

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284071](https://bugs.openjdk.java.net/browse/JDK-8284071): Collapse identical catch branches in jdk.console


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8053/head:pull/8053` \
`$ git checkout pull/8053`

Update a local copy of the PR: \
`$ git checkout pull/8053` \
`$ git pull https://git.openjdk.java.net/jdk pull/8053/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8053`

View PR using the GUI difftool: \
`$ git pr show -t 8053`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8053.diff">https://git.openjdk.java.net/jdk/pull/8053.diff</a>

</details>
