### PR TITLE
8284646: Some swing test fail in macos12-aarch64 host

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -733,10 +733,6 @@ javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.ja
 java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64
 java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 8274106 macosx-aarch64
 javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8274106 macosx-aarch64
-javax/swing/text/html/StyleSheet/bug4936917.java 8277816 macosx-aarch64
-javax/swing/plaf/metal/MetalGradient/8163193/ButtonGradientTest.java  8277816 macosx-aarch64
-javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java  8277816 macosx-aarch64
-javax/swing/JInternalFrame/8069348/bug8069348.java 8277816 macosx-aarch64
 java/awt/Robot/HiDPIScreenCapture/ScreenCaptureTest.java  8277816 macosx-aarch64
 java/awt/Robot/CheckCommonColors/CheckCommonColors.java 8277816 macosx-aarch64
 java/awt/ColorClass/AlphaColorTest.java 8277816 macosx-aarch64

--- a/test/jdk/javax/swing/JInternalFrame/8069348/bug8069348.java
+++ b/test/jdk/javax/swing/JInternalFrame/8069348/bug8069348.java
@@ -97,8 +97,11 @@ public class bug8069348 {
             robot.mouseMove(cx, cy);
             robot.waitForIdle();
             Color color = robot.getPixelColor(cx - OFFSET_X, cy - OFFSET_Y);
+            int tolerance = 7;
 
-            if (!FRAME_COLOR.equals(color)) {
+            if ((Math.abs(FRAME_COLOR.getRed() - color.getRed()) > tolerance) ||
+                 (Math.abs(FRAME_COLOR.getBlue() - color.getBlue()) > tolerance) ||
+                 (Math.abs(FRAME_COLOR.getGreen() - color.getGreen()) > tolerance)) {
                 System.out.println("cx " + cx + " cy " + cy);
                 System.err.println("FRAME_COLOR Red: " + FRAME_COLOR.getRed() + "; Green: " + FRAME_COLOR.getGreen() + "; Blue: " + FRAME_COLOR.getBlue());
                 System.err.println("Pixel color Red: " + color.getRed() + "; Green: " + color.getGreen() + "; Blue: " + color.getBlue());

--- a/test/jdk/javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java
+++ b/test/jdk/javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java
@@ -72,7 +72,18 @@ public class JInternalFrameDraggingTest {
             for (int i = 1; i < size; i++) {
                 int rgbCW = img.getRGB(i, size / 2);
                 int rgbCH = img.getRGB(size / 2, i);
-                if (rgbCW != testRGB || rgbCH != testRGB) {
+                int tolerance = 7;
+
+                Color cwCol = new Color(rgbCW);
+                Color chCol = new Color(rgbCH);
+                Color rgbCol = new Color(testRGB);
+                if ((Math.abs(cwCol.getRed() - rgbCol.getRed()) > tolerance) ||
+                   (Math.abs(cwCol.getBlue() - rgbCol.getBlue()) > tolerance) ||
+                   (Math.abs(cwCol.getGreen() - rgbCol.getGreen()) > tolerance) ||
+                   (Math.abs(chCol.getRed() - rgbCol.getRed()) > tolerance) ||
+                   (Math.abs(chCol.getBlue() - rgbCol.getBlue()) > tolerance) ||
+                   (Math.abs(chCol.getGreen() - rgbCol.getGreen()) > tolerance)) {
+
                     System.out.println("i " + i + " rgbCW " +
                                        Integer.toHexString(rgbCW) +
                                        " testRGB " + Integer.toHexString(testRGB) +

--- a/test/jdk/javax/swing/plaf/metal/MetalGradient/8163193/ButtonGradientTest.java
+++ b/test/jdk/javax/swing/plaf/metal/MetalGradient/8163193/ButtonGradientTest.java
@@ -159,6 +159,6 @@ public class ButtonGradientTest {
     }
 
     private static boolean similar(int i1, int i2) {
-        return Math.abs(i2 - i1) < 6;
+        return Math.abs(i2 - i1) < 7;
     }
 }

--- a/test/jdk/javax/swing/text/html/StyleSheet/bug4936917.java
+++ b/test/jdk/javax/swing/text/html/StyleSheet/bug4936917.java
@@ -79,11 +79,16 @@ public class bug4936917 {
         int y = p.y + 15;
         int match = 0;
         int nonmatch = 0;
+        int tolerance = 7;
 
         passed = true;
         for (int x = x0; x < x0 + 10; x++) {
             System.out.println("color ("+x+"," + y +")=" + robot.getPixelColor(x,y));
-            if (!robot.getPixelColor(x, y).equals(new Color(0xcc, 0xcc, 0xcc))) {
+            Color color = robot.getPixelColor(x, y);
+            Color expectedColor = new Color(0xcc, 0xcc, 0xcc);
+            if ((Math.abs(color.getRed() - expectedColor.getRed()) > tolerance) ||
+                (Math.abs(color.getBlue() - expectedColor.getBlue()) > tolerance) ||
+                (Math.abs(color.getGreen() - expectedColor.getGreen()) > tolerance)) {
                 nonmatch++;
             } else match++;
         }


### PR DESCRIPTION
Few tests  are seen to be failing in macos12 M1 system due to slight difference in color as mentioned in [JDK-8277816](https://bugs.openjdk.java.net/browse/JDK-8277816)

It seems the color difference was around 6-7 for swing tests, so these tests are extracted out in this issue and fixed by adding tolerance.
I could not find, in M1 osx12.3 SystemPreferences, any way to set Color Profile to sRGB IEC61966-2.1 Profile so it seems osx12.x M1 use default setting.

Several runs in CI system in all platforms including 12.x M1 pass with this change (test job link in JBS)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8284646](https://bugs.openjdk.java.net/browse/JDK-8284646): Some swing test fail in macos12-aarch64 host


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8176/head:pull/8176` \
`$ git checkout pull/8176`

Update a local copy of the PR: \
`$ git checkout pull/8176` \
`$ git pull https://git.openjdk.java.net/jdk pull/8176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8176`

View PR using the GUI difftool: \
`$ git pr show -t 8176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8176.diff">https://git.openjdk.java.net/jdk/pull/8176.diff</a>

</details>
