### PR TITLE
JDK-8284178: os::commit_memory() should assert the given range

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1675,7 +1675,13 @@ char* os::attempt_reserve_memory_at(char* addr, size_t bytes, bool executable) {
   return result;
 }
 
+static void assert_nonempty_range(const char* addr, size_t bytes) {
+  assert(addr != nullptr && bytes > 0, "invalid range (" PTR_FORMAT ", " SIZE_FORMAT ")",
+         p2i(addr), bytes);
+}
+
 bool os::commit_memory(char* addr, size_t bytes, bool executable) {
+  assert_nonempty_range(addr, bytes);
   bool res = pd_commit_memory(addr, bytes, executable);
   if (res) {
     MemTracker::record_virtual_memory_commit((address)addr, bytes, CALLER_PC);
@@ -1685,6 +1691,7 @@ bool os::commit_memory(char* addr, size_t bytes, bool executable) {
 
 bool os::commit_memory(char* addr, size_t size, size_t alignment_hint,
                               bool executable) {
+  assert_nonempty_range(addr, size);
   bool res = os::pd_commit_memory(addr, size, alignment_hint, executable);
   if (res) {
     MemTracker::record_virtual_memory_commit((address)addr, size, CALLER_PC);
@@ -1694,17 +1701,20 @@ bool os::commit_memory(char* addr, size_t size, size_t alignment_hint,
 
 void os::commit_memory_or_exit(char* addr, size_t bytes, bool executable,
                                const char* mesg) {
+  assert_nonempty_range(addr, bytes);
   pd_commit_memory_or_exit(addr, bytes, executable, mesg);
   MemTracker::record_virtual_memory_commit((address)addr, bytes, CALLER_PC);
 }
 
 void os::commit_memory_or_exit(char* addr, size_t size, size_t alignment_hint,
                                bool executable, const char* mesg) {
+  assert_nonempty_range(addr, size);
   os::pd_commit_memory_or_exit(addr, size, alignment_hint, executable, mesg);
   MemTracker::record_virtual_memory_commit((address)addr, size, CALLER_PC);
 }
 
 bool os::uncommit_memory(char* addr, size_t bytes, bool executable) {
+  assert_nonempty_range(addr, bytes);
   bool res;
   if (MemTracker::enabled()) {
     Tracker tkr(Tracker::uncommit);
@@ -1719,6 +1729,7 @@ bool os::uncommit_memory(char* addr, size_t bytes, bool executable) {
 }
 
 bool os::release_memory(char* addr, size_t bytes) {
+  assert_nonempty_range(addr, bytes);
   bool res;
   if (MemTracker::enabled()) {
     // Note: Tracker contains a ThreadCritical.

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1677,7 +1677,7 @@ char* os::attempt_reserve_memory_at(char* addr, size_t bytes, bool executable) {
 
 static void assert_nonempty_range(const char* addr, size_t bytes) {
   assert(addr != nullptr && bytes > 0, "invalid range [" PTR_FORMAT ", " PTR_FORMAT ")",
-         p2i(addr), p2i(addr + bytes));
+         p2i(addr), p2i(addr) + bytes);
 }
 
 bool os::commit_memory(char* addr, size_t bytes, bool executable) {

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1676,8 +1676,8 @@ char* os::attempt_reserve_memory_at(char* addr, size_t bytes, bool executable) {
 }
 
 static void assert_nonempty_range(const char* addr, size_t bytes) {
-  assert(addr != nullptr && bytes > 0, "invalid range (" PTR_FORMAT ", " SIZE_FORMAT ")",
-         p2i(addr), bytes);
+  assert(addr != nullptr && bytes > 0, "invalid range [" PTR_FORMAT ", " PTR_FORMAT ")",
+         p2i(addr), p2i(addr + bytes));
 }
 
 bool os::commit_memory(char* addr, size_t bytes, bool executable) {


### PR DESCRIPTION
Trivial fix to assert that ranges given to os::commit/uncommit/release_memory are not empty.

I recently hunted an error where the memory reservation failed, was not handled, and the null pointer was accidentally passed to os::commit_memory(). The resulting `mmap()` failed and this looked like a commit error, when it really was a reservation error. An assert would have saved me time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284178](https://bugs.openjdk.java.net/browse/JDK-8284178): os::commit_memory() should assert the given range


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8075/head:pull/8075` \
`$ git checkout pull/8075`

Update a local copy of the PR: \
`$ git checkout pull/8075` \
`$ git pull https://git.openjdk.java.net/jdk pull/8075/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8075`

View PR using the GUI difftool: \
`$ git pr show -t 8075`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8075.diff">https://git.openjdk.java.net/jdk/pull/8075.diff</a>

</details>
