### PR TITLE
8284581: Serial: Remove unused GenCollectedHeap::collect_locked

### DIFF
--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -847,12 +847,6 @@ void GenCollectedHeap::collect(GCCause::Cause cause, GenerationType max_generati
   collect_locked(cause, max_generation);
 }
 
-void GenCollectedHeap::collect_locked(GCCause::Cause cause) {
-  // The caller has the Heap_lock
-  assert(Heap_lock->owned_by_self(), "this thread should own the Heap_lock");
-  collect_locked(cause, OldGen);
-}
-
 // this is the private collection interface
 // The Heap_lock is expected to be held on entry.
 

--- a/src/hotspot/share/gc/shared/genCollectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.hpp
@@ -192,9 +192,6 @@ public:
   // supports. Caller does not hold the Heap_lock on entry.
   virtual void collect(GCCause::Cause cause);
 
-  // The same as above but assume that the caller holds the Heap_lock.
-  void collect_locked(GCCause::Cause cause);
-
   // Perform a full collection of generations up to and including max_generation.
   // Mostly used for testing purposes. Caller does not hold the Heap_lock on entry.
   void collect(GCCause::Cause cause, GenerationType max_generation);


### PR DESCRIPTION
Trivial change of removing some dead code.

Test: build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284581](https://bugs.openjdk.java.net/browse/JDK-8284581): Serial: Remove unused GenCollectedHeap::collect_locked


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8163/head:pull/8163` \
`$ git checkout pull/8163`

Update a local copy of the PR: \
`$ git checkout pull/8163` \
`$ git pull https://git.openjdk.java.net/jdk pull/8163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8163`

View PR using the GUI difftool: \
`$ git pr show -t 8163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8163.diff">https://git.openjdk.java.net/jdk/pull/8163.diff</a>

</details>
