### PR TITLE
JDK-8283084 RandomGenerator nextDouble(double, double) is documented incorrectly

### DIFF
--- a/src/java.base/share/classes/java/util/random/RandomGenerator.java
+++ b/src/java.base/share/classes/java/util/random/RandomGenerator.java
@@ -513,11 +513,13 @@ public interface RandomGenerator {
      * @return a pseudorandomly chosen {@code float} value between
      *         zero (inclusive) and the bound (exclusive)
      *
-     * @throws IllegalArgumentException if {@code bound} is not finite
+     * @throws IllegalArgumentException if {@code bound} is not
+     *         both positive and finite
      *
-     * @implSpec The default implementation verifies that {@code bound} is valid
-     *           then invokes {@code nextDouble()} scaling and translating the
-     *           result to fit {@code 0.0f} and {@code bound} (exclusive).
+     * @implSpec The default implementation checks that {@code bound} is a
+     * positive finite float. Then invokes {@code nextFloat()}, scaling
+     * the result so that the final result lies between {@code 0.0f} (inclusive)
+     * and {@code bound} (exclusive).
      */
     default float nextFloat(float bound) {
         RandomSupport.checkBound(bound);
@@ -577,11 +579,13 @@ public interface RandomGenerator {
      * @return a pseudorandomly chosen {@code double} value between
      *         zero (inclusive) and the bound (exclusive)
      *
-     * @throws IllegalArgumentException if {@code bound} is not finite
+     * @throws IllegalArgumentException if {@code bound} is not
+     *         both positive and finite
      *
-     * @implSpec The default implementation verifies that {@code bound} is valid
-     *           then invokes {@code nextDouble()} scaling and translating the
-     *           result to fit {@code 0.0} and {@code bound} (exclusive).
+     * @implSpec The default implementation checks that {@code bound} is a
+     * positive finite double. Then invokes {@code nextDouble()}, scaling
+     * the result so that the final result lies between {@code 0.0} (inclusive)
+     * and {@code bound} (exclusive).
      */
     default double nextDouble(double bound) {
         RandomSupport.checkBound(bound);

--- a/src/java.base/share/classes/java/util/random/RandomGenerator.java
+++ b/src/java.base/share/classes/java/util/random/RandomGenerator.java
@@ -513,19 +513,11 @@ public interface RandomGenerator {
      * @return a pseudorandomly chosen {@code float} value between
      *         zero (inclusive) and the bound (exclusive)
      *
-     * @throws IllegalArgumentException if {@code origin} is not finite,
-     *         or {@code bound} is not finite, or {@code origin}
-     *         is greater than or equal to {@code bound}, or
-     *         the difference between {@code bound} and {@code origin}
-     *         is so large that it cannot be represented as a finite
-     *         {@code float} value
+     * @throws IllegalArgumentException if {@code bound} is not finite
      *
-     * @implSpec The default implementation checks if {@code origin} is not finite,
-     *         or {@code bound} is not finite, or {@code origin}
-     *         is greater than or equal to {@code bound}, or
-     *         the difference between {@code bound} and {@code origin}
-     *         is so large that it cannot be represented as a finite
-     *         {@code float} value
+     * @implSpec The default implementation verifies that {@code bound} is valid
+     *           then invokes {@code nextDouble()} scaling and translating the
+     *           result to fit {@code 0.0f} and {@code bound} (exclusive).
      */
     default float nextFloat(float bound) {
         RandomSupport.checkBound(bound);
@@ -548,14 +540,12 @@ public interface RandomGenerator {
      *         is greater than or equal to {@code bound}, or
      *         the difference between {@code bound} and {@code origin}
      *         is so large that it cannot be represented as a finite
-     *         {@code double} value
+     *         {@code float} value
      *
-     * @implSpec The default implementation checks if {@code origin} is not finite,
-     *         or {@code bound} is not finite, or {@code origin}
-     *         is greater than or equal to {@code bound}, or
-     *         the difference between {@code bound} and {@code origin}
-     *         is so large that it cannot be represented as a finite
-     *         {@code double} value
+     * @implSpec The default implementation verifies that the {@code origin}
+     *           and {@code bound} are valid then invokes {@code nextFloat()}
+     *           scaling and translating the result to fit {@code origin} and
+     *           {@code bound} (exclusive).
      */
     default float nextFloat(float origin, float bound) {
         RandomSupport.checkRange(origin, bound);
@@ -587,13 +577,11 @@ public interface RandomGenerator {
      * @return a pseudorandomly chosen {@code double} value between
      *         zero (inclusive) and the bound (exclusive)
      *
-     * @throws IllegalArgumentException if {@code bound} is not
-     *         both positive and finite
+     * @throws IllegalArgumentException if {@code bound} is not finite
      *
-     * @implSpec The default implementation checks that {@code bound} is a
-     * positive finite double. Then invokes {@code nextDouble()}, scaling
-     * the result so that the final result lies between {@code 0.0} (inclusive)
-     * and {@code bound} (exclusive).
+     * @implSpec The default implementation verifies that {@code bound} is valid
+     *           then invokes {@code nextDouble()} scaling and translating the
+     *           result to fit {@code 0.0} and {@code bound} (exclusive).
      */
     default double nextDouble(double bound) {
         RandomSupport.checkBound(bound);
@@ -613,13 +601,15 @@ public interface RandomGenerator {
      *
      * @throws IllegalArgumentException if {@code origin} is not finite,
      *         or {@code bound} is not finite, or {@code origin}
-     *         is greater than or equal to {@code bound}
+     *         is greater than or equal to {@code bound}, or
+     *         the difference between {@code bound} and {@code origin}
+     *         is so large that it cannot be represented as a finite
+     *         {@code double} value
      *
-     * @implSpec The default implementation checks that {@code origin} and
-     * {@code bound} are positive finite doubles. Then calls
-     * {@code nextDouble()}, scaling and translating the result so that the final
-     * result lies between {@code origin} (inclusive) and {@code bound}
-     * (exclusive).
+     * @implSpec The default implementation verifies that the {@code origin}
+     *           and {@code bound} are valid, then invokes {@code nextDouble()}
+     *           scaling and translating the result to fit {@code origin} and
+     *           {@code bound}( exclusive).
      */
     default double nextDouble(double origin, double bound) {
         RandomSupport.checkRange(origin, bound);

--- a/src/java.base/share/classes/java/util/random/RandomGenerator.java
+++ b/src/java.base/share/classes/java/util/random/RandomGenerator.java
@@ -513,13 +513,19 @@ public interface RandomGenerator {
      * @return a pseudorandomly chosen {@code float} value between
      *         zero (inclusive) and the bound (exclusive)
      *
-     * @throws IllegalArgumentException if {@code bound} is not
-     *         both positive and finite
+     * @throws IllegalArgumentException if {@code origin} is not finite,
+     *         or {@code bound} is not finite, or {@code origin}
+     *         is greater than or equal to {@code bound}, or
+     *         the difference between {@code bound} and {@code origin}
+     *         is so large that it cannot be represented as a finite
+     *         {@code float} value
      *
-     * @implSpec The default implementation checks that {@code bound} is a
-     * positive finite float. Then invokes {@code nextFloat()}, scaling
-     * the result so that the final result lies between {@code 0.0f} (inclusive)
-     * and {@code bound} (exclusive).
+     * @implSpec The default implementation checks if {@code origin} is not finite,
+     *         or {@code bound} is not finite, or {@code origin}
+     *         is greater than or equal to {@code bound}, or
+     *         the difference between {@code bound} and {@code origin}
+     *         is so large that it cannot be represented as a finite
+     *         {@code float} value
      */
     default float nextFloat(float bound) {
         RandomSupport.checkBound(bound);
@@ -539,13 +545,17 @@ public interface RandomGenerator {
      *
      * @throws IllegalArgumentException if {@code origin} is not finite,
      *         or {@code bound} is not finite, or {@code origin}
-     *         is greater than or equal to {@code bound}
+     *         is greater than or equal to {@code bound}, or
+     *         the difference between {@code bound} and {@code origin}
+     *         is so large that it cannot be represented as a finite
+     *         {@code double} value
      *
-     * @implSpec The default implementation checks that {@code origin} and
-     * {@code bound} are positive finite floats. Then invokes
-     * {@code nextFloat()}, scaling and translating the result so that the final
-     * result lies between {@code origin} (inclusive) and {@code bound}
-     * (exclusive).
+     * @implSpec The default implementation checks if {@code origin} is not finite,
+     *         or {@code bound} is not finite, or {@code origin}
+     *         is greater than or equal to {@code bound}, or
+     *         the difference between {@code bound} and {@code origin}
+     *         is so large that it cannot be represented as a finite
+     *         {@code double} value
      */
     default float nextFloat(float origin, float bound) {
         RandomSupport.checkRange(origin, bound);

--- a/src/java.base/share/classes/java/util/random/RandomGenerator.java
+++ b/src/java.base/share/classes/java/util/random/RandomGenerator.java
@@ -546,8 +546,8 @@ public interface RandomGenerator {
      *
      * @implSpec The default implementation verifies that the {@code origin}
      *           and {@code bound} are valid then invokes {@code nextFloat()}
-     *           scaling and translating the result to fit {@code origin} and
-     *           {@code bound} (exclusive).
+     *           scaling and translating the result to fit between {@code origin}
+     *           and {@code bound} (exclusive).
      */
     default float nextFloat(float origin, float bound) {
         RandomSupport.checkRange(origin, bound);
@@ -612,8 +612,8 @@ public interface RandomGenerator {
      *
      * @implSpec The default implementation verifies that the {@code origin}
      *           and {@code bound} are valid, then invokes {@code nextDouble()}
-     *           scaling and translating the result to fit {@code origin} and
-     *           {@code bound}( exclusive).
+     *           scaling and translating the result to fit between {@code origin}
+     *           and {@code bound}( exclusive).
      */
     default double nextDouble(double origin, double bound) {
         RandomSupport.checkRange(origin, bound);


### PR DESCRIPTION
`default float nextFloat(float origin, float bound); ` and `default double nextDouble(double origin, double bound); ` are documented incorrectly. The default method checks (origin < bound) and (bound - origin) < +infinity. 

The exception conditions are incorrect: 
"if {@code origin} is not finite, 
 or {@code bound} is not finite, or {@code origin} 
 is greater than or equal to {@code bound}" 

This is not true. Calling with -Double.MAX_VALUE and Double.MAX_VALUE satisfies the documented requirements but actually throws an exception.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8283084](https://bugs.openjdk.java.net/browse/JDK-8283084): RandomGenerator nextDouble(double, double) is documented incorrectly
 * [JDK-8283693](https://bugs.openjdk.java.net/browse/JDK-8283693): RandomGenerator nextDouble(double, double) is documented incorrectly (**CSR**)


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8109/head:pull/8109` \
`$ git checkout pull/8109`

Update a local copy of the PR: \
`$ git checkout pull/8109` \
`$ git pull https://git.openjdk.java.net/jdk pull/8109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8109`

View PR using the GUI difftool: \
`$ git pr show -t 8109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8109.diff">https://git.openjdk.java.net/jdk/pull/8109.diff</a>

</details>
