### PR TITLE
8284579: Improve VarHandle checks for interpreter

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
@@ -99,9 +99,7 @@ import java.util.function.BiFunction;
 
     @ForceInline
     boolean checkExactAccessMode(VarHandle.AccessDescriptor ad) {
-        if (exact && accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
-            throwWrongMethodTypeException(ad);
-        }
+        super.checkExactAccessMode(ad);
         // return false to indicate this is an IndirectVarHandle
         return false;
     }

--- a/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
@@ -98,8 +98,8 @@ import java.util.function.BiFunction;
     }
 
     @ForceInline
-    boolean checkExactAccessMode(VarHandle.AccessDescriptor ad) {
-        super.checkExactAccessMode(ad);
+    boolean checkAccessModeThenIsDirect(VarHandle.AccessDescriptor ad) {
+        super.checkAccessModeThenIsDirect(ad);
         // return false to indicate this is an IndirectVarHandle
         return false;
     }

--- a/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
@@ -82,11 +82,6 @@ import java.util.function.BiFunction;
     }
 
     @Override
-    boolean isDirect() {
-        return false;
-    }
-
-    @Override
     VarHandle asDirect() {
         return directTarget;
     }
@@ -100,6 +95,15 @@ import java.util.function.BiFunction;
         return hasInvokeExactBehavior()
             ? this
             : new IndirectVarHandle(target, value, coordinates, handleFactory, vform, true);
+    }
+
+    @ForceInline
+    boolean checkExactAccessMode(VarHandle.AccessDescriptor ad) {
+        if (exact && accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
+            throwWrongMethodTypeException(ad);
+        }
+        // return false to indicate this is an IndirectVarHandle
+        return false;
     }
 
     @Override

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -522,10 +522,6 @@ public abstract sealed class VarHandle implements Constable
         return new UnsupportedOperationException();
     }
 
-    boolean isDirect() {
-        return true;
-    }
-
     VarHandle asDirect() {
         return this;
     }
@@ -2067,24 +2063,29 @@ public abstract sealed class VarHandle implements Constable
     }
 
     @ForceInline
