### PR TITLE
8284863: riscv: missing side effect for result in instruct vcount_positives

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1546,7 +1546,8 @@ void C2_MacroAssembler::count_positives_v(Register ary, Register len, Register r
   Label LOOP, SET_RESULT, DONE;
 
   BLOCK_COMMENT("count_positives_v {");
-  assert_different_registers(result, tmp);
+  assert_different_registers(ary, len, result, tmp);
+
   mv(result, zr);
 
   bind(LOOP);

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1546,6 +1546,7 @@ void C2_MacroAssembler::count_positives_v(Register ary, Register len, Register r
   Label LOOP, SET_RESULT, DONE;
 
   BLOCK_COMMENT("count_positives_v {");
+  assert_different_registers(result, tmp);
   mv(result, zr);
 
   bind(LOOP);

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -1993,11 +1993,12 @@ instruct vstring_compress(iRegP_R12 src, iRegP_R11 dst, iRegI_R13 len, iRegI_R10
   ins_pipe( pipe_slow );
 %}
 
-instruct vcount_positives(iRegP_R11 ary, iRegI_R12 len, iRegI_R10 result, iRegL tmp)
+instruct vcount_positives(iRegP_R11 ary, iRegI_R12 len, iRegI_R10 result,
+                          vReg_V1 v1, vReg_V2 v2, vReg_V3 v3, iRegL tmp)
 %{
   predicate(UseRVV);
   match(Set result (CountPositives ary len));
-  effect(USE_KILL ary, USE_KILL len, TEMP tmp);
+  effect(TEMP_DEF result, USE_KILL ary, USE_KILL len, TEMP v1, TEMP v2, TEMP v3, TEMP tmp);
 
   format %{ "count positives byte[] $ary, $len -> $result" %}
   ins_encode %{


### PR DESCRIPTION
[JDK-8283364](https://bugs.openjdk.java.net/browse/JDK-8283364) replaces `StringCoding.hasNegatives` with `countPositives`.
But the TEMP_DEF for result in vcount_positives was missing, without which `result != tmp` could not be guaranteed.
If we add `assert_different_registers(result, tmp)` in `C2_MacroAssembler::count_positives_v`,
JVM will complain assertion error for some test in hotspot and langtools when UseRVV is enabled.

After is patch, failed tests in hotspot and langtools are passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284863](https://bugs.openjdk.java.net/browse/JDK-8284863): riscv: missing side effect for result in instruct vcount_positives


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8239/head:pull/8239` \
`$ git checkout pull/8239`

Update a local copy of the PR: \
`$ git checkout pull/8239` \
`$ git pull https://git.openjdk.java.net/jdk pull/8239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8239`

View PR using the GUI difftool: \
`$ git pr show -t 8239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8239.diff">https://git.openjdk.java.net/jdk/pull/8239.diff</a>

</details>
