### PR TITLE
8284146: Disable jdk/jshell/HighlightUITest.java on macosx-aarch64

### DIFF
--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -34,6 +34,7 @@
 jdk/jshell/UserJdiUserRemoteTest.java                                           8173079    linux-all
 jdk/jshell/UserInputTest.java                                                   8169536    generic-all
 jdk/jshell/ToolBasicTest.java                                                   8265357    macosx-aarch64
+jdk/jshell/HighlightUITest.java                                                 8284144    macosx-aarch64
 
 ###########################################################################
 #


### PR DESCRIPTION
A tier1 test `jdk/jshell/HighlightUITest.java` failed on macosx-aarch64. I am proposing to disable it for now, until the failure can be investigated more fully.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284146](https://bugs.openjdk.java.net/browse/JDK-8284146): Disable jdk/jshell/HighlightUITest.java on macosx-aarch64


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8069/head:pull/8069` \
`$ git checkout pull/8069`

Update a local copy of the PR: \
`$ git checkout pull/8069` \
`$ git pull https://git.openjdk.java.net/jdk pull/8069/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8069`

View PR using the GUI difftool: \
`$ git pr show -t 8069`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8069.diff">https://git.openjdk.java.net/jdk/pull/8069.diff</a>

</details>
