### PR TITLE
JDK-8284103: AsVarargsCollector::asCollectorCache incorrectly marked @stable

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -451,7 +451,7 @@ abstract class MethodHandleImpl {
     static final class AsVarargsCollector extends DelegatingMethodHandle {
         private final MethodHandle target;
         private final Class<?> arrayType;
-        private @Stable MethodHandle asCollectorCache;
+        private MethodHandle asCollectorCache;
 
         AsVarargsCollector(MethodHandle target, Class<?> arrayType) {
             this(target.type(), target, arrayType);


### PR DESCRIPTION
As outlined in the JDK-8284103 [1], I believe the `@Stable` annotation has been incorrectly applied to the AsVarargsCollector::asCollectorCache field as the field is updated by the AsVarargsCollector::asTypeUncached method and there is no check to ensure it is only updated once.

[1] https://bugs.openjdk.java.net/browse/JDK-8284103

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284103](https://bugs.openjdk.java.net/browse/JDK-8284103): AsVarargsCollector::asCollectorCache incorrectly marked @Stable


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8062/head:pull/8062` \
`$ git checkout pull/8062`

Update a local copy of the PR: \
`$ git checkout pull/8062` \
`$ git pull https://git.openjdk.java.net/jdk pull/8062/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8062`

View PR using the GUI difftool: \
`$ git pr show -t 8062`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8062.diff">https://git.openjdk.java.net/jdk/pull/8062.diff</a>

</details>
