### PR TITLE
8282716: [macos] Enable javax/swing/JScrollPane/TestMouseWheelScroll.java on macos

### DIFF
--- a/test/jdk/javax/swing/JScrollPane/TestMouseWheelScroll.java
+++ b/test/jdk/javax/swing/JScrollPane/TestMouseWheelScroll.java
@@ -35,7 +35,6 @@ import javax.swing.UnsupportedLookAndFeelException;
 /*
  * @test
  * @key headful
- * @requires (os.family != "mac")
  * @bug  6911375
  * @summary Verifies mouseWheel effect on JList without scrollBar
  */
@@ -98,7 +97,11 @@ public class TestMouseWheelScroll {
                     viewPosition = scrollPane.getViewport().getViewPosition();
                 });
                 robot.delay(1000);
-                robot.mouseWheel(1);
+                if (!(System.getProperty("os.name").contains("OS X"))) {
+                    robot.mouseWheel(1);
+                } else {
+                    robot.mouseWheel(-1);
+                }
                 robot.delay(500);
                 SwingUtilities.invokeAndWait(() -> {
                     newPosition = scrollPane.getViewport().getViewPosition();

--- a/test/jdk/javax/swing/JScrollPane/TestMouseWheelScroll.java
+++ b/test/jdk/javax/swing/JScrollPane/TestMouseWheelScroll.java
@@ -23,6 +23,8 @@
 import java.awt.Point;
 import java.awt.Robot;
 import java.awt.event.InputEvent;
+import java.awt.event.MouseWheelEvent;
+import java.awt.event.MouseWheelListener;
 import javax.swing.DefaultListModel;
 import javax.swing.ListModel;
 import javax.swing.JScrollPane;
@@ -47,6 +49,7 @@ public class TestMouseWheelScroll {
     static volatile int height;
     static volatile Point viewPosition;
     static volatile Point newPosition;
+    static volatile int direction;
 
     private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
         try {
@@ -81,6 +84,13 @@ public class TestMouseWheelScroll {
                     frame.setSize(200,200);
                     frame.setLocationRelativeTo(null);
                     frame.setVisible(true);
+                    scrollPane.addMouseWheelListener(new MouseWheelListener() {
+                        @Override
+                        public void mouseWheelMoved(MouseWheelEvent event) {
+                            System.out.println(event.getWheelRotation());
+                            direction = event.getWheelRotation();
+                        }
+                    });
                 });
                 robot.waitForIdle();
                 robot.delay(1000);
@@ -97,12 +107,11 @@ public class TestMouseWheelScroll {
                     viewPosition = scrollPane.getViewport().getViewPosition();
                 });
                 robot.delay(1000);
-                if (!(System.getProperty("os.name").contains("OS X"))) {
-                    robot.mouseWheel(1);
-                } else {
+                robot.mouseWheel(1);
+                robot.delay(500);
+                if (direction == -1) {
                     robot.mouseWheel(-1);
                 }
-                robot.delay(500);
                 SwingUtilities.invokeAndWait(() -> {
                     newPosition = scrollPane.getViewport().getViewPosition();
                 });


### PR DESCRIPTION
The test was failing on macos and was excluded in macos because the viewposition was not changed after mouse wheel scroll. Seems like mouse wheel scroll direction is opposite in macos compared to windows etc so if we try to down-wheel scroll in macos when view position is at center of viewport (say element 3 is selected out of visible 7 elements), it cannot change viewposition as it cannot "scroll up" (since we are already at topmost viewport) whereas in windows, when we do down-wheel scroll in mouse wheel, it "scroll down" the viewport so viewposition is changed.

Fix is to use opposite scrolling motion in macos to check mouse wheel scroll is happening, which is what the testcase is meant for. CI testing of this test on all platform is ok.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282716](https://bugs.openjdk.java.net/browse/JDK-8282716): [macos] Enable javax/swing/JScrollPane/TestMouseWheelScroll.java on macos


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8123/head:pull/8123` \
`$ git checkout pull/8123`

Update a local copy of the PR: \
`$ git checkout pull/8123` \
`$ git pull https://git.openjdk.java.net/jdk pull/8123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8123`

View PR using the GUI difftool: \
`$ git pr show -t 8123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8123.diff">https://git.openjdk.java.net/jdk/pull/8123.diff</a>

</details>
