### PR TITLE
8284681: compiler/c2/aarch64/TestFarJump.java fails with "RuntimeException: for CodeHeap < 250MB the far jump is expected to be encoded with a single branch instruction"

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestFarJump.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestFarJump.java
@@ -74,9 +74,9 @@ public class TestFarJump {
             }
             int dump = (int)Long.parseLong(match, 16);
             int encoding = Integer.reverseBytes(dump);
-            if (isADRP(encoding)) {
-                return true;
-            }
+            // Check the first instruction only. The raw pointer can be confused with the encoded adrp instruction:
+            // emit_exception_handler() = far_call() + should_not_reach_here() = ADRP + ADD + BLR + DCPS1 + raw_pointer
+            return isADRP(encoding);
         }
         return false;
     }


### PR DESCRIPTION
Recently [introduced](https://bugs.openjdk.java.net/browse/JDK-8280872) TestFarJump.java test checks the PrintAssembly output for ADRP instruction. Test fails intermittently when the subsequent raw address is similar to the ADRP instruction encoding. With this fix, the test is fixed to only check the first instruction of the exception handler to avoid false positives.

False positive case, the raw pointer is disassembled as ADRP instruction:
```
[Exception Handler]
  0x0000fffdd3940410: ; {runtime_call handle_exception_from_callee Runtime1 stub}
  0x0000fffdd3940410: 5c50 8695 | c1d5 bbd4 | 78be 56f0 | fdff 0000 

Disassembly:
0x0000000000000000:  5C 50 86 95    bl    #0x6194170
0x0000000000000004:  C1 D5 BB D4    dcps1 #0xdeae
0x0000000000000008:  78 BE 56 F0    adrp  x24, #0xad7cf000
0x000000000000000c:  FC FF 00 00    n/a
```

The row pointer (above) is pointer to "should not reach here" chars:
```cpp
void MacroAssembler::stop(const char* msg) {
  BLOCK_COMMENT(msg);
  dcps1(0xdeae);
  emit_int64((uintptr_t)msg);
}

void should_not_reach_here() { stop("should not reach here"); }

int LIR_Assembler::emit_exception_handler() {
  ...
  __ far_call(RuntimeAddress(Runtime1::entry_for(Runtime1::handle_exception_from_callee_id)));  
  __ should_not_reach_here();
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284681](https://bugs.openjdk.java.net/browse/JDK-8284681): compiler/c2/aarch64/TestFarJump.java fails with "RuntimeException: for CodeHeap < 250MB the far jump is expected to be encoded with a single branch instruction"


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8223/head:pull/8223` \
`$ git checkout pull/8223`

Update a local copy of the PR: \
`$ git checkout pull/8223` \
`$ git pull https://git.openjdk.java.net/jdk pull/8223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8223`

View PR using the GUI difftool: \
`$ git pr show -t 8223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8223.diff">https://git.openjdk.java.net/jdk/pull/8223.diff</a>

</details>
