### PR TITLE
8284075: Optimize paired floorDiv and floorMod calculations in java.time

### DIFF
--- a/src/java.base/share/classes/java/time/Duration.java
+++ b/src/java.base/share/classes/java/time/Duration.java
@@ -246,9 +246,9 @@ public final class Duration
      * @throws ArithmeticException if the adjustment causes the seconds to exceed the capacity of {@code Duration}
      */
     public static Duration ofSeconds(long seconds, long nanoAdjustment) {
-        long secs = Math.addExact(seconds, Math.floorDiv(nanoAdjustment, NANOS_PER_SECOND));
-        int nos = (int) Math.floorMod(nanoAdjustment, NANOS_PER_SECOND);
-        return create(secs, nos);
+        long secs = Math.floorDiv(nanoAdjustment, NANOS_PER_SECOND);
+        int nos = (int) (nanoAdjustment - secs * NANOS_PER_SECOND);
+        return create(Math.addExact(seconds, secs), nos);
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/Instant.java
+++ b/src/java.base/share/classes/java/time/Instant.java
@@ -329,9 +329,9 @@ public final class Instant
      * @throws ArithmeticException if numeric overflow occurs
      */
     public static Instant ofEpochSecond(long epochSecond, long nanoAdjustment) {
-        long secs = Math.addExact(epochSecond, Math.floorDiv(nanoAdjustment, NANOS_PER_SECOND));
-        int nos = (int)Math.floorMod(nanoAdjustment, NANOS_PER_SECOND);
-        return create(secs, nos);
+        long nanos = Math.floorDiv(nanoAdjustment, NANOS_PER_SECOND);
+        int nos = (int) (nanoAdjustment - nanos * NANOS_PER_SECOND);
+        return create(Math.addExact(epochSecond, nanos), nos);
     }
 
     /**
@@ -346,7 +346,7 @@ public final class Instant
      */
     public static Instant ofEpochMilli(long epochMilli) {
         long secs = Math.floorDiv(epochMilli, 1000);
-        int mos = Math.floorMod(epochMilli, 1000);
+        int mos = (int) (epochMilli - secs * 1000);
         return create(secs, mos * 1000_000);
     }
 

--- a/src/java.base/share/classes/java/time/LocalDate.java
+++ b/src/java.base/share/classes/java/time/LocalDate.java
@@ -1304,9 +1304,9 @@ public final class LocalDate
         }
         long monthCount = year * 12L + (month - 1);
         long calcMonths = monthCount + monthsToAdd;  // safe overflow
