### PR TITLE
Add microbenchmarks and manually unroll expand implementations

### DIFF
--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -27,6 +27,7 @@ package java.lang;
 
 import jdk.internal.misc.CDS;
 import jdk.internal.misc.VM;
+import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 
 import java.lang.annotation.Native;
@@ -1795,11 +1796,7 @@ public final class Integer extends Number
         for (int j = 0; j < 5; j++) {
             // Parallel prefix
             // Mask prefix identifies bits of the mask that have an odd number of 0's to the right
-            int maskPrefix = maskCount  ^ (maskCount  << 1);
-            maskPrefix = maskPrefix ^ (maskPrefix << 2);
-            maskPrefix = maskPrefix ^ (maskPrefix << 4);
-            maskPrefix = maskPrefix ^ (maskPrefix << 8);
-            maskPrefix = maskPrefix ^ (maskPrefix << 16);
+            int maskPrefix = parallelSuffix(maskCount);
             // Bits to move
             int maskMove = maskPrefix & mask;
             // Compress mask
@@ -1839,51 +1836,52 @@ public final class Integer extends Number
         int maskCount = ~mask << 1;
         int maskPrefix = parallelSuffix(maskCount);
         // Bits to move
-        int part1 = maskPrefix & mask;
+        int maskMove1 = maskPrefix & mask;
         // Compress mask
-        mask = (mask ^ part1) | (part1 >>> (1 << 0));
+        mask = (mask ^ maskMove1) | (maskMove1 >>> (1 << 0));
         maskCount = maskCount & ~maskPrefix;
 
         maskPrefix = parallelSuffix(maskCount);
         // Bits to move
-        int part2 = maskPrefix & mask;
+        int maskMove2 = maskPrefix & mask;
         // Compress mask
-        mask = (mask ^ part2) | (part2 >>> (1 << 1));
+        mask = (mask ^ maskMove2) | (maskMove2 >>> (1 << 1));
         maskCount = maskCount & ~maskPrefix;
 
         maskPrefix = parallelSuffix(maskCount);
         // Bits to move
-        int part3 = maskPrefix & mask;
+        int maskMove3 = maskPrefix & mask;
         // Compress mask
-        mask = (mask ^ part3) | (part3 >>> (1 << 2));
+        mask = (mask ^ maskMove3) | (maskMove3 >>> (1 << 2));
         maskCount = maskCount & ~maskPrefix;
 
         maskPrefix = parallelSuffix(maskCount);
         // Bits to move
-        int part4 = maskPrefix & mask;
+        int maskMove4 = maskPrefix & mask;
         // Compress mask
-        mask = (mask ^ part4) | (part4 >>> (1 << 3));
+        mask = (mask ^ maskMove4) | (maskMove4 >>> (1 << 3));
         maskCount = maskCount & ~maskPrefix;
 
         maskPrefix = parallelSuffix(maskCount);
         // Bits to move
-        int part5 = maskPrefix & mask;
+        int maskMove5 = maskPrefix & mask;
 
         int t = i << (1 << 4);
-        i = (i & ~part5) | (t & part5);
+        i = (i & ~maskMove5) | (t & maskMove5);
         t = i << (1 << 3);
-        i = (i & ~part4) | (t & part4);
+        i = (i & ~maskMove4) | (t & maskMove4);
         t = i << (1 << 2);
-        i = (i & ~part3) | (t & part3);
+        i = (i & ~maskMove3) | (t & maskMove3);
         t = i << (1 << 1);
-        i = (i & ~part2) | (t & part2);
+        i = (i & ~maskMove2) | (t & maskMove2);
         t = i << (1 << 0);
-        i = (i & ~part1) | (t & part1);
+        i = (i & ~maskMove1) | (t & maskMove1);
 
         // Clear irrelevant bits
         return i & originalMask;
     }
 
