### PR TITLE
8284166: [macos] Replace deprecated alternateSelectedControlColor with selectedContentBackgroundColor

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,7 +96,11 @@ JNI_COCOA_EXIT(env);
     sColors[java_awt_SystemColor_TEXT_INACTIVE_TEXT] =        [NSColor disabledControlTextColor];
     sColors[java_awt_SystemColor_CONTROL] =                    [NSColor controlColor];
     sColors[java_awt_SystemColor_CONTROL_TEXT] =            [NSColor controlTextColor];
-    sColors[java_awt_SystemColor_CONTROL_HIGHLIGHT] =        [NSColor alternateSelectedControlColor];
+    if (@available(macOS 10.14, *)) {
+        sColors[java_awt_SystemColor_CONTROL_HIGHLIGHT] =        [NSColor selectedContentBackgroundColor];
+    } else {
+        sColors[java_awt_SystemColor_CONTROL_HIGHLIGHT] =        [NSColor alternateSelectedControlColor];
+    }
     sColors[java_awt_SystemColor_CONTROL_LT_HIGHLIGHT] =    [NSColor alternateSelectedControlTextColor];
     sColors[java_awt_SystemColor_CONTROL_SHADOW] =            [NSColor controlShadowColor];
     sColors[java_awt_SystemColor_CONTROL_DK_SHADOW] =        [NSColor controlDarkShadowColor];


### PR DESCRIPTION
[alternateSelectedControlColor](https://developer.apple.com/documentation/appkit/nscolor/1533135-alternateselectedcontrolcolor?language=objc) is deprecated since osx10.14 so we need to replace with its alternative "[selectedContentBackgroundColor](https://developer.apple.com/documentation/appkit/nscolor/2998830-selectedcontentbackgroundcolor?language=objc)"
Since our minimum supported deployment target is still [10.12](https://github.com/openjdk/jdk/blob/master/make/autoconf/flags.m4#L139)
we need to use "@available" check to use the deprecated property on older targets
Background color check is ok and also open,closed jtreg run is green