### PR TITLE
6626492: Event time in future part 2, now on X

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -138,7 +138,6 @@ java/awt/Focus/SimpleWindowActivationTest/SimpleWindowActivationTest.java 815959
 java/awt/Focus/TypeAhead/TestFocusFreeze.java 8198622,6447537 macosx-all,windows-all,linux-all
 java/awt/Focus/ToFrontFocusTest/ToFrontFocus.java 7156130 linux-all
 java/awt/Focus/WrongKeyTypedConsumedTest/WrongKeyTypedConsumedTest.java 8169096 macosx-all
-java/awt/event/KeyEvent/CorrectTime/CorrectTime.java 6626492 generic-all
 java/awt/EventQueue/6980209/bug6980209.java 8198615 macosx-all
 java/awt/Frame/ExceptionOnSetExtendedStateTest/ExceptionOnSetExtendedStateTest.java 8198237 macosx-all
 java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java 8144030 macosx-all,linux-all


### PR DESCRIPTION
This fix simply remove the test from ProblemList, since the issue is no longer reproducible.

Multiple CI test runs are green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-6626492](https://bugs.openjdk.java.net/browse/JDK-6626492): Event time in future part 2, now on X


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8232/head:pull/8232` \
`$ git checkout pull/8232`

Update a local copy of the PR: \
`$ git checkout pull/8232` \
`$ git pull https://git.openjdk.java.net/jdk pull/8232/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8232`

View PR using the GUI difftool: \
`$ git pr show -t 8232`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8232.diff">https://git.openjdk.java.net/jdk/pull/8232.diff</a>

</details>
