### PR TITLE
8284775: Simplify String.substring(_, length()) calls

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -151,7 +151,7 @@ public abstract class BasicTextUI extends TextUI implements ViewFactory {
         String nm = getClass().getName();
         int index = nm.lastIndexOf('.');
         if (index >= 0) {
-            nm = nm.substring(index+1, nm.length());
+            nm = nm.substring(index+1);
         }
         return nm;
     }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
@@ -249,7 +249,7 @@ public abstract class BasicTextUI extends TextUI implements ViewFactory {
 
             /* In an ideal situation, the following check would not be necessary
              * and we would replace the color any time the previous color was a
-             * UIResouce. However, it turns out that there is existing code that
+             * UIResource. However, it turns out that there is existing code that
              * uses the following inadvisable pattern to turn a text area into
              * what appears to be a multi-line label:
              *

--- a/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
+++ b/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
@@ -847,7 +847,7 @@ public abstract class FontConfiguration {
             start = end + 1;
         }
         if (sequence.length() > start) {
-            parts.add(sequence.substring(start, sequence.length()));
+            parts.add(sequence.substring(start));
         }
         return parts;
     }

--- a/src/java.desktop/unix/classes/sun/awt/X11/MotifColorUtilities.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/MotifColorUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -427,7 +427,7 @@ class MotifColorUtilities {
 
         for (int i=0;i<8;i++) {
             temp = bfr.readLine();
-            color = temp.substring(1,temp.length());
+            color = temp.substring(1);
             r = Integer.parseInt(color.substring(0, 4), 16) >> 8;
             g = Integer.parseInt(color.substring(4, 8), 16) >> 8;
             b = Integer.parseInt(color.substring(8, 12), 16) >> 8;

--- a/src/java.desktop/unix/classes/sun/awt/X11/XFileDialogPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XFileDialogPeer.java
@@ -202,7 +202,7 @@ class XFileDialogPeer extends XDialogPeer
 
         // Fixed 6260650: FileDialog.getDirectory() does not return null when file dialog is cancelled
         // After showing we should display 'user.dir' as current directory
-        // if user didn't set directory programatically
+        // if user didn't set directory programmatically
         pathField = new TextField(savedDir != null ? savedDir : userDir);
         @SuppressWarnings("serial") // Anonymous class
         Choice tmp = new Choice() {

--- a/src/java.desktop/unix/classes/sun/awt/X11/XFileDialogPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XFileDialogPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -728,7 +728,7 @@ class XFileDialogPeer extends XDialogPeer
         int i;
         if ((i=dir.indexOf("~")) != -1) {
 
-            dir = dir.substring(0,i) + System.getProperty("user.home") + dir.substring(i+1,dir.length());
+            dir = dir.substring(0,i) + System.getProperty("user.home") + dir.substring(i+1);
         }
 
         File fe = new File(dir).getAbsoluteFile();

--- a/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1567,7 +1567,7 @@ public final class XToolkit extends UNIXToolkit implements Runnable {
     @Override
     protected Object lazilyLoadDesktopProperty(String name) {
         if (name.startsWith(prefix)) {
-            String cursorName = name.substring(prefix.length(), name.length()) + postfix;
+            String cursorName = name.substring(prefix.length()) + postfix;
 
             try {
                 return Cursor.getSystemCustomCursor(cursorName);

--- a/src/java.desktop/windows/classes/sun/awt/windows/WToolkit.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,8 +39,6 @@ import java.awt.Dialog;
 import java.awt.Dimension;
 import java.awt.EventQueue;
 import java.awt.FileDialog;
-import java.awt.Font;
-import java.awt.FontMetrics;
 import java.awt.Frame;
 import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsDevice;
@@ -137,9 +135,6 @@ import sun.awt.Win32GraphicsEnvironment;
 import sun.awt.datatransfer.DataTransferer;
 import sun.awt.util.PerformanceLogger;
 import sun.awt.util.ThreadGroupUtils;
-import sun.font.FontManager;
-import sun.font.FontManagerFactory;
-import sun.font.SunFontManager;
 import sun.java2d.d3d.D3DRenderQueue;
 import sun.java2d.opengl.OGLRenderQueue;
 import sun.print.PrintJob2D;
@@ -937,7 +932,7 @@ public final class WToolkit extends SunToolkit implements Runnable {
     @Override
     protected Object lazilyLoadDesktopProperty(String name) {
         if (name.startsWith(prefix)) {
-            String cursorName = name.substring(prefix.length(), name.length()) + postfix;
+            String cursorName = name.substring(prefix.length()) + postfix;
 
             try {
                 return Cursor.getSystemCustomCursor(cursorName);

--- a/src/java.desktop/windows/classes/sun/awt/windows/WToolkit.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WToolkit.java
@@ -211,7 +211,7 @@ public final class WToolkit extends SunToolkit implements Runnable {
      * will lead to undefined behavior.
      *
      * embeddedInit must be called before the WToolkit() constructor.
-     * embeddedDispose should be called before the applicaton terminates the
+     * embeddedDispose should be called before the application terminates the
      * Java VM. It is currently unsafe to reinitialize the toolkit again
      * after it has been disposed. Instead, awt.dll must be reloaded and the
      * class loader which loaded WToolkit must be finalized before it is


### PR DESCRIPTION
Default `to` index for String.substring method call is length of the String.
We can simplify code a bit, by omitting default value.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284775](https://bugs.openjdk.java.net/browse/JDK-8284775): Simplify String.substring(_, length()) calls


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8212/head:pull/8212` \
`$ git checkout pull/8212`

Update a local copy of the PR: \
`$ git checkout pull/8212` \
`$ git pull https://git.openjdk.java.net/jdk pull/8212/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8212`

View PR using the GUI difftool: \
`$ git pr show -t 8212`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8212.diff">https://git.openjdk.java.net/jdk/pull/8212.diff</a>

</details>
