### PR TITLE
8283684: IGV: speed up filter application

### DIFF
--- a/src/utils/IdealGraphVisualizer/Filter/src/main/java/com/sun/hotspot/igv/filter/CustomFilter.java
+++ b/src/utils/IdealGraphVisualizer/Filter/src/main/java/com/sun/hotspot/igv/filter/CustomFilter.java
@@ -25,16 +25,8 @@
 package com.sun.hotspot.igv.filter;
 
 import com.sun.hotspot.igv.graph.Diagram;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.script.*;
 import org.openide.cookies.OpenCookie;
-import org.openide.filesystems.FileObject;
-import org.openide.filesystems.FileUtil;
 import org.openide.util.Exceptions;
 
 /**
@@ -43,13 +35,14 @@ import org.openide.util.Exceptions;
  */
 public class CustomFilter extends AbstractFilter {
 
-    public static final String JAVASCRIPT_HELPER_ID = "JavaScriptHelper";
     private String code;
     private String name;
+    private ScriptEngine engine;
 
-    public CustomFilter(String name, String code) {
+    public CustomFilter(String name, String code, ScriptEngine engine) {
         this.name = name;
         this.code = code;
+        this.engine = engine;
         getProperties().setProperty("name", name);
     }
 
@@ -96,46 +89,13 @@ public class CustomFilter extends AbstractFilter {
         return getName();
     }
 
-    private static String getJsHelperText() {
-        InputStream is = null;
-        StringBuilder sb = new StringBuilder("if (typeof importPackage === 'undefined') { try { load('nashorn:mozilla_compat.js'); } catch (e) {} }"
-                + "importPackage(Packages.com.sun.hotspot.igv.filter);"
-                + "importPackage(Packages.com.sun.hotspot.igv.graph);"
-                + "importPackage(Packages.com.sun.hotspot.igv.data);"
-                + "importPackage(Packages.com.sun.hotspot.igv.util);"
-                + "importPackage(java.awt);");
-        try {
-            FileObject fo = FileUtil.getConfigRoot().getFileObject(JAVASCRIPT_HELPER_ID);
-            is = fo.getInputStream();
-            BufferedReader r = new BufferedReader(new InputStreamReader(is));
-            String s;
-            while ((s = r.readLine()) != null) {
-                sb.append(s);
-                sb.append("\n");
-            }
-
-        } catch (IOException ex) {
-            Logger.getLogger("global").log(Level.SEVERE, null, ex);
-        } finally {
-            try {
-                is.close();
-            } catch (IOException ex) {
-                Exceptions.printStackTrace(ex);
-            }
-        }
-        return sb.toString();
-    }
 
     @Override
     public void apply(Diagram d) {
         try {
-            ScriptEngineManager sem = new ScriptEngineManager();
-            ScriptEngine e = sem.getEngineByName("ECMAScript");
-            e.eval(getJsHelperText());
-            Bindings b = e.getContext().getBindings(ScriptContext.ENGINE_SCOPE);
+            Bindings b = engine.getContext().getBindings(ScriptContext.ENGINE_SCOPE);
             b.put("graph", d);
-            b.put("IO", System.out);
-            e.eval(code, b);
+            engine.eval(code, b);
         } catch (ScriptException ex) {
             Exceptions.printStackTrace(ex);
         }

--- a/src/utils/IdealGraphVisualizer/Filter/src/main/java/com/sun/hotspot/igv/filter/CustomFilter.java
+++ b/src/utils/IdealGraphVisualizer/Filter/src/main/java/com/sun/hotspot/igv/filter/CustomFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/utils/IdealGraphVisualizer/FilterWindow/src/main/java/com/sun/hotspot/igv/filterwindow/FilterTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/FilterWindow/src/main/java/com/sun/hotspot/igv/filterwindow/FilterTopComponent.java
@@ -35,6 +35,9 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.*;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.script.*;
 import javax.swing.JComboBox;
 import javax.swing.UIManager;
 import javax.swing.border.Border;
@@ -67,10 +70,12 @@ public final class FilterTopComponent extends TopComponent implements LookupList
     public static final String AFTER_ID = "after";
     public static final String ENABLED_ID = "enabled";
     public static final String PREFERRED_ID = "FilterTopComponent";
+    public static final String JAVASCRIPT_HELPER_ID = "JavaScriptHelper";
     private CheckListView view;
     private ExplorerManager manager;
     private FilterChain filterChain;
     private FilterChain sequence;
+    private ScriptEngine engine;
     private Lookup.Result<FilterChain> result;
     private JComboBox comboBox;
     private List<FilterSetting> filterSettings;
@@ -300,6 +305,36 @@ public final class FilterTopComponent extends TopComponent implements LookupList
         return filterChain;
     }
 
+    private static String getJsHelperText() {
+        InputStream is = null;
+        StringBuilder sb = new StringBuilder("if (typeof importPackage === 'undefined') { try { load('nashorn:mozilla_compat.js'); } catch (e) {} }"
+                + "importPackage(Packages.com.sun.hotspot.igv.filter);"
+                + "importPackage(Packages.com.sun.hotspot.igv.graph);"
+                + "importPackage(Packages.com.sun.hotspot.igv.data);"
+                + "importPackage(Packages.com.sun.hotspot.igv.util);"
+                + "importPackage(java.awt);");
+        try {
+            FileObject fo = FileUtil.getConfigRoot().getFileObject(JAVASCRIPT_HELPER_ID);
+            is = fo.getInputStream();
+            BufferedReader r = new BufferedReader(new InputStreamReader(is));
+            String s;
+            while ((s = r.readLine()) != null) {
+                sb.append(s);
+                sb.append("\n");
+            }
+
+        } catch (IOException ex) {
+            Logger.getLogger("global").log(Level.SEVERE, null, ex);
+        } finally {
+            try {
+                is.close();
+            } catch (IOException ex) {
+                Exceptions.printStackTrace(ex);
+            }
+        }
+        return sb.toString();
+    }
+
     private FilterTopComponent() {
         filterSettingsChangedEvent = new ChangedEvent<>(this);
         initComponents();
@@ -309,6 +344,14 @@ public final class FilterTopComponent extends TopComponent implements LookupList
 
         sequence = new FilterChain();
         filterChain = new FilterChain();
+        ScriptEngineManager sem = new ScriptEngineManager();
+        engine = sem.getEngineByName("ECMAScript");
+        try {
+            engine.eval(getJsHelperText());
+        } catch (ScriptException ex) {
+            Exceptions.printStackTrace(ex);
+        }
+        engine.getContext().getBindings(ScriptContext.ENGINE_SCOPE).put("IO", System.out);
         initFilters();
         manager = new ExplorerManager();
         manager.setRootContext(new AbstractNode(new FilterChildren()));
@@ -339,7 +382,7 @@ public final class FilterTopComponent extends TopComponent implements LookupList
     }
 
     public void newFilter() {
-        CustomFilter cf = new CustomFilter("My custom filter", "");
+        CustomFilter cf = new CustomFilter("My custom filter", "", engine);
         if (cf.openInEditor()) {
             sequence.addFilter(cf);
             FileObject fo = getFileObject(cf);
@@ -437,7 +480,7 @@ public final class FilterTopComponent extends TopComponent implements LookupList
             String displayName = fo.getName();
 
 
-            final CustomFilter cf = new CustomFilter(displayName, code);
+            final CustomFilter cf = new CustomFilter(displayName, code, engine);
             map.put(displayName, cf);
 
             String after = (String) fo.getAttribute(AFTER_ID);

--- a/src/utils/IdealGraphVisualizer/FilterWindow/src/main/java/com/sun/hotspot/igv/filterwindow/FilterTopComponent.java
+++ b/src/utils/IdealGraphVisualizer/FilterWindow/src/main/java/com/sun/hotspot/igv/filterwindow/FilterTopComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewModel.java
+++ b/src/utils/IdealGraphVisualizer/View/src/main/java/com/sun/hotspot/igv/view/DiagramViewModel.java
@@ -27,15 +27,22 @@ package com.sun.hotspot.igv.view;
 import com.sun.hotspot.igv.data.*;
 import com.sun.hotspot.igv.data.services.Scheduler;
 import com.sun.hotspot.igv.difference.Difference;
-import com.sun.hotspot.igv.filter.CustomFilter;
+import com.sun.hotspot.igv.filter.ColorFilter;
 import com.sun.hotspot.igv.filter.FilterChain;
 import com.sun.hotspot.igv.graph.Diagram;
 import com.sun.hotspot.igv.graph.Figure;
+import com.sun.hotspot.igv.graph.MatcherSelector;
 import com.sun.hotspot.igv.settings.Settings;
 import com.sun.hotspot.igv.util.RangeSliderModel;
 import java.awt.Color;
-import java.util.*;
 import org.openide.util.Lookup;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 
 /**
  *
@@ -431,6 +438,10 @@ public class DiagramViewModel extends RangeSliderModel implements ChangedListene
         setPositions(index, index);
     }
 
+    private static ColorFilter.ColorRule stateColorRule(String state, Color color) {
+        return new ColorFilter.ColorRule(new MatcherSelector(new Properties.RegexpPropertyMatcher("state", state)), color);
+    }
+
     public Diagram getDiagramToView() {
 
         if (diagram == null) {
@@ -447,11 +458,11 @@ public class DiagramViewModel extends RangeSliderModel implements ChangedListene
                                             Settings.get().get(Settings.NODE_TINY_TEXT, Settings.NODE_TINY_TEXT_DEFAULT));
             getFilterChain().apply(diagram, getSequenceFilterChain());
             if (getFirstPosition() != getSecondPosition()) {
-                CustomFilter f = new CustomFilter(
-                        "difference", "colorize('state', 'same', white);"
-                        + "colorize('state', 'changed', orange);"
-                        + "colorize('state', 'new', green);"
-                        + "colorize('state', 'deleted', red);");
+                ColorFilter f = new ColorFilter("");
+                f.addRule(stateColorRule("same",    Color.white));
+                f.addRule(stateColorRule("changed", Color.orange));
+                f.addRule(stateColorRule("new",     Color.green));
+                f.addRule(stateColorRule("deleted", Color.red));
                 f.apply(diagram);
            }
         }


### PR DESCRIPTION
This change improves view creation time by creating a single JavaScript engine shared among all filters, rather than creating an engine every time a filter is applied. Since creating a JavaScript engine is a costly operation, this change speeds up view creation substantially for small and medium-sized graphs as soon as any filter is applied. This includes the default IGV configuration, where the "Color by category" filter is enabled.

#### Testing

##### Functionality

- Tested manually applying different filter subsets and differing on a small selection of graphs, for JDK 11 and 17 (which use different versions and ways of packaging the JavaScript engine).

- Tested automatically viewing thousands of graphs with different subsets of filters enabled (by instrumenting IGV to view graphs as they are loaded and running `java -Xcomp -XX:-TieredCompilation -XX:PrintIdealGraphLevel=4`).

##### Performance

Measured the view creation time for the default sea-of-nodes view on a selection of 94 medium-sized graphs (200-493 nodes) for different subsets of filters. Before the change, the view creating time increases roughly linearly with the number of applied filters (since an engine is created for each filter application). After the change, the view creating time remains roughly constant (even slightly decreasing) as the number of applied filters increases, yielding an average speedup of 2.4x for the default IGV configuration, and up to 8.2x when five filters are applied. The speedup is expected to diminish for larger graphs where engine creation does not dominate view creation time. The complete results are [attached](https://github.com/openjdk/jdk/files/8396784/performance-evaluation.ods) (note that each measurement in the sheet corresponds to the median of ten runs).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283684](https://bugs.openjdk.java.net/browse/JDK-8283684): IGV: speed up filter application


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8073/head:pull/8073` \
`$ git checkout pull/8073`

Update a local copy of the PR: \
`$ git checkout pull/8073` \
`$ git pull https://git.openjdk.java.net/jdk pull/8073/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8073`

View PR using the GUI difftool: \
`$ git pr show -t 8073`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8073.diff">https://git.openjdk.java.net/jdk/pull/8073.diff</a>

</details>
