### PR TITLE
8284192: SSLSocketReset test should expect EOFException on client side

### DIFF
--- a/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketReset.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketReset.java
@@ -46,9 +46,10 @@ public class SSLSocketReset {
         ServerThread serverThread = null;
         Exception clientException = null;
         try {
-            SSLContext sslContext = SSLContext.getDefault();;
+            SSLServerSocketFactory sslServerSocketFactory =
+                    SSLContext.getDefault().getServerSocketFactory();;
             SSLServerSocket sslServerSocket =
-                    (SSLServerSocket) sslContext.getServerSocketFactory().createServerSocket(0);
+                    (SSLServerSocket) sslServerSocketFactory.createServerSocket(0);
             serverThread = new ServerThread(sslServerSocket);
             serverThread.start();
             Socket socket = null;


### PR DESCRIPTION
Updated test code to expect EOFException on client side and did other cleanup to improve test code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8284192](https://bugs.openjdk.java.net/browse/JDK-8284192): SSLSocketReset test should expect EOFException on client side


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8080/head:pull/8080` \
`$ git checkout pull/8080`

Update a local copy of the PR: \
`$ git checkout pull/8080` \
`$ git pull https://git.openjdk.java.net/jdk pull/8080/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8080`

View PR using the GUI difftool: \
`$ git pr show -t 8080`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8080.diff">https://git.openjdk.java.net/jdk/pull/8080.diff</a>

</details>
