### PR TITLE
8284734: Undiscovered references if using ReferentBasedDiscovery

### DIFF
--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -1002,20 +1002,10 @@ bool ReferenceProcessor::discover_reference(oop obj, ReferenceType rt) {
     // The reference has already been discovered...
     log_develop_trace(gc, ref)("Already discovered reference (" INTPTR_FORMAT ": %s)",
                                p2i(obj), obj->klass()->internal_name());
-    if (RefDiscoveryPolicy == ReferentBasedDiscovery) {
-      // assumes that an object is not processed twice;
-      // if it's been already discovered it must be on another
-      // generation's discovered list; so we won't discover it.
-      return false;
-    } else {
-      assert(RefDiscoveryPolicy == ReferenceBasedDiscovery,
-             "Unrecognized policy");
-      // Check assumption that an object is not potentially
-      // discovered twice except by concurrent collectors that potentially
-      // trace the same Reference object twice.
-      assert(UseG1GC, "Only possible with a concurrent marking collector");
-      return true;
-    }
+    // `G1CMTask::make_reference_grey` can push the same oop twice onto the
+    // mark stack, causing the "rediscovery" of a non-strong ref.
+    assert(UseG1GC, "inv");
+    return true;
   }
 
   if (RefDiscoveryPolicy == ReferentBasedDiscovery) {

--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -860,8 +860,8 @@ inline bool ReferenceProcessor::set_discovered_link(HeapWord* discovered_addr, o
 inline void ReferenceProcessor::add_to_discovered_list(DiscoveredList& refs_list,
                                                        oop obj,
                                                        HeapWord* discovered_addr) {
-  ResourceMark rm; // needed by obj->klass()
-  
+  ResourceMark rm;
+
   oop current_head = refs_list.head();
   // Prepare value to put into the discovered field. The last ref must have its
   // discovered field pointing to itself.
@@ -999,8 +999,11 @@ bool ReferenceProcessor::discover_reference(oop obj, ReferenceType rt) {
   const oop  discovered = java_lang_ref_Reference::discovered(obj);
   assert(oopDesc::is_oop_or_null(discovered), "Expected an oop or NULL for discovered field at " PTR_FORMAT, p2i(discovered));
   if (discovered != NULL) {
-    // `G1CMTask::make_reference_grey` can push the same oop twice onto the
-    // mark stack, causing the "rediscovery" of a non-strong ref.
+    // A non-strong ref is "rediscovered". This is possible only for G1 in the
+    // following two cases:
+    //  1. `G1CMTask::make_reference_grey` can push the same oop twice onto the
+    //     mark stack.
+    //  2. CM restarts after mark-stack overflow.
     assert(UseG1GC, "inv");
     return true;
   }

--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -860,6 +860,8 @@ inline bool ReferenceProcessor::set_discovered_link(HeapWord* discovered_addr, o
 inline void ReferenceProcessor::add_to_discovered_list(DiscoveredList& refs_list,
                                                        oop obj,
                                                        HeapWord* discovered_addr) {
+  ResourceMark rm; // needed by obj->klass()
+  
   oop current_head = refs_list.head();
   // Prepare value to put into the discovered field. The last ref must have its
   // discovered field pointing to itself.
@@ -993,15 +995,10 @@ bool ReferenceProcessor::discover_reference(oop obj, ReferenceType rt) {
     }
   }
 
-  ResourceMark rm;      // Needed for tracing.
-
   HeapWord* const discovered_addr = java_lang_ref_Reference::discovered_addr_raw(obj);
   const oop  discovered = java_lang_ref_Reference::discovered(obj);
   assert(oopDesc::is_oop_or_null(discovered), "Expected an oop or NULL for discovered field at " PTR_FORMAT, p2i(discovered));
   if (discovered != NULL) {
-    // The reference has already been discovered...
-    log_develop_trace(gc, ref)("Already discovered reference (" INTPTR_FORMAT ": %s)",
-                               p2i(obj), obj->klass()->internal_name());
     // `G1CMTask::make_reference_grey` can push the same oop twice onto the
     // mark stack, causing the "rediscovery" of a non-strong ref.
     assert(UseG1GC, "inv");


### PR DESCRIPTION
Small change of fixing a crash if using `ReferentBasedDiscovery`.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8284734](https://bugs.openjdk.java.net/browse/JDK-8284734): Undiscovered references if using ReferentBasedDiscovery


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8196/head:pull/8196` \
`$ git checkout pull/8196`

Update a local copy of the PR: \
`$ git checkout pull/8196` \
`$ git pull https://git.openjdk.java.net/jdk pull/8196/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8196`

View PR using the GUI difftool: \
`$ git pr show -t 8196`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8196.diff">https://git.openjdk.java.net/jdk/pull/8196.diff</a>

</details>
