### PR TITLE
8283643: [AIX, testbug] MachCodeFramesInErrorFile test fails to find 'Native frames' text

### DIFF
--- a/src/hotspot/os/aix/porting_aix.cpp
+++ b/src/hotspot/os/aix/porting_aix.cpp
@@ -702,7 +702,7 @@ void AixNativeCallstack::print_callstack_for_context(outputStream* st, const uco
     stack_size = stackbounds.size;
   }
 
-  st->print_cr("------ current frame:");
+  st->print_cr("Native frame:");
   st->print("iar:  " PTR64_FORMAT " ", p2i(cur_iar));
   print_info_for_pc(st, cur_iar, buf, buf_size, demangle);
   st->cr();

--- a/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
@@ -71,7 +71,7 @@ public class MachCodeFramesInErrorFile {
                 crashInJava1(10);
             } else {
                 assert args[0].equals("crashInVM");
-                // AIX does not prohibit low address reads
+                // Low address reads are allowed on PPC
                 crashInNative1(Platform.isPPC() ? -1 : 10);
             }
         }

--- a/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
@@ -72,7 +72,7 @@ public class MachCodeFramesInErrorFile {
             } else {
                 assert args[0].equals("crashInVM");
                 // AIX does not prohibit low address reads
-                crashInNative1( Platform.isPPC() ? -1 : 10 );
+                crashInNative1(Platform.isPPC() ? -1 : 10);
             }
         }
 
