### PR TITLE
8284433: Cleanup Disassembler::find_prev_instr() on all platforms

### DIFF
--- a/src/hotspot/cpu/aarch64/disassembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/disassembler_aarch64.hpp
@@ -34,14 +34,6 @@
     return "";
   }
 
-  // Returns address of n-th instruction preceding addr,
-  // NULL if no preceding instruction can be found.
-  // On ARM(aarch64), we assume a constant instruction length.
-  // It might be beneficial to check "is_readable" as we do on ppc and s390.
-  static address find_prev_instr(address addr, int n_instr) {
-    return addr - Assembler::instruction_size*n_instr;
-  }
-
   // special-case instruction decoding.
   // There may be cases where the binutils disassembler doesn't do
   // the perfect job. In those cases, decode_instruction0 may kick in

--- a/src/hotspot/cpu/arm/disassembler_arm.hpp
+++ b/src/hotspot/cpu/arm/disassembler_arm.hpp
@@ -33,14 +33,6 @@
     return "";
   }
 
-  // Returns address of n-th instruction preceding addr,
-  // NULL if no preceding instruction can be found.
-  // On ARM, we assume a constant instruction length.
-  // It might be beneficial to check "is_readable" as we do on ppc and s390.
-  static address find_prev_instr(address addr, int n_instr) {
-    return addr - Assembler::InstructionSize*n_instr;
-  }
-
   // special-case instruction decoding.
   // There may be cases where the binutils disassembler doesn't do
   // the perfect job. In those cases, decode_instruction0 may kick in

--- a/src/hotspot/cpu/ppc/disassembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/disassembler_ppc.cpp
@@ -87,22 +87,6 @@
     } \
   }
 
-address Disassembler::find_prev_instr(address here, int n_instr) {
-  if (!os::is_readable_pointer(here)) return NULL;    // obviously a bad location to decode
-
-  // Find most distant possible starting point.
-  // Narrow down because we don't want to SEGV while printing.
-  address start = here - n_instr*Assembler::instr_maxlen(); // starting point can't be further away.
-  while ((start < here) && !os::is_readable_range(start, here)) {
-    start = align_down(start, os::min_page_size()) + os::min_page_size();
-  }
-  if (start >= here) {
-    // Strange. Can only happen with here on page boundary.
-    return NULL;
-  }
-  return start;
-}
-
 address Disassembler::decode_instruction0(address here, outputStream * st, address virtual_begin ) {
   if (is_abstract()) {
     // The disassembler library was not loaded (yet),

--- a/src/hotspot/cpu/ppc/disassembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/disassembler_ppc.hpp
@@ -34,15 +34,6 @@
     return "ppc64";
   }
 
-  // Find preceding instruction.
-  //
-  // Starting at the passed location, the n-th preceding (towards lower addresses)
-  // location is searched, the contents of which - if interpreted as
-  // instructions - has the passed location as n-th successor.
-  //  - If no such location exists, NULL is returned. The caller should then
-  //    terminate its search and react properly.
-  static address find_prev_instr(address here, int n_instr);
-
   // special-case instruction decoding.
   // There may be cases where the binutils disassembler doesn't do
   // the perfect job. In those cases, decode_instruction0 may kick in

--- a/src/hotspot/cpu/riscv/disassembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/disassembler_riscv.hpp
@@ -35,14 +35,6 @@ static const char* pd_cpu_opts() {
   return "";
 }
 
-// Returns address of n-th instruction preceding addr,
-// NULL if no preceding instruction can be found.
-// On riscv, we assume a constant instruction length.
-// It might be beneficial to check "is_readable" as we do on ppc and s390.
-static address find_prev_instr(address addr, int n_instr) {
-  return addr - Assembler::instruction_size * n_instr;
-}
-
 // special-case instruction decoding.
 // There may be cases where the binutils disassembler doesn't do
 // the perfect job. In those cases, decode_instruction0 may kick in

--- a/src/hotspot/cpu/s390/disassembler_s390.hpp
+++ b/src/hotspot/cpu/s390/disassembler_s390.hpp
@@ -34,21 +34,6 @@
     return "s390";
   }
 
