### PR TITLE
8284556: Ensure reachability of classes in runtime/whitebox/TestHiddenClassIsAlive.java and serviceability/dcmd/vm/ClassLoaderHierarchyTest.java

### DIFF
--- a/test/hotspot/jtreg/runtime/whitebox/TestHiddenClassIsAlive.java
+++ b/test/hotspot/jtreg/runtime/whitebox/TestHiddenClassIsAlive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.invoke.MethodType;
+import java.lang.ref.Reference;
 
 import sun.hotspot.WhiteBox;
 
@@ -48,7 +49,6 @@ final class MyClass {
 
 public class TestHiddenClassIsAlive {
 
-
     public static void main(String[] args) throws Throwable {
         byte[] classBytes = readClassFile("MyClass.class");
         Lookup lookup = MethodHandles.lookup();
@@ -56,6 +56,7 @@ public class TestHiddenClassIsAlive {
         if (!WhiteBox.getWhiteBox().isClassAlive("MyClass")) {
             throw new RuntimeException("Hidden class should be alive");
         }
+        Reference.reachabilityFence(c);
     }
 
     static byte[] readClassFile(String classFileName) throws Exception {

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/ClassLoaderHierarchyTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/ClassLoaderHierarchyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -44,6 +44,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.lang.ref.Reference;
 
 public class ClassLoaderHierarchyTest {
 
@@ -93,6 +94,10 @@ public class ClassLoaderHierarchyTest {
         output.shouldMatch("Bill.*TestClassLoader");
         output.shouldContain("TestClass2");
         output.shouldContain("Hidden Classes:");
+
+        Reference.reachabilityFence(unnamed_cl);
+        Reference.reachabilityFence(named_cl);
+        Reference.reachabilityFence(named_child_cl);
     }
 
     static class TestClassLoader extends ClassLoader {
@@ -163,4 +168,3 @@ class TestClass2 {
         r.run();
     }
 }
-


### PR DESCRIPTION
Tests are updated to ensure that classes are alive while test checks them.
Actually, fixed by @AlanBateman in repo-loom.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284556](https://bugs.openjdk.java.net/browse/JDK-8284556): Ensure reachability of classes in runtime/whitebox/TestHiddenClassIsAlive.java and serviceability/dcmd/vm/ClassLoaderHierarchyTest.java


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8152/head:pull/8152` \
`$ git checkout pull/8152`

Update a local copy of the PR: \
`$ git checkout pull/8152` \
`$ git pull https://git.openjdk.java.net/jdk pull/8152/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8152`

View PR using the GUI difftool: \
`$ git pr show -t 8152`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8152.diff">https://git.openjdk.java.net/jdk/pull/8152.diff</a>

</details>
