### PR TITLE
JDK-8284874: Add comment to ProcessHandle/OnExitTest to describe zombie problem

### DIFF
--- a/test/jdk/java/lang/ProcessHandle/OnExitTest.java
+++ b/test/jdk/java/lang/ProcessHandle/OnExitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/ProcessHandle/OnExitTest.java
+++ b/test/jdk/java/lang/ProcessHandle/OnExitTest.java
@@ -95,6 +95,23 @@ public class OnExitTest extends ProcessUtil {
      */
     @Test
     public static void test2() {
+
+        // Please note:
+        //
+        // On Unix, this test relies on the ability of the system to adopt orphaned processes and
+        // reap them in a timely fashion. In other words, the ability to prevent orphans from becoming
+        // zombies.
+        //
+        // Therefore, on misconfigured or broken systems, this test may fail. These failures will manifest
+        // as timeouts.
+        //
+        // That will rarely be a problem on bare-metal systems but may be more common when running in
+        // Docker. Misconfigured Docker instances may run with an initial process unable to reap. One
+        // infamous example would be running jtreg tests inside a Docker via Jenkins CI.
+        //
+        // This is quite difficult - and inefficient - to fix inside this test, and rather easy to
+        // avoid. For a detailed analysis, as well as proposed workarounds, please see JDK-8284282.
+        //
         ProcessHandle procHandle = null;
         try {
             ConcurrentHashMap<ProcessHandle, ProcessHandle> processes = new ConcurrentHashMap<>();

--- a/test/jdk/java/lang/ProcessHandle/OnExitTest.java
+++ b/test/jdk/java/lang/ProcessHandle/OnExitTest.java
@@ -96,14 +96,15 @@ public class OnExitTest extends ProcessUtil {
     @Test
     public static void test2() {
 
-        // Please note:
+        // Please note (JDK-8284282):
         //
         // On Unix, this test relies on the ability of the system to adopt orphaned processes and
         // reap them in a timely fashion. In other words, the ability to prevent orphans from becoming
         // zombies.
         //
         // Therefore, on misconfigured or broken systems, this test may fail. These failures will manifest
-        // as timeouts.
+        // as timeouts. The failures depend on timing: they may not happen at all, be intermittent or
+        // constant.
         //
         // That will rarely be a problem on bare-metal systems but may be more common when running in
         // Docker. Misconfigured Docker instances may run with an initial process unable to reap. One


### PR DESCRIPTION
ProcessHandle/OnExitTest is vulnerable to misconfigured systems that do not reap zombies in a timely fashion. [JDK-8284282](https://bugs.openjdk.java.net/browse/JDK-8284282) describes this problem in detail.

Until we figure out a way to fix that (if at all - see comments in JBS), let us have a clarifying comment in the test itself.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284874](https://bugs.openjdk.java.net/browse/JDK-8284874): Add comment to ProcessHandle/OnExitTest to describe zombie problem


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8240/head:pull/8240` \
`$ git checkout pull/8240`

Update a local copy of the PR: \
`$ git checkout pull/8240` \
`$ git pull https://git.openjdk.java.net/jdk pull/8240/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8240`

View PR using the GUI difftool: \
`$ git pr show -t 8240`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8240.diff">https://git.openjdk.java.net/jdk/pull/8240.diff</a>

</details>
