### PR TITLE
8284771: java/util/zip/CloseInflaterDeflaterTest.java failed with "AssertionError: Expected IOException to be thrown, but nothing was thrown"

### DIFF
--- a/test/jdk/java/util/zip/CloseInflaterDeflaterTest.java
+++ b/test/jdk/java/util/zip/CloseInflaterDeflaterTest.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8193682 8278794
+ * @bug 8193682 8278794 8284771
  * @summary Test Infinite loop while writing on closed Deflater and Inflater.
  * @run testng CloseInflaterDeflaterTest
  */
@@ -171,10 +171,11 @@ public class CloseInflaterDeflaterTest {
     /**
      * Test for infinite loop by writing bytes to closed InflaterOutputStream
      *
+     * Note: Disabling this test as it is failing intermittently.
      * @param useCloseMethod indicates whether to use Close() or finish() method
      * @throws IOException if an error occurs
      */
-    @Test(dataProvider = "testOutputStreams")
+    @Test(dataProvider = "testOutputStreams",enabled=false)
     public void testInflaterOutputStream(boolean useCloseMethod) throws IOException {
         InflaterOutputStream inf = new InflaterOutputStream(outStream);
         assertThrows(IOException.class , () -> inf.write(inputBytes, 0, INPUT_LENGTH));


### PR DESCRIPTION
CloseInflaterDeflaterTest.java is failing intermittently(Observed once in macOS and Linux), testInflaterOutputStream() is added as an extra test as part of https://bugs.openjdk.java.net/browse/JDK-8278794. Disabling this test for now before debugging any timing issues in Inflater.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284771](https://bugs.openjdk.java.net/browse/JDK-8284771): java/util/zip/CloseInflaterDeflaterTest.java failed with "AssertionError: Expected IOException to be thrown, but nothing was thrown"


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8213/head:pull/8213` \
`$ git checkout pull/8213`

Update a local copy of the PR: \
`$ git checkout pull/8213` \
`$ git pull https://git.openjdk.java.net/jdk pull/8213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8213`

View PR using the GUI difftool: \
`$ git pr show -t 8213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8213.diff">https://git.openjdk.java.net/jdk/pull/8213.diff</a>

</details>
