### PR TITLE
8282477: [x86, aarch64] vmassert(_last_Java_pc == NULL, "already walkable"); fails with async profiler

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -355,7 +355,7 @@ frame frame::sender_for_entry_frame(RegisterMap* map) const {
   assert(jfa->last_Java_sp() > sp(), "must be above this frame on stack");
   // Since we are walking the stack now this nested anchor is obviously walkable
   // even if it wasn't when it was stacked.
-  jfa->make_walkable(Thread::current());
+  jfa->make_walkable();
   map->clear();
   assert(map->include_argument_oops(), "should be set by clear");
   frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), jfa->last_Java_pc());
@@ -832,12 +832,11 @@ frame::frame(void* sp, void* fp, void* pc) {
 
 #endif
 
-void JavaFrameAnchor::make_walkable(Thread* thread) {
+void JavaFrameAnchor::make_walkable() {
   // last frame set?
   if (last_Java_sp() == NULL) return;
   // already walkable?
   if (walkable()) return;
-  vmassert(Thread::current() == thread, "not current thread");
   vmassert(last_Java_sp() != NULL, "not called from Java code?");
   vmassert(last_Java_pc() == NULL, "already walkable");
   _last_Java_pc = (address)_last_Java_sp[-1];

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -355,14 +355,14 @@ frame frame::sender_for_entry_frame(RegisterMap* map) const {
   assert(jfa->last_Java_sp() > sp(), "must be above this frame on stack");
   // Since we are walking the stack now this nested anchor is obviously walkable
   // even if it wasn't when it was stacked.
+  address last_java_pc = jfa->last_Java_pc();
   if (!jfa->walkable()) {
-    // Capture _last_Java_pc (if needed) and mark anchor walkable.
-    jfa->capture_last_Java_pc();
+    // Capture _last_Java_pc (if needed)
+    last_java_pc = jfa->obtain_last_Java_pc();
   }
   map->clear();
   assert(map->include_argument_oops(), "should be set by clear");
-  vmassert(jfa->last_Java_pc() != NULL, "not walkable");
-  frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), jfa->last_Java_pc());
+  frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), last_java_pc);
   fr.set_sp_is_trusted();
 
   return fr;
@@ -850,6 +850,11 @@ void JavaFrameAnchor::make_walkable(JavaThread* thread) {
 
 void JavaFrameAnchor::capture_last_Java_pc() {
   vmassert(_last_Java_sp != NULL, "no last frame set");
-  vmassert(_last_Java_pc == NULL || _last_Java_pc == (address)_last_Java_sp[-1], "already walkable");
+  vmassert(_last_Java_pc == NULL, "already walkable");
   _last_Java_pc = (address)_last_Java_sp[-1];
+}
+
+address JavaFrameAnchor::obtain_last_Java_pc() const {
+  vmassert(_last_Java_sp != NULL, "no last frame set");
+  return (address)_last_Java_sp[-1];
 }

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -850,6 +850,6 @@ void JavaFrameAnchor::make_walkable(JavaThread* thread) {
 
 void JavaFrameAnchor::capture_last_Java_pc() {
   vmassert(_last_Java_sp != NULL, "no last frame set");
-  vmassert(_last_Java_pc == NULL, "already walkable");
+  vmassert(_last_Java_pc == NULL || _last_Java_pc == (address)_last_Java_sp[-1], "already walkable");
   _last_Java_pc = (address)_last_Java_sp[-1];
 }

--- a/src/hotspot/cpu/aarch64/javaFrameAnchor_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/javaFrameAnchor_aarch64.hpp
@@ -65,9 +65,7 @@ public:
   }
 
   bool walkable(void)                            { return _last_Java_sp != NULL && _last_Java_pc != NULL; }
-  void make_walkable(JavaThread* thread);
-  void capture_last_Java_pc(void);
-  address obtain_last_Java_pc(void) const;
+  void make_walkable(Thread* thread);
 
   intptr_t* last_Java_sp(void) const             { return _last_Java_sp; }
 

--- a/src/hotspot/cpu/aarch64/javaFrameAnchor_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/javaFrameAnchor_aarch64.hpp
@@ -67,6 +67,7 @@ public:
   bool walkable(void)                            { return _last_Java_sp != NULL && _last_Java_pc != NULL; }
   void make_walkable(JavaThread* thread);
   void capture_last_Java_pc(void);
+  address obtain_last_Java_pc(void) const;
 
   intptr_t* last_Java_sp(void) const             { return _last_Java_sp; }
 

--- a/src/hotspot/cpu/aarch64/javaFrameAnchor_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/javaFrameAnchor_aarch64.hpp
@@ -65,7 +65,8 @@ public:
   }
 
   bool walkable(void)                            { return _last_Java_sp != NULL && _last_Java_pc != NULL; }
