### PR TITLE
8284549: JFR: FieldTable leaks FieldInfoTable member

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleWriter.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleWriter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -164,10 +164,6 @@ class FieldTable : public ResourceObj {
 
  public:
   FieldTable() : _table(new FieldInfoTable(this)), _lookup(NULL) {}
-  ~FieldTable() {
-    assert(_table != NULL, "invariant");
-    delete _table;
-  }
 
   traceid store(const ObjectSampleFieldInfo* field_info) {
     assert(field_info != NULL, "invariant");
@@ -178,6 +174,11 @@ class FieldTable : public ResourceObj {
 
   size_t size() const {
     return _table->cardinality();
+  }
+
+  void clear() {
+    assert(_table != NULL, "invariant");
+    delete _table;
   }
 
   template <typename T>
@@ -612,11 +613,6 @@ ObjectSampleWriter::ObjectSampleWriter(JfrCheckpointWriter& writer, EdgeStore* s
   assert(store != NULL, "invariant");
   assert(!store->is_empty(), "invariant");
   register_serializers();
-  sample_infos = NULL;
-  ref_infos = NULL;
-  array_infos = NULL;
-  field_infos = NULL;
-  root_infos = NULL;
 }
 
 ObjectSampleWriter::~ObjectSampleWriter() {
@@ -625,6 +621,15 @@ ObjectSampleWriter::~ObjectSampleWriter() {
   write_array_infos(_writer);
   write_field_infos(_writer);
   write_root_descriptors(_writer);
+
+  if (field_infos != NULL) {
+    field_infos->clear();
+    field_infos = NULL;
+  }
+  sample_infos = NULL;
+  ref_infos = NULL;
+  array_infos = NULL;
+  root_infos = NULL;
 }
 
 bool ObjectSampleWriter::operator()(StoredEdge& e) {


### PR DESCRIPTION
`FieldTable` is a `ResourceObj` and it has a member points to `FieldInfoTable`, which is a `CHeapObj`.

Since ResouceObj's destructor is never called, so it can not depend on `FieldTable`s destructor to  free `FieldInfoTable`, it needs to be freed explicitly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284549](https://bugs.openjdk.java.net/browse/JDK-8284549): JFR: FieldTable leaks FieldInfoTable member


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**) ⚠️ Review applies to 59f866535b89a299a9bd40db225bce5dfcfee1bd
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8149/head:pull/8149` \
`$ git checkout pull/8149`

Update a local copy of the PR: \
`$ git checkout pull/8149` \
`$ git pull https://git.openjdk.java.net/jdk pull/8149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8149`

View PR using the GUI difftool: \
`$ git pr show -t 8149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8149.diff">https://git.openjdk.java.net/jdk/pull/8149.diff</a>

</details>
