### PR TITLE
[PATCH] Invert ZipFileSystem.isOpen to avoid write default value to volatile field

### DIFF
--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -193,7 +193,7 @@ class ZipFileSystem extends FileSystem {
 
     /**
      * Return the compression method to use (STORED or DEFLATED).  If the
-     * property {@code commpressionMethod} is set use its value to determine
+     * property {@code compressionMethod} is set use its value to determine
      * the compression method to use.  If the property is not set, then the
      * default compression is DEFLATED unless the property {@code noCompression}
      * is set which is supported for backwards compatibility.
@@ -357,7 +357,7 @@ class ZipFileSystem extends FileSystem {
 
     @Override
     public boolean isOpen() {
-        return isOpen;
+        return !closed;
     }
 
     @Override
@@ -467,9 +467,9 @@ class ZipFileSystem extends FileSystem {
     public void close() throws IOException {
         beginWrite();
         try {
-            if (!isOpen)
+            if (closed)
                 return;
-            isOpen = false;          // set closed
+            closed = true;          // set closed
         } finally {
             endWrite();
         }
@@ -868,7 +868,7 @@ class ZipFileSystem extends FileSystem {
     }
 
     private void checkOptions(Set<? extends OpenOption> options) {
-        // check for options of null type and option is an intance of StandardOpenOption
+        // check for options of null type and option is an instance of StandardOpenOption
         for (OpenOption option : options) {
             if (option == null)
                 throw new NullPointerException();
@@ -1200,7 +1200,7 @@ class ZipFileSystem extends FileSystem {
 
     ///////////////////////////////////////////////////////////////////
 
-    private volatile boolean isOpen = true;
+    private volatile boolean closed;
     private final SeekableByteChannel ch; // channel to the zipfile
     final byte[]  cen;     // CEN & ENDHDR
     private END  end;
@@ -1659,7 +1659,7 @@ class ZipFileSystem extends FileSystem {
         }
     }
 
-    private final void checkEncoding( byte[] a) throws ZipException {
+    private final void checkEncoding(byte[] a) throws ZipException {
         try {
             zc.toString(a);
         } catch(Exception e) {
@@ -1669,7 +1669,7 @@ class ZipFileSystem extends FileSystem {
 
 
     private void ensureOpen() {
-        if (!isOpen)
+        if (closed)
             throw new ClosedFileSystemException();
     }
 
@@ -2429,7 +2429,7 @@ class ZipFileSystem extends FileSystem {
         }
     }
 
-    // Maxmum number of de/inflater we cache
+    // Maximum number of de/inflater we cache
     private final int MAX_FLATER = 20;
     // List of available Inflater objects for decompression
     private final List<Inflater> inflaters = new ArrayList<>();
@@ -3034,7 +3034,7 @@ class ZipFileSystem extends FileSystem {
             }
             if (elenEXTT != 0) {
                 writeShort(os, EXTID_EXTT);
-                writeShort(os, elenEXTT - 4);// size for the folowing data block
+                writeShort(os, elenEXTT - 4);// size for the following data block
                 int fbyte = 0x1;
                 if (atime != -1)           // mtime and atime
                     fbyte |= 0x2;


### PR DESCRIPTION
Writing default value to `volatile` field has performance impact (see [JDK-8145948](https://bugs.openjdk.java.net/browse/JDK-8145948)).
For `boolean` fields it's easily avoidable by inverting their logic. Similar how it was done with `AbstractInterruptibleChannel#closed` under [JDK-8145680](https://bugs.openjdk.java.net/browse/JDK-8145680)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8087/head:pull/8087` \
`$ git checkout pull/8087`

Update a local copy of the PR: \
`$ git checkout pull/8087` \
`$ git pull https://git.openjdk.java.net/jdk pull/8087/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8087`

View PR using the GUI difftool: \
`$ git pr show -t 8087`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8087.diff">https://git.openjdk.java.net/jdk/pull/8087.diff</a>

</details>
