### PR TITLE
8284877: Check type compatibility before looking up method from receiver's vtable

### DIFF
--- a/src/hotspot/share/interpreter/linkResolver.cpp
+++ b/src/hotspot/share/interpreter/linkResolver.cpp
@@ -1355,6 +1355,15 @@ void LinkResolver::runtime_resolve_virtual_method(CallInfo& result,
   // a missing receiver might result in a bogus lookup.
   assert(resolved_method->method_holder()->is_linked(), "must be linked");
 
+  // Receriver should be compatible with resolved klass, i.e. it must be a type of resolved klass
+  // or a subtype of resolved klass(receiver instanceof resolved_klass)
+  if (!recv.is_null() && !recv()->is_a(resolved_klass)) {
+    ResourceMark rm(THREAD);
+    stringStream ss;
+    ss.print("Receiver should be type/subtype of %s", resolved_klass->external_name());
+    THROW_MSG(vmSymbols::java_lang_IncompatibleClassChangeError(), ss.as_string());
+  }
+
   // do lookup based on receiver klass using the vtable index
   if (resolved_method->method_holder()->is_interface()) { // default or miranda method
     vtable_index = vtable_index_of_interface_method(resolved_klass, resolved_method);

--- a/src/hotspot/share/interpreter/linkResolver.cpp
+++ b/src/hotspot/share/interpreter/linkResolver.cpp
@@ -1350,25 +1350,28 @@ void LinkResolver::runtime_resolve_virtual_method(CallInfo& result,
     THROW(vmSymbols::java_lang_NullPointerException());
   }
 
-  // Virtual methods cannot be resolved before its klass has been linked, for otherwise the Method*'s
-  // has not been rewritten, and the vtable initialized. Make sure to do this after the nullcheck, since
-  // a missing receiver might result in a bogus lookup.
-  if (!resolved_method->method_holder()->is_linked()) {
-    ResourceMark rm(THREAD);
-    stringStream ss;
-    ss.print("Resolved method holder class %s", resolved_method->method_holder()->external_name());
-    ss.print(" must be linked");
-    THROW_MSG(vmSymbols::java_lang_IncompatibleClassChangeError(), ss.as_string());
-  }
+  // Perform additional type checks before virtual call
+  if (CheckJNICalls) {
+    // Virtual methods cannot be resolved before its klass has been linked, for otherwise the Method*'s
+    // has not been rewritten, and the vtable initialized. Make sure to do this after the nullcheck, since
+    // a missing receiver might result in a bogus lookup.
+    if (!resolved_method->method_holder()->is_linked()) {
+      ResourceMark rm(THREAD);
+      stringStream ss;
+      ss.print("Resolved method holder class %s", resolved_method->method_holder()->external_name());
+      ss.print(" must be linked.");
+      THROW_MSG(vmSymbols::java_lang_IncompatibleClassChangeError(), ss.as_string());
+    }
 
-  // Receriver should be compatible with resolved klass, i.e. it must be a type of resolved klass
-  // or a subtype of resolved klass(receiver instanceof resolved_klass)
-  if (!recv.is_null() && !recv_klass->is_subtype_of(resolved_klass)) {
-    ResourceMark rm(THREAD);
-    stringStream ss;
-    ss.print("The type of receiver %s", recv_klass->external_name());
-    ss.print(" should be or subtype of %s", resolved_klass->external_name());
-    THROW_MSG(vmSymbols::java_lang_IncompatibleClassChangeError(), ss.as_string());
+    // Receiver should be compatible with resolved klass, i.e. it must be a type of resolved klass
+    // or a subtype of resolved klass(receiver instanceof resolved_klass).
+    if (!recv.is_null() && !recv_klass->is_subtype_of(resolved_klass)) {
+      ResourceMark rm(THREAD);
+      stringStream ss;
+      ss.print("The type of receiver %s", recv_klass->external_name());
+      ss.print(" should be or subtype of %s.", resolved_klass->external_name());
+      THROW_MSG(vmSymbols::java_lang_IncompatibleClassChangeError(), ss.as_string());
+    }
   }
 
   // do lookup based on receiver klass using the vtable index

--- a/test/hotspot/jtreg/runtime/linkResolver/TestErrorReceiverType.java
+++ b/test/hotspot/jtreg/runtime/linkResolver/TestErrorReceiverType.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2022, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8284877
+ * @summary Check type compatibility before looking up method from receiver's vtable
+ * @modules java.base/jdk.internal.misc:+open
+ * @library /test/lib
+ * @run main/othervm TestErrorReceiverType
+ */
+
+import jdk.internal.misc.Unsafe;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class TestErrorReceiverType {
+    public static void main(String[] args) throws Throwable {
+        // 8284877
+        // Commenting out the following line crashes JVM at assert(resolved_method->method_holder()->is_linked(), "must be linked");
+        Class.forName("TestErrorReceiverType$LongMapSupportArrayList");
+
+        try {
+            Unsafe unsafe = getUnsafe();
+            long offset = unsafe.objectFieldOffset(
+                A.class.getDeclaredField("list")
+            );
+
+            A a = new A();
+            unsafe.putObject(a, offset, new ArrayList<>());
+            a.list.toMap();
+        } catch (NoSuchFieldException e) {
+            e.printStackTrace();
+        } catch (IncompatibleClassChangeError e1) {
+            e1.printStackTrace();
+            System.out.println("Expected");
+        } finally {
+        }
+    }
+
+    private static Unsafe getUnsafe() {
+        try {
+            Field field = Unsafe.class.getDeclaredField("theUnsafe");
+            field.setAccessible(true);
+            return (Unsafe) field.get(null);
+        } catch (Exception e) {
+        }
+        return null;
+    }
+
+    private static class LongMapSupportArrayList<T> extends ArrayList {
+        public Map<?, ?> toMap() {
+            return new HashMap<>();
+        }
+    }
+
+    private static class A {
+        private String s = "a";
+        private LongMapSupportArrayList<String> list;
+    }
+}

--- a/test/hotspot/jtreg/runtime/linkResolver/TestErrorReceiverType.java
+++ b/test/hotspot/jtreg/runtime/linkResolver/TestErrorReceiverType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Alibaba Group Holding Limited. All Rights Reserved.
+ * Copyright (c) 2023, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
  * @summary Check type compatibility before looking up method from receiver's vtable
  * @modules java.base/jdk.internal.misc:+open
  * @library /test/lib
- * @run main/othervm TestErrorReceiverType
+ * @run main/othervm -Xcheck:jni TestErrorReceiverType
  */
 
 import jdk.internal.misc.Unsafe;


### PR DESCRIPTION
Hi, can I have a review for this enhancement? This patch adds type compatibility check before method lookup for robustness. In some internal cases, serialization framework may improperly generate an object of wrong type, which leads JVM randomly crashes during method resolution.

For example:
```
invokevirtual selected method: receiver-class:java.util.ArrayList, resolved-class:com.taobao.forest.domain.util.LongMapSupportArrayList, resolved_method:com.taobao.forest.domain.util.LongMapSupportArrayList.toMap()Ljava/util/Map;, selected_method:0x458, vtable_index:56#
```
The real type of receiver is ArrayList, while the resolved method is LongMapSupportArrayList.toMap. VM attempts to select method as if looking up from receiver's vtable via vtable index of resolved method(i.e. attempts to lookup `toMap()` from 
 ArrayList), an invalid method or incorrect method would be selected, thus causing some strange crashes.

I think it's reasonable to add a type compatibility check before method lookup. If such an incompatible call is found, JVM could throw an exception instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284877](https://bugs.openjdk.org/browse/JDK-8284877): Check type compatibility before looking up method from receiver's vtable (**Enhancement** - P4) ⚠️ Issue is not open.


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/8241/head:pull/8241` \
`$ git checkout pull/8241`

Update a local copy of the PR: \
`$ git checkout pull/8241` \
`$ git pull https://git.openjdk.org/jdk.git pull/8241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8241`

View PR using the GUI difftool: \
`$ git pr show -t 8241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/8241.diff">https://git.openjdk.org/jdk/pull/8241.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/8241#issuecomment-1099059560)