-  void make_walkable(Thread* thread);
+
+  void make_walkable();
 
   intptr_t* last_Java_sp(void) const             { return _last_Java_sp; }
 

--- a/src/hotspot/cpu/arm/javaFrameAnchor_arm.hpp
+++ b/src/hotspot/cpu/arm/javaFrameAnchor_arm.hpp
@@ -65,7 +65,7 @@ public:
   // Always walkable
   bool walkable(void) { return true; }
   // Never any thing to do since we are always walkable and can find address of return addresses
-  void make_walkable(JavaThread* thread) { }
+  void make_walkable() { }
 
   intptr_t* last_Java_sp(void) const             { return _last_Java_sp; }
 

--- a/src/hotspot/cpu/ppc/javaFrameAnchor_ppc.hpp
+++ b/src/hotspot/cpu/ppc/javaFrameAnchor_ppc.hpp
@@ -67,7 +67,7 @@ public:
   // Always walkable.
   bool walkable(void) { return true; }
   // Never any thing to do since we are always walkable and can find address of return addresses.
-  void make_walkable(JavaThread* thread) { }
+  void make_walkable() { }
 
   intptr_t* last_Java_sp(void) const  { return _last_Java_sp; }
 

--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -338,7 +338,7 @@ frame frame::sender_for_entry_frame(RegisterMap* map) const {
   assert(jfa->last_Java_sp() > sp(), "must be above this frame on stack");
   // Since we are walking the stack now this nested anchor is obviously walkable
   // even if it wasn't when it was stacked.
-  jfa->make_walkable(Thread::current());
+  jfa->make_walkable();
   map->clear();
   assert(map->include_argument_oops(), "should be set by clear");
   frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), jfa->last_Java_pc());
@@ -674,12 +674,11 @@ frame::frame(void* ptr_sp, void* ptr_fp, void* pc) {
 
 #endif
 
-void JavaFrameAnchor::make_walkable(Thread* thread) {
+void JavaFrameAnchor::make_walkable() {
   // last frame set?
   if (last_Java_sp() == NULL) { return; }
   // already walkable?
   if (walkable()) { return; }
-  vmassert(Thread::current() == thread, "not current thread");
   vmassert(last_Java_sp() != NULL, "not called from Java code?");
   vmassert(last_Java_pc() == NULL, "already walkable");
   _last_Java_pc = (address)_last_Java_sp[-1];

--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -338,14 +338,10 @@ frame frame::sender_for_entry_frame(RegisterMap* map) const {
   assert(jfa->last_Java_sp() > sp(), "must be above this frame on stack");
   // Since we are walking the stack now this nested anchor is obviously walkable
   // even if it wasn't when it was stacked.
-  address last_java_pc = jfa->last_Java_pc();
-  if (!jfa->walkable()) {
-    // Capture _last_Java_pc (if needed)
-    last_java_pc = jfa->obtain_last_Java_pc();
-  }
+  jfa->make_walkable(Thread::current());
   map->clear();
   assert(map->include_argument_oops(), "should be set by clear");
-  frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), last_java_pc);
+  frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), jfa->last_Java_pc());
   return fr;
 }
 
