### PR TITLE
JDK-8284726: Print active locale settings in hs_err reports and in VM.info

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -53,6 +53,7 @@
 #include <dirent.h>
 #include <dlfcn.h>
 #include <grp.h>
+#include <locale.h>
 #include <netdb.h>
 #include <pwd.h>
 #include <pthread.h>
@@ -548,6 +549,32 @@ void os::Posix::print_user_info(outputStream* st) {
   st->cr();
 }
 
+// Print all active locale categories, one line each
+void os::Posix::print_active_locale(outputStream* st) {
+  // Posix is quiet about how exactly LC_ALL is implemented.
+  // Just print it out too, in case LC_ALL is held separately
+  // from the individual categories.
+  #define LOCALE_CAT_DO(f) \
+    f(LC_ALL) \
+    f(LC_COLLATE) \
+    f(LC_CTYPE) \
+    f(LC_MESSAGES) \
+    f(LC_MONETARY) \
+    f(LC_NUMERIC) \
+    f(LC_TIME)
+  #define XX(cat) { cat, #cat },
+  const struct { int c; const char* name; } categories[] = {
+      LOCALE_CAT_DO(XX)
+      { -1, NULL }
+  };
+  #undef XX
+  #undef LOCALE_CAT_DO
+  for (int i = 0; categories[i].c != -1; i ++) {
+    const char* locale = setlocale(categories[i].c, NULL);
+    st->print_cr("%s=%s", categories[i].name,
+                 ((locale != NULL) ? locale : ""));
+  }
+}
 
 bool os::get_host_name(char* buf, size_t buflen) {
   struct utsname name;

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -551,6 +551,7 @@ void os::Posix::print_user_info(outputStream* st) {
 
 // Print all active locale categories, one line each
 void os::Posix::print_active_locale(outputStream* st) {
+  st->print_cr("Active Locale:");
   // Posix is quiet about how exactly LC_ALL is implemented.
   // Just print it out too, in case LC_ALL is held separately
   // from the individual categories.
@@ -572,7 +573,7 @@ void os::Posix::print_active_locale(outputStream* st) {
   for (int i = 0; categories[i].c != -1; i ++) {
     const char* locale = setlocale(categories[i].c, NULL);
     st->print_cr("%s=%s", categories[i].name,
-                 ((locale != NULL) ? locale : ""));
+                 ((locale != NULL) ? locale : "<unknown>"));
   }
 }
 

--- a/src/hotspot/os/posix/os_posix.hpp
+++ b/src/hotspot/os/posix/os_posix.hpp
@@ -104,6 +104,8 @@ public:
   static bool handle_stack_overflow(JavaThread* thread, address addr, address pc,
                                     const void* ucVoid,
                                     address* stub);
+
+  static void print_active_locale(outputStream* st);
 };
 
 /*

--- a/src/hotspot/os/posix/os_posix.hpp
+++ b/src/hotspot/os/posix/os_posix.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1139,6 +1139,15 @@ void VMError::report(outputStream* st, bool _verbose) {
        st->cr();
      }
 
+#ifndef _WIN32
+  STEP("printing locale settings")
+
+     if (_verbose) {
+       os::Posix::print_active_locale(st);
+       st->cr();
+     }
+#endif
+
   STEP("printing signal handlers")
 
      if (_verbose) {
@@ -1319,6 +1328,12 @@ void VMError::print_vm_info(outputStream* st) {
 
   os::print_environment_variables(st, env_list);
   st->cr();
+
+  // STEP("printing locale settings")
+#ifndef _WIN32
+  os::Posix::print_active_locale(st);
+  st->cr();
+#endif
 
   // STEP("printing signal handlers")
 


### PR DESCRIPTION
To analyze locale problems in native code - e.g. stemming from third-party code calling `setlocale(3)` - it would be useful to print the active locale settings in hs-err reports and in VM.info.

Patch notes: 
- Posix is fuzzy about the exact role of LC_ALL. It defines LC_ALL as a way to set all locales in one go, but the implementation could still keep the individual categories separately and just let LC_ALL override the individual settings. Therefore I opted to print both, even though on glibc the information seems redundant.
- Since this is Posix specific, callers require #ifndef _WIN32 in shared files. That's not nice, but the alternative would be an empty stub implementation for windows, which I find also unappealing.

Example output, Ubuntu 20.04:

Java started with LC_ALL=C:
```
thomas@starfish $ jcmd Simple VM.info | ack LC_
LC_ALL=C
LC_ALL=C
LC_COLLATE=C
LC_CTYPE=C
LC_MESSAGES=C
LC_MONETARY=C
LC_NUMERIC=C
LC_TIME=C
```

Java started with my default system settings:
```
thomas@starfish $ jcmd Simple VM.info | ack LC_
LC_ALL=LC_CTYPE=C;LC_NUMERIC=en_DK.UTF-8;LC_TIME=en_DK.UTF-8;LC_COLLATE=C;LC_MONETARY=en_DK.UTF-8;LC_MESSAGES=C;LC_PAPER=en_DK.UTF-8;LC_NAME=en_DK.UTF-8;LC_ADDRESS=en_DK.UTF-8;LC_TELEPHONE=en_DK.UTF-8;LC_MEASUREMENT=en_DK.UTF-8;LC_IDENTIFICATION=en_DK.UTF-8
LC_COLLATE=C
LC_CTYPE=C
LC_MESSAGES=C
LC_MONETARY=en_DK.UTF-8
LC_NUMERIC=en_DK.UTF-8
LC_TIME=en_DK.UTF-8
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284726](https://bugs.openjdk.java.net/browse/JDK-8284726): Print active locale settings in hs_err reports and in VM.info


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to f168c8a9f79cfd52676f8cf62f07234058d84422
 * [Matthias Baesken](https://openjdk.java.net/census#mbaesken) (@MBaesken - **Reviewer**) ⚠️ Review applies to f168c8a9f79cfd52676f8cf62f07234058d84422
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to f168c8a9f79cfd52676f8cf62f07234058d84422


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8194/head:pull/8194` \
`$ git checkout pull/8194`

Update a local copy of the PR: \
`$ git checkout pull/8194` \
`$ git pull https://git.openjdk.java.net/jdk pull/8194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8194`

View PR using the GUI difftool: \
`$ git pr show -t 8194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8194.diff">https://git.openjdk.java.net/jdk/pull/8194.diff</a>

</details>
