### PR TITLE
8284524: Create an automated test for JDK-4422362

### DIFF
--- a/test/jdk/javax/accessibility/4422362/MaximumAccessibleValueTest.java
+++ b/test/jdk/javax/accessibility/4422362/MaximumAccessibleValueTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key headful
+ * @bug 4422362
+ * @summary Wrong Max Accessible Value with BoundedRangeModel components
+ * @run main MaximumAccessibleValueTest
+ */
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.swing.JProgressBar;
+import javax.swing.JScrollBar;
+import javax.swing.JSlider;
+import javax.swing.SwingUtilities;
+
+public class MaximumAccessibleValueTest {
+    private static JScrollBar jScrollBar;
+    private static JProgressBar jProgressBar;
+    private static JSlider jSlider;
+
+    public static void createGUI() {
+        jScrollBar = new JScrollBar();
+        jProgressBar = new JProgressBar();
+        jSlider = new JSlider();
+    }
+
+    public static void doTest() throws Exception {
+        SwingUtilities.invokeAndWait(() -> createGUI());
+        AtomicBoolean checkMaxValue = new AtomicBoolean();
+
+        SwingUtilities.invokeAndWait(
+            () -> checkMaxValue.set(((Integer) jScrollBar.getAccessibleContext()
+                .getAccessibleValue().getMaximumAccessibleValue())
+                .intValue() != jScrollBar.getMaximum()
+                - jScrollBar.getVisibleAmount()));
+        if (checkMaxValue.get()) {
+            throw new RuntimeException(
+                "Wrong MaximumAccessibleValue returned by JScrollBar");
+        }
+
+        SwingUtilities.invokeAndWait(() -> checkMaxValue.set(
+            ((Integer) jProgressBar.getAccessibleContext().getAccessibleValue()
+                .getMaximumAccessibleValue().intValue()) != (jProgressBar
+                    .getMaximum() - jProgressBar.getModel().getExtent())));
+        if (checkMaxValue.get()) {
+            throw new RuntimeException(
+                "Wrong MaximumAccessibleValue returned by JProgressBar");
+        }
+
+        SwingUtilities.invokeAndWait(() -> checkMaxValue
+            .set(((Integer) jSlider.getAccessibleContext().getAccessibleValue()
+                .getMaximumAccessibleValue()).intValue() != jSlider.getMaximum()
+                - jSlider.getModel().getExtent()));
+        if (checkMaxValue.get()) {
+            throw new RuntimeException(
+                "Wrong MaximumAccessibleValue returned by JSlider");
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        doTest();
+        System.out.println("Test Passed");
+    }
+}
+


### PR DESCRIPTION
Create an automated test for [JDK-4422362](https://bugs.openjdk.java.net/browse/JDK-4422362)

The BoundedRangeModel components (JScrollBar, JSlider, JProgressBar) return
BoundedRangeModel.getMaximum() from getMaximumAccessibleValue() in their
AccessibleValue implementation.
The real maximum value (due to the constraints on BoundedRangeModel) is
model.getMaximum() - model.getExtent().

The test verifies that the above is adhered to as expected.

This review is for migrating tests from a closed test suite to open.

Testing:
The test ran successfully on Mach5 with multiple runs (30) on windows-x64, linux-x64 and macos-x64.