@@ -678,25 +674,14 @@ frame::frame(void* ptr_sp, void* ptr_fp, void* pc) {
 
 #endif
 
-void JavaFrameAnchor::make_walkable(JavaThread* thread) {
+void JavaFrameAnchor::make_walkable(Thread* thread) {
   // last frame set?
   if (last_Java_sp() == NULL) { return; }
   // already walkable?
   if (walkable()) { return; }
-  vmassert(Thread::current() == (Thread*)thread, "not current thread");
+  vmassert(Thread::current() == thread, "not current thread");
   vmassert(last_Java_sp() != NULL, "not called from Java code?");
   vmassert(last_Java_pc() == NULL, "already walkable");
-  capture_last_Java_pc();
-  vmassert(walkable(), "something went wrong");
-}
-
-void JavaFrameAnchor::capture_last_Java_pc() {
-  vmassert(_last_Java_sp != NULL, "no last frame set");
-  vmassert(_last_Java_pc == NULL, "already walkable");
   _last_Java_pc = (address)_last_Java_sp[-1];
-}
-
-address JavaFrameAnchor::obtain_last_Java_pc() const {
-  vmassert(_last_Java_sp != NULL, "no last frame set");
-  return (address)_last_Java_sp[-1];
+  vmassert(walkable(), "something went wrong");
 }

--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -692,6 +692,6 @@ void JavaFrameAnchor::make_walkable(JavaThread* thread) {
 
 void JavaFrameAnchor::capture_last_Java_pc() {
   vmassert(_last_Java_sp != NULL, "no last frame set");
-  vmassert(_last_Java_pc == NULL, "already walkable");
+  vmassert(_last_Java_pc == NULL || _last_Java_pc == (address)_last_Java_sp[-1], "already walkable");
   _last_Java_pc = (address)_last_Java_sp[-1];
 }

--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -338,14 +338,14 @@ frame frame::sender_for_entry_frame(RegisterMap* map) const {
   assert(jfa->last_Java_sp() > sp(), "must be above this frame on stack");
   // Since we are walking the stack now this nested anchor is obviously walkable
   // even if it wasn't when it was stacked.
+  address last_java_pc = jfa->last_Java_pc();
   if (!jfa->walkable()) {
-    // Capture _last_Java_pc (if needed) and mark anchor walkable.
-    jfa->capture_last_Java_pc();
+    // Capture _last_Java_pc (if needed)
+    last_java_pc = jfa->obtain_last_Java_pc();
   }
   map->clear();
   assert(map->include_argument_oops(), "should be set by clear");
-  vmassert(jfa->last_Java_pc() != NULL, "not walkable");
-  frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), jfa->last_Java_pc());
+  frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), last_java_pc);
   return fr;
 }
 
@@ -692,6 +692,11 @@ void JavaFrameAnchor::make_walkable(JavaThread* thread) {
 
 void JavaFrameAnchor::capture_last_Java_pc() {
   vmassert(_last_Java_sp != NULL, "no last frame set");
-  vmassert(_last_Java_pc == NULL || _last_Java_pc == (address)_last_Java_sp[-1], "already walkable");
+  vmassert(_last_Java_pc == NULL, "already walkable");
   _last_Java_pc = (address)_last_Java_sp[-1];
+}
+
+address JavaFrameAnchor::obtain_last_Java_pc() const {
+  vmassert(_last_Java_sp != NULL, "no last frame set");
+  return (address)_last_Java_sp[-1];
 }

--- a/src/hotspot/cpu/riscv/javaFrameAnchor_riscv.hpp
+++ b/src/hotspot/cpu/riscv/javaFrameAnchor_riscv.hpp
@@ -66,9 +66,7 @@ public:
   }
 
   bool walkable(void)                            { return _last_Java_sp != NULL && _last_Java_pc != NULL; }
-  void make_walkable(JavaThread* thread);
-  void capture_last_Java_pc(void);
-
+  void make_walkable(Thread* thread);
   intptr_t* last_Java_sp(void) const             { return _last_Java_sp; }
 
   const address last_Java_pc(void)               { return _last_Java_pc; }

--- a/src/hotspot/cpu/riscv/javaFrameAnchor_riscv.hpp
+++ b/src/hotspot/cpu/riscv/javaFrameAnchor_riscv.hpp
@@ -66,7 +66,9 @@ public:
   }
 
   bool walkable(void)                            { return _last_Java_sp != NULL && _last_Java_pc != NULL; }
-  void make_walkable(Thread* thread);
+
+  void make_walkable();
+
   intptr_t* last_Java_sp(void) const             { return _last_Java_sp; }
 
   const address last_Java_pc(void)               { return _last_Java_pc; }

--- a/src/hotspot/cpu/s390/javaFrameAnchor_s390.hpp
+++ b/src/hotspot/cpu/s390/javaFrameAnchor_s390.hpp
@@ -72,7 +72,7 @@
 
   // We don't have to flush registers, so the stack is always walkable.
   inline bool walkable(void) { return true; }
