### PR TITLE
JDK-8276202: LogFileOutput.invalid_file_vm asserts when being executed from a read only working directory

### DIFF
--- a/test/hotspot/gtest/logging/logTestFixture.cpp
+++ b/test/hotspot/gtest/logging/logTestFixture.cpp
@@ -113,7 +113,7 @@ void LogTestFixture::clear_snapshot() {
   if (_configuration_snapshot == NULL) {
     return;
   }
-  assert(_n_snapshots > 0, "non-null array should have at least 1 element");
+  ASSERT_GT(_n_snapshots, size_t(0)) << "non-null array should have at least 1 element";
   for (size_t i = 0; i < _n_snapshots; i++) {
     os::free(_configuration_snapshot[i]);
   }

--- a/test/hotspot/gtest/logging/logTestUtils.inline.hpp
+++ b/test/hotspot/gtest/logging/logTestUtils.inline.hpp
@@ -57,14 +57,14 @@ static inline void delete_file(const char* filename) {
 }
 
 static inline void create_directory(const char* name) {
-  assert(!file_exists(name), "can't create directory: %s already exists", name);
+  ASSERT_FALSE(file_exists(name)) << "can't create directory: " << name << " already exists";
   bool failed;
 #ifdef _WINDOWS
   failed = !CreateDirectory(name, NULL);
 #else
   failed = mkdir(name, 0777);
 #endif
-  assert(!failed, "failed to create directory %s", name);
+  ASSERT_FALSE(failed) << "failed to create directory " << name;
 }
 
 static inline void delete_empty_directory(const char* name) {

--- a/test/hotspot/gtest/logging/test_logFileOutput.cpp
+++ b/test/hotspot/gtest/logging/test_logFileOutput.cpp
@@ -169,12 +169,26 @@ TEST_VM(LogFileOutput, invalid_file) {
   ResourceMark rm;
   stringStream ss;
 
+  // Generate sufficiently unique directory path and log spec for that path
+  ss.print("%s%s%s%d", os::get_temp_directory(), os::file_separator(), "tmplogdir", os::current_process_id());
+  char* path = ss.as_string();
+  ss.reset();
+
+  ss.print("%s%s", "file=", path);
+  char* log_spec = ss.as_string();
+  ss.reset();
+
+  ss.print("%s is not a regular file", path);
+  char* expected_output_substring = ss.as_string();
+  ss.reset();
+
   // Attempt to log to a directory (existing log not a regular file)
-  create_directory("tmplogdir");
-  LogFileOutput bad_file("file=tmplogdir");
+  create_directory(path);
+  LogFileOutput bad_file(log_spec);
   EXPECT_FALSE(bad_file.initialize("", &ss))
     << "file was initialized when there was an existing directory with the same name";
-  EXPECT_TRUE(string_contains_substring(ss.as_string(), "tmplogdir is not a regular file"))
-    << "missing expected error message, received msg: %s" << ss.as_string();
-  delete_empty_directory("tmplogdir");
+  char* logger_output = ss.as_string();
+  EXPECT_TRUE(string_contains_substring(logger_output, expected_output_substring))
+    << "missing expected error message, received msg: %s" << logger_output;
+  delete_empty_directory(path);
 }


### PR DESCRIPTION
This PR replaces some of the VM `assert` with gtest `ASSERT` where applicable and fixes a bug in a UL test.
The test used to create a temporary directory in cwd, failing if cwd is read-only. Now it creates the directory in /tmp/.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276202](https://bugs.openjdk.java.net/browse/JDK-8276202): LogFileOutput.invalid_file_vm asserts when being executed from a read only working directory


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8238/head:pull/8238` \
`$ git checkout pull/8238`

Update a local copy of the PR: \
`$ git checkout pull/8238` \
`$ git pull https://git.openjdk.java.net/jdk pull/8238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8238`

View PR using the GUI difftool: \
`$ git pr show -t 8238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8238.diff">https://git.openjdk.java.net/jdk/pull/8238.diff</a>

</details>
