### PR TITLE
8284378: Make Metal the default Java 2D rendering pipeline for macOS

### DIFF
--- a/src/java.desktop/macosx/classes/sun/java2d/MacOSFlags.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/MacOSFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,13 +91,12 @@ public class MacOSFlags {
                     PropertyState metalState = getBooleanProp("sun.java2d.metal", PropertyState.UNSPECIFIED);
 
                     // Handle invalid combinations to use the default rendering pipeline
-                    // Current default rendering pipeline is OpenGL
-                    // (The default can be changed to Metal in future just by toggling two states in this if condition block)
+                    // The default rendering pipeline is Metal
                     if ((oglState == PropertyState.UNSPECIFIED && metalState == PropertyState.UNSPECIFIED) ||
                         (oglState == PropertyState.DISABLED && metalState == PropertyState.DISABLED) ||
                         (oglState == PropertyState.ENABLED && metalState == PropertyState.ENABLED)) {
-                        oglState = PropertyState.ENABLED; // Enable default pipeline
-                        metalState = PropertyState.DISABLED; // Disable non-default pipeline
+                        metalState = PropertyState.ENABLED; // Enable default pipeline
+                        oglState = PropertyState.DISABLED; // Disable non-default pipeline
                     }
 
                     if (metalState == PropertyState.UNSPECIFIED) {


### PR DESCRIPTION
This PR makes Metal rendering pipeline as the default Java 2D rendering pipeline for macOS.

Please refer "JBS Description" for more details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8284378](https://bugs.openjdk.java.net/browse/JDK-8284378): Make Metal the default Java 2D rendering pipeline for macOS
 * [JDK-8284379](https://bugs.openjdk.java.net/browse/JDK-8284379): Make Metal the default Java 2D rendering pipeline for macOS (**CSR**)


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - Author)
 * [Alexey Ushakov](https://openjdk.java.net/census#avu) (@avu - Committer)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8121/head:pull/8121` \
`$ git checkout pull/8121`

Update a local copy of the PR: \
`$ git checkout pull/8121` \
`$ git pull https://git.openjdk.java.net/jdk pull/8121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8121`

View PR using the GUI difftool: \
`$ git pr show -t 8121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8121.diff">https://git.openjdk.java.net/jdk/pull/8121.diff</a>

</details>
