### PR TITLE
8284691: ProblemList javax/swing/JTable/8236907/LastVisibleRow.java on macosx

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -749,6 +749,7 @@ sanity/client/SwingSet/src/ToolTipDemoTest.java 8225012 windows-all,macosx-all
 sanity/client/SwingSet/src/ScrollPaneDemoTest.java 8225013 linux-all
 sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java 8265770 macosx-all
 javax/swing/JTree/4908142/bug4908142.java 8278348 macosx-all
+javax/swing/JTable/8236907/LastVisibleRow.java 8284619 macosx-all
 
 ############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList javax/swing/JTable/8236907/LastVisibleRow.java on macosx.

This new bug was filed late Friday and already has 6 sightings.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284691](https://bugs.openjdk.java.net/browse/JDK-8284691): ProblemList javax/swing/JTable/8236907/LastVisibleRow.java on macosx


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8186/head:pull/8186` \
`$ git checkout pull/8186`

Update a local copy of the PR: \
`$ git checkout pull/8186` \
`$ git pull https://git.openjdk.java.net/jdk pull/8186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8186`

View PR using the GUI difftool: \
`$ git pr show -t 8186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8186.diff">https://git.openjdk.java.net/jdk/pull/8186.diff</a>

</details>
