### PR TITLE
8284495: [testbug] Adapt nsk tests to the RISC-V platform

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/ArgumentHandler.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/ArgumentHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -529,6 +529,7 @@ class CheckedFeatures {
         {"linux-ppc64",     "com.sun.jdi.SharedMemoryAttach"},
         {"linux-ppc64le",   "com.sun.jdi.SharedMemoryAttach"},
         {"linux-s390x",     "com.sun.jdi.SharedMemoryAttach"},
+        {"linux-riscv64",   "com.sun.jdi.SharedMemoryAttach"},
         {"macosx-amd64",    "com.sun.jdi.SharedMemoryAttach"},
         {"mac-x64",         "com.sun.jdi.SharedMemoryAttach"},
         {"macosx-aarch64",  "com.sun.jdi.SharedMemoryAttach"},
@@ -554,6 +555,7 @@ class CheckedFeatures {
         {"linux-ppc64",     "com.sun.jdi.SharedMemoryListen"},
         {"linux-ppc64le",   "com.sun.jdi.SharedMemoryListen"},
         {"linux-s390x",     "com.sun.jdi.SharedMemoryListen"},
+        {"linux-riscv64",   "com.sun.jdi.SharedMemoryListen"},
         {"macosx-amd64",    "com.sun.jdi.SharedMemoryListen"},
         {"mac-x64",         "com.sun.jdi.SharedMemoryListen"},
         {"macosx-aarch64",  "com.sun.jdi.SharedMemoryListen"},
@@ -600,6 +602,9 @@ class CheckedFeatures {
         {"linux-s390x",     "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
         {"linux-s390x",     "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
 
+        {"linux-riscv64",   "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
+        {"linux-riscv64",   "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
+
         {"windows-i586",    "com.sun.jdi.CommandLineLaunch", "dt_socket"},
         {"windows-i586",    "com.sun.jdi.RawCommandLineLaunch", "dt_socket"},
 
@@ -637,6 +642,7 @@ class CheckedFeatures {
         {"linux-ppc64",     "dt_shmem"},
         {"linux-ppc64le",   "dt_shmem"},
         {"linux-s390x",     "dt_shmem"},
+        {"linux-riscv64",   "dt_shmem"},
         {"macosx-amd64",    "dt_shmem"},
         {"mac-x64",         "dt_shmem"},
         {"macosx-aarch64",  "dt_shmem"},


### PR DESCRIPTION
Add riscv which doesn't have shared memory connector.
Following tests passed with this patch and [CODETOOLS-7903138](https://github.com/openjdk/jtreg/pull/66):

- vmTestbase/nsk/jdb/options/connect/connect003/connect003.java
- vmTestbase/nsk/jdb/options/connect/connect005/connect005.java
- vmTestbase/nsk/jdb/options/listconnectors/listconnectors001/listconnectors001.java
- vmTestbase/nsk/jdi/AttachingConnector/attach/attach002/TestDescription.java
- vmTestbase/nsk/jdi/AttachingConnector/attach/attach005/TestDescription.java
- vmTestbase/nsk/jdi/AttachingConnector/attachnosuspend/attachnosuspend003/TestDescription.java
- vmTestbase/nsk/jdi/LaunchingConnector/launch/launch002/TestDescription.java
- vmTestbase/nsk/jdi/LaunchingConnector/launch/launch004/TestDescription.java
- vmTestbase/nsk/jdi/ListeningConnector/accept/accept002/TestDescription.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284495](https://bugs.openjdk.java.net/browse/JDK-8284495): [testbug] Adapt nsk tests to the RISC-V platform


### Reviewers
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8137/head:pull/8137` \
`$ git checkout pull/8137`

Update a local copy of the PR: \
`$ git checkout pull/8137` \
`$ git pull https://git.openjdk.java.net/jdk pull/8137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8137`

View PR using the GUI difftool: \
`$ git pr show -t 8137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8137.diff">https://git.openjdk.java.net/jdk/pull/8137.diff</a>

</details>
