### PR TITLE
8284732: FFI_GO_CLOSURES macro not defined but required for zero build on Mac OS X

### DIFF
--- a/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
+++ b/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
@@ -30,6 +30,10 @@
 #define SUPPORTS_NATIVE_CX8
 #endif
 
+#ifndef FFI_GO_CLOSURES
+#define FFI_GO_CLOSURES 0
+#endif
+
 #include <ffi.h>
 
 // Indicates whether the C calling conventions require that


### PR DESCRIPTION
It just codifies the current behavior as it defines `FFI_GO_CLOSURES` to be `0`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284732](https://bugs.openjdk.java.net/browse/JDK-8284732): FFI_GO_CLOSURES macro not defined but required for zero build on Mac OS X


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8195/head:pull/8195` \
`$ git checkout pull/8195`

Update a local copy of the PR: \
`$ git checkout pull/8195` \
`$ git pull https://git.openjdk.java.net/jdk pull/8195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8195`

View PR using the GUI difftool: \
`$ git pr show -t 8195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8195.diff">https://git.openjdk.java.net/jdk/pull/8195.diff</a>

</details>
