### PR TITLE
8284816: Make markWord::has_monitor() more robust

### DIFF
--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -176,7 +176,7 @@ class markWord {
     return (BasicLock*) value();
   }
   bool has_monitor() const {
-    return ((value() & monitor_value) != 0);
+    return ((value() & lock_mask_in_place) == monitor_value);
   }
   ObjectMonitor* monitor() const {
     assert(has_monitor(), "check");


### PR DESCRIPTION
Currently, markWord::has_monitor() is implemented like this:

`    return ((value() & monitor_value) != 0);`

monitor value is `0b10`. This means that it also reports marked or forwarded objects (`0b11`) as having a monitor, which is wrong. As far as I can tell, it does not cause any problems because relevant code is either not affected by marked/forwarded objects, or by testing bits in an order that hides the problem.

I suggest to test the bits properly to make it more robust and avoid potenial future bugs.

Testing:
 - [x] tier1
 - [ ] tier2
 - [ ] tier3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284816](https://bugs.openjdk.java.net/browse/JDK-8284816): Make markWord::has_monitor() more robust


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8219/head:pull/8219` \
`$ git checkout pull/8219`

Update a local copy of the PR: \
`$ git checkout pull/8219` \
`$ git pull https://git.openjdk.java.net/jdk pull/8219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8219`

View PR using the GUI difftool: \
`$ git pr show -t 8219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8219.diff">https://git.openjdk.java.net/jdk/pull/8219.diff</a>

</details>
