### PR TITLE
8284553: Deprecate the DEFAULT static field of OAEPParameterSpec

### DIFF
--- a/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
+++ b/src/java.base/share/classes/java/security/spec/PSSParameterSpec.java
@@ -112,12 +112,6 @@ public class PSSParameterSpec implements AlgorithmParameterSpec {
         ("SHA-1", "MGF1", MGF1ParameterSpec.SHA1, 20, TRAILER_FIELD_BC);
 
 
-    // disallowed
-    private PSSParameterSpec() {
-        throw new RuntimeException("default constructor not allowed");
-    }
-
-
     /**
      * Creates a new {@code PSSParameterSpec} as defined in
      * the PKCS #1 standard using the specified message digest,

--- a/src/java.base/share/classes/javax/crypto/spec/OAEPParameterSpec.java
+++ b/src/java.base/share/classes/javax/crypto/spec/OAEPParameterSpec.java
@@ -97,7 +97,7 @@ public class OAEPParameterSpec implements AlgorithmParameterSpec {
      * @deprecated This field uses the default values defined in the PKCS #1
      *         standard. Some of these defaults are no longer recommended due
      *         to advances in cryptanalysis -- see the
-     *         <a href="https://www.rfc-editor.org/rfc/rfc8017#appendix-B.1">Appendix B.1</a>
+     *         <a href="https://www.rfc-editor.org/rfc/rfc8017#appendix-B.1">Appendix B.1 of PKCS #1</a>
      *         for more details. Thus, it is recommended to create
      *         a new {@code OAEPParameterSpec} with the desired parameter values
      *         using the
@@ -108,11 +108,6 @@ public class OAEPParameterSpec implements AlgorithmParameterSpec {
     public static final OAEPParameterSpec DEFAULT = new OAEPParameterSpec(
             "SHA-1", "MGF1", MGF1ParameterSpec.SHA1,
             PSource.PSpecified.DEFAULT);
-
-    // disallowed
-    private OAEPParameterSpec() {
-        throw new RuntimeException("default constructor not allowed");
-    }
 
     /**
      * Constructs a parameter set for OAEP padding as defined in

--- a/src/java.base/share/classes/javax/crypto/spec/OAEPParameterSpec.java
+++ b/src/java.base/share/classes/javax/crypto/spec/OAEPParameterSpec.java
@@ -96,7 +96,7 @@ public class OAEPParameterSpec implements AlgorithmParameterSpec {
      *
      * @deprecated This field uses the default values defined in the PKCS #1
      *         standard. Some of these defaults are no longer recommended due
-     *         to advances in cryptanalysis -- see the
+     *         to advances in cryptanalysis -- see
      *         <a href="https://www.rfc-editor.org/rfc/rfc8017#appendix-B.1">Appendix B.1 of PKCS #1</a>
      *         for more details. Thus, it is recommended to create
      *         a new {@code OAEPParameterSpec} with the desired parameter values
@@ -123,7 +123,7 @@ public class OAEPParameterSpec implements AlgorithmParameterSpec {
      * if {@code null} is specified, {@code null} will be returned by
      * {@link #getMGFParameters()}
      * @param pSrc the source of the encoding input P
-     * @exception NullPointerException if {@code mdName},
+     * @throws NullPointerException if {@code mdName},
      * {@code mgfName}, or {@code pSrc} is {@code null}
      */
     public OAEPParameterSpec(String mdName, String mgfName,

--- a/src/java.base/share/classes/javax/crypto/spec/OAEPParameterSpec.java
+++ b/src/java.base/share/classes/javax/crypto/spec/OAEPParameterSpec.java
@@ -88,12 +88,17 @@ public class OAEPParameterSpec implements AlgorithmParameterSpec {
     private final PSource pSrc;
 
     /**
-     * The OAEP parameter set with all default values.
+     * The OAEP parameter set with all default values, i.e. "SHA-1" as message
+     * digest algorithm, "MGF1" as mask generation function (mgf) algorithm,
+     * {@code MGF1ParameterSpec.SHA1} as parameters for the mask generation
+     * function, and {@code PSource.PSpecified.DEFAULT} as the source of the
+     * encoding input.
+     *
      * @deprecated This field uses the default values defined in the PKCS #1
      *         standard. Some of these defaults are no longer recommended due
      *         to advances in cryptanalysis -- see the
-     *         <a href="https://tools.ietf.org/rfc/rfc8017.txt">PKCS#1 v2.2</a>
-     *         standard for more details. Thus, it is recommended to create
+     *         <a href="https://www.rfc-editor.org/rfc/rfc8017#appendix-B.1">Appendix B.1</a>
+     *         for more details. Thus, it is recommended to create
      *         a new {@code OAEPParameterSpec} with the desired parameter values
      *         using the
      *         {@link #OAEPParameterSpec(String, String, AlgorithmParameterSpec, PSource)} constructor.

--- a/src/java.base/share/classes/javax/crypto/spec/OAEPParameterSpec.java
+++ b/src/java.base/share/classes/javax/crypto/spec/OAEPParameterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,13 +72,6 @@ import java.security.spec.MGF1ParameterSpec;
  * }
  * EncodingParameters ::= OCTET STRING(SIZE(0..MAX))
  * </pre>
- * <p>Note: the OAEPParameterSpec.DEFAULT uses the following:
- * <pre>
- *     message digest  -- "SHA-1"
- *     mask generation function (mgf) -- "MGF1"
- *     parameters for mgf -- MGF1ParameterSpec.SHA1
- *     source of encoding input -- PSource.PSpecified.DEFAULT
- * </pre>
  *
  * @see java.security.spec.MGF1ParameterSpec
  * @see PSource
@@ -89,39 +82,49 @@ import java.security.spec.MGF1ParameterSpec;
  */
 public class OAEPParameterSpec implements AlgorithmParameterSpec {
 
-    private String mdName = "SHA-1";
-    private String mgfName = "MGF1";
-    private AlgorithmParameterSpec mgfSpec = MGF1ParameterSpec.SHA1;
-    private PSource pSrc = PSource.PSpecified.DEFAULT;
+    private final String mdName;
+    private final String mgfName;
+    private final AlgorithmParameterSpec mgfSpec;
+    private final PSource pSrc;
 
     /**
      * The OAEP parameter set with all default values.
+     * @deprecated This field uses the default values defined in the PKCS #1
+     *         standard. Some of these defaults are no longer recommended due
+     *         to advances in cryptanalysis -- see the
+     *         <a href="https://tools.ietf.org/rfc/rfc8017.txt">PKCS#1 v2.2</a>
+     *         standard for more details. Thus, it is recommended to create
+     *         a new {@code OAEPParameterSpec} with the desired parameter values
+     *         using the
+     *         {@link #OAEPParameterSpec(String, String, AlgorithmParameterSpec, PSource)} constructor.
+     *
      */
-    public static final OAEPParameterSpec DEFAULT = new OAEPParameterSpec();
+    @Deprecated(since="19")
+    public static final OAEPParameterSpec DEFAULT = new OAEPParameterSpec(
+            "SHA-1", "MGF1", MGF1ParameterSpec.SHA1,
+            PSource.PSpecified.DEFAULT);
 
-    /**
-     * Constructs a parameter set for OAEP padding as defined in
-     * the PKCS #1 standard using the default values.
-     */
+    // disallowed
     private OAEPParameterSpec() {
+        throw new RuntimeException("default constructor not allowed");
     }
 
     /**
      * Constructs a parameter set for OAEP padding as defined in
      * the PKCS #1 standard using the specified message digest
-     * algorithm <code>mdName</code>, mask generation function
-     * algorithm <code>mgfName</code>, parameters for the mask
-     * generation function <code>mgfSpec</code>, and source of
-     * the encoding input P <code>pSrc</code>.
+     * algorithm {@code mdName}, mask generation function
+     * algorithm {@code mgfName}, parameters for the mask
+     * generation function {@code mgfSpec}, and source of
+     * the encoding input P {@code pSrc}.
      *
-     * @param mdName the algorithm name for the message digest.
-     * @param mgfName the algorithm name for the mask generation
-     * function.
-     * @param mgfSpec the parameters for the mask generation function.
-     * If null is specified, null will be returned by getMGFParameters().
-     * @param pSrc the source of the encoding input P.
-     * @exception NullPointerException if <code>mdName</code>,
-     * <code>mgfName</code>, or <code>pSrc</code> is null.
+     * @param mdName the algorithm name for the message digest
+     * @param mgfName the algorithm name for the mask generation function
+     * @param mgfSpec the parameters for the mask generation function;
+     * if {@code null} is specified, {@code null} will be returned by
+     * {@link #getMGFParameters()}
+     * @param pSrc the source of the encoding input P
+     * @exception NullPointerException if {@code mdName},
+     * {@code mgfName}, or {@code pSrc} is {@code null}
      */
     public OAEPParameterSpec(String mdName, String mgfName,
                              AlgorithmParameterSpec mgfSpec,


### PR DESCRIPTION
This trivial change is to deprecate the DEFAULT static field of OAEPParameterSpec class. Wordings are mostly the same as the previous PSSParameterSpec deprecation change. Rest are just minor code re-factoring.

The CSR will be filed once review is somewhat finished.

Thanks,
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8284553](https://bugs.openjdk.java.net/browse/JDK-8284553): Deprecate the DEFAULT static field of OAEPParameterSpec
 * [JDK-8284919](https://bugs.openjdk.java.net/browse/JDK-8284919): Deprecate the DEFAULT static field of OAEPParameterSpec (**CSR**)


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**) ⚠️ Review applies to a760fc5148eaf04cd4b82a738c3315831446735d


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8191/head:pull/8191` \
`$ git checkout pull/8191`

Update a local copy of the PR: \
`$ git checkout pull/8191` \
`$ git pull https://git.openjdk.java.net/jdk pull/8191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8191`

View PR using the GUI difftool: \
`$ git pr show -t 8191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8191.diff">https://git.openjdk.java.net/jdk/pull/8191.diff</a>

</details>
