### PR TITLE
8284853: Fix various 'expected' typo

### DIFF
--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -52,7 +52,7 @@ static bool accesses_heap_base_zone(Node *val) {
         }
       }
       // Must recognize load operation with Decode matched in memory operand.
-      // We should not reach here exept for PPC/AIX, as os::zero_page_read_protected()
+      // We should not reach here except for PPC/AIX, as os::zero_page_read_protected()
       // returns true everywhere else. On PPC, no such memory operands
       // exist, therefore we did not yet implement a check for such operands.
       NOT_AIX(Unimplemented());

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/IncrementalSAXSource_Filter.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/dtm/ref/IncrementalSAXSource_Filter.java
@@ -485,7 +485,7 @@ implements IncrementalSAXSource, ContentHandler, DTDHandler, LexicalHandler, Err
    * routine for the convenience of subclasses: every [frequency]
    * invocations, issue a co_yield.</p>
    *
-   * @param moreExepected Should always be true unless this is being called
+   * @param moreExpected Should always be true unless this is being called
    * at the end of endDocument() handling.
    * */
   protected void count_and_yield(boolean moreExpected) throws SAXException

--- a/test/hotspot/jtreg/compiler/types/TestMeetIncompatibleInterfaceArrays.java
+++ b/test/hotspot/jtreg/compiler/types/TestMeetIncompatibleInterfaceArrays.java
@@ -216,7 +216,7 @@ public class TestMeetIncompatibleInterfaceArrays extends ClassLoader {
      *       3: areturn
      *
      * The "test()" method calls the "getName()" function from I1 on the objects returned by "run()".
-     * This will epectedly fail with an "IncompatibleClassChangeError" because the objects returned
+     * This will expectedly fail with an "IncompatibleClassChangeError" because the objects returned
      * by "run()" (and by createI2Array()) are actually of type "I2C" and only implement "I2" but not "I1".
      *
      *

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedEnumApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedEnumApp.java
@@ -34,7 +34,7 @@ public class ArchivedEnumApp {
             check(mod);
         }
         if (Modifier.values().length != 4) {
-            throw new RuntimeException("Modifier.$VALUES.length expeced: 4, actual: " + Modifier.values().length);
+            throw new RuntimeException("Modifier.$VALUES.length expected: 4, actual: " + Modifier.values().length);
         }
 
         // All 4 enums must exist in synthetic Modifier.$VALUES

--- a/test/hotspot/jtreg/vmTestbase/metaspace/gc/FirstGCTest.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/gc/FirstGCTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -144,7 +144,7 @@ public class FirstGCTest extends MetaspaceBaseGC {
                     + "the amount of committed space significantly differs "
                     + "from the expected amount");
             System.err.println("%## Real    : " + committedAmount);
-            System.err.println("%## Exepcted: " + metaspaceSize);
+            System.err.println("%## Expected: " + metaspaceSize);
             throw new Fault("GC happened at the wrong moment");
         } else {
             // -XX:MetaspaceSize is not given, check for default values

--- a/test/hotspot/jtreg/vmTestbase/metaspace/gc/HighWaterMarkTest.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/gc/HighWaterMarkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -153,7 +153,7 @@ public class HighWaterMarkTest extends FirstGCTest {
         int maxAttempts = 10_000;
 
         // in between metaspaceSize and maxMetaspaceSize
-        // no OOM is exepcted.
+        // no OOM is expected.
         long committedLevel = (metaspaceSize + maxMetaspaceSize) / 2;
 
         while (getCommitted() < committedLevel && attempts < maxAttempts) {

--- a/test/hotspot/jtreg/vmTestbase/metaspace/gc/MetaspaceBaseGC.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/gc/MetaspaceBaseGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -141,7 +141,7 @@ public abstract class MetaspaceBaseGC {
                 }
             } catch (java.net.MalformedURLException badThing) {
                 // should never occur
-                System.err.println("Unexpeted error: " + badThing);
+                System.err.println("Unexpected error: " + badThing);
                 throw new RuntimeException(badThing);
             }
         }

--- a/test/hotspot/jtreg/vmTestbase/metaspace/shrink_grow/ShrinkGrowTest/ShrinkGrowTest.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/shrink_grow/ShrinkGrowTest/ShrinkGrowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -224,7 +224,7 @@ public class ShrinkGrowTest {
             loadedClasses.put(jarUrl, foo);
         } catch (java.net.MalformedURLException badThing) {
             // should never occur
-            throwFault("Unexpeted error: " + badThing, badThing);
+            throwFault("Unexpected error: " + badThing, badThing);
         }
 
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach001/attach001TestRunner.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach001/attach001TestRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,7 @@ public class attach001TestRunner extends AODTestRunner {
         } catch (Failure f) {
             throw f;
         } catch (Throwable t) {
-            TestUtils.unexpctedException(t);
+            TestUtils.unexpectedException(t);
         }
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach036/attach036TestRunner.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach036/attach036TestRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,7 +92,7 @@ public class attach036TestRunner extends AODTestRunner {
         } catch (Failure f) {
             throw f;
         } catch (Throwable t) {
-            TestUtils.unexpctedException(t);
+            TestUtils.unexpectedException(t);
         }
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/test/TestUtils.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/test/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -118,7 +118,7 @@ public class TestUtils {
      * @throws nsk.share.Failure (given exception is set as Failure cause)
      *
      */
-    public static void unexpctedException(Throwable exception) {
+    public static void unexpectedException(Throwable exception) {
         throw new Failure("Unexpected exception: " + exception, exception);
     }
 

--- a/test/jdk/java/awt/Focus/ResetMostRecentFocusOwnerTest/ResetMostRecentFocusOwnerTest.java
+++ b/test/jdk/java/awt/Focus/ResetMostRecentFocusOwnerTest/ResetMostRecentFocusOwnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,7 @@ public class ResetMostRecentFocusOwnerTest {
         robot.delay(500);
 
         //
-        // It's expeced that the focus is restored to <button1>.
+        // It's expected that the focus is restored to <button1>.
         // If not, click <button1> to set focus on it.
         //
         if (!b1.hasFocus()) {

--- a/test/jdk/java/lang/Class/IsEnum.java
+++ b/test/jdk/java/lang/Class/IsEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public class IsEnum {
         failures += test(SpecialEnum.GREEN.getClass(), true);
 
         if (failures > 0) {
-            throw new RuntimeException("Unexepcted enum status detected.");
+            throw new RuntimeException("Unexpected enum status detected.");
         }
     }
 }

--- a/test/jdk/java/lang/StackWalker/StackStreamTest.java
+++ b/test/jdk/java/lang/StackWalker/StackStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -214,8 +214,8 @@ public class StackStreamTest {
     }
 
     private static <T> void equalsOrThrow(String label, List<T> list, List<T> expected) {
-        System.out.println("List:    " + list);
-        System.out.println("Expectd: " + list);
+        System.out.println("List:     " + list);
+        System.out.println("Expected: " + list);
         if (!list.equals(expected)) {
             System.err.println("Observed " + label);
             for (T s1 : list) {

--- a/test/jdk/java/lang/StackWalker/StackStreamTest.java
+++ b/test/jdk/java/lang/StackWalker/StackStreamTest.java
@@ -215,7 +215,7 @@ public class StackStreamTest {
 
     private static <T> void equalsOrThrow(String label, List<T> list, List<T> expected) {
         System.out.println("List:     " + list);
-        System.out.println("Expected: " + list);
+        System.out.println("Expected: " + expected);
         if (!list.equals(expected)) {
             System.err.println("Observed " + label);
             for (T s1 : list) {

--- a/test/jdk/java/nio/channels/DatagramChannel/Promiscuous.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/Promiscuous.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,13 +78,13 @@ public class Promiscuous {
     }
 
     /**
-     * Wait (with timeout) for datagram. The {@code datagramExepcted}
+     * Wait (with timeout) for datagram. The {@code datagramExpected}
      * parameter indicates whether a datagram is expected, and if
      * {@true} then {@code id} is the identifier in the payload.
      */
     static void receiveDatagram(DatagramChannel dc,
                                 String name,
-                                boolean datagramExepcted,
+                                boolean datagramExpected,
                                 int id)
         throws IOException
     {
@@ -103,7 +103,7 @@ public class Promiscuous {
 
                 // no datagram received
                 if (sa == null) {
-                    if (datagramExepcted) {
+                    if (datagramExpected) {
                         throw new RuntimeException("Expected message not received");
                     }
                     System.out.println("No message received (correct)");
@@ -126,7 +126,7 @@ public class Promiscuous {
                     System.out.format("Received message from %s (msg=%s)\n", sender, s);
                 }
 
-                if (!datagramExepcted) {
+                if (!datagramExpected) {
                     if (receivedId == id)
                         throw new RuntimeException("Message not expected");
                     System.out.println("Message ignored (has wrong id)");

--- a/test/jdk/java/nio/channels/SocketChannel/ExceptionTranslation.java
+++ b/test/jdk/java/nio/channels/SocketChannel/ExceptionTranslation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ public class ExceptionTranslation {
             chan1.socket().bind(new InetSocketAddress(0));
             throw new RuntimeException("Expected exception not thrown");
         } catch(IOException e) {
-            // Expepected result
+            // Expected result
         }
     }
 }

--- a/test/jdk/java/text/Format/DateFormat/WeekDateTest.java
+++ b/test/jdk/java/text/Format/DateFormat/WeekDateTest.java
@@ -96,7 +96,7 @@ public class WeekDateTest {
             date = ymdFormat.parse(regularDate);
             String s = ywdFormat.format(date);
             if (!s.equals(weekDate)) {
-                throw new RuntimeException("format: got="+s+", expecetd="+weekDate);
+                throw new RuntimeException("format: got="+s+", expected="+weekDate);
             }
         }
     }

--- a/test/jdk/java/time/test/java/time/TestClock_System.java
+++ b/test/jdk/java/time/test/java/time/TestClock_System.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -380,7 +380,7 @@ public class TestClock_System {
                 long expNan = (expectedMax % NANOS_IN_MICRO);
                 System.err.println("Excessive adjustment: " + adjSec + "s, "
                         + adjMil + "ms, " + adjMic + "mics, " + adjNan + "ns");
-                System.err.println("Epected max: " + expSec + "s, "
+                System.err.println("Expected max: " + expSec + "s, "
                         + expMil + "ms, " + expMic + "mics, " + expNan + "ns");
 
                 throw new RuntimeException(name

--- a/test/jdk/java/util/regex/whitebox/GraphemeTest.java
+++ b/test/jdk/java/util/regex/whitebox/GraphemeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,7 +90,7 @@ public class GraphemeTest {
                                         cp, expected, Character.getType(cp), types[GraphemeTestAccessor.getType(cp)]);
                             else
                                 fail(String.format(
-                                        "cp=[%x], expeced:[%s] result:[%s]%n",
+                                        "cp=[%x], expected:[%s] result:[%s]%n",
                                         cp, expected, types[GraphemeTestAccessor.getType(cp)]));
                         }
                     }

--- a/test/jdk/jdk/internal/misc/VM/GetNanoTimeAdjustment.java
+++ b/test/jdk/jdk/internal/misc/VM/GetNanoTimeAdjustment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -172,7 +172,7 @@ public class GetNanoTimeAdjustment {
                 long expNan = (expectedMax % NANOS_IN_MICRO);
                 System.err.println("Excessive adjustment: " + adjSec + "s, "
                         + adjMil + "ms, " + adjMic + "mics, " + adjNan + "ns");
-                System.err.println("Epected max: " + expSec + "s, "
+                System.err.println("Expected max: " + expSec + "s, "
                         + expMil + "ms, " + expMic + "mics, " + expNan + "ns");
 
                 throw new RuntimeException(name

--- a/test/jdk/jdk/jfr/api/recording/state/TestStateScheduleStart.java
+++ b/test/jdk/jdk/jfr/api/recording/state/TestStateScheduleStart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ public class TestStateScheduleStart {
         // We only check that we don't time out after 20 seconds.
         Instant started = Instant.now();
         long millis = Duration.between(start, started).toMillis();
-        System.out.println("Recording started at " + started + ". Delta millis=" + millis + ", expeced about 2000");
+        System.out.println("Recording started at " + started + ". Delta millis=" + millis + ", expected about 2000");
 
         verifyIllegalState(() -> r.start(), "double start()");
         r.stop();

--- a/test/jdk/sun/misc/JarIndex/metaInfFilenames/Basic.java
+++ b/test/jdk/sun/misc/JarIndex/metaInfFilenames/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -264,11 +264,11 @@ public class Basic {
         debug("HttpServer: " + httpServer);
 
         if (!expectbDotJar && httpServer.bDotJar > 0) {
-            debug("Unexpeced request sent to the httpserver for b.jar");
+            debug("Unexpected request sent to the httpserver for b.jar");
             return false;
         }
         if (!expectcDotJar && httpServer.cDotJar > 0) {
-            debug("Unexpeced request sent to the httpserver for c.jar");
+            debug("Unexpected request sent to the httpserver for c.jar");
             return false;
         }
 
@@ -304,11 +304,11 @@ public class Basic {
         debug("HttpServer: " + httpServer);
 
         if (!expectbDotJar && httpServer.bDotJar > 0) {
-            debug("Unexpeced request sent to the httpserver for b.jar");
+            debug("Unexpected request sent to the httpserver for b.jar");
             return false;
         }
         if (!expectcDotJar && httpServer.cDotJar > 0) {
-            debug("Unexpeced request sent to the httpserver for c.jar");
+            debug("Unexpected request sent to the httpserver for c.jar");
             return false;
         }
 

--- a/test/jdk/sun/security/x509/GeneralName/DNSNameTest.java
+++ b/test/jdk/sun/security/x509/GeneralName/DNSNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,7 +135,7 @@ public class DNSNameTest {
             fail("IOException expected");
         } catch (IOException e) {
             if (!e.getMessage().contains("DNSName"))
-                fail("Unexpeceted message: " + e);
+                fail("Unexpected message: " + e);
         }
     }
 
@@ -146,7 +146,7 @@ public class DNSNameTest {
             fail("IOException expected");
         } catch (IOException e) {
             if (!e.getMessage().contains("DNSName"))
-                fail("Unexpeceted message: " + e);
+                fail("Unexpected message: " + e);
         }
     }
 }

--- a/test/jdk/sun/text/resources/Collator/Bug6755060.java
+++ b/test/jdk/sun/text/resources/Collator/Bug6755060.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,7 +88,7 @@ public class Bug6755060 {
                     actual.append(data[i]);
                 }
 
-            String errmsg = "Error is found in collation testing in Thai\n" + "exepected order is: " + expected.toString() + "\n" + "actual order is: " + actual.toString() + "\n";
+            String errmsg = "Error is found in collation testing in Thai\n" + "expected order is: " + expected.toString() + "\n" + "actual order is: " + actual.toString() + "\n";
 
             throw new RuntimeException(errmsg);
         }

--- a/test/jdk/tools/jlink/plugins/ExcludeVMPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/ExcludeVMPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -149,7 +149,7 @@ public class ExcludeVMPluginTest {
 
     }
 
-    public void checkVM(String vm, String[] input, String jvmcfg, String[] expectedOutput, String expectdJvmCfg) throws Exception {
+    public void checkVM(String vm, String[] input, String jvmcfg, String[] expectedOutput, String expectedJvmCfg) throws Exception {
 
         for (String arch : ARCHITECTURES) {
             String[] winput = new String[input.length];
@@ -160,11 +160,11 @@ public class ExcludeVMPluginTest {
             for (int i = 0; i < expectedOutput.length; i++) {
                 woutput[i] = "/java.base/lib" + arch + expectedOutput[i];
             }
-            doCheckVM(vm, winput, jvmcfg, woutput, expectdJvmCfg);
+            doCheckVM(vm, winput, jvmcfg, woutput, expectedJvmCfg);
         }
     }
 
-    private void doCheckVM(String vm, String[] input, String jvmcfg, String[] expectedOutput, String expectdJvmCfg) throws Exception {
+    private void doCheckVM(String vm, String[] input, String jvmcfg, String[] expectedOutput, String expectedJvmCfg) throws Exception {
         // Create a pool with jvm.cfg and the input paths.
         byte[] jvmcfgContent = jvmcfg.getBytes();
         ResourcePoolManager poolMgr = new ResourcePoolManager();
@@ -194,8 +194,8 @@ public class ExcludeVMPluginTest {
 
         String newContent = new String(out.findEntry("/java.base/lib/jvm.cfg").get().contentBytes());
 
-        if (!expectdJvmCfg.equals(newContent)) {
-            throw new Exception("Got content " + newContent + " expected " + expectdJvmCfg);
+        if (!expectedJvmCfg.equals(newContent)) {
+            throw new Exception("Got content " + newContent + " expected " + expectedJvmCfg);
         }
 
         // Apart from native resources, we should find jvm.cfg and

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
@@ -114,7 +114,7 @@ final public class TKit {
     static void runTests(List<TestInstance> tests) {
         if (currentTest != null) {
             throw new IllegalStateException(
-                    "Unexpeced nested or concurrent Test.run() call");
+                    "Unexpected nested or concurrent Test.run() call");
         }
 
         withExtraLogStream(() -> {

--- a/test/jdk/tools/jpackage/share/LicenseTest.java
+++ b/test/jdk/tools/jpackage/share/LicenseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -282,11 +282,11 @@ public class LicenseTest {
                 return licenseFileText("APPLICATION_COPYRIGHT",
                         "APPLICATION_LICENSE_TEXT");
             } else {
-                return expetedLicenseFileText();
+                return expectedLicenseFileText();
             }
         }
 
-        private List<String> expetedLicenseFileText() {
+        private List<String> expectedLicenseFileText() {
             return licenseFileText(copyright, licenseText);
         }
 
@@ -326,7 +326,7 @@ public class LicenseTest {
             })
             .addInstallVerifier(cmd -> {
                 Path installedLicenseFile = linuxLicenseFile(cmd);
-                TKit.assertStringListEquals(expetedLicenseFileText(),
+                TKit.assertStringListEquals(expectedLicenseFileText(),
                         DEBIAN_COPYRIGT_FILE_STRIPPER.apply(Files.readAllLines(
                                 installedLicenseFile)), String.format(
                                 "Check contents of package license file [%s] are the same as contents of source license file [%s]",

--- a/test/make/UtilsForTests.gmk
+++ b/test/make/UtilsForTests.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
 
 # Assert two strings are equal
 # 1 - Tested value
-# 2 - Exepected value
+# 2 - Expected value
 # 3 - Error message
 AssertEquals = \
     $(if $(call equals, $(strip $1), $(strip $2)), , \
@@ -40,7 +40,7 @@ AssertEquals = \
 CreateFile = $(shell $(MKDIR) -p $(call ShellQuote, $(dir $1)) \
     && $(TOUCH) $(call ShellQuote, $1))
 
-# On macosx, file system timestamps only have 1 second resultion so must add
+# On macosx, file system timestamps only have 1 second resolution so must add
 # sleeps to properly test dependencies.
 ifeq ($(call isBuildOs, macosx), true)
   SLEEP_ON_MAC := sleep 1


### PR DESCRIPTION
Found various typos of expected: `exepected`, `exept`, `epectedly`, `expeced`, `Unexpeted`, etc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284853](https://bugs.openjdk.java.net/browse/JDK-8284853): Fix various 'expected' typo


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to fe6d989090f5336ed1b7234f21e2bbf2abab1441
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8231/head:pull/8231` \
`$ git checkout pull/8231`

Update a local copy of the PR: \
`$ git checkout pull/8231` \
`$ git pull https://git.openjdk.java.net/jdk pull/8231/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8231`

View PR using the GUI difftool: \
`$ git pr show -t 8231`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8231.diff">https://git.openjdk.java.net/jdk/pull/8231.diff</a>

</details>
