### PR TITLE
8283719: java/util/logging/CheckZombieLockTest.java failing intermittently

### DIFF
--- a/test/jdk/java/util/logging/CheckZombieLockTest.java
+++ b/test/jdk/java/util/logging/CheckZombieLockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -241,10 +241,11 @@ public class CheckZombieLockTest {
             }
 
             if (supportsLocking) {
-                FileChannel fc = FileChannel.open(Paths.get(lock.getAbsolutePath()),
+                handler2 = null;
+                try (FileChannel fc = FileChannel.open(Paths.get(lock.getAbsolutePath()),
                     StandardOpenOption.CREATE_NEW, StandardOpenOption.APPEND,
-                    StandardOpenOption.WRITE);
-                try {
+                    StandardOpenOption.WRITE)) {
+
                     if (fc.tryLock() != null) {
                         System.out.println("locked: " + lock);
                         handler2 = createFileHandler(writableDir);
@@ -261,6 +262,7 @@ public class CheckZombieLockTest {
                         throw new RuntimeException("Failed to lock: " + lock);
                     }
                 } finally {
+                    if (handler2 != null) handler2.close();
                     delete(lock);
                 }
             }

--- a/test/jdk/java/util/logging/CheckZombieLockTest.java
+++ b/test/jdk/java/util/logging/CheckZombieLockTest.java
@@ -244,8 +244,7 @@ public class CheckZombieLockTest {
 
             if (supportsLocking) {
                 handler2 = null;
-                try (FileChannel fc = FileChannel.open(Paths.get(lock.getAbsolutePath()),
-                        CREATE_NEW, APPEND, WRITE)) {
+                try (FileChannel fc = FileChannel.open(lock.toPath(), CREATE_NEW, APPEND, WRITE)) {
 
                     if (fc.tryLock() != null) {
                         System.out.println("locked: " + lock);

--- a/test/jdk/java/util/logging/CheckZombieLockTest.java
+++ b/test/jdk/java/util/logging/CheckZombieLockTest.java
@@ -50,6 +50,8 @@ import java.util.UUID;
 import java.util.logging.FileHandler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
+import static java.nio.file.StandardOpenOption.*;
+
 public class CheckZombieLockTest {
 
     private static final String WRITABLE_DIR = "writable-lockfile-dir";
@@ -243,8 +245,7 @@ public class CheckZombieLockTest {
             if (supportsLocking) {
                 handler2 = null;
                 try (FileChannel fc = FileChannel.open(Paths.get(lock.getAbsolutePath()),
-                    StandardOpenOption.CREATE_NEW, StandardOpenOption.APPEND,
-                    StandardOpenOption.WRITE)) {
+                        CREATE_NEW, APPEND, WRITE)) {
 
                     if (fc.tryLock() != null) {
                         System.out.println("locked: " + lock);
@@ -322,17 +323,12 @@ public class CheckZombieLockTest {
 
         // try to determine whether file locking is supported
         final String uniqueFileName = UUID.randomUUID().toString()+".lck";
-        try {
-            FileChannel fc = FileChannel.open(Paths.get(writableDir.getAbsolutePath(),
-                    uniqueFileName),
-                    StandardOpenOption.CREATE_NEW, StandardOpenOption.APPEND,
-                    StandardOpenOption.DELETE_ON_CLOSE);
+        try (FileChannel fc = FileChannel.open(Paths.get(writableDir.getAbsolutePath(),
+                    uniqueFileName), CREATE_NEW, APPEND, DELETE_ON_CLOSE)) {
             try {
                 fc.tryLock();
-            } catch(IOException x) {
+            } catch (IOException x) {
                 supportsLocking = false;
-            } finally {
-                fc.close();
             }
         } catch (IOException t) {
             // should not happen


### PR DESCRIPTION
Please find enclosed a patch for 
`8283719: java/util/logging/CheckZombieLockTest.java failing intermittently`

My analysis is that the test fails intermittently because the `FileChannel` created by the test is garbage collected too early, which releases the associated lock before the `FileHandler` is created.
I have replaced the `try { } finally { }` with a `try-with-resource( ) { } finally { }` which will prevent the `FileChannel` from being released before the end of the block. Additional bonus: this should also help with the code that tries to cleanup the files at the end.

Though I haven't been able to reproduce the exact failure yet, I haven't observed the new version of the test failing either.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283719](https://bugs.openjdk.java.net/browse/JDK-8283719): java/util/logging/CheckZombieLockTest.java failing intermittently


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8168/head:pull/8168` \
`$ git checkout pull/8168`

Update a local copy of the PR: \
`$ git checkout pull/8168` \
`$ git pull https://git.openjdk.java.net/jdk pull/8168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8168`

View PR using the GUI difftool: \
`$ git pr show -t 8168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8168.diff">https://git.openjdk.java.net/jdk/pull/8168.diff</a>

</details>
