### PR TITLE
8284331: Add sanity check for signal handler modification warning.

### DIFF
--- a/test/jdk/sun/tools/jcmd/TestJcmdSanity.java
+++ b/test/jdk/sun/tools/jcmd/TestJcmdSanity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.util.List;
 
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.Platform;
 import jdk.test.lib.Utils;
 
 /*
@@ -57,6 +58,7 @@ public class TestJcmdSanity {
         testJcmdPid_f();
         testJcmdPidPerfCounterPrint();
         testJcmdPidBigScript();
+        testJcmdPidVMinfo();
     }
 
     /**
@@ -164,4 +166,21 @@ public class TestJcmdSanity {
                 "The ouput should contain all content of " + path.toAbsolutePath());
     }
 
+    /**
+     * Sanity check for VM.info
+     */
+    private static void testJcmdPidVMinfo() throws Exception {
+        OutputAnalyzer output = JcmdBase.jcmd(VM_ARGS, new String[] {"VM.info"});
+        output.shouldHaveExitValue(0);
+        output.shouldContain(Long.toString(ProcessTools.getProcessId()) + ":");
+
+        // Should find the signal handler summary (except on Windows):
+        if (!Platform.isWindows()) {
+          output.shouldContain("Signal Handlers:");
+          // Should not find any of the possible signal handler modification warnings:
+          output.shouldNotContain(" handler modified!"); // e.g. Warning: SIGILL handler modified!
+          output.shouldNotContain("*** Handler was modified!");
+          output.shouldNotContain("*** Expected: "); // e.g. *** Expected: javaSignalHandler in ...
+        }
+    }
 }


### PR DESCRIPTION
A sanity check using "jcmd VM.info" to catch the signal handler modification warning: it should never trigger during this test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284331](https://bugs.openjdk.java.net/browse/JDK-8284331): Add sanity check for signal handler modification warning.


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8106/head:pull/8106` \
`$ git checkout pull/8106`

Update a local copy of the PR: \
`$ git checkout pull/8106` \
`$ git pull https://git.openjdk.java.net/jdk pull/8106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8106`

View PR using the GUI difftool: \
`$ git pr show -t 8106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8106.diff">https://git.openjdk.java.net/jdk/pull/8106.diff</a>

</details>
