### PR TITLE
8284303: runtime/Thread/AsyncExceptionTest.java timed out

### DIFF
--- a/test/hotspot/jtreg/runtime/Thread/AsyncExceptionTest.java
+++ b/test/hotspot/jtreg/runtime/Thread/AsyncExceptionTest.java
@@ -24,81 +24,33 @@
 /**
  * @test
  * @bug 8283044
+ * @requires vm.compiler1.enabled | vm.compiler2.enabled
  * @summary Stress delivery of asynchronous exceptions.
  * @library /test/lib /test/hotspot/jtreg
  * @build AsyncExceptionTest
- * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI AsyncExceptionTest
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -Xcomp
+                     -XX:CompileCommand=dontinline,AsyncExceptionTest::internalRun2
+                     -XX:CompileCommand=compileonly,AsyncExceptionTest::internalRun1
+                     -XX:CompileCommand=compileonly,AsyncExceptionTest::internalRun2
+                     AsyncExceptionTest
  */
 
-import compiler.testlibrary.CompilerUtils;
-import compiler.whitebox.CompilerWhiteBoxTest;
 import java.util.concurrent.CountDownLatch;
-import sun.hotspot.WhiteBox;
 
 public class AsyncExceptionTest extends Thread {
     private final static int DEF_TIME_MAX = 30;  // default max # secs to test
     private final static String PROG_NAME = "AsyncExceptionTest";
 
-    public static final WhiteBox WB = WhiteBox.getWhiteBox();
-
     public CountDownLatch exitSyncObj = new CountDownLatch(1);
     public CountDownLatch startSyncObj = new CountDownLatch(1);
 
-    private boolean realRun;
     private boolean firstEntry = true;
     private boolean receivedThreadDeathinInternal1 = false;
     private boolean receivedThreadDeathinInternal2 = false;
 
-    public void setDontInline(String method) {
-        java.lang.reflect.Method m;
-        try {
-            m = AsyncExceptionTest.class.getMethod(method);
-        } catch(NoSuchMethodException e) {
-            throw new RuntimeException("Unexpected: " + e);
-        }
-        WB.testSetDontInlineMethod(m, true);
-    }
-
-    public void checkCompLevel(String method) {
-        int highestLevel = CompilerUtils.getMaxCompilationLevel();
-        java.lang.reflect.Method m;
-        try {
-            m = AsyncExceptionTest.class.getMethod(method);
-        } catch(NoSuchMethodException e) {
-            throw new RuntimeException("Unexpected: " + e);
-        }
-        int compLevel = WB.getMethodCompilationLevel(m);
-        long start_time = System.currentTimeMillis();
-        while (compLevel < (highestLevel - 1)) {
-            try {
-                Thread.sleep(200);
-            } catch (InterruptedException e) { /* ignored */ }
-            if (System.currentTimeMillis() - start_time > 20000) {
-                // if more than 20 seconds have elapsed just bail out
-                break;
-            }
-            compLevel = WB.getMethodCompilationLevel(m);
-        }
-    }
-
     @Override
     public void run() {
         try {
-            setDontInline("internalRun1");
-            setDontInline("internalRun2");
-
-            int callCount = CompilerWhiteBoxTest.THRESHOLD;
-            while (callCount-- > 0) {
-                receivedThreadDeathinInternal2 = false;
-                realRun = false;
-                internalRun1();
-            }
-            checkCompLevel("internalRun1");
-            checkCompLevel("internalRun2");
-
-            receivedThreadDeathinInternal2 = false;
-            realRun = true;
             internalRun1();
         } catch (ThreadDeath td) {
             throw new RuntimeException("Catched ThreadDeath in run() instead of internalRun2() or internalRun1(). receivedThreadDeathinInternal1=" + receivedThreadDeathinInternal1 + "; receivedThreadDeathinInternal2=" + receivedThreadDeathinInternal2);
@@ -113,7 +65,6 @@ public class AsyncExceptionTest extends Thread {
     }
 
     public void internalRun1() {
-        long start_time = System.currentTimeMillis();
         try {
             while (!receivedThreadDeathinInternal2) {
               internalRun2();
@@ -128,17 +79,13 @@ public class AsyncExceptionTest extends Thread {
             Integer myLocalCount = 1;
             Integer myLocalCount2 = 1;
 
-            if (realRun && firstEntry) {
+            if (firstEntry) {
                 // Tell main thread we have started.
                 startSyncObj.countDown();
                 firstEntry = false;
             }
 
             while(myLocalCount > 0) {
-                if (!realRun) {
-                    receivedThreadDeathinInternal2 = true;
-                    break;
-                }
                 myLocalCount2 = (myLocalCount % 3) / 2;
                 myLocalCount -= 1;
             }

--- a/test/hotspot/jtreg/runtime/Thread/AsyncExceptionTest.java
+++ b/test/hotspot/jtreg/runtime/Thread/AsyncExceptionTest.java
@@ -69,10 +69,15 @@ public class AsyncExceptionTest extends Thread {
             throw new RuntimeException("Unexpected: " + e);
         }
         int compLevel = WB.getMethodCompilationLevel(m);
+        long start_time = System.currentTimeMillis();
         while (compLevel < (highestLevel - 1)) {
             try {
                 Thread.sleep(200);
             } catch (InterruptedException e) { /* ignored */ }
+            if (System.currentTimeMillis() - start_time > 20000) {
+                // if more than 20 seconds have elapsed just bail out
+                break;
+            }
             compLevel = WB.getMethodCompilationLevel(m);
         }
     }


### PR DESCRIPTION
Please review this small fix to test runtime/Thread/AsyncExceptionTest.java. On rare cases the methods never reach the desired compilation level so the worker thread just gets blocked and the test times out.
I added a bail out after a couple of seconds of waiting.
Was able to reproduce the issue and checked the test doesn't timeout anymore with the fix.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284303](https://bugs.openjdk.java.net/browse/JDK-8284303): runtime/Thread/AsyncExceptionTest.java timed out


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8097/head:pull/8097` \
`$ git checkout pull/8097`

Update a local copy of the PR: \
`$ git checkout pull/8097` \
`$ git pull https://git.openjdk.java.net/jdk pull/8097/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8097`

View PR using the GUI difftool: \
`$ git pr show -t 8097`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8097.diff">https://git.openjdk.java.net/jdk/pull/8097.diff</a>

</details>
