### PR TITLE
JDK-8284068: riscv: should call Atomic::release_store in JavaThread::set_thread_state

### DIFF
--- a/src/hotspot/share/runtime/thread.inline.hpp
+++ b/src/hotspot/share/runtime/thread.inline.hpp
@@ -162,7 +162,7 @@ inline JavaThreadState JavaThread::thread_state() const    {
 inline void JavaThread::set_thread_state(JavaThreadState s) {
   assert(current_or_null() == NULL || current_or_null() == this,
          "state change should only be called by the current thread");
-#if defined(PPC64) || defined (AARCH64)
+#if defined(PPC64) || defined (AARCH64) || defined(RISCV64)
   // Use membars when accessing volatile _thread_state. See
   // Threads::create_vm() for size checks.
   Atomic::release_store((volatile jint*)&_thread_state, (jint)s);


### PR DESCRIPTION
For RISCV, we use membars when accessing volatile _thread_state through Atomic::load_acquire in JavaThread::thread_state. 
Accordingly, we should use Atomic::release_store to access volatile _thread_state in JavaThread::set_thread_state. 
This is correct for our internal JDK 11 distribution: both functions are guarded by a single-line macro check for architectures [1].

The code is refactored in JDK mainline: each function has their own architecture macro check. 
But looks like we only kept the macro check for RISCV64 in JavaThread::thread_state when porting from JDK 11. 
The same check is missing for JavaThread::set_thread_state. We should add it back.

Tested with hotspot tier1 & jdk tier1 on Linux-riscv64 board. No new errors witnessed.
Note that this will only affect the RISCV architecture.

[1] https://gitee.com/openeuler/bishengjdk-11/blob/risc-v/src/hotspot/share/runtime/thread.inline.hpp#L123

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284068](https://bugs.openjdk.java.net/browse/JDK-8284068): riscv: should call Atomic::release_store in JavaThread::set_thread_state


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8055/head:pull/8055` \
`$ git checkout pull/8055`

Update a local copy of the PR: \
`$ git checkout pull/8055` \
`$ git pull https://git.openjdk.java.net/jdk pull/8055/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8055`

View PR using the GUI difftool: \
`$ git pr show -t 8055`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8055.diff">https://git.openjdk.java.net/jdk/pull/8055.diff</a>

</details>
