### PR TITLE
8284720: IntelliJ: JIRA integration

### DIFF
--- a/make/ide/idea/jdk/template/vcs.xml
+++ b/make/ide/idea/jdk/template/vcs.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="IssueNavigationConfiguration">
+    <option name="links">
+      <list>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="\d{7}" />
+          <option name="linkRegexp" value="https://bugs.openjdk.java.net/browse/JDK-$0" />
+        </IssueNavigationLink>
+      </list>
+    </option>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="###ROOT_DIR###" vcs="###VCS_TYPE###" />
   </component>


### PR DESCRIPTION
This patch adds clickable link to commit messages in IntelliJ's git log. Example result:
![image](https://user-images.githubusercontent.com/30433125/162882312-6a9c7666-075d-47b7-9db5-22670b885e7b.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284720](https://bugs.openjdk.java.net/browse/JDK-8284720): IntelliJ: JIRA integration


### Reviewers
 * @stsypanov (no known github.com user name / role)
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8193/head:pull/8193` \
`$ git checkout pull/8193`

Update a local copy of the PR: \
`$ git checkout pull/8193` \
`$ git pull https://git.openjdk.java.net/jdk pull/8193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8193`

View PR using the GUI difftool: \
`$ git pr show -t 8193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8193.diff">https://git.openjdk.java.net/jdk/pull/8193.diff</a>

</details>