@@ -169,12 +169,8 @@ public class MachCodeFramesInErrorFile {
      * and adds them to {@code frames}.
      */
     private static void extractFrames(String hsErr, Set<String> frames, boolean nativeStack) {
-        String marker;
-        if (Platform.isAix()) {
-            marker = nativeStack ? "------ current frame:" : "Java frames: ";
-        } else {
-            marker = (nativeStack ? "Native" : "Java") + " frames: ";
-        }
+        String marker = (nativeStack ? "Native" : "Java") + " frame";
+
         boolean seenMarker = false;
         for (String line : hsErr.split(System.lineSeparator())) {
             if (line.startsWith(marker)) {

--- a/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
@@ -128,9 +128,9 @@ public class MachCodeFramesInErrorFile {
         // Extract hs_err_pid file.
         String hs_err_file = output.firstMatch("# *(\\S*hs_err_pid\\d+\\.log)", 1);
         if (hs_err_file == null) {
-            throw new RuntimeException("Did not find hs_err_pid file in output.\n" +
-                                       "stderr:\n" + output.getStderr() + "\n" +
-                                       "stdout:\n" + output.getStdout());
+            System.out.println("stdout:\n" + output.getStdout());
+            System.err.println("stderr:\n" + output.getStderr());
+            throw new RuntimeException("Did not find hs_err_pid file in output");
         }
         Path hsErrPath = Paths.get(hs_err_file);
         if (!Files.exists(hsErrPath)) {
@@ -184,6 +184,7 @@ public class MachCodeFramesInErrorFile {
                 frames.add(line);
             }
         }
+        System.err.println(hsErr);
         throw new RuntimeException("\"" + marker + "\" line missing in hs_err_pid file");
     }
 }

--- a/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
@@ -48,6 +48,7 @@ import java.util.stream.Stream;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 
+import jdk.test.lib.Platform;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.Asserts;
@@ -55,8 +56,6 @@ import jdk.test.lib.Asserts;
 import jdk.internal.misc.Unsafe;
 
 public class MachCodeFramesInErrorFile {
-    private static final String OS_NAME = System.getProperty("os.name");
-
     private static class Crasher {
         // Make Crasher.unsafe a compile-time constant so that
         // C2 intrinsifies calls to Unsafe intrinsics.
@@ -73,7 +72,7 @@ public class MachCodeFramesInErrorFile {
             } else {
                 assert args[0].equals("crashInVM");
                 // AIX does not prohibit low address reads
-                crashInNative1( OS_NAME.startsWith("AIX") ? -1 : 10 );
+                crashInNative1( Platform.isPPC() ? -1 : 10 );
             }
         }
 
@@ -171,7 +170,7 @@ public class MachCodeFramesInErrorFile {
      */
     private static void extractFrames(String hsErr, Set<String> frames, boolean nativeStack) {
         String marker;
-        if (OS_NAME.startsWith("AIX")) {
+        if (Platform.isAix()) {
             marker = nativeStack ? "------ current frame:" : "Java frames: ";
         } else {
             marker = (nativeStack ? "Native" : "Java") + " frames: ";

--- a/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
@@ -165,7 +165,7 @@ public class MachCodeFramesInErrorFile {
 
     /**
      * Extracts the lines in {@code hsErr} below the line starting with
-     * "Native frames:" ("current frame:" on AIX) or "Java frames:" up to the next blank line
+     * "Native frame" or "Java frame" up to the next blank line
      * and adds them to {@code frames}.
      */
     private static void extractFrames(String hsErr, Set<String> frames, boolean nativeStack) {

--- a/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
@@ -128,8 +128,7 @@ public class MachCodeFramesInErrorFile {
         // Extract hs_err_pid file.
         String hs_err_file = output.firstMatch("# *(\\S*hs_err_pid\\d+\\.log)", 1);
         if (hs_err_file == null) {
-            System.out.println("stdout:\n" + output.getStdout());
-            System.err.println("stderr:\n" + output.getStderr());
+            output.reportDiagnosticSummary();
             throw new RuntimeException("Did not find hs_err_pid file in output");
         }
         Path hsErrPath = Paths.get(hs_err_file);

--- a/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
@@ -161,8 +161,6 @@ public class MachCodeFramesInErrorFile {
         if (machCodeHeaders.size() < minExpectedMachCodeSections) {
             Asserts.fail(machCodeHeaders.size() + " < " + minExpectedMachCodeSections);
         }
-
-        throw new RuntimeException("sample error");
     }
 
     /**

--- a/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
@@ -161,6 +161,8 @@ public class MachCodeFramesInErrorFile {
         if (machCodeHeaders.size() < minExpectedMachCodeSections) {
             Asserts.fail(machCodeHeaders.size() + " < " + minExpectedMachCodeSections);
         }
+
+        throw new RuntimeException("sample error");
     }
 
     /**
@@ -182,6 +184,6 @@ public class MachCodeFramesInErrorFile {
                 frames.add(line);
             }
         }
-        throw new RuntimeException("\"" + marker + "\" line missing in hs_err_pid file:\n");
+        throw new RuntimeException("\"" + marker + "\" line missing in hs_err_pid file");
     }
 }


### PR DESCRIPTION
I observed a failure of MachCodeFramesInErrorFile.java on AIX. The raised error complains that 'Native frames: ' is missing. To fix the failure, I made two changes to the test that allowed it to pass on AIX.

The first change made was to the test's `extractFrames` method. AIX overrides `os::platform_print_native_stack` with stack printing specific to AIX/Power. This code does not produce the 'Native frames: ' text that `vmError::print_native_stack` does, so the test was modified to expect the AIX output when run on AIX. [Edit: The changes made to `extractFrames` are now minimal. I made the change to `AixNativeCallstack::print_callstack_for_context` instead.]

A second change was made to the address passed to the `crashInNative1` method. AIX does not consider low-address memory to be protected as other platforms do. In fact, "the first 256 bytes are reserved for software use" according to the Power ISA. Accordingly, the read address for PPC was changed to -1 (0xFF..FF) to produce the expected failure result.

### Testing

Tier1 tests complete as expected on AIX/Power.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283643](https://bugs.openjdk.java.net/browse/JDK-8283643): [AIX, testbug] MachCodeFramesInErrorFile test fails to find 'Native frames' text


### Reviewers
 * [Doug Simon](https://openjdk.java.net/census#dnsimon) (@dougxc - Committer) ⚠️ Review applies to d0a05457a55866fa7df5cbca2501721bf50b3e9b
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to d0a05457a55866fa7df5cbca2501721bf50b3e9b


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8094/head:pull/8094` \
`$ git checkout pull/8094`

Update a local copy of the PR: \
`$ git checkout pull/8094` \
`$ git pull https://git.openjdk.java.net/jdk pull/8094/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8094`

View PR using the GUI difftool: \
`$ git pr show -t 8094`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8094.diff">https://git.openjdk.java.net/jdk/pull/8094.diff</a>

</details>
