### PR TITLE
8284866: Add test to JDK-8273056

### DIFF
--- a/test/jdk/java/util/Random/RandomExponentialTest.java
+++ b/test/jdk/java/util/Random/RandomExponentialTest.java
@@ -1,0 +1,35 @@
+import jdk.test.lib.RandomFactory;
+
+/**
+ * @test
+ * @summary Check that nextExponential() returns non-negative outcomes
+ * @bug 8284866
+ *
+ * @key randomness
+ * @library /test/lib
+ * @build jdk.test.lib.RandomFactory
+ * @run main RandomExponentialTest
+ */
+
+public class RandomExponentialTest {
+
+    private static final int SAMPLES = 1_000_000_000;
+
+    public static void main(String[] args) throws Exception {
+        var errCount = 0;
+        var errSample = Double.NaN;
+        var random = RandomFactory.getRandom();
+        for (int i = 0; i < SAMPLES; i++) {
+            var expVal = random.nextExponential();
+            if (!(expVal >= 0.0)) {
+                errCount += 1;
+                errSample = expVal;
+            }
+        }
+        if (errCount > 0) {
+            throw new RuntimeException("%d errors out of %d samples: e.g., %f"
+                            .formatted(errCount, SAMPLES, errSample));
+        }
+    }
+
+}

--- a/test/jdk/java/util/Random/RandomExponentialTest.java
+++ b/test/jdk/java/util/Random/RandomExponentialTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 import jdk.test.lib.RandomFactory;
 
 /**


### PR DESCRIPTION
Hello,
this is a followup of JDK-8273056 to add a test to check that Random.nextExponential() produces non-negative results.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284866](https://bugs.openjdk.java.net/browse/JDK-8284866): Add test to JDK-8273056


### Reviewers
 * [Jim Laskey](https://openjdk.java.net/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8243/head:pull/8243` \
`$ git checkout pull/8243`

Update a local copy of the PR: \
`$ git checkout pull/8243` \
`$ git pull https://git.openjdk.java.net/jdk pull/8243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8243`

View PR using the GUI difftool: \
`$ git pr show -t 8243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8243.diff">https://git.openjdk.java.net/jdk/pull/8243.diff</a>

</details>
