### PR TITLE
8284884: Replace polling with waiting in javax/swing/text/html/parser/Parser/8078268/bug8078268.java

### DIFF
--- a/test/jdk/javax/swing/text/html/parser/Parser/8078268/bug8078268.java
+++ b/test/jdk/javax/swing/text/html/parser/Parser/8078268/bug8078268.java
@@ -35,7 +35,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 /* @test
    @bug 8078268
    @summary  javax.swing.text.html.parser.Parser parseScript incorrectly optimized
-   @author Mikhail Cherkasov
    @run main bug8078268
 */
 public class bug8078268 {

--- a/test/jdk/javax/swing/text/html/parser/Parser/8078268/bug8078268.java
+++ b/test/jdk/javax/swing/text/html/parser/Parser/8078268/bug8078268.java
@@ -40,6 +40,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class bug8078268 {
     private static final long TIMEOUT = 10_000;
 
+    private static final String FILENAME = "slowparse.html";
+
     private static final CountDownLatch latch = new CountDownLatch(1);
     private static volatile Exception exception;
 
@@ -50,7 +52,7 @@ public class bug8078268 {
                 HTMLEditorKit htmlKit = new HTMLEditorKit();
                 Document doc = htmlKit.createDefaultDocument();
                 try {
-                    htmlKit.read(new FileReader(getDirURL() + "slowparse.html"), doc, 0);
+                    htmlKit.read(new FileReader(getAbsolutePath()), doc, 0);
                 } catch (Exception e) {
                     exception = e;
                 }
@@ -66,8 +68,8 @@ public class bug8078268 {
         }
     }
 
-    static String getDirURL() {
-        return new File(System.getProperty("test.src", ".")).getAbsolutePath() +
-                File.separator;
+    private static String getAbsolutePath() {
+        return System.getProperty("test.src", ".")
+               + File.separator + FILENAME;
     }
 }

--- a/test/jdk/javax/swing/text/html/parser/Parser/8078268/bug8078268.java
+++ b/test/jdk/javax/swing/text/html/parser/Parser/8078268/bug8078268.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,13 @@
 
 import java.io.File;
 import java.io.FileReader;
+import java.util.concurrent.CountDownLatch;
+
 import javax.swing.SwingUtilities;
 import javax.swing.text.Document;
 import javax.swing.text.html.HTMLEditorKit;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /* @test
    @bug 8078268
@@ -35,12 +39,12 @@ import javax.swing.text.html.HTMLEditorKit;
    @run main bug8078268
 */
 public class bug8078268 {
-    static volatile boolean parsingDone = false;
-    static volatile Exception exception;
+    private static final long TIMEOUT = 10_000;
+
+    private static final CountDownLatch latch = new CountDownLatch(1);
+    private static volatile Exception exception;
 
     public static void main(String[] args) throws Exception {
-        long timeout = 10_000;
-        long s = System.currentTimeMillis();
         SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
@@ -48,21 +52,18 @@ public class bug8078268 {
                 Document doc = htmlKit.createDefaultDocument();
                 try {
                     htmlKit.read(new FileReader(getDirURL() + "slowparse.html"), doc, 0);
-                    parsingDone = true;
                 } catch (Exception e) {
                     exception = e;
                 }
+                latch.countDown();
             }
         });
-        while (!parsingDone && exception == null && System.currentTimeMillis() - s < timeout) {
-            Thread.sleep(200);
+
+        if (!latch.await(TIMEOUT, MILLISECONDS)) {
+            throw new RuntimeException("Parsing takes too long.");
         }
-        final long took = System.currentTimeMillis() - s;
         if (exception != null) {
             throw exception;
-        }
-        if (took > timeout) {
-            throw new RuntimeException("Parsing takes too long.");
         }
     }
 


### PR DESCRIPTION
A quick fix for the `javax/swing/text/html/parser/Parser/8078268/bug8078268.java` which replaces `Thread.sleep` in a loop with `CountDownLatch.await`.

The code is shorter and clearer.

The test fails on the builds without the fix for [JDK-8078268](https://bugs.openjdk.java.net/browse/JDK-8078268). I ran it in the CI and it passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284884](https://bugs.openjdk.java.net/browse/JDK-8284884): Replace polling with waiting in javax/swing/text/html/parser/Parser/8078268/bug8078268.java


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8252/head:pull/8252` \
`$ git checkout pull/8252`

Update a local copy of the PR: \
`$ git checkout pull/8252` \
`$ git pull https://git.openjdk.java.net/jdk pull/8252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8252`

View PR using the GUI difftool: \
`$ git pr show -t 8252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8252.diff">https://git.openjdk.java.net/jdk/pull/8252.diff</a>

</details>
