### PR TITLE
8284616: Implement workaround for CODETOOLS-7901986 in serviceability/jvmti/RedefineClasses

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineAddLambdaExpression.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineAddLambdaExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@
  * @modules java.compiler
  *          java.instrument
  *          jdk.jartool/sun.tools.jar
+ * @build jdk.test.lib.helpers.ClassFileInstaller jdk.test.lib.compiler.InMemoryJavaCompiler
  * @run main RedefineClassHelper
  * @run main/othervm -javaagent:redefineagent.jar -XX:+AllowRedefinitionToAddDeleteMethods -Xlog:redefine+class*=trace RedefineAddLambdaExpression
  */
@@ -51,18 +52,19 @@ class B {
 
 public class RedefineAddLambdaExpression {
 
-    public static String newB =
-        "class B {" +
-        "    public static int operate(int a, int b, MathOperation mathOperation) {" +
-        "        return mathOperation.operation(a, b);" +
-        "    }" +
-        "    static int test_math(String p) {" +
-        "        MathOperation addition = (int a, int b) -> a + b;" +
-        "        System.out.println(p + \" from class B's test_math method\");" +
-        "        MathOperation subtraction = (int a, int b) -> a - b;" +
-        "        return operate(10, 5, subtraction);" +
-        "    }" +
-        "}";
+    public static String newB = """
+        class B {
+            public static int operate(int a, int b, MathOperation mathOperation) {
+                return mathOperation.operation(a, b);
+            }
+            static int test_math(String p) {
+                MathOperation addition = (int a, int b) -> a + b;
+                System.out.println(p + " from class B's test_math method");
+                MathOperation subtraction = (int a, int b) -> a - b;
+                return operate(10, 5, subtraction);
+            }
+        }
+        """;
 
     public static void main(String[] args) throws Exception {
         int res = B.test_math("Hello");

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineDoubleDelete.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineDoubleDelete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@
  * @modules java.compiler
  *          java.instrument
  *          jdk.jartool/sun.tools.jar
+ * @build jdk.test.lib.helpers.ClassFileInstaller jdk.test.lib.compiler.InMemoryJavaCompiler
  * @run main RedefineClassHelper
  * @run main/othervm/native -Xlog:redefine+class+load+exceptions -agentlib:RedefineDoubleDelete -javaagent:redefineagent.jar RedefineDoubleDelete
  */
@@ -46,15 +47,17 @@ class RedefineDoubleDelete_B {
 public class RedefineDoubleDelete {
 
     // Class gets a redefinition error because it adds a data member
-    public static String newB =
-                "class RedefineDoubleDelete_B {" +
-                "   int count1 = 0;" +
-                "}";
+    public static String newB = """
+                class RedefineDoubleDelete_B {
+                   int count1 = 0;
+                }
+                """;
 
-    public static String newerB =
-                "class RedefineDoubleDelete_B { " +
-                "   int faa() { System.out.println(\"baa\"); return 2; }" +
-                "}";
+    public static String newerB = """
+                class RedefineDoubleDelete_B {
+                   int faa() { System.out.println("baa"); return 2; }
+                }
+                """;
 
     public static void main(String args[]) throws Exception {
 

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineFinalizer.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineFinalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@
  * @modules java.compiler
  *          java.instrument
  *          jdk.jartool/sun.tools.jar
+ * @build jdk.test.lib.helpers.ClassFileInstaller jdk.test.lib.compiler.InMemoryJavaCompiler
  * @run main RedefineClassHelper
  * @run main/othervm -javaagent:redefineagent.jar RedefineFinalizer
  */
@@ -54,12 +55,13 @@ class RedefineFinalizer_B {
 
 public class RedefineFinalizer {
 
-    public static String newB =
-                "class RedefineFinalizer_B {" +
-                "   protected void finalize() { " +
-                "       System.out.println(\"Finalizer called\");" +
-                "   }" +
-                "}";
+    public static String newB = """
+                class RedefineFinalizer_B {
+                    protected void finalize() {
+                        System.out.println("Finalizer called");
+                    }
+                }
+                """;
 
     public static void main(String[] args) throws Exception {
         RedefineClassHelper.redefineClass(RedefineFinalizer_B.class, newB);

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineInterfaceCall.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineInterfaceCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@
  * @modules java.compiler
  *          java.instrument
  *          jdk.jartool/sun.tools.jar
+ * @build jdk.test.lib.helpers.ClassFileInstaller jdk.test.lib.compiler.InMemoryJavaCompiler
  * @run main RedefineClassHelper
  * @run main/othervm -javaagent:redefineagent.jar -Xlog:redefine+class+update*=trace RedefineInterfaceCall
  */
@@ -53,12 +54,13 @@ public class RedefineInterfaceCall {
     static String newI1 =
       "interface I1 { default int m() { return 1; } }";
 
-    static String newC =
-        "class RedefineInterfaceCall_C implements I2 { " +
-        "  public int test(I2 i) { " +
-        "    return i.m(); " +
-        "  } " +
-        "} ";
+    static String newC = """
+        class RedefineInterfaceCall_C implements I2 {
+            public int test(I2 i) {
+                return i.m();
+            }
+        }
+        """;
 
     static int test(I2 i) {
         return i.m(); // invokeinterface cpCacheEntry

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineInterfaceMethods.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineInterfaceMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@
  * @modules java.compiler
  *          java.instrument
  *          jdk.jartool/sun.tools.jar
+ * @build jdk.test.lib.helpers.ClassFileInstaller jdk.test.lib.compiler.InMemoryJavaCompiler
  * @run main RedefineClassHelper
  * @run main/othervm -javaagent:redefineagent.jar -Xlog:redefine+class*=trace RedefineInterfaceMethods
  */
@@ -53,29 +54,31 @@ public class RedefineInterfaceMethods {
 
     static final int RET = -2;
 
-    public static String redefinedPrivateMethod =
-        "interface RedefineInterfaceMethods_B {" +
-        "    int ORIGINAL_RETURN = 1;" +
-        "    int NEW_RETURN = 2;" +
-        "    private int privateMethod() {" +
-        "        return NEW_RETURN;" +
-        "    }" +
-        "    public default int defaultMethod() {" +
-        "       return privateMethod();" +
-        "    }" +
-        "}";
+    public static String redefinedPrivateMethod = """
+        interface RedefineInterfaceMethods_B {
+            int ORIGINAL_RETURN = 1;
+            int NEW_RETURN = 2;
+            private int privateMethod() {
+                return NEW_RETURN;
+            }
+            public default int defaultMethod() {
+                return privateMethod();
+            }
+        }
+        """;
 
-    public static String redefinedDefaultMethod =
-        "interface RedefineInterfaceMethods_B {" +
-        "    int ORIGINAL_RETURN = 1;" +
-        "    int NEW_RETURN = 2;" +
-        "    private int privateMethod() {" +
-        "        return ORIGINAL_RETURN;" +
-        "    }" +
-        "    public default int defaultMethod() {" +
-        "       return RedefineInterfaceMethods.RET;" +
-        "    }" +
-        "}";
+    public static String redefinedDefaultMethod = """
+        interface RedefineInterfaceMethods_B {
+            int ORIGINAL_RETURN = 1;
+            int NEW_RETURN = 2;
+            private int privateMethod() {
+                return ORIGINAL_RETURN;
+            }
+            public default int defaultMethod() {
+                return RedefineInterfaceMethods.RET;
+            }
+        }
+        """;
 
     static class Impl implements RedefineInterfaceMethods_B {
     }

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefinePreviousVersions.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefinePreviousVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,17 +65,19 @@ class RedefinePreviousVersions_Running {
 
 public class RedefinePreviousVersions {
 
-    public static String newB =
-                "class RedefinePreviousVersions_B {" +
-                "}";
+    public static String newB = """
+                class RedefinePreviousVersions_B {
+                }
+                """;
 
-    public static String newRunning =
-        "class RedefinePreviousVersions_Running {" +
-        "    public static volatile boolean stop = true;" +
-        "    public static volatile boolean running = true;" +
-        "    static void localSleep() { }" +
-        "    public static void infinite() { }" +
-        "}";
+    public static String newRunning = """
+        class RedefinePreviousVersions_Running {
+            public static volatile boolean stop = true;
+            public static volatile boolean running = true;
+            static void localSleep() { }
+            public static void infinite() { }
+        }
+        """;
 
     public static void main(String[] args) throws Exception {
 

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRunningMethods.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRunningMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@
  * @modules java.compiler
  *          java.instrument
  *          jdk.jartool/sun.tools.jar
+ * @build jdk.test.lib.helpers.ClassFileInstaller jdk.test.lib.compiler.InMemoryJavaCompiler
  * @run main RedefineClassHelper
  * @run main/othervm/timeout=180 -javaagent:redefineagent.jar -Xlog:redefine+class+iklass+add=trace,redefine+class+iklass+purge=trace,class+loader+data=debug,safepoint+cleanup,gc+phases=debug:rt.log RedefineRunningMethods
  */
@@ -59,41 +60,43 @@ class RedefineRunningMethods_B {
 
 public class RedefineRunningMethods {
 
-    public static String newB =
-                "class RedefineRunningMethods_B {" +
-                "   static int count1 = 0;" +
-                "   static int count2 = 0;" +
-                "   public static volatile boolean stop = false;" +
-                "  static void localSleep() { " +
-                "    try{ " +
-                "      Thread.currentThread().sleep(10);" +
-                "    } catch(InterruptedException ie) { " +
-                "    } " +
-                " } " +
-                "   public static void infinite() { " +
-                "       System.out.println(\"infinite called\");" +
-                "   }" +
-                "   public static void infinite_emcp() { " +
-                "       while (!stop) { count2++; localSleep(); }" +
-                "   }" +
-                "}";
+    public static String newB = """
+                class RedefineRunningMethods_B {
+                    static int count1 = 0;
+                    static int count2 = 0;
+                    public static volatile boolean stop = false;
+                    static void localSleep() {
+                        try {
+                            Thread.currentThread().sleep(10);
+                        } catch(InterruptedException ie) {
+                        }
+                    }
+                    public static void infinite() {
+                        System.out.println("infinite called");
+                    }
+                    public static void infinite_emcp() {
+                        while (!stop) { count2++; localSleep(); }
+                    }
+                }
+                """;
 
-    public static String evenNewerB =
-                "class RedefineRunningMethods_B {" +
-                "   static int count1 = 0;" +
-                "   static int count2 = 0;" +
-                "   public static volatile boolean stop = false;" +
-                "  static void localSleep() { " +
-                "    try{ " +
-                "      Thread.currentThread().sleep(1);" +
-                "    } catch(InterruptedException ie) { " +
-                "    } " +
-                " } " +
-                "   public static void infinite() { }" +
-                "   public static void infinite_emcp() { " +
-                "       System.out.println(\"infinite_emcp now obsolete called\");" +
-                "   }" +
-                "}";
+    public static String evenNewerB = """
+                class RedefineRunningMethods_B {
+                    static int count1 = 0;
+                    static int count2 = 0;
+                    public static volatile boolean stop = false;
+                    static void localSleep() {
+                        try {
+                            Thread.currentThread().sleep(1);
+                        } catch(InterruptedException ie) {
+                        }
+                    }
+                    public static void infinite() { }
+                    public static void infinite_emcp() {
+                        System.out.println("infinite_emcp now obsolete called");
+                    }
+                }
+                """;
 
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRunningMethodsWithBacktrace.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRunningMethodsWithBacktrace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@
  * @modules java.compiler
  *          java.instrument
  *          jdk.jartool/sun.tools.jar
+ * @build jdk.test.lib.helpers.ClassFileInstaller jdk.test.lib.compiler.InMemoryJavaCompiler
  * @run main RedefineClassHelper
  * @run main/othervm -javaagent:redefineagent.jar RedefineRunningMethodsWithBacktrace
  */
@@ -81,41 +82,43 @@ class RedefineRunningMethodsWithBacktrace_B {
 
 public class RedefineRunningMethodsWithBacktrace {
 
-    public static String newB =
-                "class RedefineRunningMethodsWithBacktrace_B {" +
-                "   static int count1 = 0;" +
-                "   static int count2 = 0;" +
-                "   public static volatile boolean stop = false;" +
-                "  static void localSleep() { " +
-                "    try{ " +
-                "      Thread.sleep(10);" +
-                "    } catch(InterruptedException ie) { " +
-                "    } " +
-                " } " +
-                "   public static void infinite() { " +
-                "       System.out.println(\"infinite called\");" +
-                "   }" +
-                "   public static void throwable() { " +
-                "       throw new RuntimeException(\"throwable called\");" +
-                "   }" +
-                "}";
+    public static String newB = """
+                class RedefineRunningMethodsWithBacktrace_B {
+                    static int count1 = 0;
+                    static int count2 = 0;
+                    public static volatile boolean stop = false;
+                    static void localSleep() {
+                        try {
+                            Thread.sleep(10);
+                        } catch(InterruptedException ie) {
+                        }
+                    }
+                    public static void infinite() {
+                        System.out.println("infinite called");
+                    }
+                    public static void throwable() {
+                        throw new RuntimeException("throwable called");
+                    }
+                }
+                """;
 
-    public static String evenNewerB =
-                "class RedefineRunningMethodsWithBacktrace_B {" +
-                "   static int count1 = 0;" +
-                "   static int count2 = 0;" +
-                "   public static volatile boolean stop = false;" +
-                "  static void localSleep() { " +
-                "    try{ " +
-                "      Thread.sleep(1);" +
-                "    } catch(InterruptedException ie) { " +
-                "    } " +
-                " } " +
-                "   public static void infinite() { }" +
-                "   public static void throwable() { " +
-                "       throw new RuntimeException(\"throwable called\");" +
-                "   }" +
-                "}";
+    public static String evenNewerB = """
+                class RedefineRunningMethodsWithBacktrace_B {
+                    static int count1 = 0;
+                    static int count2 = 0;
+                    public static volatile boolean stop = false;
+                    static void localSleep() {
+                        try {
+                            Thread.sleep(1);
+                        } catch(InterruptedException ie) {
+                        }
+                    }
+                    public static void infinite() {}
+                    public static void throwable() {
+                        throw new RuntimeException("throwable called");
+                    }
+                }
+                """;
 
     private static void touchRedefinedMethodInBacktrace(Throwable throwable) {
         System.out.println("touchRedefinedMethodInBacktrace: ");

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineSubtractLambdaExpression.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineSubtractLambdaExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@
  * @modules java.compiler
  *          java.instrument
  *          jdk.jartool/sun.tools.jar
+ * @build jdk.test.lib.helpers.ClassFileInstaller jdk.test.lib.compiler.InMemoryJavaCompiler
  * @run main RedefineClassHelper
  * @run main/othervm -javaagent:redefineagent.jar -XX:+AllowRedefinitionToAddDeleteMethods -Xlog:redefine+class*=trace RedefineSubtractLambdaExpression
  */
@@ -53,16 +54,17 @@ class B {
 
 public class RedefineSubtractLambdaExpression {
 
-    public static String newB =
-        "class B {" +
-        "    public static int operate(int a, int b, MathOperation mathOperation) {" +
-        "        return mathOperation.operation(a, b);" +
-        "    }" +
-        "    static int test_math(String p) {" +
-        "        MathOperation subtraction = (int a, int b) -> a - b;" +
-        "        return operate(10, 5, subtraction);" +
-        "    }" +
-        "}";
+    public static String newB = """
+        class B {
+            public static int operate(int a, int b, MathOperation mathOperation) {
+                return mathOperation.operation(a, b);
+            }
+            static int test_math(String p) {
+                MathOperation subtraction = (int a, int b) -> a - b;
+                return operate(10, 5, subtraction);
+            }
+        }
+        """;
 
     public static void main(String[] args) throws Exception {
         int res = B.test_math("Hello");

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/TestRedefineCondy.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/TestRedefineCondy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@
  *          java.instrument
  *          jdk.jartool/sun.tools.jar
  * @compile RedefineCondy.jasm
+ * @build jdk.test.lib.helpers.ClassFileInstaller jdk.test.lib.compiler.InMemoryJavaCompiler
  * @run main RedefineClassHelper
  * @run main/othervm -javaagent:redefineagent.jar TestRedefineCondy
  */
@@ -43,10 +44,12 @@ import jdk.test.lib.compiler.InMemoryJavaCompiler;
 public class TestRedefineCondy {
 
     static final String DEST = System.getProperty("test.classes");
-    static String newClass =
-        "public class RedefineCondy { " +
-        "public RedefineCondy(java.lang.invoke.MethodHandles.Lookup l, java.lang.String s, java.lang.Class c) { } " +
-    "public static void main(String argv[]) { } } ";
+    static String newClass = """
+        public class RedefineCondy {
+            public RedefineCondy(java.lang.invoke.MethodHandles.Lookup l, java.lang.String s, java.lang.Class c) {}
+            public static void main(String argv[]) {}
+        }
+        """;
 
     public static void main(String[] args) throws Exception  {
         Class<?> classWithCondy = Class.forName("RedefineCondy");


### PR DESCRIPTION
The tests serviceability/jvmti/RedefineClasses start failing in loom-repo with CNFE like "java.lang.NoClassDefFoundError: jdk/test/lib/compiler/InMemoryJavaCompiler"

It is not a loom specific bug, it might happen in jdk/jdk also.

The workaround is to build some classes explicitly. The fix was implemented in repo-loom in Nov 2021 and there was no such failure after the fix in the loom repo.

Also fix inlcudes some text refactoring to make push from loom smaller.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284616](https://bugs.openjdk.java.net/browse/JDK-8284616): Implement workaround for CODETOOLS-7901986 in serviceability/jvmti/RedefineClasses


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8170/head:pull/8170` \
`$ git checkout pull/8170`

Update a local copy of the PR: \
`$ git checkout pull/8170` \
`$ git pull https://git.openjdk.java.net/jdk pull/8170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8170`

View PR using the GUI difftool: \
`$ git pr show -t 8170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8170.diff">https://git.openjdk.java.net/jdk/pull/8170.diff</a>

</details>
