### PR TITLE
8284380: ProblemList jdk/jshell/HighlightUITest.java on more platforms

### DIFF
--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -34,7 +34,8 @@
 jdk/jshell/UserJdiUserRemoteTest.java                                           8173079    linux-all
 jdk/jshell/UserInputTest.java                                                   8169536    generic-all
 jdk/jshell/ToolBasicTest.java                                                   8265357    macosx-aarch64
-jdk/jshell/HighlightUITest.java                                                 8284144    macosx-aarch64
+jdk/jshell/HighlightUITest.java
+8284144    generic-aarch64,macosx-x64
 
 ###########################################################################
 #

--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -34,8 +34,7 @@
 jdk/jshell/UserJdiUserRemoteTest.java                                           8173079    linux-all
 jdk/jshell/UserInputTest.java                                                   8169536    generic-all
 jdk/jshell/ToolBasicTest.java                                                   8265357    macosx-aarch64
-jdk/jshell/HighlightUITest.java
-8284144    generic-aarch64,macosx-x64
+jdk/jshell/HighlightUITest.java                                                 8284144    generic-aarch64,macosx-x64
 
 ###########################################################################
 #


### PR DESCRIPTION
A trivia fix to ProblemList jdk/jshell/HighlightUITest.java on more platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284380](https://bugs.openjdk.java.net/browse/JDK-8284380): ProblemList jdk/jshell/HighlightUITest.java on more platforms


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8111/head:pull/8111` \
`$ git checkout pull/8111`

Update a local copy of the PR: \
`$ git checkout pull/8111` \
`$ git pull https://git.openjdk.java.net/jdk pull/8111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8111`

View PR using the GUI difftool: \
`$ git pr show -t 8111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8111.diff">https://git.openjdk.java.net/jdk/pull/8111.diff</a>

</details>