-  inline void make_walkable(JavaThread* thread) { }
+  inline void make_walkable() { }
 
  public:
 

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -734,6 +734,6 @@ void JavaFrameAnchor::make_walkable(JavaThread* thread) {
 
 void JavaFrameAnchor::capture_last_Java_pc() {
   vmassert(_last_Java_sp != NULL, "no last frame set");
-  vmassert(_last_Java_pc == NULL, "already walkable");
+  vmassert(_last_Java_pc == NULL || _last_Java_pc == (address)_last_Java_sp[-1], "already walkable");
   _last_Java_pc = (address)_last_Java_sp[-1];
 }

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -341,14 +341,14 @@ frame frame::sender_for_entry_frame(RegisterMap* map) const {
   assert(jfa->last_Java_sp() > sp(), "must be above this frame on stack");
   // Since we are walking the stack now this nested anchor is obviously walkable
   // even if it wasn't when it was stacked.
+  address last_java_pc = jfa->last_Java_pc();
   if (!jfa->walkable()) {
-    // Capture _last_Java_pc (if needed) and mark anchor walkable.
-    jfa->capture_last_Java_pc();
+    // Capture _last_Java_pc (if needed)
+    last_java_pc = jfa->obtain_last_Java_pc();
   }
   map->clear();
   assert(map->include_argument_oops(), "should be set by clear");
-  vmassert(jfa->last_Java_pc() != NULL, "not walkable");
-  frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), jfa->last_Java_pc());
+  frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), last_java_pc);
 
   return fr;
 }
@@ -377,14 +377,14 @@ frame frame::sender_for_optimized_entry_frame(RegisterMap* map) const {
   assert(jfa->last_Java_sp() > sp(), "must be above this frame on stack");
   // Since we are walking the stack now this nested anchor is obviously walkable
   // even if it wasn't when it was stacked.
+  address last_java_pc = jfa->last_Java_pc();
   if (!jfa->walkable()) {
-    // Capture _last_Java_pc (if needed) and mark anchor walkable.
-    jfa->capture_last_Java_pc();
+    // Capture _last_Java_pc (if needed)
+    last_java_pc = jfa->obtain_last_Java_pc();
   }
   map->clear();
   assert(map->include_argument_oops(), "should be set by clear");
-  vmassert(jfa->last_Java_pc() != NULL, "not walkable");
-  frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), jfa->last_Java_pc());
+  frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), last_java_pc);
 
   return fr;
 }
@@ -734,6 +734,11 @@ void JavaFrameAnchor::make_walkable(JavaThread* thread) {
 
 void JavaFrameAnchor::capture_last_Java_pc() {
   vmassert(_last_Java_sp != NULL, "no last frame set");
-  vmassert(_last_Java_pc == NULL || _last_Java_pc == (address)_last_Java_sp[-1], "already walkable");
+  vmassert(_last_Java_pc == NULL, "already walkable");
   _last_Java_pc = (address)_last_Java_sp[-1];
+}
+
+address JavaFrameAnchor::obtain_last_Java_pc() const {
+  vmassert(_last_Java_sp != NULL, "no last frame set");
+  return (address)_last_Java_sp[-1];
 }

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -717,8 +717,6 @@ void JavaFrameAnchor::make_walkable() {
   if (last_Java_sp() == NULL) return;
   // already walkable?
   if (walkable()) return;
-  vmassert(Thread::current() == thread, "not current thread");
-  vmassert(last_Java_sp() != NULL, "not called from Java code?");
   vmassert(last_Java_pc() == NULL, "already walkable");
   _last_Java_pc = (address)_last_Java_sp[-1];
   vmassert(walkable(), "something went wrong");

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -341,7 +341,7 @@ frame frame::sender_for_entry_frame(RegisterMap* map) const {
   assert(jfa->last_Java_sp() > sp(), "must be above this frame on stack");
   // Since we are walking the stack now this nested anchor is obviously walkable
   // even if it wasn't when it was stacked.
-  jfa->make_walkable(Thread::current());
+  jfa->make_walkable();
   map->clear();
   assert(map->include_argument_oops(), "should be set by clear");
   frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), jfa->last_Java_pc());
@@ -373,7 +373,7 @@ frame frame::sender_for_optimized_entry_frame(RegisterMap* map) const {
   assert(jfa->last_Java_sp() > sp(), "must be above this frame on stack");
   // Since we are walking the stack now this nested anchor is obviously walkable
   // even if it wasn't when it was stacked.
-  jfa->make_walkable(Thread::current());
+  jfa->make_walkable();
   map->clear();
   assert(map->include_argument_oops(), "should be set by clear");
   frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), jfa->last_Java_pc());
