### PR TITLE
8284533: Improve InterpreterCodelet data footprint

### DIFF
--- a/src/hotspot/share/interpreter/interpreter.hpp
+++ b/src/hotspot/share/interpreter/interpreter.hpp
@@ -46,11 +46,11 @@ class InterpreterCodelet: public Stub {
   friend class VMStructs;
   friend class CodeCacheDumper; // possible extension [do not remove]
  private:
-  int         _size;                      // the size in bytes
-  const char* _description;               // a description of the codelet, for debugging & printing
-  Bytecodes::Code _bytecode;              // associated bytecode if any
   NOT_PRODUCT(AsmRemarks _asm_remarks;)   // Comments for annotating assembler output.
   NOT_PRODUCT(DbgStrings _dbg_strings;)   // Debug strings used in generated code.
+  const char*     _description;           // A description of the codelet, for debugging & printing
+  int             _size;                  // The codelet size in bytes
+  Bytecodes::Code _bytecode;              // Associated bytecode, if any
 
  public:
   // Initialization/finalization


### PR DESCRIPTION
Current `InterpreterCodelet` lays the fields in inefficient order. Stub generation aligns codelets and their related code at `CodeEntryAlignment` (`CEA`), which means with `CEA=16` we are taking two `CEA` units for `InterpreterCodelet` data. Rearranging the fields a bit improves the interpreter code density a bit, dropping its `sizeof` to 16 and thus taking one `CEA` unit. 

It would be even more important as we tune up stub generation to allow smaller alignments for data sections in the stub, but the effect is visible even now on small `CEA`-s. These small `CEA`-s are default on some platforms (ARM, selected x86 configs).

Size instrumentation on x86_64 release bits:

```
# Before
sizeof: 24
_size: @0
_description: @8
_bytecode: @16

# After
sizeof: 16
_size: @8
_description: @0
_bytecode: @12
```

Interpreter sizes on x86_64 release bits and `-XX:CodeEntryAlignment=16`:

```
# Before
code size        =     92K bytes
avg codelet size =    347 bytes

# After
code size        =     87K bytes
avg codelet size =    331 bytes
```

Point performance run (SPECjvm2008:serial) on x86_64:

```
Before: 73.188 ± 0.113  ops/s
After:  74.952 ± 0.356  ops/s
```

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284533](https://bugs.openjdk.java.net/browse/JDK-8284533): Improve InterpreterCodelet data footprint


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8147/head:pull/8147` \
`$ git checkout pull/8147`

Update a local copy of the PR: \
`$ git checkout pull/8147` \
`$ git pull https://git.openjdk.java.net/jdk pull/8147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8147`

View PR using the GUI difftool: \
`$ git pr show -t 8147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8147.diff">https://git.openjdk.java.net/jdk/pull/8147.diff</a>

</details>
