### PR TITLE
8284387: Fix formatting of doc comments in jdk.javadoc

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/Taglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/Taglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/Taglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/Taglet.java
@@ -75,7 +75,6 @@ import com.sun.source.doctree.DocTree;
  *      for the Standard Doclet</a>
  * @since 9
  */
-
 public interface Taglet {
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/package-info.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/package-info.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/package-info.java
@@ -379,6 +379,5 @@
  * @see jdk.javadoc.doclet.Doclet
  * @see jdk.javadoc.doclet.DocletEnvironment
  * @since 9
-*/
-
+ */
 package jdk.javadoc.doclet;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/api/package-info.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/api/package-info.java
@@ -24,8 +24,8 @@
  */
 
 /**
- *  This package provides the javadoc implementation of relevant
- *  public API defined in {@link javax.tools}, which provides an
- *  API alternative to invoking javadoc via the command line.
+ * This package provides the javadoc implementation of relevant
+ * public API defined in {@link javax.tools}, which provides an
+ * API alternative to invoking javadoc via the command line.
  */
 package jdk.javadoc.internal.api;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MarkerComments.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MarkerComments.java
@@ -28,7 +28,7 @@ package jdk.javadoc.internal.doclets.formats.html;
 import jdk.javadoc.internal.doclets.formats.html.markup.Comment;
 
 /**
- *  Marker comments to identify regions in the generated files.
+ * Marker comments to identify regions in the generated files.
  */
 public class MarkerComments {
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SerializedFormWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SerializedFormWriterImpl.java
@@ -43,7 +43,7 @@ import jdk.javadoc.internal.doclets.toolkit.util.DocPaths;
 import jdk.javadoc.internal.doclets.toolkit.util.IndexItem;
 
 /**
- *  Generates the Serialized Form Information Page, <i>serialized-form.html</i>.
+ * Generates the Serialized Form Information Page, <i>serialized-form.html</i>.
  */
 public class SerializedFormWriterImpl extends SubWriterHolderWriter
     implements SerializedFormWriter {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
@@ -81,7 +81,6 @@ import jdk.javadoc.internal.doclets.toolkit.util.Utils.PreviewFlagProvider;
 /**
  * The taglet writer that writes HTML.
  */
-
 public class TagletWriterImpl extends TagletWriter {
     /**
      * A class that provides the information about the enclosing context for

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/DocType.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/DocType.java
@@ -26,7 +26,7 @@
 package jdk.javadoc.internal.doclets.formats.html.markup;
 
 /**
- *  Supported DOCTYPE declarations.
+ * Supported DOCTYPE declarations.
  */
 public enum DocType {
     HTML5("<!DOCTYPE HTML>");

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlStyle.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlStyle.java
@@ -901,8 +901,8 @@ public enum HtmlStyle {
     externalLink,
 
     /**
-     *  The class of a {@code section} element containing a hierarchical
-     *  tree view.
+     * The class of a {@code section} element containing a hierarchical
+     * tree view.
      */
     hierarchy,
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/package-info.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/package-info.java
@@ -24,14 +24,14 @@
  */
 
 /**
- *  This package contains classes that create and write HTML markup tags.
+ * This package contains classes that create and write HTML markup tags.
  *
- *  <p>The primary low level classes are
- *  {@link jdk.javadoc.internal.doclets.formats.html.markup.HtmlTree HtmlTree}
- *  and other subtypes of {@code Content}. In addition, there are mid-level builders
- *  like {@link jdk.javadoc.internal.doclets.formats.html.TableHeader TableHeader}
- *  and {@link jdk.javadoc.internal.doclets.formats.html.Table Table}
- *  to help build more complex HTML trees.
+ * <p>The primary low level classes are
+ * {@link jdk.javadoc.internal.doclets.formats.html.markup.HtmlTree HtmlTree}
+ * and other subtypes of {@code Content}. In addition, there are mid-level builders
+ * like {@link jdk.javadoc.internal.doclets.formats.html.TableHeader TableHeader}
+ * and {@link jdk.javadoc.internal.doclets.formats.html.Table Table}
+ * to help build more complex HTML trees.
  *
  * @see <a href="https://html.spec.whatwg.org/multipage/">HTML: Living Standard</a>
  * @see <a href="https://html.spec.whatwg.org/multipage/syntax,html">HTML: Living Standard: The HTML Syntax</a>

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/package-info.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/package-info.java
@@ -23,12 +23,11 @@
  * questions.
  */
 
-
 /**
- *  The set of low-level file-formats, to be used in conjunction with
- *  the {@link jdk.javadoc.internal.doclets.toolkit doclets.toolkit} API.
+ * The set of low-level file-formats, to be used in conjunction with
+ * the {@link jdk.javadoc.internal.doclets.toolkit doclets.toolkit} API.
  *
- *  <p>Currently, only {@link jdk.javadoc.internal.doclets.formats.html HTML}
- *  format is supported.
+ * <p>Currently, only {@link jdk.javadoc.internal.doclets.formats.html HTML}
+ * format is supported.
  */
 package jdk.javadoc.internal.doclets.formats;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/package-info.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/package-info.java
@@ -24,20 +24,19 @@
  */
 
 /**
- *  Doclets provide the user-selectable back ends for processing the
- *  documentation comments in Java source code.
+ * Doclets provide the user-selectable back ends for processing the
+ * documentation comments in Java source code.
  *
- *  <p>Doclets are implementations of the {@link jdk.javadoc.doclet Doclet API}.</p>
+ * <p>Doclets are implementations of the {@link jdk.javadoc.doclet Doclet API}.</p>
  *
- *  <p>Currently, there is only one supported doclet, the
- *  {@link jdk.javadoc.internal.doclets.formats.html.HtmlDoclet HtmlDoclet},
- *  for writing API documentation in HTML. Nevertheless, in order to
- *  separate the high-level code for the general content of each page
- *  from the low-level details of how to write such content, the code is
- *  organized in two sections: a format-neutral
- *  {@link jdk.javadoc.internal.doclets.toolkit toolkit API},
- *  and a specific {@link jdk.javadoc.internal.doclets.formats format},
- *  such as {@link jdk.javadoc.internal.doclets.formats.html HTML format}.
-*/
-
+ * <p>Currently, there is only one supported doclet, the
+ * {@link jdk.javadoc.internal.doclets.formats.html.HtmlDoclet HtmlDoclet},
+ * for writing API documentation in HTML. Nevertheless, in order to
+ * separate the high-level code for the general content of each page
+ * from the low-level details of how to write such content, the code is
+ * organized in two sections: a format-neutral
+ * {@link jdk.javadoc.internal.doclets.toolkit toolkit API},
+ * and a specific {@link jdk.javadoc.internal.doclets.formats format},
+ * such as {@link jdk.javadoc.internal.doclets.formats.html HTML format}.
+ */
 package jdk.javadoc.internal.doclets;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/AnnotationTypeMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/AnnotationTypeMemberWriter.java
@@ -30,7 +30,6 @@ import javax.lang.model.element.Element;
 /**
  * The interface for writing annotation type required member output.
  */
-
 public interface AnnotationTypeMemberWriter extends MemberWriter {
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/ClassWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/ClassWriter.java
@@ -32,7 +32,6 @@ import jdk.javadoc.internal.doclets.toolkit.util.DocFileIOException;
 /**
  * The interface for writing class output.
  */
-
 public interface ClassWriter {
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/CommentUtils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/CommentUtils.java
@@ -66,7 +66,7 @@ import jdk.javadoc.internal.doclets.toolkit.util.Utils;
 import jdk.javadoc.internal.doclets.toolkit.util.VisibleMemberTable;
 
 /**
- *  A utility class for handling documentation comments.
+ * A utility class for handling documentation comments.
  */
 public class CommentUtils {
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/ConstantsSummaryWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/ConstantsSummaryWriter.java
@@ -36,7 +36,6 @@ import jdk.javadoc.internal.doclets.toolkit.util.DocFileIOException;
 /**
  * The interface for writing constants summary output.
  */
-
 public interface ConstantsSummaryWriter {
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/ConstructorWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/ConstructorWriter.java
@@ -30,7 +30,6 @@ import javax.lang.model.element.ExecutableElement;
 /**
  * The interface for writing constructor output.
  */
-
 public interface ConstructorWriter extends MemberWriter {
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/DocFilesHandler.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/DocFilesHandler.java
@@ -29,10 +29,10 @@ package jdk.javadoc.internal.doclets.toolkit;
 import java.util.List;
 
 import jdk.javadoc.internal.doclets.toolkit.util.DocPath;
+
 /**
  * The interface for copying doc-files to the output.
  */
-
 public interface DocFilesHandler {
     void copyDocFiles() throws DocletException;
     List<DocPath> getStylesheets() throws DocletException;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/EnumConstantWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/EnumConstantWriter.java
@@ -31,7 +31,6 @@ import javax.lang.model.element.VariableElement;
 /**
  * The interface for writing enum constant output.
  */
-
 public interface EnumConstantWriter extends MemberWriter {
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/FieldWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/FieldWriter.java
@@ -27,11 +27,9 @@ package jdk.javadoc.internal.doclets.toolkit;
 
 import javax.lang.model.element.VariableElement;
 
-
 /**
  * The interface for writing field output.
  */
-
 public interface FieldWriter extends MemberWriter {
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/MemberSummaryWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/MemberSummaryWriter.java
@@ -35,7 +35,6 @@ import com.sun.source.doctree.DocTree;
 /**
  * The interface for writing member summary output.
  */
-
 public interface MemberSummaryWriter {
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/MethodWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/MethodWriter.java
@@ -31,7 +31,6 @@ import javax.lang.model.type.TypeMirror;
 /**
  * The interface for writing method output.
  */
-
 public interface MethodWriter extends MemberWriter {
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/ModuleSummaryWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/ModuleSummaryWriter.java
@@ -30,7 +30,6 @@ import jdk.javadoc.internal.doclets.toolkit.util.DocFileIOException;
 /**
  * The interface for writing module summary output.
  */
-
 public interface ModuleSummaryWriter {
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/NestedClassWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/NestedClassWriter.java
@@ -28,6 +28,5 @@ package jdk.javadoc.internal.doclets.toolkit;
 /**
  * The interface for writing class output.
  */
-
 public interface NestedClassWriter {
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/PackageSummaryWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/PackageSummaryWriter.java
@@ -36,7 +36,6 @@ import jdk.javadoc.internal.doclets.toolkit.util.DocFileIOException;
 /**
  * The interface for writing package summary output.
  */
-
 public interface PackageSummaryWriter {
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/PropertyWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/PropertyWriter.java
@@ -30,7 +30,6 @@ import javax.lang.model.element.ExecutableElement;
 /**
  * The interface for writing property output.
  */
-
 public interface PropertyWriter extends MemberWriter {
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/SerializedFormWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/SerializedFormWriter.java
@@ -37,7 +37,6 @@ import jdk.javadoc.internal.doclets.toolkit.util.DocFileIOException;
 /**
  * The interface for writing serialized form output.
  */
-
 public interface SerializedFormWriter {
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/WriterFactory.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/WriterFactory.java
@@ -36,7 +36,6 @@ import jdk.javadoc.internal.doclets.toolkit.util.VisibleMemberTable;
 /**
  * The interface for a factory creates writers.
  */
-
 public interface WriterFactory {
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/AbstractBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/AbstractBuilder.java
@@ -47,7 +47,6 @@ import jdk.javadoc.internal.doclets.toolkit.util.Utils;
  * do is implement the ConstantsSummaryWriter interface and pass it to the
  * builder using a WriterFactory.
  */
-
 public abstract class AbstractBuilder {
     public static class Context {
         /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/BuilderFactory.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/BuilderFactory.java
@@ -41,7 +41,6 @@ import jdk.javadoc.internal.doclets.toolkit.util.ClassTree;
 /**
  * The factory for constructing builders.
  */
-
 public class BuilderFactory {
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/package-info.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/builders/package-info.java
@@ -24,12 +24,12 @@
  */
 
 /**
- *  This doclet-independent package has a set of classes and
- *  interfaces that are the building blocks for doclets. They
- *  define the basic structure of doclets and make doclet
- *  writing much easier because they provide the content generation
- *  code to be shared among different doclets. Builders only provide
- *  the structure and content of API documentation.
- *  They do not directly provide any style markup.
+ * This doclet-independent package has a set of classes and
+ * interfaces that are the building blocks for doclets. They
+ * define the basic structure of doclets and make doclet
+ * writing much easier because they provide the content generation
+ * code to be shared among different doclets. Builders only provide
+ * the structure and content of API documentation.
+ * They do not directly provide any style markup.
  */
 package jdk.javadoc.internal.doclets.toolkit.builders;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/package-info.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/package-info.java
@@ -24,9 +24,8 @@
  */
 
 /**
-    Contains the base classes that make up a doclet.  Doclets that reuse
-    the functionality provided by the toolkit should have the following
-    characteristics:
-*/
-
+ * Contains the base classes that make up a doclet.  Doclets that reuse
+ * the functionality provided by the toolkit should have the following
+ * characteristics:
+ */
 package jdk.javadoc.internal.doclets.toolkit;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/CodeTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/CodeTaglet.java
@@ -45,7 +45,6 @@ import jdk.javadoc.internal.doclets.toolkit.Content;
  * displays as:
  * <blockquote>  The type {@code List<P>}  </blockquote>
  */
-
 public class CodeTaglet extends BaseTaglet {
 
     CodeTaglet() {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/DeprecatedTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/DeprecatedTaglet.java
@@ -35,7 +35,6 @@ import jdk.javadoc.internal.doclets.toolkit.Content;
 /**
  * A taglet that represents the @deprecated tag.
  */
-
 public class DeprecatedTaglet extends BaseTaglet {
 
     public DeprecatedTaglet() {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/DocRootTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/DocRootTaglet.java
@@ -37,7 +37,6 @@ import jdk.javadoc.internal.doclets.toolkit.Content;
  * used to get the relative path to the document's root output
  * directory.
  */
-
 public class DocRootTaglet extends BaseTaglet {
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/IndexTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/IndexTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/IndexTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/IndexTaglet.java
@@ -38,7 +38,6 @@ import jdk.javadoc.internal.doclets.toolkit.Content;
  * The enclosed text is interpreted as not containing HTML markup or
  * nested javadoc tags.
  */
-
 public class IndexTaglet extends BaseTaglet {
 
     IndexTaglet() {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/InheritDocTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/InheritDocTaglet.java
@@ -44,7 +44,6 @@ import jdk.javadoc.internal.doclets.toolkit.util.Utils;
  * be used with a method.  It is used to inherit documentation from overridden
  * and implemented methods.
  */
-
 public class InheritDocTaglet extends BaseTaglet {
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/LiteralTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/LiteralTaglet.java
@@ -32,6 +32,7 @@ import com.sun.source.doctree.DocTree;
 import com.sun.source.doctree.LiteralTree;
 import jdk.javadoc.doclet.Taglet.Location;
 import jdk.javadoc.internal.doclets.toolkit.Content;
+
 /**
  * An inline Taglet used to denote literal text.
  * For example, the text:
@@ -39,7 +40,6 @@ import jdk.javadoc.internal.doclets.toolkit.Content;
  * displays as:
  * <blockquote>  {@literal a<B>c}  </blockquote>
  */
-
 public class LiteralTaglet extends BaseTaglet {
 
     LiteralTaglet() {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SimpleTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SimpleTaglet.java
@@ -42,7 +42,6 @@ import jdk.javadoc.internal.doclets.toolkit.util.Utils;
 /**
  * A custom single-argument block tag.
  */
-
 public class SimpleTaglet extends BaseTaglet implements InheritableTaglet {
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SummaryTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SummaryTaglet.java
@@ -36,7 +36,6 @@ import jdk.javadoc.internal.doclets.toolkit.Content;
 /**
  * A taglet that represents the @summary tag.
  */
-
 public class SummaryTaglet extends BaseTaglet {
 
     public SummaryTaglet() {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SystemPropertyTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/SystemPropertyTaglet.java
@@ -36,7 +36,6 @@ import java.util.EnumSet;
 /**
  * A taglet that represents the {@code @systemProperty} tag.
  */
-
 public class SystemPropertyTaglet extends BaseTaglet {
 
     SystemPropertyTaglet(){

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/Taglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/Taglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/Taglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/Taglet.java
@@ -35,7 +35,6 @@ import jdk.javadoc.internal.doclets.toolkit.Content;
 /**
  * This is the Taglet interface used internally within the doclet.
  */
-
 public interface Taglet {
     /**
      * Returns the set of allowed locations for a block tag handled by this taglet.

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletManager.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletManager.java
@@ -83,7 +83,6 @@ import static javax.tools.DocumentationTool.Location.TAGLET_PATH;
 /**
  * Manages the {@code Taglet}s used by doclets.
  */
-
 public class TagletManager {
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletWriter.java
@@ -53,7 +53,6 @@ import jdk.javadoc.internal.doclets.toolkit.util.Utils;
 /**
  * The interface for the taglet writer.
  */
-
 public abstract class TagletWriter {
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ValueTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ValueTaglet.java
@@ -46,7 +46,6 @@ import jdk.javadoc.internal.doclets.toolkit.util.Utils;
  * is retrieved for the field that the inline tag appears on.  The name is specified
  * in the following format:  [fully qualified class name]#[constant field name].
  */
-
 public class ValueTaglet extends BaseTaglet {
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/package-info.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/package-info.java
@@ -24,23 +24,23 @@
  */
 
 /**
- *  This package has classes used to generate output for Javadoc tags.
+ * This package has classes used to generate output for Javadoc tags.
  *
- *  <p>Doclets no longer have to implement their own version of standard tags
- *  such as &#64;param and &#64;throws.  Individual taglets provide
- *  common processing, independent of the output format.
- *  Each doclet must have a taglet writer that takes a taglet
- *  as input and writes doclet-dependent output. The taglet itself will
- *  do the tag processing. For example, suppose we are outputting
- *  &#64;throws tags. The taglet would:
- *  <ul>
- *      <li> Retrieve the list of throws tags to be documented.
- *      <li> Replace {&#64;inheritDoc} with the appropriate documentation.
- *      <li> Add throws documentation for exceptions that are declared in
- *           the signature of the method but not documented with the throws tags.
- *  </ul>
- *  After doing the steps above, the taglet would pass the information to
- *  the taglet writer for writing. The taglets are essentially builders for
- *  tags.
+ * <p>Doclets no longer have to implement their own version of standard tags
+ * such as &#64;param and &#64;throws.  Individual taglets provide
+ * common processing, independent of the output format.
+ * Each doclet must have a taglet writer that takes a taglet
+ * as input and writes doclet-dependent output. The taglet itself will
+ * do the tag processing. For example, suppose we are outputting
+ * &#64;throws tags. The taglet would:
+ * <ul>
+ *     <li> Retrieve the list of throws tags to be documented.
+ *     <li> Replace {&#64;inheritDoc} with the appropriate documentation.
+ *     <li> Add throws documentation for exceptions that are declared in
+ *          the signature of the method but not documented with the throws tags.
+ * </ul>
+ * After doing the steps above, the taglet would pass the information to
+ * the taglet writer for writing. The taglets are essentially builders for
+ * tags.
  */
 package jdk.javadoc.internal.doclets.toolkit.taglets;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/ClassTree.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/ClassTree.java
@@ -275,7 +275,7 @@ public class ClassTree {
     }
 
     /**
-     *  Return the sub-class set for the class passed.
+     * Return the sub-class set for the class passed.
      *
      * @param typeElement class whose sub-class set is required.
      */
@@ -284,7 +284,7 @@ public class ClassTree {
     }
 
     /**
-     *  Return the sub-interface set for the interface passed.
+     * Return the sub-interface set for the interface passed.
      *
      * @param typeElement interface whose sub-interface set is required.
      */
@@ -293,7 +293,7 @@ public class ClassTree {
     }
 
     /**
-     *  Return the set of classes which implement the interface passed.
+     * Return the set of classes which implement the interface passed.
      *
      * @param typeElement interface whose implementing-classes set is required.
      */
@@ -318,7 +318,7 @@ public class ClassTree {
     }
 
     /**
-     *  Return the sub-class/interface set for the class/interface passed.
+     * Return the sub-class/interface set for the class/interface passed.
      *
      * @param typeElement class/interface whose sub-class/interface set is required.
      * @param isEnum true if the subClasses should be forced to come from the
@@ -369,16 +369,16 @@ public class ClassTree {
     }
 
     /**
-     *  Return a set of base classes. This will have only one element namely
-     *  the TypeElement for java.lang.Object, since this is the base class for all
-     *  classes.
+     * Return a set of base classes. This will have only one element namely
+     * the TypeElement for java.lang.Object, since this is the base class for all
+     * classes.
      */
     public SortedSet<TypeElement> baseClasses() {
         return baseClasses;
     }
 
     /**
-     *  Return the set of base interfaces. This is the set of interfaces
+     * Return the set of base interfaces. This is the set of interfaces
      * which do not have super-interface.
      */
     public SortedSet<TypeElement> baseInterfaces() {
@@ -386,8 +386,8 @@ public class ClassTree {
     }
 
     /**
-     *  Return the set of base enums. This is the set of enums
-     *  which do not have super-enums.
+     * Return the set of base enums. This is the set of enums
+     * which do not have super-enums.
      */
     public SortedSet<TypeElement> baseEnums() {
         return baseEnums;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
@@ -75,7 +75,7 @@ import jdk.javadoc.internal.doclets.toolkit.BaseConfiguration;
 import static com.sun.source.doctree.DocTree.Kind.*;
 
 /**
- *  A utility class.
+ * A utility class.
  */
 public class CommentHelper {
     private final BaseConfiguration configuration;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Comparators.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Comparators.java
@@ -42,7 +42,7 @@ import java.util.Comparator;
 import java.util.List;
 
 /**
- *  A collection of {@code Comparator} factory methods.
+ * A collection of {@code Comparator} factory methods.
  */
 public class Comparators {
 
@@ -212,17 +212,17 @@ public class Comparators {
     private Comparator<Element> indexUseComparator = null;
 
     /**
-     *  Returns an {@code Element} Comparator for index file presentations, and are sorted as follows.
-     *  If comparing modules and/or packages then simply compare the qualified names,
-     *  if comparing a module or a package with a type/member then compare the
-     *  FullyQualifiedName of the module or a package with the SimpleName of the entity,
-     *  otherwise:
-     *  1. compare the ElementKind ex: Module, Package, Interface etc.
-     *  2a. if equal and if the type is of ExecutableElement(Constructor, Methods),
-     *      a case insensitive comparison of parameter the type signatures
-     *  2b. if equal, case sensitive comparison of the type signatures
-     *  3. if equal, compare the FQNs of the entities
-     *  4. finally, if equal, compare the names of the enclosing modules
+     * Returns an {@code Element} Comparator for index file presentations, and are sorted as follows.
+     * If comparing modules and/or packages then simply compare the qualified names,
+     * if comparing a module or a package with a type/member then compare the
+     * FullyQualifiedName of the module or a package with the SimpleName of the entity,
+     * otherwise:
+     * 1. compare the ElementKind ex: Module, Package, Interface etc.
+     * 2a. if equal and if the type is of ExecutableElement(Constructor, Methods),
+     *     a case insensitive comparison of parameter the type signatures
+     * 2b. if equal, case sensitive comparison of the type signatures
+     * 3. if equal, compare the FQNs of the entities
+     * 4. finally, if equal, compare the names of the enclosing modules
      * @return an element comparator for index file use
      */
     public Comparator<Element> makeIndexElementComparator() {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexBuilder.java
@@ -40,11 +40,11 @@ import jdk.javadoc.internal.doclets.toolkit.Messages;
 import static jdk.javadoc.internal.doclets.toolkit.util.VisibleMemberTable.Kind.*;
 
 /**
- *  An alphabetical index of elements, search tags, and other items.
- *  Two tables are maintained:
- *  one is indexed by the first character of each items name;
- *  the other is index by the item's category, indicating the JavaScript
- *  file in which the item should be written.
+ * An alphabetical index of elements, search tags, and other items.
+ * Two tables are maintained:
+ * one is indexed by the first character of each items name;
+ * the other is index by the item's category, indicating the JavaScript
+ * file in which the item should be written.
  */
 public class IndexBuilder {
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberCache.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberCache.java
@@ -34,7 +34,6 @@ import java.util.Map;
 /**
  * This class manages the visible member table for each type element.
  */
-
 public class VisibleMemberCache {
     private final Map<TypeElement, VisibleMemberTable> cache;
     private final BaseConfiguration configuration;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberTable.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberTable.java
@@ -89,7 +89,6 @@ import jdk.javadoc.internal.doclets.toolkit.PropertyUtils;
  * type, as its own view, and will present some form of this to the
  * doclet as and when required to.
  */
-
 public class VisibleMemberTable {
 
     public enum Kind {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/links/LinkInfo.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/links/LinkInfo.java
@@ -35,7 +35,7 @@ import jdk.javadoc.internal.doclets.toolkit.Content;
 import jdk.javadoc.internal.doclets.toolkit.util.Utils;
 
 /**
- *  Encapsulates information about a link.
+ * Encapsulates information about a link.
  */
 public abstract class LinkInfo {
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/links/package-info.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/links/package-info.java
@@ -24,6 +24,6 @@
  */
 
 /**
- *  Provides a factory for constructing links.
+ * Provides a factory for constructing links.
  */
 package jdk.javadoc.internal.doclets.toolkit.util.links;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/package-info.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/package-info.java
@@ -24,7 +24,7 @@
  */
 
 /**
- *  This package has utility classes that perform common services required
- *  for API documentation generation.
+ * This package has utility classes that perform common services required
+ * for API documentation generation.
  */
 package jdk.javadoc.internal.doclets.toolkit.util;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/package-info.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/package-info.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/package-info.java
@@ -24,16 +24,16 @@
  */
 
 /**
- *  The implementation of the <em>javadoc</em> tool and associated doclets.
+ * The implementation of the <em>javadoc</em> tool and associated doclets.
  *
- *  <p>Internally, <em>javadoc</em> is composed of two primary parts:
- *  the {@link jdk.javadoc.internal.tool tool}, and a series of
- *  {@link jdk.javadoc.internal.doclets doclets}.
+ * <p>Internally, <em>javadoc</em> is composed of two primary parts:
+ * the {@link jdk.javadoc.internal.tool tool}, and a series of
+ * {@link jdk.javadoc.internal.doclets doclets}.
  *
- *  <p>The tool provides a common infrastructure for command-line processing,
- *  and for reading the declarations and documentation comments in Java source files,
- *  while doclets provide a user-selectable backend for determining
- *  how to process the declarations and their documentation comments.
+ * <p>The tool provides a common infrastructure for command-line processing,
+ * and for reading the declarations and documentation comments in Java source files,
+ * while doclets provide a user-selectable backend for determining
+ * how to process the declarations and their documentation comments.
  *
  * <p>The following provides a top-down description of the overall <em>javadoc</em>
  * software stack.

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/AccessKind.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/AccessKind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/AccessKind.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/AccessKind.java
@@ -28,7 +28,6 @@ package jdk.javadoc.internal.tool;
 /**
  * The access value kinds.
  */
-
 public enum AccessKind {
     /** Limits access to public entities */
     PUBLIC,

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocEnter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocEnter.java
@@ -39,8 +39,8 @@ import static com.sun.tools.javac.code.Kinds.Kind.*;
 import com.sun.tools.javac.main.JavaCompiler;
 
 /**
- *  Javadoc's own enter phase does a few things above and beyond that
- *  done by javac.
+ * Javadoc's own enter phase does a few things above and beyond that
+ * done by javac.
  */
 public class JavadocEnter extends Enter {
     public static JavadocEnter instance(Context context) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocMemberEnter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocMemberEnter.java
@@ -39,8 +39,8 @@ import static com.sun.tools.javac.code.Flags.*;
 import static com.sun.tools.javac.code.Kinds.Kind.*;
 
 /**
- *  Javadoc's own memberEnter phase does a few things above and beyond that
- *  done by javac.
+ * Javadoc's own memberEnter phase does a few things above and beyond that
+ * done by javac.
  */
 public class JavadocMemberEnter extends MemberEnter {
     public static JavadocMemberEnter instance0(Context context) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocTodo.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocTodo.java
@@ -30,8 +30,8 @@ import com.sun.tools.javac.util.*;
 import com.sun.tools.javac.util.Context.Factory;
 
 /**
- *  Javadoc's own todo queue doesn't queue its inputs, as javadoc
- *  doesn't perform attribution of method bodies or semantic checking.
+ * Javadoc's own todo queue doesn't queue its inputs, as javadoc
+ * doesn't perform attribution of method bodies or semantic checking.
  */
 public class JavadocTodo extends Todo {
     public static void preRegister(Context context) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocTool.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/JavadocTool.java
@@ -57,10 +57,10 @@ import jdk.javadoc.doclet.DocletEnvironment;
 import static jdk.javadoc.internal.tool.Main.Result.*;
 
 /**
- *  This class could be the main entry point for Javadoc when Javadoc is used as a
- *  component in a larger software system. It provides operations to
- *  construct a new javadoc processor, and to run it on a set of source
- *  files.
+ * This class could be the main entry point for Javadoc when Javadoc is used as a
+ * component in a larger software system. It provides operations to
+ * construct a new javadoc processor, and to run it on a set of source
+ * files.
  */
 public class JavadocTool extends com.sun.tools.javac.main.JavaCompiler {
     ToolEnvironment toolEnv;
@@ -93,7 +93,7 @@ public class JavadocTool extends com.sun.tools.javac.main.JavaCompiler {
     }
 
     /**
-     *  Construct a new javadoc tool.
+     * Construct a new javadoc tool.
      */
     public static JavadocTool make0(Context context) {
         JavadocLog log = null;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/Main.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/Main.java
@@ -34,7 +34,6 @@ import com.sun.tools.javac.util.Context;
 /**
  * Provides external entry points (tool and programmatic) for the javadoc program.
  */
-
 public class Main {
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/package-info.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/package-info.java
@@ -24,21 +24,21 @@
  */
 
 /**
- *  Provides the front end for the javadoc tool.
+ * Provides the front end for the javadoc tool.
  *
- *  <p>The main entry points are in {@link jdk.javadoc.internal.tool.Main}
- *  which calls the (poorly-named) {@link jdk.javadoc.internal.tool.Start}
- *  which provides the overall functionality of the tool.
+ * <p>The main entry points are in {@link jdk.javadoc.internal.tool.Main}
+ * which calls the (poorly-named) {@link jdk.javadoc.internal.tool.Start}
+ * which provides the overall functionality of the tool.
  *
- *  <p>The classes provide a framework for processing command-line options
- *  and determining the set of elements (modules, packages, types and members)
- *  to be documented.
+ * <p>The classes provide a framework for processing command-line options
+ * and determining the set of elements (modules, packages, types and members)
+ * to be documented.
  *
- *  <p>The classes also provide the means to use the javac front end to read
- *  source files, including the documentation comments.
+ * <p>The classes also provide the means to use the javac front end to read
+ * source files, including the documentation comments.
  *
- *  <p>Finally, once the appropriate files have been read, the classes invoke
- *  the selected doclet to process those files, typically to generate API
- *  documentation.
+ * <p>Finally, once the appropriate files have been read, the classes invoke
+ * the selected doclet to process those files, typically to generate API
+ * documentation.
  */
 package jdk.javadoc.internal.tool;


### PR DESCRIPTION
JDK-8284362 highlighted some issues with formatting of top-level doc comments. This PR fixes those issues and similar issues elsewhere in jdk.javadoc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284387](https://bugs.openjdk.java.net/browse/JDK-8284387): Fix formatting of doc comments in jdk.javadoc


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8126/head:pull/8126` \
`$ git checkout pull/8126`

Update a local copy of the PR: \
`$ git checkout pull/8126` \
`$ git pull https://git.openjdk.java.net/jdk pull/8126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8126`

View PR using the GUI difftool: \
`$ git pr show -t 8126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8126.diff">https://git.openjdk.java.net/jdk/pull/8126.diff</a>

</details>
