### PR TITLE
8284641: Doc errors in sun.security.ssl.SSLSessionContextImpl

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLSessionContextImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSessionContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import sun.security.util.Cache;
 
 
 /**
- * @systemProperty jdk.tls.server.enableSessionTicketExtension} determines if the
+ * {@systemProperty jdk.tls.server.enableSessionTicketExtension} determines if the
  * server will provide stateless session tickets, if the client supports it,
  * as described in RFC 5077 and RFC 8446.  a stateless session ticket
  * contains the encrypted server's state which saves server resources.
@@ -47,7 +47,7 @@ import sun.security.util.Cache;
  * client will send an extension in the ClientHello in the pre-TLS 1.3.
  * This extension allows the client to accept the server's session state for
  * Server Side stateless resumption (RFC 5077).  Setting the property to
- * "true" turns this on, by default it is false.  For TLS 1.3, the system
+ * "false" turns this off, by default it is true.  For TLS 1.3, the system
  * property is not needed as this support is part of the spec.
  *
  * {@systemProperty jdk.tls.server.sessionTicketTimeout} determines how long


### PR DESCRIPTION
JDK-8228396 turned stateless resumption on by default, but the JavaDoc was not modified accordingly.
And a "{" is missing for @systemProperty jdk.tls.server.enableSessionTicketExtension.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284641](https://bugs.openjdk.java.net/browse/JDK-8284641): Doc errors in sun.security.ssl.SSLSessionContextImpl


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Sibabrata Sahoo](https://openjdk.java.net/census#ssahoo) (@sisahoo - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8173/head:pull/8173` \
`$ git checkout pull/8173`

Update a local copy of the PR: \
`$ git checkout pull/8173` \
`$ git pull https://git.openjdk.java.net/jdk pull/8173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8173`

View PR using the GUI difftool: \
`$ git pr show -t 8173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8173.diff">https://git.openjdk.java.net/jdk/pull/8173.diff</a>

</details>
