### PR TITLE
8284687: validate-source failure after JDK-8283710

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/chains/jfrbitset.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/jfrbitset.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
A trivial copyright fix to solve validate-source failure after JDK-8283710.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284687](https://bugs.openjdk.java.net/browse/JDK-8284687): validate-source failure after JDK-8283710


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8181/head:pull/8181` \
`$ git checkout pull/8181`

Update a local copy of the PR: \
`$ git checkout pull/8181` \
`$ git pull https://git.openjdk.java.net/jdk pull/8181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8181`

View PR using the GUI difftool: \
`$ git pr show -t 8181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8181.diff">https://git.openjdk.java.net/jdk/pull/8181.diff</a>

</details>
