### PR TITLE
8282506: Clean up remaining references to TwoStacksPlain*SocketImpl

### DIFF
--- a/test/jdk/java/net/DatagramSocket/UnreferencedDatagramSockets.java
+++ b/test/jdk/java/net/DatagramSocket/UnreferencedDatagramSockets.java
@@ -232,19 +232,6 @@ public class UnreferencedDatagramSockets {
                 fileDescriptorField.setAccessible(true);
                 FileDescriptor fileDescriptor = (FileDescriptor) fileDescriptorField.get(datagramSocketImpl);
                 extractRefs(fileDescriptor, name);
-
-                Class<?> socketImplClass = datagramSocketImpl.getClass();
-                System.out.printf("socketImplClass: %s%n", socketImplClass);
-                if (socketImplClass.getName().equals("java.net.TwoStacksPlainDatagramSocketImpl")) {
-                    Field fileDescriptor1Field = socketImplClass.getDeclaredField("fd1");
-                    fileDescriptor1Field.setAccessible(true);
-                    FileDescriptor fileDescriptor1 = (FileDescriptor) fileDescriptor1Field.get(datagramSocketImpl);
-                    extractRefs(fileDescriptor1, name + "::twoStacksFd1");
-
-                } else {
-                    System.out.printf("socketImpl class name not matched: %s != %s%n",
-                            socketImplClass.getName(), "java.net.TwoStacksPlainDatagramSocketImpl");
-                }
             }
         } catch (Exception ex) {
             ex.printStackTrace();

--- a/test/jdk/java/net/MulticastSocket/UnreferencedMulticastSockets.java
+++ b/test/jdk/java/net/MulticastSocket/UnreferencedMulticastSockets.java
@@ -270,19 +270,6 @@ public class UnreferencedMulticastSockets {
                 fileDescriptorField.setAccessible(true);
                 FileDescriptor fileDescriptor = (FileDescriptor) fileDescriptorField.get(datagramSocketImpl);
                 extractRefs(fileDescriptor, name);
-
-                Class<?> socketImplClass = datagramSocketImpl.getClass();
-                System.out.printf("socketImplClass: %s%n", socketImplClass);
-                if (socketImplClass.getName().equals("java.net.TwoStacksPlainDatagramSocketImpl")) {
-                    Field fileDescriptor1Field = socketImplClass.getDeclaredField("fd1");
-                    fileDescriptor1Field.setAccessible(true);
-                    FileDescriptor fileDescriptor1 = (FileDescriptor) fileDescriptor1Field.get(datagramSocketImpl);
-                    extractRefs(fileDescriptor1, name + "::twoStacksFd1");
-
-                } else {
-                    System.out.printf("socketImpl class name not matched: %s != %s%n",
-                            socketImplClass.getName(), "java.net.TwoStacksPlainDatagramSocketImpl");
-                }
             }
         } catch (Exception ex) {
             ex.printStackTrace();

--- a/test/jdk/java/net/ServerSocket/UnreferencedSockets.java
+++ b/test/jdk/java/net/ServerSocket/UnreferencedSockets.java
@@ -185,16 +185,6 @@ public class UnreferencedSockets {
             fileDescriptorField.setAccessible(true);
             FileDescriptor fileDescriptor = (FileDescriptor) fileDescriptorField.get(socketImpl);
             extractRefs(fileDescriptor, name);
-
-            Class<?> socketImplClass = socketImpl.getClass();
-            System.out.printf("socketImplClass: %s%n", socketImplClass);
-            if (socketImplClass.getClass().getName().equals("java.net.TwoStacksPlainSocketImpl")) {
-                Field fileDescriptor1Field = socketImplClass.getDeclaredField("fd1");
-                fileDescriptor1Field.setAccessible(true);
-                FileDescriptor fileDescriptor1 = (FileDescriptor) fileDescriptor1Field.get(socketImpl);
-                extractRefs(fileDescriptor1, name + "::twoStacksFd1");
-
-            }
         } catch (NoSuchFieldException | IllegalAccessException ex) {
             ex.printStackTrace();
             throw new AssertionError("missing field", ex);


### PR DESCRIPTION
The classes `TwoStacksPlainDatagramSocketImpl` and `TwoStacksPlainSocketImpl` were removed long ago. This patch cleans up the remaining references from the test code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282506](https://bugs.openjdk.java.net/browse/JDK-8282506): Clean up remaining references to TwoStacksPlain*SocketImpl


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8104/head:pull/8104` \
`$ git checkout pull/8104`

Update a local copy of the PR: \
`$ git checkout pull/8104` \
`$ git pull https://git.openjdk.java.net/jdk pull/8104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8104`

View PR using the GUI difftool: \
`$ git pr show -t 8104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8104.diff">https://git.openjdk.java.net/jdk/pull/8104.diff</a>

</details>
