### PR TITLE
8284330: jcmd may not be able to find processes in the container

### DIFF
--- a/src/jdk.internal.jvmstat/linux/classes/sun/jvmstat/PlatformSupportImpl.java
+++ b/src/jdk.internal.jvmstat/linux/classes/sun/jvmstat/PlatformSupportImpl.java
@@ -108,13 +108,12 @@ public class PlatformSupportImpl extends PlatformSupport {
      *
      * 1. duplication of tmp directories
      *
-     * /proc/{hostpid}/root/tmp directories exist for many processes
-     * that are running on a Linux kernel that has cgroups enabled even
-     * if they are not running in a container.  To avoid this duplication,
-     * we compare the inode of the /proc tmp directories to /tmp and
-     * skip these duplicated directories.
-     * Host and container devices could have the same inode value,
-     * so we also need to check the device id.
+     * When cgroups is enabled, the directory /proc/{pid}/root/tmp may
+     * exist even if the given pid is not running inside a container. In
+     * this case, this directory is usually the same as /tmp and should
+     * be skipped, or else we would get duplicated hsperfdata files.
+     * This case can be detected if the inode and device id of
+     * /proc/{pid}/root/tmp are the same as /tmp.
      *
      * 2. Containerized processes without PID namespaces being enabled.
      *

--- a/src/jdk.internal.jvmstat/linux/classes/sun/jvmstat/PlatformSupportImpl.java
+++ b/src/jdk.internal.jvmstat/linux/classes/sun/jvmstat/PlatformSupportImpl.java
@@ -56,7 +56,7 @@ public class PlatformSupportImpl extends PlatformSupport {
         }
     }
 
-    private boolean isSameWithTemporaryDirectory(Path p) {
+    private boolean tempDirectoryEquals(Path p) {
         try {
             long ino = (Long)Files.getAttribute(p, "unix:ino");
             long dev = (Long)Files.getAttribute(p, "unix:dev");
@@ -113,8 +113,8 @@ public class PlatformSupportImpl extends PlatformSupport {
      * if they are not running in a container.  To avoid this duplication,
      * we compare the inode of the /proc tmp directories to /tmp and
      * skip these duplicated directories.
-     * inode maybe same value between other devices in some case.
-     * So we also need to check device id.
+     * Host and container devices could have the same inode value,
+     * so we also need to check the device id.
      *
      * 2. Containerized processes without PID namespaces being enabled.
      *
@@ -161,7 +161,7 @@ public class PlatformSupportImpl extends PlatformSupport {
 
             if (containerFile.exists() && containerFile.isDirectory() &&
                 containerFile.canRead() &&
-                !isSameWithTemporaryDirectory(containerFile.toPath())) {
+                !tempDirectoryEquals(containerFile.toPath())) {
                 v.add(containerTmpDir);
             }
         }


### PR DESCRIPTION
jcmd uses src/jdk.internal.jvmstat/linux/classes/sun/jvmstat/PlatformSupportImpl.java to scan temporary directories to find out processes in the container. It checks inode to ensure the temp directory is not conflicted. However inode maybe same value between the container and others. Thus we should check device id for that case.

For example I saw following case on [distroless cc-debian11](https://github.com/GoogleContainerTools/distroless/blob/main/cc/README.md) container. I started rescue:jdk19 container with sharing PID namespace. `/proc/1/root/tmp` is different from `/tmp` on rescue:jdk19, but they are same inode value. However we can see the differense in device id.

```
$ podman run -it --rm --entrypoint=sh --pid=container:fa39662f7352 rescue:jdk19
/ #
/ # stat /tmp
  File: /tmp
  Size: 29              Blocks: 0          IO Block: 4096   directory
Device: efh/239d        Inode: 135674931   Links: 1
Access: (1777/drwxrwxrwt)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 2022-04-05 08:51:37.000000000
Modify: 2022-04-05 08:51:37.000000000
Change: 2022-04-05 08:51:37.000000000

/ # stat /proc/1/root/tmp
  File: /proc/1/root/tmp
  Size: 29              Blocks: 0          IO Block: 4096   directory
Device: e1h/225d        Inode: 135674931   Links: 1
Access: (1777/drwxrwxrwt)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 2022-04-05 08:51:37.000000000
Modify: 2022-04-05 08:50:42.000000000
Change: 2022-04-05 08:50:42.000000000
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284330](https://bugs.openjdk.java.net/browse/JDK-8284330): jcmd may not be able to find processes in the container


### Reviewers
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to 0e0ccbe0f2c7ee223e2672151ba98c54c5d77bc1
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to 0e0ccbe0f2c7ee223e2672151ba98c54c5d77bc1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8103/head:pull/8103` \
`$ git checkout pull/8103`

Update a local copy of the PR: \
`$ git checkout pull/8103` \
`$ git pull https://git.openjdk.java.net/jdk pull/8103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8103`

View PR using the GUI difftool: \
`$ git pr show -t 8103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8103.diff">https://git.openjdk.java.net/jdk/pull/8103.diff</a>

</details>
