### PR TITLE
JDK-8283714: REDO - Unexpected TypeElement in ANALYZE TaskEvent

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1305,7 +1305,7 @@ public class JavaCompiler {
             log.printVerbose("checking.attribution", env.enclClass.sym);
 
         if (!taskListener.isEmpty()) {
-            TaskEvent e = new TaskEvent(TaskEvent.Kind.ANALYZE, env.toplevel, env.enclClass.sym);
+            TaskEvent e = newAnalyzeTaskEvent(env);
             taskListener.started(e);
         }
 
@@ -1390,10 +1390,28 @@ public class JavaCompiler {
         }
         finally {
             if (!taskListener.isEmpty()) {
-                TaskEvent e = new TaskEvent(TaskEvent.Kind.ANALYZE, env.toplevel, env.enclClass.sym);
+                TaskEvent e = newAnalyzeTaskEvent(env);
                 taskListener.finished(e);
             }
         }
+    }
+
+    private TaskEvent newAnalyzeTaskEvent(Env<AttrContext> env) {
+        JCCompilationUnit toplevel = env.toplevel;
+        ClassSymbol sym;
+        if (env.enclClass.sym == syms.predefClass) {
+            if (TreeInfo.isModuleInfo(toplevel)) {
+                sym = toplevel.modle.module_info;
+            } else if (TreeInfo.isPackageInfo(toplevel)) {
+                sym = toplevel.packge.package_info;
+            } else {
+                throw new IllegalStateException("unknown env.toplevel");
+            }
+        } else {
+            sym = env.enclClass.sym;
+        }
+
+        return new TaskEvent(TaskEvent.Kind.ANALYZE, toplevel, sym);
     }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/model/JavacElements.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/model/JavacElements.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -445,10 +445,8 @@ public class JavacElements implements Elements {
 
     @DefinedBy(Api.LANGUAGE_MODEL)
     public PackageElement getPackageOf(Element e) {
-        if (e.getKind() == ElementKind.MODULE)
-            return null;
-        else
-            return cast(Symbol.class, e).packge();
+        Symbol sym = cast(Symbol.class, e);
+        return (sym.kind == MDL || sym.owner.kind == MDL) ? null : sym.packge();
     }
 
     @DefinedBy(Api.LANGUAGE_MODEL)
@@ -456,7 +454,9 @@ public class JavacElements implements Elements {
         Symbol sym = cast(Symbol.class, e);
         if (modules.getDefaultModule() == syms.noModule)
             return null;
-        return (sym.kind == MDL) ? ((ModuleElement) e) : sym.packge().modle;
+        return (sym.kind == MDL) ? ((ModuleElement) e)
+                : (sym.owner.kind == MDL) ? (ModuleElement) sym.owner
+                : sym.packge().modle;
     }
 
     @DefinedBy(Api.LANGUAGE_MODEL)

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
@@ -30,10 +30,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.ModuleElement;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 
 import com.sun.source.doctree.AttributeTree;
@@ -162,7 +164,10 @@ public class CommentHelper {
             return null;
         }
         DocTrees doctrees = configuration.docEnv.getDocTrees();
-        return doctrees.getElement(docTreePath);
+        // Workaround JDK-8284193
+        // DocTrees.getElement(DocTreePath) returns javac-internal Symbols
+        var e = doctrees.getElement(docTreePath);
+        return e == null || e.getKind() == ElementKind.CLASS && e.asType().getKind() != TypeKind.DECLARED ? null : e;
     }
 
     public TypeMirror getType(ReferenceTree rtree) {

--- a/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTagletPrimitive.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTagletPrimitive.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug      8284030
+ * @summary  LinkFactory should not attempt to link to primitive types
+ * @library  /tools/lib ../../lib
+ * @modules  jdk.javadoc/jdk.javadoc.internal.tool
+ * @build    toolbox.ToolBox javadoc.tester.*
+ * @run main TestLinkTagletPrimitive
+ */
+
+import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class TestLinkTagletPrimitive extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        TestLinkTagletPrimitive tester = new TestLinkTagletPrimitive();
+        tester.runTests();
+    }
+
+    ToolBox tb = new ToolBox();
+
+    @Test
+    public void testSimple(Path base) throws IOException {
+        Path src = base.resolve("src");
+
+        tb.writeJavaFiles(src, """
+                /**
+                 * Comment.
+                 * Byte: {@link byte}
+                 * Void: {@link void}
+                 */
+                public class C {\s
+                    private C() { }
+                }
+                """);
+
+        javadoc("-Xdoclint:none",
+                "-d", base.resolve("api").toString(),
+                "-sourcepath", src.toString(),
+                src.resolve("C.java").toString());
+        checkExit(Exit.OK);
+
+        checkOutput("C.html", true,
+                """
+                    <div class="block">Comment.
+                     Byte:\s
+                    <details class="invalid-tag">
+                    <summary>invalid @link</summary>
+                    <pre><code>byte</code></pre>
+                    </details>
+                                        
+                     Void:\s
+                    <details class="invalid-tag">
+                    <summary>invalid @link</summary>
+                    <pre><code>void</code></pre>
+                    </details>
+                    </div>
+                    """);
+    }
+    @Test
+    public void testArray(Path base) throws IOException {
+        Path src = base.resolve("src");
+
+        tb.writeJavaFiles(src, """
+                /**
+                 * Comment.
+                 * Byte[]: {@link byte[]}
+                 */
+                public class C {\s
+                    private C() { }
+                }
+                """);
+
+        javadoc("-Xdoclint:none",
+                "-d", base.resolve("api").toString(),
+                "-sourcepath", src.toString(),
+                src.resolve("C.java").toString());
+        checkExit(Exit.OK);
+
+        checkOutput("C.html", true,
+                """
+                    <div class="block">Comment.
+                     Byte[]:\s
+                    <details class="invalid-tag">
+                    <summary>invalid @link</summary>
+                    <pre><code>byte[]</code></pre>
+                    </details>
+                    </div>
+                    """);
+    }
+}

