### PR TITLE
8159599: [TEST_BUG] java/awt/Modal/ModalInternalFrameTest/ModalInternalFrameTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -133,7 +133,6 @@ java/awt/Focus/ClearLwQueueBreakTest/ClearLwQueueBreakTest.java 8198618 macosx-a
 java/awt/Focus/ConsumeNextKeyTypedOnModalShowTest/ConsumeNextKeyTypedOnModalShowTest.java 6986252 macosx-all
 java/awt/Focus/MouseClickRequestFocusRaceTest/MouseClickRequestFocusRaceTest.java 8194753 linux-all,macosx-all
 java/awt/Focus/NoAutotransferToDisabledCompTest/NoAutotransferToDisabledCompTest.java 7152980 macosx-all
-java/awt/Focus/SimpleWindowActivationTest/SimpleWindowActivationTest.java 8159599 macosx-all
 java/awt/Focus/TypeAhead/TestFocusFreeze.java 8198622,6447537 macosx-all,windows-all,linux-all
 java/awt/Focus/ToFrontFocusTest/ToFrontFocus.java 7156130 linux-all
 java/awt/Focus/WrongKeyTypedConsumedTest/WrongKeyTypedConsumedTest.java 8169096 macosx-all

--- a/test/jdk/java/awt/Focus/SimpleWindowActivationTest/SimpleWindowActivationTest.java
+++ b/test/jdk/java/awt/Focus/SimpleWindowActivationTest/SimpleWindowActivationTest.java
@@ -68,9 +68,11 @@ public class SimpleWindowActivationTest {
 
         createAndShowWindow();
         robot.waitForIdle();
+        robot.delay(500);
 
         createAndShowFrame();
         robot.waitForIdle();
+        robot.delay(500);
 
         // click on Frame
         clickOn(getClickPoint(frame));

--- a/test/jdk/java/awt/Focus/SimpleWindowActivationTest/SimpleWindowActivationTest.java
+++ b/test/jdk/java/awt/Focus/SimpleWindowActivationTest/SimpleWindowActivationTest.java
@@ -27,15 +27,24 @@
  * @bug       6385277
  * @summary   Tests that override redirect window gets activated on click.
  * @author    anton.tarasov@sun.com: area=awt.focus
- * @library   ../../regtesthelpers
- * @build     Util
  * @run       main SimpleWindowActivationTest
  */
-import java.awt.*;
-import java.awt.event.*;
-import java.util.concurrent.Callable;
-import javax.swing.SwingUtilities;
-import test.java.awt.regtesthelpers.Util;
+
+import java.awt.AWTEvent;
+import java.awt.Button;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Label;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.Window;
+import java.awt.event.AWTEventListener;
+import java.awt.event.FocusEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.WindowEvent;
 
 public class SimpleWindowActivationTest {
 
@@ -130,8 +139,8 @@ public class SimpleWindowActivationTest {
         robot.mouseMove(point.x, point.y);
         robot.waitForIdle();
 
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
 
         robot.waitForIdle();
     }


### PR DESCRIPTION
The SimpleWindowActivationTest test does not fail even without modifications(multiple CI test runs are green).
So just remove it from ProblemList would be enough.

However I did some clean up and added some delays for  "extra safety".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8159599](https://bugs.openjdk.java.net/browse/JDK-8159599): [TEST_BUG] java/awt/Modal/ModalInternalFrameTest/ModalInternalFrameTest.java


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8244/head:pull/8244` \
`$ git checkout pull/8244`

Update a local copy of the PR: \
`$ git checkout pull/8244` \
`$ git pull https://git.openjdk.java.net/jdk pull/8244/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8244`

View PR using the GUI difftool: \
`$ git pr show -t 8244`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8244.diff">https://git.openjdk.java.net/jdk/pull/8244.diff</a>

</details>
