### PR TITLE
8284689: ProblemList java/lang/Integer/Unsigned.java in -Xcomp mode

### DIFF
--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -27,4 +27,5 @@
 #
 #############################################################################
 
+java/lang/Integer/Unsigned.java 8284635 generic-all
 java/lang/invoke/MethodHandles/CatchExceptionTest.java 8146623 generic-all


### PR DESCRIPTION
A trivial fix to ProblemList java/lang/Integer/Unsigned.java in -Xcomp mode.

We already have more than 20 sightings of this failure in the CI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284689](https://bugs.openjdk.java.net/browse/JDK-8284689): ProblemList java/lang/Integer/Unsigned.java in -Xcomp mode


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8184/head:pull/8184` \
`$ git checkout pull/8184`

Update a local copy of the PR: \
`$ git checkout pull/8184` \
`$ git pull https://git.openjdk.java.net/jdk pull/8184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8184`

View PR using the GUI difftool: \
`$ git pr show -t 8184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8184.diff">https://git.openjdk.java.net/jdk/pull/8184.diff</a>

</details>
