### PR TITLE
8283935: Parallel: Crash during pretouch after large pages allocation failure

### DIFF
--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -589,7 +589,7 @@ void MutableNUMASpace::initialize(MemRegion mr,
 
   // Compute chunk sizes
   size_t prev_page_size = page_size();
-  set_page_size(UseLargePages ? alignment() : os::vm_page_size());
+  set_page_size(alignment());
   HeapWord* rounded_bottom = align_up(bottom(), page_size());
   HeapWord* rounded_end = align_down(end(), page_size());
   size_t base_space_size_pages = pointer_delta(rounded_end, rounded_bottom, sizeof(char)) / page_size();

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -270,7 +270,7 @@ bool MutableNUMASpace::update_layout(bool force) {
         }
       }
       if (!found) {
-        lgrp_spaces()->append(new LGRPSpace(lgrp_ids[i], alignment()));
+        lgrp_spaces()->append(new LGRPSpace(lgrp_ids[i], page_size()));
       }
     }
 
@@ -492,10 +492,10 @@ void MutableNUMASpace::select_tails(MemRegion new_region, MemRegion intersection
   // Is there bottom?
   if (new_region.start() < intersection.start()) { // Yes
     // Try to coalesce small pages into a large one.
-    if (UseLargePages && page_size() >= alignment()) {
-      HeapWord* p = align_up(intersection.start(), alignment());
+    if (UseLargePages && page_size() >= page_size()) {
+      HeapWord* p = align_up(intersection.start(), page_size());
       if (new_region.contains(p)
-          && pointer_delta(p, new_region.start(), sizeof(char)) >= alignment()) {
+          && pointer_delta(p, new_region.start(), sizeof(char)) >= page_size()) {
         if (intersection.contains(p)) {
           intersection = MemRegion(p, intersection.end());
         } else {
@@ -511,10 +511,10 @@ void MutableNUMASpace::select_tails(MemRegion new_region, MemRegion intersection
   // Is there top?
   if (intersection.end() < new_region.end()) { // Yes
     // Try to coalesce small pages into a large one.
-    if (UseLargePages && page_size() >= alignment()) {
-      HeapWord* p = align_down(intersection.end(), alignment());
+    if (UseLargePages && page_size() >= page_size()) {
+      HeapWord* p = align_down(intersection.end(), page_size());
       if (new_region.contains(p)
-          && pointer_delta(new_region.end(), p, sizeof(char)) >= alignment()) {
+          && pointer_delta(new_region.end(), p, sizeof(char)) >= page_size()) {
         if (intersection.contains(p)) {
           intersection = MemRegion(intersection.start(), p);
         } else {
@@ -553,12 +553,12 @@ void MutableNUMASpace::merge_regions(MemRegion new_region, MemRegion* intersecti
             // That's the only case we have to make an additional bias_region() call.
             HeapWord* start = invalid_region->start();
             HeapWord* end = invalid_region->end();
-            if (UseLargePages && page_size() >= alignment()) {
-              HeapWord *p = align_down(start, alignment());
+            if (UseLargePages && page_size() >= page_size()) {
+              HeapWord *p = align_down(start, page_size());
               if (new_region.contains(p)) {
                 start = p;
               }
-              p = align_up(end, alignment());
+              p = align_up(end, page_size());
               if (new_region.contains(end)) {
                 end = p;
               }
@@ -589,7 +589,7 @@ void MutableNUMASpace::initialize(MemRegion mr,
 
   // Compute chunk sizes
   size_t prev_page_size = page_size();
-  set_page_size(UseLargePages ? alignment() : os::vm_page_size());
+  set_page_size(UseLargePages ? page_size() : os::vm_page_size());
   HeapWord* rounded_bottom = align_up(bottom(), page_size());
   HeapWord* rounded_end = align_down(end(), page_size());
   size_t base_space_size_pages = pointer_delta(rounded_end, rounded_bottom, sizeof(char)) / page_size();

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -270,7 +270,7 @@ bool MutableNUMASpace::update_layout(bool force) {
         }
       }
       if (!found) {
-        lgrp_spaces()->append(new LGRPSpace(lgrp_ids[i], page_size()));
+        lgrp_spaces()->append(new LGRPSpace(lgrp_ids[i], alignment()));
       }
     }
 
@@ -492,10 +492,10 @@ void MutableNUMASpace::select_tails(MemRegion new_region, MemRegion intersection
   // Is there bottom?
   if (new_region.start() < intersection.start()) { // Yes
     // Try to coalesce small pages into a large one.
-    if (UseLargePages && page_size() >= page_size()) {
-      HeapWord* p = align_up(intersection.start(), page_size());
+    if (UseLargePages && page_size() >= alignment()) {
+      HeapWord* p = align_up(intersection.start(), alignment());
       if (new_region.contains(p)
-          && pointer_delta(p, new_region.start(), sizeof(char)) >= page_size()) {
+          && pointer_delta(p, new_region.start(), sizeof(char)) >= alignment()) {
         if (intersection.contains(p)) {
           intersection = MemRegion(p, intersection.end());
         } else {
@@ -511,10 +511,10 @@ void MutableNUMASpace::select_tails(MemRegion new_region, MemRegion intersection
   // Is there top?
   if (intersection.end() < new_region.end()) { // Yes
     // Try to coalesce small pages into a large one.
-    if (UseLargePages && page_size() >= page_size()) {
-      HeapWord* p = align_down(intersection.end(), page_size());
+    if (UseLargePages && page_size() >= alignment()) {
+      HeapWord* p = align_down(intersection.end(), alignment());
       if (new_region.contains(p)
-          && pointer_delta(new_region.end(), p, sizeof(char)) >= page_size()) {
+          && pointer_delta(new_region.end(), p, sizeof(char)) >= alignment()) {
         if (intersection.contains(p)) {
           intersection = MemRegion(intersection.start(), p);
         } else {
@@ -553,12 +553,12 @@ void MutableNUMASpace::merge_regions(MemRegion new_region, MemRegion* intersecti
             // That's the only case we have to make an additional bias_region() call.
             HeapWord* start = invalid_region->start();
             HeapWord* end = invalid_region->end();
-            if (UseLargePages && page_size() >= page_size()) {
-              HeapWord *p = align_down(start, page_size());
+            if (UseLargePages && page_size() >= alignment()) {
+              HeapWord *p = align_down(start, alignment());
               if (new_region.contains(p)) {
                 start = p;
               }
-              p = align_up(end, page_size());
+              p = align_up(end, alignment());
               if (new_region.contains(end)) {
                 end = p;
               }
@@ -589,7 +589,7 @@ void MutableNUMASpace::initialize(MemRegion mr,
 
   // Compute chunk sizes
   size_t prev_page_size = page_size();
-  set_page_size(UseLargePages ? page_size() : os::vm_page_size());
+  set_page_size(UseLargePages ? alignment() : os::vm_page_size());
   HeapWord* rounded_bottom = align_up(bottom(), page_size());
   HeapWord* rounded_end = align_down(end(), page_size());
   size_t base_space_size_pages = pointer_delta(rounded_end, rounded_bottom, sizeof(char)) / page_size();

--- a/src/hotspot/share/gc/parallel/mutableSpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.cpp
@@ -52,9 +52,8 @@ MutableSpace::~MutableSpace() {
   delete _mangler;
 }
 
-void MutableSpace::numa_setup_pages(MemRegion mr, bool clear_space) {
+void MutableSpace::numa_setup_pages(MemRegion mr, size_t page_size, bool clear_space) {
   if (!mr.is_empty()) {
-    size_t page_size = UseLargePages ? alignment() : os::vm_page_size();
     HeapWord *start = align_up(mr.start(), page_size);
     HeapWord *end =   align_down(mr.end(), page_size);
     if (end > start) {
@@ -113,14 +112,14 @@ void MutableSpace::initialize(MemRegion mr,
     }
     assert(mr.contains(head) && mr.contains(tail), "Sanity");
 
+    size_t page_size = UseLargePages ? alignment() : os::vm_page_size();
+
     if (UseNUMA) {
-      numa_setup_pages(head, clear_space);
-      numa_setup_pages(tail, clear_space);
+      numa_setup_pages(head, page_size, clear_space);
+      numa_setup_pages(tail, page_size, clear_space);
     }
 
     if (AlwaysPreTouch) {
-      size_t page_size = UseLargePages ? os::large_page_size() : os::vm_page_size();
-
       PretouchTask::pretouch("ParallelGC PreTouch head", (char*)head.start(), (char*)head.end(),
                              page_size, pretouch_workers);
 

--- a/src/hotspot/share/gc/parallel/mutableSpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.cpp
@@ -35,15 +35,16 @@
 #include "utilities/align.hpp"
 #include "utilities/macros.hpp"
 
-MutableSpace::MutableSpace(size_t alignment) :
+MutableSpace::MutableSpace(size_t page_size) :
   _mangler(NULL),
   _last_setup_region(),
-  _alignment(alignment),
+  _page_size(page_size),
   _bottom(NULL),
   _top(NULL),
   _end(NULL)
 {
-  assert(MutableSpace::alignment() % os::vm_page_size() == 0,
+  assert(MutableSpace::page_size() > 0, "invalid page size");
+  assert(MutableSpace::page_size() % os::vm_page_size() == 0,
          "Space should be aligned");
   _mangler = new MutableSpaceMangler(this);
 }
@@ -112,19 +113,17 @@ void MutableSpace::initialize(MemRegion mr,
     }
     assert(mr.contains(head) && mr.contains(tail), "Sanity");
 
-    size_t page_size = UseLargePages ? alignment() : os::vm_page_size();
-
     if (UseNUMA) {
-      numa_setup_pages(head, page_size, clear_space);
-      numa_setup_pages(tail, page_size, clear_space);
+      numa_setup_pages(head, page_size(), clear_space);
+      numa_setup_pages(tail, page_size(), clear_space);
     }
 
     if (AlwaysPreTouch) {
       PretouchTask::pretouch("ParallelGC PreTouch head", (char*)head.start(), (char*)head.end(),
-                             page_size, pretouch_workers);
+                             page_size(), pretouch_workers);
 
       PretouchTask::pretouch("ParallelGC PreTouch tail", (char*)tail.start(), (char*)tail.end(),
-                             page_size, pretouch_workers);
+                             page_size(), pretouch_workers);
     }
 
     // Remember where we stopped so that we can continue later.

--- a/src/hotspot/share/gc/parallel/mutableSpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.cpp
@@ -112,7 +112,7 @@ void MutableSpace::initialize(MemRegion mr,
     }
     assert(mr.contains(head) && mr.contains(tail), "Sanity");
 
-    size_t page_size = UseLargePages ? alignment() : os::vm_page_size();
+    size_t page_size = alignment();
 
     if (UseNUMA) {
       numa_setup_pages(head, page_size, clear_space);

--- a/src/hotspot/share/gc/parallel/mutableSpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.hpp
@@ -67,8 +67,6 @@ class MutableSpace: public CHeapObj<mtGC> {
   void set_last_setup_region(MemRegion mr) { _last_setup_region = mr;   }
   MemRegion last_setup_region() const      { return _last_setup_region; }
 
-  size_t used_page_size() const;
-
  public:
   virtual ~MutableSpace();
   MutableSpace(size_t page_size);

--- a/src/hotspot/share/gc/parallel/mutableSpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.hpp
@@ -55,7 +55,7 @@ class MutableSpace: public CHeapObj<mtGC> {
   MutableSpaceMangler* _mangler;
   // The last region which page had been setup to be interleaved.
   MemRegion _last_setup_region;
-  size_t _page_size;
+  size_t _alignment;
   HeapWord* _bottom;
   HeapWord* volatile _top;
   HeapWord* _end;
@@ -66,6 +66,8 @@ class MutableSpace: public CHeapObj<mtGC> {
 
   void set_last_setup_region(MemRegion mr) { _last_setup_region = mr;   }
   MemRegion last_setup_region() const      { return _last_setup_region; }
+
+  size_t used_page_size() const;
 
  public:
   virtual ~MutableSpace();
@@ -83,7 +85,7 @@ class MutableSpace: public CHeapObj<mtGC> {
   HeapWord* volatile* top_addr()           { return &_top; }
   HeapWord** end_addr()                    { return &_end; }
 
-  size_t page_size()                       { return _page_size; }
+  size_t alignment()                       { return _alignment; }
 
   MemRegion region() const { return MemRegion(bottom(), end()); }
 

--- a/src/hotspot/share/gc/parallel/mutableSpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.hpp
@@ -62,10 +62,12 @@ class MutableSpace: public CHeapObj<mtGC> {
 
   MutableSpaceMangler* mangler() { return _mangler; }
 
-  void numa_setup_pages(MemRegion mr, bool clear_space);
+  void numa_setup_pages(MemRegion mr, size_t page_size, bool clear_space);
 
   void set_last_setup_region(MemRegion mr) { _last_setup_region = mr;   }
   MemRegion last_setup_region() const      { return _last_setup_region; }
+
+  size_t used_page_size() const;
 
  public:
   virtual ~MutableSpace();

--- a/src/hotspot/share/gc/parallel/mutableSpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.hpp
@@ -55,7 +55,7 @@ class MutableSpace: public CHeapObj<mtGC> {
   MutableSpaceMangler* _mangler;
   // The last region which page had been setup to be interleaved.
   MemRegion _last_setup_region;
-  size_t _alignment;
+  size_t _page_size;
   HeapWord* _bottom;
   HeapWord* volatile _top;
   HeapWord* _end;
@@ -66,8 +66,6 @@ class MutableSpace: public CHeapObj<mtGC> {
 
   void set_last_setup_region(MemRegion mr) { _last_setup_region = mr;   }
   MemRegion last_setup_region() const      { return _last_setup_region; }
-
-  size_t used_page_size() const;
 
  public:
   virtual ~MutableSpace();
@@ -85,7 +83,7 @@ class MutableSpace: public CHeapObj<mtGC> {
   HeapWord* volatile* top_addr()           { return &_top; }
   HeapWord** end_addr()                    { return &_end; }
 
-  size_t alignment()                       { return _alignment; }
+  size_t page_size()                       { return _page_size; }
 
   MemRegion region() const { return MemRegion(bottom(), end()); }
 


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that fixes a crash with Parallel GC, `AlwaysPretouch` and misconfigured large pages?

The `AlwaysPreTouch` code for Parallel GC does not use the actual used large page size for the heap, but the one passed in by the user. If that page size is not actually available, and the heap is not aligned to that used page size, there will be an out-of-bounds access by the pretouch code.

The change simply makes the code use the correct page size (which is passed in as `alignment` into `MutableSpace` - but that is another issue).

Testing: local testing of failing test case (see CR), tier1-3

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283935](https://bugs.openjdk.java.net/browse/JDK-8283935): Parallel: Crash during pretouch after large pages allocation failure


### Reviewers
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8090/head:pull/8090` \
`$ git checkout pull/8090`

Update a local copy of the PR: \
`$ git checkout pull/8090` \
`$ git pull https://git.openjdk.java.net/jdk pull/8090/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8090`

View PR using the GUI difftool: \
`$ git pr show -t 8090`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8090.diff">https://git.openjdk.java.net/jdk/pull/8090.diff</a>

</details>
