### PR TITLE
8284308: mismatch between key and content in compiler error message

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -2608,7 +2608,7 @@ compiler.misc.eq.bounds=\
 
 # 0: list of type
 compiler.misc.upper.bounds=\
-        lower bounds: {0}
+        upper bounds: {0}
 
 # 0: list of type, 1: type, 2: type
 compiler.misc.infer.no.conforming.instance.exists=\


### PR DESCRIPTION
This compiler error message:

compiler.misc.upper.bounds=\
        lower bounds: {0}

had a clear mismatch between its key and its contents. It should be:

compiler.misc.upper.bounds=\
        upper bounds: {0}

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284308](https://bugs.openjdk.java.net/browse/JDK-8284308): mismatch between key and content in compiler error message


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8099/head:pull/8099` \
`$ git checkout pull/8099`

Update a local copy of the PR: \
`$ git checkout pull/8099` \
`$ git pull https://git.openjdk.java.net/jdk pull/8099/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8099`

View PR using the GUI difftool: \
`$ git pr show -t 8099`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8099.diff">https://git.openjdk.java.net/jdk/pull/8099.diff</a>

</details>
