### PR TITLE
8177107: Reduce memory footprint of java.lang.reflect.Constructor/Method

### DIFF
--- a/src/hotspot/share/runtime/reflection.cpp
+++ b/src/hotspot/share/runtime/reflection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/reflection.cpp
+++ b/src/hotspot/share/runtime/reflection.cpp
@@ -728,8 +728,15 @@ static objArrayHandle get_parameter_types(const methodHandle& method,
                                           int parameter_count,
                                           oop* return_type,
                                           TRAPS) {
-  // Allocate array holding parameter types (java.lang.Class instances)
-  objArrayOop m = oopFactory::new_objArray(vmClasses::Class_klass(), parameter_count, CHECK_(objArrayHandle()));
+  objArrayOop m;
+  if (parameter_count == 0) {
+    // Avoid allocating an array for the empty case
+    // Still need to parse the signature for the return type below
+    m = Universe::the_empty_class_array();
+  } else {
+    // Allocate array holding parameter types (java.lang.Class instances)
+    m = oopFactory::new_objArray(vmClasses::Class_klass(), parameter_count, CHECK_(objArrayHandle()));
+  }
   objArrayHandle mirrors(THREAD, m);
   int index = 0;
   // Collect parameter types

--- a/src/java.base/share/classes/java/lang/reflect/Constructor.java
+++ b/src/java.base/share/classes/java/lang/reflect/Constructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import jdk.internal.vm.annotation.Stable;
 import sun.reflect.annotation.TypeAnnotation;
 import sun.reflect.annotation.TypeAnnotationParser;
 import sun.reflect.generics.repository.ConstructorRepository;
+import sun.reflect.generics.repository.GenericDeclRepository;
 import sun.reflect.generics.factory.CoreReflectionFactory;
 import sun.reflect.generics.factory.GenericsFactory;
 import sun.reflect.generics.scope.ConstructorScope;
@@ -244,7 +245,7 @@ public final class Constructor<T> extends Executable {
       if (getSignature() != null) {
         return (TypeVariable<Constructor<T>>[])getGenericInfo().getTypeParameters();
       } else
-          return (TypeVariable<Constructor<T>>[])new TypeVariable[0];
+          return (TypeVariable<Constructor<T>>[])GenericDeclRepository.EMPTY_TYPE_VARS;
     }
 
 

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
 import jdk.internal.vm.annotation.Stable;
 import sun.reflect.annotation.ExceptionProxy;
 import sun.reflect.annotation.TypeNotPresentExceptionProxy;
+import sun.reflect.generics.repository.GenericDeclRepository;
 import sun.reflect.generics.repository.MethodRepository;
 import sun.reflect.generics.factory.CoreReflectionFactory;
 import sun.reflect.generics.factory.GenericsFactory;
@@ -254,7 +255,7 @@ public final class Method extends Executable {
         if (getGenericSignature() != null)
             return (TypeVariable<Method>[])getGenericInfo().getTypeParameters();
         else
-            return (TypeVariable<Method>[])new TypeVariable[0];
+            return (TypeVariable<Method>[])GenericDeclRepository.EMPTY_TYPE_VARS;
     }
 
     /**

--- a/src/java.base/share/classes/sun/reflect/generics/repository/GenericDeclRepository.java
+++ b/src/java.base/share/classes/sun/reflect/generics/repository/GenericDeclRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,8 @@ import sun.reflect.generics.visitor.Reifier;
 public abstract class GenericDeclRepository<S extends Signature>
     extends AbstractRepository<S> {
 
+    public static final TypeVariable<?>[] EMPTY_TYPE_VARS = new TypeVariable<?>[0];
+
     /** The formal type parameters.  Lazily initialized. */
     private volatile TypeVariable<?>[] typeParameters;
 
@@ -77,6 +79,9 @@ public abstract class GenericDeclRepository<S extends Signature>
         FormalTypeParameter[] ftps = getTree().getFormalTypeParameters();
         // create array to store reified subtree(s)
         int length = ftps.length;
+        if (length == 0) {
+            return EMPTY_TYPE_VARS;
+        }
         TypeVariable<?>[] typeParameters = new TypeVariable<?>[length];
         // reify all subtrees
         for (int i = 0; i < length; i++) {


### PR DESCRIPTION
As an alternative to #7667 I took a look at injecting an empty class array from the VM. Turns out we already do this for exception types - see https://github.com/openjdk/jdk/blob/master/src/hotspot/share/oops/method.cpp#L918 - and we can do similarly for the parameter types array. We still need to parse the signature for the return type, though.

I've verified by dumping and inspecting heaps that this means we are not allocating extra `Class<?>[]` on `Method` reflection.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8177107](https://bugs.openjdk.java.net/browse/JDK-8177107): Reduce memory footprint of java.lang.reflect.Constructor/Method


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8089/head:pull/8089` \
`$ git checkout pull/8089`

Update a local copy of the PR: \
`$ git checkout pull/8089` \
`$ git pull https://git.openjdk.java.net/jdk pull/8089/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8089`

View PR using the GUI difftool: \
`$ git pr show -t 8089`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8089.diff">https://git.openjdk.java.net/jdk/pull/8089.diff</a>

</details>
