### PR TITLE
8284368: Remove finalizer method in jdk.crypto.cryptoki

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java
@@ -25,6 +25,7 @@
 
 package sun.security.pkcs11;
 
+import java.lang.ref.Cleaner;
 import java.math.BigInteger;
 
 import java.io.InputStream;
@@ -231,6 +232,8 @@ final class P11KeyStore extends KeyStoreSpi {
         private PasswordCallbackHandler(char[] password) {
             if (password != null) {
                 this.password = password.clone();
+                Cleaner.create().register(this,
+                        () -> Arrays.fill(this.password, ' '));
             }
         }
 
@@ -241,14 +244,6 @@ final class P11KeyStore extends KeyStoreSpi {
             }
             PasswordCallback pc = (PasswordCallback)callbacks[0];
             pc.setPassword(password);  // this clones the password if not null
-        }
-
-        @SuppressWarnings("removal")
-        protected void finalize() throws Throwable {
-            if (password != null) {
-                Arrays.fill(password, ' ');
-            }
-            super.finalize();
         }
     }
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
@@ -47,6 +47,7 @@
 
 package sun.security.pkcs11.wrapper;
 
+import java.lang.ref.Cleaner;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
@@ -161,6 +162,9 @@ public class PKCS11 {
                 // give up; just use what is returned by connect()
             }
         }
+
+        // Calls disconnect() to cleanup the native part of the wrapper.
+        Cleaner.create().register(this, this::disconnect);
     }
 
     public CK_VERSION getVersion() {
@@ -1655,18 +1659,6 @@ public class PKCS11 {
      */
     public String toString() {
         return "Module name: " + pkcs11ModulePath;
-    }
-
-    /**
-     * Calls disconnect() to cleanup the native part of the wrapper. Once this
-     * method is called, this object cannot be used any longer. Any subsequent
-     * call to a C_* method will result in a runtime exception.
-     *
-     * @exception Throwable If finalization fails.
-     */
-    @SuppressWarnings("removal")
-    protected void finalize() throws Throwable {
-        disconnect();
     }
 
 // PKCS11 subclass that has all methods synchronized and delegating to the


### PR DESCRIPTION
Please review the update to remove finalizer method in the jdk.crypto.cryptoki module. It is one of the efforts to clean up the use of finalizer method in JDK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284368](https://bugs.openjdk.java.net/browse/JDK-8284368): Remove finalizer method in jdk.crypto.cryptoki


### Reviewers
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8112/head:pull/8112` \
`$ git checkout pull/8112`

Update a local copy of the PR: \
`$ git checkout pull/8112` \
`$ git pull https://git.openjdk.java.net/jdk pull/8112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8112`

View PR using the GUI difftool: \
`$ git pr show -t 8112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8112.diff">https://git.openjdk.java.net/jdk/pull/8112.diff</a>

</details>
