### PR TITLE
8277816: Client tests fail on macos-Aarch64 host

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -733,14 +733,6 @@ javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.ja
 java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64
 java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 8274106 macosx-aarch64
 javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8274106 macosx-aarch64
-javax/swing/text/html/StyleSheet/bug4936917.java 8277816 macosx-aarch64
-javax/swing/plaf/metal/MetalGradient/8163193/ButtonGradientTest.java  8277816 macosx-aarch64
-javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java  8277816 macosx-aarch64
-javax/swing/JInternalFrame/8069348/bug8069348.java 8277816 macosx-aarch64
-java/awt/Robot/HiDPIScreenCapture/ScreenCaptureTest.java  8277816 macosx-aarch64
-java/awt/Robot/CheckCommonColors/CheckCommonColors.java 8277816 macosx-aarch64
-java/awt/ColorClass/AlphaColorTest.java 8277816 macosx-aarch64
-java/awt/AlphaComposite/WindowAlphaCompositeTest.java 8277816 macosx-aarch64
 
 # macos12 failure
 javax/swing/JMenu/4515762/bug4515762.java 8276074 macosx-all


### PR DESCRIPTION
This tests was failing on macos12 M1 systems due to wrong color profile configurations set in CI systems.
If correct sRGB IEC61966-2.1 is set, then these test passed. Test job link in JBS..

So, removing from Problem list..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277816](https://bugs.openjdk.java.net/browse/JDK-8277816): Client tests fail on macos-Aarch64 host


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8216/head:pull/8216` \
`$ git checkout pull/8216`

Update a local copy of the PR: \
`$ git checkout pull/8216` \
`$ git pull https://git.openjdk.java.net/jdk pull/8216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8216`

View PR using the GUI difftool: \
`$ git pr show -t 8216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8216.diff">https://git.openjdk.java.net/jdk/pull/8216.diff</a>

</details>