@@ -712,7 +712,7 @@ frame::frame(void* sp, void* fp, void* pc) {
 
 #endif
 
-void JavaFrameAnchor::make_walkable(Thread* thread) {
+void JavaFrameAnchor::make_walkable() {
   // last frame set?
   if (last_Java_sp() == NULL) return;
   // already walkable?

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -341,14 +341,10 @@ frame frame::sender_for_entry_frame(RegisterMap* map) const {
   assert(jfa->last_Java_sp() > sp(), "must be above this frame on stack");
   // Since we are walking the stack now this nested anchor is obviously walkable
   // even if it wasn't when it was stacked.
-  address last_java_pc = jfa->last_Java_pc();
-  if (!jfa->walkable()) {
-    // Capture _last_Java_pc (if needed)
-    last_java_pc = jfa->obtain_last_Java_pc();
-  }
+  jfa->make_walkable(Thread::current());
   map->clear();
   assert(map->include_argument_oops(), "should be set by clear");
-  frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), last_java_pc);
+  frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), jfa->last_Java_pc());
 
   return fr;
 }
@@ -377,14 +373,10 @@ frame frame::sender_for_optimized_entry_frame(RegisterMap* map) const {
   assert(jfa->last_Java_sp() > sp(), "must be above this frame on stack");
   // Since we are walking the stack now this nested anchor is obviously walkable
   // even if it wasn't when it was stacked.
-  address last_java_pc = jfa->last_Java_pc();
-  if (!jfa->walkable()) {
-    // Capture _last_Java_pc (if needed)
-    last_java_pc = jfa->obtain_last_Java_pc();
-  }
+  jfa->make_walkable(Thread::current());
   map->clear();
   assert(map->include_argument_oops(), "should be set by clear");
-  frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), last_java_pc);
+  frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), jfa->last_Java_pc());
 
   return fr;
 }
@@ -720,25 +712,14 @@ frame::frame(void* sp, void* fp, void* pc) {
 
 #endif
 
-void JavaFrameAnchor::make_walkable(JavaThread* thread) {
+void JavaFrameAnchor::make_walkable(Thread* thread) {
   // last frame set?
   if (last_Java_sp() == NULL) return;
   // already walkable?
   if (walkable()) return;
-  vmassert(Thread::current() == (Thread*)thread, "not current thread");
+  vmassert(Thread::current() == thread, "not current thread");
   vmassert(last_Java_sp() != NULL, "not called from Java code?");
   vmassert(last_Java_pc() == NULL, "already walkable");
-  capture_last_Java_pc();
-  vmassert(walkable(), "something went wrong");
-}
-
-void JavaFrameAnchor::capture_last_Java_pc() {
-  vmassert(_last_Java_sp != NULL, "no last frame set");
-  vmassert(_last_Java_pc == NULL, "already walkable");
   _last_Java_pc = (address)_last_Java_sp[-1];
-}
-
-address JavaFrameAnchor::obtain_last_Java_pc() const {
-  vmassert(_last_Java_sp != NULL, "no last frame set");
-  return (address)_last_Java_sp[-1];
+  vmassert(walkable(), "something went wrong");
 }

--- a/src/hotspot/cpu/x86/javaFrameAnchor_x86.hpp
+++ b/src/hotspot/cpu/x86/javaFrameAnchor_x86.hpp
@@ -65,6 +65,7 @@ public:
   bool walkable(void)                            { return _last_Java_sp != NULL && _last_Java_pc != NULL; }
   void make_walkable(JavaThread* thread);
   void capture_last_Java_pc(void);
+  address obtain_last_Java_pc() const;
 
   intptr_t* last_Java_sp(void) const             { return _last_Java_sp; }
 

--- a/src/hotspot/cpu/x86/javaFrameAnchor_x86.hpp
+++ b/src/hotspot/cpu/x86/javaFrameAnchor_x86.hpp
@@ -63,9 +63,7 @@ public:
   }
 
   bool walkable(void)                            { return _last_Java_sp != NULL && _last_Java_pc != NULL; }
-  void make_walkable(JavaThread* thread);
-  void capture_last_Java_pc(void);
-  address obtain_last_Java_pc() const;
+  void make_walkable(Thread* thread);
 
   intptr_t* last_Java_sp(void) const             { return _last_Java_sp; }
 

--- a/src/hotspot/cpu/x86/javaFrameAnchor_x86.hpp
+++ b/src/hotspot/cpu/x86/javaFrameAnchor_x86.hpp
@@ -63,7 +63,7 @@ public:
   }
 
   bool walkable(void)                            { return _last_Java_sp != NULL && _last_Java_pc != NULL; }
