### PR TITLE
8273115: CountedLoopEndNode::stride_con crash in debug build with -XX:+TraceLoopOpts

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/TestBadlyFormedCountedLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestBadlyFormedCountedLoop.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8273115
+ * @summary CountedLoopEndNode::stride_con crash in debug build with -XX:+TraceLoopOpts
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+TraceLoopOpts -Xcomp -XX:-TieredCompilation
+ *                   -XX:CompileOnly=TestBadlyFormedCountedLoop.main TestBadlyFormedCountedLoop
+ */
+
+public class TestBadlyFormedCountedLoop {
+    static int y;
+    static int[] A = new int[1];
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10; i+=2) {
+            int k;
+            int j;
+            for (j = 1; (j += 3) < 5; ) {
+                A[0] = 0;
+                for (k = j; k < 5; k++) {
+                    y++;
+                }
+            }
+            y = j;
+        }
+    }
+
+}


### PR DESCRIPTION
The crash occurs because a counted loop has an unexpected shape: the
exit test doesn't depend on a trip count phi. It's similar to a crash
I encountered in (not yet integrated) PR
https://github.com/openjdk/jdk/pull/7823 and fixed with an extra
CastII:
https://github.com/openjdk/jdk/pull/7823/files#diff-6a59f91cb710d682247df87c75faf602f0ff9f87e2855ead1b80719704fbedff

That fix is not sufficient here, though. But the fix I proposed here
works for both.

After the counted loop is created initially, the bounds of the loop
are captured in the iv Phi. Pre/main/post loops are created and the
main loop is unrolled once. CCP next runs and in the process, the type
of the iv Phi of the main loop becomes a constant. The reason is that
as types propagate, the type captured by the iv Phi and the improved
type that's computed by CCP for the Phi are joined and the end result
is a constant. Next the iv Phi constant folds but the exit test
doesn't. This results in a badly shaped counted loop. This happens
because on first unroll, an Opaque2 node is added that hides the type
of the loop limit. I propose adding a CastII to make sure the type of
the new limit (which cannot exceed the initial limit) is not lost.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273115](https://bugs.openjdk.java.net/browse/JDK-8273115): CountedLoopEndNode::stride_con crash in debug build with -XX:+TraceLoopOpts


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8178/head:pull/8178` \
`$ git checkout pull/8178`

Update a local copy of the PR: \
`$ git checkout pull/8178` \
`$ git pull https://git.openjdk.java.net/jdk pull/8178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8178`

View PR using the GUI difftool: \
`$ git pr show -t 8178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8178.diff">https://git.openjdk.java.net/jdk/pull/8178.diff</a>

</details>
