### PR TITLE
8284702: Add @since for java.time.LocalDate.EPOCH

### DIFF
--- a/src/java.base/share/classes/java/time/LocalDate.java
+++ b/src/java.base/share/classes/java/time/LocalDate.java
@@ -152,6 +152,8 @@ public final class LocalDate
     public static final LocalDate MAX = LocalDate.of(Year.MAX_VALUE, 12, 31);
     /**
      * The epoch year {@code LocalDate}, '1970-01-01'.
+     *
+     * @since 9
      */
     public static final LocalDate EPOCH = LocalDate.of(1970, 1, 1);
 


### PR DESCRIPTION
`java.time.LocalDate.EPOCH` was introduced in Java 9, but there is no corresponding `@since` in the javadoc. The absence of `@since` makes it impossible for IDEs to check for misuse of it, it may be misused by users targeting Java 8 and crash at runtime.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284702](https://bugs.openjdk.java.net/browse/JDK-8284702): Add @since for java.time.LocalDate.EPOCH


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * @ice1000 (no known github.com user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8192/head:pull/8192` \
`$ git checkout pull/8192`

Update a local copy of the PR: \
`$ git checkout pull/8192` \
`$ git pull https://git.openjdk.java.net/jdk pull/8192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8192`

View PR using the GUI difftool: \
`$ git pr show -t 8192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8192.diff">https://git.openjdk.java.net/jdk/pull/8192.diff</a>

</details>