-    final void checkExactAccessMode(VarHandle.AccessDescriptor ad) {
+    boolean checkExactAccessMode(VarHandle.AccessDescriptor ad) {
         if (exact && accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throwWrongMethodTypeException(ad);
         }
+        // return true unless overridden in an IndirectVarHandle
+        return true;
     }
 
     @DontInline
-    private final void throwWrongMethodTypeException(VarHandle.AccessDescriptor ad) {
+    final void throwWrongMethodTypeException(VarHandle.AccessDescriptor ad) {
         throw new WrongMethodTypeException("expected " + accessModeType(ad.type) + " but found "
                 + ad.symbolicMethodTypeExact);
     }
 
     @ForceInline
     final MethodType accessModeType(int accessTypeOrdinal) {
-        TypesAndInvokers tis = getTypesAndInvokers();
-        MethodType mt = tis.methodType_table[accessTypeOrdinal];
+        MethodType[] mtTable = methodTypeTable;
+        if (mtTable == null) {
+            mtTable = methodTypeTable = new MethodType[VarHandle.AccessType.COUNT];
+        }
+        MethodType mt = mtTable[accessTypeOrdinal];
         if (mt == null) {
-            mt = tis.methodType_table[accessTypeOrdinal] =
+            mt = mtTable[accessTypeOrdinal] =
                     accessModeTypeUncached(accessTypeOrdinal);
         }
         return mt;
@@ -2159,34 +2160,24 @@ public abstract sealed class VarHandle implements Constable
     }
 
     @Stable
-    TypesAndInvokers typesAndInvokers;
+    MethodType[] methodTypeTable;
 
-    static class TypesAndInvokers {
-        final @Stable
-        MethodType[] methodType_table = new MethodType[VarHandle.AccessType.COUNT];
-
-        final @Stable
-        MethodHandle[] methodHandle_table = new MethodHandle[AccessMode.COUNT];
-    }
-
-    @ForceInline
-    private final TypesAndInvokers getTypesAndInvokers() {
-        TypesAndInvokers tis = typesAndInvokers;
-        if (tis == null) {
-            tis = typesAndInvokers = new TypesAndInvokers();
-        }
-        return tis;
-    }
+    @Stable
+    MethodHandle[] methodHandleTable;
 
     @ForceInline
     MethodHandle getMethodHandle(int mode) {
-        TypesAndInvokers tis = getTypesAndInvokers();
-        MethodHandle mh = tis.methodHandle_table[mode];
+        MethodHandle[] mhTable = methodHandleTable;
+        if (mhTable == null) {
+            mhTable = methodHandleTable = new MethodHandle[AccessMode.COUNT];
+        }
+        MethodHandle mh = mhTable[mode];
         if (mh == null) {
-            mh = tis.methodHandle_table[mode] = getMethodHandleUncached(mode);
+            mh = mhTable[mode] = getMethodHandleUncached(mode);
         }
         return mh;
     }
+
     private final MethodHandle getMethodHandleUncached(int mode) {
         MethodType mt = accessModeType(AccessMode.values()[mode]).
                 insertParameterTypes(0, VarHandle.class);

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -2070,7 +2070,7 @@ public abstract sealed class VarHandle implements Constable
      *
      * @return true if this is a direct VarHandle, false if it's an indirect
      *         VarHandle.
-     * @throws WrongMethodTypeException if there's a access type mismatch
+     * @throws WrongMethodTypeException if there's an access type mismatch
      */
     @ForceInline
     boolean checkAccessModeThenIsDirect(VarHandle.AccessDescriptor ad) {

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -2062,6 +2062,15 @@ public abstract sealed class VarHandle implements Constable
         return accessModeType(accessMode.at.ordinal());
     }
 
+    /**
+     * Validates that the given access descriptors method type matches up with
+     * the access mode of this VarHandle. This checking and accessor was merged
+     * to slightly improve efficiency during warmup.
+     *
+     * @return true if this is a direct VarHandle, false if it's an indirect
+     *         VarHandle.
+     * @throws WrongMethodTypeException if there's a access type mismatch
+     */
     @ForceInline
     boolean checkAccessModeThenIsDirect(VarHandle.AccessDescriptor ad) {
         if (exact && accessModeType(ad.type) != ad.symbolicMethodTypeExact) {

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -2064,8 +2064,9 @@ public abstract sealed class VarHandle implements Constable
 
     /**
      * Validates that the given access descriptors method type matches up with
-     * the access mode of this VarHandle. This checking and accessor was merged
-     * to slightly improve efficiency during warmup.
+     * the access mode of this VarHandle, then returns if this is a direct
+     * method handle. These operations were grouped together to slightly
+     * improve efficiency during startup/warmup.
      *
      * @return true if this is a direct VarHandle, false if it's an indirect
      *         VarHandle.

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -2063,7 +2063,7 @@ public abstract sealed class VarHandle implements Constable
     }
 
     @ForceInline
-    boolean checkExactAccessMode(VarHandle.AccessDescriptor ad) {
+    boolean checkAccessModeThenIsDirect(VarHandle.AccessDescriptor ad) {
         if (exact && accessModeType(ad.type) != ad.symbolicMethodTypeExact) {
             throwWrongMethodTypeException(ad);
         }
@@ -2072,7 +2072,7 @@ public abstract sealed class VarHandle implements Constable
     }
 
     @DontInline
-    final void throwWrongMethodTypeException(VarHandle.AccessDescriptor ad) {
+    private final void throwWrongMethodTypeException(VarHandle.AccessDescriptor ad) {
         throw new WrongMethodTypeException("expected " + accessModeType(ad.type) + " but found "
                 + ad.symbolicMethodTypeExact);
     }

--- a/src/java.base/share/classes/java/lang/invoke/VarHandleGuards.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandleGuards.java
@@ -34,8 +34,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final Object guard_L_L(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             Object r = MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
             return ad.returnType.cast(r);
         } else {
@@ -48,10 +48,10 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LL_V(VarHandle handle, Object arg0, Object arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
-        } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
+        } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -63,8 +63,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LLL_Z(VarHandle handle, Object arg0, Object arg1, Object arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -76,8 +76,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final Object guard_LLL_L(VarHandle handle, Object arg0, Object arg1, Object arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             Object r = MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
             return ad.returnType.cast(r);
         } else {
@@ -90,8 +90,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final Object guard_LL_L(VarHandle handle, Object arg0, Object arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             Object r = MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
             return ad.returnType.cast(r);
         } else {
@@ -104,8 +104,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_L_I(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -117,10 +117,10 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LI_V(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
-        } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
+        } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -132,8 +132,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LII_Z(VarHandle handle, Object arg0, int arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -145,8 +145,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_LII_I(VarHandle handle, Object arg0, int arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -158,8 +158,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_LI_I(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -171,8 +171,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_L_J(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -184,10 +184,10 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LJ_V(VarHandle handle, Object arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
-        } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
+        } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -199,8 +199,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LJJ_Z(VarHandle handle, Object arg0, long arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -212,8 +212,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_LJJ_J(VarHandle handle, Object arg0, long arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -225,8 +225,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_LJ_J(VarHandle handle, Object arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -238,8 +238,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_L_F(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -251,10 +251,10 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LF_V(VarHandle handle, Object arg0, float arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
-        } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
+        } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -266,8 +266,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LFF_Z(VarHandle handle, Object arg0, float arg1, float arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -279,8 +279,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_LFF_F(VarHandle handle, Object arg0, float arg1, float arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -292,8 +292,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_LF_F(VarHandle handle, Object arg0, float arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -305,8 +305,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_L_D(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -318,10 +318,10 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LD_V(VarHandle handle, Object arg0, double arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
-        } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
+        } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -333,8 +333,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LDD_Z(VarHandle handle, Object arg0, double arg1, double arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -346,8 +346,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_LDD_D(VarHandle handle, Object arg0, double arg1, double arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -359,8 +359,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_LD_D(VarHandle handle, Object arg0, double arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -372,8 +372,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final Object guard__L(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             Object r = MethodHandle.linkToStatic(handle, handle.vform.getMemberName(ad.mode));
             return ad.returnType.cast(r);
         } else {
@@ -386,10 +386,10 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_L_V(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
-        } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
+        } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -401,8 +401,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LL_Z(VarHandle handle, Object arg0, Object arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -414,8 +414,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard__I(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -427,10 +427,10 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_I_V(VarHandle handle, int arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
-        } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
+        } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -442,8 +442,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_II_Z(VarHandle handle, int arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -455,8 +455,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_II_I(VarHandle handle, int arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -468,8 +468,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_I_I(VarHandle handle, int arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -481,8 +481,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard__J(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -494,10 +494,10 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_J_V(VarHandle handle, long arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
-        } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
+        } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -509,8 +509,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_JJ_Z(VarHandle handle, long arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -522,8 +522,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_JJ_J(VarHandle handle, long arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -535,8 +535,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_J_J(VarHandle handle, long arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -548,8 +548,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard__F(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -561,10 +561,10 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_F_V(VarHandle handle, float arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
-        } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
+        } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -576,8 +576,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_FF_Z(VarHandle handle, float arg0, float arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -589,8 +589,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_FF_F(VarHandle handle, float arg0, float arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -602,8 +602,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_F_F(VarHandle handle, float arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -615,8 +615,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard__D(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -628,10 +628,10 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_D_V(VarHandle handle, double arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
-        } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
+        } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -643,8 +643,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_DD_Z(VarHandle handle, double arg0, double arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -656,8 +656,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_DD_D(VarHandle handle, double arg0, double arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -669,8 +669,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_D_D(VarHandle handle, double arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -682,8 +682,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final Object guard_LI_L(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             Object r = MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
             return ad.returnType.cast(r);
         } else {
@@ -696,10 +696,10 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LIL_V(VarHandle handle, Object arg0, int arg1, Object arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
-        } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
+        } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -711,8 +711,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LILL_Z(VarHandle handle, Object arg0, int arg1, Object arg2, Object arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -724,8 +724,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final Object guard_LILL_L(VarHandle handle, Object arg0, int arg1, Object arg2, Object arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             Object r = MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
             return ad.returnType.cast(r);
         } else {
@@ -738,8 +738,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final Object guard_LIL_L(VarHandle handle, Object arg0, int arg1, Object arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             Object r = MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
             return ad.returnType.cast(r);
         } else {
@@ -752,10 +752,10 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LII_V(VarHandle handle, Object arg0, int arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
-        } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
+        } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -767,8 +767,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LIII_Z(VarHandle handle, Object arg0, int arg1, int arg2, int arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -780,8 +780,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_LIII_I(VarHandle handle, Object arg0, int arg1, int arg2, int arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -793,8 +793,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_LI_J(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -806,10 +806,10 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LIJ_V(VarHandle handle, Object arg0, int arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
-        } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
+        } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -821,8 +821,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LIJJ_Z(VarHandle handle, Object arg0, int arg1, long arg2, long arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -834,8 +834,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_LIJJ_J(VarHandle handle, Object arg0, int arg1, long arg2, long arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -847,8 +847,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_LIJ_J(VarHandle handle, Object arg0, int arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -860,8 +860,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_LI_F(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -873,10 +873,10 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LIF_V(VarHandle handle, Object arg0, int arg1, float arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
-        } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
+        } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -888,8 +888,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LIFF_Z(VarHandle handle, Object arg0, int arg1, float arg2, float arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -901,8 +901,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_LIFF_F(VarHandle handle, Object arg0, int arg1, float arg2, float arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -914,8 +914,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_LIF_F(VarHandle handle, Object arg0, int arg1, float arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -927,8 +927,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_LI_D(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -940,10 +940,10 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LID_V(VarHandle handle, Object arg0, int arg1, double arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
-        } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
+        } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -955,8 +955,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LIDD_Z(VarHandle handle, Object arg0, int arg1, double arg2, double arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -968,8 +968,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_LIDD_D(VarHandle handle, Object arg0, int arg1, double arg2, double arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -981,8 +981,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_LID_D(VarHandle handle, Object arg0, int arg1, double arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -994,8 +994,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_LJ_I(VarHandle handle, Object arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -1007,10 +1007,10 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LJI_V(VarHandle handle, Object arg0, long arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
-        } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
+        } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -1022,8 +1022,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LJII_Z(VarHandle handle, Object arg0, long arg1, int arg2, int arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -1035,8 +1035,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_LJII_I(VarHandle handle, Object arg0, long arg1, int arg2, int arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -1048,8 +1048,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_LJI_I(VarHandle handle, Object arg0, long arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -1061,10 +1061,10 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LJJ_V(VarHandle handle, Object arg0, long arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
-        } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
+        } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -1076,8 +1076,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LJJJ_Z(VarHandle handle, Object arg0, long arg1, long arg2, long arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -1089,8 +1089,8 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_LJJJ_J(VarHandle handle, Object arg0, long arg1, long arg2, long arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        handle.checkExactAccessMode(ad);
-        if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+        boolean direct = handle.checkExactAccessMode(ad);
+        if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
             MethodHandle mh = handle.getMethodHandle(ad.mode);

--- a/src/java.base/share/classes/java/lang/invoke/VarHandleGuards.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandleGuards.java
@@ -34,7 +34,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final Object guard_L_L(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             Object r = MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
             return ad.returnType.cast(r);
@@ -48,7 +48,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LL_V(VarHandle handle, Object arg0, Object arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -63,7 +63,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LLL_Z(VarHandle handle, Object arg0, Object arg1, Object arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -76,7 +76,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final Object guard_LLL_L(VarHandle handle, Object arg0, Object arg1, Object arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             Object r = MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
             return ad.returnType.cast(r);
@@ -90,7 +90,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final Object guard_LL_L(VarHandle handle, Object arg0, Object arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             Object r = MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
             return ad.returnType.cast(r);
@@ -104,7 +104,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_L_I(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
@@ -117,7 +117,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LI_V(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -132,7 +132,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LII_Z(VarHandle handle, Object arg0, int arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -145,7 +145,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_LII_I(VarHandle handle, Object arg0, int arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -158,7 +158,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_LI_I(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -171,7 +171,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_L_J(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
@@ -184,7 +184,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LJ_V(VarHandle handle, Object arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -199,7 +199,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LJJ_Z(VarHandle handle, Object arg0, long arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -212,7 +212,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_LJJ_J(VarHandle handle, Object arg0, long arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -225,7 +225,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_LJ_J(VarHandle handle, Object arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -238,7 +238,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_L_F(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
@@ -251,7 +251,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LF_V(VarHandle handle, Object arg0, float arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -266,7 +266,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LFF_Z(VarHandle handle, Object arg0, float arg1, float arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -279,7 +279,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_LFF_F(VarHandle handle, Object arg0, float arg1, float arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -292,7 +292,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_LF_F(VarHandle handle, Object arg0, float arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -305,7 +305,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_L_D(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
@@ -318,7 +318,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LD_V(VarHandle handle, Object arg0, double arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -333,7 +333,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LDD_Z(VarHandle handle, Object arg0, double arg1, double arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -346,7 +346,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_LDD_D(VarHandle handle, Object arg0, double arg1, double arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -359,7 +359,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_LD_D(VarHandle handle, Object arg0, double arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -372,7 +372,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final Object guard__L(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             Object r = MethodHandle.linkToStatic(handle, handle.vform.getMemberName(ad.mode));
             return ad.returnType.cast(r);
@@ -386,7 +386,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_L_V(VarHandle handle, Object arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -401,7 +401,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LL_Z(VarHandle handle, Object arg0, Object arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -414,7 +414,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard__I(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, handle.vform.getMemberName(ad.mode));
         } else {
@@ -427,7 +427,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_I_V(VarHandle handle, int arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -442,7 +442,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_II_Z(VarHandle handle, int arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -455,7 +455,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_II_I(VarHandle handle, int arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -468,7 +468,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_I_I(VarHandle handle, int arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
@@ -481,7 +481,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard__J(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, handle.vform.getMemberName(ad.mode));
         } else {
@@ -494,7 +494,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_J_V(VarHandle handle, long arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -509,7 +509,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_JJ_Z(VarHandle handle, long arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -522,7 +522,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_JJ_J(VarHandle handle, long arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -535,7 +535,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_J_J(VarHandle handle, long arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
@@ -548,7 +548,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard__F(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, handle.vform.getMemberName(ad.mode));
         } else {
@@ -561,7 +561,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_F_V(VarHandle handle, float arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -576,7 +576,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_FF_Z(VarHandle handle, float arg0, float arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -589,7 +589,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_FF_F(VarHandle handle, float arg0, float arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -602,7 +602,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_F_F(VarHandle handle, float arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
@@ -615,7 +615,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard__D(VarHandle handle, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, handle.vform.getMemberName(ad.mode));
         } else {
@@ -628,7 +628,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_D_V(VarHandle handle, double arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -643,7 +643,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_DD_Z(VarHandle handle, double arg0, double arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -656,7 +656,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_DD_D(VarHandle handle, double arg0, double arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -669,7 +669,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_D_D(VarHandle handle, double arg0, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, handle.vform.getMemberName(ad.mode));
         } else {
@@ -682,7 +682,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final Object guard_LI_L(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             Object r = MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
             return ad.returnType.cast(r);
@@ -696,7 +696,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LIL_V(VarHandle handle, Object arg0, int arg1, Object arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -711,7 +711,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LILL_Z(VarHandle handle, Object arg0, int arg1, Object arg2, Object arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -724,7 +724,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final Object guard_LILL_L(VarHandle handle, Object arg0, int arg1, Object arg2, Object arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             Object r = MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
             return ad.returnType.cast(r);
@@ -738,7 +738,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final Object guard_LIL_L(VarHandle handle, Object arg0, int arg1, Object arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             Object r = MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
             return ad.returnType.cast(r);
@@ -752,7 +752,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LII_V(VarHandle handle, Object arg0, int arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -767,7 +767,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LIII_Z(VarHandle handle, Object arg0, int arg1, int arg2, int arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -780,7 +780,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_LIII_I(VarHandle handle, Object arg0, int arg1, int arg2, int arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -793,7 +793,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_LI_J(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -806,7 +806,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LIJ_V(VarHandle handle, Object arg0, int arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -821,7 +821,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LIJJ_Z(VarHandle handle, Object arg0, int arg1, long arg2, long arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -834,7 +834,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_LIJJ_J(VarHandle handle, Object arg0, int arg1, long arg2, long arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -847,7 +847,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_LIJ_J(VarHandle handle, Object arg0, int arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -860,7 +860,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_LI_F(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -873,7 +873,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LIF_V(VarHandle handle, Object arg0, int arg1, float arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -888,7 +888,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LIFF_Z(VarHandle handle, Object arg0, int arg1, float arg2, float arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -901,7 +901,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_LIFF_F(VarHandle handle, Object arg0, int arg1, float arg2, float arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -914,7 +914,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final float guard_LIF_F(VarHandle handle, Object arg0, int arg1, float arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (float) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -927,7 +927,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_LI_D(VarHandle handle, Object arg0, int arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -940,7 +940,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LID_V(VarHandle handle, Object arg0, int arg1, double arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -955,7 +955,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LIDD_Z(VarHandle handle, Object arg0, int arg1, double arg2, double arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -968,7 +968,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_LIDD_D(VarHandle handle, Object arg0, int arg1, double arg2, double arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -981,7 +981,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final double guard_LID_D(VarHandle handle, Object arg0, int arg1, double arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (double) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -994,7 +994,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_LJ_I(VarHandle handle, Object arg0, long arg1, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, arg1, handle.vform.getMemberName(ad.mode));
         } else {
@@ -1007,7 +1007,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LJI_V(VarHandle handle, Object arg0, long arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -1022,7 +1022,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LJII_Z(VarHandle handle, Object arg0, long arg1, int arg2, int arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -1035,7 +1035,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_LJII_I(VarHandle handle, Object arg0, long arg1, int arg2, int arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -1048,7 +1048,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final int guard_LJI_I(VarHandle handle, Object arg0, long arg1, int arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (int) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else {
@@ -1061,7 +1061,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final void guard_LJJ_V(VarHandle handle, Object arg0, long arg1, long arg2, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             MethodHandle.linkToStatic(handle, arg0, arg1, arg2, handle.vform.getMemberName(ad.mode));
         } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -1076,7 +1076,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final boolean guard_LJJJ_Z(VarHandle handle, Object arg0, long arg1, long arg2, long arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (boolean) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {
@@ -1089,7 +1089,7 @@ final class VarHandleGuards {
     @LambdaForm.Compiled
     @Hidden
     static final long guard_LJJJ_J(VarHandle handle, Object arg0, long arg1, long arg2, long arg3, VarHandle.AccessDescriptor ad) throws Throwable {
-        boolean direct = handle.checkExactAccessMode(ad);
+        boolean direct = handle.checkAccessModeThenIsDirect(ad);
         if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
             return (long) MethodHandle.linkToStatic(handle, arg0, arg1, arg2, arg3, handle.vform.getMemberName(ad.mode));
         } else {

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -695,8 +695,8 @@ final class VarHandles {
 //                @LambdaForm.Compiled
 //                @Hidden
 //                static final <METHOD> throws Throwable {
-//                    handle.checkExactAccessMode(ad);
-//                    if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+//                    boolean direct = handle.checkExactAccessMode(ad);
+//                    if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
 //                        <RESULT_ERASED>MethodHandle.linkToStatic(<LINK_TO_STATIC_ARGS>);<RETURN_ERASED>
 //                    } else {
 //                        MethodHandle mh = handle.getMethodHandle(ad.mode);
@@ -710,10 +710,10 @@ final class VarHandles {
 //                @LambdaForm.Compiled
 //                @Hidden
 //                static final <METHOD> throws Throwable {
-//                    handle.checkExactAccessMode(ad);
-//                    if (handle.isDirect() && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
+//                    boolean direct = handle.checkExactAccessMode(ad);
+//                    if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
 //                        MethodHandle.linkToStatic(<LINK_TO_STATIC_ARGS>);
-//                    } else if (handle.isDirect() && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
+//                    } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
 //                        MethodHandle.linkToStatic(<LINK_TO_STATIC_ARGS>);
 //                    } else {
 //                        MethodHandle mh = handle.getMethodHandle(ad.mode);

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -695,7 +695,7 @@ final class VarHandles {
 //                @LambdaForm.Compiled
 //                @Hidden
 //                static final <METHOD> throws Throwable {
-//                    boolean direct = handle.checkExactAccessMode(ad);
+//                    boolean direct = handle.checkAccessModeThenIsDirect(ad);
 //                    if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
 //                        <RESULT_ERASED>MethodHandle.linkToStatic(<LINK_TO_STATIC_ARGS>);<RETURN_ERASED>
 //                    } else {
@@ -710,7 +710,7 @@ final class VarHandles {
 //                @LambdaForm.Compiled
 //                @Hidden
 //                static final <METHOD> throws Throwable {
-//                    boolean direct = handle.checkExactAccessMode(ad);
+//                    boolean direct = handle.checkAccessModeThenIsDirect(ad);
 //                    if (direct && handle.vform.methodType_table[ad.type] == ad.symbolicMethodTypeErased) {
 //                        MethodHandle.linkToStatic(<LINK_TO_STATIC_ARGS>);
 //                    } else if (direct && handle.vform.getMethodType_V(ad.type) == ad.symbolicMethodTypeErased) {
@@ -859,9 +859,6 @@ final class VarHandles {
 //            List<String> LINK_TO_STATIC_ARGS = params.keySet().stream().
 //                    collect(toList());
 //            LINK_TO_STATIC_ARGS.add("handle.vform.getMemberName(ad.mode)");
-//            List<String> LINK_TO_STATIC_ARGS_V = params.keySet().stream().
-//                    collect(toList());
-//            LINK_TO_STATIC_ARGS_V.add("handle.vform.getMemberName_V(ad.mode)");
 //
 //            List<String> LINK_TO_INVOKER_ARGS = params.keySet().stream().
 //                    collect(toList());
@@ -893,8 +890,6 @@ final class VarHandles {
 //                    replace("<RESULT_ERASED>", RESULT_ERASED).
 //                    replace("<RETURN_ERASED>", RETURN_ERASED).
 //                    replaceAll("<LINK_TO_STATIC_ARGS>", LINK_TO_STATIC_ARGS.stream().
-//                            collect(joining(", "))).
-//                    replaceAll("<LINK_TO_STATIC_ARGS_V>", LINK_TO_STATIC_ARGS_V.stream().
 //                            collect(joining(", "))).
 //                    replace("<LINK_TO_INVOKER_ARGS>", LINK_TO_INVOKER_ARGS.stream().
 //                            collect(joining(", ")))


### PR DESCRIPTION
A few additional enhancements aiming to improve VH performance in the interpreter:

- Flatten `TypeAndInvokers`: adds a pointer to `VarHandle` (a small increase 40->48) but removes an object and an indirection on any instance actually used - and might avoid allocating the `MethodHandle[]` unnecessarily on some instances
- Have `checkExactAccessMode` return the directness of the `VarHandle` so that we can avoid some `isDirect` method calls.

Baseline, `-Xint`
```
Benchmark                                 Mode  Cnt    Score   Error  Units
VarHandleExact.exact_exactInvocation      avgt   30  478.324 ? 5.762  ns/op
VarHandleExact.generic_exactInvocation    avgt   30  392.114 ? 1.644  ns/op
VarHandleExact.generic_genericInvocation  avgt   30  822.484 ? 1.865  ns/op
```

Patched, `-Xint`
```
Benchmark                                 Mode  Cnt    Score   Error  Units
VarHandleExact.exact_exactInvocation      avgt   30  437.704 ? 5.320  ns/op
VarHandleExact.generic_exactInvocation    avgt   30  374.512 ? 3.154  ns/op
VarHandleExact.generic_genericInvocation  avgt   30  757.054 ? 1.237  ns/op
```

No significant performance difference in normal mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284579](https://bugs.openjdk.java.net/browse/JDK-8284579): Improve VarHandle checks for interpreter


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to 68f414a14a85dc91ded4863c288a42f8be403cbf
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to 2a4fbd6df78e5b0f2d463f2602016308f641714d


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8160/head:pull/8160` \
`$ git checkout pull/8160`

Update a local copy of the PR: \
`$ git checkout pull/8160` \
`$ git pull https://git.openjdk.java.net/jdk pull/8160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8160`

View PR using the GUI difftool: \
`$ git pr show -t 8160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8160.diff">https://git.openjdk.java.net/jdk/pull/8160.diff</a>

</details>
