### PR TITLE
8213445: jcmd VM.symboltable and VM.stringtable -verbose output contains no shared symbols or strings

### DIFF
--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -654,7 +654,7 @@ size_t StringTable::verify_and_compare_entries() {
   return vcs._errors;
 }
 
-static void print_string(Thread* thr, outputStream* st, oop s) {
+static void print_string(Thread* current, outputStream* st, oop s) {
   typeArrayOop value     = java_lang_String::value_no_keepalive(s);
   int          length    = java_lang_String::length(s);
   bool         is_latin1 = java_lang_String::is_latin1(s);
@@ -662,7 +662,7 @@ static void print_string(Thread* thr, outputStream* st, oop s) {
   if (length <= 0) {
     st->print("%d: ", length);
   } else {
-    ResourceMark rm(thr);
+    ResourceMark rm(current);
     int utf8_length = length;
     char* utf8_string;
 

--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -584,10 +584,14 @@ TableStatistics StringTable::get_table_statistics() {
   return ts;
 }
 
-void StringTable::print_table_statistics(outputStream* st,
-                                         const char* table_name) {
+void StringTable::print_table_statistics(outputStream* st) {
   SizeFunc sz;
-  _local_table->statistics_to(Thread::current(), sz, st, table_name);
+  _local_table->statistics_to(Thread::current(), sz, st, "StringTable");
+#if INCLUDE_CDS_JAVA_HEAP
+  if (!_shared_table.empty()) {
+    _shared_table.print_table_statistics(st, "Shared String Table");
+  }
+#endif
 }
 
 // Verification
@@ -650,6 +654,32 @@ size_t StringTable::verify_and_compare_entries() {
   return vcs._errors;
 }
 
+static void print_string(Thread* thr, outputStream* st, oop s) {
+  typeArrayOop value     = java_lang_String::value_no_keepalive(s);
+  int          length    = java_lang_String::length(s);
+  bool         is_latin1 = java_lang_String::is_latin1(s);
+
+  if (length <= 0) {
+    st->print("%d: ", length);
+  } else {
+    ResourceMark rm(thr);
+    int utf8_length = length;
+    char* utf8_string;
+
+    if (!is_latin1) {
+      jchar* chars = value->char_at_addr(0);
+      utf8_string = UNICODE::as_utf8(chars, utf8_length);
+    } else {
+      jbyte* bytes = value->byte_at_addr(0);
+      utf8_string = UNICODE::as_utf8(bytes, utf8_length);
+    }
+
+    st->print("%d: ", utf8_length);
+    HashtableTextDump::put_utf8(st, utf8_string, utf8_length);
+  }
+  st->cr();
+}
+
 // Dumping
 class PrintString : StackObj {
   Thread* _thr;
@@ -661,36 +691,27 @@ class PrintString : StackObj {
     if (s == NULL) {
       return true;
     }
-    typeArrayOop value     = java_lang_String::value_no_keepalive(s);
-    int          length    = java_lang_String::length(s);
-    bool         is_latin1 = java_lang_String::is_latin1(s);
-
-    if (length <= 0) {
-      _st->print("%d: ", length);
-    } else {
-      ResourceMark rm(_thr);
-      int utf8_length = length;
-      char* utf8_string;
-
-      if (!is_latin1) {
-        jchar* chars = value->char_at_addr(0);
-        utf8_string = UNICODE::as_utf8(chars, utf8_length);
-      } else {
-        jbyte* bytes = value->byte_at_addr(0);
-        utf8_string = UNICODE::as_utf8(bytes, utf8_length);
-      }
-
-      _st->print("%d: ", utf8_length);
-      HashtableTextDump::put_utf8(_st, utf8_string, utf8_length);
-    }
-    _st->cr();
+    print_string(_thr, _st, s);
     return true;
+  };
+};
+
+class PrintSharedString : StackObj {
+  Thread* _thr;
+  outputStream* _st;
+public:
+  PrintSharedString(Thread* thr, outputStream* st) : _thr(thr), _st(st) {}
+  void do_value(oop s) {
+    if (s == NULL) {
+      return;
+    }
+    print_string(_thr, _st, s);
   };
 };
 
 void StringTable::dump(outputStream* st, bool verbose) {
   if (!verbose) {
-    print_table_statistics(st, "StringTable");
+    print_table_statistics(st);
   } else {
     Thread* thr = Thread::current();
     ResourceMark rm(thr);
@@ -699,6 +720,15 @@ void StringTable::dump(outputStream* st, bool verbose) {
     if (!_local_table->try_scan(thr, ps)) {
       st->print_cr("dump unavailable at this moment");
     }
+#if INCLUDE_CDS_JAVA_HEAP
+    if (!_shared_table.empty()) {
+      st->print_cr("---------------");
+      st->print_cr("Shared strings:");
+      st->print_cr("---------------");
+      PrintSharedString pss(thr, st);
+      _shared_table.iterate(&pss);
+    }
+#endif
   }
 }
 

--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -722,9 +722,9 @@ void StringTable::dump(outputStream* st, bool verbose) {
     }
 #if INCLUDE_CDS_JAVA_HEAP
     if (!_shared_table.empty()) {
-      st->print_cr("---------------");
-      st->print_cr("Shared strings:");
-      st->print_cr("---------------");
+      st->print_cr("#----------------");
+      st->print_cr("# Shared strings:");
+      st->print_cr("#----------------");
       PrintSharedString pss(thr, st);
       _shared_table.iterate(&pss);
     }

--- a/src/hotspot/share/classfile/stringTable.hpp
+++ b/src/hotspot/share/classfile/stringTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,7 @@ class StringTable : public CHeapObj<mtSymbol>{
   static oop do_intern(Handle string_or_null, const jchar* name, int len, uintx hash, TRAPS);
   static oop do_lookup(const jchar* name, int len, uintx hash);
 
-  static void print_table_statistics(outputStream* st, const char* table_name);
+  static void print_table_statistics(outputStream* st);
 
   static bool do_rehash();
 

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -613,16 +613,16 @@ void SymbolTable::dump(outputStream* st, bool verbose) {
       log_info(symboltable)("dump unavailable at this moment");
     }
     if (!_shared_table.empty()) {
-      st->print_cr("---------------");
-      st->print_cr("Shared symbols:");
-      st->print_cr("---------------");
+      st->print_cr("#----------------");
+      st->print_cr("# Shared symbols:");
+      st->print_cr("#----------------");
       DumpSharedSymbol dss(st);
       _shared_table.iterate(&dss);
     }
     if (!_dynamic_shared_table.empty()) {
-      st->print_cr("---------------");
-      st->print_cr("Dynamic shared symbols:");
-      st->print_cr("---------------");
+      st->print_cr("#------------------------");
+      st->print_cr("# Dynamic shared symbols:");
+      st->print_cr("#------------------------");
       DumpSharedSymbol dss(st);
       _dynamic_shared_table.iterate(&dss);
     }

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -535,10 +535,17 @@ TableStatistics SymbolTable::get_table_statistics() {
   return ts;
 }
 
-void SymbolTable::print_table_statistics(outputStream* st,
-                                         const char* table_name) {
+void SymbolTable::print_table_statistics(outputStream* st) {
   SizeFunc sz;
-  _local_table->statistics_to(Thread::current(), sz, st, table_name);
+  _local_table->statistics_to(Thread::current(), sz, st, "SymbolTable");
+
+  if (!_shared_table.empty()) {
+    _shared_table.print_table_statistics(st, "Shared Symbol Table");
+  }
+
+  if (!_dynamic_shared_table.empty()) {
+    _dynamic_shared_table.print_table_statistics(st, "Dynamic Shared Symbol Table");
+  }
 }
 
 // Verification
@@ -562,6 +569,14 @@ void SymbolTable::verify() {
   }
 }
 
+static void print_symbol(outputStream* st, Symbol* sym) {
+  const char* utf8_string = (const char*)sym->bytes();
+  int utf8_length = sym->utf8_length();
+  st->print("%d %d: ", utf8_length, sym->refcount());
+  HashtableTextDump::put_utf8(st, utf8_string, utf8_length);
+  st->cr();
+}
+
 // Dumping
 class DumpSymbol : StackObj {
   Thread* _thr;
@@ -571,19 +586,24 @@ public:
   bool operator()(Symbol** value) {
     assert(value != NULL, "expected valid value");
     assert(*value != NULL, "value should point to a symbol");
-    Symbol* sym = *value;
-    const char* utf8_string = (const char*)sym->bytes();
-    int utf8_length = sym->utf8_length();
-    _st->print("%d %d: ", utf8_length, sym->refcount());
-    HashtableTextDump::put_utf8(_st, utf8_string, utf8_length);
-    _st->cr();
+    print_symbol(_st, *value);
     return true;
+  };
+};
+
+class DumpSharedSymbol : StackObj {
+  outputStream* _st;
+public:
+  DumpSharedSymbol(outputStream* st) : _st(st) {}
+  void do_value(Symbol* value) {
+    assert(value != NULL, "value should point to a symbol");
+    print_symbol(_st, value);
   };
 };
 
 void SymbolTable::dump(outputStream* st, bool verbose) {
   if (!verbose) {
-    print_table_statistics(st, "SymbolTable");
+    print_table_statistics(st);
   } else {
     Thread* thr = Thread::current();
     ResourceMark rm(thr);
@@ -591,6 +611,20 @@ void SymbolTable::dump(outputStream* st, bool verbose) {
     DumpSymbol ds(thr, st);
     if (!_local_table->try_scan(thr, ds)) {
       log_info(symboltable)("dump unavailable at this moment");
+    }
+    if (!_shared_table.empty()) {
+      st->print_cr("---------------");
+      st->print_cr("Shared symbols:");
+      st->print_cr("---------------");
+      DumpSharedSymbol dss(st);
+      _shared_table.iterate(&dss);
+    }
+    if (!_dynamic_shared_table.empty()) {
+      st->print_cr("---------------");
+      st->print_cr("Dynamic shared symbols:");
+      st->print_cr("---------------");
+      DumpSharedSymbol dss(st);
+      _dynamic_shared_table.iterate(&dss);
     }
   }
 }

--- a/src/hotspot/share/classfile/symbolTable.hpp
+++ b/src/hotspot/share/classfile/symbolTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -146,7 +146,7 @@ class SymbolTable : public AllStatic {
   static Arena*  _arena;
   static Arena* arena() { return _arena; }  // called for statistics
 
-  static void print_table_statistics(outputStream* st, const char* table_name);
+  static void print_table_statistics(outputStream* st);
 
   static void try_rehash_table();
   static bool do_rehash();

--- a/test/hotspot/jtreg/runtime/cds/DumpSymbolAndStringTable.java
+++ b/test/hotspot/jtreg/runtime/cds/DumpSymbolAndStringTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,34 +23,53 @@
 
 /*
  * @test
- * @bug 8059510
+ * @bug 8059510 8213445
  * @summary Test jcmd VM.symboltable, VM.stringtable and VM.systemdictionary options
  * @library /test/lib
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions DumpSymbolAndStringTable
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI DumpSymbolAndStringTable
  */
 import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.JDKToolFinder;
+import sun.hotspot.WhiteBox;
 
 public class DumpSymbolAndStringTable {
     public static void main(String[] args) throws Exception {
         // Grab my own PID
         String pid = Long.toString(ProcessTools.getProcessId());
 
+        WhiteBox wb = WhiteBox.getWhiteBox();
+        boolean sharingEnabled = wb.isSharingEnabled();
+
         ProcessBuilder pb = new ProcessBuilder();
         pb.command(new String[] {JDKToolFinder.getJDKTool("jcmd"), pid, "VM.symboltable", "-verbose"});
         OutputAnalyzer output = CDSTestUtils.executeAndLog(pb, "jcmd-symboltable");
+        final String sharedSymbolsHeader = "Shared symbols:\n";
         try {
             output.shouldContain("24 2: DumpSymbolAndStringTable\n");
+            if (sharingEnabled) {
+                output.shouldContain(sharedSymbolsHeader);
+                output.shouldContain("17 65535: java.lang.runtime\n");
+            }
         } catch (RuntimeException e) {
             output.shouldContain("Unknown diagnostic command");
         }
 
         pb.command(new String[] {JDKToolFinder.getJDKTool("jcmd"), pid, "VM.stringtable", "-verbose"});
         output = CDSTestUtils.executeAndLog(pb, "jcmd-stringtable");
+        final String sharedStringsHeader = "Shared strings:\n";
         try {
             output.shouldContain("24: DumpSymbolAndStringTable\n");
+            if (sharingEnabled && wb.canWriteJavaHeapArchive()) {
+                output.shouldContain(sharedStringsHeader);
+                if (!wb.isSharedInternedString("MILLI_OF_SECOND")) {
+                    throw new RuntimeException("'MILLI_OF_SECOND' should be a shared string");
+                }
+            }
         } catch (RuntimeException e) {
             output.shouldContain("Unknown diagnostic command");
         }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicSharedSymbols.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicSharedSymbols.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+import jdk.test.lib.JDKToolFinder;
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jtreg.SkippedException;
+
+/*
+ * @test
+ * @bug 8213445
+ * @summary Test dumping of dynamic shared symbols using jcmd
+ * @requires vm.cds
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ *          /test/hotspot/jtreg/runtime/cds/appcds/test-classes
+ *          /test/hotspot/jtreg/runtime/cds/appcds/jcmd
+ * @build JCmdTestLingeredApp Hello jdk.test.lib.apps.LingeredApp
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar loadclass.jar JCmdTestLingeredApp
+ *             jdk.test.lib.apps.LingeredApp jdk.test.lib.apps.LingeredApp$1
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
+ * @run main/othervm/timeout=500 -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:./WhiteBox.jar DynamicSharedSymbols
+ */
+
+import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.helpers.ClassFileInstaller;
+import sun.hotspot.WhiteBox;
+
+public class DynamicSharedSymbols extends DynamicArchiveTestBase {
+
+    public static void main(String[] args) throws Exception {
+        runTest(DynamicSharedSymbols::testDefaultBase);
+    }
+
+    static void testDefaultBase() throws Exception {
+        String topArchiveName = getNewArchiveName("top");
+        doTest(topArchiveName);
+    }
+
+    private static void doTest(String topArchiveName) throws Exception {
+        WhiteBox wb = WhiteBox.getWhiteBox();
+        if (!wb.isSharingEnabled()) {
+            throw new SkippedException("Sharing is not enabled, test is skipped.");
+        }
+
+        String appJar = ClassFileInstaller.getJarPath("loadclass.jar");
+
+        // Create a dynamic archive.
+        String dynamicDumpArg = "-XX:ArchiveClassesAtExit=" + topArchiveName;
+        JCmdTestLingeredApp theApp = new JCmdTestLingeredApp();
+        LingeredApp.startApp(theApp, dynamicDumpArg,
+                             "-Xlog:cds,cds+dynamic=info",
+                             "-cp", appJar);
+        long pid = theApp.getPid();
+        LingeredApp.stopApp(theApp);
+
+        // Run with dynamic archive.
+        String sharedArchiveArg = "-XX:SharedArchiveFile=" + topArchiveName;
+        theApp = new JCmdTestLingeredApp();
+        LingeredApp.startApp(theApp,
+                             "-Xshare:on", sharedArchiveArg,
+                             "-Xlog:cds,class+load",
+                             "-cp", appJar);
+        pid = theApp.getPid();
+
+
+        // Use jcmd to dump the symbols of the above process running
+        // with dynamic shared archive.
+        ProcessBuilder pb = new ProcessBuilder();
+        pb.command(new String[] {JDKToolFinder.getJDKTool("jcmd"), Long.toString(pid), "VM.symboltable", "-verbose"});
+        OutputAnalyzer output = CDSTestUtils.executeAndLog(pb, "jcmd-symboltable");
+        output.shouldContain("17 2: jdk/test/lib/apps\n");
+        output.shouldContain("Dynamic shared symbols:\n");
+        output.shouldContain("5 65535: Hello\n");
+
+        LingeredApp.stopApp(theApp);
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDumpBase.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDumpBase.java
@@ -30,6 +30,7 @@ import java.util.List;
 import jdk.test.lib.apps.LingeredApp;
 import jdk.test.lib.dcmd.CommandExecutorException;
 import jdk.test.lib.dcmd.PidJcmdExecutor;
+import jdk.test.lib.helpers.ClassFileInstaller;
 import jdk.test.lib.process.OutputAnalyzer;
 import jtreg.SkippedException;
 import sun.hotspot.WhiteBox;
@@ -88,8 +89,8 @@ public abstract class JCmdTestDumpBase {
     }
 
     protected static void buildJars() throws Exception {
-        testJar = JarBuilder.build("test", TEST_CLASSES);
-        bootJar = JarBuilder.build("boot", BOOT_CLASSES);
+        testJar = ClassFileInstaller.writeJar("test", TEST_CLASSES);
+        bootJar = ClassFileInstaller.writeJar("boot", BOOT_CLASSES);
         System.out.println("Jar file created: " + testJar);
         System.out.println("Jar file created: " + bootJar);
         allJars = testJar + File.pathSeparator + bootJar;

--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDynamicDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDynamicDump.java
@@ -28,12 +28,10 @@
  * @summary Test jcmd to dump dynamic shared archive.
  * @requires vm.cds
  * @requires vm.flagless
- * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @modules jdk.jcmd/sun.tools.common:+open
- * @compile ../../../../../../lib/jdk/test/lib/apps/LingeredApp.java
- * @compile ../test-classes/Hello.java JCmdTestDumpBase.java
- * @build sun.hotspot.WhiteBox
- * @build JCmdTestLingeredApp JCmdTestDynamicDump
+ * @build jdk.test.lib.apps.LingeredApp sun.hotspot.WhiteBox Hello
+ *        JCmdTestDumpBase JCmdTestLingeredApp JCmdTestDynamicDump
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm/timeout=480 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI JCmdTestDynamicDump
  */

--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDynamicDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDynamicDump.java
@@ -30,6 +30,7 @@
  * @requires vm.flagless
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @modules jdk.jcmd/sun.tools.common:+open
+ * @compile ../../../../../../lib/jdk/test/lib/apps/LingeredApp.java
  * @compile ../test-classes/Hello.java JCmdTestDumpBase.java
  * @build sun.hotspot.WhiteBox
  * @build JCmdTestLingeredApp JCmdTestDynamicDump

--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestFileSafety.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestFileSafety.java
@@ -27,12 +27,10 @@
  * @bug 8265465 8267075
  * @summary Test jcmd to dump static shared archive.
  * @requires vm.cds
- * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @modules jdk.jcmd/sun.tools.common:+open
- * @compile ../../../../../../lib/jdk/test/lib/apps/LingeredApp.java
- * @compile ../test-classes/Hello.java JCmdTestDumpBase.java
- * @build sun.hotspot.WhiteBox
- * @build JCmdTestLingeredApp JCmdTestFileSafety
+ * @build jdk.test.lib.apps.LingeredApp sun.hotspot.WhiteBox Hello
+ *        JCmdTestDumpBase JCmdTestLingeredApp JCmdTestFileSafety
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm/timeout=480 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI JCmdTestFileSafety
  */

--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestFileSafety.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestFileSafety.java
@@ -29,6 +29,7 @@
  * @requires vm.cds
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @modules jdk.jcmd/sun.tools.common:+open
+ * @compile ../../../../../../lib/jdk/test/lib/apps/LingeredApp.java
  * @compile ../test-classes/Hello.java JCmdTestDumpBase.java
  * @build sun.hotspot.WhiteBox
  * @build JCmdTestLingeredApp JCmdTestFileSafety

--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestStaticDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestStaticDump.java
@@ -27,12 +27,10 @@
  * @bug 8259070
  * @summary Test jcmd to dump static shared archive.
  * @requires vm.cds
- * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @modules jdk.jcmd/sun.tools.common:+open
- * @compile ../../../../../../lib/jdk/test/lib/apps/LingeredApp.java
- * @compile ../test-classes/Hello.java JCmdTestDumpBase.java
- * @build sun.hotspot.WhiteBox
- * @build JCmdTestLingeredApp JCmdTestStaticDump
+ * @build jdk.test.lib.apps.LingeredApp sun.hotspot.WhiteBox Hello
+ *         JCmdTestDumpBase JCmdTestLingeredApp JCmdTestStaticDump
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm/timeout=480 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI JCmdTestStaticDump
  */

--- a/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestStaticDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestStaticDump.java
@@ -29,6 +29,7 @@
  * @requires vm.cds
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @modules jdk.jcmd/sun.tools.common:+open
+ * @compile ../../../../../../lib/jdk/test/lib/apps/LingeredApp.java
  * @compile ../test-classes/Hello.java JCmdTestDumpBase.java
  * @build sun.hotspot.WhiteBox
  * @build JCmdTestLingeredApp JCmdTestStaticDump


### PR DESCRIPTION
Please review this change which will include shared symbols and strings when using the commands `jcmd VMsymboltable -verbose` and `jcmd VM.stringtable -verbose`, respectively.

This change also prints the shared symbol and shared string tables statistics if the `-verbose` option is not specified.

An example output of shared symbols:

```
48084:
VERSION: 1.1
25 2: [Ljava/util/jar/Manifest;
13 65535: jdk/jfr/Event
26 2: [Ljava/lang/AutoCloseable;
5 1: 'app'
10 1: 'platform'
24 65535: jdk/internal/event/Event
---------------
Shared symbols:
---------------
0 65535:
10 65535: toIndex =
3 65535: sbc
14 65535: package.access
...
---------------
Dynamic shared symbols:
---------------
19 65535: findResourceInPatch
71 65535: (Ljava/util/List<Ljdk/internal/module/ModulePatcher$ResourceFinder;>;)V
8 65535: overflow
49 65535: sun/net/www/protocol/jrt/JavaRuntimeURLConnection
24 65535: com/sun/tools/javac/Main
29 65535: com/sun/tools/javac/main/Main
```

Note that the `Dynamic shared symbols` section only shows up if the `jcmd` is used on a running process which is using a dynamic archive.

An example output of symbol table statistics:

```
48494:
SymbolTable statistics:
Number of buckets       :     32768 =    262144 bytes, each 8
Number of entries       :         6 =        96 bytes, each 16
Number of literals      :         6 =       152 bytes, avg  25.000
Total footprint         :           =    262392 bytes
Average bucket size     :     0.000
Variance of bucket size :     0.000
Std. dev. of bucket size:     0.014
Maximum bucket size     :         1
Shared Symbol Table statistics:
Number of buckets       :     10332
Number of entries       :     39893
Maximum bucket size     :        13
Dynamic Shared Symbol Table statistics:
Number of buckets       :        51
Number of entries       :        42
Maximum bucket size     :         3
```

Note that the `Dynamic Shared Symbol Table statistics` section only shows up if the `jcmd` is used on a running process which is using a dynamic archive.

Passed CI tiers 1 and 2 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8213445](https://bugs.openjdk.java.net/browse/JDK-8213445): jcmd VM.symboltable and VM.stringtable -verbose output contains no shared symbols or strings


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to 5f5a5bbb5e70efbc8257bad5fb8af84e5c243a6c
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8234/head:pull/8234` \
`$ git checkout pull/8234`

Update a local copy of the PR: \
`$ git checkout pull/8234` \
`$ git pull https://git.openjdk.java.net/jdk pull/8234/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8234`

View PR using the GUI difftool: \
`$ git pr show -t 8234`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8234.diff">https://git.openjdk.java.net/jdk/pull/8234.diff</a>

</details>
