### PR TITLE
[PATCH] Collapse identical catch branches in security libs

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/KeyProtector.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/KeyProtector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -221,10 +221,8 @@ final class KeyProtector {
             // Note: this catch needed to be here because of the
             // later catch of GeneralSecurityException
             throw ex;
-        } catch (IOException ioe) {
-            throw new UnrecoverableKeyException(ioe.getMessage());
-        } catch (GeneralSecurityException gse) {
-            throw new UnrecoverableKeyException(gse.getMessage());
+        } catch (IOException | GeneralSecurityException e) {
+            throw new UnrecoverableKeyException(e.getMessage());
         } finally {
             if (plain != null) Arrays.fill(plain, (byte) 0x00);
             if (sKey != null) {
@@ -403,12 +401,8 @@ final class KeyProtector {
             // Note: this catch needed to be here because of the
             // later catch of GeneralSecurityException
             throw ex;
-        } catch (IOException ioe) {
-            throw new UnrecoverableKeyException(ioe.getMessage());
-        } catch (ClassNotFoundException cnfe) {
-            throw new UnrecoverableKeyException(cnfe.getMessage());
-        } catch (GeneralSecurityException gse) {
-            throw new UnrecoverableKeyException(gse.getMessage());
+        } catch (IOException | GeneralSecurityException | ClassNotFoundException e) {
+            throw new UnrecoverableKeyException(e.getMessage());
         } finally {
             if (sKey != null) {
                 try {

--- a/src/java.base/share/classes/com/sun/crypto/provider/TlsMasterSecretGenerator.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/TlsMasterSecretGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,9 +148,7 @@ public final class TlsMasterSecretGenerator extends KeyGeneratorSpi {
             // Do not touch it anymore.
             return new TlsMasterSecretKey(master, premasterMajor,
                 premasterMinor);
-        } catch (NoSuchAlgorithmException e) {
-            throw new ProviderException(e);
-        } catch (DigestException e) {
+        } catch (NoSuchAlgorithmException | DigestException e) {
             throw new ProviderException(e);
         } finally {
             if (premaster != null) {

--- a/src/java.base/share/classes/com/sun/security/ntlm/NTLM.java
+++ b/src/java.base/share/classes/com/sun/security/ntlm/NTLM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,9 +84,7 @@ class NTLM {
             md4 = sun.security.provider.MD4.getInstance();
             hmac = Mac.getInstance("HmacMD5");
             md5 = MessageDigest.getInstance("MD5");
-        } catch (NoSuchPaddingException e) {
-            throw new AssertionError();
-        } catch (NoSuchAlgorithmException e) {
+        } catch (NoSuchPaddingException | NoSuchAlgorithmException e) {
             throw new AssertionError();
         }
     }
@@ -346,11 +344,7 @@ class NTLM {
             return result;
         } catch (IllegalBlockSizeException ex) {    // None will happen
             assert false;
-        } catch (BadPaddingException ex) {
-            assert false;
-        } catch (InvalidKeySpecException ex) {
-            assert false;
-        } catch (InvalidKeyException ex) {
+        } catch (BadPaddingException | InvalidKeyException | InvalidKeySpecException ex) {
             assert false;
         }
         return null;
@@ -364,9 +358,7 @@ class NTLM {
                     new SecretKeySpec(Arrays.copyOf(key, 16), "HmacMD5");
             hmac.init(skey);
             return hmac.doFinal(text);
-        } catch (InvalidKeyException ex) {
-            assert false;
-        } catch (RuntimeException e) {
+        } catch (InvalidKeyException | RuntimeException e) {
             assert false;
         }
         return null;

--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -867,10 +867,8 @@ public class KeyStore {
         try {
             Object[] objs = Security.getImpl(type, "KeyStore", (String)null);
             return new KeyStore((KeyStoreSpi)objs[0], (Provider)objs[1], type);
-        } catch (NoSuchAlgorithmException nsae) {
-            throw new KeyStoreException(type + " not found", nsae);
-        } catch (NoSuchProviderException nspe) {
-            throw new KeyStoreException(type + " not found", nspe);
+        } catch (NoSuchAlgorithmException | NoSuchProviderException e) {
+            throw new KeyStoreException(type + " not found", e);
         }
     }
 

--- a/src/java.base/share/classes/java/security/Signature.java
+++ b/src/java.base/share/classes/java/security/Signature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1507,9 +1507,7 @@ public abstract class Signature extends SignatureSpi {
         protected byte[] engineSign() throws SignatureException {
             try {
                 return cipher.doFinal();
-            } catch (IllegalBlockSizeException e) {
-                throw new SignatureException("doFinal() failed", e);
-            } catch (BadPaddingException e) {
+            } catch (IllegalBlockSizeException | BadPaddingException e) {
                 throw new SignatureException("doFinal() failed", e);
             }
         }

--- a/src/java.base/share/classes/javax/crypto/CipherSpi.java
+++ b/src/java.base/share/classes/javax/crypto/CipherSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,14 +25,10 @@
 
 package javax.crypto;
 
-import java.util.StringTokenizer;
-import java.util.NoSuchElementException;
 import java.security.AlgorithmParameters;
-import java.security.Provider;
 import java.security.Key;
 import java.security.SecureRandom;
 import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 import java.security.InvalidKeyException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.ProviderException;
@@ -558,10 +554,7 @@ public abstract class CipherSpi {
             throws ShortBufferException {
         try {
             return bufferCrypt(input, output, true);
-        } catch (IllegalBlockSizeException e) {
-            // never thrown for engineUpdate()
-            throw new ProviderException("Internal error in update()");
-        } catch (BadPaddingException e) {
+        } catch (IllegalBlockSizeException | BadPaddingException e) {
             // never thrown for engineUpdate()
             throw new ProviderException("Internal error in update()");
         }

--- a/src/java.base/share/classes/javax/crypto/SealedObject.java
+++ b/src/java.base/share/classes/javax/crypto/SealedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -259,10 +259,8 @@ public class SealedObject implements Serializable {
             // them into NoSuchAlgorithmException's with details about
             // the failing algorithm
             throw new NoSuchAlgorithmException("algorithm not found");
-        } catch (IllegalBlockSizeException ibse) {
-            throw new InvalidKeyException(ibse.getMessage());
-        } catch (BadPaddingException bpe) {
-            throw new InvalidKeyException(bpe.getMessage());
+        } catch (IllegalBlockSizeException | BadPaddingException e) {
+            throw new InvalidKeyException(e.getMessage());
         }
     }
 

--- a/src/java.base/share/classes/javax/security/auth/Subject.java
+++ b/src/java.base/share/classes/javax/security/auth/Subject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1542,9 +1542,7 @@ public final class Subject implements java.io.Serializable {
 
             try {
                 return containsAll(c);
-            } catch (ClassCastException unused)   {
-                return false;
-            } catch (NullPointerException unused) {
+            } catch (ClassCastException | NullPointerException unused) {
                 return false;
             }
         }

--- a/src/java.base/share/classes/sun/security/provider/DSAParameterGenerator.java
+++ b/src/java.base/share/classes/sun/security/provider/DSAParameterGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -145,10 +145,7 @@ public class DSAParameterGenerator extends AlgorithmParameterGeneratorSpi {
         } catch (InvalidParameterSpecException e) {
             // this should never happen
             throw new RuntimeException(e.getMessage());
-        } catch (NoSuchAlgorithmException e) {
-            // this should never happen, because we provide it
-            throw new RuntimeException(e.getMessage());
-        } catch (NoSuchProviderException e) {
+        } catch (NoSuchAlgorithmException | NoSuchProviderException e) {
             // this should never happen, because we provide it
             throw new RuntimeException(e.getMessage());
         }

--- a/src/java.base/share/classes/sun/security/provider/DomainKeyStore.java
+++ b/src/java.base/share/classes/sun/security/provider/DomainKeyStore.java
@@ -29,13 +29,11 @@ import java.io.*;
 import java.net.*;
 import java.security.*;
 import java.security.cert.Certificate;
-import java.security.cert.CertificateFactory;
 import java.security.cert.CertificateException;
 import java.util.*;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import sun.security.pkcs.EncryptedPrivateKeyInfo;
 import sun.security.util.PolicyUtil;
 
 /**
@@ -798,11 +796,8 @@ abstract class DomainKeyStore extends KeyStoreSpi {
             parser.read(configurationReader);
             domains = parser.getDomainEntries();
 
-        } catch (MalformedURLException mue) {
-            throw new IOException(mue);
-
-        } catch (PolicyParser.ParsingException pe) {
-            throw new IOException(pe);
+        } catch (MalformedURLException | PolicyParser.ParsingException e) {
+            throw new IOException(e);
         }
 
         for (PolicyParser.DomainEntry domain : domains) {

--- a/src/java.base/share/classes/sun/security/util/HostnameChecker.java
+++ b/src/java.base/share/classes/sun/security/util/HostnameChecker.java
@@ -157,8 +157,7 @@ public class HostnameChecker {
                                 InetAddress.getByName(ipAddress))) {
                             return;
                         }
-                    } catch (UnknownHostException e) {
-                    } catch (SecurityException e) {}
+                    } catch (UnknownHostException | SecurityException e) {}
                 }
             }
         }

--- a/src/java.base/share/classes/sun/security/x509/CRLExtensions.java
+++ b/src/java.base/share/classes/sun/security/x509/CRLExtensions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -168,9 +168,7 @@ public class CRLExtensions {
                 tmp = seq;
 
             out.write(tmp.toByteArray());
-        } catch (IOException e) {
-            throw new CRLException("Encoding error: " + e.toString());
-        } catch (CertificateException e) {
+        } catch (IOException | CertificateException e) {
             throw new CRLException("Encoding error: " + e.toString());
         }
     }

--- a/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
@@ -648,9 +648,7 @@ public class X509CertImpl extends X509Certificate implements DerEncoder {
             if (attr.getSuffix() != null) {
                 try {
                     return info.get(attr.getSuffix());
-                } catch (IOException e) {
-                    throw new CertificateParsingException(e.toString());
-                } catch (CertificateException e) {
+                } catch (IOException | CertificateException e) {
                     throw new CertificateParsingException(e.toString());
                 }
             } else {

--- a/src/java.base/share/classes/sun/security/x509/X509CertInfo.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CertInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -229,9 +229,7 @@ public class X509CertInfo implements CertAttrSet<String> {
                 rawCertInfo = tmp.toByteArray();
             }
             return rawCertInfo.clone();
-        } catch (IOException e) {
-            throw new CertificateEncodingException(e.toString());
-        } catch (CertificateException e) {
+        } catch (IOException | CertificateException e) {
             throw new CertificateEncodingException(e.toString());
         }
     }

--- a/src/java.base/share/classes/sun/security/x509/X509Key.java
+++ b/src/java.base/share/classes/sun/security/x509/X509Key.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -264,8 +264,7 @@ public class X509Key implements PublicKey {
                 result.parseKeyBits();
                 return result;
             }
-        } catch (ClassNotFoundException e) {
-        } catch (InstantiationException e) {
+        } catch (ClassNotFoundException | InstantiationException e) {
         } catch (IllegalAccessException e) {
             // this should not happen.
             throw new IOException (classname + " [internal error]");

--- a/src/java.security.jgss/share/classes/javax/security/auth/kerberos/KerberosTicket.java
+++ b/src/java.security.jgss/share/classes/javax/security/auth/kerberos/KerberosTicket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import javax.security.auth.Destroyable;
 import javax.security.auth.RefreshFailedException;
 import javax.security.auth.DestroyFailedException;
 
+import sun.security.krb5.KrbException;
 import sun.security.util.HexDumpEncoder;
 
 /**
@@ -596,7 +597,6 @@ public class KerberosTicket implements Destroyable, Refreshable,
             throw new RefreshFailedException("This ticket is past "
                                            + "its last renewal time.");
         }
-        Throwable e = null;
         sun.security.krb5.Credentials krb5Creds = null;
 
         try {
@@ -616,13 +616,7 @@ public class KerberosTicket implements Destroyable, Refreshable,
                                                     renewTill,
                                                     clientAddresses);
             krb5Creds = krb5Creds.renew();
-        } catch (sun.security.krb5.KrbException krbException) {
-            e = krbException;
-        } catch (java.io.IOException ioException) {
-            e = ioException;
-        }
-
-        if (e != null) {
+        } catch (KrbException | IOException e) {
             RefreshFailedException rfException
                 = new RefreshFailedException("Failed to renew Kerberos Ticket "
                                              + "for client " + client

--- a/src/java.security.jgss/share/classes/sun/security/jgss/ProviderList.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/ProviderList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -304,17 +304,7 @@ public final class ProviderList {
                 throw createGSSException(p, className, "is not a " +
                                          SPI_MECH_FACTORY_TYPE, null);
             }
-        } catch (ClassNotFoundException e) {
-            throw createGSSException(p, className, "cannot be created", e);
-        } catch (NoSuchMethodException e) {
-            throw createGSSException(p, className, "cannot be created", e);
-        } catch (InvocationTargetException e) {
-            throw createGSSException(p, className, "cannot be created", e);
-        } catch (InstantiationException e) {
-            throw createGSSException(p, className, "cannot be created", e);
-        } catch (IllegalAccessException e) {
-            throw createGSSException(p, className, "cannot be created", e);
-        } catch (SecurityException e) {
+        } catch (SecurityException | ReflectiveOperationException e) {
             throw createGSSException(p, className, "cannot be created", e);
         }
     }

--- a/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5InitCredential.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5InitCredential.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,10 +107,7 @@ public class Krb5InitCredential
                                               endTime,
                                               renewTill,
                                               clientAddresses);
-        } catch (KrbException e) {
-            throw new GSSException(GSSException.NO_CRED, -1,
-                                   e.getMessage());
-        } catch (IOException e) {
+        } catch (KrbException | IOException e) {
             throw new GSSException(GSSException.NO_CRED, -1,
                                    e.getMessage());
         }

--- a/src/java.security.jgss/share/classes/sun/security/krb5/Credentials.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/Credentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -240,13 +240,9 @@ public class Credentials {
         byte[] retVal = null;
         try {
             retVal = ticket.asn1Encode();
-        } catch (Asn1Exception e) {
+        } catch (Asn1Exception | IOException e) {
             if (DEBUG) {
                 System.out.println(e);
-            }
-        } catch (IOException ioe) {
-            if (DEBUG) {
-                System.out.println(ioe);
             }
         }
         return retVal;

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/ccache/FileCredentialsCache.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/ccache/FileCredentialsCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,12 +89,7 @@ public class FileCredentialsCache extends CredentialsCache
             }
             fcc.load(cacheName);
             return fcc;
-        } catch (IOException e) {
-            // we don't handle it now, instead we return a null at the end.
-            if (DEBUG) {
-                e.printStackTrace();
-            }
-        } catch (KrbException e) {
+        } catch (IOException | KrbException e) {
             // we don't handle it now, instead we return a null at the end.
             if (DEBUG) {
                 e.printStackTrace();
@@ -119,9 +114,7 @@ public class FileCredentialsCache extends CredentialsCache
             fcc.init(principal, cacheName);
             return fcc;
         }
-        catch (IOException e) {
-        }
-        catch (KrbException e) {
+        catch (IOException | KrbException e) {
         }
         return null;
     }
@@ -133,15 +126,10 @@ public class FileCredentialsCache extends CredentialsCache
             fcc.init(principal, cacheName);
             return fcc;
         }
-        catch (IOException e) {
+        catch (IOException | KrbException e) {
             if (DEBUG) {
                 e.printStackTrace();
             }
-        } catch (KrbException e) {
-            if (DEBUG) {
-                e.printStackTrace();
-            }
-
         }
         return null;
     }

--- a/src/java.security.sasl/share/classes/com/sun/security/sasl/CramMD5Server.java
+++ b/src/java.security.sasl/share/classes/com/sun/security/sasl/CramMD5Server.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -225,12 +225,9 @@ final class CramMD5Server extends CramMD5Base implements SaslServer {
         } catch (NoSuchAlgorithmException e) {
             aborted = true;
             throw new SaslException("MD5 algorithm not available on platform", e);
-        } catch (UnsupportedCallbackException e) {
-            aborted = true;
-            throw new SaslException("CRAM-MD5 authentication failed", e);
         } catch (SaslException e) {
             throw e; // rethrow
-        } catch (IOException e) {
+        } catch (UnsupportedCallbackException | IOException e) {
             aborted = true;
             throw new SaslException("CRAM-MD5 authentication failed", e);
         }

--- a/src/java.security.sasl/share/classes/com/sun/security/sasl/digest/DigestMD5Base.java
+++ b/src/java.security.sasl/share/classes/com/sun/security/sasl/digest/DigestMD5Base.java
@@ -433,9 +433,7 @@ abstract class DigestMD5Base extends AbstractSaslImpl {
 
                 logger.log(Level.FINE, "DIGEST01:Platform supports {0}", JCE_CIPHER_NAME[i]);
                 ciphers[i] |= CIPHER_MASKS[i];
-            } catch (NoSuchAlgorithmException e) {
-                // no implementation found for requested algorithm.
-            } catch (NoSuchPaddingException e) {
+            } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
                 // no implementation found for requested algorithm.
             }
         }

--- a/src/java.security.sasl/share/classes/com/sun/security/sasl/digest/DigestMD5Client.java
+++ b/src/java.security.sasl/share/classes/com/sun/security/sasl/digest/DigestMD5Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -662,10 +662,7 @@ final class DigestMD5Client extends DigestMD5Base implements SaslClient {
                 throw new SaslException(
                     "Server's rspauth value does not match what client expects");
             }
-        } catch (NoSuchAlgorithmException e) {
-            throw new SaslException(
-                "Problem generating response value for verification", e);
-        } catch (IOException e) {
+        } catch (NoSuchAlgorithmException | IOException e) {
             throw new SaslException(
                 "Problem generating response value for verification", e);
         }

--- a/src/java.security.sasl/share/classes/com/sun/security/sasl/digest/DigestMD5Server.java
+++ b/src/java.security.sasl/share/classes/com/sun/security/sasl/digest/DigestMD5Server.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -614,10 +614,7 @@ final class DigestMD5Server extends DigestMD5Base implements SaslServer {
                     passwd, nonce /* use own nonce */,
                     cnonce, NONCE_COUNT_VALUE, authzidBytes);
 
-            } catch (NoSuchAlgorithmException e) {
-                throw new SaslException(
-                    "DIGEST-MD5: problem duplicating client response", e);
-            } catch (IOException e) {
+            } catch (NoSuchAlgorithmException | IOException e) {
                 throw new SaslException(
                     "DIGEST-MD5: problem duplicating client response", e);
             }
@@ -705,9 +702,7 @@ final class DigestMD5Server extends DigestMD5Base implements SaslServer {
 
             return challenge;
 
-        } catch (NoSuchAlgorithmException e) {
-            throw new SaslException("DIGEST-MD5: problem generating response", e);
-        } catch (IOException e) {
+        } catch (NoSuchAlgorithmException | IOException e) {
             throw new SaslException("DIGEST-MD5: problem generating response", e);
         }
     }

--- a/src/java.security.sasl/share/classes/com/sun/security/sasl/ntlm/NTLMServer.java
+++ b/src/java.security.sasl/share/classes/com/sun/security/sasl/ntlm/NTLMServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package com.sun.security.sasl.ntlm;
 import com.sun.security.ntlm.NTLMException;
 import com.sun.security.ntlm.Server;
 import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Map;
 import java.util.Random;
 import javax.security.auth.callback.Callback;
@@ -153,9 +152,7 @@ final class NTLMServer implements SaslServer {
                         char[] passwd = pcb.getPassword();
                         pcb.clearPassword();
                         return passwd;
-                    } catch (IOException ioe) {
-                        return null;
-                    } catch (UnsupportedCallbackException uce) {
+                    } catch (IOException | UnsupportedCallbackException e) {
                         return null;
                     }
                 }

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECKeyFactory.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,9 +59,7 @@ public final class ECKeyFactory extends KeyFactorySpi {
         if (instance == null) {
             try {
                 instance = KeyFactory.getInstance("EC", "SunEC");
-            } catch (NoSuchProviderException e) {
-                throw new RuntimeException(e);
-            } catch (NoSuchAlgorithmException e) {
+            } catch (NoSuchProviderException | NoSuchAlgorithmException e) {
                 throw new RuntimeException(e);
             }
         }

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECPrivateKeyImpl.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECPrivateKeyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -200,9 +200,7 @@ public final class ECPrivateKeyImpl extends PKCS8Key implements ECPrivateKey {
                     + "encoded in the algorithm identifier");
             }
             params = algParams.getParameterSpec(ECParameterSpec.class);
-        } catch (IOException e) {
-            throw new InvalidKeyException("Invalid EC private key", e);
-        } catch (InvalidParameterSpecException e) {
+        } catch (IOException | InvalidParameterSpecException e) {
             throw new InvalidKeyException("Invalid EC private key", e);
         }
     }

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECPublicKeyImpl.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECPublicKeyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,9 +110,7 @@ public final class ECPublicKeyImpl extends X509Key implements ECPublicKey {
         try {
             params = algParams.getParameterSpec(ECParameterSpec.class);
             w = ECUtil.decodePoint(key, params.getCurve());
-        } catch (IOException e) {
-            throw new InvalidKeyException("Invalid EC key", e);
-        } catch (InvalidParameterSpecException e) {
+        } catch (IOException | InvalidParameterSpecException e) {
             throw new InvalidKeyException("Invalid EC key", e);
         }
     }

--- a/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CKeyStore.java
+++ b/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CKeyStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -814,13 +814,7 @@ abstract class CKeyStore extends KeyStoreSpi {
             Collection<? extends Certificate> c =
                     certificateFactory.generateCertificates(bis);
             certCollection.addAll(c);
-        } catch (CertificateException e) {
-            // Ignore the exception and skip this certificate
-            // If e is thrown, remember to deal with it in
-            // native code.
-        }
-        catch (Throwable te)
-        {
+        } catch (Throwable te) {
             // Ignore the exception and skip this certificate
             // If e is thrown, remember to deal with it in
             // native code.

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/module/KeyStoreLoginModule.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/module/KeyStoreLoginModule.java
@@ -607,12 +607,7 @@ public class KeyStoreLoginModule implements LoginModule {
                                 ("Incorrect keyStoreURL option");
             le.initCause(e);
             throw le;
-        } catch (GeneralSecurityException e) {
-            LoginException le = new LoginException
-                                ("Error initializing keystore");
-            le.initCause(e);
-            throw le;
-        } catch (IOException e) {
+        } catch (GeneralSecurityException | IOException e) {
             LoginException le = new LoginException
                                 ("Error initializing keystore");
             le.initCause(e);
@@ -677,11 +672,7 @@ public class KeyStoreLoginModule implements LoginModule {
 
             privateCredential = new X500PrivateCredential(
                 certificate, (PrivateKey) privateKey, keyStoreAlias);
-        } catch (KeyStoreException e) {
-            LoginException le = new LoginException("Error using keystore");
-            le.initCause(e);
-            throw le;
-        } catch (NoSuchAlgorithmException e) {
+        } catch (KeyStoreException | NoSuchAlgorithmException e) {
             LoginException le = new LoginException("Error using keystore");
             le.initCause(e);
             throw le;

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/module/Krb5LoginModule.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/module/Krb5LoginModule.java
@@ -785,14 +785,10 @@ public class Krb5LoginModule implements LoginModule {
                 }
 
             }
-        } catch (KrbException e) {
+        } catch (KrbException | IOException e) {
             LoginException le = new LoginException(e.getMessage());
             le.initCause(e);
             throw le;
-        } catch (IOException ioe) {
-            LoginException ie = new LoginException(ioe.getMessage());
-            ie.initCause(ioe);
-            throw ie;
         }
     }
 

--- a/src/jdk.security.jgss/share/classes/com/sun/security/sasl/gsskerb/GssKrb5Server.java
+++ b/src/jdk.security.jgss/share/classes/com/sun/security/sasl/gsskerb/GssKrb5Server.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -327,9 +327,7 @@ final class GssKrb5Server extends GssKrb5Base implements SaslServer {
             return null;
         } catch (GSSException e) {
             throw new SaslException("Final handshake step failed", e);
-        } catch (IOException e) {
-            throw new SaslException("Problem with callback handler", e);
-        } catch (UnsupportedCallbackException e) {
+        } catch (IOException | UnsupportedCallbackException e) {
             throw new SaslException("Problem with callback handler", e);
         }
     }


### PR DESCRIPTION
Let's take advantage of Java 7 language feature - "Catching Multiple Exception Types".
It simplifies code. Reduces duplication.
Found by IntelliJ IDEA inspection `Identical 'catch' branches in 'try' statement`
