### PR TITLE
8282080: Lambda deserialization fails for Object method references on interfaces

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -309,6 +309,12 @@ public class Flags {
     public static final long NAME_FILLED = 1L<<52; //ParamSymbols only
 
     /**
+     * Flag to indicate the given MethodSymbol is a method from java.lang.Object transferred to an
+     * interface, which does not declare the method explicitly.
+     */
+    public static final long OBJECT_METHOD_IN_INTERFACE = 1L<<52; // MethodSymbols
+
+    /**
      * Flag to indicate the given ModuleSymbol is a system module.
      */
     public static final long SYSTEM_MODULE = 1L<<53; //ModuleSymbols only

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -755,6 +755,12 @@ public class LambdaToMethod extends TreeTranslator {
         String functionalInterfaceClass = classSig(targetType);
         String functionalInterfaceMethodName = samSym.getSimpleName().toString();
         String functionalInterfaceMethodSignature = typeSig(types.erasure(samSym.type));
+        if ((refSym.flags_field & OBJECT_METHOD_IN_INTERFACE) != 0) {
+            //the implementation method is a java.lang.Object method transferred to an
+            //interface that does not declare it. Runtime will refer to this method as to
+            //a java.lang.Object method, so do the same:
+            refSym = ((MethodSymbol) refSym.baseSymbol().baseSymbol()).asHandle();
+        }
         String implClass = classSig(types.erasure(refSym.owner.type));
         String implMethodName = refSym.getQualifiedName().toString();
         String implMethodSignature = typeSig(types.erasure(refSym.type));

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -1898,7 +1898,7 @@ public class Resolve {
                     syms.objectType.tsym.members(), bestSoFar, allowBoxing, useVarargs, true);
             if (bestSoFar.kind.isValid()) {
                 Symbol baseSymbol = bestSoFar;
-                bestSoFar = new MethodSymbol(bestSoFar.flags_field, bestSoFar.name, bestSoFar.type, intype.tsym) {
+                bestSoFar = new MethodSymbol(bestSoFar.flags_field | OBJECT_METHOD_IN_INTERFACE, bestSoFar.name, bestSoFar.type, intype.tsym) {
                     @Override
                     public Symbol baseSymbol() {
                         return baseSymbol;

--- a/test/langtools/tools/javac/lambda/SerializableObjectMethods.java
+++ b/test/langtools/tools/javac/lambda/SerializableObjectMethods.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8282080
+ * @summary Check that serializable lambdas referring to j.l.Object methods work.
+ * @compile SerializableObjectMethods.java
+ * @run main SerializableObjectMethods
+ */
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+public class SerializableObjectMethods {
+
+    interface I1 extends Serializable {}
+
+    interface I2 extends I1 {
+
+        @Override
+        public int hashCode();
+
+    }
+
+    interface F<T, R> extends Serializable {
+
+        R apply(T t);
+    }
+
+    public static void main(String[] args) throws Exception {
+        new SerializableObjectMethods().run();
+    }
+
+    void run() throws IOException, ClassNotFoundException {
+        saveLoad((F<I1, Integer>) I1::hashCode).apply(new I1() {});
+        saveLoad((F<I2, Integer>) I2::hashCode).apply(new I2() {});
+    }
+
+    <T, R> F<T, R> saveLoad(F<T, R> value) throws IOException, ClassNotFoundException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try ( ObjectOutputStream oos = new ObjectOutputStream(out)) {
+            oos.writeObject(value);
+        }
+        try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(out.toByteArray()))) {
+            return (F<T, R>) ois.readObject();
+        }
+    }
+}


### PR DESCRIPTION
Per JLS, every interface with no superinterfaces implicitly has all public methods `java.lang.Object` has (unless the interface declares them explicitly). So, having:
```
interface I {}
```
the interface has methods like `hashCode()`. But, before https://bugs.openjdk.java.net/browse/JDK-8272564, javac was referring to them as if they were a `java.lang.Object` methods, not the interface methods. E.g. saying `I i = null; i.hashCode()` lead to a reference to `java.lang.Object.hashCode()` not `I.hashCode()`. That was changed in JDK-8272564, and now the reference is to `I.hashCode()`.

There is one issue, though: when the reference is for a serializable (and serialized) method handle, the runtime method is still `java.lang.Object::hashCode`, but the deserialization code generated by javac expects `I::hashCode`, and hence the serialized method handle fails to deserialize.

The proposal here is to fix just this case, by changing the deserialization code to expect the method from `java.lang.Object`, which should revert the deserialization behavior back to JDK 17 behavior.