### PR TITLE
8284828: Use `os::ThreadCrashProtection` to protect AsyncGetCallTrace from crashing

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -1155,7 +1155,6 @@ os::ThreadCrashProtection* os::ThreadCrashProtection::_crash_protection = NULL;
 
 os::ThreadCrashProtection::ThreadCrashProtection() {
   _protected_thread = Thread::current();
-  assert(_protected_thread->is_JfrSampler_thread(), "should be JFRSampler");
 }
 
 /*

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -1150,8 +1150,9 @@ bool os::Posix::matches_effective_uid_and_gid_or_root(uid_t uid, gid_t gid) {
     return is_root(uid) || (geteuid() == uid && getegid() == gid);
 }
 
-Thread* os::ThreadCrashProtection::_protected_thread = NULL;
 os::ThreadCrashProtection* os::ThreadCrashProtection::_crash_protection = NULL;
+sigset_t os::ThreadCrashProtection::_saved_sig_mask;
+
 
 os::ThreadCrashProtection::ThreadCrashProtection() {
   _protected_thread = Thread::current();
@@ -1164,26 +1165,27 @@ os::ThreadCrashProtection::ThreadCrashProtection() {
  * The callback is supposed to provide the method that should be protected.
  */
 bool os::ThreadCrashProtection::call(os::CrashProtectionCallback& cb) {
-  sigset_t saved_sig_mask;
-
   // we cannot rely on sigsetjmp/siglongjmp to save/restore the signal mask
   // since on at least some systems (OS X) siglongjmp will restore the mask
   // for the process, not the thread
-  pthread_sigmask(0, NULL, &saved_sig_mask);
+  if (_outer_protection == NULL) { // only for the outer most crash protection
+    pthread_sigmask(0, NULL, &_saved_sig_mask);
+  }
   if (sigsetjmp(_jmpbuf, 0) == 0) {
+    // store the currently active crash protection
+    // this happens if crash protections are nested
+    _outer_protection = _crash_protection;
     // make sure we can see in the signal handler that we have crash protection
     // installed
     _crash_protection = this;
     cb.call();
-    // and clear the crash protection
-    _crash_protection = NULL;
-    _protected_thread = NULL;
+    // and reset the crash protection
+    _crash_protection = _outer_protection;
     return true;
   }
   // this happens when we siglongjmp() back
-  pthread_sigmask(SIG_SETMASK, &saved_sig_mask, NULL);
-  _crash_protection = NULL;
-  _protected_thread = NULL;
+  pthread_sigmask(SIG_SETMASK, &_saved_sig_mask, NULL);
+  _crash_protection = _outer_protection;
   return false;
 }
 
