### PR TITLE
JDK-8284165: Add pid to process reaper thread name

### DIFF
--- a/src/java.base/share/classes/java/lang/ProcessHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/ProcessHandleImpl.java
@@ -140,6 +140,8 @@ final class ProcessHandleImpl implements ProcessHandle {
                 processReaperExecutor.execute(new Runnable() {
                     // Use inner class to avoid lambda stack overhead
                     public void run() {
+                        String threadName = Thread.currentThread().getName();
+                        Thread.currentThread().setName("process reaper (pid " + pid + ")");
                         int exitValue = waitForProcessExit0(pid, shouldReap);
                         if (exitValue == NOT_A_CHILD) {
                             // pid not alive or not a child of this process
@@ -167,6 +169,8 @@ final class ProcessHandleImpl implements ProcessHandle {
                         newCompletion.complete(exitValue);
                         // remove from cache afterwards
                         completions.remove(pid, newCompletion);
+                        // Restore thread name
+                        Thread.currentThread().setName(threadName);
                     }
                 });
             }

--- a/src/java.base/share/classes/java/lang/ProcessHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/ProcessHandleImpl.java
@@ -142,35 +142,38 @@ final class ProcessHandleImpl implements ProcessHandle {
                     public void run() {
                         String threadName = Thread.currentThread().getName();
                         Thread.currentThread().setName("process reaper (pid " + pid + ")");
-                        int exitValue = waitForProcessExit0(pid, shouldReap);
-                        if (exitValue == NOT_A_CHILD) {
-                            // pid not alive or not a child of this process
-                            // If it is alive wait for it to terminate
-                            long sleep = 300;     // initial milliseconds to sleep
-                            int incr = 30;        // increment to the sleep time
+                        try {
+                            int exitValue = waitForProcessExit0(pid, shouldReap);
+                            if (exitValue == NOT_A_CHILD) {
+                                // pid not alive or not a child of this process
+                                // If it is alive wait for it to terminate
+                                long sleep = 300;     // initial milliseconds to sleep
+                                int incr = 30;        // increment to the sleep time
 
-                            long startTime = isAlive0(pid);
-                            long origStart = startTime;
-                            while (startTime >= 0) {
-                                try {
-                                    Thread.sleep(Math.min(sleep, 5000L)); // no more than 5 sec
-                                    sleep += incr;
-                                } catch (InterruptedException ie) {
-                                    // ignore and retry
+                                long startTime = isAlive0(pid);
+                                long origStart = startTime;
+                                while (startTime >= 0) {
+                                    try {
+                                        Thread.sleep(Math.min(sleep, 5000L)); // no more than 5 sec
+                                        sleep += incr;
+                                    } catch (InterruptedException ie) {
+                                        // ignore and retry
+                                    }
+                                    startTime = isAlive0(pid);  // recheck if it is alive
+                                    if (startTime > 0 && origStart > 0 && startTime != origStart) {
+                                        // start time changed (and is not zero), pid is not the same process
+                                        break;
+                                    }
                                 }
-                                startTime = isAlive0(pid);  // recheck if it is alive
-                                if (startTime > 0 && origStart > 0 && startTime != origStart) {
-                                    // start time changed (and is not zero), pid is not the same process
-                                    break;
-                                }
+                                exitValue = 0;
                             }
-                            exitValue = 0;
+                            newCompletion.complete(exitValue);
+                            // remove from cache afterwards
+                            completions.remove(pid, newCompletion);
+                        } finally {
+                            // Restore thread name
+                            Thread.currentThread().setName(threadName);
                         }
-                        newCompletion.complete(exitValue);
-                        // remove from cache afterwards
-                        completions.remove(pid, newCompletion);
-                        // Restore thread name
-                        Thread.currentThread().setName(threadName);
                     }
                 });
             }

--- a/test/jdk/java/lang/ProcessBuilder/ProcessReaperCCL.java
+++ b/test/jdk/java/lang/ProcessBuilder/ProcessReaperCCL.java
@@ -57,7 +57,7 @@ public class ProcessReaperCCL {
 
         // Verify all "Process Reaper" threads have a null CCL
         for (Thread th : Thread.getAllStackTraces().keySet()) {
-            if ("process reaper".equals(th.getName())) {
+            if (th.getName().startsWith("process reaper")) {
                 Assert.assertEquals(th.getContextClassLoader(), null, "CCL not null");
             }
         }

--- a/test/jdk/java/util/concurrent/Phaser/Basic.java
+++ b/test/jdk/java/util/concurrent/Phaser/Basic.java
@@ -440,7 +440,7 @@ public class Basic {
             if ("Finalizer".equals(name)
                 && info.getLockName().startsWith("java.lang.ref.ReferenceQueue$Lock"))
                 continue;
-            if ("process reaper".equals(name))
+            if (name.startsWith("process reaper"))
                 continue;
             if (name != null && name.startsWith("ForkJoinPool.commonPool-worker"))
                 continue;


### PR DESCRIPTION
To help with analyzing fork-heavy scenarios, it would help if we could see at one glance which process a reaper is servicing. A pragmatic way would be to add the pid to its name - that way, e.g. thread dumps with lots of reaper threads would be more enlightening.

Since reaper threads get reused we have to change the name back to some base name when the reaper is done with the process. This has the additional benefit of showing us in the thread dump which reapers are actually reaping, and which are just idling around in the pool.

With this patch, reaper threads are:
- named "reaper thread (pid: xxx)" when assigned to a process
- remain named "reaper thread" without pid when not being assigned to a process.

```
thomas@starfish:/shared/projects/openjdk/jdk-jdk/source$ jcmd Test Thread.print | grep 'reaper'
"process reaper (pid 1358320)" #114 daemon prio=10 os_prio=0 cpu=4034,46ms elapsed=20,66s tid=0x00007f7860003ec0 nid=1277510 runnable  [0x00007f7944765000]
"process reaper" #105 daemon prio=10 os_prio=0 cpu=0,51ms elapsed=20,66s tid=0x00007f7900099e20 nid=1277511 waiting on condition  [0x00007f7944031000]
"process reaper" #102 daemon prio=10 os_prio=0 cpu=0,24ms elapsed=20,66s tid=0x00007f78b0003720 nid=1277512 waiting on condition  [0x00007f7869cca000]
"process reaper" #110 daemon prio=10 os_prio=0 cpu=0,39ms elapsed=20,66s tid=0x00007f78a8003260 nid=1277517 waiting on condition  [0x00007f7869c16000]
"process reaper" #106 daemon prio=10 os_prio=0 cpu=0,34ms elapsed=20,66s tid=0x00007f78480034a0 nid=1277518 waiting on condition  [0x00007f7869bf2000]
"process reaper (pid 1358355)" #118 daemon prio=10 os_prio=0 cpu=2762,03ms elapsed=20,66s tid=0x00007f78800042a0 nid=1277519 runnable  [0x00007f7869b8e000]
"process reaper" #119 daemon prio=10 os_prio=0 cpu=0,20ms elapsed=20,66s tid=0x00007f78a0013610 nid=1277520 waiting on condition  [0x00007f7869b6a000]
"process reaper (pid 1358365)" #97 daemon prio=10 os_prio=0 cpu=3608,37ms elapsed=20,66s tid=0x00007f78f4005b70 nid=1277521 runnable  [0x00007f7869bce000]
"process reaper (pid 1358388)" #95 daemon prio=10 os_prio=0 cpu=6079,07ms elapsed=20,66s tid=0x00007f7898003260 nid=1277522 runnable  [0x00007f7869b46000]
"process reaper" #86 daemon prio=10 os_prio=0 cpu=3897,96ms elapsed=20,66s tid=0x00007f7890003ce0 nid=1277523 waiting on condition  [0x00007f7869b22000]
"process reaper (pid 1358389)" #115 daemon prio=10 os_prio=0 cpu=5020,85ms elapsed=20,66s tid=0x00007f783c003840 nid=1277524 runnable  [0x00007f7869afe000]
"process reaper" #111 daemon prio=10 os_prio=0 cpu=4823,39ms elapsed=20,66s tid=0x00007f78fc111c20 nid=1277525 waiting on condition  [0x00007f7869ada000]
"process reaper" #91 daemon prio=10 os_prio=0 cpu=2566,21ms elapsed=20,66s tid=0x00007f78840042c0 nid=1277526 waiting on condition  [0x00007f7869ab6000]
"process reaper" #81 daemon prio=10 os_prio=0 cpu=2954,63ms elapsed=20,66s tid=0x00007f78c8003e90 nid=1277527 waiting on condition  [0x00007f7869a92000]
"process reaper" #121 daemon prio=10 os_prio=0 cpu=2966,19ms elapsed=20,66s tid=0x00007f789c003910 nid=1277528 waiting on condition  [0x00007f7869a6e000]
```

Tests:
- I manually tested java/lang/Process* jtreg test groups, as well as java/util/concurrent/Phaser
- GHAs
- nightlies at SAP scheduled

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284165](https://bugs.openjdk.java.net/browse/JDK-8284165): Add pid to process reaper thread name


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8070/head:pull/8070` \
`$ git checkout pull/8070`

Update a local copy of the PR: \
`$ git checkout pull/8070` \
`$ git pull https://git.openjdk.java.net/jdk pull/8070/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8070`

View PR using the GUI difftool: \
`$ git pr show -t 8070`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8070.diff">https://git.openjdk.java.net/jdk/pull/8070.diff</a>

</details>
