### PR TITLE
8284532: Memory leak in BitSet::BitMapFragmentTable in JFR leak profiler

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/chains/bitset.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/bitset.cpp
@@ -30,14 +30,14 @@ BitSet::BitMapFragment::BitMapFragment(uintptr_t granule, BitMapFragment* next) 
 }
 
 BitSet::BitMapFragmentTable::~BitMapFragmentTable() {
-    for (int index = 0; index < table_size(); index ++) {
-      Entry* e = bucket(index);
-      while (e != nullptr) {
-        Entry* tmp = e;
-        e = e->next();
-        free_entry(tmp);
-      }
+  for (int index = 0; index < table_size(); index ++) {
+    Entry* e = bucket(index);
+    while (e != nullptr) {
+      Entry* tmp = e;
+      e = e->next();
+      free_entry(tmp);
     }
+  }
 }
 
 BitSet::BitSet() :

--- a/src/hotspot/share/jfr/leakprofiler/chains/bitset.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/bitset.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,18 @@
 BitSet::BitMapFragment::BitMapFragment(uintptr_t granule, BitMapFragment* next) :
     _bits(_bitmap_granularity_size >> LogMinObjAlignmentInBytes, mtTracing, true /* clear */),
     _next(next) {
+}
+
+BitSet::BitMapFragmentTable::~BitMapFragmentTable() {
+    for (int index = 0; index < table_size(); index ++) {
+      Entry* e = bucket(index);
+      while (e != nullptr) {
+        Entry* tmp = e;
+        e = e->next();
+        free_entry(tmp);
+      }
+    }
+    free_buckets();
 }
 
 BitSet::BitSet() :

--- a/src/hotspot/share/jfr/leakprofiler/chains/bitset.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/bitset.cpp
@@ -38,7 +38,6 @@ BitSet::BitMapFragmentTable::~BitMapFragmentTable() {
         free_entry(tmp);
       }
     }
-    free_buckets();
 }
 
 BitSet::BitSet() :

--- a/src/hotspot/share/jfr/leakprofiler/chains/bitset.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/bitset.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,6 +68,7 @@ class BitSet : public CHeapObj<mtTracing> {
 
   public:
     BitMapFragmentTable(int table_size) : BasicHashtable<mtTracing>(table_size, sizeof(Entry)) {}
+    ~BitMapFragmentTable();
     void add(uintptr_t key, CHeapBitMap* value);
     CHeapBitMap** lookup(uintptr_t key);
   };


### PR DESCRIPTION
BitSet::BitMapFragmentTable needs a destructor to cleanup its contents to avoid leaking hashtable entries.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284532](https://bugs.openjdk.java.net/browse/JDK-8284532): Memory leak in BitSet::BitMapFragmentTable in JFR leak profiler


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to 0ae03a26221ab385f72f54be20306c2b9db2e073
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**) ⚠️ Review applies to 0ae03a26221ab385f72f54be20306c2b9db2e073
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to 0ae03a26221ab385f72f54be20306c2b9db2e073


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8148/head:pull/8148` \
`$ git checkout pull/8148`

Update a local copy of the PR: \
`$ git checkout pull/8148` \
`$ git pull https://git.openjdk.java.net/jdk pull/8148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8148`

View PR using the GUI difftool: \
`$ git pr show -t 8148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8148.diff">https://git.openjdk.java.net/jdk/pull/8148.diff</a>

</details>
