### PR TITLE
8284181: ArgumentsTest.set_numeric_flag_double_vm fails on some locales

### DIFF
--- a/test/hotspot/gtest/runtime/test_arguments.cpp
+++ b/test/hotspot/gtest/runtime/test_arguments.cpp
@@ -572,7 +572,7 @@ TEST_VM_F(ArgumentsTest, set_numeric_flag_double) {
   check_numeric_flag<double>(flag, getvalue, valid_strings,
                              ARRAY_SIZE(valid_strings), /*is_double=*/true);
 
-  const char* more_valid_strings[] = {
+  const char* more_test_strings[] = {
     // These examples are from https://en.cppreference.com/w/cpp/language/floating_literal
     // (but with the L and F suffix removed).
     "1e10", "1e-5",
@@ -582,6 +582,7 @@ TEST_VM_F(ArgumentsTest, set_numeric_flag_double) {
     "0x1.p0", "0xf.p-1",
     "0x0.123p-1", "0xa.bp10",
     "0x1.4p3",
+
     // More test cases
     "1.5", "6.02e23", "-6.02e+23",
     "1.7976931348623157E+308", // max double
@@ -589,18 +590,25 @@ TEST_VM_F(ArgumentsTest, set_numeric_flag_double) {
     "0x1.91eb85p+1",
     "999999999999999999999999999999",
   };
-  for (uint i = 0; i < ARRAY_SIZE(more_valid_strings); i++) {
-    const char* str = more_valid_strings[i];
+  for (uint i = 0; i < ARRAY_SIZE(more_test_strings); i++) {
+    const char* str = more_test_strings[i];
 
     char* dummy;
+    errno = 0;
     double expected = strtod(str, &dummy);
-    ASSERT_TRUE(errno == 0);
-
-    ASSERT_TRUE(ArgumentsTest::parse_argument(flag->name(), str))
-        << "Valid string '" <<
+    if (errno == 0) {
+      ASSERT_TRUE(ArgumentsTest::parse_argument(flag->name(), str))
+        << "Test string '" <<
         str << "' did not parse for type " << flag->type_string() << ".";
-    double d = flag->get_double();
-    ASSERT_TRUE(d == expected)
+      double d = flag->get_double();
+      ASSERT_TRUE(d == expected)
         << "Parsed number " << d << " is not the same as expected " << expected;
+    } else {
+      // Some of the strings like "1.e-2" are not valid in certain locales.
+      // The decimal-point character is also locale dependent.
+      ASSERT_FALSE(ArgumentsTest::parse_argument(flag->name(), str))
+        << "Invalid string '" << str << "' parsed without error.";
+
+    }
   }
 }


### PR DESCRIPTION
Please review this small change for parsing floating point numbers in test_arguments.cpp. 

Accord to [the `strtod()` man page](https://linux.die.net/man/3/strtod), some input are locale-dependent. E.g.,

> ... decimal digits possibly containing a radix character (decimal point, locale-dependent, usually '.')

I feel it's too complicated to internationalize this test, so I just changed the test to check

- the VM must fail if `strtod()` rejects the input
- otherwise the VM must get the same result as `strtod()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284181](https://bugs.openjdk.java.net/browse/JDK-8284181): ArgumentsTest.set_numeric_flag_double_vm fails on some locales


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8078/head:pull/8078` \
`$ git checkout pull/8078`

Update a local copy of the PR: \
`$ git checkout pull/8078` \
`$ git pull https://git.openjdk.java.net/jdk pull/8078/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8078`

View PR using the GUI difftool: \
`$ git pr show -t 8078`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8078.diff">https://git.openjdk.java.net/jdk/pull/8078.diff</a>

</details>
