### PR TITLE
8284725: Fix include guard in jfrbitset.hpp

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/chains/jfrbitset.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/jfrbitset.hpp
@@ -22,12 +22,12 @@
  *
  */
 
-#ifndef SHARE_JFR_LEAKPROFILER_JFRBITMAP_HPP
-#define SHARE_JFR_LEAKPROFILER_JFRBITMAP_HPP
+#ifndef SHARE_JFR_LEAKPROFILER_JFRBITSET_HPP
+#define SHARE_JFR_LEAKPROFILER_JFRBITSET_HPP
 
 #include "memory/allocation.hpp"
 #include "utilities/objectBitSet.inline.hpp"
 
 typedef ObjectBitSet<mtTracing> JFRBitSet;
 
-#endif // SHARE_JFR_LEAKPROFILER_JFRBITMAP_HPP
+#endif // SHARE_JFR_LEAKPROFILER_JFRBITSET_HPP


### PR DESCRIPTION
In the fix for #7964 (https://bugs.openjdk.java.net/browse/JDK-8283710) I got the include guard for jfrbitset.hpp wrong. I made it:

SHARE_JFR_LEAKPROFILER_JFRBITMAP_HPP

but it should be:

SHARE_JFR_LEAKPROFILER_JFRBITSET_HPP

Testing:
 - [x] Build
 - [x] tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284725](https://bugs.openjdk.java.net/browse/JDK-8284725): Fix include guard in jfrbitset.hpp


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8198/head:pull/8198` \
`$ git checkout pull/8198`

Update a local copy of the PR: \
`$ git checkout pull/8198` \
`$ git pull https://git.openjdk.java.net/jdk pull/8198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8198`

View PR using the GUI difftool: \
`$ git pr show -t 8198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8198.diff">https://git.openjdk.java.net/jdk/pull/8198.diff</a>

</details>
