### PR TITLE
8284620: CodeBuffer may leak _overflow_arena

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,10 +133,9 @@ CodeBuffer::~CodeBuffer() {
     // Previous incarnations of this buffer are held live, so that internal
     // addresses constructed before expansions will not be confused.
     cb->free_blob();
+    // free any overflow storage
+    delete cb->_overflow_arena;
   }
-
-  // free any overflow storage
-  delete _overflow_arena;
 
   NOT_PRODUCT(clear_strings());
 
@@ -932,6 +931,7 @@ void CodeBuffer::take_over_code_from(CodeBuffer* cb) {
     this_sect->take_over_code_from(cb_sect);
   }
   _overflow_arena = cb->_overflow_arena;
+  cb->_overflow_arena = NULL;
   // Make sure the old cb won't try to use it or free it.
   DEBUG_ONLY(cb->_blob = (BufferBlob*)badAddress);
 }


### PR DESCRIPTION
`CodeBuffer` is declared as `StackObj`, but it also has `ResourceObj` style `new operator`, to complicate thing further more, it has _overflow_arena that is C Heap allocated.

When Stack allocated `CodeBuffer` owns `_overflow_arena`, it works fine, because its destructor frees `_overflow_arena`. But if resource allocated `CodeBuffer` owns `_overflow_arena`, the arena is leaked, because its destructor is never called.

Test:
- [x] hotspot_compiler on Linux x86_64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284620](https://bugs.openjdk.java.net/browse/JDK-8284620): CodeBuffer may leak _overflow_arena


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8172/head:pull/8172` \
`$ git checkout pull/8172`

Update a local copy of the PR: \
`$ git checkout pull/8172` \
`$ git pull https://git.openjdk.java.net/jdk pull/8172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8172`

View PR using the GUI difftool: \
`$ git pr show -t 8172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8172.diff">https://git.openjdk.java.net/jdk/pull/8172.diff</a>

</details>
