### PR TITLE
unnecessary volatile for int hash field

### DIFF
--- a/src/java.base/share/classes/sun/util/locale/BaseLocale.java
+++ b/src/java.base/share/classes/sun/util/locale/BaseLocale.java
@@ -97,7 +97,7 @@ public final class BaseLocale {
     private final String region;
     private final String variant;
 
-    private volatile int hash;
+    private int hash;
 
     /**
      * Boolean for the old ISO language code compatibility.


### PR DESCRIPTION
Why can we remove volatile:
- since int is 32 bit we can guarantee atomic read and write on all platforms
- the result of the hash code is always immutable (final field)
- all this will work provided that we read the field once (which we do)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8145/head:pull/8145` \
`$ git checkout pull/8145`

Update a local copy of the PR: \
`$ git checkout pull/8145` \
`$ git pull https://git.openjdk.java.net/jdk pull/8145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8145`

View PR using the GUI difftool: \
`$ git pr show -t 8145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8145.diff">https://git.openjdk.java.net/jdk/pull/8145.diff</a>

</details>
