### PR TITLE
JDK-8284754: print more interesting env variables in hs_err and VM.info

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -101,7 +101,8 @@ static const char* env_list[] = {
   // Env variables that are defined on Linux/BSD
   "LD_LIBRARY_PATH", "LD_PRELOAD", "SHELL", "DISPLAY",
   "HOSTTYPE", "OSTYPE", "ARCH", "MACHTYPE",
-  "LANG", "LC_ALL", "LC_CTYPE", "TZ",
+  "LANG", "LC_ALL", "LC_CTYPE", "LC_NUMERIC", "LC_TIME",
+  "TERM", "TMPDIR", "TZ",
 
   // defined on AIX
   "LIBPATH", "LDR_PRELOAD", "LDR_PRELOAD64",


### PR DESCRIPTION
There are a few more interesting env variables, e.g. documented here 
https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html
that should be printed in hs_err for better supportability.
For example, TMPDIR is a cross platform addition to what was done for Windows with : 8283497: [windows] print TMP and TEMP in hs_err and VM.info .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284754](https://bugs.openjdk.java.net/browse/JDK-8284754): print more interesting env variables in hs_err and VM.info


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8205/head:pull/8205` \
`$ git checkout pull/8205`

Update a local copy of the PR: \
`$ git checkout pull/8205` \
`$ git pull https://git.openjdk.java.net/jdk pull/8205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8205`

View PR using the GUI difftool: \
`$ git pr show -t 8205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8205.diff">https://git.openjdk.java.net/jdk/pull/8205.diff</a>

</details>
