### PR TITLE
8279876: Clean up: isAssignableFrom usages in xpath and jdk internal classes

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/jaxp/XPathExpressionImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/jaxp/XPathExpressionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -37,6 +37,7 @@ import org.xml.sax.InputSource;
  * The XPathExpression interface encapsulates a (compiled) XPath expression.
  *
  * @author  Ramesh Mandava
+ * @LastModified: Apr 2022
  */
 public class XPathExpressionImpl extends XPathImplUtil implements XPathExpression {
 
@@ -136,7 +137,7 @@ public class XPathExpressionImpl extends XPathImplUtil implements XPathExpressio
 
         try {
             XObject resultObject = eval(item, xpath);
-            if (type.isAssignableFrom(XPathEvaluationResult.class)) {
+            if (type == XPathEvaluationResult.class) {
                 return getXPathResult(resultObject, type);
             } else {
                 return XPathResultImpl.getValue(resultObject, type);

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/jaxp/XPathImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/jaxp/XPathImpl.java
@@ -209,7 +209,7 @@ public class XPathImpl extends XPathImplUtil implements javax.xml.xpath.XPath {
         isSupportedClassType(type);
         try {
             XObject resultObject = eval(expression, item);
-            if (type.isAssignableFrom(XPathEvaluationResult.class)) {
+            if (type == XPathEvaluationResult.class) {
                 return getXPathResult(resultObject, type);
             } else {
                 return XPathResultImpl.getValue(resultObject, type);

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/jaxp/XPathImplUtil.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/jaxp/XPathImplUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -212,14 +212,14 @@ class XPathImplUtil {
      */
     <T> void isSupportedClassType(Class<T> type) {
         requireNonNull(type, "The class type");
-        if (type.isAssignableFrom(Boolean.class) ||
-                type.isAssignableFrom(Double.class) ||
-                type.isAssignableFrom(Integer.class) ||
-                type.isAssignableFrom(Long.class) ||
-                type.isAssignableFrom(String.class) ||
-                type.isAssignableFrom(XPathNodes.class) ||
-                type.isAssignableFrom(Node.class) ||
-                type.isAssignableFrom(XPathEvaluationResult.class)) {
+        if (type == Boolean.class ||
+                type == Double.class ||
+                type == Integer.class ||
+                type == Long.class ||
+                type == String.class ||
+                type == XPathNodes.class ||
+                type == Node.class ||
+                type == XPathEvaluationResult.class) {
             return;
         }
         String fmsg = XSLMessages.createXPATHMessage(

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/jaxp/XPathResultImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/jaxp/XPathResultImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -142,7 +142,7 @@ class XPathResultImpl<T> implements XPathEvaluationResult<T> {
      */
     static <T> T getValue(XObject resultObject, Class<T> type) throws TransformerException {
         Objects.requireNonNull(type);
-        if (type.isAssignableFrom(XPathEvaluationResult.class)) {
+        if (type == XPathEvaluationResult.class) {
             return type.cast(new XPathResultImpl<T>(resultObject, type));
         }
         int resultType = classToInternalType(type);
@@ -150,11 +150,11 @@ class XPathResultImpl<T> implements XPathEvaluationResult<T> {
             case XObject.CLASS_BOOLEAN:
                 return type.cast(resultObject.bool());
             case XObject.CLASS_NUMBER:
-                if (Double.class.isAssignableFrom(type)) {
+                if (Double.class == type) {
                     return type.cast(resultObject.num());
-                } else if (Integer.class.isAssignableFrom(type)) {
+                } else if (Integer.class == type) {
                     return type.cast((int)resultObject.num());
-                } else if (Long.class.isAssignableFrom(type)) {
+                } else if (Long.class == type) {
                     return type.cast((long)resultObject.num());
                 }
                 /*
@@ -185,15 +185,15 @@ class XPathResultImpl<T> implements XPathEvaluationResult<T> {
      * @return the internal XObject type.
      */
     static <T> int classToInternalType(Class<T> type) {
-        if (type.isAssignableFrom(Boolean.class)) {
+        if (type == Boolean.class) {
             return XObject.CLASS_BOOLEAN;
         } else if (Number.class.isAssignableFrom(type)) {
             return XObject.CLASS_NUMBER;
-        } else if (type.isAssignableFrom(String.class)) {
+        } else if (type == String.class) {
             return XObject.CLASS_STRING;
-        } else if (type.isAssignableFrom(XPathNodes.class)) {
+        } else if (type == XPathNodes.class) {
             return XObject.CLASS_NODESET;
-        } else if (type.isAssignableFrom(Node.class)) {
+        } else if (type == Node.class) {
             return XObject.CLASS_RTREEFRAG;
         }
         return XObject.CLASS_NULL;

--- a/src/java.xml/share/classes/jdk/xml/internal/JdkXmlFeatures.java
+++ b/src/java.xml/share/classes/jdk/xml/internal/JdkXmlFeatures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -323,7 +323,7 @@ public class JdkXmlFeatures {
      */
     public void setFeature(int index, State state, Object value) {
         boolean temp;
-        if (Boolean.class.isAssignableFrom(value.getClass())) {
+        if (Boolean.class.isInstance(value)) {
             temp = (Boolean)value;
         } else {
             temp = Boolean.parseBoolean((String) value);

--- a/src/java.xml/share/classes/jdk/xml/internal/JdkXmlFeatures.java
+++ b/src/java.xml/share/classes/jdk/xml/internal/JdkXmlFeatures.java
@@ -323,7 +323,7 @@ public class JdkXmlFeatures {
      */
     public void setFeature(int index, State state, Object value) {
         boolean temp;
-        if (Boolean.class.isInstance(value)) {
+        if (value instanceof Boolean) {
             temp = (Boolean)value;
         } else {
             temp = Boolean.parseBoolean((String) value);

--- a/src/java.xml/share/classes/jdk/xml/internal/SecuritySupport.java
+++ b/src/java.xml/share/classes/jdk/xml/internal/SecuritySupport.java
@@ -117,9 +117,9 @@ public class SecuritySupport {
         if (value == null) {
             value = defValue;
         }
-        if (Integer.class.isAssignableFrom(type)) {
+        if (Integer.class == type) {
             return type.cast(Integer.parseInt(value));
-        } else if (Boolean.class.isAssignableFrom(type)) {
+        } else if (Boolean.class == type) {
             return type.cast(Boolean.parseBoolean(value));
         }
         return type.cast(value);


### PR DESCRIPTION
Clean up the usages of isAssignableFrom in a few xpath and jdk/internal classes where the checks were really about equality or whether they were the exact class types. It was why they worked nonetheless even though some of them were backwards.

Test: existing tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279876](https://bugs.openjdk.java.net/browse/JDK-8279876): Clean up: isAssignableFrom usages in xpath and jdk internal classes


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8116/head:pull/8116` \
`$ git checkout pull/8116`

Update a local copy of the PR: \
`$ git checkout pull/8116` \
`$ git pull https://git.openjdk.java.net/jdk pull/8116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8116`

View PR using the GUI difftool: \
`$ git pr show -t 8116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8116.diff">https://git.openjdk.java.net/jdk/pull/8116.diff</a>

</details>
