### PR TITLE
Improve return speed when rem is 0

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/IOUtil.java
+++ b/src/java.base/share/classes/sun/nio/ch/IOUtil.java
@@ -86,6 +86,8 @@ public class IOUtil {
         int lim = src.limit();
         assert (pos <= lim);
         int rem = (pos <= lim ? lim - pos : 0);
+        if(rem == 0)
+            return 0;
         ByteBuffer bb;
         if (directIO) {
             Util.checkRemainingBufferSizeAligned(rem, alignment);
@@ -126,9 +128,9 @@ public class IOUtil {
             Util.checkRemainingBufferSizeAligned(rem, alignment);
         }
 
-        int written = 0;
         if (rem == 0)
             return 0;
+        int written = 0;
         var handle = acquireScope(bb, async);
         try {
             if (position != -1) {


### PR DESCRIPTION
Improve the return 0 speed when the remaing byte count is zero.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8119/head:pull/8119` \
`$ git checkout pull/8119`

Update a local copy of the PR: \
`$ git checkout pull/8119` \
`$ git pull https://git.openjdk.java.net/jdk pull/8119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8119`

View PR using the GUI difftool: \
`$ git pr show -t 8119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8119.diff">https://git.openjdk.java.net/jdk/pull/8119.diff</a>

</details>
