### PR TITLE
8284190: disable G1RegionToSpaceMapper.largeStressAdjacent_vm on windows

### DIFF
--- a/test/hotspot/gtest/gc/g1/test_stressCommitUncommit.cpp
+++ b/test/hotspot/gtest/gc/g1/test_stressCommitUncommit.cpp
@@ -97,7 +97,12 @@ TEST_VM(G1RegionToSpaceMapper, smallStressAdjacent) {
   G1MapperWorkers::run_task(&task);
 }
 
+#if defined(_WINDOWS)
+// See JDK-8283899.
+TEST_VM(G1RegionToSpaceMapper, DISABLED_largeStressAdjacent) {
+#else
 TEST_VM(G1RegionToSpaceMapper, largeStressAdjacent) {
+#endif
   // Fake a heap with 2m regions and create a BOT like mapper. This
   // will give a G1RegionsLargerThanCommitSizeMapper to stress.
   uint num_regions = G1MapperWorkers::MaxWorkers;


### PR DESCRIPTION
A trivial fix to disable G1RegionToSpaceMapper.largeStressAdjacent_vm on windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284190](https://bugs.openjdk.java.net/browse/JDK-8284190): disable G1RegionToSpaceMapper.largeStressAdjacent_vm on windows


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8077/head:pull/8077` \
`$ git checkout pull/8077`

Update a local copy of the PR: \
`$ git checkout pull/8077` \
`$ git pull https://git.openjdk.java.net/jdk pull/8077/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8077`

View PR using the GUI difftool: \
`$ git pr show -t 8077`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8077.diff">https://git.openjdk.java.net/jdk/pull/8077.diff</a>

</details>
