### PR TITLE
8284892: java/net/httpclient/http2/TLSConnection.java fails intermittently

### DIFF
--- a/test/jdk/java/net/httpclient/http2/TLSConnection.java
+++ b/test/jdk/java/net/httpclient/http2/TLSConnection.java
@@ -166,12 +166,13 @@ public class TLSConnection {
                 System.out.println(new String(body));
             }
 
+            sslSession = t.getSSLSession();
+
             try (OutputStream os = t.getResponseBody()) {
                 t.sendResponseHeaders(200, BODY.length);
                 os.write(BODY);
             }
 
-            sslSession = t.getSSLSession();
         }
 
         SSLSession getSSLSession() {

--- a/test/jdk/java/net/httpclient/http2/TLSConnection.java
+++ b/test/jdk/java/net/httpclient/http2/TLSConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
java/net/httpclient/http2/TLSConnection.java has been observed failing (even though rarely) in test jobs.

The issue is that the handler used on the the server sides maintains a volatile `sslSession` field which it sets when receiving a request, so that the client can check which SSLParameters were negotiated after receiving the response.
However that field is set a little too late: after writing the request body bytes. This means that sometimes the client is able to receive the last byte before the server has updated the field, and can observe the previous value, which was set by the previous request. Checking of SSL parameters on the client side then usually fails, as it is looking at the wrong session.

The proposed fix is very simple: just update the `sslSession` field a little earlier - before writing the response.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284892](https://bugs.openjdk.java.net/browse/JDK-8284892): java/net/httpclient/http2/TLSConnection.java fails intermittently


### Reviewers
 * [Daniel Jeliński](https://openjdk.java.net/census#djelinski) (@djelinski - Committer) ⚠️ Review applies to 91626f6da646f03a39d92108bebcfac39939c388
 * [Jaikiran Pai](https://openjdk.java.net/census#jpai) (@jaikiran - Committer)
 * [Michael McMahon](https://openjdk.java.net/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8249/head:pull/8249` \
`$ git checkout pull/8249`

Update a local copy of the PR: \
`$ git checkout pull/8249` \
`$ git pull https://git.openjdk.java.net/jdk pull/8249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8249`

View PR using the GUI difftool: \
`$ git pr show -t 8249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8249.diff">https://git.openjdk.java.net/jdk/pull/8249.diff</a>

</details>