-        int newYear = YEAR.checkValidIntValue(Math.floorDiv(calcMonths, 12));
-        int newMonth = Math.floorMod(calcMonths, 12) + 1;
-        return resolvePreviousValid(newYear, newMonth, day);
+        long newYear = Math.floorDiv(calcMonths, 12);
+        int newMonth = (int) (calcMonths - newYear * 12 + 1); // safe cast
+        return resolvePreviousValid(YEAR.checkValidIntValue(newYear), newMonth, day);
     }
 
     /**

--- a/src/java.base/share/classes/java/time/LocalDateTime.java
+++ b/src/java.base/share/classes/java/time/LocalDateTime.java
@@ -420,9 +420,9 @@ public final class LocalDateTime
         NANO_OF_SECOND.checkValidValue(nanoOfSecond);
         long localSecond = epochSecond + offset.getTotalSeconds();  // overflow caught later
         long localEpochDay = Math.floorDiv(localSecond, SECONDS_PER_DAY);
-        int secsOfDay = Math.floorMod(localSecond, SECONDS_PER_DAY);
+        long nanoOfDay = (localSecond - localEpochDay * SECONDS_PER_DAY) * NANOS_PER_SECOND + nanoOfSecond;
         LocalDate date = LocalDate.ofEpochDay(localEpochDay);
-        LocalTime time = LocalTime.ofNanoOfDay(secsOfDay * NANOS_PER_SECOND + nanoOfSecond);
+        LocalTime time = LocalTime.ofNanoOfDay(nanoOfDay);
         return new LocalDateTime(date, time);
     }
 
@@ -1559,8 +1559,9 @@ public final class LocalDateTime
                 (hours % HOURS_PER_DAY) * NANOS_PER_HOUR;          //   max  86400000000000
         long curNoD = time.toNanoOfDay();                       //   max  86400000000000
         totNanos = totNanos * sign + curNoD;                    // total 432000000000000
-        totDays += Math.floorDiv(totNanos, NANOS_PER_DAY);
-        long newNoD = Math.floorMod(totNanos, NANOS_PER_DAY);
+        long daysToAdd = Math.floorDiv(totNanos, NANOS_PER_DAY);
+        totDays += daysToAdd;
+        long newNoD = totNanos - daysToAdd * NANOS_PER_DAY;
         LocalTime newTime = (newNoD == curNoD ? time : LocalTime.ofNanoOfDay(newNoD));
         return with(newDate.plusDays(totDays), newTime);
     }

--- a/src/java.base/share/classes/java/time/YearMonth.java
+++ b/src/java.base/share/classes/java/time/YearMonth.java
@@ -850,9 +850,9 @@ public final class YearMonth
         }
         long monthCount = year * 12L + (month - 1);
         long calcMonths = monthCount + monthsToAdd;  // safe overflow
-        int newYear = YEAR.checkValidIntValue(Math.floorDiv(calcMonths, 12));
-        int newMonth = Math.floorMod(calcMonths, 12) + 1;
-        return with(newYear, newMonth);
+        long newYear = Math.floorDiv(calcMonths, 12);
+        int newMonth = (int) (calcMonths - newYear * 12 + 1);
+        return with(YEAR.checkValidIntValue(newYear), newMonth);
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/chrono/IsoChronology.java
+++ b/src/java.base/share/classes/java/time/chrono/IsoChronology.java
@@ -593,8 +593,10 @@ public final class IsoChronology extends AbstractChronology implements Serializa
             if (resolverStyle != ResolverStyle.LENIENT) {
                 PROLEPTIC_MONTH.checkValidValue(pMonth);
             }
-            addFieldValue(fieldValues, MONTH_OF_YEAR, Math.floorMod(pMonth, 12) + 1);
-            addFieldValue(fieldValues, YEAR, Math.floorDiv(pMonth, 12));
+            long month = pMonth.longValue();
+            long year = Math.floorDiv(month, 12);
+            addFieldValue(fieldValues, MONTH_OF_YEAR, month - year * 12 + 1);
+            addFieldValue(fieldValues, YEAR, year);
         }
     }
 

--- a/test/micro/org/openjdk/bench/java/time/GetYearBench.java
+++ b/test/micro/org/openjdk/bench/java/time/GetYearBench.java
@@ -71,9 +71,9 @@ public class GetYearBench {
 
     @Setup
     public void createInstants() {
-        // Various instants during the same day
-        final Instant loInstant = Instant.EPOCH.plus(Duration.ofDays(365*50)); // 2020-01-01
-        final Instant hiInstant = loInstant.plus(Duration.ofDays(1));
+        // Various instants during a few years (2020-2024)
+        final Instant loInstant = Instant.EPOCH.plus(Duration.ofDays(365 * 50)); // 2020-01-01
+        final Instant hiInstant = loInstant.plus(Duration.ofDays(4 * 365));
         final long maxOffsetNanos = Duration.between(loInstant, hiInstant).toNanos();
         final Random random = new Random(0);
         INSTANT_MILLIS = IntStream


### PR DESCRIPTION
A common arithmetic pattern in java.time is to calculate both `Math.floorDiv` and `floorMod` for the same arguments. In such cases `floorMod` can be calculated more efficiently using the result of `floorDiv`.

From the javadoc for `floorMod`, the relationship is such that:

```java
floorDiv(x, y) * y + floorMod(x, y) == x
```
or:
```java
floorMod(x, y) == x - floorDiv(x, y) * y;
```

Simplifying like so bring a 15% or so speed-up on `GetYearBench`, which benefits from the changes `Instant::ofEpochMilli` and `LocalDateTime::ofEpochSecond`:

```
Benchmark                                                   Mode  Cnt       Score       Error   Units
GetYearBench.getYearFromMillisZoneOffset                   thrpt    5      34.522 ±     0.054  ops/ms
GetYearBench.getYearFromMillisZoneRegion                   thrpt    5       9.984 ±     0.151  ops/ms
GetYearBench.getYearFromMillisZoneRegionNormalized         thrpt    5      34.844 ±     0.281  ops/ms
GetYearBench.getYearFromMillisZoneRegionUTC                thrpt    5      34.517 ±     0.007  ops/ms
```

```
Benchmark                                                   Mode  Cnt       Score       Error   Units
GetYearBench.getYearFromMillisZoneOffset                   thrpt    5      39.709 ±     0.048  ops/ms
GetYearBench.getYearFromMillisZoneRegion                   thrpt    5      11.703 ±     0.510  ops/ms
GetYearBench.getYearFromMillisZoneRegionNormalized         thrpt    5      39.612 ±     0.023  ops/ms
GetYearBench.getYearFromMillisZoneRegionUTC                thrpt    5      39.511 ±     0.050  ops/ms
```

Testing: java.time tests locally, tier1+2 ongoing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8284075](https://bugs.openjdk.java.net/browse/JDK-8284075): Optimize paired floorDiv and floorMod calculations in java.time


### Reviewers
 * [Stephen Colebourne](https://openjdk.java.net/census#scolebourne) (@jodastephen - Author) ⚠️ Review applies to 37b33695e529b080faa75c2a0b87dd1829f8e5d8


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8056/head:pull/8056` \
`$ git checkout pull/8056`

Update a local copy of the PR: \
`$ git checkout pull/8056` \
`$ git pull https://git.openjdk.java.net/jdk pull/8056/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8056`

View PR using the GUI difftool: \
`$ git pr show -t 8056`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8056.diff">https://git.openjdk.java.net/jdk/pull/8056.diff</a>

</details>
