### PR TITLE
8284094: Memory leak in invoker_completeInvokeRequest()

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/invoker.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/invoker.c
@@ -810,6 +810,7 @@ invoker_completeInvokeRequest(jthread thread)
             tossGlobalRef(env, &exc);
         }
         outStream_sendReply(&out);
+        outStream_destroy(&out);
     }
 }
 


### PR DESCRIPTION
In invoker.c in the function invoker_completeInvokeRequest(), we allocate a PacketOutputStream object called out using outStream_initReply(), but never reclaim it. We need to call outStream_destroy() before going out of scope.

Testing:
 - [x] com/sun/jdi
 - [x] vmTestbase/nsk/jdi
 - [x] vmTestbase/nsk/jdb
 - [x] vmTestbase/nsk/jdwp
 - [x] tier1
 - [x] tier2
 - [x] tier3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284094](https://bugs.openjdk.java.net/browse/JDK-8284094): Memory leak in invoker_completeInvokeRequest()


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8059/head:pull/8059` \
`$ git checkout pull/8059`

Update a local copy of the PR: \
`$ git checkout pull/8059` \
`$ git pull https://git.openjdk.java.net/jdk pull/8059/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8059`

View PR using the GUI difftool: \
`$ git pr show -t 8059`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8059.diff">https://git.openjdk.java.net/jdk/pull/8059.diff</a>

</details>
