### PR TITLE
8284369: TestFailedAllocationBadGraph fails with -XX:TieredStopAtLevel < 4

### DIFF
--- a/test/hotspot/jtreg/compiler/allocation/TestFailedAllocationBadGraph.java
+++ b/test/hotspot/jtreg/compiler/allocation/TestFailedAllocationBadGraph.java
@@ -25,10 +25,11 @@
  * @test
  * bug 8279219
  * @summary C2 crash when allocating array of size too large
+ * @requires vm.compiler2.enabled
  * @library /test/lib /
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm  -ea -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:-BackgroundCompilation TestFailedAllocationBadGraph
+ * @run main/othervm -ea -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:-BackgroundCompilation TestFailedAllocationBadGraph
  */
 
 import sun.hotspot.WhiteBox;


### PR DESCRIPTION
Trivial fix that adds a missing `@requires` to guard against the case when C2 is not available (for example, when `TieredStopAtLevel < 4`).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284369](https://bugs.openjdk.java.net/browse/JDK-8284369): TestFailedAllocationBadGraph fails with -XX:TieredStopAtLevel < 4


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8118/head:pull/8118` \
`$ git checkout pull/8118`

Update a local copy of the PR: \
`$ git checkout pull/8118` \
`$ git pull https://git.openjdk.java.net/jdk pull/8118/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8118`

View PR using the GUI difftool: \
`$ git pr show -t 8118`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8118.diff">https://git.openjdk.java.net/jdk/pull/8118.diff</a>

</details>
