### PR TITLE
8283307: Vectorize unsigned shift right on signed subword types

### DIFF
--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2458,6 +2458,20 @@ void Node_List::yank( Node *n ) {
   }
 }
 
+//------------------------------replace-------------------------------------------
+// Replace o with n
+void Node_List::replace( Node *o, Node *n ) {
+  uint i;
+  for (i = 0; i < _cnt; i++) {
+    if (_nodes[i] == o) {
+      break;
+    }
+  }
+
+  if (i < _cnt) {
+    _nodes[i] = n;
+  }
+}
 //------------------------------dump-------------------------------------------
 void Node_List::dump() const {
 #ifndef PRODUCT

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1583,6 +1583,7 @@ public:
   void remove( uint i ) { Node_Array::remove(i); _cnt--; }
   void push( Node *b ) { map(_cnt++,b); }
   void yank( Node *n );         // Find and remove
+  void replace( Node *o, Node *n );               // Replace o with n
   Node *pop() { return _nodes[--_cnt]; }
   void clear() { _cnt = 0; Node_Array::clear(); } // retain storage
   void copy(const Node_List& from) {

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -3345,6 +3345,13 @@ void SuperWord::compute_vector_element_type() {
                 vt = TypeInt::INT;
               }
             }
+
+            if (op == Op_URShiftI && can_transform_to_rshift(in, vt)) {
+              // Transform urshift(short/byte) to rshift(short/byte) in hoping that
+              // the shift operation may be vectorized.
+              in = transform_to_rshift(in);
+            }
+
             set_velt_type(in, vt);
           }
         }
@@ -4604,6 +4611,39 @@ bool SuperWord::same_origin_idx(Node* a, Node* b) const {
 }
 bool SuperWord::same_generation(Node* a, Node* b) const {
   return a != NULL && b != NULL && _clone_map.same_gen(a->_idx, b->_idx);
+}
+
+bool SuperWord::can_transform_to_rshift(const Node* urshift_node, const Type* type) const {
+  assert(urshift_node->Opcode() == Op_URShiftI, "Can be only called with a urshift node");
+  const TypeInt *t = _igvn.type(urshift_node->in(2))->isa_int();
+  if(t && t->is_con()) {
+    int shift_cnt = t->get_con();
+    if (((type == TypeInt::SHORT) && (shift_cnt <= 16)) ||
+        ((type == TypeInt::BYTE)  && (shift_cnt <= 24))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+Node* SuperWord::transform_to_rshift(Node* urshift_node) {
+  assert(urshift_node->Opcode() == Op_URShiftI, "Can be only called with a urshift node");
+  Node* rshift_node = new RShiftINode(urshift_node->in(1), urshift_node->in(2));
+
+  int idx = bb_idx(urshift_node);
+  set_bb_idx(rshift_node, idx);
+  _phase->set_ctrl(rshift_node, _phase->get_ctrl(urshift_node));
+  _igvn.register_new_node_with_optimizer(rshift_node, urshift_node);
+  _igvn.replace_node(urshift_node, rshift_node);
+
+  // Update block, loop body and packset
+  _block.at_put(idx, rshift_node);
+  lpt()->_body.replace(urshift_node, rshift_node);
+  for (int i = 0; i < _packset.length(); i++) {
+    _packset.at(i)->replace(urshift_node, rshift_node);
+  }
+
+  return rshift_node;
 }
 
 Node*  SuperWord::find_phi_for_mem_dep(LoadNode* ld) {

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -458,6 +458,12 @@ class SuperWord : public ResourceObj {
   bool same_origin_idx(Node* a, Node* b) const;
   bool same_generation(Node* a, Node* b) const;
 
+  // Check whether urshift_node can be transformed to rshift node
+  bool can_transform_to_rshift(const Node* urshift_node, const Type* type) const;
+
+  // Transform urshift_node to rshift node
+  Node* transform_to_rshift(Node* urshift_node);
+
   // methods
 
   // Extract the superword level parallelism


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8283307](https://bugs.openjdk.java.net/browse/JDK-8283307): Vectorize unsigned shift right on signed subword types


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8224/head:pull/8224` \
`$ git checkout pull/8224`

Update a local copy of the PR: \
`$ git checkout pull/8224` \
`$ git pull https://git.openjdk.java.net/jdk pull/8224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8224`

View PR using the GUI difftool: \
`$ git pr show -t 8224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8224.diff">https://git.openjdk.java.net/jdk/pull/8224.diff</a>

</details>
