### PR TITLE
8284894: Fix typos in langtools

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
@@ -230,7 +230,7 @@ public class Annotate {
      *
      * @param annotations the list of JCAnnotations to attribute and enter
      * @param localEnv    the enclosing env
-     * @param s           ths Symbol on which to enter the annotations
+     * @param s           the Symbol on which to enter the annotations
      * @param deferPos    report errors here
      */
     public void annotateLater(List<JCAnnotation> annotations, Env<AttrContext> localEnv,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -3337,7 +3337,7 @@ public class Check {
 
     boolean annotationApplicable(JCAnnotation a, Symbol s) {
         Optional<Set<Name>> targets = getApplicableTargets(a, s);
-        /* the optional could be emtpy if the annotation is unknown in that case
+        /* the optional could be empty if the annotation is unknown in that case
          * we return that it is applicable and if it is erroneous that should imply
          * an error at the declaration site
          */

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
@@ -1121,7 +1121,7 @@ public class Infer {
      * t = java.util.ArrayList<java.lang.String>
      * s = java.util.List<T>
      *
-     * we get this ouput (singleton list):
+     * we get this output (singleton list):
      *
      * [Pair[java.util.List<java.lang.String>,java.util.List<T>]]
      */

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
@@ -60,7 +60,7 @@ public class JavaTokenizer extends UnicodeReader {
     private static final boolean scannerDebug = false;
 
     /**
-     * Sentinal for non-value.
+     * Sentinel for non-value.
      */
     private int NOT_FOUND = -1;
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/Tokens.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/Tokens.java
@@ -319,14 +319,14 @@ public class Tokens {
 
         Token[] split(Tokens tokens) {
             if (kind.name.length() < 2 || kind.tag != Tag.DEFAULT) {
-                throw new AssertionError("Cant split" + kind);
+                throw new AssertionError("Can't split" + kind);
             }
 
             TokenKind t1 = tokens.lookupKind(kind.name.substring(0, 1));
             TokenKind t2 = tokens.lookupKind(kind.name.substring(1));
 
             if (t1 == null || t2 == null) {
-                throw new AssertionError("Cant split - bad subtokens");
+                throw new AssertionError("Can't split - bad subtokens");
             }
             return new Token[] {
                 new Token(t1, pos, pos + t1.name.length(), comments),

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/UnicodeReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/UnicodeReader.java
@@ -436,7 +436,7 @@ public class UnicodeReader {
     }
 
     /**
-     * Skip over all occurances of character.
+     * Skip over all occurrences of character.
      *
      * @param ch character to accept.
      */

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Dependencies.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Dependencies.java
@@ -181,7 +181,7 @@ public abstract class Dependencies {
         public abstract static class Node extends GraphUtils.AbstractNode<ClassSymbol, Node>
                 implements GraphUtils.DottableNode<ClassSymbol, Node> {
             /**
-             * dependant nodes grouped by kind
+             * dependent nodes grouped by kind
              */
             EnumMap<CompletionCause, List<Node>> depsByKind;
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Iterators.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Iterators.java
@@ -39,20 +39,20 @@ import java.util.function.Predicate;
  */
 public class Iterators {
 
-    public static <I, O> Iterator<O> createCompoundIterator(Iterable<I> inputs, Function<I, Iterator<O>> convertor) {
-        return new CompoundIterator<>(inputs, convertor);
+    public static <I, O> Iterator<O> createCompoundIterator(Iterable<I> inputs, Function<I, Iterator<O>> converter) {
+        return new CompoundIterator<>(inputs, converter);
     }
 
     private static class CompoundIterator<I, O> implements Iterator<O> {
 
         private final Iterator<I> inputs;
-        private final Function<I, Iterator<O>> convertor;
+        private final Function<I, Iterator<O>> converter;
         @SuppressWarnings("unchecked")
         private Iterator<O> currentIterator = EMPTY;
 
-        public CompoundIterator(Iterable<I> inputs, Function<I, Iterator<O>> convertor) {
+        public CompoundIterator(Iterable<I> inputs, Function<I, Iterator<O>> converter) {
             this.inputs = inputs.iterator();
-            this.convertor = convertor;
+            this.converter = converter;
         }
 
         public boolean hasNext() {
@@ -75,7 +75,7 @@ public class Iterators {
 
         private void update() {
             while (inputs.hasNext()) {
-                currentIterator = convertor.apply(inputs.next());
+                currentIterator = converter.apply(inputs.next());
                 if (currentIterator.hasNext()) return;
             }
             currentIterator = null;

--- a/src/jdk.compiler/share/classes/com/sun/tools/sjavac/JavacState.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/sjavac/JavacState.java
@@ -270,8 +270,8 @@ public class JavacState {
             b.append("# S L link_only_source timestamp\n");
             b.append("# G C generated_source timestamp\n");
             b.append("# A artifact timestamp\n");
-            b.append("# D S dependant -> source dependency\n");
-            b.append("# D C dependant -> classpath dependency\n");
+            b.append("# D S dependent -> source dependency\n");
+            b.append("# D C dependent -> classpath dependency\n");
             b.append("# I pubapi\n");
             b.append("R ").append(theArgs).append("\n");
 

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/TypeAnnotation.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/TypeAnnotation.java
@@ -338,7 +338,7 @@ public class TypeAnnotation {
         public TargetType type = TargetType.UNKNOWN;
 
         // For generic/array types.
-        // TODO: or should we use null? Noone will use this object.
+        // TODO: or should we use null? No one will use this object.
         public List<TypePathEntry> location = new ArrayList<>(0);
 
         // Tree position.


### PR DESCRIPTION
I ran `codespell` on the langtools directories, and accepted those changes where it indeed discovered real typos.

(Due to false positives this can unfortunately not be run automatically)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284894](https://bugs.openjdk.java.net/browse/JDK-8284894): Fix typos in langtools


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8251/head:pull/8251` \
`$ git checkout pull/8251`

Update a local copy of the PR: \
`$ git checkout pull/8251` \
`$ git pull https://git.openjdk.java.net/jdk pull/8251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8251`

View PR using the GUI difftool: \
`$ git pr show -t 8251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8251.diff">https://git.openjdk.java.net/jdk/pull/8251.diff</a>

</details>
