### PR TITLE
8284796: sun.security.ssl.Finished::toString misses a line feed in the message format pattern

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/Finished.java
+++ b/src/java.base/share/classes/sun/security/ssl/Finished.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -146,7 +146,7 @@ final class Finished {
                     "\"Finished\": '{'\n" +
                     "  \"verify data\": '{'\n" +
                     "{0}\n" +
-                    "  '}'" +
+                    "  '}'\n" +
                     "'}'",
                     Locale.ENGLISH);
 


### PR DESCRIPTION
The log for Finished message looks like the below,
```
"Finished": {
  "verify data": {
    0000: ... ...
  }'}  // looks weird
```
because a line feed is missing in the format pattern.
```
"\"Finished\": '{'\n" +
"  \"verify data\": '{'\n" +
"{0}\n" +
"  '}'" +  // a line feed is needed
"'}'",
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284796](https://bugs.openjdk.java.net/browse/JDK-8284796): sun.security.ssl.Finished::toString misses a line feed in the message format pattern


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8215/head:pull/8215` \
`$ git checkout pull/8215`

Update a local copy of the PR: \
`$ git checkout pull/8215` \
`$ git pull https://git.openjdk.java.net/jdk pull/8215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8215`

View PR using the GUI difftool: \
`$ git pr show -t 8215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8215.diff">https://git.openjdk.java.net/jdk/pull/8215.diff</a>

</details>
