### PR TITLE
8284572: Remove unneeded null check in ReferenceProcessor::discover_reference

### DIFF
--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -828,9 +828,6 @@ inline DiscoveredList* ReferenceProcessor::get_discovered_list(ReferenceType rt)
   // Get the discovered queue to which we will add
   DiscoveredList* list = NULL;
   switch (rt) {
-    case REF_OTHER:
-      // Unknown reference type, no special treatment
-      break;
     case REF_SOFT:
       list = &_discoveredSoftRefs[id];
       break;
@@ -843,6 +840,8 @@ inline DiscoveredList* ReferenceProcessor::get_discovered_list(ReferenceType rt)
     case REF_PHANTOM:
       list = &_discoveredPhantomRefs[id];
       break;
+    case REF_OTHER:
+      // Unknown reference type, impossible
     case REF_NONE:
       // we should not reach here if we are an InstanceRefKlass
     default:
@@ -1036,10 +1035,6 @@ bool ReferenceProcessor::discover_reference(oop obj, ReferenceType rt) {
 
   // Get the right type of discovered queue head.
   DiscoveredList* list = get_discovered_list(rt);
-  if (list == NULL) {
-    return false;   // nothing special needs to be done
-  }
-
   add_to_discovered_list(*list, obj, discovered_addr);
 
   assert(oopDesc::is_oop(obj), "Discovered a bad reference");


### PR DESCRIPTION
Simple change of removing an always-false if-check.

Test: tier1-6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284572](https://bugs.openjdk.java.net/browse/JDK-8284572): Remove unneeded null check in ReferenceProcessor::discover_reference


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8157/head:pull/8157` \
`$ git checkout pull/8157`

Update a local copy of the PR: \
`$ git checkout pull/8157` \
`$ git pull https://git.openjdk.java.net/jdk pull/8157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8157`

View PR using the GUI difftool: \
`$ git pr show -t 8157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8157.diff">https://git.openjdk.java.net/jdk/pull/8157.diff</a>

</details>
