### PR TITLE
8283697: On macOS, the locale should be settable using environment LANG, LC_*

### DIFF
--- a/src/java.base/macosx/native/libjava/java_props_macosx.c
+++ b/src/java.base/macosx/native/libjava/java_props_macosx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -212,14 +212,16 @@ const char * convertToPOSIXLocale(const char* src) {
     return src;
 }
 
+/**
+ * Return locale from Posix if it is defined and non-empty,
+ * with a fallback to macOS language environment.
+ */
 char *setupMacOSXLocale(int cat) {
-    char * ret = getMacOSXLocale(cat);
-
-    if (ret == NULL) {
-        return getPosixLocale(cat);
-    } else {
+    char * ret = getPosixLocale(cat);
+    if (ret != NULL && strlen(ret) > 0) {
         return ret;
     }
+    return getMacOSXLocale(cat);
 }
 
 // 10.9 SDK does not include the NSOperatingSystemVersion struct.


### PR DESCRIPTION
On macOS, the initialization of the Java default locale is changed to use the Unix environment variables for locale including LANG and LC_*. Using the Unix environment variables instead of the native macOS locale will not be a visible change unless the environment has been modified by the user.

Change the Java Runtime to set the locale related properties using the Posix setLocale APIs as is done on other Unix platforms. A fallback is provided on macOS to use the Core Foundation locale APIs if thePosix setlocale API does not provide a locale.