-  static bool valid_opcodes[256];
-  static bool is_valid_opcode_at(address here);
-
-  // Find preceding instruction.
-  //
-  // Starting at the passed location, the n-th preceding (towards lower addresses)
-  // location is searched, the contents of which - if interpreted as
-  // instructions - has the passed location as n-th successor.
-  //  - If multiple such locations exist between (here-n*instr_maxlen()) and here,
-  //    the most distant location is selected.
-  //  - If no such location exists, NULL is returned. The caller should then
-  //    terminate its search and react properly.
-  static address find_prev_instr(address here, int n_instr);
-  static int     count_instr(address begin, address end);
-
   // special-case instruction decoding.
   // There may be cases where the binutils disassembler doesn't do
   // the perfect job. In those cases, decode_instruction0 may kick in

--- a/src/hotspot/cpu/x86/disassembler_x86.hpp
+++ b/src/hotspot/cpu/x86/disassembler_x86.hpp
@@ -33,15 +33,6 @@
     return "";
   }
 
-  // Returns address of n-th instruction preceding addr,
-  // NULL if no preceding instruction can be found.
-  // On CISC architectures, it is difficult to impossible to step
-  // backwards in the instruction stream. Therefore just return NULL.
-  // It might be beneficial to check "is_readable" as we do on ppc and s390.
-  static address find_prev_instr(address addr, int n_instr) {
-    return NULL;
-  }
-
   // special-case instruction decoding.
   // There may be cases where the binutils disassembler doesn't do
   // the perfect job. In those cases, decode_instruction0 may kick in

--- a/src/hotspot/cpu/zero/disassembler_zero.hpp
+++ b/src/hotspot/cpu/zero/disassembler_zero.hpp
@@ -34,14 +34,6 @@
     return "";
   }
 
-  // Returns address of n-th instruction preceding addr,
-  // NULL if no preceding instruction can be found.
-  // On ZERO, we assume a constant instruction length of 1 byte.
-  // It might be beneficial to check "is_readable" as we do on ppc and s390.
-  static address find_prev_instr(address addr, int n_instr) {
-    return addr - 1*n_instr;
-  }
-
   // special-case instruction decoding.
   // There may be cases where the binutils disassembler doesn't do
   // the perfect job. In those cases, decode_instruction0 may kick in


### PR DESCRIPTION
Hi team,

This is a trivial cleanup for `Disassembler::find_prev_instr()` on all platforms. This function is used nowhere and seems to be loaded in JDK-13 (JDK-8213084) [1]. I looked through the code and found it very solid that it checks many corner cases (unreadable pages on s390x, etc.). But it is not used so modifying and testing it might be hard, especially the corner cases that could increase burdens to maintenance. On RISC-V we also need to make the current semantics of this function[2] right (Thanks to Felix @RealFYang pointing out that) because there is an extension 'C' that can compress the size of some instructions from 4-byte to 2-byte. Though I have written one version on my local branch, I began to think if removing this might be a better choice anyway.

Tested by building hotspot on x86, x86-zero, AArch64, RISC-V 64, and s390x. (I don't have access to s390x and ppc real machines, but have an s390x sysroot and qemu)

(I feel also pleased to retract this patch if there are objections.)

[1] https://github.com/openjdk/jdk13u-dev/commit/b730805159695107fbf950a0ef48e6bed5cf5bba
[2] https://github.com/openjdk/jdk/blob/0a67d686709000581e29440ef13324d1f2eba9ff/src/hotspot/cpu/riscv/disassembler_riscv.hpp#L38-L44

Thanks,
Xiaolin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284433](https://bugs.openjdk.java.net/browse/JDK-8284433): Cleanup Disassembler::find_prev_instr() on all platforms


### Reviewers
 * [Lutz Schmidt](https://openjdk.java.net/census#lucy) (@RealLucy - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8120/head:pull/8120` \
`$ git checkout pull/8120`

Update a local copy of the PR: \
`$ git checkout pull/8120` \
`$ git pull https://git.openjdk.java.net/jdk pull/8120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8120`

View PR using the GUI difftool: \
`$ git pr show -t 8120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8120.diff">https://git.openjdk.java.net/jdk/pull/8120.diff</a>

</details>
