### PR TITLE
8284635: Crashes after 8282221: assert(ctrl == kit.control()) failed: Control flow was added although the intrinsic bailed out

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2194,31 +2194,32 @@ bool LibraryCallKit::inline_number_methods(vmIntrinsics::ID id) {
 }
 
 //--------------------------inline_unsigned_divmod_methods-----------------------------
-// inline int Integer.divideUnsigned(init, int)
+// inline int Integer.divideUnsigned(int, int)
 // inline int Integer.remainderUnsigned(int, int)
+// inline long Long.divideUnsigned(long, long)
+// inline long Long.remainderUnsigned(long, long)
 bool LibraryCallKit::inline_divmod_methods(vmIntrinsics::ID id) {
   Node* n = NULL;
   switch(id) {
     case vmIntrinsics::_divideUnsigned_i:
       zero_check_int(argument(1));
-      // Compile-time detect of null-exception?
-      if (stopped()) return false;
-      n = new UDivINode(control(), argument(0), argument(1));
-      break;
+      // Compile-time detect of null-exception
+      if (stopped()) return true; // keep the graph constructed so far
+      n = new UDivINode(control(), argument(0), argument(1)); break;
     case vmIntrinsics::_divideUnsigned_l:
       zero_check_long(argument(2));
-      // Compile-time detect of null-exception?
-      if (stopped()) return false;
+      // Compile-time detect of null-exception
+      if (stopped()) return true; // keep the graph constructed so far
       n = new UDivLNode(control(), argument(0), argument(2));  break;
     case vmIntrinsics::_remainderUnsigned_i:
       zero_check_int(argument(1));
-      // Compile-time detect of null-exception?
-      if (stopped()) return false;
+      // Compile-time detect of null-exception
+      if (stopped()) return true; // keep the graph constructed so far
       n = new UModINode(control(), argument(0), argument(1));  break;
     case vmIntrinsics::_remainderUnsigned_l:
       zero_check_long(argument(2));
-      // Compile-time detect of null-exception?
-      if (stopped()) return false;
+      // Compile-time detect of null-exception
+      if (stopped()) return true; // keep the graph constructed so far
       n = new UModLNode(control(), argument(0), argument(2));  break;
     default:  fatal_unexpected_iid(id);  break;
   }

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2200,27 +2200,43 @@ bool LibraryCallKit::inline_number_methods(vmIntrinsics::ID id) {
 // inline long Long.remainderUnsigned(long, long)
 bool LibraryCallKit::inline_divmod_methods(vmIntrinsics::ID id) {
   Node* n = NULL;
-  switch(id) {
-    case vmIntrinsics::_divideUnsigned_i:
+  switch (id) {
+    case vmIntrinsics::_divideUnsigned_i: {
       zero_check_int(argument(1));
       // Compile-time detect of null-exception
-      if (stopped()) return true; // keep the graph constructed so far
-      n = new UDivINode(control(), argument(0), argument(1)); break;
-    case vmIntrinsics::_divideUnsigned_l:
+      if (stopped()) {
+        return true; // keep the graph constructed so far
+      }
+      n = new UDivINode(control(), argument(0), argument(1));
+      break;
+    }
+    case vmIntrinsics::_divideUnsigned_l: {
       zero_check_long(argument(2));
       // Compile-time detect of null-exception
-      if (stopped()) return true; // keep the graph constructed so far
-      n = new UDivLNode(control(), argument(0), argument(2));  break;
-    case vmIntrinsics::_remainderUnsigned_i:
+      if (stopped()) {
+        return true; // keep the graph constructed so far
+      }
+      n = new UDivLNode(control(), argument(0), argument(2));
+      break;
+    }
+    case vmIntrinsics::_remainderUnsigned_i: {
       zero_check_int(argument(1));
       // Compile-time detect of null-exception
-      if (stopped()) return true; // keep the graph constructed so far
-      n = new UModINode(control(), argument(0), argument(1));  break;
-    case vmIntrinsics::_remainderUnsigned_l:
+      if (stopped()) {
+        return true; // keep the graph constructed so far
+      }
+      n = new UModINode(control(), argument(0), argument(1));
+      break;
+    }
+    case vmIntrinsics::_remainderUnsigned_l: {
       zero_check_long(argument(2));
       // Compile-time detect of null-exception
-      if (stopped()) return true; // keep the graph constructed so far
-      n = new UModLNode(control(), argument(0), argument(2));  break;
+      if (stopped()) {
+        return true; // keep the graph constructed so far
+      }
+      n = new UModLNode(control(), argument(0), argument(2));
+      break;
+    }
     default:  fatal_unexpected_iid(id);  break;
   }
   set_result(_gvn.transform(n));

--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -27,5 +27,4 @@
 #
 #############################################################################
 
-java/lang/Integer/Unsigned.java 8284635 generic-all
 java/lang/invoke/MethodHandles/CatchExceptionTest.java 8146623 generic-all


### PR DESCRIPTION
Bug fix for the crashes caused after 8282221.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284635](https://bugs.openjdk.java.net/browse/JDK-8284635): Crashes after 8282221:  assert(ctrl == kit.control()) failed: Control flow was added although the intrinsic bailed out


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8190/head:pull/8190` \
`$ git checkout pull/8190`

Update a local copy of the PR: \
`$ git checkout pull/8190` \
`$ git pull https://git.openjdk.java.net/jdk pull/8190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8190`

View PR using the GUI difftool: \
`$ git pr show -t 8190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8190.diff">https://git.openjdk.java.net/jdk/pull/8190.diff</a>

</details>
