### PR TITLE
8283698: Refactor Locale constructors used in src/test

### DIFF
--- a/src/java.base/share/classes/java/text/CompactNumberFormat.java
+++ b/src/java.base/share/classes/java/text/CompactNumberFormat.java
@@ -74,7 +74,7 @@ import java.util.stream.Collectors;
  *
  * <blockquote><pre>
  * NumberFormat fmt = NumberFormat.getCompactNumberInstance(
- *                             new Locale("hi", "IN"), NumberFormat.Style.SHORT);
+ *                             Locale.forLanguageTag("hi-IN"), NumberFormat.Style.SHORT);
  * String result = fmt.format(1000);
  * </pre></blockquote>
  *

--- a/src/java.base/share/classes/java/util/ResourceBundle.java
+++ b/src/java.base/share/classes/java/util/ResourceBundle.java
@@ -2438,7 +2438,7 @@ public abstract class ResourceBundle {
      * import static java.util.ResourceBundle.Control.*;
      * ...
      * ResourceBundle bundle =
-     *   ResourceBundle.getBundle("MyResources", new Locale("fr", "CH"),
+     *   ResourceBundle.getBundle("MyResources", Locale.forLanguageTag("fr-CH"),
      *                            ResourceBundle.Control.getControl(FORMAT_PROPERTIES));
      * </pre>
      *

--- a/test/jdk/java/awt/ComponentOrientation/BasicTest.java
+++ b/test/jdk/java/awt/ComponentOrientation/BasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,16 +94,16 @@ public class BasicTest {
         ComponentOrientation orient = ComponentOrientation.getOrientation(Locale.US);
         Assert(orient == ComponentOrientation.LEFT_TO_RIGHT, "US == LEFT_TO_RIGHT");
 
-        orient = ComponentOrientation.getOrientation(new Locale("iw", ""));
+        orient = ComponentOrientation.getOrientation(Locale.of("iw"));
         Assert(orient == ComponentOrientation.RIGHT_TO_LEFT, "iw == RIGHT_TO_LEFT");
 
-        orient = ComponentOrientation.getOrientation(new Locale("ar", ""));
+        orient = ComponentOrientation.getOrientation(Locale.of("ar"));
         Assert(orient == ComponentOrientation.RIGHT_TO_LEFT, "ar == RIGHT_TO_LEFT");
 
-        orient = ComponentOrientation.getOrientation(new Locale("he", ""));
+        orient = ComponentOrientation.getOrientation(Locale.of("he"));
         Assert(orient == ComponentOrientation.RIGHT_TO_LEFT, "he == RIGHT_TO_LEFT");
 
-        orient = ComponentOrientation.getOrientation(new Locale("yi", ""));
+        orient = ComponentOrientation.getOrientation(Locale.of("yi"));
         Assert(orient == ComponentOrientation.RIGHT_TO_LEFT, "yi == RIGHT_TO_LEFT");
 
         System.out.println("  } Pass");
@@ -119,8 +119,8 @@ public class BasicTest {
 
         // This will fall back to the default locale's bundle or root bundle
         ResourceBundle rb = ResourceBundle.getBundle("TestBundle",
-                                                        new Locale("et", ""));
-        if (rb.getLocale().getLanguage().equals(new Locale("iw").getLanguage())) {
+                                                        Locale.of("et"));
+        if (rb.getLocale().getLanguage().equals(Locale.of("iw").getLanguage())) {
             assertEquals(rb, ComponentOrientation.RIGHT_TO_LEFT, "et == RIGHT_TO_LEFT" );
         } else if (rb.getLocale().getLanguage() == "es") {
             assertEquals(rb, ComponentOrientation.LEFT_TO_RIGHT, "et == LEFT_TO_RIGHT" );
@@ -130,19 +130,19 @@ public class BasicTest {
 
         // We have actual bundles for "es" and "iw", so it should just fetch
         // the orientation object out of them
-        rb = ResourceBundle.getBundle("TestBundle",new Locale("es", ""));
+        rb = ResourceBundle.getBundle("TestBundle",Locale.of("es"));
         assertEquals(rb, ComponentOrientation.LEFT_TO_RIGHT, "es == LEFT_TO_RIGHT" );
 
-        rb = ResourceBundle.getBundle("TestBundle", new Locale("iw", "IL"));
+        rb = ResourceBundle.getBundle("TestBundle", Locale.of("iw", "IL"));
         assertEquals(rb, ComponentOrientation.RIGHT_TO_LEFT, "iw == RIGHT_TO_LEFT" );
 
         // Test with "he" locale. This should load TestBundle_iw and fetch the orientation from there
-        rb = ResourceBundle.getBundle("TestBundle", new Locale("he", "IL"));
+        rb = ResourceBundle.getBundle("TestBundle", Locale.of("he", "IL"));
         assertEquals(rb, ComponentOrientation.RIGHT_TO_LEFT, "he == RIGHT_TO_LEFT" );
 
         // This bundle has no orientation setting at all, so we should get
         // the system's default orientation for Arabic
-        rb = ResourceBundle.getBundle("TestBundle1", new Locale("ar", ""));
+        rb = ResourceBundle.getBundle("TestBundle1", Locale.of("ar"));
         assertEquals(rb, ComponentOrientation.RIGHT_TO_LEFT, "ar == RIGHT_TO_LEFT" );
 
         System.out.println("  } Pass");

--- a/test/jdk/java/awt/ComponentOrientation/WindowTest.java
+++ b/test/jdk/java/awt/ComponentOrientation/WindowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,12 +98,12 @@ public class WindowTest {
                         ResourceBundle.getBundle("TestBundle1", Locale.getDefault())));
 
         System.out.println("  Applying TestBundle_iw and verifying...");
-        rb = ResourceBundle.getBundle("TestBundle", new Locale("iw", ""));
+        rb = ResourceBundle.getBundle("TestBundle", Locale.of("iw"));
         myFrame.applyResourceBundle(rb);
         verifyOrientation(myFrame, ComponentOrientation.RIGHT_TO_LEFT);
 
         System.out.println("  Applying TestBundle_es and verifying...");
-        rb = ResourceBundle.getBundle("TestBundle", new Locale("es", ""));
+        rb = ResourceBundle.getBundle("TestBundle", Locale.of("es"));
         myFrame.applyResourceBundle(rb);
         verifyOrientation(myFrame, ComponentOrientation.LEFT_TO_RIGHT);
 

--- a/test/jdk/java/awt/font/FontNames/GetLCIDFromLocale.java
+++ b/test/jdk/java/awt/font/FontNames/GetLCIDFromLocale.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,12 +52,12 @@ public class GetLCIDFromLocale {
         test(Locale.US, 0x0409);
         test(Locale.GERMAN, 0x0407);
         test(Locale.GERMANY, 0x0407);
-        test(new Locale("de", "AT"), 0x0c07);
-        test(new Locale("ar"), 0x0401);
-        test(new Locale("ar", "SA"), 0x0401);
-        test(new Locale("ar", "EG"), 0x0c01);
-        test(new Locale("??"), 0x0409);
-        test(new Locale("??", "??"), 0x0409);
+        test(Locale.of("de", "AT"), 0x0c07);
+        test(Locale.of("ar"), 0x0401);
+        test(Locale.of("ar", "SA"), 0x0401);
+        test(Locale.of("ar", "EG"), 0x0c01);
+        test(Locale.of("??"), 0x0409);
+        test(Locale.of("??", "??"), 0x0409);
         test(Locale.KOREA, 0x0412);
     }
 

--- a/test/jdk/java/awt/font/FontNames/TrueTypeFontLocaleNameTest.java
+++ b/test/jdk/java/awt/font/FontNames/TrueTypeFontLocaleNameTest.java
@@ -1,6 +1,5 @@
-
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +41,7 @@ public class TrueTypeFontLocaleNameTest {
         }
         System.setProperty("user.language", "de");
         System.setProperty("user.country", "AT");
-        Locale de_atLocale = new Locale("de", "AT");
+        Locale de_atLocale = Locale.of("de", "AT");
         Locale.setDefault(de_atLocale);
 
         String family = "Verdana";
@@ -53,7 +52,7 @@ public class TrueTypeFontLocaleNameTest {
         }
 
         String atFontName = font.getFontName();
-        Locale deGELocale = new Locale("de", "GE");
+        Locale deGELocale = Locale.of("de", "GE");
         String deFontName = font.getFontName(deGELocale);
         System.out.println("Austrian font name: " + atFontName);
         System.out.println("German font name: " + deFontName);

--- a/test/jdk/java/beans/XMLDecoder/Test6341798.java
+++ b/test/jdk/java/beans/XMLDecoder/Test6341798.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import java.util.Locale;
 import static java.util.Locale.ENGLISH;
 
 public class Test6341798 {
-    private static final Locale TURKISH = new Locale("tr");
+    private static final Locale TURKISH = Locale.of("tr");
 
     private static final String DATA
             = "<java>\n"

--- a/test/jdk/java/io/pathNames/win32/bug6344646.java
+++ b/test/jdk/java/io/pathNames/win32/bug6344646.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ public class bug6344646 {
                 return;
             }
 
-            Locale.setDefault(new Locale("lt"));
+            Locale.setDefault(Locale.of("lt"));
             File f1 = new File("J\u0301");
             File f2 = new File("j\u0301");
 

--- a/test/jdk/java/lang/Character/DumpCharProperties.java
+++ b/test/jdk/java/lang/Character/DumpCharProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ import java.util.*;
 import static java.lang.Character.*;
 
 public class DumpCharProperties {
-    final static Locale turkish = new Locale("tr");
+    final static Locale turkish = Locale.of("tr");
 
     static String charProps(int i) {
         String s = new String(new int[]{i},0,1);

--- a/test/jdk/java/lang/Character/UnicodeCasingTest.java
+++ b/test/jdk/java/lang/Character/UnicodeCasingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public class UnicodeCasingTest {
     // Locales which are used for testing
     private static List<Locale> locales = new ArrayList<>();
     static {
-        locales.add(new Locale("az", ""));
+        locales.add(Locale.of("az"));
         locales.addAll(java.util.Arrays.asList(Locale.getAvailableLocales()));
     }
 

--- a/test/jdk/java/lang/String/NonCharacterMapping.java
+++ b/test/jdk/java/lang/String/NonCharacterMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,11 +28,11 @@
  */
 
 import java.util.Locale;
+import static java.util.Locale.ENGLISH;
 
 public class NonCharacterMapping {
 
-    private static final Locale ENGLISH = new Locale("en");
-    private static final Locale TURKISH = new Locale("tr");
+    private static final Locale TURKISH = Locale.of("tr");
 
     public static void main(String[] args) {
         if (Character.toLowerCase('\uFFFF') != '\uFFFF') {

--- a/test/jdk/java/lang/String/SpecialCasingTest.java
+++ b/test/jdk/java/lang/String/SpecialCasingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ public class SpecialCasingTest {
     // Locales which are used for testing
     private static List<Locale> locales = new ArrayList<>();
     static {
-        locales.add(new Locale("az", ""));
+        locales.add(Locale.of("az"));
         locales.addAll(java.util.Arrays.asList(Locale.getAvailableLocales()));
     }
 
@@ -302,7 +302,7 @@ public class SpecialCasingTest {
     private void testLowerCase(String orig, String expected,
                                String lang, String condition) {
         String got = (lang == null) ?
-            orig.toLowerCase() : orig.toLowerCase(new Locale(lang, ""));
+            orig.toLowerCase() : orig.toLowerCase(Locale.of(lang));
 
         if (!expected.equals(got)) {
             err = true;
@@ -318,7 +318,7 @@ public class SpecialCasingTest {
     private void testUpperCase(String orig, String expected,
                                String lang, String condition) {
         String got = (lang == null) ?
-            orig.toUpperCase() : orig.toUpperCase(new Locale(lang, ""));
+            orig.toUpperCase() : orig.toUpperCase(Locale.of(lang));
 
         if (!expected.equals(got)) {
             err = true;

--- a/test/jdk/java/lang/String/ToLowerCase.java
+++ b/test/jdk/java/lang/String/ToLowerCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,9 +35,9 @@ import java.util.Locale;
 public class ToLowerCase {
 
     public static void main(String[] args) {
-        Locale turkish = new Locale("tr", "TR");
-        Locale lt = new Locale("lt"); // Lithanian
-        Locale az = new Locale("az"); // Azeri
+        Locale turkish = Locale.of("tr", "TR");
+        Locale lt = Locale.of("lt"); // Lithanian
+        Locale az = Locale.of("az"); // Azeri
 
         // Greek Sigma final/non-final tests
         test("\u03A3", Locale.US, "\u03C3");

--- a/test/jdk/java/lang/String/ToUpperCase.java
+++ b/test/jdk/java/lang/String/ToUpperCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,9 +36,9 @@ import java.util.Locale;
 public class ToUpperCase {
 
     public static void main(String[] args) {
-        Locale turkish = new Locale("tr", "TR");
-        Locale lt = new Locale("lt"); // Lithanian
-        Locale az = new Locale("az"); // Azeri
+        Locale turkish = Locale.of("tr", "TR");
+        Locale lt = Locale.of("lt"); // Lithanian
+        Locale az = Locale.of("az"); // Azeri
 
         test("\u00DF", turkish, "SS");
         test("a\u00DF", turkish, "ASS");

--- a/test/jdk/java/lang/String/UnicodeCasingTest.java
+++ b/test/jdk/java/lang/String/UnicodeCasingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class UnicodeCasingTest {
     // Locales which are used for testing
     private static List<Locale> locales =  new ArrayList<>();
     static {
-        locales.add(new Locale("az", ""));
+        locales.add(Locale.of("az"));
         locales.addAll(java.util.Arrays.asList(Locale.getAvailableLocales()));
     }
 

--- a/test/jdk/java/security/Provider/Turkish.java
+++ b/test/jdk/java/security/Provider/Turkish.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ public class Turkish {
 
         Locale loc = Locale.getDefault();
         try {
-            Locale.setDefault(new Locale("tr", "TR"));
+            Locale.setDefault(Locale.of("tr", "TR"));
 
             Provider p2 = new TProvider("T2");
             System.out.println(p2.getServices()); // trigger service parsing

--- a/test/jdk/java/text/BreakIterator/BreakIteratorTest.java
+++ b/test/jdk/java/text/BreakIterator/BreakIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1391,7 +1391,7 @@ public class BreakIteratorTest extends IntlTest
 
 
         // Confirm changes in BreakIteratorRules_th.java have been reflected.
-        iter = BreakIterator.getLineInstance(new Locale("th", ""));
+        iter = BreakIterator.getLineInstance(Locale.of("th"));
 
         /* Thai <Seven(Nd)>
          *      <Left Double Quotation Mark(Pi)>

--- a/test/jdk/java/text/BreakIterator/NewVSOld_th_TH.java
+++ b/test/jdk/java/text/BreakIterator/NewVSOld_th_TH.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ public class NewVSOld_th_TH {
                                                   UnsupportedEncodingException,
                                                   IOException {
         final String ENCODING = "UTF-8";
-        final Locale THAI_LOCALE = new Locale("th", "TH");
+        final Locale THAI_LOCALE = Locale.of("th", "TH");
 
         String rawFileName = "test_th_TH.txt";
         String oldFileName = "broken_th_TH.txt";

--- a/test/jdk/java/text/Collator/APITest.java
+++ b/test/jdk/java/text/Collator/APITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,7 +115,7 @@ public class APITest extends CollatorTest {
         }
 
         logln("Create junk collation: ");
-        Locale abcd = new Locale("ab", "CD", "");
+        Locale abcd = Locale.of("ab", "CD");
         Collator junk = null;
         try {
             junk = Collator.getInstance(abcd);
@@ -145,7 +145,7 @@ public class APITest extends CollatorTest {
             errln("Default collation creation failed.");
         }
         Collator col2 = null;
-        Locale dk = new Locale("da", "DK", "");
+        Locale dk = Locale.of("da", "DK");
         try {
             col2 = Collator.getInstance(dk);
         } catch (Exception bar) {

--- a/test/jdk/java/text/Collator/Bug5047314.java
+++ b/test/jdk/java/text/Collator/Bug5047314.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,8 +32,8 @@ import java.util.Locale;
 
 public class Bug5047314 {
 
-    private static Collator colLao = Collator.getInstance(new Locale("lo"));
-    private static Collator colThai = Collator.getInstance(new Locale("th"));
+    private static Collator colLao = Collator.getInstance(Locale.of("lo"));
+    private static Collator colThai = Collator.getInstance(Locale.of("th"));
 
     private static String[] textLao = {
         "\u0ec0", "\u0ec1", "\u0ec2", "\u0ec3", "\u0ec4"

--- a/test/jdk/java/text/Collator/DanishTest.java
+++ b/test/jdk/java/text/Collator/DanishTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -212,5 +212,5 @@ public class DanishTest extends CollatorTest {
         }
     }
 
-    private final Collator myCollation = Collator.getInstance(new Locale("da", "", ""));
+    private final Collator myCollation = Collator.getInstance(Locale.of("da"));
 }

--- a/test/jdk/java/text/Collator/FinnishTest.java
+++ b/test/jdk/java/text/Collator/FinnishTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,5 +95,5 @@ public class FinnishTest extends CollatorTest {
               tertiarySourceData, tertiaryTargetData, tertiaryResults);
     }
 
-    private final Collator myCollation = Collator.getInstance(new Locale("fi", "FI", ""));
+    private final Collator myCollation = Collator.getInstance(Locale.of("fi", "FI"));
 }

--- a/test/jdk/java/text/Collator/Regression.java
+++ b/test/jdk/java/text/Collator/Regression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -346,7 +346,7 @@ public class Regression extends CollatorTest {
     //
     public void Test4087241() {
         RuleBasedCollator c = (RuleBasedCollator) Collator.getInstance(
-                                                        new Locale("da", "DK"));
+                                                        Locale.of("da", "DK"));
         c.setStrength(Collator.SECONDARY);
 
         String[] tests = {
@@ -375,7 +375,7 @@ public class Regression extends CollatorTest {
     // Micro symbol and greek lowercase letter Mu should sort identically
     //
     public void Test4092260() {
-        Collator c = Collator.getInstance(new Locale("el", ""));
+        Collator c = Collator.getInstance(Locale.of("el"));
 
         // will only be equal when FULL_DECOMPOSITION is used
         c.setDecomposition(Collator.FULL_DECOMPOSITION);
@@ -388,7 +388,7 @@ public class Regression extends CollatorTest {
     }
 
     void Test4095316() {
-        Collator c = Collator.getInstance(new Locale("el", "GR"));
+        Collator c = Collator.getInstance(Locale.of("el", "GR"));
         c.setStrength(Collator.TERTIARY);
         // javadocs for RuleBasedCollator clearly specify that characters containing compatability
         // chars MUST use FULL_DECOMPOSITION to get accurate comparisons.
@@ -544,7 +544,7 @@ public class Regression extends CollatorTest {
         // Code pasted straight from the bug report
         //
         // create spanish locale and collator
-        Locale l = new Locale("es", "es");
+        Locale l = Locale.of("es", "es");
         Collator col = Collator.getInstance(l);
 
         // this spanish phrase kills it!

--- a/test/jdk/java/text/Collator/SpanishTest.java
+++ b/test/jdk/java/text/Collator/SpanishTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,5 +102,5 @@ public class SpanishTest extends CollatorTest {
                tertiarySourceData, tertiaryTargetData, tertiaryResults);
     }
 
-    private final Collator myCollation = Collator.getInstance(new Locale("es", "ES", ""));
+    private final Collator myCollation = Collator.getInstance(Locale.of("es", "ES"));
 }

--- a/test/jdk/java/text/Collator/ThaiTest.java
+++ b/test/jdk/java/text/Collator/ThaiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -153,5 +153,5 @@ public class ThaiTest extends CollatorTest {
                primarySourceData, primaryTargetData, primaryResults);
     }
 
-    private final Collator myCollation = Collator.getInstance(new Locale("th"));
+    private final Collator myCollation = Collator.getInstance(Locale.of("th"));
 }

--- a/test/jdk/java/text/Collator/TurkishTest.java
+++ b/test/jdk/java/text/Collator/TurkishTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,5 +115,5 @@ public class TurkishTest extends CollatorTest {
                tertiarySourceData, tertiaryTargetData, tertiaryResults);
     }
 
-    private final Collator myCollation = Collator.getInstance(new Locale("tr", "TR", ""));
+    private final Collator myCollation = Collator.getInstance(Locale.of("tr", "TR"));
 }

--- a/test/jdk/java/text/Collator/VietnameseTest.java
+++ b/test/jdk/java/text/Collator/VietnameseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -361,5 +361,5 @@ public class VietnameseTest extends CollatorTest {
         }
     }
 
-    private final Collator myCollation = Collator.getInstance(new Locale("vi", "VN"));
+    private final Collator myCollation = Collator.getInstance(Locale.of("vi", "VN"));
 }

--- a/test/jdk/java/text/Format/CompactNumberFormat/TestCompactNumber.java
+++ b/test/jdk/java/text/Format/CompactNumberFormat/TestCompactNumber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,43 +43,43 @@ import org.testng.annotations.Test;
 public class TestCompactNumber {
 
     private static final NumberFormat FORMAT_DZ_LONG = NumberFormat
-            .getCompactNumberInstance(new Locale("dz"), NumberFormat.Style.LONG);
+            .getCompactNumberInstance(Locale.of("dz"), NumberFormat.Style.LONG);
 
     private static final NumberFormat FORMAT_EN_US_SHORT = NumberFormat
             .getCompactNumberInstance(Locale.US, NumberFormat.Style.SHORT);
 
     private static final NumberFormat FORMAT_EN_LONG = NumberFormat
-            .getCompactNumberInstance(new Locale("en"), NumberFormat.Style.LONG);
+            .getCompactNumberInstance(Locale.ENGLISH, NumberFormat.Style.LONG);
 
     private static final NumberFormat FORMAT_HI_IN_LONG = NumberFormat
-            .getCompactNumberInstance(new Locale("hi", "IN"), NumberFormat.Style.LONG);
+            .getCompactNumberInstance(Locale.of("hi", "IN"), NumberFormat.Style.LONG);
 
     private static final NumberFormat FORMAT_JA_JP_SHORT = NumberFormat
             .getCompactNumberInstance(Locale.JAPAN, NumberFormat.Style.SHORT);
 
     private static final NumberFormat FORMAT_IT_SHORT = NumberFormat
-            .getCompactNumberInstance(new Locale("it"), NumberFormat.Style.SHORT);
+            .getCompactNumberInstance(Locale.ITALIAN, NumberFormat.Style.SHORT);
 
     private static final NumberFormat FORMAT_CA_LONG = NumberFormat
-            .getCompactNumberInstance(new Locale("ca"), NumberFormat.Style.LONG);
+            .getCompactNumberInstance(Locale.of("ca"), NumberFormat.Style.LONG);
 
     private static final NumberFormat FORMAT_AS_LONG = NumberFormat
-            .getCompactNumberInstance(new Locale("as"), NumberFormat.Style.LONG);
+            .getCompactNumberInstance(Locale.of("as"), NumberFormat.Style.LONG);
 
     private static final NumberFormat FORMAT_BRX_SHORT = NumberFormat
-            .getCompactNumberInstance(new Locale("brx"), NumberFormat.Style.SHORT);
+            .getCompactNumberInstance(Locale.of("brx"), NumberFormat.Style.SHORT);
 
     private static final NumberFormat FORMAT_SW_LONG = NumberFormat
-            .getCompactNumberInstance(new Locale("sw"), NumberFormat.Style.LONG);
+            .getCompactNumberInstance(Locale.of("sw"), NumberFormat.Style.LONG);
 
     private static final NumberFormat FORMAT_SE_SHORT = NumberFormat
-            .getCompactNumberInstance(new Locale("se"), NumberFormat.Style.SHORT);
+            .getCompactNumberInstance(Locale.of("se"), NumberFormat.Style.SHORT);
 
     private static final NumberFormat FORMAT_DE_LONG = NumberFormat
             .getCompactNumberInstance(Locale.GERMAN, NumberFormat.Style.LONG);
 
     private static final NumberFormat FORMAT_SL_LONG = NumberFormat
-            .getCompactNumberInstance(new Locale("sl"), NumberFormat.Style.LONG);
+            .getCompactNumberInstance(Locale.of("sl"), NumberFormat.Style.LONG);
 
     @DataProvider(name = "format")
     Object[][] compactFormatData() {

--- a/test/jdk/java/text/Format/CompactNumberFormat/TestEquality.java
+++ b/test/jdk/java/text/Format/CompactNumberFormat/TestEquality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -165,10 +165,10 @@ public class TestEquality {
     @Test
     public void testEqualsAndHashCode() {
         NumberFormat cnf1 = NumberFormat
-                .getCompactNumberInstance(new Locale("hi", "IN"), NumberFormat.Style.SHORT);
+                .getCompactNumberInstance(Locale.of("hi", "IN"), NumberFormat.Style.SHORT);
         cnf1.setMinimumIntegerDigits(5);
         NumberFormat cnf2 = NumberFormat
-                .getCompactNumberInstance(new Locale("hi", "IN"), NumberFormat.Style.SHORT);
+                .getCompactNumberInstance(Locale.of("hi", "IN"), NumberFormat.Style.SHORT);
         cnf2.setMinimumIntegerDigits(5);
         if (cnf1.equals(cnf2)) {
             if (cnf1.hashCode() != cnf2.hashCode()) {

--- a/test/jdk/java/text/Format/CompactNumberFormat/TestFormatToCharacterIterator.java
+++ b/test/jdk/java/text/Format/CompactNumberFormat/TestFormatToCharacterIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ import org.testng.annotations.Test;
 public class TestFormatToCharacterIterator {
 
     private static final NumberFormat FORMAT_DZ = NumberFormat
-            .getCompactNumberInstance(new Locale("dz"),
+            .getCompactNumberInstance(Locale.of("dz"),
                     NumberFormat.Style.LONG);
 
     private static final NumberFormat FORMAT_EN_US = NumberFormat
@@ -51,7 +51,7 @@ public class TestFormatToCharacterIterator {
                     NumberFormat.Style.SHORT);
 
     private static final NumberFormat FORMAT_EN_LONG = NumberFormat
-            .getCompactNumberInstance(new Locale("en"),
+            .getCompactNumberInstance(Locale.ENGLISH,
                     NumberFormat.Style.LONG);
 
     @DataProvider(name = "fieldPositions")

--- a/test/jdk/java/text/Format/CompactNumberFormat/TestMutatingInstance.java
+++ b/test/jdk/java/text/Format/CompactNumberFormat/TestMutatingInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,16 +45,16 @@ import org.testng.annotations.Test;
 public class TestMutatingInstance {
 
     private static final NumberFormat FORMAT_FRACTION = NumberFormat
-            .getCompactNumberInstance(new Locale("en"), NumberFormat.Style.LONG);
+            .getCompactNumberInstance(Locale.ENGLISH, NumberFormat.Style.LONG);
 
     private static final CompactNumberFormat FORMAT_GROUPING = (CompactNumberFormat) NumberFormat
-            .getCompactNumberInstance(new Locale("en"), NumberFormat.Style.LONG);
+            .getCompactNumberInstance(Locale.ENGLISH, NumberFormat.Style.LONG);
 
     private static final NumberFormat FORMAT_MININTEGER = NumberFormat
-            .getCompactNumberInstance(new Locale("en"), NumberFormat.Style.LONG);
+            .getCompactNumberInstance(Locale.ENGLISH, NumberFormat.Style.LONG);
 
     private static final NumberFormat FORMAT_PARSEINTONLY = NumberFormat
-            .getCompactNumberInstance(new Locale("en"), NumberFormat.Style.LONG);
+            .getCompactNumberInstance(Locale.ENGLISH, NumberFormat.Style.LONG);
 
     // No compact patterns are specified for this instance except at index 4.
     // This is to test how the behaviour differs between compact number formatting

--- a/test/jdk/java/text/Format/CompactNumberFormat/TestParseBigDecimal.java
+++ b/test/jdk/java/text/Format/CompactNumberFormat/TestParseBigDecimal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,28 +41,28 @@ import java.util.Locale;
 public class TestParseBigDecimal {
 
     private static final CompactNumberFormat FORMAT_DZ_LONG = (CompactNumberFormat) NumberFormat
-            .getCompactNumberInstance(new Locale("dz"), NumberFormat.Style.LONG);
+            .getCompactNumberInstance(Locale.of("dz"), NumberFormat.Style.LONG);
 
     private static final CompactNumberFormat FORMAT_EN_US_SHORT = (CompactNumberFormat) NumberFormat
             .getCompactNumberInstance(Locale.US, NumberFormat.Style.SHORT);
 
     private static final CompactNumberFormat FORMAT_EN_LONG = (CompactNumberFormat) NumberFormat
-            .getCompactNumberInstance(new Locale("en"), NumberFormat.Style.LONG);
+            .getCompactNumberInstance(Locale.ENGLISH, NumberFormat.Style.LONG);
 
     private static final CompactNumberFormat FORMAT_HI_IN_LONG = (CompactNumberFormat) NumberFormat
-            .getCompactNumberInstance(new Locale("hi", "IN"), NumberFormat.Style.LONG);
+            .getCompactNumberInstance(Locale.of("hi", "IN"), NumberFormat.Style.LONG);
 
     private static final CompactNumberFormat FORMAT_JA_JP_SHORT = (CompactNumberFormat) NumberFormat
             .getCompactNumberInstance(Locale.JAPAN, NumberFormat.Style.SHORT);
 
     private static final CompactNumberFormat FORMAT_IT_SHORT = (CompactNumberFormat) NumberFormat
-            .getCompactNumberInstance(new Locale("it"), NumberFormat.Style.SHORT);
+            .getCompactNumberInstance(Locale.ITALIAN, NumberFormat.Style.SHORT);
 
     private static final CompactNumberFormat FORMAT_SW_LONG = (CompactNumberFormat) NumberFormat
-            .getCompactNumberInstance(new Locale("sw"), NumberFormat.Style.LONG);
+            .getCompactNumberInstance(Locale.of("sw"), NumberFormat.Style.LONG);
 
     private static final CompactNumberFormat FORMAT_SE_SHORT = (CompactNumberFormat) NumberFormat
-            .getCompactNumberInstance(new Locale("se"), NumberFormat.Style.SHORT);
+            .getCompactNumberInstance(Locale.of("se"), NumberFormat.Style.SHORT);
 
     @BeforeTest
     public void mutateInstances() {

--- a/test/jdk/java/text/Format/CompactNumberFormat/TestWithCompatProvider.java
+++ b/test/jdk/java/text/Format/CompactNumberFormat/TestWithCompatProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ import org.testng.annotations.Test;
 public class TestWithCompatProvider {
 
     private static final NumberFormat FORMAT_DZ_SHORT = NumberFormat
-            .getCompactNumberInstance(new Locale("dz"), NumberFormat.Style.SHORT);
+            .getCompactNumberInstance(Locale.of("dz"), NumberFormat.Style.SHORT);
 
     private static final NumberFormat FORMAT_EN_US_SHORT = NumberFormat
             .getCompactNumberInstance(Locale.US, NumberFormat.Style.SHORT);

--- a/test/jdk/java/text/Format/CompactNumberFormat/serialization/TestSerialization.java
+++ b/test/jdk/java/text/Format/CompactNumberFormat/serialization/TestSerialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ import static org.testng.Assert.*;
 public class TestSerialization {
 
     private static final NumberFormat FORMAT_HI = NumberFormat.getCompactNumberInstance(
-            new Locale("hi"), NumberFormat.Style.SHORT);
+            Locale.of("hi"), NumberFormat.Style.SHORT);
     private static final CompactNumberFormat FORMAT_EN_US = (CompactNumberFormat) NumberFormat
             .getCompactNumberInstance(Locale.US, NumberFormat.Style.LONG);
     private static final NumberFormat FORMAT_JA_JP = NumberFormat.getCompactNumberInstance(

--- a/test/jdk/java/text/Format/DateFormat/Bug4322313.java
+++ b/test/jdk/java/text/Format/DateFormat/Bug4322313.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ public class Bug4322313 extends IntlTest {
         boolean err = false;
         long mpm = 60 * 1000;   /* Milliseconds per a minute */
 
-        Locale[] locs = {Locale.US, Locale.JAPAN, Locale.UK, new Locale("ar")};
+        Locale[] locs = {Locale.US, Locale.JAPAN, Locale.UK, Locale.of("ar")};
 
         String[] formats = {
             "z",

--- a/test/jdk/java/text/Format/DateFormat/Bug4823811.java
+++ b/test/jdk/java/text/Format/DateFormat/Bug4823811.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import java.util.*;
 
 public class Bug4823811 {
 
-    private static Locale localeEG = new Locale("ar", "EG");
+    private static Locale localeEG = Locale.of("ar", "EG");
     private static Locale localeUS = Locale.US;
 
     private static String JuneInArabic = "\u064a\u0648\u0646\u064a\u0648";

--- a/test/jdk/java/text/Format/DateFormat/Bug6683975.java
+++ b/test/jdk/java/text/Format/DateFormat/Bug6683975.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,8 +35,8 @@ public class Bug6683975 {
 
     private static boolean err = false;
 
-    private static Locale th = new Locale("th", "");
-    private static Locale th_TH = new Locale("th", "TH");
+    private static Locale th = Locale.of("th");
+    private static Locale th_TH = Locale.of("th", "TH");
     private static String expected_th[] = {
         "\u0e27\u0e31\u0e19\u0e2d\u0e31\u0e07\u0e04\u0e32\u0e23\u0e17\u0e35\u0e48 30 \u0e01\u0e31\u0e19\u0e22\u0e32\u0e22\u0e19 \u0e04.\u0e28. 2008, 8 \u0e19\u0e32\u0e2c\u0e34\u0e01\u0e32 0 \u0e19\u0e32\u0e17\u0e35 00 \u0e27\u0e34\u0e19\u0e32\u0e17\u0e35",  // 0: FULL
         "30 \u0e01\u0e31\u0e19\u0e22\u0e32\u0e22\u0e19 2008, 8 \u0e19\u0e32\u0e2c\u0e34\u0e01\u0e32 0 \u0e19\u0e32\u0e17\u0e35",  // 1: LONG

--- a/test/jdk/java/text/Format/DateFormat/Bug8139572.java
+++ b/test/jdk/java/text/Format/DateFormat/Bug8139572.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import java.util.Locale;
 
 public class Bug8139572 {
 
-    private static final Locale RUSSIAN = new Locale("ru");
+    private static final Locale RUSSIAN = Locale.of("ru");
     private static final Date SEPT12 = new GregorianCalendar(2015, Calendar.SEPTEMBER, 12).getTime();
 
     private static final String[] PATTERNS = {

--- a/test/jdk/java/text/Format/DateFormat/ContextMonthNamesTest.java
+++ b/test/jdk/java/text/Format/DateFormat/ContextMonthNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import java.text.*;
 import java.util.*;
 
 public class ContextMonthNamesTest {
-    static Locale CZECH = new Locale("cs");
+    static Locale CZECH = Locale.of("cs");
     static Date JAN30 = new GregorianCalendar(2012, Calendar.JANUARY, 30).getTime();
 
     static String[] PATTERNS = {

--- a/test/jdk/java/text/Format/DateFormat/DateFormatRegression.java
+++ b/test/jdk/java/text/Format/DateFormat/DateFormatRegression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -265,7 +265,7 @@ public class DateFormatRegression extends IntlTest {
         Locale saveLocale = Locale.getDefault();
         TimeZone saveZone = TimeZone.getDefault();
         try {
-            Locale curLocale = new Locale("de","DE");
+            Locale curLocale = Locale.GERMANY;
             Locale.setDefault(curLocale);
             TimeZone.setDefault(TimeZone.getTimeZone("EST"));
             curDate = new Date(98, 0, 1);

--- a/test/jdk/java/text/Format/DateFormat/DateFormatRoundTripTest.java
+++ b/test/jdk/java/text/Format/DateFormat/DateFormatRoundTripTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,7 +78,7 @@ public class DateFormatRoundTripTest extends IntlTest {
     }
 
     /**
-     * Parse a name like "fr_FR" into new Locale("fr", "FR", "");
+     * Parse a name like "fr_FR" into Locale.of("fr", "FR", "");
      */
     static Locale createLocale(String name) {
         String country = "",
@@ -92,7 +92,7 @@ public class DateFormatRoundTripTest extends IntlTest {
             variant = country.substring(i+1);
             country = country.substring(0, i);
         }
-        return new Locale(name, country, variant);
+        return Locale.of(name, country, variant);
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/java/text/Format/DateFormat/DateFormatTest.java
+++ b/test/jdk/java/text/Format/DateFormat/DateFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -413,7 +413,7 @@ public class DateFormatTest extends IntlTest
     public void TestCzechMonths459()
     {
         // Use Czech, which has month names with shared prefixes for June and July
-        DateFormat fmt = DateFormat.getDateInstance(DateFormat.FULL, new Locale("cs", "", ""));
+        DateFormat fmt = DateFormat.getDateInstance(DateFormat.FULL, Locale.of("cs"));
         //((SimpleDateFormat)fmt).applyPattern("MMMM d yyyy");
         logln("Pattern " + ((SimpleDateFormat)fmt).toPattern());
 
@@ -988,7 +988,7 @@ test commented out pending API-change approval
      */
     public void TestBuddhistEraBugId4469904() {
         String era = "\u0e1e.\u0e28.";
-        Locale loc = new Locale("th", "TH");
+        Locale loc = Locale.of("th", "TH");
         Calendar cal = Calendar.getInstance(Locale.US);
         cal.set(2001, 7, 23);
         Date date = cal.getTime();
@@ -1208,7 +1208,7 @@ test commented out pending API-change approval
     }
 
     public void Test8216969() throws Exception {
-        Locale locale = new Locale("ru");
+        Locale locale = Locale.of("ru");
         String format = "\u0434\u0435\u043a";
         String standalone = "\u0434\u0435\u043a.";
 

--- a/test/jdk/java/text/Format/DateFormat/LocaleDateFormats.java
+++ b/test/jdk/java/text/Format/DateFormat/LocaleDateFormats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,5 +60,5 @@ public class LocaleDateFormats {
         };
     }
     // en_SG Locale instance
-    private static final Locale localeEnSG = new Locale("en", "SG");
+    private static final Locale localeEnSG = Locale.of("en", "SG");
 }

--- a/test/jdk/java/text/Format/DateFormat/NonGregorianFormatTest.java
+++ b/test/jdk/java/text/Format/DateFormat/NonGregorianFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -128,7 +128,7 @@ public class NonGregorianFormatTest {
         Locale.setDefault(locale);
 
         // Tests with the Japanese imperial calendar
-        Locale calendarLocale = new Locale("ja", "JP", "JP");
+        Locale calendarLocale = Locale.of("ja", "JP", "JP");
         testRoundTrip(calendarLocale);
         testRoundTripSimple(calendarLocale,
                             locale == Locale.ENGLISH ? JAPANESE_EN : JAPANESE_JA);
@@ -136,7 +136,7 @@ public class NonGregorianFormatTest {
                             locale == Locale.ENGLISH ? EXCEPTION_JAPANESE_EN : EXCEPTION_JAPANESE_JA);
 
         // Tests with the Thai Buddhist calendar
-        calendarLocale = new Locale("th", "TH");
+        calendarLocale = Locale.of("th", "TH");
         testRoundTrip(calendarLocale);
         testRoundTripSimple(calendarLocale,
                             locale == Locale.ENGLISH ? BUDDHIST_EN : BUDDHIST_JA);

--- a/test/jdk/java/text/Format/DateFormat/TestDayPeriodWithSDF.java
+++ b/test/jdk/java/text/Format/DateFormat/TestDayPeriodWithSDF.java
@@ -45,7 +45,7 @@ import java.util.Locale;
 
 public class TestDayPeriodWithSDF {
 
-    private static final Locale BURMESE = new Locale("my");
+    private static final Locale BURMESE = Locale.of("my");
     private static final DateFormat FORMAT_SHORT_BURMESE = DateFormat.getTimeInstance(DateFormat.SHORT, BURMESE);
     private static final DateFormat FORMAT_MEDIUM_BURMESE = DateFormat.getTimeInstance(DateFormat.MEDIUM, BURMESE);
 

--- a/test/jdk/java/text/Format/DateFormat/WeekDateTest.java
+++ b/test/jdk/java/text/Format/DateFormat/WeekDateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,7 +135,7 @@ public class WeekDateTest {
     private static void noWeekDateSupport() throws Exception {
         // Tests with Japanese Imperial Calendar that doesn't support week dates.
         Calendar jcal = Calendar.getInstance(TimeZone.getTimeZone("GMT"),
-                                             new Locale("ja", "JP", "JP"));
+                                             Locale.of("ja", "JP", "JP"));
 
         String format = "2-W01-2"; // 2019-12-31 == R1-12-31
         int expectedYear = 2019;

--- a/test/jdk/java/text/Format/DateFormat/bug4358730.java
+++ b/test/jdk/java/text/Format/DateFormat/bug4358730.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ public class bug4358730 extends IntlTest {
 
         try {
             TimeZone.setDefault(TimeZone.getTimeZone("PST"));
-            Locale.setDefault(new Locale("en", "US"));
+            Locale.setDefault(Locale.US);
             SimpleDateFormat sdf = new SimpleDateFormat();
 
             for (int i = 0; i < datasize; i++) {

--- a/test/jdk/java/text/Format/DecimalFormat/GoldenDoubleValues.java
+++ b/test/jdk/java/text/Format/DecimalFormat/GoldenDoubleValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,12 +58,12 @@ class GoldenDoubleValues {
 
     // TestLocale is the testing locale used by RoundingAndPropertyTest test,
     // when testing the golden double values
-    static final Locale TestLocale = new Locale("en", "US");
+    static final Locale TestLocale = Locale.US;
 
 
     // FullTestLocale is the testing locale used by RoundingAndPropertyTest test,
     // when testing full localization of double values.
-    static final Locale FullLocalizationTestLocale = new Locale("hi", "IN");
+    static final Locale FullLocalizationTestLocale = Locale.of("hi", "IN");
 
 
     /* Below are the two double values used for exercising the changes of

--- a/test/jdk/java/text/Format/DecimalFormat/RoundingAndPropertyTest.java
+++ b/test/jdk/java/text/Format/DecimalFormat/RoundingAndPropertyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -704,7 +704,7 @@ public class RoundingAndPropertyTest {
         System.out.print("Checking " + propertyName + " property.");
         DecimalFormatSymbols initialDecimalFormatSymbols = df.getDecimalFormatSymbols();
         firstFormatResult = df.format(d1);
-        Locale bizarreLocale = new Locale("fr", "FR");
+        Locale bizarreLocale = Locale.FRANCE;
         DecimalFormatSymbols unusualSymbols = new DecimalFormatSymbols(bizarreLocale);
         unusualSymbols.setDecimalSeparator('@');
         unusualSymbols.setGroupingSeparator('|');

--- a/test/jdk/java/text/Format/NumberFormat/Bug8132125.java
+++ b/test/jdk/java/text/Format/NumberFormat/Bug8132125.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import java.util.*;
 
 public class Bug8132125 {
     public static void main(String[] args) {
-        Locale deCH = new Locale("de", "CH");
+        Locale deCH = Locale.of("de", "CH");
         NumberFormat nf = NumberFormat.getInstance(deCH);
 
         String expected = "54\u2019839\u2019483.142"; // i.e. "\u2019" as decimal separator, "\u2019" as grouping separator

--- a/test/jdk/java/text/Format/NumberFormat/CurrencyFormat.java
+++ b/test/jdk/java/text/Format/NumberFormat/CurrencyFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@ public class CurrencyFormat {
             Locale.JAPAN,
             Locale.GERMANY,
             Locale.ITALY,
-            new Locale("it", "IT", "EURO"),
+            Locale.of("it", "IT", "EURO"),
             Locale.forLanguageTag("de-AT"),
             Locale.forLanguageTag("fr-CH"),
         };

--- a/test/jdk/java/text/Format/NumberFormat/MultipleNumberScriptTest.java
+++ b/test/jdk/java/text/Format/NumberFormat/MultipleNumberScriptTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,9 +34,9 @@ import java.util.*;
 public class MultipleNumberScriptTest {
 
     static Locale[] locales = {
-        new Locale("ar"),
-        new Locale("ar", "EG"),
-        new Locale("ar", "DZ"),
+        Locale.of("ar"),
+        Locale.of("ar", "EG"),
+        Locale.of("ar", "DZ"),
         Locale.forLanguageTag("ar-EG-u-nu-arab"),
         Locale.forLanguageTag("ar-EG-u-nu-latn"),
         Locale.forLanguageTag("ar-DZ-u-nu-arab"),
@@ -44,7 +44,7 @@ public class MultipleNumberScriptTest {
         Locale.forLanguageTag("ee"),
         Locale.forLanguageTag("ee-GH"),
         Locale.forLanguageTag("ee-GH-u-nu-latn"),
-        new Locale("th", "TH", "TH"),
+        Locale.of("th", "TH", "TH"),
         Locale.forLanguageTag("th-TH"),
         Locale.forLanguageTag("th-TH-u-nu-thai"),
         Locale.forLanguageTag("th-TH-u-nu-hoge"),

--- a/test/jdk/java/text/Format/NumberFormat/NumberRegression.java
+++ b/test/jdk/java/text/Format/NumberFormat/NumberRegression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -487,7 +487,7 @@ public class NumberRegression extends IntlTest {
      * interpreted as monetary separator if currency symbol is seen!
      */
     public void Test4087244 () {
-        Locale de = new Locale("pt", "PT");
+        Locale de = Locale.of("pt", "PT");
         DecimalFormat df = (DecimalFormat) NumberFormat.getCurrencyInstance(de);
         DecimalFormatSymbols sym = df.getDecimalFormatSymbols();
         sym.setMonetaryDecimalSeparator('$');

--- a/test/jdk/java/text/Format/NumberFormat/TestPeruCurrencyFormat.java
+++ b/test/jdk/java/text/Format/NumberFormat/TestPeruCurrencyFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ public class TestPeruCurrencyFormat {
     public static void main(String[] args) {
         final String expected = "S/.1,234.56";
         NumberFormat currencyFmt =
-                NumberFormat.getCurrencyInstance(new Locale("es", "PE"));
+                NumberFormat.getCurrencyInstance(Locale.of("es", "PE"));
         String s = currencyFmt.format(1234.56);
 
         if (!s.equals(expected)) {

--- a/test/jdk/java/text/Format/common/Bug6215962.java
+++ b/test/jdk/java/text/Format/common/Bug6215962.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,25 +55,25 @@ public class Bug6215962 {
         mf2 = new MessageFormat("{0}", Locale.JAPAN);
         check(mf1, mf2, false);
 
-        mf1 = new MessageFormat("{0}", new Locale("ja", "JP"));
+        mf1 = new MessageFormat("{0}", Locale.of("ja", "JP"));
         check(mf1, mf2, true);
 
         mf1.setLocale(null);
         check(mf1, mf2, false);
 
-        mf1 = new MessageFormat("{0}", new Locale("ja", "JP", "FOO"));
+        mf1 = new MessageFormat("{0}", Locale.of("ja", "JP", "FOO"));
         check(mf1, mf2, false);
 
-        mf2 = new MessageFormat("{1}", new Locale("ja", "JP", "FOO"));
+        mf2 = new MessageFormat("{1}", Locale.of("ja", "JP", "FOO"));
         check(mf1, mf2, false);
 
-        mf1 = new MessageFormat("{1}", new Locale("ja", "JP", "FOO"));
+        mf1 = new MessageFormat("{1}", Locale.of("ja", "JP", "FOO"));
         check(mf1, mf2, true);
 
-        mf1 = new MessageFormat("{1, date}", new Locale("ja", "JP", "FOO"));
+        mf1 = new MessageFormat("{1, date}", Locale.of("ja", "JP", "FOO"));
         check(mf1, mf2, false);
 
-        mf2 = new MessageFormat("{1, date}", new Locale("ja", "JP", "FOO"));
+        mf2 = new MessageFormat("{1, date}", Locale.of("ja", "JP", "FOO"));
         check(mf1, mf2, true);
     }
 

--- a/test/jdk/java/time/tck/java/time/chrono/TCKJapaneseChronology.java
+++ b/test/jdk/java/time/tck/java/time/chrono/TCKJapaneseChronology.java
@@ -1,5 +1,5 @@
 /*
- o Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ o Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -151,21 +151,21 @@ public class TCKJapaneseChronology {
 
     @Test
     public void test_chrono_byLocale_oldJP_noVariant() {
-        Chronology test = Chronology.ofLocale(new Locale("ja", "JP"));
+        Chronology test = Chronology.ofLocale(Locale.JAPAN);
         Assert.assertEquals(test.getId(), "ISO");
         Assert.assertEquals(test, IsoChronology.INSTANCE);
     }
 
     @Test
     public void test_chrono_byLocale_oldJP_variant() {
-        Chronology test = Chronology.ofLocale(new Locale("ja", "JP", "JP"));
+        Chronology test = Chronology.ofLocale(Locale.of("ja", "JP", "JP"));
         Assert.assertEquals(test.getId(), "Japanese");
         Assert.assertEquals(test, JapaneseChronology.INSTANCE);
     }
 
     @Test
     public void test_chrono_byLocale_iso() {
-        Assert.assertEquals(Chronology.ofLocale(new Locale("ja", "JP")).getId(), "ISO");
+        Assert.assertEquals(Chronology.ofLocale(Locale.JAPAN).getId(), "ISO");
         Assert.assertEquals(Chronology.ofLocale(Locale.forLanguageTag("ja-JP")).getId(), "ISO");
         Assert.assertEquals(Chronology.ofLocale(Locale.forLanguageTag("ja-JP-JP")).getId(), "ISO");
     }

--- a/test/jdk/java/time/tck/java/time/chrono/TCKThaiBuddhistChronology.java
+++ b/test/jdk/java/time/tck/java/time/chrono/TCKThaiBuddhistChronology.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -140,21 +140,21 @@ public class TCKThaiBuddhistChronology {
 
     @Test
     public void test_chrono_byLocale_oldTH_noVariant() {  // deliberately different to Calendar
-        Chronology test = Chronology.ofLocale(new Locale("th", "TH"));
+        Chronology test = Chronology.ofLocale(Locale.of("th", "TH"));
         Assert.assertEquals(test.getId(), "ISO");
         Assert.assertEquals(test, IsoChronology.INSTANCE);
     }
 
     @Test
     public void test_chrono_byLocale_oldTH_variant() {
-        Chronology test = Chronology.ofLocale(new Locale("th", "TH", "TH"));
+        Chronology test = Chronology.ofLocale(Locale.of("th", "TH", "TH"));
         Assert.assertEquals(test.getId(), "ISO");
         Assert.assertEquals(test, IsoChronology.INSTANCE);
     }
 
     @Test
     public void test_chrono_byLocale_iso() {
-        Assert.assertEquals(Chronology.ofLocale(new Locale("th", "TH")).getId(), "ISO");
+        Assert.assertEquals(Chronology.ofLocale(Locale.of("th", "TH")).getId(), "ISO");
         Assert.assertEquals(Chronology.ofLocale(Locale.forLanguageTag("th-TH")).getId(), "ISO");
         Assert.assertEquals(Chronology.ofLocale(Locale.forLanguageTag("th-TH-TH")).getId(), "ISO");
     }

--- a/test/jdk/java/time/test/java/time/format/TestDateTimeTextProvider.java
+++ b/test/jdk/java/time/test/java/time/format/TestDateTimeTextProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,7 +79,7 @@ import org.testng.annotations.Test;
 @Test
 public class TestDateTimeTextProvider extends AbstractTestPrinterParser {
 
-    Locale enUS = new Locale("en", "US");
+    Locale enUS = Locale.US;
 
     //-----------------------------------------------------------------------
     @DataProvider(name = "Text")

--- a/test/jdk/java/time/test/java/time/format/TestDateTimeTextProviderWithLocale.java
+++ b/test/jdk/java/time/test/java/time/format/TestDateTimeTextProviderWithLocale.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,8 +86,8 @@ import org.testng.annotations.Test;
 @Test
 public class TestDateTimeTextProviderWithLocale extends AbstractTestPrinterParser {
 
-    Locale enUS = new Locale("en", "US");
-    Locale ptBR = new Locale("pt", "BR");
+    Locale enUS = Locale.US;
+    Locale ptBR = Locale.of("pt", "BR");
 
     //-----------------------------------------------------------------------
     @DataProvider(name = "Text")

--- a/test/jdk/java/time/test/java/time/format/TestDayPeriodWithDTF.java
+++ b/test/jdk/java/time/test/java/time/format/TestDayPeriodWithDTF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ import java.util.Locale;
 @Test
 public class TestDayPeriodWithDTF {
 
-    private static final Locale BURMESE = new Locale("my");
+    private static final Locale BURMESE = Locale.of("my");
 
     private static final DateTimeFormatter FORMAT_SHORT_BURMESE = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withLocale(BURMESE);
     private static final DateTimeFormatter FORMAT_MEDIUM_BURMESE = DateTimeFormatter.ofLocalizedTime(FormatStyle.MEDIUM).withLocale(BURMESE);

--- a/test/jdk/java/time/test/java/time/format/TestLocalizedOffsetPrinterParser.java
+++ b/test/jdk/java/time/test/java/time/format/TestLocalizedOffsetPrinterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@ public class TestLocalizedOffsetPrinterParser {
 
     private static final LocalDateTime DT_2012_06_30_12_30_40 = LocalDateTime.of(2012, 6, 30, 12, 30, 40);
 
-    private static final Locale LOCALE_GA = new Locale("ga");
+    private static final Locale LOCALE_GA = Locale.of("ga");
 
     @DataProvider(name="print_localized_custom_locale")
     Object[][] data_print_localized_custom_locale() {

--- a/test/jdk/java/time/test/java/time/format/TestNarrowMonthNamesAndDayNames.java
+++ b/test/jdk/java/time/test/java/time/format/TestNarrowMonthNamesAndDayNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ public class TestNarrowMonthNamesAndDayNames {
     private static final List<Locale> LOCARR = Arrays.asList(Locale.US,
             Locale.GERMANY,
             Locale.FRANCE,
-            new Locale("no", "NO"));
+            Locale.of("no", "NO"));
 
     /**
      * Locale en_US, de_DE, fr_FR, no_NO will have same Narrow and
@@ -106,7 +106,7 @@ public class TestNarrowMonthNamesAndDayNames {
             {Locale.US, new String[]{"M", "T", "W", "T", "F", "S", "S"}},
             {Locale.GERMANY, new String[]{"M", "D", "M", "D", "F", "S", "S"}},
             {Locale.FRANCE, new String[]{"L", "M", "M", "J", "V", "S", "D"}},
-            {new Locale("no", "NO"), new String[]{"M", "T", "O", "T", "F", "L", "S"}},};
+            {Locale.of("no", "NO"), new String[]{"M", "T", "O", "T", "F", "L", "S"}},};
     }
 
     //-----------------------------------------------------------------------

--- a/test/jdk/java/time/test/java/time/format/TestNonIsoFormatter.java
+++ b/test/jdk/java/time/test/java/time/format/TestNonIsoFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,8 +71,8 @@ public class TestNonIsoFormatter {
 
     private static final LocalDate IsoDate = LocalDate.of(2013, 2, 11);
 
-    private static final Locale ARABIC = new Locale("ar");
-    private static final Locale thTH = new Locale("th", "TH");
+    private static final Locale ARABIC = Locale.of("ar");
+    private static final Locale thTH = Locale.of("th", "TH");
     private static final Locale thTHTH = Locale.forLanguageTag("th-TH-u-nu-thai");
     private static final Locale jaJPJP = Locale.forLanguageTag("ja-JP-u-ca-japanese");
 

--- a/test/jdk/java/time/test/java/time/format/TestTextParserWithLocale.java
+++ b/test/jdk/java/time/test/java/time/format/TestTextParserWithLocale.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,8 +95,8 @@ import static org.testng.Assert.assertEquals;
  */
 @Test
 public class TestTextParserWithLocale extends AbstractTestPrinterParser {
-    static final Locale RUSSIAN = new Locale("ru");
-    static final Locale FINNISH = new Locale("fi");
+    static final Locale RUSSIAN = Locale.of("ru");
+    static final Locale FINNISH = Locale.of("fi");
 
     @DataProvider(name="parseDayOfWeekText")
     Object[][] providerDayOfWeekData() {

--- a/test/jdk/java/time/test/java/time/format/TestTextPrinterWithLocale.java
+++ b/test/jdk/java/time/test/java/time/format/TestTextPrinterWithLocale.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,8 +90,8 @@ import test.java.time.temporal.MockFieldValue;
  */
 @Test
 public class TestTextPrinterWithLocale extends AbstractTestPrinterParser {
-    static final Locale RUSSIAN = new Locale("ru");
-    static final Locale FINNISH = new Locale("fi");
+    static final Locale RUSSIAN = Locale.of("ru");
+    static final Locale FINNISH = Locale.of("fi");
 
     //-----------------------------------------------------------------------
     @DataProvider(name="print_DayOfWeekData")

--- a/test/jdk/java/util/Calendar/BuddhistCalendarTest.java
+++ b/test/jdk/java/util/Calendar/BuddhistCalendarTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import static java.util.Calendar.*;
 
 public class BuddhistCalendarTest {
 
-    private static final Locale THAI_LOCALE = new Locale("th", "TH");
+    private static final Locale THAI_LOCALE = Locale.of("th", "TH");
 
     public static void main(String[] args) {
         testAddRoll();

--- a/test/jdk/java/util/Calendar/Bug4302966.java
+++ b/test/jdk/java/util/Calendar/Bug4302966.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import java.util.Locale;
 public class Bug4302966 {
 
     public static void main(String[] args) {
-        Calendar czechCalendar = Calendar.getInstance(new Locale("cs", "CZ"));
+        Calendar czechCalendar = Calendar.getInstance(Locale.of("cs", "CZ"));
         int firstDayOfWeek = czechCalendar.getFirstDayOfWeek();
         if (firstDayOfWeek != Calendar.MONDAY) {
             throw new RuntimeException();

--- a/test/jdk/java/util/Calendar/Bug6448234.java
+++ b/test/jdk/java/util/Calendar/Bug6448234.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import static java.util.Calendar.*;
 
 public class Bug6448234 {
     public static void main(String[] args) {
-        Calendar jcal = Calendar.getInstance(new Locale("ja", "JP", "JP"));
+        Calendar jcal = Calendar.getInstance(Locale.of("ja", "JP", "JP"));
         Calendar gcal = Calendar.getInstance(Locale.US);
 
         for (int i = SUNDAY; i <= SATURDAY; i++) {

--- a/test/jdk/java/util/Calendar/Bug8167273.java
+++ b/test/jdk/java/util/Calendar/Bug8167273.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,8 +83,8 @@ public class Bug8167273 {
     public static void testEraName() {
         Set<Locale> allLocales = Set.of(Locale.getAvailableLocales());
         Set<Locale> JpThlocales = Set.of(
-                new Locale("th", "TH"), Locale.forLanguageTag("th-Thai-TH"),
-                new Locale("ja", "JP", "JP"), new Locale("th", "TH", "TH")
+                Locale.of("th", "TH"), Locale.forLanguageTag("th-Thai-TH"),
+                Locale.of("ja", "JP", "JP"), Locale.of("th", "TH", "TH")
         );
         Set<Locale> allLocs = new HashSet<>(allLocales);
         // Removing Japanese and Thai Locales to check  Gregorian Calendar Locales

--- a/test/jdk/java/util/Calendar/Builder/BuilderTest.java
+++ b/test/jdk/java/util/Calendar/Builder/BuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,8 +32,8 @@ import java.util.*;
 import static java.util.Calendar.*;
 
 public class BuilderTest {
-    private static final Locale jaJPJP = new Locale("ja", "JP", "JP");
-    private static final Locale thTH = new Locale("th", "TH");
+    private static final Locale jaJPJP = Locale.of("ja", "JP", "JP");
+    private static final Locale thTH = Locale.of("th", "TH");
     private static final TimeZone LA = TimeZone.getTimeZone("America/Los_Angeles");
     private static final TimeZone TOKYO = TimeZone.getTimeZone("Asia/Tokyo");
     private static int error;

--- a/test/jdk/java/util/Calendar/CalendarDataTest.java
+++ b/test/jdk/java/util/Calendar/CalendarDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class CalendarDataTest {
 
     public static void main(String... args) throws Exception {
         // world
-        Calendar cal = Calendar.getInstance(new Locale("", "001"));
+        Calendar cal = Calendar.getInstance(Locale.of("", "001"));
         checkResult("001",
             cal.getFirstDayOfWeek(),
             cal.getMinimalDaysInFirstWeek());
@@ -71,7 +71,7 @@ public class CalendarDataTest {
                 IntStream.range(0x41, 0x5b)
                     .mapToObj(c2 -> String.valueOf((char)c1) + String.valueOf((char)c2))
                     .forEach(region -> {
-                        Calendar c = Calendar.getInstance(new Locale("", region));
+                        Calendar c = Calendar.getInstance(Locale.of("", region));
                         checkResult(region,
                                 c.getFirstDayOfWeek(),
                                 c.getMinimalDaysInFirstWeek());

--- a/test/jdk/java/util/Calendar/CalendarRegression.java
+++ b/test/jdk/java/util/Calendar/CalendarRegression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2255,7 +2255,7 @@ public class CalendarRegression extends IntlTest {
             errln("equals threw IllegalArugumentException with non-lenient");
         }
 
-        cal1 = Calendar.getInstance(new Locale("th", "TH"));
+        cal1 = Calendar.getInstance(Locale.of("th", "TH"));
         cal1.setTimeInMillis(0L);
         cal2 = Calendar.getInstance(Locale.US);
         cal2.setTimeInMillis(0L);

--- a/test/jdk/java/util/Calendar/CalendarTest.java
+++ b/test/jdk/java/util/Calendar/CalendarTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -974,7 +974,7 @@ public class CalendarTest extends IntlTest {
 
         try {
             for (int j = 0; j < lt.length; j++) {
-                Locale l = new Locale(lt[j][0], lt[j][1]);
+                Locale l = Locale.of(lt[j][0], lt[j][1]);
                 TimeZone z = TimeZone.getTimeZone(lt[j][2]);
                 Locale.setDefault(l);
                 TimeZone.setDefault(z);

--- a/test/jdk/java/util/Calendar/CalendarTestScripts/CalendarTestEngine.java
+++ b/test/jdk/java/util/Calendar/CalendarTestScripts/CalendarTestEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,7 +111,7 @@ public class CalendarTestEngine {
                                 var = sc.next();
                             }
                         }
-                        locale = new Locale(lang, country, var);
+                        locale = Locale.of(lang, country, var);
                     }
                     break;
 

--- a/test/jdk/java/util/Calendar/CalendarTypeTest.java
+++ b/test/jdk/java/util/Calendar/CalendarTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,9 +38,9 @@ public class CalendarTypeTest {
     static Locale[] locales = new Locale[] {
         Locale.US,
         Locale.forLanguageTag("th-TH-u-ca-gregory"),
-        new Locale("th", "TH"),
+        Locale.of("th", "TH"),
         Locale.forLanguageTag("en-US-u-ca-buddhist"),
-        new Locale("ja", "JP", "JP"),
+        Locale.of("ja", "JP", "JP"),
         Locale.forLanguageTag("en-US-u-ca-japanese")};
     static final String[] TYPES = new String[] {
         "gregory",

--- a/test/jdk/java/util/Calendar/CldrFormatNamesTest.java
+++ b/test/jdk/java/util/Calendar/CldrFormatNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import static java.util.Calendar.*;
 import sun.util.locale.provider.*;
 
 public class CldrFormatNamesTest {
-    private static final Locale ARABIC = new Locale("ar");
+    private static final Locale ARABIC = Locale.of("ar");
     private static final Locale ZH_HANT = Locale.forLanguageTag("zh-Hant");
 
     /*

--- a/test/jdk/java/util/Calendar/JapanEraNameCompatTest.java
+++ b/test/jdk/java/util/Calendar/JapanEraNameCompatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,10 +69,10 @@ public class JapanEraNameCompatTest {
             { KOREAN,   KoreanName, "R" },
             { CHINA,    CJName,     "R" },
             { TAIWAN,   CJName,     "R" }, // fallback to zh
-            { new Locale("ar"), ArabicName, ArabicName },
-            { new Locale("th"), ThaiName, "R" },
+            { Locale.of("ar"), ArabicName, ArabicName },
+            { Locale.of("th"), ThaiName, "R" },
             // hi_IN fallback to root
-            { new Locale("hi", "IN"), EngName, "R" }
+            { Locale.of("hi", "IN"), EngName, "R" }
         };
     }
 
@@ -91,20 +91,20 @@ public class JapanEraNameCompatTest {
             { KOREAN, KoreanName, KoreanName },
             { CHINA, CJName, CJName },
             { TAIWAN, CJName, CJName },
-            { new Locale("ar"), ArabicName, ArabicName },
-            { new Locale("th"), ThaiName, ThaiName },
-            { new Locale("hi", "IN"), HindiName, HindiName },
-            { new Locale("ru"), RussianName, RussianName },
-            { new Locale("sr"), SerbianName, SerbianName },
+            { Locale.of("ar"), ArabicName, ArabicName },
+            { Locale.of("th"), ThaiName, ThaiName },
+            { Locale.of("hi", "IN"), HindiName, HindiName },
+            { Locale.of("ru"), RussianName, RussianName },
+            { Locale.of("sr"), SerbianName, SerbianName },
             { Locale.forLanguageTag("sr-Latn"), SerbLatinName, SerbLatinName },
-            { new Locale("hr"), EngName, EngName },
-            { new Locale("in"), EngName, EngName },
-            { new Locale("lt"), EngName, EngName },
-            { new Locale("nl"), EngName, EngName },
-            { new Locale("no"), EngName, "R" },
-            { new Locale("sv"), EngName, EngName },
+            { Locale.of("hr"), EngName, EngName },
+            { Locale.of("in"), EngName, EngName },
+            { Locale.of("lt"), EngName, EngName },
+            { Locale.of("nl"), EngName, EngName },
+            { Locale.of("no"), EngName, "R" },
+            { Locale.of("sv"), EngName, EngName },
             // el fallback to root
-            { new Locale("el"), EngName, EngName }
+            { Locale.of("el"), EngName, EngName }
         };
     }
 

--- a/test/jdk/java/util/Calendar/NarrowNamesTest.java
+++ b/test/jdk/java/util/Calendar/NarrowNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,8 +44,8 @@ import static java.util.GregorianCalendar.*;
 
 public class NarrowNamesTest {
     private static final Locale US = Locale.US;
-    private static final Locale JAJPJP = new Locale("ja", "JP", "JP");
-    private static final Locale THTH = new Locale("th", "TH");
+    private static final Locale JAJPJP = Locale.of("ja", "JP", "JP");
+    private static final Locale THTH = Locale.of("th", "TH");
 
     private static final String RESET_INDEX = "RESET_INDEX";
 

--- a/test/jdk/java/util/Calendar/ZoneOffsets.java
+++ b/test/jdk/java/util/Calendar/ZoneOffsets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,8 +87,8 @@ public class ZoneOffsets {
 
     private static Locale[] locales = {
         Locale.getDefault(),
-        new Locale("th", "TH"),
-        new Locale("ja", "JP", "JP")};
+        Locale.of("th", "TH"),
+        Locale.of("ja", "JP", "JP")};
 
     private static final int HOUR = 60 * 60 * 1000;
 

--- a/test/jdk/java/util/Currency/Bug4512215.java
+++ b/test/jdk/java/util/Currency/Bug4512215.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ public class Bug4512215 {
     private static void testCountryCurrency(String country, String currencyCode,
             int digits) {
         testCurrencyDefined(currencyCode, digits);
-        Currency currency = Currency.getInstance(new Locale("", country));
+        Currency currency = Currency.getInstance(Locale.of("", country));
         if (!currency.getCurrencyCode().equals(currencyCode)) {
             throw new RuntimeException("[" + country
                     + "] expected: " + currencyCode

--- a/test/jdk/java/util/Currency/CurrencyTest.java
+++ b/test/jdk/java/util/Currency/CurrencyTest.java
@@ -166,7 +166,7 @@ public class CurrencyTest {
         // check an invalid country code
         boolean gotException = false;
         try {
-            Currency.getInstance(new Locale("", "EU"));
+            Currency.getInstance(Locale.of("", "EU"));
         } catch (IllegalArgumentException e) {
             gotException = true;
         }
@@ -176,7 +176,7 @@ public class CurrencyTest {
     }
 
     static void checkCountryCurrency(String countryCode, String expected) {
-        Locale locale = new Locale("", countryCode);
+        Locale locale = Locale.of("", countryCode);
         Currency currency = Currency.getInstance(locale);
         String code = (currency != null) ? currency.getCurrencyCode() : null;
         if (!(expected == null ? code == null : expected.equals(code))) {
@@ -257,11 +257,11 @@ public class CurrencyTest {
         testDisplayName("USD", Locale.ENGLISH, "US Dollar");
         testDisplayName("FRF", Locale.FRENCH, "franc fran\u00e7ais");
         testDisplayName("DEM", Locale.GERMAN, "Deutsche Mark");
-        testDisplayName("ESP", new Locale("es"), "peseta espa\u00f1ola");
-        testDisplayName("ITL", new Locale("it"), "lira italiana");
+        testDisplayName("ESP", Locale.of("es"), "peseta espa\u00f1ola");
+        testDisplayName("ITL", Locale.ITALIAN, "lira italiana");
         testDisplayName("JPY", Locale.JAPANESE, "\u65e5\u672c\u5186");
         testDisplayName("KRW", Locale.KOREAN, "\ub300\ud55c\ubbfc\uad6d \uc6d0");
-        testDisplayName("SEK", new Locale("sv"), "svensk krona");
+        testDisplayName("SEK", Locale.of("sv"), "svensk krona");
         testDisplayName("CNY", Locale.SIMPLIFIED_CHINESE, "\u4eba\u6c11\u5e01");
         testDisplayName("TWD", Locale.TRADITIONAL_CHINESE, "\u65b0\u53f0\u5e63");
     }

--- a/test/jdk/java/util/Currency/PropertiesTest.java
+++ b/test/jdk/java/util/Currency/PropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class PropertiesTest {
             for (char c2 = 'A'; c2 <= 'Z'; c2++) {
                 String ctry = new StringBuilder().append(c1).append(c2).toString();
                 try {
-                    Currency c = Currency.getInstance(new Locale("", ctry));
+                    Currency c = Currency.getInstance(Locale.of("", ctry));
                     if (c != null) {
                         pw.printf(Locale.ROOT, "%s=%s,%03d,%1d\n",
                             ctry,
@@ -195,7 +195,7 @@ public class PropertiesTest {
 
     private static void bug7102969() {
         // check the correct overriding of special case entries
-        Currency cur = Currency.getInstance(new Locale("", "JP"));
+        Currency cur = Currency.getInstance(Locale.of("", "JP"));
         if (!cur.getCurrencyCode().equals("ABC")) {
             throw new RuntimeException("[Expected: ABC as currency code of JP, found: "
                     + cur.getCurrencyCode() + "]");

--- a/test/jdk/java/util/Currency/ValidateISO4217.java
+++ b/test/jdk/java/util/Currency/ValidateISO4217.java
@@ -199,7 +199,7 @@ public class ValidateISO4217 {
         }
         testCurrencyDefined(currencyCode, numericCode, digits);
 
-        Locale loc = new Locale("", country);
+        Locale loc = Locale.of("", country);
         try {
             Currency currency = Currency.getInstance(loc);
             if (!currency.getCurrencyCode().equals(currencyCode)) {
@@ -257,7 +257,7 @@ public class ValidateISO4217 {
                 if (codes[toIndex(country)] == UNDEFINED) {
                     ex = false;
                     try {
-                        Currency.getInstance(new Locale("", country));
+                        Currency.getInstance(Locale.of("", country));
                     }
                     catch (IllegalArgumentException e) {
                         ex = true;
@@ -270,7 +270,7 @@ public class ValidateISO4217 {
                 } else if (codes[toIndex(country)] == SKIPPED) {
                     Currency cur = null;
                     try {
-                        cur = Currency.getInstance(new Locale("", country));
+                        cur = Currency.getInstance(Locale.of("", country));
                     }
                     catch (Exception e) {
                         System.err.println("Error: " + e + ": Country=" +

--- a/test/jdk/java/util/Formatter/FormatLocale.java
+++ b/test/jdk/java/util/Formatter/FormatLocale.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ import java.util.stream.IntStream;
 
 public class FormatLocale {
 
-    static final Locale TURKISH = new Locale("tr");
+    static final Locale TURKISH = Locale.of("tr");
 
     static final List<String> conversions = List.of(
         "%S",

--- a/test/jdk/java/util/Formatter/spi/FormatterWithProvider.java
+++ b/test/jdk/java/util/Formatter/spi/FormatterWithProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ public class FormatterWithProvider {
         try {
             testFormatter(Locale.JAPANESE, formatString, number);
             testFormatter(Locale.FRENCH, formatString, number);
-            testFormatter(new Locale("hi", "IN"), formatString, number);
+            testFormatter(Locale.of("hi", "IN"), formatString, number);
 
         } catch (ClassCastException ex) {
             throw new RuntimeException("[FAILED: A ClassCastException is" +

--- a/test/jdk/java/util/Formatter/spi/NoGroupingUsed.java
+++ b/test/jdk/java/util/Formatter/spi/NoGroupingUsed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import java.util.Locale;
 public class NoGroupingUsed {
 
     public static void main(String[] args) {
-        Locale locale = new Locale("xx", "YY");
+        Locale locale = Locale.of("xx", "YY");
         String number = "1234567";
         String formatString = "%,d";
 

--- a/test/jdk/java/util/Formatter/spi/provider/test/NumberFormatProviderImpl.java
+++ b/test/jdk/java/util/Formatter/spi/provider/test/NumberFormatProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import java.util.Locale;
 public class NumberFormatProviderImpl extends NumberFormatProvider {
 
     private static final Locale[] locales = {Locale.FRENCH, Locale.JAPANESE,
-            new Locale("hi", "IN"), new Locale("xx", "YY")};
+            Locale.of("hi", "IN"), Locale.of("xx", "YY")};
 
     @Override
     public NumberFormat getCurrencyInstance(Locale locale) {

--- a/test/jdk/java/util/Locale/Bug4175998Test.java
+++ b/test/jdk/java/util/Locale/Bug4175998Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class Bug4175998Test extends IntlTest {
         boolean bad = false;
         for (int i = 0; i < CODES.length; i++) {
             final String[] localeCodes = CODES[i];
-            final Locale l = new Locale(localeCodes[0], "");
+            final Locale l = Locale.of(localeCodes[0]);
             final String iso3 = l.getISO3Language();
             if (!iso3.equals(localeCodes[1]) /*&& !iso3.equals(localeCodes[2])*/) {
                 logln("Locale("+l+") returned bad ISO3 language code."

--- a/test/jdk/java/util/Locale/Bug4184873Test.java
+++ b/test/jdk/java/util/Locale/Bug4184873Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,7 +84,7 @@ public class Bug4184873Test extends IntlTest {
             ObjectInputStream in = getStream(lang);
             if (in != null) {
                 final Locale loc = (Locale)in.readObject();
-                final Locale expected = new Locale(lang, "XX");
+                final Locale expected = Locale.of(lang, "XX");
                 if (!(expected.equals(loc))) {
                     errln("Locale didn't maintain invariants for: "+lang);
                     errln("         got: "+loc);
@@ -123,7 +123,7 @@ public class Bug4184873Test extends IntlTest {
         try {
             ObjectOutputStream out = new ObjectOutputStream(
                     new FileOutputStream("Bug4184873_"+lang));
-            out.writeObject(new Locale(lang, "XX"));
+            out.writeObject(Locale.of(lang, "XX"));
             out.close();
         } catch (Exception e) {
             System.out.println(e);

--- a/test/jdk/java/util/Locale/Bug4210525.java
+++ b/test/jdk/java/util/Locale/Bug4210525.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ public class Bug4210525 {
         String country = "US";
         String variant = "socal";
 
-        Locale aLocale = new Locale(language, country, variant);
+        Locale aLocale = Locale.of(language, country, variant);
 
         String localeVariant = aLocale.getVariant();
         if (localeVariant.equals(variant)) {

--- a/test/jdk/java/util/Locale/Bug4316602.java
+++ b/test/jdk/java/util/Locale/Bug4316602.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ public class Bug4316602 {
 
     public static void main(String[] args) throws Exception {
         String language = "ja";
-        Locale aLocale = new Locale(language);
+        Locale aLocale = Locale.of(language);
         if (aLocale.toString().equals(language)) {
             System.out.println("passed");
         } else {

--- a/test/jdk/java/util/Locale/Bug4518797.java
+++ b/test/jdk/java/util/Locale/Bug4518797.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ public class Bug4518797 {
         if (args.length == 1) {
             duration = Math.max(5, Integer.parseInt(args[0]));
         }
-        final Locale loc = new Locale("ja", "US");
+        final Locale loc = Locale.of("ja", "US");
         final int hashcode = loc.hashCode();
 
         System.out.println("correct hash code: " + hashcode);

--- a/test/jdk/java/util/Locale/Bug8135061.java
+++ b/test/jdk/java/util/Locale/Bug8135061.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ public class Bug8135061 {
          * return "nv" as the matching tag
          */
         ranges = LanguageRange.parse("i-navajo");
-        locales = Collections.singleton(new Locale("nv"));
+        locales = Collections.singleton(Locale.of("nv"));
 
         try {
             Locale match = Locale.lookup(ranges, locales);

--- a/test/jdk/java/util/Locale/Bug8154797.java
+++ b/test/jdk/java/util/Locale/Bug8154797.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ public class Bug8154797 {
 
     public static void main(String args[]) {
         Bug8154797.generateExpectedValues();
-        Locale[] locArr = {new Locale("hi", "IN"), Locale.UK, new Locale("fi", "FI"),
+        Locale[] locArr = {Locale.of("hi", "IN"), Locale.UK, Locale.of("fi", "FI"),
                            Locale.ROOT, Locale.GERMAN, Locale.JAPANESE,
                            Locale.ENGLISH, Locale.FRANCE};
         for (Locale loc : locArr) {

--- a/test/jdk/java/util/Locale/Bug8159420.java
+++ b/test/jdk/java/util/Locale/Bug8159420.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ public class Bug8159420 {
         try {
 
             origLocale = Locale.getDefault();
-            Locale.setDefault(new Locale("tr", "TR"));
+            Locale.setDefault(Locale.of("tr", "TR"));
             testParse();
             testFilter(EXTENDED_FILTERING);
             testFilter(AUTOSELECT_FILTERING);

--- a/test/jdk/java/util/Locale/ExtensionsTest.java
+++ b/test/jdk/java/util/Locale/ExtensionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import java.util.*;
 
 public class ExtensionsTest {
     public static void main(String[] args) {
-        Locale jaJPJP = new Locale("ja", "JP", "JP");
+        Locale jaJPJP = Locale.of("ja", "JP", "JP");
         if (!jaJPJP.hasExtensions()) {
             error(jaJPJP + " should have an extension.");
         }

--- a/test/jdk/java/util/Locale/GenerateKeyList.java
+++ b/test/jdk/java/util/Locale/GenerateKeyList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ public class GenerateKeyList {
         Locale[] availableLocales = Locale.getAvailableLocales();
 
         ResourceBundle bundle = ResourceBundle.getBundle(packageName +
-                        resourceBundleName, new Locale("", "", ""));
+                        resourceBundleName, Locale.of(""));
         dumpResourceBundle(resourceBundleName + "/", bundle, out);
         for (int i = 0; i < availableLocales.length; i++) {
             bundle = ResourceBundle.getBundle(packageName + resourceBundleName,

--- a/test/jdk/java/util/Locale/InternationalBAT.java
+++ b/test/jdk/java/util/Locale/InternationalBAT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,26 +69,26 @@ public class InternationalBAT {
     // http://webwork.eng/j2se/1.4/docs/guide/intl/locale.doc.html#util-text
 
     private static Locale[] requiredLocales = {
-        new Locale("ar", "SA"),
-        new Locale("zh", "CN"),
-        new Locale("zh", "TW"),
-        new Locale("nl", "NL"),
-        new Locale("en", "AU"),
-        new Locale("en", "CA"),
-        new Locale("en", "GB"),
-        new Locale("en", "US"),
-        new Locale("fr", "CA"),
-        new Locale("fr", "FR"),
-        new Locale("de", "DE"),
-        new Locale("iw", "IL"),
-        new Locale("hi", "IN"),
-        new Locale("it", "IT"),
-        new Locale("ja", "JP"),
-        new Locale("ko", "KR"),
-        new Locale("pt", "BR"),
-        new Locale("es", "ES"),
-        new Locale("sv", "SE"),
-        new Locale("th", "TH"),
+        Locale.of("ar", "SA"),
+        Locale.CHINA,
+        Locale.TAIWAN,
+        Locale.of("nl", "NL"),
+        Locale.of("en", "AU"),
+        Locale.of("en", "CA"),
+        Locale.UK,
+        Locale.US,
+        Locale.of("fr", "CA"),
+        Locale.FRANCE,
+        Locale.GERMANY,
+        Locale.of("iw", "IL"),
+        Locale.of("hi", "IN"),
+        Locale.ITALY,
+        Locale.JAPAN,
+        Locale.KOREA,
+        Locale.of("pt", "BR"),
+        Locale.of("es", "ES"),
+        Locale.of("sv", "SE"),
+        Locale.of("th", "TH"),
     };
 
     // Date strings for May 10, 2001, for the required locales
@@ -181,26 +181,26 @@ public class InternationalBAT {
     // one sample locale each for the required encodings
 
     private static Locale[] sampleLocales = {
-        new Locale("ar", "SA"),
-        new Locale("zh", "CN"),
-        new Locale("zh", "TW"),
-        new Locale("iw", "IL"),
-        new Locale("ja", "JP"),
-        new Locale("ko", "KR"),
-        new Locale("it", "IT"),
-        new Locale("th", "TH"),
-        new Locale("ar", "SA"),
-        new Locale("zh", "CN"),
-        new Locale("zh", "CN"),
-        new Locale("zh", "CN"),
-        new Locale("zh", "TW"),
-        new Locale("iw", "IL"),
-        new Locale("ja", "JP"),
-        new Locale("ja", "JP"),
-        new Locale("ko", "KR"),
-        new Locale("it", "IT"),
-        new Locale("it", "IT"),
-        new Locale("th", "TH"),
+        Locale.of("ar", "SA"),
+        Locale.of("zh", "CN"),
+        Locale.of("zh", "TW"),
+        Locale.of("iw", "IL"),
+        Locale.of("ja", "JP"),
+        Locale.of("ko", "KR"),
+        Locale.of("it", "IT"),
+        Locale.of("th", "TH"),
+        Locale.of("ar", "SA"),
+        Locale.of("zh", "CN"),
+        Locale.of("zh", "CN"),
+        Locale.of("zh", "CN"),
+        Locale.of("zh", "TW"),
+        Locale.of("iw", "IL"),
+        Locale.of("ja", "JP"),
+        Locale.of("ja", "JP"),
+        Locale.of("ko", "KR"),
+        Locale.of("it", "IT"),
+        Locale.of("it", "IT"),
+        Locale.of("th", "TH"),
     };
 
     // expected conversion results for the date strings of the sample locales

--- a/test/jdk/java/util/Locale/LocaleEnhanceTest.java
+++ b/test/jdk/java/util/Locale/LocaleEnhanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -309,7 +309,7 @@ public class LocaleEnhanceTest extends IntlTest {
         for (int i = 0; i < tests.length; ++ i) {
             String[] test = tests[i];
             String id = String.valueOf(i);
-            Locale locale = new Locale(test[0], test[1], test[2]);
+            Locale locale = Locale.of(test[0], test[1], test[2]);
             assertEquals(id + " lang", test.length > 3 ? test[3] : test[0], locale.getLanguage());
             assertEquals(id + " region", test.length > 4 ? test[4] : test[1], locale.getCountry());
             assertEquals(id + " variant", test.length > 5 ? test[5] : test[2], locale.getVariant());
@@ -480,7 +480,7 @@ public class LocaleEnhanceTest extends IntlTest {
         };
         for (int i = 0; i < tests.length; ++i) {
             String[] test = tests[i];
-            Locale locale = new Locale(test[0], test[1], test[2]);
+            Locale locale = Locale.of(test[0], test[1], test[2]);
             assertEquals("case " + i, test[3], locale.toLanguageTag());
         }
 
@@ -638,11 +638,11 @@ public class LocaleEnhanceTest extends IntlTest {
     public void testGetDisplayName() {
         final Locale[] testLocales = {
                 Locale.ROOT,
-                new Locale("en"),
-                new Locale("en", "US"),
-                new Locale("", "US"),
-                new Locale("no", "NO", "NY"),
-                new Locale("", "", "NY"),
+                Locale.ENGLISH,
+                Locale.US,
+                Locale.of("", "US"),
+                Locale.of("no", "NO", "NY"),
+                Locale.of("", "", "NY"),
                 Locale.forLanguageTag("zh-Hans"),
                 Locale.forLanguageTag("zh-Hant"),
                 Locale.forLanguageTag("zh-Hans-CN"),
@@ -709,15 +709,15 @@ public class LocaleEnhanceTest extends IntlTest {
 
         // builder canonicalizes the three legacy locales:
         // ja_JP_JP, th_TH_TH, no_NY_NO.
-        locale = builder.setLocale(new Locale("ja", "JP", "JP")).build();
+        locale = builder.setLocale(Locale.of("ja", "JP", "JP")).build();
         assertEquals("ja_JP_JP languagetag", "ja-JP-u-ca-japanese", locale.toLanguageTag());
         assertEquals("ja_JP_JP variant", "", locale.getVariant());
 
-        locale = builder.setLocale(new Locale("th", "TH", "TH")).build();
+        locale = builder.setLocale(Locale.of("th", "TH", "TH")).build();
         assertEquals("th_TH_TH languagetag", "th-TH-u-nu-thai", locale.toLanguageTag());
         assertEquals("th_TH_TH variant", "", locale.getVariant());
 
-        locale = builder.setLocale(new Locale("no", "NO", "NY")).build();
+        locale = builder.setLocale(Locale.of("no", "NO", "NY")).build();
         assertEquals("no_NO_NY languagetag", "nn-NO", locale.toLanguageTag());
         assertEquals("no_NO_NY language", "nn", locale.getLanguage());
         assertEquals("no_NO_NY variant", "", locale.getVariant());
@@ -725,7 +725,7 @@ public class LocaleEnhanceTest extends IntlTest {
         // non-canonical, non-legacy locales are invalid
         new BuilderILE("123_4567_89") {
             public void call() {
-                b.setLocale(new Locale("123", "4567", "89"));
+                b.setLocale(Locale.of("123", "4567", "89"));
             }
         };
     }
@@ -1119,24 +1119,24 @@ public class LocaleEnhanceTest extends IntlTest {
     public void testSerialize() {
         final Locale[] testLocales = {
             Locale.ROOT,
-            new Locale("en"),
-            new Locale("en", "US"),
-            new Locale("en", "US", "Win"),
-            new Locale("en", "US", "Win_XP"),
-            new Locale("ja", "JP"),
-            new Locale("ja", "JP", "JP"),
-            new Locale("th", "TH"),
-            new Locale("th", "TH", "TH"),
-            new Locale("no", "NO"),
-            new Locale("nb", "NO"),
-            new Locale("nn", "NO"),
-            new Locale("no", "NO", "NY"),
-            new Locale("nn", "NO", "NY"),
-            new Locale("he", "IL"),
-            new Locale("he", "IL", "var"),
-            new Locale("Language", "Country", "Variant"),
-            new Locale("", "US"),
-            new Locale("", "", "Java"),
+            Locale.ENGLISH,
+            Locale.US,
+            Locale.of("en", "US", "Win"),
+            Locale.of("en", "US", "Win_XP"),
+            Locale.JAPAN,
+            Locale.of("ja", "JP", "JP"),
+            Locale.of("th", "TH"),
+            Locale.of("th", "TH", "TH"),
+            Locale.of("no", "NO"),
+            Locale.of("nb", "NO"),
+            Locale.of("nn", "NO"),
+            Locale.of("no", "NO", "NY"),
+            Locale.of("nn", "NO", "NY"),
+            Locale.of("he", "IL"),
+            Locale.of("he", "IL", "var"),
+            Locale.of("Language", "Country", "Variant"),
+            Locale.of("", "US"),
+            Locale.of("", "", "Java"),
             Locale.forLanguageTag("en-Latn-US"),
             Locale.forLanguageTag("zh-Hans"),
             Locale.forLanguageTag("zh-Hant-TW"),
@@ -1209,7 +1209,7 @@ public class LocaleEnhanceTest extends IntlTest {
                 String lang = fields[0];
                 String country = (fields.length >= 2) ? fields[1] : "";
                 String variant = (fields.length == 3) ? fields[2] : "";
-                locale = new Locale(lang, country, variant);
+                locale = Locale.of(lang, country, variant);
             }
 
             // deserialize
@@ -1287,17 +1287,17 @@ public class LocaleEnhanceTest extends IntlTest {
      * 7033504: (lc) incompatible behavior change for ja_JP_JP and th_TH_TH locales
      */
     public void testBug7033504() {
-        checkCalendar(new Locale("ja", "JP", "jp"), "java.util.GregorianCalendar");
-        checkCalendar(new Locale("ja", "jp", "jp"), "java.util.GregorianCalendar");
-        checkCalendar(new Locale("ja", "JP", "JP"), "java.util.JapaneseImperialCalendar");
-        checkCalendar(new Locale("ja", "jp", "JP"), "java.util.JapaneseImperialCalendar");
+        checkCalendar(Locale.of("ja", "JP", "jp"), "java.util.GregorianCalendar");
+        checkCalendar(Locale.of("ja", "jp", "jp"), "java.util.GregorianCalendar");
+        checkCalendar(Locale.of("ja", "JP", "JP"), "java.util.JapaneseImperialCalendar");
+        checkCalendar(Locale.of("ja", "jp", "JP"), "java.util.JapaneseImperialCalendar");
         checkCalendar(Locale.forLanguageTag("en-u-ca-japanese"),
                       "java.util.JapaneseImperialCalendar");
 
-        checkDigit(new Locale("th", "TH", "th"), '0');
-        checkDigit(new Locale("th", "th", "th"), '0');
-        checkDigit(new Locale("th", "TH", "TH"), '\u0e50');
-        checkDigit(new Locale("th", "TH", "TH"), '\u0e50');
+        checkDigit(Locale.of("th", "TH", "th"), '0');
+        checkDigit(Locale.of("th", "th", "th"), '0');
+        checkDigit(Locale.of("th", "TH", "TH"), '\u0e50');
+        checkDigit(Locale.of("th", "TH", "TH"), '\u0e50');
         checkDigit(Locale.forLanguageTag("en-u-nu-thai"), '\u0e50');
     }
 

--- a/test/jdk/java/util/Locale/LocaleProviders.java
+++ b/test/jdk/java/util/Locale/LocaleProviders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -127,7 +127,7 @@ public class LocaleProviders {
     }
 
     static void adapterTest(String expected, String lang, String ctry) {
-        Locale testLocale = new Locale(lang, ctry);
+        Locale testLocale = Locale.of(lang, ctry);
         LocaleProviderAdapter ldaExpected =
             LocaleProviderAdapter.forType(LocaleProviderAdapter.Type.valueOf(expected));
         if (!ldaExpected.getDateFormatProvider().isSupportedLocale(testLocale)) {
@@ -248,7 +248,7 @@ public class LocaleProviders {
     static void bug8013086Test(String lang, String ctry) {
         try {
             // Throws a NullPointerException if the test fails.
-            System.out.println(new SimpleDateFormat("z", new Locale(lang, ctry)).parse("UTC"));
+            System.out.println(new SimpleDateFormat("z", Locale.of(lang, ctry)).parse("UTC"));
         } catch (ParseException pe) {
             // ParseException is fine in this test, as it's not "UTC"
         }
@@ -258,7 +258,7 @@ public class LocaleProviders {
         if (IS_WINDOWS) {
             Date sampleDate = new Date(0x10000000000L);
             String expected = "\u5e73\u6210 16.11.03 (\u6c34) \u5348\u524d 11:53:47";
-            Locale l = new Locale("ja", "JP", "JP");
+            Locale l = Locale.of("ja", "JP", "JP");
             SimpleDateFormat sdf = new SimpleDateFormat("GGGG yyyy.MMM.dd '('E')' a hh:mm:ss", l);
             sdf.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
             String result = sdf.format(sampleDate);
@@ -295,7 +295,7 @@ public class LocaleProviders {
 
     static void bug8220227Test() {
         if (IS_WINDOWS) {
-            Locale l = new Locale("xx","XX");
+            Locale l = Locale.of("xx","XX");
             String country = l.getDisplayCountry();
             if (country.endsWith("(XX)")) {
                 throw new RuntimeException(

--- a/test/jdk/java/util/Locale/LocaleTest.java
+++ b/test/jdk/java/util/Locale/LocaleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -194,7 +194,7 @@ public class LocaleTest extends IntlTest {
 
     public void TestBasicGetters() {
         for (int i = 0; i <= MAX_LOCALES; i++) {
-            Locale testLocale = new Locale(dataTable[LANG][i], dataTable[CTRY][i], dataTable[VAR][i]);
+            Locale testLocale = Locale.of(dataTable[LANG][i], dataTable[CTRY][i], dataTable[VAR][i]);
             logln("Testing " + testLocale + "...");
 
             if (!testLocale.getLanguage().equals(dataTable[LANG][i])) {
@@ -217,7 +217,7 @@ public class LocaleTest extends IntlTest {
 
         logln("Same thing without variant codes...");
         for (int i = 0; i <= MAX_LOCALES; i++) {
-            Locale testLocale = new Locale(dataTable[LANG][i], dataTable[CTRY][i]);
+            Locale testLocale = Locale.of(dataTable[LANG][i], dataTable[CTRY][i]);
             logln("Testing " + testLocale + "...");
 
             if (!testLocale.getLanguage().equals(dataTable[LANG][i])) {
@@ -240,7 +240,7 @@ public class LocaleTest extends IntlTest {
                 continue;
             }
 
-            Locale testLocale = new Locale(dataTable[LANG][i], dataTable[CTRY][i], dataTable[VAR][i]);
+            Locale testLocale = Locale.of(dataTable[LANG][i], dataTable[CTRY][i], dataTable[VAR][i]);
             logln("Testing " + testLocale + "...");
 
             if (!testLocale.getISO3Language().equals(dataTable[LANG3][i])) {
@@ -268,10 +268,10 @@ public class LocaleTest extends IntlTest {
      */
     public void TestDisplayNames() {
         Locale saveDefault = Locale.getDefault();
-        Locale english = new Locale("en", "US");
-        Locale french = new Locale("fr", "FR");
-        Locale croatian = new Locale("hr", "HR");
-        Locale greek = new Locale("el", "GR");
+        Locale english = Locale.US;
+        Locale french = Locale.FRANCE;
+        Locale croatian = Locale.of("hr", "HR");
+        Locale greek = Locale.of("el", "GR");
 
         Locale.setDefault(english);
         logln("With default = en_US...");
@@ -312,7 +312,7 @@ public class LocaleTest extends IntlTest {
         }
 
         for (int i = 0; i <= MAX_LOCALES; i++) {
-            Locale testLocale = new Locale(dataTable[LANG][i], dataTable[CTRY][i], dataTable[VAR][i]);
+            Locale testLocale = Locale.of(dataTable[LANG][i], dataTable[CTRY][i], dataTable[VAR][i]);
             logln("  Testing " + testLocale + "...");
 
             String testLang;
@@ -384,11 +384,12 @@ public class LocaleTest extends IntlTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     public void TestSimpleObjectStuff() {
         Locale test1 = new Locale("aa", "AA");
         Locale test2 = new Locale("aa", "AA");
         Locale test3 = (Locale) test1.clone();
-        Locale test4 = new Locale("zz", "ZZ");
+        Locale test4 = Locale.of("zz", "ZZ");
 
         if (test1 == test2 || test1 == test3 || test1 == test4 || test2 == test3) {
             errln("Some of the test variables point to the same locale!");
@@ -419,7 +420,7 @@ public class LocaleTest extends IntlTest {
      * @bug 4011756 4011380
      */
     public void TestISO3Fallback() {
-        Locale test = new Locale("xx", "YY", "");
+        Locale test = Locale.of("xx", "YY");
         boolean gotException = false;
         String result = "";
 
@@ -612,7 +613,7 @@ test commented out pending API-change approval
         obstream = new ByteArrayOutputStream();
         ostream = new ObjectOutputStream(obstream);
 
-        Locale test1 = new Locale("zh", "TW", "");
+        Locale test1 = Locale.of("zh", "TW");
         int dummy = test1.hashCode();   // fill in the cached hash-code value
         ostream.writeObject(test1);
 
@@ -640,7 +641,7 @@ test commented out pending API-change approval
             "Zhuang"};
 
         for (int i = 0; i < languageCodes.length; i++) {
-            String test = (new Locale(languageCodes[i], "", "")).getDisplayLanguage(Locale.US);
+            String test = (Locale.of(languageCodes[i])).getDisplayLanguage(Locale.US);
             if (!test.equals(languageNames[i])) {
                 errln("Got wrong display name for " + languageCodes[i] + ": Expected \""
                         + languageNames[i] + "\", got \"" + test + "\".");
@@ -658,7 +659,7 @@ test commented out pending API-change approval
         String[] iso3Languages = {"amh", "bak", "fry", "mar", "run", "ssw", "twi", "zul"};
 
         for (int i = 0; i < iso2Languages.length; i++) {
-            String test = (new Locale(iso2Languages[i], "", "")).getISO3Language();
+            String test = (Locale.of(iso2Languages[i])).getISO3Language();
             if (!test.equals(iso3Languages[i])) {
                 errln("Got wrong ISO3 code for " + iso2Languages[i] + ": Expected \""
                         + iso3Languages[i] + "\", got \"" + test + "\".");
@@ -669,7 +670,7 @@ test commented out pending API-change approval
         String[] iso3Countries = {"AFG", "BWA", "KAZ", "MAC", "MNG", "SLB", "TCA", "ZWE"};
 
         for (int i = 0; i < iso2Countries.length; i++) {
-            String test = (new Locale("", iso2Countries[i], "")).getISO3Country();
+            String test = (Locale.of("", iso2Countries[i])).getISO3Country();
             if (!test.equals(iso3Countries[i])) {
                 errln("Got wrong ISO3 code for " + iso2Countries[i] + ": Expected \""
                         + iso3Countries[i] + "\", got \"" + test + "\".");
@@ -681,12 +682,12 @@ test commented out pending API-change approval
      * @bug 4052404 4778440 8263202
      */
     public void TestChangedISO639Codes() {
-        Locale hebrewOld = new Locale("iw", "IL", "");
-        Locale hebrewNew = new Locale("he", "IL", "");
-        Locale yiddishOld = new Locale("ji", "IL", "");
-        Locale yiddishNew = new Locale("yi", "IL", "");
-        Locale indonesianOld = new Locale("in", "", "");
-        Locale indonesianNew = new Locale("id", "", "");
+        Locale hebrewOld = Locale.of("iw", "IL");
+        Locale hebrewNew = Locale.of("he", "IL");
+        Locale yiddishOld = Locale.of("ji", "IL");
+        Locale yiddishNew = Locale.of("yi", "IL");
+        Locale indonesianOld = Locale.of("in");
+        Locale indonesianNew = Locale.of("id");
 
         if ("true".equalsIgnoreCase(System.getProperty("java.locale.useOldISOCodes"))) {
             if (!hebrewNew.getLanguage().equals("iw")) {
@@ -736,15 +737,15 @@ test commented out pending API-change approval
      *
      */
     public void TestAtypicalLocales() {
-        Locale[] localesToTest = { new Locale("de", "CA"),
-                                   new Locale("ja", "ZA"),
-                                   new Locale("ru", "MX"),
-                                   new Locale("en", "FR"),
-                                   new Locale("es", "DE"),
-                                   new Locale("", "HR"),
-                                   new Locale("", "SE"),
-                                   new Locale("", "DO"),
-                                   new Locale("", "BE") };
+        Locale[] localesToTest = { Locale.of("de", "CA"),
+                                   Locale.of("ja", "ZA"),
+                                   Locale.of("ru", "MX"),
+                                   Locale.of("en", "FR"),
+                                   Locale.of("es", "DE"),
+                                   Locale.of("", "HR"),
+                                   Locale.of("", "SE"),
+                                   Locale.of("", "DO"),
+                                   Locale.of("", "BE") };
         String[] englishDisplayNames = { "German (Canada)",
                                          "Japanese (South Africa)",
                                          "Russian (Mexico)",
@@ -788,7 +789,7 @@ test commented out pending API-change approval
         }
 
         for (int i = 0; i < localesToTest.length; i++) {
-            String name = localesToTest[i].getDisplayName(new Locale("es", "ES"));
+            String name = localesToTest[i].getDisplayName(Locale.of("es", "ES"));
             logln(name);
             if (!name.equals(spanishDisplayNames[i])) {
                 errln("Lookup in Spanish failed: expected \"" + spanishDisplayNames[i]
@@ -837,7 +838,7 @@ test commented out pending API-change approval
      */
     public void TestThaiCurrencyFormat() {
         DecimalFormat thaiCurrency = (DecimalFormat) NumberFormat.getCurrencyInstance(
-                new Locale("th", "TH"));
+                Locale.of("th", "TH"));
         if (!thaiCurrency.getPositivePrefix().equals("\u0e3f")) {
             errln("Thai currency prefix wrong: expected \"\u0e3f\", got \""
                     + thaiCurrency.getPositivePrefix() + "\"");
@@ -892,13 +893,13 @@ test commented out pending API-change approval
      */
     public void TestToString() {
         Object[] DATA = {
-            new Locale("xx", "", ""), "xx",
-            new Locale("", "YY", ""), "_YY",
-            new Locale("", "", "ZZ"), "",
-            new Locale("xx", "YY", ""), "xx_YY",
-            new Locale("xx", "", "ZZ"), "xx__ZZ",
-            new Locale("", "YY", "ZZ"), "_YY_ZZ",
-            new Locale("xx", "YY", "ZZ"), "xx_YY_ZZ",
+            Locale.of("xx", "", ""), "xx",
+            Locale.of("", "YY", ""), "_YY",
+            Locale.of("", "", "ZZ"), "",
+            Locale.of("xx", "YY", ""), "xx_YY",
+            Locale.of("xx", "", "ZZ"), "xx__ZZ",
+            Locale.of("", "YY", "ZZ"), "_YY_ZZ",
+            Locale.of("xx", "YY", "ZZ"), "xx_YY_ZZ",
         };
         for (int i = 0; i < DATA.length; i += 2) {
             Locale loc = (Locale) DATA[i];
@@ -915,8 +916,8 @@ test commented out pending API-change approval
      * end to test the whole pipe.
      */
     public void Test4105828() {
-        Locale[] LOC = {Locale.CHINESE, new Locale("zh", "CN", ""),
-            new Locale("zh", "TW", ""), new Locale("zh", "HK", "")};
+        Locale[] LOC = {Locale.CHINESE, Locale.of("zh", "CN"),
+            Locale.of("zh", "TW"), Locale.of("zh", "HK")};
         for (int i = 0; i < LOC.length; ++i) {
             NumberFormat fmt = NumberFormat.getPercentInstance(LOC[i]);
             String result = fmt.format(1);
@@ -943,7 +944,7 @@ test commented out pending API-change approval
      * test that here.
      */
     public void Test4139940() {
-        Locale mylocale = new Locale("hu", "", "");
+        Locale mylocale = Locale.of("hu");
         @SuppressWarnings("deprecation")
         Date mydate = new Date(98, 3, 13); // A Monday
         DateFormat df_full = new SimpleDateFormat("EEEE", mylocale);
@@ -960,7 +961,7 @@ test commented out pending API-change approval
      * Russian first day of week should be Monday. Confirmed.
      */
     public void Test4143951() {
-        Calendar cal = Calendar.getInstance(new Locale("ru", "", ""));
+        Calendar cal = Calendar.getInstance(Locale.of("ru"));
         if (cal.getFirstDayOfWeek() != Calendar.MONDAY) {
             errln("Fail: First day of week in Russia should be Monday");
         }
@@ -974,7 +975,7 @@ test commented out pending API-change approval
     public void Test4147315() {
         // Try with codes that are the wrong length but happen to match text
         // at a valid offset in the mapping table
-        Locale locale = new Locale("aaa", "CCC");
+        Locale locale = Locale.of("aaa", "CCC");
 
         try {
             String result = locale.getISO3Country();
@@ -994,7 +995,7 @@ test commented out pending API-change approval
     public void Test4147317() {
         // Try a three letter language code, and check whether it is
         // returned as is.
-        Locale locale = new Locale("aaa", "CCC");
+        Locale locale = Locale.of("aaa", "CCC");
 
         String result = locale.getISO3Language();
         if (!result.equals("aaa")) {
@@ -1004,7 +1005,7 @@ test commented out pending API-change approval
 
         // Try an invalid two letter language code, and check whether it
         // throws a MissingResourceException.
-        locale = new Locale("zz", "CCC");
+        locale = Locale.of("zz", "CCC");
 
         try {
             result = locale.getISO3Language();
@@ -1019,9 +1020,9 @@ test commented out pending API-change approval
      * @bug 4147552 4778440 8030696
      */
     public void Test4147552() {
-        Locale[] locales = {new Locale("no", "NO"), new Locale("no", "NO", "B"),
-            new Locale("no", "NO", "NY"), new Locale("nb", "NO"),
-            new Locale("nn", "NO")};
+        Locale[] locales = {Locale.of("no", "NO"), Locale.of("no", "NO", "B"),
+            Locale.of("no", "NO", "NY"), Locale.of("nb", "NO"),
+            Locale.of("nn", "NO")};
         String[] englishDisplayNames = {"Norwegian (Norway)",
             "Norwegian (Norway,Bokm\u00e5l)",
             "Norwegian (Norway,Nynorsk)",
@@ -1050,8 +1051,8 @@ test commented out pending API-change approval
      */
     public void Test8030696() {
         List<Locale> av = Arrays.asList(Locale.getAvailableLocales());
-        if (!av.contains(new Locale("nb", "NO"))
-                || !av.contains(new Locale("nn", "NO"))) {
+        if (!av.contains(Locale.of("nb", "NO"))
+                || !av.contains(Locale.of("nn", "NO"))) {
             errln("\"nb-NO\" and/or \"nn-NO\" locale(s) not returned from getAvailableLocales().");
         }
     }

--- a/test/jdk/java/util/Locale/SoftKeys.java
+++ b/test/jdk/java/util/Locale/SoftKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ public class SoftKeys {
             // been cleared.
             for (int i = 0; i < 2; i++) {
                 for (int j = 0; j < 512*1024; j++) {
-                    new Locale(HexFormat.of().toHexDigits((short)j), "", "");
+                    Locale.of(HexFormat.of().toHexDigits((short)j));
                 }
             }
         } catch (OutOfMemoryError e) {

--- a/test/jdk/java/util/Locale/ThaiGov.java
+++ b/test/jdk/java/util/Locale/ThaiGov.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ public class ThaiGov {
         final String strExpected = "\u0E51\u0E52\u002C\u0E53\u0E54\u0E55\u002C\u0E56\u0E57\u0E58\u002E\u0E52\u0E53\u0E54";
         final double value =  12345678.234;
 
-        Locale locTH = new Locale("th", "TH", "TH");
+        Locale locTH = Locale.of("th", "TH", "TH");
 
         // th_TH_TH test
         NumberFormat nf = NumberFormat.getInstance(locTH);
@@ -58,7 +58,7 @@ public class ThaiGov {
         final String strExpected = "\u0E3F\u0E51\u0E52\u002C\u0E53\u0E54\u0E55\u002C\u0E56\u0E57\u0E58\u002E\u0E52\u0E53";
         final double value =  12345678.234;
 
-        Locale locTH = new Locale("th", "TH", "TH");
+        Locale locTH = Locale.of("th", "TH", "TH");
 
         // th_TH_TH test
         NumberFormat nf = NumberFormat.getCurrencyInstance(locTH);
@@ -71,7 +71,7 @@ public class ThaiGov {
     }
 
     void dateTest() throws RuntimeException {
-        Locale locTH = new Locale("th", "TH", "TH");
+        Locale locTH = Locale.of("th", "TH", "TH");
         TimeZone tz = TimeZone.getTimeZone("PST");
 
         Calendar calGregorian = Calendar.getInstance(tz, Locale.US);

--- a/test/jdk/java/util/Locale/bcp47u/DisplayNameTests.java
+++ b/test/jdk/java/util/Locale/bcp47u/DisplayNameTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class DisplayNameTests {
                                                              "-ss-standard" +
                                                              "-tz-jptyo" +
                                                              "-va-posix");
-    private static final Locale loc2 = new Locale("ja", "JP", "JP");
+    private static final Locale loc2 = Locale.of("ja", "JP", "JP");
     private static final Locale loc3 = new Locale.Builder()
                                             .setRegion("US")
                                             .setScript("Latn")

--- a/test/jdk/java/util/Locale/bcp47u/spi/LocaleNameProviderTests.java
+++ b/test/jdk/java/util/Locale/bcp47u/spi/LocaleNameProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ public class LocaleNameProviderTests {
     private static final String expected = "foo (foo_ca:foo_japanese)";
 
     public static void main(String... args) {
-        String name = Locale.forLanguageTag("foo-u-ca-japanese").getDisplayName(new Locale("foo"));
+        String name = Locale.forLanguageTag("foo-u-ca-japanese").getDisplayName(Locale.of("foo"));
         if (!name.equals(expected)) {
             throw new RuntimeException("Unicode extension key and/or type name(s) is incorrect. " +
                 "Expected: \"" + expected + "\", got: \"" + name + "\"");

--- a/test/jdk/java/util/Locale/bcp47u/spi/provider/foo/LocaleNameProviderImpl.java
+++ b/test/jdk/java/util/Locale/bcp47u/spi/provider/foo/LocaleNameProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import java.util.spi.LocaleNameProvider;
  * values for Unicode Locale Extension key/type names.
  */
 public class LocaleNameProviderImpl extends LocaleNameProvider {
-    private static final Locale[] avail = {new Locale("foo")};
+    private static final Locale[] avail = {Locale.of("foo")};
 
     @Override
     public Locale[] getAvailableLocales() {

--- a/test/jdk/java/util/Locale/bug6277243.java
+++ b/test/jdk/java/util/Locale/bug6277243.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import java.util.Locale;
 public class bug6277243 {
 
     public static void main(String[] args) throws Exception {
-        Locale root = new Locale("", "", "");
+        Locale root = Locale.of("", "", "");
         if (!Locale.ROOT.equals(root)) {
             throw new RuntimeException("Locale.ROOT is not equal to Locale(\"\", \"\", \"\")");
         }

--- a/test/jdk/java/util/PluggableLocale/CalendarDataProviderTest.java
+++ b/test/jdk/java/util/PluggableLocale/CalendarDataProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ public class CalendarDataProviderTest {
     }
 
     void test() {
-        Locale kids = new Locale("ja", "JP", "kids"); // test provider's supported locale
+        Locale kids = Locale.of("ja", "JP", "kids"); // test provider's supported locale
         Calendar kcal = Calendar.getInstance(kids);
 
         // check the week parameters

--- a/test/jdk/java/util/PluggableLocale/CalendarNameProviderTest.java
+++ b/test/jdk/java/util/PluggableLocale/CalendarNameProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,7 @@ public class CalendarNameProviderTest {
     }
 
     void test() {
-        Locale kids = new Locale("ja", "JP", "kids"); // test provider's supported locale
+        Locale kids = Locale.of("ja", "JP", "kids"); // test provider's supported locale
         Calendar kcal = Calendar.getInstance(kids);
         Calendar jcal = Calendar.getInstance(Locale.JAPAN);
 

--- a/test/jdk/java/util/PluggableLocale/ClasspathTest.java
+++ b/test/jdk/java/util/PluggableLocale/ClasspathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ public class ClasspathTest {
          * Since providers can be loaded from the application's classpath,
          * this test will fail if they are NOT loaded from classpath.
          */
-        Locale OSAKA = new Locale("ja", "JP", "osaka");
+        Locale OSAKA = Locale.of("ja", "JP", "osaka");
         List<Locale> availableLocales = Arrays.asList(Locale.getAvailableLocales());
         if (!availableLocales.contains(OSAKA)) {
             throw new RuntimeException("LSS providers were NOT loaded from the class path.");

--- a/test/jdk/java/util/PluggableLocale/CollatorProviderTest.java
+++ b/test/jdk/java/util/PluggableLocale/CollatorProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,7 +80,7 @@ public class CollatorProviderTest extends ProviderTest {
     }
 
     void objectValidityTest() {
-        Collator def = Collator.getInstance(new Locale(""));
+        Collator def = Collator.getInstance(Locale.of(""));
         String defrules = ((RuleBasedCollator)def).getRules();
 
         for (Locale target: availloc) {

--- a/test/jdk/java/util/PluggableLocale/CurrencyNameProviderTest.java
+++ b/test/jdk/java/util/PluggableLocale/CurrencyNameProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -140,9 +140,9 @@ public class CurrencyNameProviderTest extends ProviderTest {
     final String YEN_IN_OSAKA = "100,000\u5186\u3084\u3002";
     final String YEN_IN_KYOTO = "100,000\u5186\u3069\u3059\u3002";
     final String YEN_IN_TOKYO= "100,000JPY-tokyo";
-    final Locale OSAKA = new Locale("ja", "JP", "osaka");
-    final Locale KYOTO = new Locale("ja", "JP", "kyoto");
-    final Locale TOKYO = new Locale("ja", "JP", "tokyo");
+    final Locale OSAKA = Locale.of("ja", "JP", "osaka");
+    final Locale KYOTO = Locale.of("ja", "JP", "kyoto");
+    final Locale TOKYO = Locale.of("ja", "JP", "tokyo");
     Integer i = new Integer(100000);
     String formatted;
     DecimalFormat df;

--- a/test/jdk/java/util/PluggableLocale/DateFormatProviderTest.java
+++ b/test/jdk/java/util/PluggableLocale/DateFormatProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -149,9 +149,9 @@ public class DateFormatProviderTest extends ProviderTest {
     // Check that fallback correctly occurs with locales with variant including '_'s
     // This test assumes that the provider supports the ja_JP_osaka locale, and JRE does not.
     void extendedVariantTest() {
-        Locale[] testlocs = {new Locale("ja", "JP", "osaka_extended"),
-                             new Locale("ja", "JP", "osaka_extended_further"),
-                             new Locale("ja", "JP", "osaka_")};
+        Locale[] testlocs = {Locale.of("ja", "JP", "osaka_extended"),
+                             Locale.of("ja", "JP", "osaka_extended_further"),
+                             Locale.of("ja", "JP", "osaka_")};
         for (Locale test: testlocs) {
             DateFormat df = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL, test);
             DateFormat provider = dfp.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL, test);

--- a/test/jdk/java/util/PluggableLocale/GenericTest.java
+++ b/test/jdk/java/util/PluggableLocale/GenericTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -117,8 +117,8 @@ public class GenericTest {
      * are done in each xxxProviderTest test cases.
      */
     void localeFallbackTest() {
-        Locale xx = new Locale("xx");
-        Locale dispLocale = new Locale ("xx", "YY", "ZZ");
+        Locale xx = Locale.of("xx");
+        Locale dispLocale = Locale.of("xx", "YY", "ZZ");
 
         String xxname = xx.getDisplayLanguage(xx);
         String expected = localeNP.getDisplayLanguage(xx.getLanguage(), dispLocale);

--- a/test/jdk/java/util/PluggableLocale/LocaleNameProviderTest.java
+++ b/test/jdk/java/util/PluggableLocale/LocaleNameProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,8 +123,8 @@ public class LocaleNameProviderTest extends ProviderTest {
     }
 
     void variantFallbackTest() {
-        Locale YY = new Locale("yy", "YY", "YYYY");
-        Locale YY_suffix = new Locale("yy", "YY", "YYYY_suffix");
+        Locale YY = Locale.of("yy", "YY", "YYYY");
+        Locale YY_suffix = Locale.of("yy", "YY", "YYYY_suffix");
         String retVrnt = null;
         String message = "variantFallbackTest() succeeded.";
 

--- a/test/jdk/java/util/PluggableLocale/SupportedLocalesTest.java
+++ b/test/jdk/java/util/PluggableLocale/SupportedLocalesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,8 +63,8 @@ public class SupportedLocalesTest {
 
     private static class TestLocaleServiceProvider extends LocaleServiceProvider {
         private static final Locale[] locales = {
-            new Locale("ja", "JP", "JP"),
-            new Locale("th", "TH", "TH"),
+            Locale.of("ja", "JP", "JP"),
+            Locale.of("th", "TH", "TH"),
             Locale.forLanguageTag("en-US-u-ca-buddhist"),
         };
 

--- a/test/jdk/java/util/PluggableLocale/TimeZoneNameProviderTest.java
+++ b/test/jdk/java/util/PluggableLocale/TimeZoneNameProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,9 +115,9 @@ public class TimeZoneNameProviderTest extends ProviderTest {
     }
 
     final String pattern = "z";
-    final Locale OSAKA = new Locale("ja", "JP", "osaka");
-    final Locale KYOTO = new Locale("ja", "JP", "kyoto");
-    final Locale GENERIC = new Locale("ja", "JP", "generic");
+    final Locale OSAKA = Locale.of("ja", "JP", "osaka");
+    final Locale KYOTO = Locale.of("ja", "JP", "kyoto");
+    final Locale GENERIC = Locale.of("ja", "JP", "generic");
 
     final String[] TIMEZONES = {
         "GMT", "America/Los_Angeles", "SystemV/PST8",

--- a/test/jdk/java/util/PluggableLocale/providersrc/barprovider/com/bar/CalendarDataProviderImpl.java
+++ b/test/jdk/java/util/PluggableLocale/providersrc/barprovider/com/bar/CalendarDataProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import java.util.spi.CalendarDataProvider;
 public class CalendarDataProviderImpl extends CalendarDataProvider {
     static final char FULLWIDTH_ZERO = '\uff10';
     static final Locale[] avail = {
-        new Locale("ja", "JP", "kids"),
+        Locale.of("ja", "JP", "kids"),
     };
 
     @Override

--- a/test/jdk/java/util/PluggableLocale/providersrc/barprovider/com/bar/CalendarNameProviderImpl.java
+++ b/test/jdk/java/util/PluggableLocale/providersrc/barprovider/com/bar/CalendarNameProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import java.util.spi.CalendarNameProvider;
 public class CalendarNameProviderImpl extends CalendarNameProvider {
     static final char FULLWIDTH_ZERO = '\uff10';
     static final Locale[] avail = {
-        new Locale("ja", "JP", "kids"),
+        Locale.of("ja", "JP", "kids"),
     };
 
     @Override

--- a/test/jdk/java/util/PluggableLocale/providersrc/barprovider/com/bar/CurrencyNameProviderImpl.java
+++ b/test/jdk/java/util/PluggableLocale/providersrc/barprovider/com/bar/CurrencyNameProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,10 +32,10 @@ import java.util.spi.*;
 import com.foobar.Utils;
 
 public class CurrencyNameProviderImpl extends CurrencyNameProvider {
-    static Locale[] avail = {new Locale("ja", "JP", "osaka"),
-        new Locale("ja", "JP", "kyoto"),
+    static Locale[] avail = {Locale.of("ja", "JP", "osaka"),
+        Locale.of("ja", "JP", "kyoto"),
         Locale.JAPAN,
-        new Locale("xx")};
+        Locale.of("xx")};
 
     public Locale[] getAvailableLocales() {
         return avail;

--- a/test/jdk/java/util/PluggableLocale/providersrc/barprovider/com/bar/CurrencyNameProviderImpl2.java
+++ b/test/jdk/java/util/PluggableLocale/providersrc/barprovider/com/bar/CurrencyNameProviderImpl2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,8 +32,8 @@ import java.util.spi.*;
 import com.foobar.Utils;
 
 public class CurrencyNameProviderImpl2 extends CurrencyNameProvider {
-    static Locale[] avail = {new Locale("ja", "JP", "tokyo"),
-                             new Locale("ja", "JP", "osaka"), };
+    static Locale[] avail = {Locale.of("ja", "JP", "tokyo"),
+                             Locale.of("ja", "JP", "osaka"), };
     public Locale[] getAvailableLocales() {
         return avail;
     }

--- a/test/jdk/java/util/PluggableLocale/providersrc/barprovider/com/bar/GenericTimeZoneNameProviderImpl.java
+++ b/test/jdk/java/util/PluggableLocale/providersrc/barprovider/com/bar/GenericTimeZoneNameProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,8 +35,8 @@ import com.foobar.Utils;
  * Implementation class for getGenericTimeZoneName which returns "Generic "+<standard name in OSAKA>.
  */
 public class GenericTimeZoneNameProviderImpl extends TimeZoneNameProviderImpl {
-    static final Locale jaJPGeneric = new Locale("ja", "JP", "generic");
-    static final Locale OSAKA = new Locale("ja", "JP", "osaka");
+    static final Locale jaJPGeneric = Locale.of("ja", "JP", "generic");
+    static final Locale OSAKA = Locale.of("ja", "JP", "osaka");
 
     static Locale[] avail = {
         jaJPGeneric

--- a/test/jdk/java/util/PluggableLocale/providersrc/barprovider/com/bar/LocaleNameProviderImpl.java
+++ b/test/jdk/java/util/PluggableLocale/providersrc/barprovider/com/bar/LocaleNameProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,10 +35,10 @@ import com.foobar.Utils;
 public class LocaleNameProviderImpl extends LocaleNameProvider {
     static Locale[] avail = {Locale.JAPANESE,
                              Locale.JAPAN,
-                             new Locale("ja", "JP", "osaka"),
-                             new Locale("ja", "JP", "kyoto"),
-                             new Locale("xx"),
-                             new Locale("yy", "YY", "YYYY")};
+                             Locale.of("ja", "JP", "osaka"),
+                             Locale.of("ja", "JP", "kyoto"),
+                             Locale.of("xx"),
+                             Locale.of("yy", "YY", "YYYY")};
     static List<Locale> availList = Arrays.asList(avail);
     public Locale[] getAvailableLocales() {
         return avail;

--- a/test/jdk/java/util/PluggableLocale/providersrc/barprovider/com/bar/TimeZoneNameProviderImpl.java
+++ b/test/jdk/java/util/PluggableLocale/providersrc/barprovider/com/bar/TimeZoneNameProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,9 +32,9 @@ import java.util.spi.*;
 import com.foobar.Utils;
 
 public class TimeZoneNameProviderImpl extends TimeZoneNameProvider {
-    static Locale[] avail = {new Locale("ja", "JP", "osaka"),
-                        new Locale("ja", "JP", "kyoto"),
-                        new Locale("xx"),
+    static Locale[] avail = {Locale.of("ja", "JP", "osaka"),
+                        Locale.of("ja", "JP", "kyoto"),
+                        Locale.of("xx"),
                         Locale.JAPAN};
 
     static String[][] zoneOsaka = {

--- a/test/jdk/java/util/PluggableLocale/providersrc/fooprovider/com/foo/BreakIteratorProviderImpl.java
+++ b/test/jdk/java/util/PluggableLocale/providersrc/fooprovider/com/foo/BreakIteratorProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,9 +35,9 @@ public class BreakIteratorProviderImpl extends BreakIteratorProvider {
 
     static Locale[] avail = {
         Locale.JAPAN,
-        new Locale("ja", "JP", "osaka"),
-        new Locale("ja", "JP", "kyoto"),
-        new Locale("xx", "YY")};
+        Locale.of("ja", "JP", "osaka"),
+        Locale.of("ja", "JP", "kyoto"),
+        Locale.of("xx", "YY")};
 
     static String[] dialect = {
         "\u3067\u3059\u3002",

--- a/test/jdk/java/util/PluggableLocale/providersrc/fooprovider/com/foo/CollatorProviderImpl.java
+++ b/test/jdk/java/util/PluggableLocale/providersrc/fooprovider/com/foo/CollatorProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,9 +36,9 @@ public class CollatorProviderImpl extends CollatorProvider {
 
     static Locale[] avail = {
         Locale.JAPAN,
-        new Locale("ja", "JP", "osaka"),
-        new Locale("ja", "JP", "kyoto"),
-        new Locale("xx", "YY", "ZZZZ")};
+        Locale.of("ja", "JP", "osaka"),
+        Locale.of("ja", "JP", "kyoto"),
+        Locale.of("xx", "YY", "ZZZZ")};
 
     static String[] dialect = {
         "\u3067\u3059\u3002",

--- a/test/jdk/java/util/PluggableLocale/providersrc/fooprovider/com/foo/DateFormatProviderImpl.java
+++ b/test/jdk/java/util/PluggableLocale/providersrc/fooprovider/com/foo/DateFormatProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,9 +36,9 @@ public class DateFormatProviderImpl extends DateFormatProvider {
 
     static Locale[] avail = {
         Locale.JAPAN,
-        new Locale("ja", "JP", "osaka"),
-        new Locale("ja", "JP", "kyoto"),
-        new Locale("yy")};
+        Locale.of("ja", "JP", "osaka"),
+        Locale.of("ja", "JP", "kyoto"),
+        Locale.of("yy")};
 
     static String[] datePattern = {
         "yyyy'\u5e74'M'\u6708'd'\u65e5'", // full date pattern

--- a/test/jdk/java/util/PluggableLocale/providersrc/fooprovider/com/foo/DateFormatSymbolsProviderImpl.java
+++ b/test/jdk/java/util/PluggableLocale/providersrc/fooprovider/com/foo/DateFormatSymbolsProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,10 +35,10 @@ import com.foobar.Utils;
 public class DateFormatSymbolsProviderImpl extends DateFormatSymbolsProvider {
 
     static Locale[] avail = {
-        new Locale("ja", "JP", "osaka"),
-        new Locale("ja", "JP", "kyoto"),
+        Locale.of("ja", "JP", "osaka"),
+        Locale.of("ja", "JP", "kyoto"),
         Locale.JAPAN,
-        new Locale("yy", "ZZ")
+        Locale.of("yy", "ZZ")
     };
     static List<Locale> availList = Arrays.asList(avail);
 

--- a/test/jdk/java/util/PluggableLocale/providersrc/fooprovider/com/foo/DecimalFormatSymbolsProviderImpl.java
+++ b/test/jdk/java/util/PluggableLocale/providersrc/fooprovider/com/foo/DecimalFormatSymbolsProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,10 +35,10 @@ import com.foobar.Utils;
 public class DecimalFormatSymbolsProviderImpl extends DecimalFormatSymbolsProvider {
 
     static Locale[] avail = {
-        new Locale("ja", "JP", "osaka"),
-        new Locale("ja", "JP", "kyoto"),
+        Locale.of("ja", "JP", "osaka"),
+        Locale.of("ja", "JP", "kyoto"),
         Locale.JAPAN,
-        new Locale("yy", "ZZ", "UUU")
+        Locale.of("yy", "ZZ", "UUU")
     };
     static List<Locale> availList = Arrays.asList(avail);
 

--- a/test/jdk/java/util/PluggableLocale/providersrc/fooprovider/com/foo/NumberFormatProviderImpl.java
+++ b/test/jdk/java/util/PluggableLocale/providersrc/fooprovider/com/foo/NumberFormatProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,9 +36,9 @@ public class NumberFormatProviderImpl extends NumberFormatProvider {
 
     static Locale[] avail = {
         Locale.JAPAN,
-        new Locale("ja", "JP", "osaka"),
-        new Locale("ja", "JP", "kyoto"),
-        new Locale("zz")};
+        Locale.of("ja", "JP", "osaka"),
+        Locale.of("ja", "JP", "kyoto"),
+        Locale.of("zz")};
 
     static String[] dialect = {
         "\u3067\u3059\u3002",

--- a/test/jdk/java/util/ResourceBundle/Bug4165815Test.java
+++ b/test/jdk/java/util/ResourceBundle/Bug4165815Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,7 @@ public class Bug4165815Test extends RBTestFmwk {
     private static final String bundleName = "/Bug4165815Bundle";
     public void testIt() throws Exception {
         try {
-            ResourceBundle bundle = ResourceBundle.getBundle(bundleName, new Locale("en", "US"));
+            ResourceBundle bundle = ResourceBundle.getBundle(bundleName, Locale.US);
             errln("ResourceBundle returned a bundle when it should not have.");
         } catch (IllegalArgumentException e) {
             //This is what we should get when the base name contains a "/" character.

--- a/test/jdk/java/util/ResourceBundle/Bug4168625Test.java
+++ b/test/jdk/java/util/ResourceBundle/Bug4168625Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,9 +61,9 @@ public class Bug4168625Test extends RBTestFmwk {
      */
     public void testMissingParent() throws Exception {
         final Locale oldDefault = Locale.getDefault();
-        Locale.setDefault(new Locale("en", "US"));
+        Locale.setDefault(Locale.US);
         try {
-            final Locale loc = new Locale("jf", "jf");
+            final Locale loc = Locale.of("jf", "jf");
             ResourceBundle bundle = ResourceBundle.getBundle("Bug4168625Resource2", loc);
             final String s1 = bundle.getString("name");
             if (!s1.equals("Bug4168625Resource2_en_US")) {
@@ -87,7 +87,7 @@ public class Bug4168625Test extends RBTestFmwk {
      *  locale is en_US.
      *  <P>
      *  <pre>
-     *  getBundle("Bug4168625Resource", new Locale("fr", "FR"));
+     *  getBundle("Bug4168625Resource", Locale.FRANCE);
      *      -->try to load Bug4168625Resource_fr_FR
      *      -->try to load Bug4168625Resource_fr
      *      -->try to load Bug4168625Resource_en_US
@@ -97,7 +97,7 @@ public class Bug4168625Test extends RBTestFmwk {
      *      -->cache Bug4168625Resource as Bug4168625Resource_en
      *      -->cache Bug4168625Resource as Bug4168625Resource_en_US
      *      -->return Bug4168625Resource
-     *  getBundle("Bug4168625Resource", new Locale("fr", "FR"));
+     *  getBundle("Bug4168625Resource", Locale.FRANCE);
      *      -->try to load Bug4168625Resource_fr_FR
      *      -->try to load Bug4168625Resource_fr
      *      -->find cached Bug4168625Resource_en_US
@@ -112,7 +112,7 @@ public class Bug4168625Test extends RBTestFmwk {
      *  The following, more efficient behavior is desired:
      *  <P>
      *  <pre>
-     *  getBundle("Bug4168625Resource", new Locale("fr", "FR"));
+     *  getBundle("Bug4168625Resource", Locale.FRANCE);
      *      -->try to load Bug4168625Resource_fr_FR
      *      -->try to load Bug4168625Resource_fr
      *      -->try to load Bug4168625Resource_en_US
@@ -124,7 +124,7 @@ public class Bug4168625Test extends RBTestFmwk {
      *      -->cache Bug4168625Resource as Bug4168625Resource_fr
      *      -->cache Bug4168625Resource as Bug4168625Resource_fr_FR
      *      -->return Bug4168625Resource
-     *  getBundle("Bug4168625Resource", new Locale("fr", "FR"));
+     *  getBundle("Bug4168625Resource", Locale.FRANCE);
      *      -->find cached Bug4168625Resource_fr_FR
      *      -->return Bug4168625Resource_en_US (which is realy Bug4168625Resource)
      *  </pre>
@@ -132,7 +132,7 @@ public class Bug4168625Test extends RBTestFmwk {
      *
      */
     public void testCacheFailures() throws Exception {
-        checkResourceLoading("Bug4168625Resource", new Locale("fr", "FR"));
+        checkResourceLoading("Bug4168625Resource", Locale.FRANCE);
     }
 
     /**
@@ -142,7 +142,7 @@ public class Bug4168625Test extends RBTestFmwk {
      *  exist.  The class Bug4168625Resource does.
      *  <P>
      *  <pre>
-     *  getBundle("Bug4168625Resource", new Locale("en", "US"));
+     *  getBundle("Bug4168625Resource", Locale.US);
      *      -->try to load Bug4168625Resource_en_US
      *      -->try to load Bug4168625Resource_en
      *      -->try to load Bug4168625Resource_en_US
@@ -158,7 +158,7 @@ public class Bug4168625Test extends RBTestFmwk {
      *  should not occur.  The desired behavior is as follows:
      *  <P>
      *  <pre>
-     *  getBundle("Bug4168625Resource", new Locale("en", "US"));
+     *  getBundle("Bug4168625Resource", Locale.US);
      *      -->try to load Bug4168625Resource_en_US
      *      -->try to load Bug4168625Resource_en
      *      -->load Bug4168625Resource
@@ -276,8 +276,8 @@ public class Bug4168625Test extends RBTestFmwk {
         final Class c = loader.loadClass("Bug4168625Class");
         final Bug4168625Getter test = (Bug4168625Getter)c.newInstance();
 
-        ConcurrentLoadingThread thread1 = new ConcurrentLoadingThread(loader, test, new Locale("en", "CA"));
-        ConcurrentLoadingThread thread2 = new ConcurrentLoadingThread(loader, test, new Locale("en", "IE"));
+        ConcurrentLoadingThread thread1 = new ConcurrentLoadingThread(loader, test, Locale.of("en", "CA"));
+        ConcurrentLoadingThread thread2 = new ConcurrentLoadingThread(loader, test, Locale.of("en", "IE"));
 
         thread1.start();            //start thread 1
         loader.waitForNotify(1);    //wait for thread1 to do getBundle & block in loader
@@ -306,7 +306,7 @@ public class Bug4168625Test extends RBTestFmwk {
         final Bug4168625Getter test = (Bug4168625Getter)c.newInstance();
         causeResourceBundleCacheFlush();
 
-        ConcurrentLoadingThread thread1 = new ConcurrentLoadingThread(loader, test, new Locale("en", "US"));
+        ConcurrentLoadingThread thread1 = new ConcurrentLoadingThread(loader, test, Locale.US);
         thread1.start();            //start thread 1
         loader.waitForNotify(1);    //wait for thread1 to do getBundle(en_US) & block in loader
         causeResourceBundleCacheFlush();    //cause a cache flush
@@ -561,11 +561,11 @@ public class Bug4168625Test extends RBTestFmwk {
      *  returning from findBundle).
      *  <P>
      *  <pre>
-     *  ThreadA.getBundle("Bug4168625Resource", new Locale("sp"));
+     *  ThreadA.getBundle("Bug4168625Resource", Locale.of("sp"));
      *      A-->load Bug4168625Resource_sp
      *      A-->find cached Bug4168625Resource
      *      A-->cache Bug4168625Resource_sp as Bug4168625Resource_sp
-     *  ThreadB.getBundle("Bug4168625Resource", new Locale("sp"));
+     *  ThreadB.getBundle("Bug4168625Resource", Locale.of("sp"));
      *      B-->find cached Bug4168625Resource_sp
      *      B-->return Bug4168625Resource_sp
      *  ThreadB.bundle.getString("language");

--- a/test/jdk/java/util/ResourceBundle/Bug4177489Test.java
+++ b/test/jdk/java/util/ResourceBundle/Bug4177489Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,13 +55,13 @@ public class Bug4177489Test extends RBTestFmwk {
             errln("ResourceBundle didn't handle resource class name with '_' in it.");
         }
 
-        Locale loc = new Locale("jf", "");
+        Locale loc = Locale.of("jf");
         ResourceBundle rb2 = ResourceBundle.getBundle( "Bug4177489_Resource", loc );
         if (!loc.equals(rb2.getLocale())) {
             errln("ResourceBundle didn't return proper locale name:"+rb2.getLocale());
         }
 
-        loc = new Locale("jf", "JF");
+        loc = Locale.of("jf", "JF");
         ResourceBundle rb3 = ResourceBundle.getBundle("Bug4177489_Resource", loc);
         if (!loc.equals(rb3.getLocale())) {
             errln("ResourceBundle didn't return proper locale name for property bundle:"+rb3.getLocale());

--- a/test/jdk/java/util/ResourceBundle/Bug4353454.java
+++ b/test/jdk/java/util/ResourceBundle/Bug4353454.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ public class Bug4353454 {
     }
 
     private static void test() {
-        ResourceBundle myResources = ResourceBundle.getBundle("RB4353454", new Locale(""));
+        ResourceBundle myResources = ResourceBundle.getBundle("RB4353454", Locale.of(""));
         if (!"Got it!".equals(myResources.getString("text"))) {
             throw new RuntimeException("returned wrong resource for key 'text': "
                                        + myResources.getString("text"));

--- a/test/jdk/java/util/ResourceBundle/Bug6190861.java
+++ b/test/jdk/java/util/ResourceBundle/Bug6190861.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,13 +34,13 @@ public class Bug6190861 {
     public static void main(String[] args) {
         Locale reservedLocale = Locale.getDefault();
         try {
-            Locale.setDefault(new Locale("en", "US"));
+            Locale.setDefault(Locale.US);
 
             List localeList = new ArrayList();
             localeList.add(Locale.ENGLISH);
             localeList.add(Locale.KOREA);
             localeList.add(Locale.UK);
-            localeList.add(new Locale("en", "CA"));
+            localeList.add(Locale.of("en", "CA"));
             localeList.add(Locale.ENGLISH);
 
             Iterator iter = localeList.iterator();

--- a/test/jdk/java/util/ResourceBundle/Bug6299235/Bug6299235Test.java
+++ b/test/jdk/java/util/ResourceBundle/Bug6299235/Bug6299235Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ import java.util.Locale;
  */
 
 public class Bug6299235Test {
-    private static final Locale ru_RU = new Locale("ru", "RU");
+    private static final Locale ru_RU = Locale.of("ru", "RU");
 
     public static void main(String args[]) {
         Locale locale = Locale.getDefault();

--- a/test/jdk/java/util/ResourceBundle/Control/DefaultControlTest.java
+++ b/test/jdk/java/util/ResourceBundle/Control/DefaultControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -141,32 +141,32 @@ public class DefaultControlTest {
 
     private static void testGetCandidateLocales() {
         Map<Locale, Locale[]> candidateData = new HashMap<Locale, Locale[]>();
-        candidateData.put(new Locale("ja", "JP", "YOK"), new Locale[] {
-                              new Locale("ja", "JP", "YOK"),
-                              new Locale("ja", "JP"),
-                              new Locale("ja"),
+        candidateData.put(Locale.of("ja", "JP", "YOK"), new Locale[] {
+                              Locale.of("ja", "JP", "YOK"),
+                              Locale.of("ja", "JP"),
+                              Locale.of("ja"),
                               Locale.ROOT });
-        candidateData.put(new Locale("ja", "JP"), new Locale[] {
-                              new Locale("ja", "JP"),
-                              new Locale("ja"),
+        candidateData.put(Locale.of("ja", "JP"), new Locale[] {
+                              Locale.of("ja", "JP"),
+                              Locale.of("ja"),
                               Locale.ROOT });
-        candidateData.put(new Locale("ja"), new Locale[] {
-                              new Locale("ja"),
+        candidateData.put(Locale.of("ja"), new Locale[] {
+                              Locale.of("ja"),
                               Locale.ROOT });
 
-        candidateData.put(new Locale("ja", "", "YOK"), new Locale[] {
-                              new Locale("ja", "", "YOK"),
-                              new Locale("ja"),
+        candidateData.put(Locale.of("ja", "", "YOK"), new Locale[] {
+                              Locale.of("ja", "", "YOK"),
+                              Locale.of("ja"),
                               Locale.ROOT });
-        candidateData.put(new Locale("", "JP", "YOK"), new Locale[] {
-                              new Locale("", "JP", "YOK"),
-                              new Locale("", "JP"),
+        candidateData.put(Locale.of("", "JP", "YOK"), new Locale[] {
+                              Locale.of("", "JP", "YOK"),
+                              Locale.of("", "JP"),
                               Locale.ROOT });
-        candidateData.put(new Locale("", "", "YOK"), new Locale[] {
-                              new Locale("", "", "YOK"),
+        candidateData.put(Locale.of("", "", "YOK"), new Locale[] {
+                              Locale.of("", "", "YOK"),
                               Locale.ROOT });
-        candidateData.put(new Locale("", "JP"), new Locale[] {
-                              new Locale("", "JP"),
+        candidateData.put(Locale.of("", "JP"), new Locale[] {
+                              Locale.of("", "JP"),
                               Locale.ROOT });
         candidateData.put(Locale.ROOT, new Locale[] {
                               Locale.ROOT });
@@ -354,19 +354,19 @@ public class DefaultControlTest {
     private static void testToBundleName() {
         final String name = "J2SE";
         Map<Locale, String> bundleNames = new HashMap<Locale, String>();
-        bundleNames.put(new Locale("ja", "JP", "YOK"),
+        bundleNames.put(Locale.of("ja", "JP", "YOK"),
                         name + "_" + "ja" + "_" + "JP" + "_" + "YOK");
-        bundleNames.put(new Locale("ja", "JP"),
+        bundleNames.put(Locale.of("ja", "JP"),
                         name + "_" + "ja" + "_" + "JP");
-        bundleNames.put(new Locale("ja"),
+        bundleNames.put(Locale.of("ja"),
                         name + "_" + "ja");
-        bundleNames.put(new Locale("ja", "", "YOK"),
+        bundleNames.put(Locale.of("ja", "", "YOK"),
                         name + "_" + "ja" + "_" + "" + "_" + "YOK");
-        bundleNames.put(new Locale("", "JP", "YOK"),
+        bundleNames.put(Locale.of("", "JP", "YOK"),
                         name + "_" + "" + "_" + "JP" + "_" + "YOK");
-        bundleNames.put(new Locale("", "", "YOK"),
+        bundleNames.put(Locale.of("", "", "YOK"),
                         name + "_" + "" + "_" + "" + "_" + "YOK");
-        bundleNames.put(new Locale("", "JP"),
+        bundleNames.put(Locale.of("", "JP"),
                         name + "_" + "" + "_" + "JP");
         bundleNames.put(Locale.ROOT,
                         name);

--- a/test/jdk/java/util/ResourceBundle/Control/LoadingStrategiesTest.java
+++ b/test/jdk/java/util/ResourceBundle/Control/LoadingStrategiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,7 +85,7 @@ public class LoadingStrategiesTest {
             if (locale.equals(Locale.TAIWAN)) {
                 return Arrays.asList(locale,
                                      // no Locale("zh")
-                                     new Locale(""));
+                                     Locale.of(""));
             }
             return super.getCandidateLocales(baseName, locale);
         }

--- a/test/jdk/java/util/ResourceBundle/Control/StressTest.java
+++ b/test/jdk/java/util/ResourceBundle/Control/StressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,12 +33,11 @@ import java.util.concurrent.atomic.*;
 
 // Usage: java StressTest [threadsFactor [duration]]
 public class StressTest {
-    static final Locale ROOT_LOCALE = new Locale("");
     static final Random rand = new Random();
     static final Locale[] locales = {
         Locale.US,
         Locale.CHINA,
-        ROOT_LOCALE,
+        Locale.ROOT,
         Locale.JAPAN,
         Locale.CANADA,
         Locale.KOREA
@@ -160,7 +159,7 @@ public class StressTest {
             id = i;
             index = i % locales.length;
             locale = locales[index];
-            cleaner = locale.equals(ROOT_LOCALE);
+            cleaner = locale.equals(Locale.ROOT);
             str = expected[index];
             max = rand.nextInt((index + 1) * 500) + 1000;
             control = new TestControl(max);

--- a/test/jdk/java/util/ResourceBundle/Control/XMLResourceBundleTest.java
+++ b/test/jdk/java/util/ResourceBundle/Control/XMLResourceBundleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,7 +76,7 @@ public class XMLResourceBundleTest {
                        return bundle;
                    }
                };
-        ResourceBundle rb = ResourceBundle.getBundle("XmlRB", new Locale(""), xmlControl);
+        ResourceBundle rb = ResourceBundle.getBundle("XmlRB", Locale.ROOT, xmlControl);
         String type = rb.getString("type");
         if (!type.equals("XML")) {
             throw new RuntimeException("Root Locale: type: got " + type

--- a/test/jdk/java/util/ResourceBundle/ResourceBundleTest.java
+++ b/test/jdk/java/util/ResourceBundle/ResourceBundleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,7 +78,7 @@ public class ResourceBundleTest extends RBTestFmwk {
 
     public void TestResourceBundle() {
         Locale  saveDefault = Locale.getDefault();
-        Locale.setDefault(new Locale("fr", "FR"));
+        Locale.setDefault(Locale.FRANCE);
 
         // load up the resource bundle, and make sure we got the right one
         ResourceBundle  bundle = ResourceBundle.getBundle("TestResource");
@@ -136,7 +136,7 @@ public class ResourceBundleTest extends RBTestFmwk {
         // load up the resource and check to make sure we got the right class
         // (we don't define be_BY or be, so we fall back on the root default)
         ResourceBundle  bundle = ResourceBundle.getBundle("TestResource",
-                            new Locale("be", "BY"),
+                            Locale.of("be", "BY"),
                             Control.getNoFallbackControl(Control.FORMAT_DEFAULT));
         if (!bundle.getClass().getName().equals("TestResource"))
             errln("Expected TestResource, got " + bundle.getClass().getName());
@@ -152,7 +152,7 @@ public class ResourceBundleTest extends RBTestFmwk {
      */
     public void TestEmptyListResourceBundle() {
         ResourceBundle bundle = ResourceBundle.getBundle("TestResource",
-                            new Locale("it", "IT"));
+                            Locale.ITALY);
         doListResourceBundleTest(bundle);
     }
 
@@ -210,7 +210,7 @@ public class ResourceBundleTest extends RBTestFmwk {
      */
     public void TestPropertyResourceBundle() {
         ResourceBundle  bundle = ResourceBundle.getBundle("TestResource",
-                            new Locale("es", "ES"));
+                            Locale.of("es", "ES"));
 
         // these resources are defined in TestResource_es.properties
         String  test = bundle.getString("Now");
@@ -256,14 +256,14 @@ public class ResourceBundleTest extends RBTestFmwk {
     public void TestGetLocale() {
         // try to find TestResource_fr_CH.  Should get fr_CH as its locale
         ResourceBundle test = ResourceBundle.getBundle("TestResource",
-                        new Locale("fr", "CH", ""));
+                        Locale.of("fr", "CH"));
         Locale locale = test.getLocale();
         if (!(locale.getLanguage().equals("fr")) || !(locale.getCountry().equals("CH")))
             errln("Actual locale for TestResource_fr_CH should have been fr_CH, got " + locale);
 
         // try to find TestResource_fr_BE, which doesn't exist.  Should get fr as its locale
         test = ResourceBundle.getBundle("TestResource",
-                        new Locale("fr", "BE", ""));
+                        Locale.of("fr", "BE"));
         locale = test.getLocale();
         if (!(locale.getLanguage().equals("fr")) || !(locale.getCountry().equals("")))
             errln("Actual locale for TestResource_fr_BE should have been fr, got " + locale);
@@ -271,7 +271,7 @@ public class ResourceBundleTest extends RBTestFmwk {
         // try to find TestResource_iw_IL, which doesn't exist.  Should get root locale
         // as its locale
         test = ResourceBundle.getBundle("TestResource",
-                        new Locale("iw", "IL", ""),
+                        Locale.of("iw", "IL"),
                         Control.getNoFallbackControl(Control.FORMAT_DEFAULT));
         locale = test.getLocale();
         if (!(locale.getLanguage().equals("")) || !(locale.getCountry().equals("")))
@@ -315,7 +315,7 @@ public class ResourceBundleTest extends RBTestFmwk {
         final String className = "TestResource";
         final String keyName = "DontGetThis";
         ResourceBundle bundle = ResourceBundle.getBundle(className,
-                            new Locale("it", "IT"));
+                            Locale.ITALY);
         try {
             Object o = bundle.getObject(keyName);
             errln(bundle.getClass().getName()+" returned a value for tag \""+keyName+"\" when it should have thrown an exception.  It returned "+o);

--- a/test/jdk/java/util/ResourceBundle/Test4314141.java
+++ b/test/jdk/java/util/ResourceBundle/Test4314141.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,7 @@ public class Test4314141 {
      * Verifies the example from the getBundle specification.
      */
     static void testExample() {
-        Locale.setDefault(new Locale("en", "UK"));
+        Locale.setDefault(Locale.of("en", "UK"));
         doTestExample("fr", "CH", new String[] {"_fr_CH.class", "_fr.properties", ".class"});
         doTestExample("fr", "FR", new String[] {"_fr.properties", ".class"});
         doTestExample("de", "DE", new String[] {"_en.properties", ".class"});
@@ -87,7 +87,7 @@ public class Test4314141 {
     static void doTest(String baseName, String language, String country, String variant,
             String[] expectedSuffixes) {
         System.out.print("Looking for " + baseName + " \"" + language + "\", \"" + country + "\", \"" + variant + "\"");
-        ResourceBundle bundle = ResourceBundle.getBundle(baseName, new Locale(language, country, variant));
+        ResourceBundle bundle = ResourceBundle.getBundle(baseName, Locale.of(language, country, variant));
         System.out.print(" => got ");
         String previousName = null;
         int nameCount = 0;

--- a/test/jdk/java/util/ResourceBundle/modules/basic/srcBasic/asiabundles/jdk/test/resources/asia/MyResourcesAsia.java
+++ b/test/jdk/java/util/ResourceBundle/modules/basic/srcBasic/asiabundles/jdk/test/resources/asia/MyResourcesAsia.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,6 @@ public class MyResourcesAsia extends MyResourcesProvider {
     public MyResourcesAsia() {
         super("java.properties", "asia",
               Locale.JAPANESE, Locale.JAPAN, Locale.CHINESE, Locale.TAIWAN,
-              new Locale("vi"), new Locale("in"));
+              Locale.of("vi"), Locale.of("in"));
     }
 }

--- a/test/jdk/java/util/ResourceBundle/modules/basic/srcBasic/eubundles/jdk/test/resources/eu/MyResourcesEU.java
+++ b/test/jdk/java/util/ResourceBundle/modules/basic/srcBasic/eubundles/jdk/test/resources/eu/MyResourcesEU.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,6 @@ import jdk.test.resources.spi.MyResourcesProvider;
 public class MyResourcesEU extends MyResourcesProvider {
     public MyResourcesEU() {
         super("java.class", "eu",
-              Locale.GERMAN, Locale.FRENCH, new Locale("es"), new Locale("yi"));
+              Locale.GERMAN, Locale.FRENCH, Locale.of("es"), Locale.of("yi"));
     }
 }

--- a/test/jdk/java/util/Scanner/ScanTest.java
+++ b/test/jdk/java/util/Scanner/ScanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1466,7 +1466,7 @@ public class ScanTest {
         // Test case reported from India
         try {
             String Message = "123978.90 $";
-            Locale locale = new Locale("hi","IN");
+            Locale locale = Locale.of("hi","IN");
             NumberFormat form = NumberFormat.getInstance(locale);
             double myNumber = 1902.09;
             Scanner scanner = new Scanner(form.format(myNumber).toString());
@@ -1485,7 +1485,7 @@ public class ScanTest {
         Pattern delimiter = sc.delimiter();
         Pattern a = Pattern.compile("A");
         sc.useDelimiter(a);
-        Locale dummy = new Locale("en", "US", "dummy");
+        Locale dummy = Locale.of("en", "US", "dummy");
         sc.useLocale(dummy);
         sc.useRadix(16);
         if (sc.radix() != 16 ||

--- a/test/jdk/java/util/Scanner/spi/UseLocaleWithProvider.java
+++ b/test/jdk/java/util/Scanner/spi/UseLocaleWithProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ public class UseLocaleWithProvider {
 
         try {
             testScannerUseLocale("-123.4", Locale.US, -123.4);
-            testScannerUseLocale("-123,45", new Locale("fi", "FI"), -123.45);
+            testScannerUseLocale("-123,45", Locale.of("fi", "FI"), -123.45);
             testScannerUseLocale("334,65", Locale.FRENCH, 334.65);
             testScannerUseLocale("4.334,65", Locale.GERMAN, 4334.65);
         } catch (ClassCastException ex) {

--- a/test/jdk/java/util/Scanner/spi/provider/test/NumberFormatProviderImpl.java
+++ b/test/jdk/java/util/Scanner/spi/provider/test/NumberFormatProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@ import java.util.Locale;
 public class NumberFormatProviderImpl extends NumberFormatProvider {
 
     private static final Locale[] locales = {Locale.US, Locale.FRENCH,
-            Locale.GERMAN, new Locale("fi", "FI")};
+            Locale.GERMAN, Locale.of("fi", "FI")};
 
     @Override
     public NumberFormat getCurrencyInstance(Locale locale) {

--- a/test/jdk/java/util/TimeZone/Bug8167143.java
+++ b/test/jdk/java/util/TimeZone/Bug8167143.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,7 +115,7 @@ public class Bug8167143 {
      * all Available Locales.
      */
     private static void testTimeZoneParsing() {
-        Set<Locale> locales = Set.of(Locale.forLanguageTag("zh-hant"), new Locale("no", "NO", "NY"));
+        Set<Locale> locales = Set.of(Locale.forLanguageTag("zh-hant"), Locale.of("no", "NO", "NY"));
         // Set<Locale> locales = Set.of(Locale.getAvailableLocales());
         locales.forEach((locale) -> {
             final SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd z", locale);
@@ -180,8 +180,8 @@ public class Bug8167143 {
      * for th-TH should not be cached in cache of DateFormatSymbols class.
      */
     private static void testDateFormatSymbolsCache() {
-        Locale th_TH_TH = new Locale("th", "TH", "TH");
-        Locale th_TH = new Locale("th", "TH");
+        Locale th_TH_TH = Locale.of("th", "TH", "TH");
+        Locale th_TH = Locale.of("th", "TH");
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd z", th_TH_TH);
         String[][] thTHTHZoneStrings = sdf.getDateFormatSymbols().getZoneStrings();
         String[][] thTHZoneStrings = sdf.getDateFormatSymbols().getZoneStrings();

--- a/test/jdk/java/util/TimeZone/HongKong.java
+++ b/test/jdk/java/util/TimeZone/HongKong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ public class HongKong {
     public static void main(String[] args) {
         Locale reservedLocale = Locale.getDefault();
         try {
-            Locale.setDefault(new Locale("zh", "HK"));
+            Locale.setDefault(Locale.of("zh", "HK"));
             checkCountry(Locale.GERMANY, "\u5fb7\u570b");
             checkCountry(Locale.FRANCE, "\u6cd5\u570b");
             checkCountry(Locale.ITALY, "\u7fa9\u5927\u5229");

--- a/test/jdk/java/util/jar/JarFile/TurkCert.java
+++ b/test/jdk/java/util/jar/JarFile/TurkCert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ public class TurkCert {
     public static void main(String[] args) throws Exception{
         Locale reservedLocale = Locale.getDefault();
         try {
-            Locale.setDefault(new Locale("TR", "tr"));
+            Locale.setDefault(Locale.of("tr", "TR"));
             File f = new File(System.getProperty("test.src","."), "test.jar");
             try (JarFile jf = new JarFile(f, true)) {
                 JarEntry je = (JarEntry)jf.getEntry("test.class");

--- a/test/jdk/javax/crypto/Cipher/Turkish.java
+++ b/test/jdk/javax/crypto/Cipher/Turkish.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ public class Turkish {
     public static void main(String[] args) throws Exception {
         Locale reservedLocale = Locale.getDefault();
         try {
-            Locale.setDefault(new Locale("tr", "TR"));
+            Locale.setDefault(Locale.of("tr", "TR"));
 
             System.out.println(Cipher.getInstance("RSA/ECB/PKCS1Padding"));
             System.out.println(Cipher.getInstance("RSA/ECB/PKCS1PADDING"));

--- a/test/jdk/javax/imageio/AppletResourceTest.java
+++ b/test/jdk/javax/imageio/AppletResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,13 +60,13 @@ public class AppletResourceTest {
     public void init() {
         DummyImageReaderImpl reader;
         MyReadWarningListener listener = new MyReadWarningListener();
-        Locale[] locales = {new Locale("ru"),
-                            new Locale("fr"),
-                            new Locale("uk")};
+        Locale[] locales = {Locale.of("ru"),
+                            Locale.FRENCH,
+                            Locale.of("uk")};
 
         reader = new DummyImageReaderImpl(new DummyImageReaderSpiImpl());
         reader.setAvailableLocales(locales);
-        reader.setLocale(new Locale("fr"));
+        reader.setLocale(Locale.FRENCH);
         reader.addIIOReadWarningListener(listener);
 
         String baseName = "AppletResourceTest$BugStats";

--- a/test/jdk/javax/management/loading/MletParserLocaleTest.java
+++ b/test/jdk/javax/management/loading/MletParserLocaleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,7 @@ public class MletParserLocaleTest {
         System.out.println("MLet File = " + mletFile);
         try {
             // Change default Locale to Turkish
-            Locale.setDefault(new Locale("tr", "TR"));
+            Locale.setDefault(Locale.of("tr", "TR"));
             mlet.getMBeansFromURL(mletFile);
             System.out.println("Test Passes");
         } catch (Exception e) {

--- a/test/jdk/javax/management/modelmbean/DescriptorSupportXMLLocaleTest.java
+++ b/test/jdk/javax/management/modelmbean/DescriptorSupportXMLLocaleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ public class DescriptorSupportXMLLocaleTest {
                 + "</DESCRIPTOR>";
         Locale loc = Locale.getDefault();
         try {
-            Locale.setDefault(new Locale("tr", "TR"));
+            Locale.setDefault(Locale.of("tr", "TR"));
             new DescriptorSupport(xmlDesc);
         } catch (Exception e) {
             e.printStackTrace(System.out);

--- a/test/jdk/javax/management/remote/mandatory/connection/JMXServiceURLLocaleTest.java
+++ b/test/jdk/javax/management/remote/mandatory/connection/JMXServiceURLLocaleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ public class JMXServiceURLLocaleTest {
         try {
             echo("Setting Turkish locale");
             // Set locale other than Locale.ENGLISH
-            Locale.setDefault(new Locale("tr", "TR"));
+            Locale.setDefault(Locale.of("tr", "TR"));
             new JMXServiceURL("service:jmx:RMI://");
         } catch (Exception e) {
             e.printStackTrace(System.out);

--- a/test/jdk/javax/swing/JFileChooser/8080628/bug8080628.java
+++ b/test/jdk/javax/swing/JFileChooser/8080628/bug8080628.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,17 +46,17 @@ public class bug8080628 {
     };
 
     public static final Locale[] LOCALES = new Locale[] {
-            new Locale("en"),
-            new Locale("de"),
-            new Locale("es"),
-            new Locale("fr"),
-            new Locale("it"),
-            new Locale("ja"),
-            new Locale("ko"),
-            new Locale("pt", "BR"),
-            new Locale("sv"),
-            new Locale("zh", "CN"),
-            new Locale("zh", "TW")
+            Locale.of("en"),
+            Locale.of("de"),
+            Locale.of("es"),
+            Locale.of("fr"),
+            Locale.of("it"),
+            Locale.of("ja"),
+            Locale.of("ko"),
+            Locale.of("pt", "BR"),
+            Locale.of("sv"),
+            Locale.of("zh", "CN"),
+            Locale.of("zh", "TW")
     };
 
     private static volatile Exception exception;

--- a/test/jdk/javax/swing/JInternalFrame/8020708/bug8020708.java
+++ b/test/jdk/javax/swing/JInternalFrame/8020708/bug8020708.java
@@ -47,16 +47,16 @@ public class bug8020708 {
 
     private static final Locale[] SUPPORTED_LOCALES = {
         Locale.ENGLISH,
-        new Locale("de"),
-        new Locale("es"),
-        new Locale("fr"),
-        new Locale("it"),
-        new Locale("ja"),
-        new Locale("ko"),
-        new Locale("pt", "BR"),
-        new Locale("sv"),
-        new Locale("zh", "CN"),
-        new Locale("zh", "TW")
+        Locale.of("de"),
+        Locale.of("es"),
+        Locale.of("fr"),
+        Locale.of("it"),
+        Locale.of("ja"),
+        Locale.of("ko"),
+        Locale.of("pt", "BR"),
+        Locale.of("sv"),
+        Locale.of("zh", "CN"),
+        Locale.of("zh", "TW")
     };
     private static final String[] LOOK_AND_FEELS = {
         "Nimbus",

--- a/test/jdk/sun/nio/cs/Test4206507.java
+++ b/test/jdk/sun/nio/cs/Test4206507.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ public class Test4206507 {
     public static void main(String[] args) throws UnsupportedEncodingException {
         Locale l = Locale.getDefault();
         try {
-            Locale.setDefault(new Locale("tr", "TR"));
+            Locale.setDefault(Locale.of("tr", "TR"));
             byte[] b = "".getBytes("ISO8859-9");
         } finally {
             Locale.setDefault(l);

--- a/test/jdk/sun/security/util/Resources/customSysClassLoader/MessageFormatting.java
+++ b/test/jdk/sun/security/util/Resources/customSysClassLoader/MessageFormatting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ public class MessageFormatting {
         if (str.indexOf('{') < 0) {
             return str;
         }
-        Locale loc = new Locale("en", "US");
+        Locale loc = Locale.of("en", "US");
         MessageFormat format = new MessageFormat(str, loc);
         return format.format(args);
     }

--- a/test/jdk/sun/text/resources/Format/Bug4395196.java
+++ b/test/jdk/sun/text/resources/Format/Bug4395196.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ public class Bug4395196
         public static void main(String[] arg)
         {
                 int result = 0;
-                Locale loc = new Locale("ko","KR");
+                Locale loc = Locale.of("ko","KR");
                 Date now = new Date(108, Calendar.APRIL, 9);
 
                 DateFormat df =

--- a/test/jdk/sun/text/resources/Format/Bug4442855.java
+++ b/test/jdk/sun/text/resources/Format/Bug4442855.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,14 +46,14 @@ public static void main(String[] argv){
 }
 
 private boolean TestAD(){
-        Locale zhTWloc = new Locale("zh", "TW");
+        Locale zhTWloc = Locale.of("zh", "TW");
         SimpleDateFormat sdf = new SimpleDateFormat("G", zhTWloc);
 
         return Test(sdf.format(new Date()), "\u897f\u5143", "AD");
 }
 
 private boolean TestBC(){
-        Locale zhTWloc = new Locale("zh", "TW");
+        Locale zhTWloc = Locale.of("zh", "TW");
         SimpleDateFormat sdf = new SimpleDateFormat("G", zhTWloc);
 
         Calendar cdar = sdf.getCalendar();

--- a/test/jdk/sun/text/resources/Format/Bug4621320.java
+++ b/test/jdk/sun/text/resources/Format/Bug4621320.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import java.util.Locale;
 public class Bug4621320 {
 
     public static void main(String args[]) {
-        DateFormatSymbols dfs = new DateFormatSymbols(new Locale("uk","UA"));
+        DateFormatSymbols dfs = new DateFormatSymbols(Locale.of("uk","UA"));
         if
 (!dfs.getMonths()[2].equals("\u0431\u0435\u0440\u0435\u0437\u043d\u044f")) {
             throw new RuntimeException();

--- a/test/jdk/sun/text/resources/Format/Bug4762201.java
+++ b/test/jdk/sun/text/resources/Format/Bug4762201.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ public class Bug4762201
         public static void main(String[] arg)
         {
                 int result = 0;
-                Locale loc = new Locale("zh","CN");
+                Locale loc = Locale.of("zh","CN");
                 Date now = new Date();
 
                 DateFormat df =

--- a/test/jdk/sun/text/resources/Format/Bug4807540.java
+++ b/test/jdk/sun/text/resources/Format/Bug4807540.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import java.util.Calendar;
 public class Bug4807540 {
 
     public static void main(String[] args) {
-        Locale si = new Locale("sl", "si");
+        Locale si = Locale.of("sl", "si");
 
         String expected = "30.4.2008";
         DateFormat dfSi = DateFormat.getDateInstance (DateFormat.MEDIUM, si);

--- a/test/jdk/sun/text/resources/Format/Bug5096553.java
+++ b/test/jdk/sun/text/resources/Format/Bug5096553.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public class Bug5096553
       String expectedMed = "30-04-2008";
       String expectedShort="30-04-08";
 
-      Locale dk = new Locale("da", "DK");
+      Locale dk = Locale.of("da", "DK");
       DateFormat df1 = DateFormat.getDateInstance(DateFormat.MEDIUM, dk);
       DateFormat df2 = DateFormat.getDateInstance(DateFormat.SHORT, dk);
       String medString = new String (df1.format(new Date(108, Calendar.APRIL, 30)));

--- a/test/jdk/sun/text/resources/Format/Bug8037343.java
+++ b/test/jdk/sun/text/resources/Format/Bug8037343.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ public class Bug8037343
 
     public static void main(String[] arg)
     {
-        final Locale esDO = new Locale("es", "DO");
+        final Locale esDO = Locale.of("es", "DO");
         final String expectedShort = "31/03/12";
         final String expectedMedium = "31/03/2012";
 

--- a/test/jdk/sun/text/resources/Format/Bug8074791.java
+++ b/test/jdk/sun/text/resources/Format/Bug8074791.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import static java.text.DateFormat.LONG;
 import static java.util.Calendar.JANUARY;
 
 public class Bug8074791 {
-    private static Locale FINNISH = new Locale("fi");
+    private static Locale FINNISH = Locale.of("fi");
     private static String JAN_FORMAT = "tammikuuta";
     private static String JAN_STANDALONE = "tammikuu";
 

--- a/test/jdk/sun/text/resources/LocaleDataTest.java
+++ b/test/jdk/sun/text/resources/LocaleDataTest.java
@@ -341,7 +341,7 @@ public class LocaleDataTest
             if (use_tag) {
                 locale = Locale.forLanguageTag(localeName);
             } else {
-                locale = new Locale(language, country, variant);
+                locale = Locale.of(language, country, variant);
             }
             ResourceBundle bundle = LocaleData.getBundle(fullName, locale);
             resource = bundle.getObject(resTag);

--- a/test/jdk/sun/util/calendar/Bug6653944.java
+++ b/test/jdk/sun/util/calendar/Bug6653944.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ public class Bug6653944 {
     private static int errorCount = 0;
 
     public static void main(String[] args) throws Exception {
-        Calendar buddhist = Calendar.getInstance(new Locale("th", "TH"));
+        Calendar buddhist = Calendar.getInstance(Locale.of("th", "TH"));
         int expectedYear = buddhist.get(Calendar.YEAR);
 
         Calendar deserialized = (Calendar) deserialize(serialize(buddhist));

--- a/test/jdk/sun/util/resources/Calendar/Bug4518811.java
+++ b/test/jdk/sun/util/resources/Calendar/Bug4518811.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ public class Bug4518811 {
 
     static int getDays(String lang, String loc){
         int errors=0;
-        Locale newlocale = new Locale(lang, loc);
+        Locale newlocale = Locale.of(lang, loc);
 
         Calendar newCal = Calendar.getInstance(newlocale);
 

--- a/test/jdk/sun/util/resources/Calendar/Bug4527203.java
+++ b/test/jdk/sun/util/resources/Calendar/Bug4527203.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,13 +34,13 @@ import java.util.Locale;
 public class Bug4527203 {
 
     public static void main(String[] args) {
-        Calendar huCalendar = Calendar.getInstance(new Locale("hu","HU"));
+        Calendar huCalendar = Calendar.getInstance(Locale.of("hu","HU"));
         int hufirstDayOfWeek = huCalendar.getFirstDayOfWeek();
         if (hufirstDayOfWeek != Calendar.MONDAY) {
             throw new RuntimeException();
         }
 
-        Calendar ukCalendar = Calendar.getInstance(new Locale("uk","UA"));
+        Calendar ukCalendar = Calendar.getInstance(Locale.of("uk","UA"));
         int ukfirstDayOfWeek = ukCalendar.getFirstDayOfWeek();
         if (ukfirstDayOfWeek != Calendar.MONDAY) {
             throw new RuntimeException();

--- a/test/jdk/sun/util/resources/Locale/Bug4429024.java
+++ b/test/jdk/sun/util/resources/Locale/Bug4429024.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,8 +110,8 @@ public class Bug4429024 {
 
         static int getLanguage(String inLang, String localizedName){
 
-            Locale fiLocale = new Locale("fi", "FI");
-            Locale inLocale = new Locale (inLang, "");
+            Locale fiLocale = Locale.of("fi", "FI");
+            Locale inLocale = Locale.of(inLang);
 
             if (!inLocale.getDisplayLanguage(fiLocale).equals(localizedName)){
                 System.out.println("Language " + inLang +" should be \"" + localizedName  + "\", not \"" + inLocale.getDisplayLanguage(fiLocale) + "\"");
@@ -124,8 +124,8 @@ public class Bug4429024 {
 
     static int getCountry(String inCountry, String localizedName){
 
-            Locale fiLocale = new Locale("fi", "FI");
-            Locale inLocale = new Locale ("", inCountry);
+            Locale fiLocale = Locale.of("fi", "FI");
+            Locale inLocale = Locale.of("", inCountry);
 
             if (!inLocale.getDisplayCountry(fiLocale).equals(localizedName)){
                 System.out.println("Country " + inCountry + " should be \"" + localizedName + "\", not \"" + inLocale.getDisplayCountry(fiLocale) + "\"");

--- a/test/jdk/sun/util/resources/Locale/Bug4965260.java
+++ b/test/jdk/sun/util/resources/Locale/Bug4965260.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,11 +34,11 @@ public class Bug4965260  {
 
     // Define supported locales
     static Locale[] locales2Test = new Locale[] {
-        new Locale("de"),
-        new Locale("es"),
-        new Locale("fr"),
-        new Locale("it"),
-        new Locale("sv")
+        Locale.GERMAN,
+        Locale.of("es"),
+        Locale.FRENCH,
+        Locale.ITALIAN,
+        Locale.of("sv")
     };
 
     static String[] expectedNames = new String[] {
@@ -58,7 +58,7 @@ public class Bug4965260  {
             }
 
             StringBuffer message = new StringBuffer("");
-            Locale dutch = new Locale("nl", "BE");
+            Locale dutch = Locale.of("nl", "BE");
             String current;
             for (int i = 0; i < locales2Test.length; i++) {
                 Locale locale = locales2Test[i];

--- a/test/jdk/sun/util/resources/TimeZone/Bug4640234.java
+++ b/test/jdk/sun/util/resources/TimeZone/Bug4640234.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,15 +63,16 @@ public class Bug4640234  {
 
     // Define supported locales
     static Locale[] locales2Test = new Locale[] {
-        new Locale("de"),
-        new Locale("es"),
-        new Locale("fr"),
-        new Locale("it"),
-        new Locale("ja"),
-        new Locale("ko"),
-        new Locale("sv"),
-        new Locale("zh", "CN"),
-        new Locale("zh", "TW")
+        Locale.ENGLISH,
+        Locale.GERMAN,
+        Locale.of("es"),
+        Locale.FRENCH,
+        Locale.ITALIAN,
+        Locale.JAPANESE,
+        Locale.KOREAN,
+        Locale.of("sv"),
+        Locale.SIMPLIFIED_CHINESE,
+        Locale.TRADITIONAL_CHINESE
     };
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/sun/util/resources/TimeZone/Bug4848242.java
+++ b/test/jdk/sun/util/resources/TimeZone/Bug4848242.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ public class Bug4848242 {
 
     static void getTzInfo(String langName, String locName)
     {
-        Locale tzLocale = new Locale(langName, locName);
+        Locale tzLocale = Locale.of(langName, locName);
         TimeZone euroTz = TimeZone.getTimeZone("MET");
 
         System.out.println("Locale is " + langName + "_" + locName);

--- a/test/jdk/sun/util/resources/TimeZone/Bug4858517.java
+++ b/test/jdk/sun/util/resources/TimeZone/Bug4858517.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,17 +34,17 @@ import java.util.TimeZone;
 public class Bug4858517 {
 
     static Locale[] locales2Test = new Locale[] {
-        new Locale("en"),
-        new Locale("de"),
-        new Locale("es"),
-        new Locale("fr"),
-        new Locale("it"),
-        new Locale("ja"),
-        new Locale("ko"),
-        new Locale("sv"),
-        new Locale("zh","CN"),
-        new Locale("zh","TW")
-        };
+        Locale.ENGLISH,
+        Locale.GERMAN,
+        Locale.of("es"),
+        Locale.FRENCH,
+        Locale.ITALIAN,
+        Locale.JAPANESE,
+        Locale.KOREAN,
+        Locale.of("sv"),
+        Locale.SIMPLIFIED_CHINESE,
+        Locale.TRADITIONAL_CHINESE
+    };
 
     public static void main(String[] args) {
 

--- a/test/jdk/sun/util/resources/TimeZone/Bug4938846.java
+++ b/test/jdk/sun/util/resources/TimeZone/Bug4938846.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ public class Bug4938846 {
 
    public static void main(String[] args) {
        String zoneInfo = new String();
-       Locale tzLocale = new Locale("en", "IE");
+       Locale tzLocale = Locale.of("en", "IE");
 
        TimeZone ieTz = TimeZone.getTimeZone("Europe/London");
 

--- a/test/jdk/sun/util/resources/TimeZone/Bug6271396.java
+++ b/test/jdk/sun/util/resources/TimeZone/Bug6271396.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ public class Bug6271396 {
     public static void main(String[] args) {
 
         TimeZone Lord_Howe = TimeZone.getTimeZone("Australia/Lord_Howe");
-        Locale tzLocale = new Locale("fr");
+        Locale tzLocale = Locale.FRENCH;
 
         if (!Lord_Howe.getDisplayName(false, TimeZone.LONG, tzLocale).equals
            ("Heure standard de Lord Howe"))
@@ -52,7 +52,7 @@ public class Bug6271396 {
                                         "Australia/Lord_Howe should be " +
                                         "\"Heure d'\u00e9t\u00e9 de Lord Howe\"");
 
-        tzLocale = new Locale("zh", "TW");
+        tzLocale = Locale.TRADITIONAL_CHINESE;
         if (!Lord_Howe.getDisplayName(false, TimeZone.LONG, tzLocale).equals
            ("\u8c6a\u52f3\u7235\u5cf6\u6a19\u6e96\u6642\u9593"))
              throw new RuntimeException("\n" + tzLocale + ": LONG, " +

--- a/test/jdk/sun/util/resources/TimeZone/Bug6317929.java
+++ b/test/jdk/sun/util/resources/TimeZone/Bug6317929.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,16 +34,16 @@ import java.util.TimeZone;
 
 public class Bug6317929 {
     static Locale[] locales2Test = new Locale[] {
-        new Locale("en"),
-        new Locale("de"),
-        new Locale("es"),
-        new Locale("fr"),
-        new Locale("it"),
-        new Locale("ja"),
-        new Locale("ko"),
-        new Locale("sv"),
-        new Locale("zh","CN"),
-        new Locale("zh","TW")
+        Locale.ENGLISH,
+        Locale.GERMAN,
+        Locale.of("es"),
+        Locale.FRENCH,
+        Locale.ITALIAN,
+        Locale.JAPANESE,
+        Locale.KOREAN,
+        Locale.of("sv"),
+        Locale.SIMPLIFIED_CHINESE,
+        Locale.TRADITIONAL_CHINESE
     };
 
     public static void main(String[] args) {

--- a/test/jdk/sun/util/resources/TimeZone/Bug6377794.java
+++ b/test/jdk/sun/util/resources/TimeZone/Bug6377794.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,16 +34,16 @@ import java.util.TimeZone;
 
 public class Bug6377794 {
     static Locale[] locales2Test = new Locale[] {
-        new Locale("en"),
-        new Locale("de"),
-        new Locale("es"),
-        new Locale("fr"),
-        new Locale("it"),
-        new Locale("ja"),
-        new Locale("ko"),
-        new Locale("sv"),
-        new Locale("zh","CN"),
-        new Locale("zh","TW")
+        Locale.ENGLISH,
+        Locale.GERMAN,
+        Locale.of("es"),
+        Locale.FRENCH,
+        Locale.ITALIAN,
+        Locale.JAPANESE,
+        Locale.KOREAN,
+        Locale.of("sv"),
+        Locale.SIMPLIFIED_CHINESE,
+        Locale.TRADITIONAL_CHINESE
     };
 
     public static void main(String[] args) {

--- a/test/jdk/sun/util/resources/TimeZone/Bug6442006.java
+++ b/test/jdk/sun/util/resources/TimeZone/Bug6442006.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ public class Bug6442006 {
     public static void main(String[] args) {
 
         TimeZone tz = TimeZone.getTimeZone("Asia/Taipei");
-        Locale tzLocale = new Locale("ja");
+        Locale tzLocale = Locale.JAPANESE;
         String jaStdName = "\u4e2d\u56fd\u6a19\u6e96\u6642";
         String jaDstName = "\u4e2d\u56fd\u590f\u6642\u9593";
 

--- a/test/langtools/tools/javac/util/StringUtilsTest.java
+++ b/test/langtools/tools/javac/util/StringUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ public class StringUtilsTest {
     }
 
     void run() throws Exception {
-        Locale.setDefault(new Locale("tr", "TR"));
+        Locale.setDefault(Locale.of("tr", "TR"));
 
         //verify the properties of the default locale:
         assertEquals("\u0131", "I".toLowerCase());


### PR DESCRIPTION
This is a follow-on task after deprecating the Locale constructors (https://bugs.openjdk.java.net/browse/JDK-8282819). Most of the changes are simple replacements to Locale constructors with `Locale.of()` or Locale constants, such as `Locale.US`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283698](https://bugs.openjdk.java.net/browse/JDK-8283698): Refactor Locale constructors used in src/test


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Joe Wang](https://openjdk.java.net/census#joehw) (@JoeWang-Java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8130/head:pull/8130` \
`$ git checkout pull/8130`

Update a local copy of the PR: \
`$ git checkout pull/8130` \
`$ git pull https://git.openjdk.java.net/jdk pull/8130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8130`

View PR using the GUI difftool: \
`$ git pr show -t 8130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8130.diff">https://git.openjdk.java.net/jdk/pull/8130.diff</a>

</details>