--- a/test/langtools/tools/javac/api/taskListeners/TestTypeElement.java
+++ b/test/langtools/tools/javac/api/taskListeners/TestTypeElement.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8283661 8283714
+ * @summary Unexpected TypeElement in ANALYZE TaskEvent
+ * @modules jdk.compiler
+ * @run main TestTypeElement
+ */
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.ToolProvider;
+
+import com.sun.source.util.JavacTask;
+import com.sun.source.util.TaskEvent;
+import com.sun.source.util.TaskListener;
+
+public class TestTypeElement {
+    public static void main(String... args) throws Exception {
+        new TestTypeElement().run();
+    }
+
+    private PrintStream log;
+    private Elements elements;
+    private int errors;
+
+    void run() throws Exception {
+        log = System.err;
+
+        List<JavaFileObject> files = List.of(
+                createFileObject("module-info.java", "module m { }"),
+                createFileObject("p/package-info.java", "/** Comment. */ package p;"),
+                createFileObject("p/C.java", "package p; public class C { }")
+        );
+
+        JavaCompiler c = ToolProvider.getSystemJavaCompiler();
+        JavacTask t = (JavacTask) c.getTask(null, null, null,  List.of("-d", "classes"), null, files);
+        t.addTaskListener(new TaskListener() {
+            @Override
+            public void started(TaskEvent e) {
+                log.println("started: " + e);
+                checkTypeElement(e);
+            }
+            @Override
+            public void finished(TaskEvent e) {
+                log.println("finished: " + e);
+                checkTypeElement(e);
+            }
+        });
+        elements = t.getElements();
+        t.call();
+
+        if (errors > 0) {
+            log.println(errors + " errors occurred");
+            throw new Exception(errors + " errors occurred");
+        }
+    }
+
+    private void checkTypeElement(TaskEvent e) {
+        TypeElement te = e.getTypeElement();
+
+        if (te != null) {
+            showTypeElement(e.getTypeElement());
+        }
+
+        switch (e.getKind()) {
+            case COMPILATION, PARSE, ENTER -> {
+                checkEqual(te, null);
+            }
+
+            case ANALYZE, GENERATE -> {
+                if (te == null) {
+                    error("type element is null");
+                    return;
+                }
+
+
+                switch (te.getQualifiedName().toString()) {
+                    case "m.module-info" -> {
+                        checkEqual(elements.getModuleOf(te), elements.getModuleElement("m"));
+                        checkEqual(elements.getPackageOf(te), null);
+                    }
+                    case "p.package-info", "p.C" -> {
+                        checkEqual(elements.getModuleOf(te), elements.getModuleElement("m"));
+                        checkEqual(elements.getPackageOf(te), elements.getPackageElement("p"));
+                    }
+                }
+            }
+        }
+    }
+
+    private void showTypeElement(TypeElement e) {
+        log.println("type element: " + e);
+
+        try {
+            log.println("    module element: " + elements.getModuleOf(e));
+        } catch (Throwable t) {
+            log.println("    module element: " + t);
+        }
+
+        try {
+            log.println("    package element: " + elements.getPackageOf(e));
+        } catch (Throwable t) {
+            log.println("    package element: " + t);
+        }
+    }
+
+    private <T> void checkEqual(T found, T expected) {
+        if (found != expected) {
+            error("mismatch");
+            log.println("   found: " + found);
+            log.println("expected: " + expected);
+        }
+    }
+
+    private void error(String message) {
+        log.println("Error: " + message);
+        errors++;
+    }
+
+    private JavaFileObject createFileObject(String name, String body) {
+        return createFileObject(name, JavaFileObject.Kind.SOURCE, body);
+    }
+
+    private JavaFileObject createFileObject(String name, JavaFileObject.Kind kind, String body) {
+        try {
+            return new SimpleJavaFileObject(new URI("myfo:///" + name), kind) {
+                @Override
+                public CharSequence getCharContent(boolean ignoreEncodingErrors) throws IOException {
+                    return body;
+                }
+            };
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(name, e);
+        }
+    }
+}