+    @ForceInline
     private static int parallelSuffix(int maskCount) {
         int maskPrefix = maskCount ^ (maskCount << 1);
         maskPrefix = maskPrefix ^ (maskPrefix << 2);

--- a/src/java.base/share/classes/java/lang/Long.java
+++ b/src/java.base/share/classes/java/lang/Long.java
@@ -2009,7 +2009,7 @@ public final class Long extends Number
         // Bits to move
         long part5 = maskPrefix & mask;
         // Compress mask
-        mask = (mask ^ part4) | (part4 >>> (1 << 4));
+        mask = (mask ^ part5) | (part5 >>> (1 << 4));
         maskCount = maskCount & ~maskPrefix;
 
         maskPrefix = parallelSuffix(maskCount);

--- a/test/micro/org/openjdk/bench/java/lang/Integers.java
+++ b/test/micro/org/openjdk/bench/java/lang/Integers.java
@@ -109,4 +109,20 @@ public class Integers {
             bh.consume(Integer.toString(i));
         }
     }
+
+    /** Performs expand on small values */
+    @Benchmark
+    public void expand(Blackhole bh) {
+        for (int i : intsSmall) {
+            bh.consume(Integer.expand(i, 0xFF00F0F0));
+        }
+    }
+
+    /** Performs compress on large values */
+    @Benchmark
+    public void compress(Blackhole bh) {
+        for (int i : intsBig) {
+            bh.consume(Integer.compress(i, 0x000F0F1F));
+        }
+    }
 }

--- a/test/micro/org/openjdk/bench/java/lang/Longs.java
+++ b/test/micro/org/openjdk/bench/java/lang/Longs.java
@@ -89,6 +89,22 @@ public class Longs {
         }
     }
 
+    /** Performs expand on small values */
+    @Benchmark
+    public void expand(Blackhole bh) {
+        for (long i : longArraySmall) {
+            bh.consume(Long.expand(i, 0xFF00F0F0F0000000L));
+        }
+    }
+
+    /** Performs compress on large values */
+    @Benchmark
+    public void compress(Blackhole bh) {
+        for (long i : longArrayBig) {
+            bh.consume(Long.compress(i, 0x000000000F0F0F1FL));
+        }
+    }
+
     /*
      * Have them public to avoid total unrolling
      */


### PR DESCRIPTION
Possible improvements to #8115, including simple microbenchmarks

The improvement comes from manually unrolling the `expand` implementations, avoiding allocating an array in the process. 

Benchmarks results, #8115 baseline:
```
Benchmark                                         (size)  Mode  Cnt      Score      Error   Units
Integers.expand                                      500  avgt   15      2.708 ±    0.057   us/op
Integers.expand:-gc.alloc.rate.norm                  500  avgt   15  20000.368 ±    0.051    B/op
Longs.expand                                         500  avgt   15      4.032 ±    0.061   us/op
Longs.expand:-gc.alloc.rate.norm                     500  avgt   15  32000.569 ±    0.133    B/op
```

This PR:
```
Benchmark                            (size)  Mode  Cnt   Score    Error   Units
Integers.expand                         500  avgt   15   1.229 ±  0.001   us/op
Longs.expand                            500  avgt   15   1.484 ±  0.001   us/op
```

More efficient intrinsics will make optimizing this moot on some platforms, but it seems this unrolling also improve interpreted performance and thus reduce warmup costs, which will help applications perform better until the intrinsic kicks in:

Baseline, `-Xint`:
```
Benchmark                            (size)  Mode  Cnt      Score   Error   Units
Integers.expand                         500  avgt   15    411.433 ± 1.141   us/op
Longs.expand                            500  avgt   15    596.307 ± 4.337   us/op
```

Experiment, `-Xint`:
```
Benchmark                            (size)  Mode  Cnt    Score    Error   Units
Integers.expand                         500  avgt   15  342.897 ±  6.289   us/op
Longs.expand                            500  avgt   15  490.286 ±  3.468   us/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ Dependency #8115 must be integrated first

### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8146/head:pull/8146` \
`$ git checkout pull/8146`

Update a local copy of the PR: \
`$ git checkout pull/8146` \
`$ git pull https://git.openjdk.java.net/jdk pull/8146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8146`

View PR using the GUI difftool: \
`$ git pr show -t 8146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8146.diff">https://git.openjdk.java.net/jdk/pull/8146.diff</a>

</details>
