### PR TITLE
8282040: Remove unnecessary check made obsolete by JDK-8261941

### DIFF
--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -1047,14 +1047,7 @@ void SystemDictionaryShared::record_linking_constraint(Symbol* name, InstanceKla
     return;
   }
 
-  if (DumpSharedSpaces && !is_builtin(klass)) {
-    // During static dump, unregistered classes (those intended for
-    // custom loaders) are loaded by the boot loader. Need to
-    // exclude these for the same reason as above.
-    // This should be fixed by JDK-8261941.
-    return;
-  }
-
+  assert(is_builtin(klass), "must be");
   assert(klass_loader != NULL, "should not be called for boot loader");
   assert(loader1 != loader2, "must be");
 


### PR DESCRIPTION
Please review this simple change for replacing an `if` block with an `assert`.

Passed CI tiers 1 and 2 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282040](https://bugs.openjdk.java.net/browse/JDK-8282040): Remove unnecessary check made obsolete by JDK-8261941


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8133/head:pull/8133` \
`$ git checkout pull/8133`

Update a local copy of the PR: \
`$ git checkout pull/8133` \
`$ git pull https://git.openjdk.java.net/jdk pull/8133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8133`

View PR using the GUI difftool: \
`$ git pr show -t 8133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8133.diff">https://git.openjdk.java.net/jdk/pull/8133.diff</a>

</details>
