### PR TITLE
8284283: javac crashes when several transitive supertypes are missing

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -894,7 +894,12 @@ public class Attr extends JCTree.Visitor {
         Type t = tree.type != null ?
             tree.type :
             attribType(tree, env);
-        return checkBase(t, tree, env, classExpected, interfaceExpected, checkExtensible);
+        try {
+            return checkBase(t, tree, env, classExpected, interfaceExpected, checkExtensible);
+        } catch (CompletionFailure ex) {
+            chk.completionError(tree.pos(), ex);
+            return t;
+        }
     }
     Type checkBase(Type t,
                    JCTree tree,

--- a/test/langtools/tools/javac/missingSuperRecovery/MissingSuperRecovery.java
+++ b/test/langtools/tools/javac/missingSuperRecovery/MissingSuperRecovery.java
@@ -5,7 +5,7 @@
  * class is no longer available during a subsequent compilation.
  * @author maddox
  * @build impl
- * @compile/fail/ref=MissingSuperRecovery.out --diags=layout=%b:%l:%_%m MissingSuperRecovery.java
+ * @compile/fail/ref=MissingSuperRecovery.out -XDrawDiagnostics MissingSuperRecovery.java
  */
 
 // Requires "golden" class file 'impl.class', which contains

--- a/test/langtools/tools/javac/missingSuperRecovery/MissingSuperRecovery.out
+++ b/test/langtools/tools/javac/missingSuperRecovery/MissingSuperRecovery.out
@@ -1,5 +1,2 @@
-MissingSuperRecovery.java:15: cannot access base
-public class MissingSuperRecovery extends impl {
-       ^
-  class file for base not found
+MissingSuperRecovery.java:15:43: compiler.err.cant.access: base, (compiler.misc.class.file.not.found: base)
 1 error

--- a/test/langtools/tools/javac/recovery/MissingTransitiveSuperTypes.java
+++ b/test/langtools/tools/javac/recovery/MissingTransitiveSuperTypes.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8284283
+ * @summary Verify javac's error recovery can handle multiple missing transitive supertypes
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.main
+ *          jdk.compiler/com.sun.tools.javac.api
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main MissingTransitiveSuperTypes
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Arrays;
+
+import toolbox.ToolBox;
+import toolbox.TestRunner;
+import toolbox.JavacTask;
+import toolbox.Task;
+
+public class MissingTransitiveSuperTypes extends TestRunner {
+    ToolBox tb;
+
+    public MissingTransitiveSuperTypes() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public static void main(String[] args) throws Exception {
+        new MissingTransitiveSuperTypes().runTests(m -> new Object[] {Paths.get(m.getName())});
+    }
+
+    @Test
+    public void testMultipleTransitiveSuperTypesMissing(Path base) throws Exception {
+        Path libClasses = base.resolve("libclasses");
+        Files.createDirectories(libClasses);
+        new JavacTask(tb)
+            .outdir(libClasses)
+            .sources("""
+                     package lib;
+                     public class Lib implements A, B {}
+                     """,
+                     """
+                     package lib;
+                     public interface A {}
+                     """,
+                     """
+                     package lib;
+                     public interface B {}
+                     """)
+            .options()
+            .run()
+            .writeAll();
+        Files.delete(libClasses.resolve("lib").resolve("A.class"));
+        Files.delete(libClasses.resolve("lib").resolve("B.class"));
+        String code = """
+                      public class Test<E> extends lib.Lib {}
+                      """;
+        List<String> output = new JavacTask(tb)
+                .classpath(libClasses)
+                .sources(code)
+                .options("-XDrawDiagnostics", "-XDdev")
+                .run(Task.Expect.FAIL)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+        List<String> expected = Arrays.asList(
+                "Test.java:1:33: compiler.err.cant.access: lib.A, (compiler.misc.class.file.not.found: lib.A)",
+                "Test.java:1:8: compiler.err.cant.access: lib.B, (compiler.misc.class.file.not.found: lib.B)",
+                "2 errors");
+        tb.checkEqual(expected, output);
+    }
+
+}


### PR DESCRIPTION
Consider this testcase:
```
---Lib.java
package lib;
public class Lib implements A, B {}
interface A {}
interface B {}
---Test.java
public class Test<E> extends lib.Lib {}
---

$ javac -d out Lib.java
$ rm out/lib/A.class out/lib/B.class
$ javac -classpath out -XDdev Test.java
Test.java:1: error: cannot access A
public class Test<E> extends lib.Lib {}
       ^
  class file for lib.A not found
1 error
An exception has occurred in the compiler (17-internal). Please file a bug against the Java compiler via the Java bug reporting page (http://bugreport.java.com/) after checking the Bug Database (http://bugs.java.com/) for duplicates. Include your program, the following diagnostic, and the parameters passed to the Java compiler in your report. Thank you.
java.lang.NullPointerException: Cannot invoke "com.sun.tools.javac.code.Type.hasTag(com.sun.tools.javac.code.TypeTag)" because the return value of "com.sun.tools.javac.code.Type$TypeVar.getUpperBound()" is null
        at jdk.compiler/com.sun.tools.javac.code.Types.getBounds(Types.java:2732)
....
```

The reason for the cache is insufficient error recovery - when the missing class `A` and `B` are encountered, the processing in `TypeEnter` (`TypeEnter.HierarchyPhase` for `A` and `TypeEnter.HeaderPhase` for `B`) is interrupted, and the rest of the processing is skipped to the end of the phase, leaving unprocessed tree, which ultimately leads to the exception.

The proposed patch is to enhance the error recovery, catch the `CompletionFailure` for the missing classes sooner, and let the rest of the `TypeEnter` processing finish normally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284283](https://bugs.openjdk.java.net/browse/JDK-8284283): javac crashes when several transitive supertypes are missing


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8095/head:pull/8095` \
`$ git checkout pull/8095`

Update a local copy of the PR: \
`$ git checkout pull/8095` \
`$ git pull https://git.openjdk.java.net/jdk pull/8095/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8095`

View PR using the GUI difftool: \
`$ git pr show -t 8095`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8095.diff">https://git.openjdk.java.net/jdk/pull/8095.diff</a>

</details>
