### PR TITLE
8284539: Configure --with-source-date=version fails on MacOS

### DIFF
--- a/make/autoconf/util.m4
+++ b/make/autoconf/util.m4
@@ -239,11 +239,16 @@ AC_DEFUN([UTIL_GET_EPOCH_TIMESTAMP],
     timestamp=$($DATE --utc --date=$2 +"%s" 2> /dev/null)
   else
     # BSD date
-    timestamp=$($DATE -u -j -f "%FZ %TZ" "$2" "+%s" 2> /dev/null)
+    # ISO-8601 date&time in Zulu 'date'T'time'Z
+    timestamp=$($DATE -u -j -f "%FT%TZ" "$2" "+%s" 2> /dev/null)
     if test "x$timestamp" = x; then
       # BSD date cannot handle trailing milliseconds.
       # Try again ignoring characters at end
       timestamp=$($DATE -u -j -f "%Y-%m-%dT%H:%M:%S" "$2" "+%s" 2> /dev/null)
+    fi
+    if test "x$timestamp" = x; then
+      # Perhaps the time was missing.
+      timestamp=$($DATE -u -j -f "%FT%TZ" "$2""T00:00:00Z" "+%s" 2> /dev/null)
     fi
   fi
   $1=$timestamp


### PR DESCRIPTION
JDK-8282769 added support for more ISO-8601 formats, but remove handling of just a date "YYYY-MM-DD" being present, which is the case for a configure using --with-source-date=version which uses the date string from version-numbers.conf.
Also, the first date parse had an invalid format string "%FZ %TZ", with too many Zs.
This PR corrects the first date parse to parse a standard ISO-8601 Zulu date&time: "%FT%TZ"
Then it adds the final check for no time being specified.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284539](https://bugs.openjdk.java.net/browse/JDK-8284539): Configure --with-source-date=version fails on MacOS


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8247/head:pull/8247` \
`$ git checkout pull/8247`

Update a local copy of the PR: \
`$ git checkout pull/8247` \
`$ git pull https://git.openjdk.java.net/jdk pull/8247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8247`

View PR using the GUI difftool: \
`$ git pr show -t 8247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8247.diff">https://git.openjdk.java.net/jdk/pull/8247.diff</a>

</details>
