### PR TITLE
8284036: Make ConcurrentHashMap.CollectionView a sealed hierarchy

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
@@ -4416,8 +4416,8 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
     /**
      * Base class for views.
      */
-    abstract static class CollectionView<K,V,E>
-        implements Collection<E>, java.io.Serializable {
+    abstract static sealed class CollectionView<K,V,E>
+        implements Collection<E>, java.io.Serializable permits EntrySetView, KeySetView, ValuesView {
         private static final long serialVersionUID = 7249069246763182397L;
         final ConcurrentHashMap<K,V> map;
         CollectionView(ConcurrentHashMap<K,V> map)  { this.map = map; }
@@ -4589,7 +4589,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
      *
      * @since 1.8
      */
-    public static class KeySetView<K,V> extends CollectionView<K,V,K>
+    public static final class KeySetView<K,V> extends CollectionView<K,V,K>
         implements Set<K>, java.io.Serializable {
         private static final long serialVersionUID = 7249069246763182397L;
         @SuppressWarnings("serial") // Conditionally serializable


### PR DESCRIPTION
Can I please get a review of this change which now marks `CollectionView` as a `sealed` class with only `EntrySetView`, `KeySetView` and  `ValuesView` as the sub-classes? This change corresponds to https://bugs.openjdk.java.net/browse/JDK-8284036.

A CSR has also been drafted for this change https://bugs.openjdk.java.net/browse/JDK-8284272. As noted in the CSR, marking this class as `sealed` and marking `KeySetView` as `final` shouldn't have any impact in general and also in context of serialization/de-serialization.

tier1, tier2, tier3 tests have been run successfully with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8284036](https://bugs.openjdk.java.net/browse/JDK-8284036): Make ConcurrentHashMap.CollectionView a sealed hierarchy
 * [JDK-8284272](https://bugs.openjdk.java.net/browse/JDK-8284272): Make ConcurrentHashMap.CollectionView a sealed hierarchy (**CSR**)


### Reviewers
 * [Stuart Marks](https://openjdk.java.net/census#smarks) (@stuart-marks - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8085/head:pull/8085` \
`$ git checkout pull/8085`

Update a local copy of the PR: \
`$ git checkout pull/8085` \
`$ git pull https://git.openjdk.java.net/jdk pull/8085/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8085`

View PR using the GUI difftool: \
`$ git pr show -t 8085`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8085.diff">https://git.openjdk.java.net/jdk/pull/8085.diff</a>

</details>
