### PR TITLE
8212136: Remove finalizer implementation in SSLSocketImpl

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/BaseSSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/BaseSSLSocketImpl.java
@@ -42,8 +42,9 @@ import javax.net.ssl.*;
  * overridden in SSLSocketImpl.
  *
  * There used to be a finalize() implementation that sent close_notify's, but
- * decided that was not needed.  An application should close its sockets and
- * not let them get garbage collected without closing them.
+ * decided that was not needed.  Not closing properly is more properly an
+ * error condition that should be avoided.  Applications should close sockets
+ * and not rely on garbage collection.
  *
  * The underlying native resources are handled by the Socket Cleaner.
  *

--- a/src/java.base/share/classes/sun/security/ssl/BaseSSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/BaseSSLSocketImpl.java
@@ -63,7 +63,6 @@ abstract class BaseSSLSocketImpl extends SSLSocket {
         this.consumedInput = null;
     }
 
-
     BaseSSLSocketImpl(Socket socket) {
         super();
         this.self = socket;

--- a/src/java.base/share/classes/sun/security/ssl/BaseSSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/BaseSSLSocketImpl.java
@@ -41,6 +41,11 @@ import javax.net.ssl.*;
  * Methods are defined final to ensure that they are not accidentally
  * overridden in SSLSocketImpl.
  *
+ * There used to be a finalize() implementation, but decided that was
+ * not needed.  The native resources are handled by the Socket Cleaner.
+ * An application should close its sockets and not let them get garbage
+ * collected without closing them.
+ *
  * @see javax.net.ssl.SSLSocket
  * @see SSLSocketImpl
  */

--- a/src/java.base/share/classes/sun/security/ssl/BaseSSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/BaseSSLSocketImpl.java
@@ -41,10 +41,11 @@ import javax.net.ssl.*;
  * Methods are defined final to ensure that they are not accidentally
  * overridden in SSLSocketImpl.
  *
- * There used to be a finalize() implementation, but decided that was
- * not needed.  The native resources are handled by the Socket Cleaner.
- * An application should close its sockets and not let them get garbage
- * collected without closing them.
+ * There used to be a finalize() implementation that sent close_notify's, but
+ * decided that was not needed.  An application should close its sockets and
+ * not let them get garbage collected without closing them.
+ *
+ * The underlying native resources are handled by the Socket Cleaner.
  *
  * @see javax.net.ssl.SSLSocket
  * @see SSLSocketImpl

--- a/src/java.base/share/classes/sun/security/ssl/BaseSSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/BaseSSLSocketImpl.java
@@ -31,8 +31,6 @@ import java.nio.channels.SocketChannel;
 import java.util.Set;
 import javax.net.ssl.*;
 
-import jdk.internal.ref.CleanerFactory;
-
 /**
  * Abstract base class for SSLSocketImpl.
  *
@@ -63,8 +61,6 @@ abstract class BaseSSLSocketImpl extends SSLSocket {
         super();
         this.self = this;
         this.consumedInput = null;
-
-        CleanerFactory.cleaner().register(this, this::tryClose);
     }
 
 
@@ -72,16 +68,12 @@ abstract class BaseSSLSocketImpl extends SSLSocket {
         super();
         this.self = socket;
         this.consumedInput = null;
-
-        CleanerFactory.cleaner().register(this, this::tryClose);
     }
 
     BaseSSLSocketImpl(Socket socket, InputStream consumed) {
         super();
         this.self = socket;
         this.consumedInput = consumed;
-
-        CleanerFactory.cleaner().register(this, this::tryClose);
     }
 
     //
@@ -268,27 +260,6 @@ abstract class BaseSSLSocketImpl extends SSLSocket {
             return super.isOutputShutdown();
         } else {
             return self.isOutputShutdown();
-        }
-    }
-
-    /**
-     * Ensures that the SSL connection is closed down as cleanly
-     * as possible, in case the application forgets to do so.
-     * This allows SSL connections to be implicitly reclaimed,
-     * rather than forcing them to be explicitly reclaimed at
-     * the penalty of prematurely killing SSL sessions.
-     */
-    private void tryClose() {
-        try {
-            close();
-        } catch (IOException ioe) {
-            try {
-                if (self == this) {
-                    super.close();
-                }
-            } catch (IOException e) {
-                // ignore
-            }
         }
     }
 


### PR DESCRIPTION
Please review the update to remove finalizer method in the SunJSSE provider implementation.  It is one of the efforts to clean up the use of finalizer method in JDK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8212136](https://bugs.openjdk.java.net/browse/JDK-8212136): Remove finalizer implementation in SSLSocketImpl
 * [JDK-8286064](https://bugs.openjdk.java.net/browse/JDK-8286064): Remove finalizer implementation in SSLSocketImpl (**CSR**)


### Reviewers
 * [Bradford Wetmore](https://openjdk.java.net/census#wetmore) (@bradfordwetmore - **Reviewer**) ⚠️ Review applies to [ccfc42da](https://git.openjdk.java.net/jdk/pull/8065/files/ccfc42dab0942675d42ca37ee85a1abe055c916e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8065/head:pull/8065` \
`$ git checkout pull/8065`

Update a local copy of the PR: \
`$ git checkout pull/8065` \
`$ git pull https://git.openjdk.java.net/jdk pull/8065/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8065`

View PR using the GUI difftool: \
`$ git pr show -t 8065`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8065.diff">https://git.openjdk.java.net/jdk/pull/8065.diff</a>

</details>
