### PR TITLE
8283396: Null pointer dereference in loopnode.cpp:2851

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -853,6 +853,7 @@ bool PhaseIdealLoop::create_loop_nest(IdealLoopTree* loop, Node_List &old_new) {
   if (bt == T_INT && head->as_CountedLoop()->is_strip_mined()) {
     // Loop is strip mined: use the safepoint of the outer strip mined loop
     OuterStripMinedLoopNode* outer_loop = head->as_CountedLoop()->outer_loop();
+    assert(outer_loop != NULL, "no outer loop");
     safepoint = outer_loop->outer_safepoint();
     outer_loop->transform_to_counted_loop(&_igvn, this);
     exit_test = head->loopexit();


### PR DESCRIPTION
This fix guards against a possible null pointer dereference in PhaseIdealLoop::create_loop_nest around line 855, where it assumes the result of outer_loop() is not NULL.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283396](https://bugs.openjdk.java.net/browse/JDK-8283396): Null pointer dereference in loopnode.cpp:2851


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8096/head:pull/8096` \
`$ git checkout pull/8096`

Update a local copy of the PR: \
`$ git checkout pull/8096` \
`$ git pull https://git.openjdk.java.net/jdk pull/8096/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8096`

View PR using the GUI difftool: \
`$ git pr show -t 8096`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8096.diff">https://git.openjdk.java.net/jdk/pull/8096.diff</a>

</details>
