### PR TITLE
8283704: Add sealed modifier to java.awt.MultipleGradientPaint

### DIFF
--- a/src/java.desktop/share/classes/java/awt/MultipleGradientPaint.java
+++ b/src/java.desktop/share/classes/java/awt/MultipleGradientPaint.java
@@ -39,7 +39,9 @@ import java.util.Arrays;
  * @author Nicholas Talian, Vincent Hardy, Jim Graham, Jerry Evans
  * @since 1.6
  */
-public abstract class MultipleGradientPaint implements Paint {
+public abstract sealed class MultipleGradientPaint implements Paint
+    permits LinearGradientPaint,
+            RadialGradientPaint {
 
     /** The method to use when painting outside the gradient bounds.
      * @since 1.6


### PR DESCRIPTION
Along the same lines as other recent additions of the sealed modifier but this one is quite simple.
Only MultiGradientPaint is touched. The two extant sub-classes it permits are already final

CSR for review : https://bugs.openjdk.java.net/browse/JDK-8284188

jtreg and JCK API tests pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8283704](https://bugs.openjdk.java.net/browse/JDK-8283704): Add sealed modifier to java.awt.MultipleGradientPaint
 * [JDK-8284188](https://bugs.openjdk.java.net/browse/JDK-8284188): Add sealed modifier to java.awt.MultipleGradientPaint (**CSR**)


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8079/head:pull/8079` \
`$ git checkout pull/8079`

Update a local copy of the PR: \
`$ git checkout pull/8079` \
`$ git pull https://git.openjdk.java.net/jdk pull/8079/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8079`

View PR using the GUI difftool: \
`$ git pr show -t 8079`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8079.diff">https://git.openjdk.java.net/jdk/pull/8079.diff</a>

</details>
