### PR TITLE
8284299: Handle inheritDoc misuse more gracefully

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets.properties
@@ -115,6 +115,7 @@ doclet.Version=Version:
 doclet.Factory=Factory:
 doclet.UnknownTag={0} is an unknown tag.
 doclet.UnknownTagLowercase={0} is an unknown tag -- same as a known tag except for case.
+doclet.unsuitableInheritDocContext=@inheritDoc cannot be used in this context
 doclet.noInheritedDoc=@inheritDoc used but {0} does not override or implement any method.
 doclet.tag_misuse=Tag {0} cannot be used in {1} documentation.  It can only be used in the following types of documentation: {2}.
 doclet.Package_Summary=Package Summary

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/InheritDocTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/InheritDocTaglet.java
@@ -87,7 +87,8 @@ public class InheritDocTaglet extends BaseTaglet {
                         ? utils.flatSignature((ExecutableElement)e, writer.getCurrentPageElement())
                         : "");
                 //This tag does not support inheritance.
-                messages.warning(e, "doclet.noInheritedDoc", message);
+                var path = writer.configuration().utils.getCommentHelper(e).getDocTreePath(holderTag);
+                messages.warning(path, "doclet.unsuitableInheritDocContext", message);
                 return replacement;
         }
         Input input = new DocFinder.Input(utils, e,

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/InheritDocTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/InheritDocTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,6 +88,7 @@ public class InheritDocTaglet extends BaseTaglet {
                         : "");
                 //This tag does not support inheritance.
                 messages.warning(e, "doclet.noInheritedDoc", message);
+                return replacement;
         }
         Input input = new DocFinder.Input(utils, e,
                 (InheritableTaglet) inheritableTaglet, new DocFinder.DocTreeInfo(holderTag, e),

--- a/test/langtools/jdk/javadoc/doclet/testInheritDocBadContext/TestInheritDocInappropriateTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testInheritDocBadContext/TestInheritDocInappropriateTag.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8284299
+ * @library /tools/lib ../../lib
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ * @build toolbox.ToolBox javadoc.tester.*
+ * @run main TestInheritDocInappropriateTag
+ */
+
+import java.nio.file.Path;
+
+import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+public class TestInheritDocInappropriateTag extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        new TestInheritDocInappropriateTag()
+                .runTests(m -> new Object[]{Path.of(m.getName())});
+    }
+
+    private final ToolBox tb = new ToolBox();
+
+    @Test
+    public void test(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                """
+                        public class A {
+                            /**
+                             * A.x().
+                             */
+                            public void x() { }
+                        }
+                        """,
+                """
+                        public class B extends A {
+                            /**
+                             * {@summary {@inheritDoc}}
+                             *
+                             * {@link Object#hashCode() {@inheritDoc}}
+                             * {@linkplain Object#hashCode() {@inheritDoc}}
+                             *
+                             * {@index term {@inheritDoc}}
+                             */
+                            @Override
+                            public void x() { }
+                        }
+                        """);
+        javadoc("-d", base.resolve("out").toString(),
+                src.resolve("A.java").toString(),
+                src.resolve("B.java").toString());
+        checkExit(Exit.OK);
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/testInheritDocBadContext/TestInheritDocInappropriateTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testInheritDocBadContext/TestInheritDocInappropriateTag.java
@@ -70,9 +70,31 @@ public class TestInheritDocInappropriateTag extends JavadocTester {
                             public void x() { }
                         }
                         """);
-        javadoc("-d", base.resolve("out").toString(),
+        javadoc("-Xdoclint:none",
+                "-d", base.resolve("out").toString(),
                 src.resolve("A.java").toString(),
                 src.resolve("B.java").toString());
         checkExit(Exit.OK);
+        new OutputChecker(Output.OUT).setExpectOrdered(false).check(
+                """
+                        warning: @inheritDoc cannot be used in this context
+                             * {@summary {@inheritDoc}}
+                               ^
+                        """,
+                """
+                        warning: @inheritDoc cannot be used in this context
+                             * {@link Object#hashCode() {@inheritDoc}}
+                               ^
+                        """,
+                """
+                        warning: @inheritDoc cannot be used in this context
+                             * {@linkplain Object#hashCode() {@inheritDoc}}
+                               ^
+                        """,
+                """
+                        warning: @inheritDoc cannot be used in this context
+                             * {@index term {@inheritDoc}}
+                               ^
+                        """);
     }
 }


### PR DESCRIPTION
This is a straightforward change that fixes a certain type of crashes and improves diagnosability. For details, see the individual commit messages.

One non-intuitive thing is that I had to specify `-Xdoclint:none` in the test to capture the respective warnings in the output. When I omitted `-Xdoclint` option or specified it in any other way, the warnings would disappear from the console. I know the mechanics of why that happens, but am unsure if it makes sense or is a bug.