### PR TITLE
8284125: AArch64: Remove partial masked operations for SVE

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64_sve.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_sve.ad
@@ -342,8 +342,7 @@ instruct storeV_partial(vReg src, vmemA mem, pRegGov pgtmp, rFlagsReg cr) %{
 // vector load/store - predicated
 
 instruct loadV_masked(vReg dst, vmemA mem, pRegGov pg) %{
-  predicate(UseSVE > 0 &&
-            n->as_LoadVector()->memory_size() == MaxVectorSize);
+  predicate(UseSVE > 0);
   match(Set dst (LoadVectorMasked mem pg));
   ins_cost(4 * SVE_COST);
   format %{ "sve_ldr $dst, $pg, $mem\t# load vector predicated (sve)" %}
@@ -356,29 +355,8 @@ instruct loadV_masked(vReg dst, vmemA mem, pRegGov pg) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct loadV_masked_partial(vReg dst, vmemA mem, pRegGov pg, pRegGov pgtmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->as_LoadVector()->memory_size() < MaxVectorSize);
-  match(Set dst (LoadVectorMasked mem pg));
-  effect(TEMP pgtmp, KILL cr);
-  ins_cost(6 * SVE_COST);
-  format %{ "sve_ldr $dst, $pg, $mem\t# load vector predicated partial (sve)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ sve_ptrue_lanecnt(as_PRegister($pgtmp$$reg), __ elemType_to_regVariant(bt),
-                         Matcher::vector_length(this));
-    __ sve_and(as_PRegister($pgtmp$$reg), as_PRegister($pgtmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    loadStoreA_predicated(C2_MacroAssembler(&cbuf), false, as_FloatRegister($dst$$reg),
-                          as_PRegister($pgtmp$$reg), bt, bt, $mem->opcode(),
-                          as_Register($mem$$base), $mem$$index, $mem$$scale, $mem$$disp);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
 instruct storeV_masked(vReg src, vmemA mem, pRegGov pg) %{
-  predicate(UseSVE > 0 &&
-            n->as_StoreVector()->memory_size() == MaxVectorSize);
+  predicate(UseSVE > 0);
   match(Set mem (StoreVectorMasked mem (Binary src pg)));
   ins_cost(4 * SVE_COST);
   format %{ "sve_str $mem, $pg, $src\t# store vector predicated (sve)" %}
@@ -387,114 +365,6 @@ instruct storeV_masked(vReg src, vmemA mem, pRegGov pg) %{
     loadStoreA_predicated(C2_MacroAssembler(&cbuf), true, as_FloatRegister($src$$reg),
                           as_PRegister($pg$$reg), bt, bt, $mem->opcode(),
                           as_Register($mem$$base), $mem$$index, $mem$$scale, $mem$$disp);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct storeV_masked_partial(vReg src, vmemA mem, pRegGov pg, pRegGov pgtmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->as_StoreVector()->memory_size() < MaxVectorSize);
-  match(Set mem (StoreVectorMasked mem (Binary src pg)));
-  effect(TEMP pgtmp, KILL cr);
-  ins_cost(6 * SVE_COST);
-  format %{ "sve_str $mem, $pg, $src\t# store vector predicated partial (sve)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this, $src);
-    __ sve_ptrue_lanecnt(as_PRegister($pgtmp$$reg), __ elemType_to_regVariant(bt),
-                         Matcher::vector_length(this, $src));
-    __ sve_and(as_PRegister($pgtmp$$reg), as_PRegister($pgtmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    loadStoreA_predicated(C2_MacroAssembler(&cbuf), true, as_FloatRegister($src$$reg),
-                          as_PRegister($pgtmp$$reg), bt, bt, $mem->opcode(),
-                          as_Register($mem$$base), $mem$$index, $mem$$scale, $mem$$disp);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-// maskAll (full or partial predicate size)
-
-instruct vmaskAll_immI(pRegGov dst, immI src) %{
-  predicate(UseSVE > 0);
-  match(Set dst (MaskAll src));
-  ins_cost(SVE_COST);
-  format %{ "sve_ptrue_lanecnt/sve_pfalse $dst\t# mask all (sve) (B/H/S)" %}
-  ins_encode %{
-    int con = (int)$src$$constant;
-    if (con == 0) {
-      __ sve_pfalse(as_PRegister($dst$$reg));
-    } else {
-      assert(con == -1, "invalid constant value for mask");
-      BasicType bt = Matcher::vector_element_basic_type(this);
-      __ sve_ptrue_lanecnt(as_PRegister($dst$$reg), __ elemType_to_regVariant(bt),
-                           Matcher::vector_length(this));
-    }
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vmaskAllI(pRegGov dst, iRegIorL2I src, vReg tmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0);
-  match(Set dst (MaskAll src));
-  effect(TEMP tmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_dup $tmp, $src\n\t"
-            "sve_ptrue $dst, vector_length\n\t"
-            "sve_cmpne $dst, $dst, $tmp, 0\t# mask all (sve) (B/H/S)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    uint length_in_bytes = Matcher::vector_length_in_bytes(this);
-    __ sve_dup(as_FloatRegister($tmp$$reg), size, as_Register($src$$reg));
-    if (length_in_bytes < MaxVectorSize) {
-      __ sve_ptrue_lanecnt(as_PRegister($dst$$reg), size, Matcher::vector_length(this));
-      __ sve_cmp(Assembler::NE, as_PRegister($dst$$reg), size,
-                 as_PRegister($dst$$reg), as_FloatRegister($tmp$$reg), 0);
-    } else {
-      __ sve_cmp(Assembler::NE, as_PRegister($dst$$reg), size, ptrue, as_FloatRegister($tmp$$reg), 0);
-    }
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vmaskAll_immL(pRegGov dst, immL src) %{
-  predicate(UseSVE > 0);
-  match(Set dst (MaskAll src));
-  ins_cost(SVE_COST);
-  format %{ "sve_ptrue_lanecnt/sve_pfalse $dst\t# mask all (sve) (D)" %}
-  ins_encode %{
-    long con = (long)$src$$constant;
-    if (con == 0) {
-      __ sve_pfalse(as_PRegister($dst$$reg));
-    } else {
-      assert(con == -1, "invalid constant value for mask");
-      BasicType bt = Matcher::vector_element_basic_type(this);
-      __ sve_ptrue_lanecnt(as_PRegister($dst$$reg), __ elemType_to_regVariant(bt),
-                           Matcher::vector_length(this));
-    }
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vmaskAllL(pRegGov dst, iRegL src, vReg tmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0);
-  match(Set dst (MaskAll src));
-  effect(TEMP tmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_dup $tmp, $src\n\t"
-            "sve_ptrue $dst, vector_length\n\t"
-            "sve_cmpne $dst, $dst, $tmp, 0\t# mask all (sve) (D)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    uint length_in_bytes = Matcher::vector_length_in_bytes(this);
-    __ sve_dup(as_FloatRegister($tmp$$reg), size, as_Register($src$$reg));
-    if (length_in_bytes < MaxVectorSize) {
-      __ sve_ptrue_lanecnt(as_PRegister($dst$$reg), size, Matcher::vector_length(this));
-      __ sve_cmp(Assembler::NE, as_PRegister($dst$$reg), size,
-                 as_PRegister($dst$$reg), as_FloatRegister($tmp$$reg), 0);
-    } else {
-      __ sve_cmp(Assembler::NE, as_PRegister($dst$$reg), size, ptrue, as_FloatRegister($tmp$$reg), 0);
-    }
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2058,36 +1928,6 @@ instruct vpopcountI(vReg dst, vReg src) %{
   ins_pipe(pipe_slow);
 %}
 
-// vector mask compare
-
-instruct vmaskcmp(pRegGov dst, vReg src1, vReg src2, immI cond, rFlagsReg cr) %{
-  predicate(UseSVE > 0);
-  match(Set dst (VectorMaskCmp (Binary src1 src2) cond));
-  effect(KILL cr);
-  ins_cost(SVE_COST);
-  format %{ "sve_cmp $dst, $src1, $src2\t# vector mask cmp (sve)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ sve_compare(as_PRegister($dst$$reg), bt, ptrue, as_FloatRegister($src1$$reg),
-                   as_FloatRegister($src2$$reg), (int)$cond$$constant);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vmaskcmp_masked(pRegGov dst, vReg src1, vReg src2, immI cond, pRegGov pg, rFlagsReg cr) %{
-  predicate(UseSVE > 0);
-  match(Set dst (VectorMaskCmp (Binary src1 src2) (Binary cond pg)));
-  effect(KILL cr);
-  ins_cost(SVE_COST);
-  format %{ "sve_cmp $dst, $pg, $src1, $src2\t# vector mask cmp (sve)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ sve_compare(as_PRegister($dst$$reg), bt, as_PRegister($pg$$reg), as_FloatRegister($src1$$reg),
-                   as_FloatRegister($src2$$reg), (int)$cond$$constant);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
 // vector blend
 
 instruct vblend(vReg dst, vReg src1, vReg src2, pRegGov pg) %{
@@ -2100,37 +1940,6 @@ instruct vblend(vReg dst, vReg src1, vReg src2, pRegGov pg) %{
                __ elemType_to_regVariant(Matcher::vector_element_basic_type(this));
     __ sve_sel(as_FloatRegister($dst$$reg), size, as_PRegister($pg$$reg),
                as_FloatRegister($src2$$reg), as_FloatRegister($src1$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-// vector load mask
-
-instruct vloadmaskB(pRegGov dst, vReg src, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->bottom_type()->is_vect()->element_basic_type() == T_BYTE);
-  match(Set dst (VectorLoadMask src));
-  effect(KILL cr);
-  ins_cost(SVE_COST);
-  format %{ "vloadmaskB $dst, $src\t# vector load mask (sve) (B)" %}
-  ins_encode %{
-    __ sve_cmp(Assembler::NE, as_PRegister($dst$$reg), __ B,
-               ptrue, as_FloatRegister($src$$reg), 0);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vloadmask_extend(pRegGov dst, vReg src, vReg tmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 && n->bottom_type()->is_vect()->element_basic_type() != T_BYTE);
-  match(Set dst (VectorLoadMask src));
-  effect(TEMP tmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "vloadmask $dst, $src\t# vector load mask (sve) (H/S/D)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    __ sve_vector_extend(as_FloatRegister($tmp$$reg), size, as_FloatRegister($src$$reg), __ B);
-    __ sve_cmp(Assembler::NE, as_PRegister($dst$$reg), size, ptrue, as_FloatRegister($tmp$$reg), 0);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2384,8 +2193,7 @@ instruct reduce_addD_partial(vRegD src1_dst, vReg src2, pRegGov ptmp, rFlagsReg 
 // vector add reduction - predicated
 
 instruct reduce_addI_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD tmp, pRegGov pg) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);
+  predicate(UseSVE > 0);
   match(Set dst (AddReductionVI (Binary src1 src2) pg));
   effect(TEMP_DEF dst, TEMP tmp);
   ins_cost(SVE_COST);
@@ -2400,8 +2208,7 @@ instruct reduce_addI_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD tmp
 %}
 
 instruct reduce_addL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegD tmp, pRegGov pg) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);
+  predicate(UseSVE > 0);
   match(Set dst (AddReductionVL (Binary src1 src2) pg));
   effect(TEMP_DEF dst, TEMP tmp);
   ins_cost(SVE_COST);
@@ -2415,8 +2222,7 @@ instruct reduce_addL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegD tmp, pRe
 %}
 
 instruct reduce_addF_masked(vRegF src1_dst, vReg src2, pRegGov pg) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);
+  predicate(UseSVE > 0);
   match(Set src1_dst (AddReductionVF (Binary src1_dst src2) pg));
   ins_cost(SVE_COST);
   format %{ "sve_reduce_addF $src1_dst, $pg, $src2\t# addF reduction predicated (sve)" %}
@@ -2428,88 +2234,13 @@ instruct reduce_addF_masked(vRegF src1_dst, vReg src2, pRegGov pg) %{
 %}
 
 instruct reduce_addD_masked(vRegD src1_dst, vReg src2, pRegGov pg) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);
+  predicate(UseSVE > 0);
   match(Set src1_dst (AddReductionVD (Binary src1_dst src2) pg));
   ins_cost(SVE_COST);
   format %{ "sve_reduce_addD $src1_dst, $pg, $src2\t# addD reduction predicated (sve)" %}
   ins_encode %{
     __ sve_fadda(as_FloatRegister($src1_dst$$reg), __ D,
                  as_PRegister($pg$$reg), as_FloatRegister($src2$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct reduce_addI_masked_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD vtmp,
-                                  pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);
-  match(Set dst (AddReductionVI (Binary src1 src2) pg));
-  effect(TEMP_DEF dst, TEMP vtmp, TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_reduce_addI $dst, $src1, $pg, $src2\t# addI reduction predicated partial (sve) (may extend)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this, $src2);
-    Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
-                           $src1$$Register, as_FloatRegister($src2$$reg),
-                           as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct reduce_addL_masked_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD vtmp,
-                                  pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);
-  match(Set dst (AddReductionVL (Binary src1 src2) pg));
-  effect(TEMP_DEF dst, TEMP vtmp, TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_reduce_addL $dst, $src1, $pg, $src2\t# addL reduction predicated partial (sve)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
-                           $src1$$Register, as_FloatRegister($src2$$reg),
-                           as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct reduce_addF_masked_partial(vRegF src1_dst, vReg src2, pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);
-  match(Set src1_dst (AddReductionVF (Binary src1_dst src2) pg));
-  effect(TEMP ptmp, KILL cr);
-  ins_cost(SVE_COST);
-  format %{ "sve_reduce_addF $src1_dst, $pg, $src2\t# addF reduction predicated partial (sve)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ S, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_fadda(as_FloatRegister($src1_dst$$reg), __ S,
-                 as_PRegister($ptmp$$reg), as_FloatRegister($src2$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct reduce_addD_masked_partial(vRegD src1_dst, vReg src2, pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);
-  match(Set src1_dst (AddReductionVD (Binary src1_dst src2) pg));
-  effect(TEMP ptmp, KILL cr);
-  ins_cost(SVE_COST);
-  format %{ "sve_reduce_addD $src1_dst, $pg, $src2\t# addD reduction predicated partial (sve)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_fadda(as_FloatRegister($src1_dst$$reg), __ D,
-                 as_PRegister($ptmp$$reg), as_FloatRegister($src2$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2591,8 +2322,7 @@ instruct reduce_andL_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD vtmp,
 
 instruct reduce_andI_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD tmp, pRegGov pg) %{
   predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() != T_LONG &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);
+            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() != T_LONG);
   match(Set dst (AndReductionV (Binary src1 src2) pg));
   effect(TEMP_DEF dst, TEMP tmp);
   ins_cost(SVE_COST);
@@ -2608,8 +2338,7 @@ instruct reduce_andI_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD tmp
 
 instruct reduce_andL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegD tmp, pRegGov pg) %{
   predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_LONG &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);
+            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_LONG);
   match(Set dst (AndReductionV (Binary src1 src2) pg));
   effect(TEMP_DEF dst, TEMP tmp);
   ins_cost(SVE_COST);
@@ -2618,48 +2347,6 @@ instruct reduce_andL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegD tmp, pRe
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
                            $src1$$Register, as_FloatRegister($src2$$reg),
                            as_PRegister($pg$$reg), as_FloatRegister($tmp$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct reduce_andI_masked_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD vtmp,
-                                  pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() != T_LONG &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);
-  match(Set dst (AndReductionV (Binary src1 src2) pg));
-  effect(TEMP_DEF dst, TEMP vtmp, TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_reduce_andI $dst, $src1, $pg, $src2\t# andI reduction predicated partial (sve) (may extend)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this, $src2);
-    Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
-                           $src1$$Register, as_FloatRegister($src2$$reg),
-                           as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct reduce_andL_masked_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD vtmp,
-                                  pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_LONG &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);
-  match(Set dst (AndReductionV (Binary src1 src2) pg));
-  effect(TEMP_DEF dst, TEMP vtmp, TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_reduce_andL $dst, $src1, $pg, $src2\t# andL reduction predicated partial (sve)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
-                           $src1$$Register, as_FloatRegister($src2$$reg),
-                           as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2741,8 +2428,7 @@ instruct reduce_orL_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD vtmp,
 
 instruct reduce_orI_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD tmp, pRegGov pg) %{
   predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() != T_LONG &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);
+            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() != T_LONG);
   match(Set dst (OrReductionV (Binary src1 src2) pg));
   effect(TEMP_DEF dst, TEMP tmp);
   ins_cost(SVE_COST);
@@ -2758,8 +2444,7 @@ instruct reduce_orI_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD tmp,
 
 instruct reduce_orL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegD tmp, pRegGov pg) %{
   predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_LONG &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);
+            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_LONG);
   match(Set dst (OrReductionV (Binary src1 src2) pg));
   effect(TEMP_DEF dst, TEMP tmp);
   ins_cost(SVE_COST);
@@ -2768,48 +2453,6 @@ instruct reduce_orL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegD tmp, pReg
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
                            $src1$$Register, as_FloatRegister($src2$$reg),
                            as_PRegister($pg$$reg), as_FloatRegister($tmp$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct reduce_orI_masked_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD vtmp,
-                                  pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() != T_LONG &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);
-  match(Set dst (OrReductionV (Binary src1 src2) pg));
-  effect(TEMP_DEF dst, TEMP vtmp, TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_reduce_orI $dst, $src1, $pg, $src2\t# orI reduction predicated partial (sve) (may extend)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this, $src2);
-    Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
-                           $src1$$Register, as_FloatRegister($src2$$reg),
-                           as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct reduce_orL_masked_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD vtmp,
-                                  pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_LONG &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);
-  match(Set dst (OrReductionV (Binary src1 src2) pg));
-  effect(TEMP_DEF dst, TEMP vtmp, TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_reduce_orL $dst, $src1, $pg, $src2\t# orL reduction predicated partial (sve)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
-                           $src1$$Register, as_FloatRegister($src2$$reg),
-                           as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2891,8 +2534,7 @@ instruct reduce_eorL_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD vtmp,
 
 instruct reduce_eorI_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD tmp, pRegGov pg) %{
   predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() != T_LONG &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);
+            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() != T_LONG);
   match(Set dst (XorReductionV (Binary src1 src2) pg));
   effect(TEMP_DEF dst, TEMP tmp);
   ins_cost(SVE_COST);
@@ -2908,8 +2550,7 @@ instruct reduce_eorI_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD tmp
 
 instruct reduce_eorL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegD tmp, pRegGov pg) %{
   predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_LONG &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);
+            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_LONG);
   match(Set dst (XorReductionV (Binary src1 src2) pg));
   effect(TEMP_DEF dst, TEMP tmp);
   ins_cost(SVE_COST);
@@ -2918,48 +2559,6 @@ instruct reduce_eorL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegD tmp, pRe
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
                            $src1$$Register, as_FloatRegister($src2$$reg),
                            as_PRegister($pg$$reg), as_FloatRegister($tmp$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct reduce_eorI_masked_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD vtmp,
-                                  pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() != T_LONG &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);
-  match(Set dst (XorReductionV (Binary src1 src2) pg));
-  effect(TEMP_DEF dst, TEMP vtmp, TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_reduce_eorI $dst, $src1, $pg, $src2\t# eorI reduction predicated partial (sve) (may extend)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this, $src2);
-    Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
-                           $src1$$Register, as_FloatRegister($src2$$reg),
-                           as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct reduce_eorL_masked_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD vtmp,
-                                  pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_LONG &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);
-  match(Set dst (XorReductionV (Binary src1 src2) pg));
-  effect(TEMP_DEF dst, TEMP vtmp, TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_reduce_eorL $dst, $src1, $pg, $src2\t# eorL reduction predicated partial (sve)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
-                           $src1$$Register, as_FloatRegister($src2$$reg),
-                           as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -3108,7 +2707,6 @@ instruct reduce_maxD_partial(vRegD dst, vRegD src1, vReg src2,
 instruct reduce_maxI_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD tmp,
                            pRegGov pg, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize &&
             n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() != T_LONG &&
             is_integral_type(n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type()));
   match(Set dst (MaxReductionV (Binary src1 src2) pg));
@@ -3127,7 +2725,6 @@ instruct reduce_maxI_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD tmp
 instruct reduce_maxL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegD tmp,
                           pRegGov pg, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize &&
             n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_LONG);
   match(Set dst (MaxReductionV (Binary src1 src2) pg));
   effect(TEMP_DEF dst, TEMP tmp, KILL cr);
@@ -3141,53 +2738,9 @@ instruct reduce_maxL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegD tmp,
   ins_pipe(pipe_slow);
 %}
 
-instruct reduce_maxI_masked_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD vtmp,
-                                  pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() != T_LONG &&
-            is_integral_type(n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type()));
-  match(Set dst (MaxReductionV (Binary src1 src2) pg));
-  effect(TEMP_DEF dst, TEMP vtmp, TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_reduce_maxI $dst, $src1, $pg, $src2\t# maxI reduction predicated partial (sve)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this, $src2);
-    Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
-                           $src1$$Register, as_FloatRegister($src2$$reg),
-                           as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct reduce_maxL_masked_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD vtmp,
-                                  pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_LONG);
-  match(Set dst (MaxReductionV (Binary src1 src2) pg));
-  effect(TEMP_DEF dst, TEMP vtmp, TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_reduce_maxL $dst, $src1, $pg, $src2\t# maxL reduction predicated partial (sve)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
-                           $src1$$Register, as_FloatRegister($src2$$reg),
-                           as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
 instruct reduce_maxF_masked(vRegF dst, vRegF src1, vReg src2, pRegGov pg) %{
   predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_FLOAT &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);
+            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_FLOAT);
   match(Set dst (MaxReductionV (Binary src1 src2) pg));
   ins_cost(SVE_COST);
   effect(TEMP_DEF dst);
@@ -3201,54 +2754,13 @@ instruct reduce_maxF_masked(vRegF dst, vRegF src1, vReg src2, pRegGov pg) %{
 
 instruct reduce_maxD_masked(vRegD dst, vRegD src1, vReg src2, pRegGov pg) %{
   predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);
+            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE);
   match(Set dst (MaxReductionV (Binary src1 src2) pg));
   ins_cost(SVE_COST);
   effect(TEMP_DEF dst);
   format %{ "sve_reduce_maxD $dst, $src1, $pg, $src2\t# maxD reduction predicated (sve)" %}
   ins_encode %{
     __ sve_fmaxv(as_FloatRegister($dst$$reg), __ D, as_PRegister($pg$$reg), as_FloatRegister($src2$$reg));
-    __ fmaxd(as_FloatRegister($dst$$reg), as_FloatRegister($dst$$reg), as_FloatRegister($src1$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct reduce_maxF_masked_partial(vRegF dst, vRegF src1, vReg src2, pRegGov pg,
-                                    pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_FLOAT &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);
-  match(Set dst (MaxReductionV (Binary src1 src2) pg));
-  effect(TEMP_DEF dst, TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_reduce_maxF $dst, $src1, $pg, $src2\t# maxF reduction predicated partial (sve)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ S, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_fmaxv(as_FloatRegister($dst$$reg), __ S,
-               as_PRegister($ptmp$$reg), as_FloatRegister($src2$$reg));
-    __ fmaxs(as_FloatRegister($dst$$reg), as_FloatRegister($dst$$reg), as_FloatRegister($src1$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct reduce_maxD_masked_partial(vRegD dst, vRegD src1, vReg src2, pRegGov pg,
-                                    pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);
-  match(Set dst (MaxReductionV (Binary src1 src2) pg));
-  effect(TEMP_DEF dst, TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_reduce_maxD $dst, $src1, $pg, $src2\t# maxD reduction predicated partial (sve)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_fmaxv(as_FloatRegister($dst$$reg), __ D,
-               as_PRegister($ptmp$$reg), as_FloatRegister($src2$$reg));
     __ fmaxd(as_FloatRegister($dst$$reg), as_FloatRegister($dst$$reg), as_FloatRegister($src1$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -3398,7 +2910,6 @@ instruct reduce_minD_partial(vRegD dst, vRegD src1, vReg src2,
 instruct reduce_minI_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD tmp,
                            pRegGov pg, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize &&
             n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() != T_LONG &&
             is_integral_type(n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type()));
   match(Set dst (MinReductionV (Binary src1 src2) pg));
@@ -3417,7 +2928,6 @@ instruct reduce_minI_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD tmp
 instruct reduce_minL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegD tmp,
                           pRegGov pg, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize &&
             n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_LONG);
   match(Set dst (MinReductionV (Binary src1 src2) pg));
   effect(TEMP_DEF dst, TEMP tmp, KILL cr);
@@ -3431,53 +2941,9 @@ instruct reduce_minL_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegD tmp,
   ins_pipe(pipe_slow);
 %}
 
-instruct reduce_minI_masked_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD vtmp,
-                                  pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() != T_LONG &&
-            is_integral_type(n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type()));
-  match(Set dst (MinReductionV (Binary src1 src2) pg));
-  effect(TEMP_DEF dst, TEMP vtmp, TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_reduce_minI $dst, $src1, $pg, $src2\t# minI reduction predicated partial (sve)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this, $src2);
-    Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
-                           $src1$$Register, as_FloatRegister($src2$$reg),
-                           as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct reduce_minL_masked_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD vtmp,
-                                  pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_LONG);
-  match(Set dst (MinReductionV (Binary src1 src2) pg));
-  effect(TEMP_DEF dst, TEMP vtmp, TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_reduce_minL $dst, $src1, $pg, $src2\t# minL reduction predicated partial (sve)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
-                           $src1$$Register, as_FloatRegister($src2$$reg),
-                           as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
 instruct reduce_minF_masked(vRegF dst, vRegF src1, vReg src2, pRegGov pg) %{
   predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_FLOAT &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);
+            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_FLOAT);
   match(Set dst (MinReductionV (Binary src1 src2) pg));
   ins_cost(SVE_COST);
   effect(TEMP_DEF dst);
@@ -3491,54 +2957,13 @@ instruct reduce_minF_masked(vRegF dst, vRegF src1, vReg src2, pRegGov pg) %{
 
 instruct reduce_minD_masked(vRegD dst, vRegD src1, vReg src2, pRegGov pg) %{
   predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);
+            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE);
   match(Set dst (MinReductionV (Binary src1 src2) pg));
   ins_cost(SVE_COST);
   effect(TEMP_DEF dst);
   format %{ "sve_reduce_minD $dst, $src1, $pg, $src2\t# minD reduction predicated (sve)" %}
   ins_encode %{
     __ sve_fminv(as_FloatRegister($dst$$reg), __ D, as_PRegister($pg$$reg), as_FloatRegister($src2$$reg));
-    __ fmind(as_FloatRegister($dst$$reg), as_FloatRegister($dst$$reg), as_FloatRegister($src1$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct reduce_minF_masked_partial(vRegF dst, vRegF src1, vReg src2, pRegGov pg,
-                                    pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_FLOAT &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);
-  match(Set dst (MinReductionV (Binary src1 src2) pg));
-  effect(TEMP_DEF dst, TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_reduce_minF $dst, $src1, $pg, $src2\t# minF reduction predicated partial (sve)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ S, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_fminv(as_FloatRegister($dst$$reg), __ S,
-               as_PRegister($ptmp$$reg), as_FloatRegister($src2$$reg));
-    __ fmins(as_FloatRegister($dst$$reg), as_FloatRegister($dst$$reg), as_FloatRegister($src1$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct reduce_minD_masked_partial(vRegD dst, vRegD src1, vReg src2, pRegGov pg,
-                                    pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);
-  match(Set dst (MinReductionV (Binary src1 src2) pg));
-  effect(TEMP_DEF dst, TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_reduce_minD $dst, $src1, $pg, $src2\t# minD reduction predicated partial (sve)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_fminv(as_FloatRegister($dst$$reg), __ D,
-               as_PRegister($ptmp$$reg), as_FloatRegister($src2$$reg));
     __ fmind(as_FloatRegister($dst$$reg), as_FloatRegister($dst$$reg), as_FloatRegister($src1$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -5047,7 +4472,6 @@ instruct extractD(vRegD dst, vReg src, immI idx, pRegGov pgtmp, rFlagsReg cr)
 instruct vtest_alltrue(iRegINoSp dst, pRegGov src1, pRegGov src2, pReg ptmp, rFlagsReg cr)
 %{
   predicate(UseSVE > 0 &&
-            n->in(1)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize &&
             static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::overflow);
   match(Set dst (VectorTest src1 src2));
   effect(TEMP ptmp, KILL cr);
@@ -5065,7 +4489,6 @@ instruct vtest_alltrue(iRegINoSp dst, pRegGov src1, pRegGov src2, pReg ptmp, rFl
 instruct vtest_anytrue(iRegINoSp dst, pRegGov src1, pRegGov src2, rFlagsReg cr)
 %{
   predicate(UseSVE > 0 &&
-            n->in(1)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize &&
             static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::ne);
   match(Set dst (VectorTest src1 src2));
   effect(KILL cr);
@@ -5079,47 +4502,6 @@ instruct vtest_anytrue(iRegINoSp dst, pRegGov src1, pRegGov src2, rFlagsReg cr)
   %}
   ins_pipe(pipe_slow);
 %}
-
-instruct vtest_alltrue_partial(iRegINoSp dst, pRegGov src1, pRegGov src2, pRegGov ptmp, rFlagsReg cr)
-%{
-  predicate(UseSVE > 0 &&
-            n->in(1)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize &&
-            static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::overflow);
-  match(Set dst (VectorTest src1 src2));
-  effect(TEMP ptmp, KILL cr);
-  ins_cost(SVE_COST);
-  format %{ "vtest_alltrue_partial $dst, $src1, $src2\t# VectorTest partial (sve) - alltrue" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this, $src1);
-    Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src1));
-    __ sve_eors(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-          as_PRegister($src1$$reg), as_PRegister($src2$$reg));
-    __ csetw(as_Register($dst$$reg), Assembler::EQ);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vtest_anytrue_partial(iRegINoSp dst, pRegGov src1, pRegGov src2, pRegGov ptmp, rFlagsReg cr)
-%{
-  predicate(UseSVE > 0 &&
-            n->in(1)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize &&
-            static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::ne);
-  match(Set dst (VectorTest src1 src2));
-  effect(TEMP ptmp, KILL cr);
-  ins_cost(SVE_COST);
-  format %{ "vtest_anytrue_partial $dst, $src1, $src2\t# VectorTest partial (sve) - anytrue" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this, $src1);
-    Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src1));
-    __ sve_ands(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-          as_PRegister($src1$$reg), as_PRegister($src2$$reg));
-    __ csetw(as_Register($dst$$reg), Assembler::NE);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
 // ------------------------------ Vector insert ---------------------------------
 
 instruct insertI_small(vReg dst, vReg src, iRegIorL2I val, immI idx, pRegGov pgtmp, rFlagsReg cr)
@@ -5376,7 +4758,6 @@ instruct gatherL_partial(vReg dst, indirect mem, vReg idx, pRegGov ptmp, rFlagsR
 
 instruct gatherI_masked(vReg dst, indirect mem, vReg idx, pRegGov pg) %{
   predicate(UseSVE > 0 &&
-            n->as_LoadVector()->memory_size() == MaxVectorSize &&
             (n->bottom_type()->is_vect()->element_basic_type() == T_INT ||
              n->bottom_type()->is_vect()->element_basic_type() == T_FLOAT));
   match(Set dst (LoadVectorGatherMasked mem (Binary idx pg)));
@@ -5391,7 +4772,6 @@ instruct gatherI_masked(vReg dst, indirect mem, vReg idx, pRegGov pg) %{
 
 instruct gatherL_masked(vReg dst, indirect mem, vReg idx, pRegGov pg) %{
   predicate(UseSVE > 0 &&
-            n->as_LoadVector()->memory_size() == MaxVectorSize &&
             (n->bottom_type()->is_vect()->element_basic_type() == T_LONG ||
              n->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE));
   match(Set dst (LoadVectorGatherMasked mem (Binary idx pg)));
@@ -5400,47 +4780,6 @@ instruct gatherL_masked(vReg dst, indirect mem, vReg idx, pRegGov pg) %{
   ins_encode %{
     __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
     __ sve_ld1d_gather(as_FloatRegister($dst$$reg), as_PRegister($pg$$reg),
-                       as_Register($mem$$base), as_FloatRegister($idx$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-// ------------------------------ Vector Load Gather Predicated Partial -------------------------------
-
-instruct gatherI_masked_partial(vReg dst, indirect mem, vReg idx, pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->as_LoadVector()->memory_size() < MaxVectorSize &&
-            (n->bottom_type()->is_vect()->element_basic_type() == T_INT ||
-             n->bottom_type()->is_vect()->element_basic_type() == T_FLOAT));
-  match(Set dst (LoadVectorGatherMasked mem (Binary idx pg)));
-  effect(TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "load_vector_gather $dst, $pg, $mem, $idx\t# vector load gather predicated partial (S)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ S, Matcher::vector_length(this));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_ld1w_gather(as_FloatRegister($dst$$reg), as_PRegister($ptmp$$reg),
-                       as_Register($mem$$base), as_FloatRegister($idx$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct gatherL_masked_partial(vReg dst, indirect mem, vReg idx, pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->as_LoadVector()->memory_size() < MaxVectorSize &&
-            (n->bottom_type()->is_vect()->element_basic_type() == T_LONG ||
-             n->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE));
-  match(Set dst (LoadVectorGatherMasked mem (Binary idx pg)));
-  effect(TEMP ptmp, KILL cr);
-  ins_cost(4 * SVE_COST);
-  format %{ "load_vector_gather $dst, $pg, $mem, $idx\t# vector load gather predicated partial (D)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
-    __ sve_ld1d_gather(as_FloatRegister($dst$$reg), as_PRegister($ptmp$$reg),
                        as_Register($mem$$base), as_FloatRegister($idx$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -5520,7 +4859,6 @@ instruct scatterL_partial(indirect mem, vReg src, vReg idx, pRegGov ptmp, rFlags
 
 instruct scatterI_masked(indirect mem, vReg src, vReg idx, pRegGov pg) %{
   predicate(UseSVE > 0 &&
-            n->as_StoreVector()->memory_size() == MaxVectorSize &&
             (n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_INT ||
              n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_FLOAT));
   match(Set mem (StoreVectorScatterMasked mem (Binary src (Binary idx pg))));
@@ -5535,7 +4873,6 @@ instruct scatterI_masked(indirect mem, vReg src, vReg idx, pRegGov pg) %{
 
 instruct scatterL_masked(indirect mem, vReg src, vReg idx, pRegGov pg) %{
   predicate(UseSVE > 0 &&
-            n->as_StoreVector()->memory_size() == MaxVectorSize &&
             (n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_LONG ||
              n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE));
   match(Set mem (StoreVectorScatterMasked mem (Binary src (Binary idx pg))));
@@ -5544,47 +4881,6 @@ instruct scatterL_masked(indirect mem, vReg src, vReg idx, pRegGov pg) %{
   ins_encode %{
     __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
     __ sve_st1d_scatter(as_FloatRegister($src$$reg), as_PRegister($pg$$reg),
-                        as_Register($mem$$base), as_FloatRegister($idx$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-// ------------------------------ Vector Store Scatter Predicated Partial -------------------------------
-
-instruct scatterI_masked_partial(indirect mem, vReg src, vReg idx, pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->as_StoreVector()->memory_size() < MaxVectorSize &&
-            (n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_INT ||
-             n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_FLOAT));
-  match(Set mem (StoreVectorScatterMasked mem (Binary src (Binary idx pg))));
-  effect(TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "store_vector_scatter $mem, $pg, $idx, $src\t# vector store scatter predicated partial (S)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ S, Matcher::vector_length(this, $src));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_st1w_scatter(as_FloatRegister($src$$reg), as_PRegister($ptmp$$reg),
-                        as_Register($mem$$base), as_FloatRegister($idx$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct scatterL_masked_partial(indirect mem, vReg src, vReg idx, pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->as_StoreVector()->memory_size() < MaxVectorSize &&
-            (n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_LONG ||
-             n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE));
-  match(Set mem (StoreVectorScatterMasked mem (Binary src (Binary idx pg))));
-  effect(TEMP ptmp, KILL cr);
-  ins_cost(4 * SVE_COST);
-  format %{ "store_vector_scatter $mem, $pg, $idx, $src\t# vector store scatter predicated partial (D)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
-    __ sve_st1d_scatter(as_FloatRegister($src$$reg), as_PRegister($ptmp$$reg),
                         as_Register($mem$$base), as_FloatRegister($idx$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -5645,8 +4941,7 @@ instruct stringU_indexof_char_sve(iRegP_R1 str1, iRegI_R2 cnt1, iRegI_R3 ch,
 
 // ---------------------------- Vector mask reductions ---------------------------
 instruct vmask_truecount(iRegINoSp dst, pReg src) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);
+  predicate(UseSVE > 0);
   match(Set dst (VectorMaskTrueCount src));
   ins_cost(SVE_COST);
   format %{ "vmask_truecount $dst, $src\t# vector mask truecount (sve)" %}
@@ -5658,25 +4953,33 @@ instruct vmask_truecount(iRegINoSp dst, pReg src) %{
   ins_pipe(pipe_slow);
 %}
 
+// Return the index of the first mask lane that is set, or vector length if none of
+// them are set.
 instruct vmask_firsttrue(iRegINoSp dst, pReg src, pReg ptmp) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);
+  predicate(UseSVE > 0);
   match(Set dst (VectorMaskFirstTrue src));
   effect(TEMP ptmp);
-  ins_cost(2 * SVE_COST);
+  ins_cost(3 * SVE_COST);
   format %{ "vmask_firsttrue $dst, $src\t# vector mask firsttrue (sve)" %}
   ins_encode %{
+    uint length_in_bytes = Matcher::vector_length_in_bytes(this, $src);
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
     Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    __ sve_brkb(as_PRegister($ptmp$$reg), ptrue, as_PRegister($src$$reg), false);
+    // When the input predicate is all-false, the result should be the vector length
+    // instead of max vector register size.
+    if (length_in_bytes == MaxVectorSize) {
+      __ sve_brkb(as_PRegister($ptmp$$reg), ptrue, as_PRegister($src$$reg), false);
+    } else {
+      __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src));
+      __ sve_brkb(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg), as_PRegister($src$$reg), false);
+    }
     __ sve_cntp($dst$$Register, size, ptrue, as_PRegister($ptmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
 
 instruct vmask_lasttrue(iRegINoSp dst, pReg src, pReg ptmp) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);
+  predicate(UseSVE > 0);
   match(Set dst (VectorMaskLastTrue src));
   effect(TEMP ptmp);
   ins_cost(3 * SVE_COST);
@@ -5684,57 +4987,6 @@ instruct vmask_lasttrue(iRegINoSp dst, pReg src, pReg ptmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
     __ sve_vmask_lasttrue($dst$$Register, bt, as_PRegister($src$$reg), as_PRegister($ptmp$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vmask_truecount_partial(iRegINoSp dst, pReg src, pReg ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);
-  match(Set dst (VectorMaskTrueCount src));
-  effect(TEMP ptmp, KILL cr);
-  ins_cost(2 * SVE_COST);
-  format %{ "vmask_truecount_partial $dst, $src\t# vector mask truecount partial (sve)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this, $src);
-    Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src));
-    __ sve_cntp($dst$$Register, size, as_PRegister($ptmp$$reg), as_PRegister($src$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vmask_firsttrue_partial(iRegINoSp dst, pReg src, pReg ptmp1, pReg ptmp2, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);
-  match(Set dst (VectorMaskFirstTrue src));
-  effect(TEMP ptmp1, TEMP ptmp2, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "vmask_firsttrue_partial $dst, $src\t# vector mask firsttrue partial (sve)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this, $src);
-    Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp1$$reg), size,
-                          Matcher::vector_length(this, $src));
-    __ sve_brkb(as_PRegister($ptmp2$$reg), as_PRegister($ptmp1$$reg), as_PRegister($src$$reg), false);
-    __ sve_cntp($dst$$Register, size, as_PRegister($ptmp1$$reg), as_PRegister($ptmp2$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vmask_lasttrue_partial(iRegINoSp dst, pReg src, pReg ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);
-  match(Set dst (VectorMaskLastTrue src));
-  effect(TEMP ptmp, KILL cr);
-  ins_cost(5 * SVE_COST);
-  format %{ "vmask_lasttrue_partial $dst, $src\t# vector mask lasttrue partial (sve)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this, $src);
-    Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src));
-    __ sve_and(as_PRegister($ptmp$$reg), ptrue, as_PRegister($ptmp$$reg), as_PRegister($src$$reg));
-    __ sve_vmask_lasttrue($dst$$Register, bt, as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -5755,7 +5007,170 @@ instruct vmask_tolong(iRegLNoSp dst, pReg src, vReg vtmp1, vReg vtmp2, pRegGov p
   %}
   ins_pipe(pipe_slow);
 %}
+
 // ---------------------------- Vector mask generation ---------------------------
+// The rules below set predicate registers. They can guarantee the high bits of dst
+// are cleared with zero when the vector length is less than the full size of
+// hardware vector register width.
+
+
+// maskAll (full or partial predicate size)
+
+instruct vmaskAll_immI(pRegGov dst, immI src) %{
+  predicate(UseSVE > 0);
+  match(Set dst (MaskAll src));
+  ins_cost(SVE_COST);
+  format %{ "sve_ptrue_lanecnt/sve_pfalse $dst\t# mask all (sve) (B/H/S)" %}
+  ins_encode %{
+    int con = (int)$src$$constant;
+    if (con == 0) {
+      __ sve_pfalse(as_PRegister($dst$$reg));
+    } else {
+      assert(con == -1, "invalid constant value for mask");
+      BasicType bt = Matcher::vector_element_basic_type(this);
+      __ sve_ptrue_lanecnt(as_PRegister($dst$$reg), __ elemType_to_regVariant(bt),
+                           Matcher::vector_length(this));
+    }
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmaskAllI(pRegGov dst, iRegIorL2I src, vReg tmp, rFlagsReg cr) %{
+  predicate(UseSVE > 0);
+  match(Set dst (MaskAll src));
+  effect(TEMP tmp, KILL cr);
+  ins_cost(3 * SVE_COST);
+  format %{ "sve_dup $tmp, $src\n\t"
+            "sve_ptrue $dst, vector_length\n\t"
+            "sve_cmpne $dst, $dst, $tmp, 0\t# mask all (sve) (B/H/S)" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
+    uint length_in_bytes = Matcher::vector_length_in_bytes(this);
+    __ sve_dup(as_FloatRegister($tmp$$reg), size, as_Register($src$$reg));
+    if (length_in_bytes < MaxVectorSize) {
+      __ sve_ptrue_lanecnt(as_PRegister($dst$$reg), size, Matcher::vector_length(this));
+      __ sve_cmp(Assembler::NE, as_PRegister($dst$$reg), size,
+                 as_PRegister($dst$$reg), as_FloatRegister($tmp$$reg), 0);
+    } else {
+      __ sve_cmp(Assembler::NE, as_PRegister($dst$$reg), size, ptrue, as_FloatRegister($tmp$$reg), 0);
+    }
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmaskAll_immL(pRegGov dst, immL src) %{
+  predicate(UseSVE > 0);
+  match(Set dst (MaskAll src));
+  ins_cost(SVE_COST);
+  format %{ "sve_ptrue_lanecnt/sve_pfalse $dst\t# mask all (sve) (D)" %}
+  ins_encode %{
+    long con = (long)$src$$constant;
+    if (con == 0) {
+      __ sve_pfalse(as_PRegister($dst$$reg));
+    } else {
+      assert(con == -1, "invalid constant value for mask");
+      BasicType bt = Matcher::vector_element_basic_type(this);
+      __ sve_ptrue_lanecnt(as_PRegister($dst$$reg), __ elemType_to_regVariant(bt),
+                           Matcher::vector_length(this));
+    }
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmaskAllL(pRegGov dst, iRegL src, vReg tmp, rFlagsReg cr) %{
+  predicate(UseSVE > 0);
+  match(Set dst (MaskAll src));
+  effect(TEMP tmp, KILL cr);
+  ins_cost(3 * SVE_COST);
+  format %{ "sve_dup $tmp, $src\n\t"
+            "sve_ptrue $dst, vector_length\n\t"
+            "sve_cmpne $dst, $dst, $tmp, 0\t# mask all (sve) (D)" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
+    uint length_in_bytes = Matcher::vector_length_in_bytes(this);
+    __ sve_dup(as_FloatRegister($tmp$$reg), size, as_Register($src$$reg));
+    if (length_in_bytes < MaxVectorSize) {
+      __ sve_ptrue_lanecnt(as_PRegister($dst$$reg), size, Matcher::vector_length(this));
+      __ sve_cmp(Assembler::NE, as_PRegister($dst$$reg), size,
+                 as_PRegister($dst$$reg), as_FloatRegister($tmp$$reg), 0);
+    } else {
+      __ sve_cmp(Assembler::NE, as_PRegister($dst$$reg), size, ptrue, as_FloatRegister($tmp$$reg), 0);
+    }
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// vector mask compare
+
+instruct vmaskcmp(pRegGov dst, vReg src1, vReg src2, immI cond, rFlagsReg cr) %{
+  predicate(UseSVE > 0);
+  match(Set dst (VectorMaskCmp (Binary src1 src2) cond));
+  effect(KILL cr);
+  ins_cost(2 * SVE_COST);
+  format %{ "sve_cmp $dst, $src1, $src2\t# vector mask cmp (sve)" %}
+  ins_encode %{
+    uint length_in_bytes = Matcher::vector_length_in_bytes(this);
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    if (length_in_bytes == MaxVectorSize) {
+      __ sve_compare(as_PRegister($dst$$reg), bt, ptrue, as_FloatRegister($src1$$reg),
+                     as_FloatRegister($src2$$reg), (int)$cond$$constant);
+    } else {
+      __ sve_ptrue_lanecnt(as_PRegister($dst$$reg), __ elemType_to_regVariant(bt),
+                           Matcher::vector_length(this));
+      __ sve_compare(as_PRegister($dst$$reg), bt, as_PRegister($dst$$reg), as_FloatRegister($src1$$reg),
+                     as_FloatRegister($src2$$reg), (int)$cond$$constant);
+    }
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmaskcmp_masked(pRegGov dst, vReg src1, vReg src2, immI cond, pRegGov pg, rFlagsReg cr) %{
+  predicate(UseSVE > 0);
+  match(Set dst (VectorMaskCmp (Binary src1 src2) (Binary cond pg)));
+  effect(KILL cr);
+  ins_cost(SVE_COST);
+  format %{ "sve_cmp $dst, $pg, $src1, $src2\t# vector mask cmp (sve)" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ sve_compare(as_PRegister($dst$$reg), bt, as_PRegister($pg$$reg), as_FloatRegister($src1$$reg),
+                   as_FloatRegister($src2$$reg), (int)$cond$$constant);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// vector load mask
+
+instruct vloadmaskB(pRegGov dst, vReg src, rFlagsReg cr) %{
+  predicate(UseSVE > 0 &&
+            n->bottom_type()->is_vect()->element_basic_type() == T_BYTE);
+  match(Set dst (VectorLoadMask src));
+  effect(KILL cr);
+  ins_cost(SVE_COST);
+  format %{ "vloadmaskB $dst, $src\t# vector load mask (sve) (B)" %}
+  ins_encode %{
+    __ sve_cmp(Assembler::NE, as_PRegister($dst$$reg), __ B,
+               ptrue, as_FloatRegister($src$$reg), 0);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vloadmask_extend(pRegGov dst, vReg src, vReg tmp, rFlagsReg cr) %{
+  predicate(UseSVE > 0 && n->bottom_type()->is_vect()->element_basic_type() != T_BYTE);
+  match(Set dst (VectorLoadMask src));
+  effect(TEMP tmp, KILL cr);
+  ins_cost(3 * SVE_COST);
+  format %{ "vloadmask $dst, $src\t# vector load mask (sve) (H/S/D)" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
+    __ sve_vector_extend(as_FloatRegister($tmp$$reg), size, as_FloatRegister($src$$reg), __ B);
+    __ sve_cmp(Assembler::NE, as_PRegister($dst$$reg), size, ptrue, as_FloatRegister($tmp$$reg), 0);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
 instruct vmask_gen(pRegGov pg, iRegL len, rFlagsReg cr) %{
   predicate(UseSVE > 0);
   match(Set pg (VectorMaskGen len));

--- a/src/hotspot/cpu/aarch64/aarch64_sve_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_sve_ad.m4
@@ -279,8 +279,7 @@ instruct storeV_partial(vReg src, vmemA mem, pRegGov pgtmp, rFlagsReg cr) %{
 // vector load/store - predicated
 
 instruct loadV_masked(vReg dst, vmemA mem, pRegGov pg) %{
-  predicate(UseSVE > 0 &&
-            n->as_LoadVector()->memory_size() == MaxVectorSize);
+  predicate(UseSVE > 0);
   match(Set dst (LoadVectorMasked mem pg));
   ins_cost(4 * SVE_COST);
   format %{ "sve_ldr $dst, $pg, $mem\t# load vector predicated (sve)" %}
@@ -293,29 +292,8 @@ instruct loadV_masked(vReg dst, vmemA mem, pRegGov pg) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct loadV_masked_partial(vReg dst, vmemA mem, pRegGov pg, pRegGov pgtmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->as_LoadVector()->memory_size() < MaxVectorSize);
-  match(Set dst (LoadVectorMasked mem pg));
-  effect(TEMP pgtmp, KILL cr);
-  ins_cost(6 * SVE_COST);
-  format %{ "sve_ldr $dst, $pg, $mem\t# load vector predicated partial (sve)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ sve_ptrue_lanecnt(as_PRegister($pgtmp$$reg), __ elemType_to_regVariant(bt),
-                         Matcher::vector_length(this));
-    __ sve_and(as_PRegister($pgtmp$$reg), as_PRegister($pgtmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    loadStoreA_predicated(C2_MacroAssembler(&cbuf), false, as_FloatRegister($dst$$reg),
-                          as_PRegister($pgtmp$$reg), bt, bt, $mem->opcode(),
-                          as_Register($mem$$base), $mem$$index, $mem$$scale, $mem$$disp);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
 instruct storeV_masked(vReg src, vmemA mem, pRegGov pg) %{
-  predicate(UseSVE > 0 &&
-            n->as_StoreVector()->memory_size() == MaxVectorSize);
+  predicate(UseSVE > 0);
   match(Set mem (StoreVectorMasked mem (Binary src pg)));
   ins_cost(4 * SVE_COST);
   format %{ "sve_str $mem, $pg, $src\t# store vector predicated (sve)" %}
@@ -327,82 +305,6 @@ instruct storeV_masked(vReg src, vmemA mem, pRegGov pg) %{
   %}
   ins_pipe(pipe_slow);
 %}
-
-instruct storeV_masked_partial(vReg src, vmemA mem, pRegGov pg, pRegGov pgtmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->as_StoreVector()->memory_size() < MaxVectorSize);
-  match(Set mem (StoreVectorMasked mem (Binary src pg)));
-  effect(TEMP pgtmp, KILL cr);
-  ins_cost(6 * SVE_COST);
-  format %{ "sve_str $mem, $pg, $src\t# store vector predicated partial (sve)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this, $src);
-    __ sve_ptrue_lanecnt(as_PRegister($pgtmp$$reg), __ elemType_to_regVariant(bt),
-                         Matcher::vector_length(this, $src));
-    __ sve_and(as_PRegister($pgtmp$$reg), as_PRegister($pgtmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    loadStoreA_predicated(C2_MacroAssembler(&cbuf), true, as_FloatRegister($src$$reg),
-                          as_PRegister($pgtmp$$reg), bt, bt, $mem->opcode(),
-                          as_Register($mem$$base), $mem$$index, $mem$$scale, $mem$$disp);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-dnl
-dnl MASKALL_IMM($1,   $2  )
-dnl MASKALL_IMM(type, size)
-define(`MASKALL_IMM', `
-instruct vmaskAll_imm$1(pRegGov dst, imm$1 src) %{
-  predicate(UseSVE > 0);
-  match(Set dst (MaskAll src));
-  ins_cost(SVE_COST);
-  format %{ "sve_ptrue_lanecnt/sve_pfalse $dst\t# mask all (sve) ($2)" %}
-  ins_encode %{
-    ifelse($1, `I', int, long) con = (ifelse($1, `I', int, long))$src$$constant;
-    if (con == 0) {
-      __ sve_pfalse(as_PRegister($dst$$reg));
-    } else {
-      assert(con == -1, "invalid constant value for mask");
-      BasicType bt = Matcher::vector_element_basic_type(this);
-      __ sve_ptrue_lanecnt(as_PRegister($dst$$reg), __ elemType_to_regVariant(bt),
-                           Matcher::vector_length(this));
-    }
-  %}
-  ins_pipe(pipe_slow);
-%}')dnl
-dnl
-dnl MASKALL($1,   $2  )
-dnl MASKALL(type, size)
-define(`MASKALL', `
-instruct vmaskAll$1(pRegGov dst, ifelse($1, `I', iRegIorL2I, iRegL) src, vReg tmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0);
-  match(Set dst (MaskAll src));
-  effect(TEMP tmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_dup $tmp, $src\n\t"
-            "sve_ptrue $dst, vector_length\n\t"
-            "sve_cmpne $dst, $dst, $tmp, 0\t# mask all (sve) ($2)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    uint length_in_bytes = Matcher::vector_length_in_bytes(this);
-    __ sve_dup(as_FloatRegister($tmp$$reg), size, as_Register($src$$reg));
-    if (length_in_bytes < MaxVectorSize) {
-      __ sve_ptrue_lanecnt(as_PRegister($dst$$reg), size, Matcher::vector_length(this));
-      __ sve_cmp(Assembler::NE, as_PRegister($dst$$reg), size,
-                 as_PRegister($dst$$reg), as_FloatRegister($tmp$$reg), 0);
-    } else {
-      __ sve_cmp(Assembler::NE, as_PRegister($dst$$reg), size, ptrue, as_FloatRegister($tmp$$reg), 0);
-    }
-  %}
-  ins_pipe(pipe_slow);
-%}')dnl
-dnl
-// maskAll (full or partial predicate size)
-MASKALL_IMM(I, B/H/S)
-MASKALL(I, B/H/S)
-MASKALL_IMM(L, D)
-MASKALL(L, D)
 
 dnl
 dnl MASK_LOGICAL_OP($1,        $2,      $3  )
@@ -1119,36 +1021,6 @@ instruct vpopcountI(vReg dst, vReg src) %{
   ins_pipe(pipe_slow);
 %}
 
-// vector mask compare
-
-instruct vmaskcmp(pRegGov dst, vReg src1, vReg src2, immI cond, rFlagsReg cr) %{
-  predicate(UseSVE > 0);
-  match(Set dst (VectorMaskCmp (Binary src1 src2) cond));
-  effect(KILL cr);
-  ins_cost(SVE_COST);
-  format %{ "sve_cmp $dst, $src1, $src2\t# vector mask cmp (sve)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ sve_compare(as_PRegister($dst$$reg), bt, ptrue, as_FloatRegister($src1$$reg),
-                   as_FloatRegister($src2$$reg), (int)$cond$$constant);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vmaskcmp_masked(pRegGov dst, vReg src1, vReg src2, immI cond, pRegGov pg, rFlagsReg cr) %{
-  predicate(UseSVE > 0);
-  match(Set dst (VectorMaskCmp (Binary src1 src2) (Binary cond pg)));
-  effect(KILL cr);
-  ins_cost(SVE_COST);
-  format %{ "sve_cmp $dst, $pg, $src1, $src2\t# vector mask cmp (sve)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ sve_compare(as_PRegister($dst$$reg), bt, as_PRegister($pg$$reg), as_FloatRegister($src1$$reg),
-                   as_FloatRegister($src2$$reg), (int)$cond$$constant);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
 // vector blend
 
 instruct vblend(vReg dst, vReg src1, vReg src2, pRegGov pg) %{
@@ -1161,37 +1033,6 @@ instruct vblend(vReg dst, vReg src1, vReg src2, pRegGov pg) %{
                __ elemType_to_regVariant(Matcher::vector_element_basic_type(this));
     __ sve_sel(as_FloatRegister($dst$$reg), size, as_PRegister($pg$$reg),
                as_FloatRegister($src2$$reg), as_FloatRegister($src1$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-// vector load mask
-
-instruct vloadmaskB(pRegGov dst, vReg src, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->bottom_type()->is_vect()->element_basic_type() == T_BYTE);
-  match(Set dst (VectorLoadMask src));
-  effect(KILL cr);
-  ins_cost(SVE_COST);
-  format %{ "vloadmaskB $dst, $src\t# vector load mask (sve) (B)" %}
-  ins_encode %{
-    __ sve_cmp(Assembler::NE, as_PRegister($dst$$reg), __ B,
-               ptrue, as_FloatRegister($src$$reg), 0);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vloadmask_extend(pRegGov dst, vReg src, vReg tmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 && n->bottom_type()->is_vect()->element_basic_type() != T_BYTE);
-  match(Set dst (VectorLoadMask src));
-  effect(TEMP tmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "vloadmask $dst, $src\t# vector load mask (sve) (H/S/D)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    __ sve_vector_extend(as_FloatRegister($tmp$$reg), size, as_FloatRegister($src$$reg), __ B);
-    __ sve_cmp(Assembler::NE, as_PRegister($dst$$reg), size, ptrue, as_FloatRegister($tmp$$reg), 0);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1454,11 +1295,9 @@ dnl REDUCE_I_PREDICATE(insn_name, op_name)
 define(`REDUCE_I_PREDICATE', `
 instruct reduce_$1I_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD tmp, pRegGov pg) %{
   ifelse($2, AddReductionVI,
+       `predicate(UseSVE > 0);',
        `predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);',
-       `predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() != T_LONG &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);')
+            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() != T_LONG);')
   match(Set dst ($2 (Binary src1 src2) pg));
   effect(TEMP_DEF dst, TEMP tmp);
   ins_cost(SVE_COST);
@@ -1477,11 +1316,9 @@ dnl REDUCE_L_PREDICATE(insn_name, op_name)
 define(`REDUCE_L_PREDICATE', `
 instruct reduce_$1L_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegD tmp, pRegGov pg) %{
   ifelse($2, AddReductionVL,
+       `predicate(UseSVE > 0);',
        `predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);',
-       `predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_LONG &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);')
+            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_LONG);')
   match(Set dst ($2 (Binary src1 src2) pg));
   effect(TEMP_DEF dst, TEMP tmp);
   ins_cost(SVE_COST);
@@ -1494,92 +1331,17 @@ instruct reduce_$1L_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegD tmp, pReg
   ins_pipe(pipe_slow);
 %}')dnl
 dnl
-dnl REDUCE_I_PREDICATE_PARTIAL($1,        $2     )
-dnl REDUCE_I_PREDICATE_PARTIAL(insn_name, op_name)
-define(`REDUCE_I_PREDICATE_PARTIAL', `
-instruct reduce_$1I_masked_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD vtmp,
-                                  pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  ifelse($2, AddReductionVI,
-       `predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);',
-       `predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() != T_LONG &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);')
-  match(Set dst ($2 (Binary src1 src2) pg));
-  effect(TEMP_DEF dst, TEMP vtmp, TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_reduce_$1I $dst, $src1, $pg, $src2\t# $1I reduction predicated partial (sve) (may extend)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this, $src2);
-    Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
-                           $src1$$Register, as_FloatRegister($src2$$reg),
-                           as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}')dnl
-dnl
-dnl REDUCE_L_PREDICATE_PARTIAL($1,        $2    )
-dnl REDUCE_L_PREDICATE_PARTIAL(insn_name, op_name)
-define(`REDUCE_L_PREDICATE_PARTIAL', `
-instruct reduce_$1L_masked_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD vtmp,
-                                  pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  ifelse($2, AddReductionVL,
-       `predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);',
-       `predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_LONG &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);')
-  match(Set dst ($2 (Binary src1 src2) pg));
-  effect(TEMP_DEF dst, TEMP vtmp, TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_reduce_$1L $dst, $src1, $pg, $src2\t# $1L reduction predicated partial (sve)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
-                           $src1$$Register, as_FloatRegister($src2$$reg),
-                           as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}')dnl
-dnl
 dnl REDUCE_ADDF_PREDICATE($1,        $2,      $3,      $4  )
 dnl REDUCE_ADDF_PREDICATE(insn_name, op_name, reg_dst, size)
 define(`REDUCE_ADDF_PREDICATE', `
 instruct reduce_$1_masked($3 src1_dst, vReg src2, pRegGov pg) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);
+  predicate(UseSVE > 0);
   match(Set src1_dst ($2 (Binary src1_dst src2) pg));
   ins_cost(SVE_COST);
   format %{ "sve_reduce_$1 $src1_dst, $pg, $src2\t# $1 reduction predicated (sve)" %}
   ins_encode %{
     __ sve_fadda(as_FloatRegister($src1_dst$$reg), __ $4,
                  as_PRegister($pg$$reg), as_FloatRegister($src2$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}')dnl
-dnl
-dnl REDUCE_ADDF_PREDICATE_PARTIAL($1,        $2,      $3,      $4  )
-dnl REDUCE_ADDF_PREDICATE_PARTIAL(insn_name, op_name, reg_dst, size)
-define(`REDUCE_ADDF_PREDICATE_PARTIAL', `
-instruct reduce_$1_masked_partial($3 src1_dst, vReg src2, pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);
-  match(Set src1_dst ($2 (Binary src1_dst src2) pg));
-  effect(TEMP ptmp, KILL cr);
-  ins_cost(SVE_COST);
-  format %{ "sve_reduce_$1 $src1_dst, $pg, $src2\t# $1 reduction predicated partial (sve)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ $4, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_fadda(as_FloatRegister($src1_dst$$reg), __ $4,
-                 as_PRegister($ptmp$$reg), as_FloatRegister($src2$$reg));
   %}
   ins_pipe(pipe_slow);
 %}')dnl
@@ -1600,10 +1362,6 @@ REDUCE_I_PREDICATE(add, AddReductionVI)
 REDUCE_L_PREDICATE(add, AddReductionVL)
 REDUCE_ADDF_PREDICATE(addF, AddReductionVF, vRegF, S)
 REDUCE_ADDF_PREDICATE(addD, AddReductionVD, vRegD, D)
-REDUCE_I_PREDICATE_PARTIAL(add, AddReductionVI)
-REDUCE_L_PREDICATE_PARTIAL(add, AddReductionVL)
-REDUCE_ADDF_PREDICATE_PARTIAL(addF, AddReductionVF, vRegF, S)
-REDUCE_ADDF_PREDICATE_PARTIAL(addD, AddReductionVD, vRegD, D)
 
 // vector and reduction
 REDUCE_I(and, AndReductionV)
@@ -1614,8 +1372,6 @@ REDUCE_L_PARTIAL(and, AndReductionV)
 // vector and reduction - predicated
 REDUCE_I_PREDICATE(and, AndReductionV)
 REDUCE_L_PREDICATE(and, AndReductionV)
-REDUCE_I_PREDICATE_PARTIAL(and, AndReductionV)
-REDUCE_L_PREDICATE_PARTIAL(and, AndReductionV)
 
 // vector or reduction
 REDUCE_I(or, OrReductionV)
@@ -1626,8 +1382,6 @@ REDUCE_L_PARTIAL(or, OrReductionV)
 // vector or reduction - predicated
 REDUCE_I_PREDICATE(or, OrReductionV)
 REDUCE_L_PREDICATE(or, OrReductionV)
-REDUCE_I_PREDICATE_PARTIAL(or, OrReductionV)
-REDUCE_L_PREDICATE_PARTIAL(or, OrReductionV)
 
 // vector xor reduction
 REDUCE_I(eor, XorReductionV)
@@ -1638,8 +1392,6 @@ REDUCE_L_PARTIAL(eor, XorReductionV)
 // vector xor reduction - predicated
 REDUCE_I_PREDICATE(eor, XorReductionV)
 REDUCE_L_PREDICATE(eor, XorReductionV)
-REDUCE_I_PREDICATE_PARTIAL(eor, XorReductionV)
-REDUCE_L_PREDICATE_PARTIAL(eor, XorReductionV)
 
 dnl
 dnl REDUCE_MAXMIN_I($1,        $2     )
@@ -1733,7 +1485,6 @@ define(`REDUCE_MAXMIN_I_PREDICATE', `
 instruct reduce_$1I_masked(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD tmp,
                            pRegGov pg, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize &&
             n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() != T_LONG &&
             is_integral_type(n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type()));
   match(Set dst ($2 (Binary src1 src2) pg));
@@ -1755,7 +1506,6 @@ define(`REDUCE_MAXMIN_L_PREDICATE', `
 instruct reduce_$1L_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegD tmp,
                           pRegGov pg, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize &&
             n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_LONG);
   match(Set dst ($2 (Binary src1 src2) pg));
   effect(TEMP_DEF dst, TEMP tmp, KILL cr);
@@ -1765,55 +1515,6 @@ instruct reduce_$1L_masked(iRegLNoSp dst, iRegL src1, vReg src2, vRegD tmp,
     __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
                            $src1$$Register, as_FloatRegister($src2$$reg),
                            as_PRegister($pg$$reg), as_FloatRegister($tmp$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}')dnl
-dnl
-dnl REDUCE_MAXMIN_I_PREDICATE_PARTIAL($1     , $2     )
-dnl REDUCE_MAXMIN_I_PREDICATE_PARTIAL(min_max, op_name)
-define(`REDUCE_MAXMIN_I_PREDICATE_PARTIAL', `
-instruct reduce_$1I_masked_partial(iRegINoSp dst, iRegIorL2I src1, vReg src2, vRegD vtmp,
-                                  pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() != T_LONG &&
-            is_integral_type(n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type()));
-  match(Set dst ($2 (Binary src1 src2) pg));
-  effect(TEMP_DEF dst, TEMP vtmp, TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_reduce_$1I $dst, $src1, $pg, $src2\t# $1I reduction predicated partial (sve)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this, $src2);
-    Assembler::SIMD_RegVariant variant = __ elemType_to_regVariant(bt);
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), variant, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, bt,
-                           $src1$$Register, as_FloatRegister($src2$$reg),
-                           as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}')dnl
-dnl
-dnl REDUCE_MAXMIN_L_PREDICATE_PARTIAL($1     , $2     )
-dnl REDUCE_MAXMIN_L_PREDICATE_PARTIAL(min_max, op_name)
-define(`REDUCE_MAXMIN_L_PREDICATE_PARTIAL', `
-instruct reduce_$1L_masked_partial(iRegLNoSp dst, iRegL src1, vReg src2, vRegD vtmp,
-                                  pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == T_LONG);
-  match(Set dst ($2 (Binary src1 src2) pg));
-  effect(TEMP_DEF dst, TEMP vtmp, TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_reduce_$1L $dst, $src1, $pg, $src2\t# $1L reduction predicated partial (sve)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_reduce_integral(this->ideal_Opcode(), $dst$$Register, T_LONG,
-                           $src1$$Register, as_FloatRegister($src2$$reg),
-                           as_PRegister($ptmp$$reg), as_FloatRegister($vtmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}')dnl
@@ -1861,8 +1562,7 @@ dnl REDUCE_FMINMAX_PREDICATE(min_max, name_suffix, element_type, size, reg_src_d
 define(`REDUCE_FMINMAX_PREDICATE', `
 instruct reduce_$1$2_masked($5 dst, $5 src1, vReg src2, pRegGov pg) %{
   predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == $3 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);
+            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == $3);
   match(Set dst (translit($1, `m', `M')ReductionV (Binary src1 src2) pg));
   ins_cost(SVE_COST);
   effect(TEMP_DEF dst);
@@ -1874,28 +1574,6 @@ instruct reduce_$1$2_masked($5 dst, $5 src1, vReg src2, pRegGov pg) %{
   ins_pipe(pipe_slow);
 %}')dnl
 dnl
-dnl REDUCE_FMINMAX_PREDICATE_PARTIAL($1,      $2,          $3,           $4,   $5         )
-dnl REDUCE_FMINMAX_PREDICATE_PARTIAL(min_max, name_suffix, element_type, size, reg_src_dst)
-define(`REDUCE_FMINMAX_PREDICATE_PARTIAL', `
-instruct reduce_$1$2_masked_partial($5 dst, $5 src1, vReg src2, pRegGov pg,
-                                    pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->element_basic_type() == $3 &&
-            n->in(1)->in(2)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);
-  match(Set dst (translit($1, `m', `M')ReductionV (Binary src1 src2) pg));
-  effect(TEMP_DEF dst, TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "sve_reduce_$1$2 $dst, $src1, $pg, $src2\t# $1$2 reduction predicated partial (sve)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ $4, Matcher::vector_length(this, $src2));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_f$1v(as_FloatRegister($dst$$reg), __ $4,
-               as_PRegister($ptmp$$reg), as_FloatRegister($src2$$reg));
-    __ f`$1'translit($4, `SD', `sd')(as_FloatRegister($dst$$reg), as_FloatRegister($dst$$reg), as_FloatRegister($src1$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}')dnl
 // vector max reduction
 REDUCE_MAXMIN_I(max, MaxReductionV)
 REDUCE_MAXMIN_L(max, MaxReductionV)
@@ -1909,12 +1587,8 @@ REDUCE_FMINMAX_PARTIAL(max, D, T_DOUBLE, D, vRegD)
 // vector max reduction - predicated
 REDUCE_MAXMIN_I_PREDICATE(max, MaxReductionV)
 REDUCE_MAXMIN_L_PREDICATE(max, MaxReductionV)
-REDUCE_MAXMIN_I_PREDICATE_PARTIAL(max, MaxReductionV)
-REDUCE_MAXMIN_L_PREDICATE_PARTIAL(max, MaxReductionV)
 REDUCE_FMINMAX_PREDICATE(max, F, T_FLOAT,  S, vRegF)
 REDUCE_FMINMAX_PREDICATE(max, D, T_DOUBLE, D, vRegD)
-REDUCE_FMINMAX_PREDICATE_PARTIAL(max, F, T_FLOAT,  S, vRegF)
-REDUCE_FMINMAX_PREDICATE_PARTIAL(max, D, T_DOUBLE, D, vRegD)
 
 // vector min reduction
 REDUCE_MAXMIN_I(min, MinReductionV)
@@ -1929,12 +1603,8 @@ REDUCE_FMINMAX_PARTIAL(min, D, T_DOUBLE, D, vRegD)
 // vector min reduction - predicated
 REDUCE_MAXMIN_I_PREDICATE(min, MinReductionV)
 REDUCE_MAXMIN_L_PREDICATE(min, MinReductionV)
-REDUCE_MAXMIN_I_PREDICATE_PARTIAL(min, MinReductionV)
-REDUCE_MAXMIN_L_PREDICATE_PARTIAL(min, MinReductionV)
 REDUCE_FMINMAX_PREDICATE(min, F, T_FLOAT,  S, vRegF)
 REDUCE_FMINMAX_PREDICATE(min, D, T_DOUBLE, D, vRegD)
-REDUCE_FMINMAX_PREDICATE_PARTIAL(min, F, T_FLOAT,  S, vRegF)
-REDUCE_FMINMAX_PREDICATE_PARTIAL(min, D, T_DOUBLE, D, vRegD)
 
 // vector Math.rint, floor, ceil
 
@@ -2542,7 +2212,6 @@ VECTOR_EXTRACT(D, vRegD,     D, FloatRegister)
 instruct vtest_alltrue(iRegINoSp dst, pRegGov src1, pRegGov src2, pReg ptmp, rFlagsReg cr)
 %{
   predicate(UseSVE > 0 &&
-            n->in(1)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize &&
             static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::overflow);
   match(Set dst (VectorTest src1 src2));
   effect(TEMP ptmp, KILL cr);
@@ -2560,7 +2229,6 @@ instruct vtest_alltrue(iRegINoSp dst, pRegGov src1, pRegGov src2, pReg ptmp, rFl
 instruct vtest_anytrue(iRegINoSp dst, pRegGov src1, pRegGov src2, rFlagsReg cr)
 %{
   predicate(UseSVE > 0 &&
-            n->in(1)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize &&
             static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::ne);
   match(Set dst (VectorTest src1 src2));
   effect(KILL cr);
@@ -2575,33 +2243,6 @@ instruct vtest_anytrue(iRegINoSp dst, pRegGov src1, pRegGov src2, rFlagsReg cr)
   ins_pipe(pipe_slow);
 %}
 dnl
-dnl
-dnl VTEST_PARTIAL($1,      $2,   $3,   $4  )
-dnl VTEST_PARTIAL(op_name, pred, inst, cond)
-define(`VTEST_PARTIAL', `
-instruct vtest_$1_partial`'(iRegINoSp dst, pRegGov src1, pRegGov src2, pRegGov ptmp, rFlagsReg cr)
-%{
-  predicate(UseSVE > 0 &&
-            n->in(1)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize &&
-            static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::$2);
-  match(Set dst (VectorTest src1 src2));
-  effect(TEMP ptmp, KILL cr);
-  ins_cost(SVE_COST);
-  format %{ "vtest_$1_partial $dst, $src1, $src2\t# VectorTest partial (sve) - $1" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this, $src1);
-    Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src1));
-    __ $3(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-          as_PRegister($src1$$reg), as_PRegister($src2$$reg));
-    __ csetw(as_Register($dst$$reg), Assembler::$4);
-  %}
-  ins_pipe(pipe_slow);
-%}')dnl
-dnl
-VTEST_PARTIAL(alltrue, overflow, sve_eors, EQ)
-VTEST_PARTIAL(anytrue, ne,       sve_ands, NE)
-
 // ------------------------------ Vector insert ---------------------------------
 
 instruct insertI_small(vReg dst, vReg src, iRegIorL2I val, immI idx, pRegGov pgtmp, rFlagsReg cr)
@@ -2842,7 +2483,6 @@ instruct gatherL_partial(vReg dst, indirect mem, vReg idx, pRegGov ptmp, rFlagsR
 
 instruct gatherI_masked(vReg dst, indirect mem, vReg idx, pRegGov pg) %{
   predicate(UseSVE > 0 &&
-            n->as_LoadVector()->memory_size() == MaxVectorSize &&
             (n->bottom_type()->is_vect()->element_basic_type() == T_INT ||
              n->bottom_type()->is_vect()->element_basic_type() == T_FLOAT));
   match(Set dst (LoadVectorGatherMasked mem (Binary idx pg)));
@@ -2857,7 +2497,6 @@ instruct gatherI_masked(vReg dst, indirect mem, vReg idx, pRegGov pg) %{
 
 instruct gatherL_masked(vReg dst, indirect mem, vReg idx, pRegGov pg) %{
   predicate(UseSVE > 0 &&
-            n->as_LoadVector()->memory_size() == MaxVectorSize &&
             (n->bottom_type()->is_vect()->element_basic_type() == T_LONG ||
              n->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE));
   match(Set dst (LoadVectorGatherMasked mem (Binary idx pg)));
@@ -2866,47 +2505,6 @@ instruct gatherL_masked(vReg dst, indirect mem, vReg idx, pRegGov pg) %{
   ins_encode %{
     __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
     __ sve_ld1d_gather(as_FloatRegister($dst$$reg), as_PRegister($pg$$reg),
-                       as_Register($mem$$base), as_FloatRegister($idx$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-// ------------------------------ Vector Load Gather Predicated Partial -------------------------------
-
-instruct gatherI_masked_partial(vReg dst, indirect mem, vReg idx, pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->as_LoadVector()->memory_size() < MaxVectorSize &&
-            (n->bottom_type()->is_vect()->element_basic_type() == T_INT ||
-             n->bottom_type()->is_vect()->element_basic_type() == T_FLOAT));
-  match(Set dst (LoadVectorGatherMasked mem (Binary idx pg)));
-  effect(TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "load_vector_gather $dst, $pg, $mem, $idx\t# vector load gather predicated partial (S)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ S, Matcher::vector_length(this));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_ld1w_gather(as_FloatRegister($dst$$reg), as_PRegister($ptmp$$reg),
-                       as_Register($mem$$base), as_FloatRegister($idx$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct gatherL_masked_partial(vReg dst, indirect mem, vReg idx, pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->as_LoadVector()->memory_size() < MaxVectorSize &&
-            (n->bottom_type()->is_vect()->element_basic_type() == T_LONG ||
-             n->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE));
-  match(Set dst (LoadVectorGatherMasked mem (Binary idx pg)));
-  effect(TEMP ptmp, KILL cr);
-  ins_cost(4 * SVE_COST);
-  format %{ "load_vector_gather $dst, $pg, $mem, $idx\t# vector load gather predicated partial (D)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
-    __ sve_ld1d_gather(as_FloatRegister($dst$$reg), as_PRegister($ptmp$$reg),
                        as_Register($mem$$base), as_FloatRegister($idx$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -2986,7 +2584,6 @@ instruct scatterL_partial(indirect mem, vReg src, vReg idx, pRegGov ptmp, rFlags
 
 instruct scatterI_masked(indirect mem, vReg src, vReg idx, pRegGov pg) %{
   predicate(UseSVE > 0 &&
-            n->as_StoreVector()->memory_size() == MaxVectorSize &&
             (n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_INT ||
              n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_FLOAT));
   match(Set mem (StoreVectorScatterMasked mem (Binary src (Binary idx pg))));
@@ -3001,7 +2598,6 @@ instruct scatterI_masked(indirect mem, vReg src, vReg idx, pRegGov pg) %{
 
 instruct scatterL_masked(indirect mem, vReg src, vReg idx, pRegGov pg) %{
   predicate(UseSVE > 0 &&
-            n->as_StoreVector()->memory_size() == MaxVectorSize &&
             (n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_LONG ||
              n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE));
   match(Set mem (StoreVectorScatterMasked mem (Binary src (Binary idx pg))));
@@ -3010,47 +2606,6 @@ instruct scatterL_masked(indirect mem, vReg src, vReg idx, pRegGov pg) %{
   ins_encode %{
     __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
     __ sve_st1d_scatter(as_FloatRegister($src$$reg), as_PRegister($pg$$reg),
-                        as_Register($mem$$base), as_FloatRegister($idx$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-// ------------------------------ Vector Store Scatter Predicated Partial -------------------------------
-
-instruct scatterI_masked_partial(indirect mem, vReg src, vReg idx, pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->as_StoreVector()->memory_size() < MaxVectorSize &&
-            (n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_INT ||
-             n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_FLOAT));
-  match(Set mem (StoreVectorScatterMasked mem (Binary src (Binary idx pg))));
-  effect(TEMP ptmp, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "store_vector_scatter $mem, $pg, $idx, $src\t# vector store scatter predicated partial (S)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ S, Matcher::vector_length(this, $src));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_st1w_scatter(as_FloatRegister($src$$reg), as_PRegister($ptmp$$reg),
-                        as_Register($mem$$base), as_FloatRegister($idx$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct scatterL_masked_partial(indirect mem, vReg src, vReg idx, pRegGov pg, pRegGov ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->as_StoreVector()->memory_size() < MaxVectorSize &&
-            (n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_LONG ||
-             n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE));
-  match(Set mem (StoreVectorScatterMasked mem (Binary src (Binary idx pg))));
-  effect(TEMP ptmp, KILL cr);
-  ins_cost(4 * SVE_COST);
-  format %{ "store_vector_scatter $mem, $pg, $idx, $src\t# vector store scatter predicated partial (D)" %}
-  ins_encode %{
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src));
-    __ sve_and(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg),
-               as_PRegister($pg$$reg), as_PRegister($pg$$reg));
-    __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
-    __ sve_st1d_scatter(as_FloatRegister($src$$reg), as_PRegister($ptmp$$reg),
                         as_Register($mem$$base), as_FloatRegister($idx$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -3097,8 +2652,7 @@ STRING_INDEXOF_CHAR(U, UTF16,  false)
 
 // ---------------------------- Vector mask reductions ---------------------------
 instruct vmask_truecount(iRegINoSp dst, pReg src) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);
+  predicate(UseSVE > 0);
   match(Set dst (VectorMaskTrueCount src));
   ins_cost(SVE_COST);
   format %{ "vmask_truecount $dst, $src\t# vector mask truecount (sve)" %}
@@ -3110,25 +2664,33 @@ instruct vmask_truecount(iRegINoSp dst, pReg src) %{
   ins_pipe(pipe_slow);
 %}
 
+// Return the index of the first mask lane that is set, or vector length if none of
+// them are set.
 instruct vmask_firsttrue(iRegINoSp dst, pReg src, pReg ptmp) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);
+  predicate(UseSVE > 0);
   match(Set dst (VectorMaskFirstTrue src));
   effect(TEMP ptmp);
-  ins_cost(2 * SVE_COST);
+  ins_cost(3 * SVE_COST);
   format %{ "vmask_firsttrue $dst, $src\t# vector mask firsttrue (sve)" %}
   ins_encode %{
+    uint length_in_bytes = Matcher::vector_length_in_bytes(this, $src);
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
     Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    __ sve_brkb(as_PRegister($ptmp$$reg), ptrue, as_PRegister($src$$reg), false);
+    // When the input predicate is all-false, the result should be the vector length
+    // instead of max vector register size.
+    if (length_in_bytes == MaxVectorSize) {
+      __ sve_brkb(as_PRegister($ptmp$$reg), ptrue, as_PRegister($src$$reg), false);
+    } else {
+      __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src));
+      __ sve_brkb(as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg), as_PRegister($src$$reg), false);
+    }
     __ sve_cntp($dst$$Register, size, ptrue, as_PRegister($ptmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
 
 instruct vmask_lasttrue(iRegINoSp dst, pReg src, pReg ptmp) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->bottom_type()->is_vect()->length_in_bytes() == MaxVectorSize);
+  predicate(UseSVE > 0);
   match(Set dst (VectorMaskLastTrue src));
   effect(TEMP ptmp);
   ins_cost(3 * SVE_COST);
@@ -3136,57 +2698,6 @@ instruct vmask_lasttrue(iRegINoSp dst, pReg src, pReg ptmp) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this, $src);
     __ sve_vmask_lasttrue($dst$$Register, bt, as_PRegister($src$$reg), as_PRegister($ptmp$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vmask_truecount_partial(iRegINoSp dst, pReg src, pReg ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);
-  match(Set dst (VectorMaskTrueCount src));
-  effect(TEMP ptmp, KILL cr);
-  ins_cost(2 * SVE_COST);
-  format %{ "vmask_truecount_partial $dst, $src\t# vector mask truecount partial (sve)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this, $src);
-    Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src));
-    __ sve_cntp($dst$$Register, size, as_PRegister($ptmp$$reg), as_PRegister($src$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vmask_firsttrue_partial(iRegINoSp dst, pReg src, pReg ptmp1, pReg ptmp2, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);
-  match(Set dst (VectorMaskFirstTrue src));
-  effect(TEMP ptmp1, TEMP ptmp2, KILL cr);
-  ins_cost(3 * SVE_COST);
-  format %{ "vmask_firsttrue_partial $dst, $src\t# vector mask firsttrue partial (sve)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this, $src);
-    Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp1$$reg), size,
-                          Matcher::vector_length(this, $src));
-    __ sve_brkb(as_PRegister($ptmp2$$reg), as_PRegister($ptmp1$$reg), as_PRegister($src$$reg), false);
-    __ sve_cntp($dst$$Register, size, as_PRegister($ptmp1$$reg), as_PRegister($ptmp2$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vmask_lasttrue_partial(iRegINoSp dst, pReg src, pReg ptmp, rFlagsReg cr) %{
-  predicate(UseSVE > 0 &&
-            n->in(1)->bottom_type()->is_vect()->length_in_bytes() < MaxVectorSize);
-  match(Set dst (VectorMaskLastTrue src));
-  effect(TEMP ptmp, KILL cr);
-  ins_cost(5 * SVE_COST);
-  format %{ "vmask_lasttrue_partial $dst, $src\t# vector mask lasttrue partial (sve)" %}
-  ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this, $src);
-    Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
-    __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), size, Matcher::vector_length(this, $src));
-    __ sve_and(as_PRegister($ptmp$$reg), ptrue, as_PRegister($ptmp$$reg), as_PRegister($src$$reg));
-    __ sve_vmask_lasttrue($dst$$Register, bt, as_PRegister($ptmp$$reg), as_PRegister($ptmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -3206,9 +2717,133 @@ instruct vmask_tolong(iRegLNoSp dst, pReg src, vReg vtmp1, vReg vtmp2, pRegGov p
                         as_PRegister($pgtmp$$reg));
   %}
   ins_pipe(pipe_slow);
-%}dnl
+%}
 
 // ---------------------------- Vector mask generation ---------------------------
+// The rules below set predicate registers. They can guarantee the high bits of dst
+// are cleared with zero when the vector length is less than the full size of
+// hardware vector register width.
+
+define(`MASKALL_IMM', `
+instruct vmaskAll_imm$1(pRegGov dst, imm$1 src) %{
+  predicate(UseSVE > 0);
+  match(Set dst (MaskAll src));
+  ins_cost(SVE_COST);
+  format %{ "sve_ptrue_lanecnt/sve_pfalse $dst\t# mask all (sve) ($2)" %}
+  ins_encode %{
+    ifelse($1, `I', int, long) con = (ifelse($1, `I', int, long))$src$$constant;
+    if (con == 0) {
+      __ sve_pfalse(as_PRegister($dst$$reg));
+    } else {
+      assert(con == -1, "invalid constant value for mask");
+      BasicType bt = Matcher::vector_element_basic_type(this);
+      __ sve_ptrue_lanecnt(as_PRegister($dst$$reg), __ elemType_to_regVariant(bt),
+                           Matcher::vector_length(this));
+    }
+  %}
+  ins_pipe(pipe_slow);
+%}')dnl
+
+define(`MASKALL', `
+instruct vmaskAll$1(pRegGov dst, ifelse($1, `I', iRegIorL2I, iRegL) src, vReg tmp, rFlagsReg cr) %{
+  predicate(UseSVE > 0);
+  match(Set dst (MaskAll src));
+  effect(TEMP tmp, KILL cr);
+  ins_cost(3 * SVE_COST);
+  format %{ "sve_dup $tmp, $src\n\t"
+            "sve_ptrue $dst, vector_length\n\t"
+            "sve_cmpne $dst, $dst, $tmp, 0\t# mask all (sve) ($2)" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
+    uint length_in_bytes = Matcher::vector_length_in_bytes(this);
+    __ sve_dup(as_FloatRegister($tmp$$reg), size, as_Register($src$$reg));
+    if (length_in_bytes < MaxVectorSize) {
+      __ sve_ptrue_lanecnt(as_PRegister($dst$$reg), size, Matcher::vector_length(this));
+      __ sve_cmp(Assembler::NE, as_PRegister($dst$$reg), size,
+                 as_PRegister($dst$$reg), as_FloatRegister($tmp$$reg), 0);
+    } else {
+      __ sve_cmp(Assembler::NE, as_PRegister($dst$$reg), size, ptrue, as_FloatRegister($tmp$$reg), 0);
+    }
+  %}
+  ins_pipe(pipe_slow);
+%}')dnl
+dnl
+// maskAll (full or partial predicate size)
+MASKALL_IMM(I, B/H/S)
+MASKALL(I, B/H/S)
+MASKALL_IMM(L, D)
+MASKALL(L, D)
+
+// vector mask compare
+
+instruct vmaskcmp(pRegGov dst, vReg src1, vReg src2, immI cond, rFlagsReg cr) %{
+  predicate(UseSVE > 0);
+  match(Set dst (VectorMaskCmp (Binary src1 src2) cond));
+  effect(KILL cr);
+  ins_cost(2 * SVE_COST);
+  format %{ "sve_cmp $dst, $src1, $src2\t# vector mask cmp (sve)" %}
+  ins_encode %{
+    uint length_in_bytes = Matcher::vector_length_in_bytes(this);
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    if (length_in_bytes == MaxVectorSize) {
+      __ sve_compare(as_PRegister($dst$$reg), bt, ptrue, as_FloatRegister($src1$$reg),
+                     as_FloatRegister($src2$$reg), (int)$cond$$constant);
+    } else {
+      __ sve_ptrue_lanecnt(as_PRegister($dst$$reg), __ elemType_to_regVariant(bt),
+                           Matcher::vector_length(this));
+      __ sve_compare(as_PRegister($dst$$reg), bt, as_PRegister($dst$$reg), as_FloatRegister($src1$$reg),
+                     as_FloatRegister($src2$$reg), (int)$cond$$constant);
+    }
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmaskcmp_masked(pRegGov dst, vReg src1, vReg src2, immI cond, pRegGov pg, rFlagsReg cr) %{
+  predicate(UseSVE > 0);
+  match(Set dst (VectorMaskCmp (Binary src1 src2) (Binary cond pg)));
+  effect(KILL cr);
+  ins_cost(SVE_COST);
+  format %{ "sve_cmp $dst, $pg, $src1, $src2\t# vector mask cmp (sve)" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ sve_compare(as_PRegister($dst$$reg), bt, as_PRegister($pg$$reg), as_FloatRegister($src1$$reg),
+                   as_FloatRegister($src2$$reg), (int)$cond$$constant);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// vector load mask
+
+instruct vloadmaskB(pRegGov dst, vReg src, rFlagsReg cr) %{
+  predicate(UseSVE > 0 &&
+            n->bottom_type()->is_vect()->element_basic_type() == T_BYTE);
+  match(Set dst (VectorLoadMask src));
+  effect(KILL cr);
+  ins_cost(SVE_COST);
+  format %{ "vloadmaskB $dst, $src\t# vector load mask (sve) (B)" %}
+  ins_encode %{
+    __ sve_cmp(Assembler::NE, as_PRegister($dst$$reg), __ B,
+               ptrue, as_FloatRegister($src$$reg), 0);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vloadmask_extend(pRegGov dst, vReg src, vReg tmp, rFlagsReg cr) %{
+  predicate(UseSVE > 0 && n->bottom_type()->is_vect()->element_basic_type() != T_BYTE);
+  match(Set dst (VectorLoadMask src));
+  effect(TEMP tmp, KILL cr);
+  ins_cost(3 * SVE_COST);
+  format %{ "vloadmask $dst, $src\t# vector load mask (sve) (H/S/D)" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    Assembler::SIMD_RegVariant size = __ elemType_to_regVariant(bt);
+    __ sve_vector_extend(as_FloatRegister($tmp$$reg), size, as_FloatRegister($src$$reg), __ B);
+    __ sve_cmp(Assembler::NE, as_PRegister($dst$$reg), size, ptrue, as_FloatRegister($tmp$$reg), 0);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
 instruct vmask_gen(pRegGov pg, iRegL len, rFlagsReg cr) %{
   predicate(UseSVE > 0);
   match(Set pg (VectorMaskGen len));


### PR DESCRIPTION
Currently there are match rules named as xxx_masked_partial, which are
expected to work on masked vector operations when the vector size is not
the full size of hardware vector reg width, i.e. partial vector. Those
rules will make sure the given masked (predicate) high bits are cleared
with vector width. Actually, for those masked rules with predicate
input, if we can guarantee the input predicate high bits are already
cleared with vector width, we don't need to re-do the clear work before
use. Currently, there are only 4 nodes on AArch64 backend which
initializes (defines) predicate registers:

  1.MaskAllNode
  2.VectorLoadMaskNode
  3.VectorMaskGen
  4.VectorMaskCmp

We can ensure that the predicate register will be well initialized with
proper vector size, so that most of the masked partial rules with a mask
input could be removed.

[TEST]
vector api jtreg tests passed on my SVE testing system.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284125](https://bugs.openjdk.java.net/browse/JDK-8284125): AArch64: Remove partial masked operations for SVE


### Reviewers
 * [Ningsheng Jian](https://openjdk.java.net/census#njian) (@nsjian - Committer)
 * [Nick Gasson](https://openjdk.java.net/census#ngasson) (@nick-arm - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8144/head:pull/8144` \
`$ git checkout pull/8144`

Update a local copy of the PR: \
`$ git checkout pull/8144` \
`$ git pull https://git.openjdk.java.net/jdk pull/8144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8144`

View PR using the GUI difftool: \
`$ git pr show -t 8144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8144.diff">https://git.openjdk.java.net/jdk/pull/8144.diff</a>

</details>