-  void make_walkable(Thread* thread);
+  void make_walkable();
 
   intptr_t* last_Java_sp(void) const             { return _last_Java_sp; }
 

--- a/src/hotspot/cpu/zero/javaFrameAnchor_zero.hpp
+++ b/src/hotspot/cpu/zero/javaFrameAnchor_zero.hpp
@@ -73,7 +73,7 @@
     return true;
   }
 
-  void make_walkable(JavaThread* thread) {
+  void make_walkable(Thread* thread) {
     // nothing to do
   }
 

--- a/src/hotspot/cpu/zero/javaFrameAnchor_zero.hpp
+++ b/src/hotspot/cpu/zero/javaFrameAnchor_zero.hpp
@@ -73,7 +73,7 @@
     return true;
   }
 
-  void make_walkable(Thread* thread) {
+  void make_walkable() {
     // nothing to do
   }
 

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -155,7 +155,7 @@ public:
 
     thread->push_jni_handle_block();
     assert(thread == JavaThread::current(), "thread must be current!");
-    thread->frame_anchor()->make_walkable(thread);
+    thread->frame_anchor()->make_walkable();
   };
 
   ~JvmtiEventMark() {

--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -515,7 +515,7 @@ bool HandshakeState::process_by_self(bool allow_suspend, bool check_async_except
   assert(Thread::current() == _handshakee, "should call from _handshakee");
   assert(!_handshakee->is_terminated(), "should not be a terminated thread");
 
-  _handshakee->frame_anchor()->make_walkable(_handshakee);
+  _handshakee->frame_anchor()->make_walkable();
   // Threads shouldn't block if they are in the middle of printing, but...
   ttyLocker::break_tty_lock_for_safepoint(os::current_thread_id());
 

--- a/src/hotspot/share/runtime/interfaceSupport.inline.hpp
+++ b/src/hotspot/share/runtime/interfaceSupport.inline.hpp
@@ -113,7 +113,7 @@ class ThreadStateTransition : public StackObj {
       thread->check_possible_safepoint();
 
       // Once we are in native/blocked vm expects stack to be walkable
-      thread->frame_anchor()->make_walkable(thread);
+      thread->frame_anchor()->make_walkable();
       OrderAccess::storestore(); // Keep thread_state change and make_walkable() separate.
       thread->set_thread_state(to);
     }

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -608,7 +608,7 @@ void vm_perform_shutdown_actions() {
       JavaThread* jt = JavaThread::cast(thread);
       // Must always be walkable or have no last_Java_frame when in
       // thread_in_native
-      jt->frame_anchor()->make_walkable(jt);
+      jt->frame_anchor()->make_walkable();
       jt->set_thread_state(_thread_in_native);
     }
   }

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -714,7 +714,7 @@ void SafepointSynchronize::block(JavaThread *thread) {
   }
 
   JavaThreadState state = thread->thread_state();
-  thread->frame_anchor()->make_walkable(thread);
+  thread->frame_anchor()->make_walkable();
 
   uint64_t safepoint_id = SafepointSynchronize::safepoint_counter();
 

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1583,7 +1583,7 @@ void JavaThread::remove_monitor_chunk(MonitorChunk* chunk) {
 
 void JavaThread::handle_special_runtime_exit_condition() {
   if (is_obj_deopt_suspend()) {
-    frame_anchor()->make_walkable(this);
+    frame_anchor()->make_walkable();
     wait_for_object_deoptimization();
   }
   JFR_ONLY(SUSPEND_THREAD_CONDITIONAL(this);)

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1413,7 +1413,7 @@ class JavaThread: public Thread {
 
   // Accessing frames
   frame last_frame() {
-    _anchor.make_walkable(this);
+    _anchor.make_walkable();
     return pd_last_frame();
   }
   javaVFrame* last_java_vframe(RegisterMap* reg_map);


### PR DESCRIPTION
Fix the assertion by replacing it by assertion that does not fail.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [JDK-8282477](https://bugs.openjdk.java.net/browse/JDK-8282477): [x86, aarch64] vmassert(_last_Java_pc == NULL, "already walkable"); fails with async profiler


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8209/head:pull/8209` \
`$ git checkout pull/8209`

Update a local copy of the PR: \
`$ git checkout pull/8209` \
`$ git pull https://git.openjdk.java.net/jdk pull/8209/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8209`

View PR using the GUI difftool: \
`$ git pr show -t 8209`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8209.diff">https://git.openjdk.java.net/jdk/pull/8209.diff</a>

</details>
