### PR TITLE
8159694: HiDPI, Unity, java/awt/dnd/DropTargetEnterExitTest/MissedDragExitTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -125,7 +125,6 @@ java/awt/Frame/FrameLocation/FrameLocation.java 8238436 linux-all
 java/awt/FileDialog/FileDialogIconTest/FileDialogIconTest.java 8160558 windows-all
 java/awt/event/MouseWheelEvent/InfiniteRecursion/InfiniteRecursion.java 8060176 windows-all,macosx-all
 java/awt/event/MouseWheelEvent/InfiniteRecursion/InfiniteRecursion_1.java 8060176 windows-all,macosx-all
-java/awt/dnd/DropTargetEnterExitTest/MissedDragExitTest.java 8159694 linux-all
 java/awt/dnd/MissingEventsOnModalDialog/MissingEventsOnModalDialogTest.java 8164464 linux-all,macosx-all
 java/awt/dnd/URIListBetweenJVMsTest/URIListBetweenJVMsTest.java 8171510 macosx-all
 javax/swing/dnd/7171812/bug7171812.java 8041447 macosx-all

--- a/test/jdk/java/awt/dnd/DropTargetEnterExitTest/MissedDragExitTest.java
+++ b/test/jdk/java/awt/dnd/DropTargetEnterExitTest/MissedDragExitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,7 @@ public class MissedDragExitTest {
 
     private static void initAndShowUI() {
         f = new Frame("Test frame");
+        f.setUndecorated(true);
         f.setBounds(FRAME_LOCATION,FRAME_LOCATION,FRAME_SIZE,FRAME_SIZE);
 
         final DraggablePanel dragSource = new DraggablePanel();
@@ -102,7 +103,7 @@ public class MissedDragExitTest {
             Util.drag(r,
                     new Point(FRAME_LOCATION + FRAME_SIZE / 3, FRAME_LOCATION + FRAME_SIZE / 3),
                     new Point(FRAME_LOCATION + FRAME_SIZE / 3 * 2, FRAME_LOCATION + FRAME_SIZE / 3 * 2),
-                    InputEvent.BUTTON1_MASK);
+                    InputEvent.BUTTON1_DOWN_MASK);
             Util.waitForIdle(r);
 
             if (!dragExitCalled) {

--- a/test/jdk/java/awt/regtesthelpers/Util.java
+++ b/test/jdk/java/awt/regtesthelpers/Util.java
@@ -307,8 +307,13 @@ public final class Util {
      *     {@code InputEvent.BUTTON3_MASK}
      */
     public static void drag(Robot robot, Point startPoint, Point endPoint, int button) {
-        if (!(button == InputEvent.BUTTON1_MASK || button == InputEvent.BUTTON2_MASK
-                || button == InputEvent.BUTTON3_MASK))
+        if (!(button == InputEvent.BUTTON1_MASK
+                || button == InputEvent.BUTTON2_MASK
+                || button == InputEvent.BUTTON3_MASK
+                || button == InputEvent.BUTTON1_DOWN_MASK
+                || button == InputEvent.BUTTON2_DOWN_MASK
+                || button == InputEvent.BUTTON3_DOWN_MASK
+        ))
         {
             throw new IllegalArgumentException("invalid mouse button");
         }


### PR DESCRIPTION
Window's title height was increased in Gnome/Unity since it was written, so the test tries to initiate drag on frame's header instead of its body. 
Making the frame undecorated solves the issue. 
Testing is green on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8159694](https://bugs.openjdk.java.net/browse/JDK-8159694): HiDPI, Unity, java/awt/dnd/DropTargetEnterExitTest/MissedDragExitTest.java


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8221/head:pull/8221` \
`$ git checkout pull/8221`

Update a local copy of the PR: \
`$ git checkout pull/8221` \
`$ git pull https://git.openjdk.java.net/jdk pull/8221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8221`

View PR using the GUI difftool: \
`$ git pr show -t 8221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8221.diff">https://git.openjdk.java.net/jdk/pull/8221.diff</a>

</details>
