### PR TITLE
8284680: sun.font.FontConfigManager.getFontConfig() leaks charset

### DIFF
--- a/src/java.desktop/unix/native/common/awt/fontpath.c
+++ b/src/java.desktop/unix/native/common/awt/fontpath.c
@@ -1086,6 +1086,9 @@ Java_sun_font_FontConfigManager_getFontConfig
                 free(file);
                 (*FcPatternDestroy)(pattern);
                 (*FcFontSetDestroy)(fontset);
+                if (prevUnionCharset != NULL) {
+                    (*FcCharSetDestroy)(prevUnionCharset);
+                }
                 closeFontConfig(libfontconfig, JNI_FALSE);
                 if (locale) {
                     (*env)->ReleaseStringUTFChars(env, localeStr, (const char*)locale);


### PR DESCRIPTION
Please review this small patch that releases temporary charsets to avoid memory leak.

Test:

- [x] jdk_2d

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 reviewer, 1 author)

### Issue
 * [JDK-8284680](https://bugs.openjdk.java.net/browse/JDK-8284680): sun.font.FontConfigManager.getFontConfig() leaks charset


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.java.net/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8187/head:pull/8187` \
`$ git checkout pull/8187`

Update a local copy of the PR: \
`$ git checkout pull/8187` \
`$ git pull https://git.openjdk.java.net/jdk pull/8187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8187`

View PR using the GUI difftool: \
`$ git pr show -t 8187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8187.diff">https://git.openjdk.java.net/jdk/pull/8187.diff</a>

</details>