### PR DESCRIPTION
This is a redo of a recent fix, which passed all tier1 tests but broke "make docs".

The reason for the crash was a combination of a number of factors, such that fixing any one (or more) would make the problem go away, making it hard(er) to determine the correct path forward.

1. In a doc comment in JDK code, the author had mistakenly written a number of tags like `{@link byte}` instead of `{@code byte}` and `{@link byte[]}` instead of `{@code byte[]}`

2. `DocTrees.getElement` returns the javac-internal symbol for primitive types (instead of `null`) and the base type for arrays. So for both `{@link byte}` and `{@link byte[]}` the `LinkFactory` was given a javac-internal symbol (instead of null).  Filed as JDK-8284315.

3. Thinking the value was a declared type, and so in a named or unnamed package, the `LinkFactory` attempts to create a link based on the package of the value.    The package for the java-internal symbols for primitive type is a special `rootPackage` which has no equivalent in the Language Model world, and which has a `null` owner.

4. The new code in `JavacElements.getModuleOf` assumes that (as is generally standard in javac) all symbols have a non-`null` owner, this giving an NPE when called with `rootPackage`.

So, there are various possible ways to fix this.

1. put a broad null check for `sym.owner` in `JavacElements.getModuleOf`
2. put a specific check for `rootPackage` in `JavacElements.getMOduleOf`
3. fix `DocTrees.getElement` to not return javac-internal symbols
4. change javadoc to workaround the issue with `DocTrees.getElement`
5. fix the javadoc comments to not use bad forms, like `{@link byte}` etc.

1 and 2 would both be atypical idioms in the code.

3 is desirable, but may cause additional work/updates/etc. It would be a change to the behavior of a public API, and so compatibility concerns would need to be addressed, although arguably the change in behavior is a bug fix, not a spec change. (The current behavior is under-specified!)

By itself, 5 would just be ignoring the underlying problem.

That leaves 4, which is the solution adopted here. It localizes the change/check to javadoc internal code. It is an interim measure until we can fix 3. (JDK-8284315)

* The javac part of the fix is essentially the same as before (a redundant import has been removed, this time.)  By itself the code was not wrong, when used as intended.

* `DocTrees.getElement` is called from a single place in javadoc, in `CommentHelper` and so a check is made on the result such that `null` is returned when the result would otherwise not be a declared type.

* A new (javadoc) test is added to verify the new behavior for `{@link byte}` etc. The prior behavior (even before the original fix) was to display the type in monospace font.  The new behavior is for javadoc to fall back on the recently-new mechanism to display a "invalid tag" block.

With these fixes, "make docs" works, and does not crash(!) Comparing the result of "make docs" before and after this fix, the only significant differences arise from the 5 bad `{@link ...}` tags in `MemorySegment.java`. These should (separately) be fixed. 