@@ -1194,11 +1196,7 @@ void os::ThreadCrashProtection::restore() {
 
 void os::ThreadCrashProtection::check_crash_protection(int sig,
     Thread* thread) {
-
-  if (thread != NULL &&
-      thread == _protected_thread &&
-      _crash_protection != NULL) {
-
+  if (thread != NULL && is_crash_protected(thread)) {
     if (sig == SIGSEGV || sig == SIGBUS) {
       _crash_protection->restore();
     }

--- a/src/hotspot/os/posix/os_posix.hpp
+++ b/src/hotspot/os/posix/os_posix.hpp
@@ -107,8 +107,8 @@ public:
 };
 
 /*
- * Crash protection for the JfrSampler thread. Wrap the callback
- * with a sigsetjmp and in case of a SIGSEGV/SIGBUS we siglongjmp
+ * Crash protection for the JfrSampler thread (but also used for AsyncGetCallTrace).
+ * Wrap the callback with a sigsetjmp and in case of a SIGSEGV/SIGBUS we siglongjmp
  * back.
  * To be able to use this - don't take locks, don't rely on destructors,
  * don't make OS library calls, don't allocate memory, don't print,

--- a/src/hotspot/os/posix/os_posix.hpp
+++ b/src/hotspot/os/posix/os_posix.hpp
@@ -118,7 +118,7 @@ public:
 class ThreadCrashProtection : public StackObj {
 public:
   static bool is_crash_protected(Thread* thr) {
-    return _crash_protection != NULL && _protected_thread == thr;
+    return _crash_protection != NULL && _crash_protection->_protected_thread == thr;
   }
 
   ThreadCrashProtection();
@@ -126,10 +126,13 @@ public:
 
   static void check_crash_protection(int signal, Thread* thread);
 private:
-  static Thread* _protected_thread;
+
   static ThreadCrashProtection* _crash_protection;
+  ThreadCrashProtection* _outer_protection;
+  Thread* _protected_thread;
   void restore();
   sigjmp_buf _jmpbuf;
+  static sigset_t _saved_sig_mask;
 };
 
 /*

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -5311,7 +5311,6 @@ os::ThreadCrashProtection* os::ThreadCrashProtection::_crash_protection = NULL;
 
 os::ThreadCrashProtection::ThreadCrashProtection() {
   _protected_thread = Thread::current();
-  assert(_protected_thread->is_JfrSampler_thread(), "should be JFRSampler");
 }
 
 // See the caveats for this class in os_windows.hpp

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -142,8 +142,9 @@ public:
 };
 
 /*
- * Crash protection for the JfrSampler thread. Wrap the callback
- * with a __try { call() }
+ * Crash protection for the JfrSampler thread (but also used for AsyncGetCallTrace).
+ * Wrap the callback with a sigsetjmp and in case of a SIGSEGV/SIGBUS we siglongjmp
+ * back.
  * To be able to use this - don't take locks, don't rely on destructors,
  * don't make OS library calls, don't allocate memory, don't print,
  * don't call code that could leave the heap / memory in an inconsistent state,

--- a/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
+++ b/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
@@ -352,7 +352,6 @@ class JfrThreadSampler : public NonJavaThread {
  public:
   virtual const char* name() const { return "JFR Thread Sampler"; }
   virtual const char* type_name() const { return "JfrThreadSampler"; }
-  bool is_JfrSampler_thread() const { return true; }
   void run();
   static Monitor* transition_block() { return JfrThreadSampler_lock; }
   static void on_javathread_suspend(JavaThread* thread);

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -666,7 +666,6 @@ public:
 extern "C" {
 JNIEXPORT
 void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
-#ifndef ASSERT
   if (Thread::current_or_null_safe() == NULL) {
     // we need the current Thread object for crash protection
     trace->num_frames = ticks_thread_exit;
@@ -680,10 +679,6 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
       trace->num_frames = ticks_unknown_state;
     }
   }
-#else
-  // we still want to see crashes in debug mode as they include asserts
-  asyncGetCallTraceImpl(trace, depth, ucontext);
-#endif
 }
 
 

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -505,63 +505,7 @@ static void forte_fill_call_trace_given_top(JavaThread* thd,
 }
 
 
-// Forte Analyzer AsyncGetCallTrace() entry point. Currently supported
-// on Linux X86, Solaris SPARC and Solaris X86.
-//
-// Async-safe version of GetCallTrace being called from a signal handler
-// when a LWP gets interrupted by SIGPROF but the stack traces are filled
-// with different content (see below).
-//
-// This function must only be called when JVM/TI
-// CLASS_LOAD events have been enabled since agent startup. The enabled
-// event will cause the jmethodIDs to be allocated at class load time.
-// The jmethodIDs cannot be allocated in a signal handler because locks
-// cannot be grabbed in a signal handler safely.
-//
-// void (*AsyncGetCallTrace)(ASGCT_CallTrace *trace, jint depth, void* ucontext)
-//
-// Called by the profiler to obtain the current method call stack trace for
-// a given thread. The thread is identified by the env_id field in the
-// ASGCT_CallTrace structure. The profiler agent should allocate a ASGCT_CallTrace
-// structure with enough memory for the requested stack depth. The VM fills in
-// the frames buffer and the num_frames field.
-//
-// Arguments:
-//
-//   trace    - trace data structure to be filled by the VM.
-//   depth    - depth of the call stack trace.
-//   ucontext - ucontext_t of the LWP
-//
-// ASGCT_CallTrace:
-//   typedef struct {
-//       JNIEnv *env_id;
-//       jint num_frames;
-//       ASGCT_CallFrame *frames;
-//   } ASGCT_CallTrace;
-//
-// Fields:
-//   env_id     - ID of thread which executed this trace.
-//   num_frames - number of frames in the trace.
-//                (< 0 indicates the frame is not walkable).
-//   frames     - the ASGCT_CallFrames that make up this trace. Callee followed by callers.
-//
-//  ASGCT_CallFrame:
-//    typedef struct {
-//        jint lineno;
-//        jmethodID method_id;
-//    } ASGCT_CallFrame;
-//
-//  Fields:
-//    1) For Java frame (interpreted and compiled),
-//       lineno    - bci of the method being executed or -1 if bci is not available
-//       method_id - jmethodID of the method being executed
-//    2) For native method
-//       lineno    - (-3)
-//       method_id - jmethodID of the method being executed
-
-extern "C" {
-JNIEXPORT
-void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
+void asyncGetCallTraceImpl(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
 
   JavaThread* thread;
 
@@ -648,6 +592,93 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
     trace->num_frames = ticks_unknown_state; // -7
     break;
   }
+}
+
+// Helps to wrap ASGCT in crash protection similar to JFR
+class AsyncGetCallTraceCallBack : public os::CrashProtectionCallback {
+public:
+  AsyncGetCallTraceCallBack(ASGCT_CallTrace *trace, jint depth, void* ucontext) :
+    _trace(trace), _depth(depth), _ucontext(ucontext) {
+  }
+  virtual void call() {
+    asyncGetCallTraceImpl(_trace, _depth, _ucontext);
+  }
+ private:
+  ASGCT_CallTrace* _trace;
+  jint _depth;
+  void* _ucontext;
+};
+
+// Forte Analyzer AsyncGetCallTrace() entry point. Currently supported
+// on Linux X86, Solaris SPARC and Solaris X86.
+//
+// Async-safe version of GetCallTrace being called from a signal handler
+// when a LWP gets interrupted by SIGPROF but the stack traces are filled
+// with different content (see below).
+//
+// This function must only be called when JVM/TI
+// CLASS_LOAD events have been enabled since agent startup. The enabled
+// event will cause the jmethodIDs to be allocated at class load time.
+// The jmethodIDs cannot be allocated in a signal handler because locks
+// cannot be grabbed in a signal handler safely.
+//
+// void (*AsyncGetCallTrace)(ASGCT_CallTrace *trace, jint depth, void* ucontext)
+//
+// Called by the profiler to obtain the current method call stack trace for
+// a given thread. The thread is identified by the env_id field in the
+// ASGCT_CallTrace structure. The profiler agent should allocate a ASGCT_CallTrace
+// structure with enough memory for the requested stack depth. The VM fills in
+// the frames buffer and the num_frames field.
+//
+// Arguments:
+//
+//   trace    - trace data structure to be filled by the VM.
+//   depth    - depth of the call stack trace.
+//   ucontext - ucontext_t of the LWP
+//
+// ASGCT_CallTrace:
+//   typedef struct {
+//       JNIEnv *env_id;
+//       jint num_frames;
+//       ASGCT_CallFrame *frames;
+//   } ASGCT_CallTrace;
+//
+// Fields:
+//   env_id     - ID of thread which executed this trace.
+//   num_frames - number of frames in the trace.
+//                (< 0 indicates the frame is not walkable).
+//   frames     - the ASGCT_CallFrames that make up this trace. Callee followed by callers.
+//
+//  ASGCT_CallFrame:
+//    typedef struct {
+//        jint lineno;
+//        jmethodID method_id;
+//    } ASGCT_CallFrame;
+//
+//  Fields:
+//    1) For Java frame (interpreted and compiled),
+//       lineno    - bci of the method being executed or -1 if bci is not available
+//       method_id - jmethodID of the method being executed
+//    2) For native method
+//       lineno    - (-3)
+//       method_id - jmethodID of the method being executed
+
+extern "C" {
+JNIEXPORT
+void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
+#ifndef ASSERT
+  trace->num_frames = ticks_unknown_state;
+  AsyncGetCallTraceCallBack cb(trace, depth, ucontext);
+  os::ThreadCrashProtection crash_protection;
+  if (!crash_protection.call(cb)) {
+    if (trace->num_frames < -10 || trace->num_frames >= 0) {
+      trace->num_frames = ticks_unknown_state;
+    }
+  }
+#else
+  // we still want to see crashes in debug mode as they include asserts
+  asyncGetCallTraceImpl(trace, depth, ucontext);
+#endif
 }
 
 

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -458,8 +458,6 @@ static void forte_fill_call_trace_given_top(JavaThread* thd,
                                             ASGCT_CallTrace* trace,
                                             int depth,
                                             frame top_frame) {
-  NoHandleMark nhm;
-
   frame initial_Java_frame;
   Method* method;
   int bci = -1; // assume BCI is not available for method
@@ -666,6 +664,7 @@ public:
 extern "C" {
 JNIEXPORT
 void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
+  NoHandleMark nhm;
   if (Thread::current_or_null_safe() == NULL) {
     // we need the current Thread object for crash protection
     trace->num_frames = ticks_thread_exit;

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -506,9 +506,9 @@ static void forte_fill_call_trace_given_top(JavaThread* thd,
 
 static void asyncGetCallTraceImpl(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
 
-  JavaThread* thread = JavaThread::current();
+  JavaThread* thread = JavaThread::current_or_null();
 
-  if (trace->env_id == NULL || thread->is_terminated() || thread->is_exiting()) {
+  if (trace->env_id == NULL || thread == NULL || thread->is_terminated() || thread->is_exiting()) {
     // bad env_id, thread has exited or thread is exiting
     trace->num_frames = ticks_thread_exit; // -8
     return;

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -458,6 +458,7 @@ static void forte_fill_call_trace_given_top(JavaThread* thd,
                                             ASGCT_CallTrace* trace,
                                             int depth,
                                             frame top_frame) {
+
   frame initial_Java_frame;
   Method* method;
   int bci = -1; // assume BCI is not available for method

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -506,10 +506,9 @@ static void forte_fill_call_trace_given_top(JavaThread* thd,
 
 static void asyncGetCallTraceImpl(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
 
-  JavaThread* thread;
+  JavaThread* thread = JavaThread::current();
 
-  if (trace->env_id == NULL ||
-      (thread = JavaThread::thread_from_jni_environment(trace->env_id))->is_exiting()) {
+  if (trace->env_id == NULL || thread->is_terminated() || thread->is_exiting()) {
     // bad env_id, thread has exited or thread is exiting
     trace->num_frames = ticks_thread_exit; // -8
     return;
@@ -521,7 +520,7 @@ static void asyncGetCallTraceImpl(ASGCT_CallTrace *trace, jint depth, void* ucon
     return;
   }
 
-  assert(JavaThread::current() == thread,
+  assert(thread == JavaThread::thread_from_jni_environment(trace->env_id),
          "AsyncGetCallTrace must be called by the current interrupted thread");
 
   if (!JvmtiExport::should_post_class_load()) {

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -671,13 +671,17 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
     trace->num_frames = ticks_thread_exit;
     return;
   }
-  trace->num_frames = ticks_unknown_state;
-  AsyncGetCallTraceCallBack cb(trace, depth, ucontext);
-  os::ThreadCrashProtection crash_protection;
-  if (!crash_protection.call(cb)) {
-    if (trace->num_frames >= 0) {
-      trace->num_frames = ticks_unknown_state;
+  if (CrashProtectAsyncGetCallTrace) {
+    trace->num_frames = ticks_unknown_state;
+    AsyncGetCallTraceCallBack cb(trace, depth, ucontext);
+    os::ThreadCrashProtection crash_protection;
+    if (!crash_protection.call(cb)) {
+      if (trace->num_frames >= 0) {
+        trace->num_frames = ticks_unknown_state;
+      }
     }
+  } else {
+    asyncGetCallTraceImpl(trace, depth, ucontext);
   }
 }
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2028,6 +2028,9 @@ const intx ObjectAlignmentInBytes = 8;
                                                                             \
   develop(bool, TraceOptimizedUpcallStubs, false,                              \
                 "Trace optimized upcall stub generation")                      \
+                                                                            \
+  product(bool, CrashProtectAsyncGetCallTrace, true,                        \
+                "Catch segmentation fault in AsyncGetCallTrace silently ")  \
 
 // end of RUNTIME_FLAGS
 

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -335,7 +335,6 @@ class Thread: public ThreadShadow {
   virtual bool is_ConcurrentGC_thread() const        { return false; }
   virtual bool is_Named_thread() const               { return false; }
   virtual bool is_Worker_thread() const              { return false; }
-  virtual bool is_JfrSampler_thread() const          { return false; }
 
   // Can this thread make Java upcalls
   virtual bool can_call_java() const                 { return false; }


### PR DESCRIPTION
Move the AsyncGetCallTrace method implementation into a separate method and wrap its call in non-assert compilation mode in `os::ThreadCrashProtection` like it is done in [JFR](https://github.com/openjdk/jdk/blob/965ea8d9cd29aee41ba2b1b0b0c67bb67eca22dd/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp#L165).
This prevents AsyncGetCallTrace from crashing on segmentation faults (but not on `guarantee`s).

If a crash is observed, then the `num_frames` field of the trace is set to `ticks_unknown_state` (-7) to signal a state that cannot be properly handled. `ticks_unknown_state` is currently also used for signaling unknown thread states but this should not be a problem, as the semantic is the same. If `num_frames` already has an error code then this error code is not changed. This helps to distinguish between errors in walking threads in Java and non-Java mode, as `num_frames` is set there before the walking to the appropriate error code.

_Thanks for @tstuefe for suggesting this._

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8284828](https://bugs.openjdk.java.net/browse/JDK-8284828): Use `os::ThreadCrashProtection` to protect AsyncGetCallTrace from crashing


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8225/head:pull/8225` \
`$ git checkout pull/8225`

Update a local copy of the PR: \
`$ git checkout pull/8225` \
`$ git pull https://git.openjdk.java.net/jdk pull/8225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8225`

View PR using the GUI difftool: \
`$ git pr show -t 8225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8225.diff">https://git.openjdk.java.net/jdk/pull/8225.diff</a>

</details>
