### PR TITLE
JDK-8281006 Module::getResourceAsStream should check if the resource is open unconditionally when caller is null

### DIFF
--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -65,6 +65,7 @@ ifeq ($(call isTargetOs, windows), true)
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeNullCallerClassLoaderTest := jvm.lib
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeNullCallerLookupTest := jvm.lib
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeNullCallerResourceBundle := jvm.lib
+  BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeNullCallerGetResource := jvm.lib
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exerevokeall := advapi32.lib
   BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libAsyncStackWalk := /EHsc
   BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libAsyncInvokers := /EHsc
@@ -86,6 +87,7 @@ else
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeNullCallerClassLoaderTest := -ljvm
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeNullCallerLookupTest := -ljvm
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeNullCallerResourceBundle := -ljvm
+  BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeNullCallerGetResource := -ljvm
 endif
 
 ifeq ($(call isTargetOs, macosx), true)

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -3002,9 +3002,9 @@ public final class Class<T> implements java.io.Serializable,
         if (callerModule != thisModule) {
             String pn = Resources.toPackageName(name);
             if (thisModule.getDescriptor().packages().contains(pn)) {
-                if (callerModule == null && !thisModule.isOpen(pn)) {
-                    // no caller, package not open
-                    return false;
+                if (callerModule == null) {
+                    // no caller
+                    return thisModule.isOpen(pn);
                 }
                 if (!thisModule.isOpen(pn, callerModule)) {
                     // package not open to caller

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -3003,7 +3003,7 @@ public final class Class<T> implements java.io.Serializable,
             String pn = Resources.toPackageName(name);
             if (thisModule.getDescriptor().packages().contains(pn)) {
                 if (callerModule == null) {
-                    // no caller
+                    // no caller, return true if the package is open to all modules
                     return thisModule.isOpen(pn);
                 }
                 if (!thisModule.isOpen(pn, callerModule)) {

--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -558,8 +558,7 @@ public final class Module implements AnnotatedElement {
      */
     public boolean isOpen(String pn, Module other) {
         Objects.requireNonNull(pn);
-        Objects.requireNonNull(other);
-        return implIsExportedOrOpen(pn, other, /*open*/true);
+        return implIsExportedOrOpen(pn, (other == null) ? EVERYONE_MODULE : other, /*open*/true);
     }
 
     /**
@@ -1654,10 +1653,6 @@ public final class Module implements AnnotatedElement {
             if (caller != this && caller != Object.class.getModule()) {
                 String pn = Resources.toPackageName(name);
                 if (getPackages().contains(pn)) {
-                    if (caller == null && !isOpen(pn)) {
-                        // no caller, package not open
-                        return null;
-                    }
                     if (!isOpen(pn, caller)) {
                         // package not open to caller
                         return null;

--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -1655,7 +1655,7 @@ public final class Module implements AnnotatedElement {
                 String pn = Resources.toPackageName(name);
                 if (getPackages().contains(pn)) {
                     if (caller == null) {
-                        if (! isOpen(pn)) {
+                        if (!isOpen(pn)) {
                             return null;
                         }
                     } else if (!isOpen(pn, caller)) {

--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -558,7 +558,8 @@ public final class Module implements AnnotatedElement {
      */
     public boolean isOpen(String pn, Module other) {
         Objects.requireNonNull(pn);
-        return implIsExportedOrOpen(pn, (other == null) ? EVERYONE_MODULE : other, /*open*/true);
+        Objects.requireNonNull(other);
+        return implIsExportedOrOpen(pn, other, /*open*/true);
     }
 
     /**
@@ -1653,7 +1654,11 @@ public final class Module implements AnnotatedElement {
             if (caller != this && caller != Object.class.getModule()) {
                 String pn = Resources.toPackageName(name);
                 if (getPackages().contains(pn)) {
-                    if (!isOpen(pn, caller)) {
+                    if (caller == null) {
+                        if (! isOpen(pn)) {
+                            return null;
+                        }
+                    } else if (!isOpen(pn, caller)) {
                         // package not open to caller
                         return null;
                     }

--- a/test/jdk/java/lang/module/exeNullCallerGetResource/NullCallerGetResource.java
+++ b/test/jdk/java/lang/module/exeNullCallerGetResource/NullCallerGetResource.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/**
+ * @test
+ * @bug 8281006
+ * @summary Test uses custom launcher that starts VM using JNI that verifies
+ *          Module::getResourceAsStream and Class::getResourceAsStream with
+ *          a null caller class functions properly.
+ * @library /test/lib
+ * @modules java.base/jdk.internal.module
+ *          jdk.compiler
+ * @build NullCallerGetResource
+ *        jdk.test.lib.compiler.CompilerUtils
+ * @requires os.family != "aix"
+ * @run main/native NullCallerGetResource
+ */
+
+// Test disabled on AIX since we cannot invoke the JVM on the primordial thread.
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import jdk.test.lib.Platform;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.compiler.CompilerUtils;
+
+public class NullCallerGetResource {
+
+    private static final String TEST_SRC = System.getProperty("test.src");
+
+    // the module name of the test module
+    private static final String TEST_MODULE = "n";
+
+    private static final Path SRC_DIR    = Paths.get(TEST_SRC, "src");
+    private static final Path MODS_DIR   = Paths.get("mods");
+    private static final Path TEST_MOD_DIR = MODS_DIR.resolve(TEST_MODULE);
+
+    /*
+     * Build the test module called 'n' which opens the package 'open'
+     * to everyone.  There is also a package 'closed' which is neither
+     * opened or exported.
+     */
+    static void compileTestModule() throws Exception {
+        // javac -d mods/$TESTMODULE src/$TESTMODULE/**
+        boolean compiled
+                = CompilerUtils.compile(SRC_DIR.resolve(TEST_MODULE), TEST_MOD_DIR);
+        assert (compiled);
+        var open = TEST_MOD_DIR.resolve("open/test.txt");
+        try (var out = Files.newBufferedWriter(open)) {
+            out.write("open");
+            out.flush();
+        }
+        var closed = TEST_MOD_DIR.resolve("closed/test.txt");
+        try (var out = Files.newBufferedWriter(closed)) {
+            out.write("closed");
+            out.flush();
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        // build the module used for the test
+        compileTestModule();
+
+        var launcher = Path.of(System.getProperty("test.nativepath"), "NullCallerGetResource");
+        var pb = new ProcessBuilder(launcher.toString());
+        var env = pb.environment();
+
+        var libDir = Platform.libDir().toString();
+        var vmDir = Platform.jvmLibDir().toString();
+
+        // set up shared library path
+        var sharedLibraryPathEnvName = Platform.sharedLibraryPathVariableName();
+        env.compute(sharedLibraryPathEnvName,
+                (k, v) -> (v == null) ? libDir : v + File.pathSeparator + libDir);
+        env.compute(sharedLibraryPathEnvName,
+                (k, v) -> (v == null) ? vmDir : v + File.pathSeparator + vmDir);
+
+        // launch the actual test
+        System.out.println("Launching: " + launcher + " shared library path: " +
+                env.get(sharedLibraryPathEnvName));
+        new OutputAnalyzer(pb.start())
+                .outputTo(System.out)
+                .errorTo(System.err)
+                .shouldHaveExitValue(0);
+
+    }
+
+}
+

--- a/test/jdk/java/lang/module/exeNullCallerGetResource/exeNullCallerGetResource.c
+++ b/test/jdk/java/lang/module/exeNullCallerGetResource/exeNullCallerGetResource.c
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "jni.h"
+#undef NDEBUG
+#include "assert.h"
+#include "string.h"
+
+static jclass class_InputStream = NULL;
+static jmethodID mid_InputStream_close = NULL;
+
+// in.close();
+void closeInputStream(JNIEnv *env, jobject in) {
+    (*env)->CallObjectMethod(env, in, mid_InputStream_close);
+    if ((*env)->ExceptionOccurred(env) != NULL) {
+        printf("ERROR: Exception was thrown calling InputStream::close.\n");
+        (*env)->ExceptionDescribe(env);
+        exit(-1);
+    }
+}
+
+/*
+ * The java test running this native test creates a test module named 'n'
+ * which opens the package 'open'.  It has a text file resource named
+ * 'test.txt' in the open package.  It also has a class called
+ * open.OpenResources.  One should be able to get the resource through
+ * either the Class or the Module with getResourceAsStream.
+ *
+ * Class c = open.OpenResources.fetchClass();
+ * InputStream in1 = c.getResourceAsStream("test.txt");
+ * Module n = c.getModule();
+ * InputStream in2 = n.getResourceAsStream("open/test.txt");
+ *
+ * The test also checks that closed resources are not available and
+ * don't throw any exceptions.  The test module contains a class
+ * called closed.ClosedResources and a file 'test.txt' in the package
+ * 'closed'.
+ *
+ * Class closed = closed.ClosedResources.fetchClass();
+ * assert(closed.getResourceAsStream("test.txt") == null);
+ * assert(n.getResourceAsStream("closed/test.txt") == null);
+ *
+ */
+int main(int argc, char** args) {
+    JavaVM *jvm;
+    JNIEnv *env;
+    JavaVMInitArgs vm_args;
+    JavaVMOption options[4];
+    jint rc;
+
+    options[0].optionString = "--module-path=mods";
+    options[1].optionString = "--add-modules=n";
+
+    vm_args.version = JNI_VERSION_9;
+    vm_args.nOptions = 2;
+    vm_args.options = options;
+
+    if ((rc = JNI_CreateJavaVM(&jvm, (void**)&env, &vm_args)) != JNI_OK) {
+        printf("ERROR: cannot create VM.\n");
+        exit(-1);
+    }
+
+    // initialize for stream close
+    class_InputStream = (*env)->FindClass(env, "java/io/InputStream");
+    assert(class_InputStream != NULL);
+    mid_InputStream_close = (*env)->GetMethodID(env, class_InputStream, "close", "()V" );
+    assert(mid_InputStream_close != NULL);
+
+    // Class c = OpenResources.fetchClass();
+    jclass class_OpenResources = (*env)->FindClass(env, "open/OpenResources");
+    assert(class_OpenResources != NULL);
+    jmethodID mid_OpenResources_fetchClass = (*env)->GetStaticMethodID(env, class_OpenResources, "fetchClass", "()Ljava/lang/Class;" );
+    assert(mid_OpenResources_fetchClass != NULL);
+    jobject c =(*env)->CallStaticObjectMethod(env, class_OpenResources, mid_OpenResources_fetchClass);
+    if ((*env)->ExceptionOccurred(env) != NULL) {
+        printf("ERROR: Exception was thrown calling OpenResources::fetchClass.\n");
+        (*env)->ExceptionDescribe(env);
+        exit(-1);
+    }
+    assert(c != NULL);
+
+    // Module n = c.getModule();
+    jclass class_Class = (*env)->FindClass(env, "java/lang/Class");
+    assert(class_Class != NULL);
+    jmethodID mid_Class_getModule = (*env)->GetMethodID(env, class_Class, "getModule", "()Ljava/lang/Module;" );
+    assert(mid_Class_getModule != NULL);
+    jobject n =(*env)->CallObjectMethod(env, c, mid_Class_getModule);
+    if ((*env)->ExceptionOccurred(env) != NULL) {
+        printf("ERROR: Exception was thrown calling Class::getModule.\n");
+        (*env)->ExceptionDescribe(env);
+        exit(-1);
+    }
+    assert(n != NULL);
+
+    // InputStream in = n.getResourceAsStream("open/test.txt");
+    jclass class_Module = (*env)->FindClass(env, "java/lang/Module");
+    assert(class_Module != NULL);
+    jmethodID mid_Module_getResourceAsStream =
+        (*env)->GetMethodID(env, class_Module, "getResourceAsStream", "(Ljava/lang/String;)Ljava/io/InputStream;" );
+    assert(mid_Module_getResourceAsStream != NULL);
+    jobject in = (*env)->CallObjectMethod(env, n, mid_Module_getResourceAsStream,
+        (*env)->NewStringUTF(env, "open/test.txt"));
+    if ((*env)->ExceptionOccurred(env) != NULL) {
+        printf("ERROR: Exception was thrown calling Module::getResourceAsStream on 'open/test.txt'.\n");
+        (*env)->ExceptionDescribe(env);
+        exit(-1);
+    }
+    assert(in != NULL);
+
+    // in.close();
+    closeInputStream(env, in);
+
+    // in = n.getResourceAsStream("closed/test.txt");
+    in =  (*env)->CallObjectMethod(env, n, mid_Module_getResourceAsStream,
+        (*env)->NewStringUTF(env, "closed/test.txt"));
+    if ((*env)->ExceptionOccurred(env) != NULL) {
+        printf("ERROR: Exception was thrown calling Module::getResourceAsStream on 'closed/test.txt'.\n");
+        (*env)->ExceptionDescribe(env);
+        exit(-1);
+    }
+    assert(in == NULL);
+
+    // in = c.getResourceAsStream("test.txt");
+    jmethodID mid_Class_getResourceAsStream =
+        (*env)->GetMethodID(env, class_Class, "getResourceAsStream", "(Ljava/lang/String;)Ljava/io/InputStream;" );
+    assert(mid_Class_getResourceAsStream != NULL);
+    in =  (*env)->CallObjectMethod(env, c, mid_Class_getResourceAsStream,
+        (*env)->NewStringUTF(env, "test.txt"));
+    if ((*env)->ExceptionOccurred(env) != NULL) {
+        printf("ERROR: Exception was thrown calling Class::getResourceAsStream on 'test.txt'.\n");
+        (*env)->ExceptionDescribe(env);
+        exit(-1);
+    }
+    assert(in != NULL);
+
+    // in.close();
+    closeInputStream(env, in);
+
+    // Class closed = closed.ClosedResources.fetchClass();
+    jclass class_ClosedResources = (*env)->FindClass(env, "closed/ClosedResources");
+    assert(class_ClosedResources != NULL);
+    jmethodID mid_ClosedResources_fetchClass = (*env)->GetStaticMethodID(env, class_ClosedResources, "fetchClass", "()Ljava/lang/Class;" );
+    assert(mid_ClosedResources_fetchClass != NULL);
+    jobject closed =(*env)->CallStaticObjectMethod(env, class_ClosedResources, mid_ClosedResources_fetchClass);
+    if ((*env)->ExceptionOccurred(env) != NULL) {
+        printf("ERROR: Exception was thrown calling ClosedResources::fetchClass.\n");
+        (*env)->ExceptionDescribe(env);
+        exit(-1);
+    }
+    assert(closed != NULL);
+
+    // in = closed.getResourceAsStream("test.txt");
+    in =  (*env)->CallObjectMethod(env, closed, mid_Class_getResourceAsStream,
+        (*env)->NewStringUTF(env, "test.txt"));
+    if ((*env)->ExceptionOccurred(env) != NULL) {
+        printf("ERROR: Exception was thrown calling Class::getResourceAsStream on closed 'test.txt'.\n");
+        (*env)->ExceptionDescribe(env);
+        exit(-1);
+    }
+    assert(in == NULL);
+
+    (*jvm)->DestroyJavaVM(jvm);
+    return 0;
+}
+

--- a/test/jdk/java/lang/module/exeNullCallerGetResource/src/n/closed/ClosedResources.java
+++ b/test/jdk/java/lang/module/exeNullCallerGetResource/src/n/closed/ClosedResources.java
@@ -23,9 +23,7 @@
 
 package closed;
 
+// class to test relative access to a closed resource
+// with Class::getResourceAsStream with no caller frame
 public class ClosedResources {
-
-    public static Class fetchClass() {
-        return ClosedResources.class;
-    }
 }

--- a/test/jdk/java/lang/module/exeNullCallerGetResource/src/n/closed/ClosedResources.java
+++ b/test/jdk/java/lang/module/exeNullCallerGetResource/src/n/closed/ClosedResources.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package closed;
+
+public class ClosedResources {
+
+    public static Class fetchClass() {
+        return ClosedResources.class;
+    }
+}

--- a/test/jdk/java/lang/module/exeNullCallerGetResource/src/n/module-info.java
+++ b/test/jdk/java/lang/module/exeNullCallerGetResource/src/n/module-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+module n {
+    opens open;
+}

--- a/test/jdk/java/lang/module/exeNullCallerGetResource/src/n/module-info.java
+++ b/test/jdk/java/lang/module/exeNullCallerGetResource/src/n/module-info.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+// module to test access to both open and closed resources using
+// Module::getResourceAsStream with no caller frame
 module n {
     opens open;
 }

--- a/test/jdk/java/lang/module/exeNullCallerGetResource/src/n/open/OpenResources.java
+++ b/test/jdk/java/lang/module/exeNullCallerGetResource/src/n/open/OpenResources.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package open;
+
+public class OpenResources {
+
+    public static Class fetchClass() {
+        return OpenResources.class;
+    }
+}

--- a/test/jdk/java/lang/module/exeNullCallerGetResource/src/n/open/OpenResources.java
+++ b/test/jdk/java/lang/module/exeNullCallerGetResource/src/n/open/OpenResources.java
@@ -23,9 +23,7 @@
 
 package open;
 
+// class used to test relative access to an open resource
+// with Class::getResourceAsStream with no caller frame
 public class OpenResources {
-
-    public static Class fetchClass() {
-        return OpenResources.class;
-    }
 }


### PR DESCRIPTION
Created a test called NullCallerGetResource to test Module::getResourceAsStream and Class::getResourceAsStream from the native level.

At the java level the test builds a test module called 'n' which opens the package 'open' to everyone. There is also a package 'closed' which is neither opened or exported. Both packages have a text file called 'test.txt'. The open package has a class called OpenResources and the closed package has a class called ClosedResources. The native test is launched with the test module n added.

At the native level the test tries to read both the open and closed resource from both the classes and the module. It performs the equivalent of the following java operations:

Class c = open.OpenResources.fetchClass();
InputStream in = c.getResourceAsStream("test.txt");
assert(in != null); in.close();

Module n = c.getModule();
in = n.getResourceAsStream("open/test.txt");
assert(in != null); in.close();

Class closed = closed.ClosedResources.fetchClass();
assert(closedsStream("test.txt") == null);
assert(n.getResourceAsStream("closed/test.txt") == null);

The test initially threw an NPE when trying to fetch the open resource. The Module class was fixed by removing the fragment with the (caller == null) test in getResourceAsStream, and changing the call to isOpen(String,Module) to use EVERYONE_MODULE if the caller module is null.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281006](https://bugs.openjdk.java.net/browse/JDK-8281006): Module::getResourceAsStream should check if the resource is open unconditionally when caller is null


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to 4b344e4de98b9ccdd3ab49731599bf6bff11cfd8
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8134/head:pull/8134` \
`$ git checkout pull/8134`

Update a local copy of the PR: \
`$ git checkout pull/8134` \
`$ git pull https://git.openjdk.java.net/jdk pull/8134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8134`

View PR using the GUI difftool: \
`$ git pr show -t 8134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8134.diff">https://git.openjdk.java.net/jdk/pull/8134.diff</a>

</details>
