### PR TITLE
8284316 : Support accessibility ManualTestFrame.java for non SwingSet tests

### DIFF
--- a/test/jdk/javax/accessibility/manual/SwingSetTest.java
+++ b/test/jdk/javax/accessibility/manual/SwingSetTest.java
@@ -34,7 +34,7 @@ public class SwingSetTest {
         Supplier<TestResult> resultSupplier = ManualTestFrame.showUI(args[0],
                 "Wait for SwingSet2 to load, follow the instructions, select pass or fail. " +
                         "Do not close windows manually.",
-                testInstructionProvider , 10);
+                testInstructionProvider);
 
         String swingSetJar = System.getenv("SWINGSET2_JAR");
         if (swingSetJar == null) {

--- a/test/jdk/javax/accessibility/manual/SwingSetTest.java
+++ b/test/jdk/javax/accessibility/manual/SwingSetTest.java
@@ -1,19 +1,18 @@
 /**
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
  * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
  */
 
 import lib.ManualTestFrame;
 import lib.TestResult;
 
-import javax.imageio.ImageIO;
-import java.io.File;
+import java.util.function.Consumer;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.nio.file.Files;
 import java.util.function.Supplier;
+import javax.swing.JEditorPane;
 
 import static java.io.File.separator;
 
@@ -22,10 +21,21 @@ public class SwingSetTest {
     public static void main(String[] args) throws IOException, InterruptedException,
             ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         System.out.println("test image " + System.getenv("TEST_IMAGE_DIR"));
+
+        Consumer<JEditorPane> testInstructionProvider = e -> {
+            try {
+                e.setContentType("text/html");
+                e.setPage(SwingSetTest.class.getResource(args[0] + ".html"));
+            } catch (IOException exception) {
+                exception.printStackTrace();
+            }
+        };
+
         Supplier<TestResult> resultSupplier = ManualTestFrame.showUI(args[0],
                 "Wait for SwingSet2 to load, follow the instructions, select pass or fail. " +
                         "Do not close windows manually.",
-                SwingSetTest.class.getResource(args[0] + ".html"));
+                testInstructionProvider , 10);
+
         String swingSetJar = System.getenv("SWINGSET2_JAR");
         if (swingSetJar == null) {
             swingSetJar = "file://" + System.getProperty("java.home") +
@@ -37,23 +47,10 @@ public class SwingSetTest {
         System.out.println("Loading SwingSet2 from " + swingSetJar);
         ClassLoader ss = new URLClassLoader(new URL[]{new URL(swingSetJar)});
         ss.loadClass("SwingSet2").getMethod("main", String[].class).invoke(null, (Object)new String[0]);
+
         //this will block until user decision to pass or fail the test
         TestResult result = resultSupplier.get();
-        if (result != null) {
-            System.err.println("Failure reason: \n" + result.getFailureDescription());
-            if (result.getScreenCapture() != null) {
-                File screenDump = new File(System.getProperty("test.classes") + separator + args[0] + ".png");
-                System.err.println("Saving screen image to " + screenDump.getAbsolutePath());
-                ImageIO.write(result.getScreenCapture(), "png", screenDump);
-            }
-            Throwable e = result.getException();
-            if (e != null) {
-                throw new RuntimeException(e);
-            } else {
-                if (!result.getStatus()) throw new RuntimeException("Test failed!");
-            }
-        } else {
-            throw new RuntimeException("No result returned!");
-        }
+        ManualTestFrame.handleResult(result, args[0]);
     }
 }
+

--- a/test/jdk/javax/accessibility/manual/TestJProgressBarAccessibility.java
+++ b/test/jdk/javax/accessibility/manual/TestJProgressBarAccessibility.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/*
+@test
+@key headful
+@summary manual test for accessibility JProgressBar
+@run main/manual TestJProgressBarAccessibility
+*/
+
+import java.awt.BorderLayout;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import javax.accessibility.AccessibleContext;
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.JProgressBar;
+import javax.swing.SwingUtilities;
+
+import lib.ManualTestFrame;
+import lib.TestResult;
+
+public class TestJProgressBarAccessibility {
+
+    private static JFrame frame;
+    private static volatile int value = 10;
+    private static final String instruction = """
+            Aim : Check whether JProgressBar value is read in case of VoiceOver or
+            Screen magnifier shows the magnified value in case of Screen magnifier is enabled
+            1) Move the mouse pointer over the JProgressBar and if you
+            hear the JProgressBar value in case of VoiceOver then the test pass else fail.
+            2) Move the mouse pointer over the JProgressBar and if you see the magnified value
+            when Screen magnifier is enabled then the test pass else fail.
+            """;
+
+    private static void createTestUI() throws InterruptedException, InvocationTargetException {
+        SwingUtilities.invokeAndWait(() -> {
+            frame = new JFrame("Test JProgressBar accessibility");
+            JProgressBar progressBar = new JProgressBar();
+            progressBar.setValue(value);
+            progressBar.setStringPainted(true);
+
+            progressBar.addMouseListener(new MouseAdapter() {
+                @Override
+                public void mouseClicked(MouseEvent e) {
+                    super.mouseClicked(e);
+                    if ( value == 100) {
+                        value = 0;
+                    } else {
+                        value += 5;
+                    }
+                    progressBar.setValue(value);
+                }
+            });
+
+            AccessibleContext accessibleContext =
+                    progressBar.getAccessibleContext();
+            accessibleContext.setAccessibleName("JProgressBar accessibility name");
+            accessibleContext.setAccessibleDescription("Jprogress accessibility " +
+                    "description");
+
+            frame.getContentPane().add(progressBar, BorderLayout.CENTER);
+
+            frame.setSize(200,200);
+            frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+            frame.setLocationRelativeTo(null);
+            frame.setVisible(true);
+        });
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException, IOException {
+
+        Consumer<JEditorPane> testInstProvider = e -> {
+            e.setContentType("text/plain");
+            e.setText(instruction);
+        };
+
+        Supplier<TestResult> resultSupplier = ManualTestFrame.showUI(
+                "JProgressBar " +
+                        "Accessibility Test" , "Wait until the Test UI is " +
+                        "seen" , testInstProvider , 3);
+
+        // Create and show TestUI
+        createTestUI();
+
+        //this will block until user decision to pass or fail the test
+        TestResult  testResult = resultSupplier.get();
+        ManualTestFrame.handleResult(testResult,"TestJProgressBarAccessibility");
+    }
+}
+

--- a/test/jdk/javax/accessibility/manual/TestJProgressBarAccessibility.java
+++ b/test/jdk/javax/accessibility/manual/TestJProgressBarAccessibility.java
@@ -103,8 +103,8 @@ public class TestJProgressBarAccessibility {
 
         Supplier<TestResult> resultSupplier = ManualTestFrame.showUI(
                 "JProgressBar " +
-                        "Accessibility Test" , "Wait until the Test UI is " +
-                        "seen" , testInstProvider , 3);
+                        "Accessibility Test", "Wait until the Test UI is " +
+                        "seen", testInstProvider);
 
         // Create and show TestUI
         createTestUI();

--- a/test/jdk/javax/accessibility/manual/TestJProgressBarAccessibility.java
+++ b/test/jdk/javax/accessibility/manual/TestJProgressBarAccessibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/accessibility/manual/lib/DescriptionPane.java
+++ b/test/jdk/javax/accessibility/manual/lib/DescriptionPane.java
@@ -20,26 +20,26 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package lib;
 
-import javax.swing.JEditorPane;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.io.IOException;
-import java.net.URL;
+import java.util.function.Consumer;
+import javax.swing.JEditorPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
 
 /**
  * Displays instructions provided through a URL.
  */
 class DescriptionPane extends JPanel {
 
-    DescriptionPane(URL instructions) throws IOException {
+    DescriptionPane(Consumer<JEditorPane> instructions) {
         JEditorPane editorPane = new JEditorPane();
         editorPane.setFocusable(false);
-        editorPane.setContentType("text/html");
-        editorPane.setPage(instructions);
+        instructions.accept(editorPane);
         editorPane.setEditable(false);
 
         JScrollPane esp = new JScrollPane(editorPane);
@@ -51,3 +51,4 @@ class DescriptionPane extends JPanel {
         add(esp);
     }
 }
+

--- a/test/jdk/javax/accessibility/manual/lib/ManualTestFrame.java
+++ b/test/jdk/javax/accessibility/manual/lib/ManualTestFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -132,16 +132,17 @@ public class ManualTestFrame extends JFrame {
 
     /**
      * Show a test control frame which allows a user to either pass or fail the test.
-     * @param testName
-     * @param headerText
-     * @param instructions
+     *
+     * @param testName     name of the testcase
+     * @param headerText   information to the user to wait for the test frame.
+     * @param instructions test instruction for the user
      * @return Returning supplier blocks till the test is passed or failed by the user.
-     * @throws InterruptedException
-     * @throws InvocationTargetException
+     * @throws InterruptedException      exception
+     * @throws InvocationTargetException exception
      */
     public static Supplier<TestResult> showUI(String testName,
                                               String headerText,
-                                              Consumer<JEditorPane> instructions , int timeout)
+                                              Consumer<JEditorPane> instructions)
             throws InterruptedException, InvocationTargetException {
         AtomicReference<TestResult> resultContainer = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);
@@ -158,6 +159,8 @@ public class ManualTestFrame extends JFrame {
         });
         return () -> {
             try {
+		int timeout = Integer.getInteger("timeout", 3);
+                System.out.println("timeout value : " + timeout);
                 if (!latch.await(timeout, TimeUnit.MINUTES)) {
                     throw new RuntimeException("Timeout : User failed to " +
                             "take decision on the test result.");
@@ -173,11 +176,11 @@ public class ManualTestFrame extends JFrame {
      * Checks the TestResult after user interacted with the manual TestFrame
      * and the test UI.
      *
-     * @param result
+     * @param result   Instance of the TestResult
      * @param testName name of the testcase
-     * @throws IOException
+     * @throws IOException exception
      */
-    public static void handleResult(TestResult result , String testName) throws IOException {
+    public static void handleResult(TestResult result, String testName) throws IOException {
         if (result != null) {
             System.err.println("Failure reason: \n" + result.getFailureDescription());
             if (result.getScreenCapture() != null) {
@@ -189,7 +192,8 @@ public class ManualTestFrame extends JFrame {
             if (e != null) {
                 throw new RuntimeException(e);
             } else {
-                if (!result.getStatus()) throw new RuntimeException("Test failed!");
+                if (!result.getStatus())
+                    throw new RuntimeException("Test failed!");
             }
         } else {
             throw new RuntimeException("No result returned!");

--- a/test/jdk/javax/accessibility/manual/lib/ManualTestFrame.java
+++ b/test/jdk/javax/accessibility/manual/lib/ManualTestFrame.java
@@ -159,7 +159,7 @@ public class ManualTestFrame extends JFrame {
         });
         return () -> {
             try {
-		int timeout = Integer.getInteger("timeout", 3);
+                int timeout = Integer.getInteger("timeout", 10);
                 System.out.println("timeout value : " + timeout);
                 if (!latch.await(timeout, TimeUnit.MINUTES)) {
                     throw new RuntimeException("Timeout : User failed to " +


### PR DESCRIPTION
1) Modified  ManualTestFrame.java to support non SwingSet2 and this include modification of SwingSetTest.java
2) Added new TestJProgressBarAccessibility.java testcase that uses ManualTestFrame
3) Added timeout support in case user does not interact with the ManualTestFrame 

@shurymury
@azuev-java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [JDK-8284316](https://bugs.openjdk.java.net/browse/JDK-8284316): Support accessibility ManualTestFrame.java for non SwingSet tests


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8100/head:pull/8100` \
`$ git checkout pull/8100`

Update a local copy of the PR: \
`$ git checkout pull/8100` \
`$ git pull https://git.openjdk.java.net/jdk pull/8100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8100`

View PR using the GUI difftool: \
`$ git pr show -t 8100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8100.diff">https://git.openjdk.java.net/jdk/pull/8100.diff</a>

</details>
