### PR TITLE
8283179: SA tests fail with "ERROR: catch_mach_exception_raise: Message doesn't denote a Unix soft signal."

### DIFF
--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
@@ -861,7 +861,7 @@ kern_return_t catch_mach_exception_raise(
               "task port %d exc type = %d num_codes %d\n",
               exception_port, thread_port, task_port, exception_type, num_codes);
 
-  // Uncommon traps in the JVM can result in a "crash. We just ignore them.
+  // Uncommon traps in the JVM can result in a "crash". We just ignore them.
   // Returning a result other than KERN_SUCCESS means it will be passed on to the
   // next handler, which should be in the JVM so it can do the right thing with it.
   if (exception_type == EXC_BAD_INSTRUCTION || exception_type == EXC_BAD_ACCESS) {

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -849,6 +849,9 @@ static bool ptrace_attach(pid_t pid) {
   return true;
 }
 
+#define GOT_HOTSPOT_TRAP (KERN_SUCCESS + 1)
+#define GOT_UNKNOWN_EXC  (KERN_SUCCESS + 2)
+
 kern_return_t catch_mach_exception_raise(
   mach_port_t exception_port, mach_port_t thread_port, mach_port_t task_port,
   exception_type_t exception_type, mach_exception_data_t codes,
@@ -857,6 +860,13 @@ kern_return_t catch_mach_exception_raise(
   print_debug("catch_mach_exception_raise: Exception port = %d thread_port = %d "
               "task port %d exc type = %d num_codes %d\n",
               exception_port, thread_port, task_port, exception_type, num_codes);
+
+  // Uncommon traps in the JVM can result in a "crash. We just ignore them.
+  // Returning a result other than KERN_SUCCESS means it will be passed on to the
+  // next handler, which should be in the JVM so it can do the right thing with it.
+  if (exception_type == EXC_BAD_INSTRUCTION || exception_type == EXC_BAD_ACCESS) {
+    return GOT_HOTSPOT_TRAP;
+  }
 
   // This message should denote a Unix soft signal, with
   // 1. the exception type = EXC_SOFTWARE
@@ -867,9 +877,9 @@ kern_return_t catch_mach_exception_raise(
         codes[num_codes -1] == SIGSTOP)) {
     print_error("catch_mach_exception_raise: Message doesn't denote a Unix "
                 "soft signal. exception_type = %d, codes[0] = %d, "
-                "codes[num_codes -1] = %d, num_codes = %d\n",
+                "codes[num_codes -1] = 0x%llx, num_codes = %d\n",
                 exception_type, codes[0], codes[num_codes - 1], num_codes);
-    return MACH_RCV_INVALID_TYPE;
+    return GOT_UNKNOWN_EXC;
   }
   return KERN_SUCCESS;
 }
@@ -892,8 +902,12 @@ kern_return_t catch_mach_exception_raise_state_identity(
   return MACH_RCV_INVALID_TYPE;
 }
 
+#define WAIT_SUCCESS 0
+#define WAIT_RETRY   1
+#define WAIT_FAILURE 2
+
 // wait to receive an exception message
-static bool wait_for_exception() {
+static int wait_for_exception() {
   kern_return_t result;
 
   result = mach_msg(&exc_msg.header,
@@ -907,17 +921,21 @@ static bool wait_for_exception() {
   if (result != MACH_MSG_SUCCESS) {
     print_error("attach: wait_for_exception: mach_msg() failed: '%s' (%d)\n",
                 mach_error_string(result), result);
-    return false;
+    return WAIT_FAILURE;
   }
 
-  if (mach_exc_server(&exc_msg.header, &rep_msg.header) == false ||
-      rep_msg.ret_code != KERN_SUCCESS) {
-    print_error("attach: wait_for_exception: mach_exc_server failure\n");
-    if (rep_msg.ret_code != KERN_SUCCESS) {
-      print_error("catch_mach_exception_raise() failed '%s' (%d)\n",
-                  mach_error_string(rep_msg.ret_code), rep_msg.ret_code);
-    }
-    return false;
+  if (!mach_exc_server(&exc_msg.header, &rep_msg.header)) {
+    print_error("attach: wait_for_exception: mach_exc_server failed\n");
+    return WAIT_FAILURE;
+  }
+  if (rep_msg.ret_code == GOT_UNKNOWN_EXC) {
+    print_error("attach: wait_for_exception: catch_mach_exception_raise() got unknown exception type\n");
+    return WAIT_FAILURE;
+  }
+  if (rep_msg.ret_code == GOT_HOTSPOT_TRAP) {
+    // hotspot uncommon trap. Just retry.
+    print_debug("attach: wait_for_exception: retrying\n");
+    return WAIT_RETRY;
   }
 
   print_debug("reply msg from mach_exc_server: (msg->{bits = %#x, size = %u, "
@@ -926,7 +944,7 @@ static bool wait_for_exception() {
               rep_msg.header.msgh_remote_port, rep_msg.header.msgh_local_port,
               rep_msg.header.msgh_reserved, rep_msg.header.msgh_id);
 
-  return true;
+  return WAIT_SUCCESS;
 }
 
 /*
@@ -1020,7 +1038,14 @@ Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_attach0__I(
     THROW_NEW_DEBUGGER_EXCEPTION("Can't ptrace attach to the process");
   }
 
-  if (wait_for_exception() != true) {
+  int retry_count = 0;
+  int wait_result;
+  do {
+    wait_result = wait_for_exception();
+  } while (wait_result == WAIT_RETRY && retry_count++ < 5);
+
+  if (wait_result != WAIT_SUCCESS) {
+    print_error("attach: wait_for_exception() failed. Retried %d times\n", retry_count);
     mach_port_deallocate(mach_task_self(), gTask);
     mach_port_deallocate(mach_task_self(), tgt_exception_port);
     THROW_NEW_DEBUGGER_EXCEPTION(


### PR DESCRIPTION
During the SA attach process on macOS, SA installs an exception handler and expects to get an EXC_SOFTWARE exception for the expected SIGSTOP signal. On aarch64, sometimes it instead gets an EXC_BAD_INSTRUCTION exception. I found if I changed the code to just ignore this, it eventually gets the EXC_SOFTWARE exception and everything is fine.

The EXC_BAD_INSTRUCTION is from the following code in the JIT and is expected behavior:

```
bool NativeInstruction::is_sigill_zombie_not_entrant() {
  return uint_at(0) == 0xd4bbd5a1; // dcps1 #0xdead
}

void NativeIllegalInstruction::insert(address code_pos) {
  *(juint*)code_pos = 0xd4bbd5a1; // dcps1 #0xdead
}

void NativeJump::patch_verified_entry(address entry, address verified_entry, address dest) {
...
  if (Assembler::reachable_from_branch_at(verified_entry, dest)) {
...
  } else {
    // We use an illegal instruction for marking a method as
    // not_entrant or zombie.
    NativeIllegalInstruction::insert(verified_entry);
  } 
```

I fixed SA to retry each time it gets EXC_BAD_INSTRUCTION. I also did the same for EXC_BAD_ACCESS. We saw this once on x64, and it looks like it is for a trap-based NPE, given that the bad address that was provided as part of the exception data is for address 0x8.

Although the fix is somewhat straight forward, the context in which it is run is not. SA does a `ptrace_attach()`. This seems to result in a SIGSTOP being generated. SA provides an exception handler called `catch_mach_exception_raise()`. It gets called for any pending exception when SA calls `mach_msg(&exc_msg.header, MACH_RCV_MSG, ...)` from `wait_for_exception()`. So `catch_mach_exception_raise()` should see the SIGSTOP, return KERN_SUCCESS (which means to ignore the exception), and then `mach_msg()` returns to `wait_for_exception()`, which checks for success of having received the SIGSTOP, and then allows SA to continue with its attach process (like suspending all threads).

The details of attaching and exception handling are actually much uglier than that, and I don't pretend to even understand half of it. https://www.spaceflint.com/?p=150 is an interesting read if you are looking for more details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283179](https://bugs.openjdk.java.net/browse/JDK-8283179): SA tests fail with "ERROR: catch_mach_exception_raise: Message doesn't denote a Unix soft signal."


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8255/head:pull/8255` \
`$ git checkout pull/8255`

Update a local copy of the PR: \
`$ git checkout pull/8255` \
`$ git pull https://git.openjdk.java.net/jdk pull/8255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8255`

View PR using the GUI difftool: \
`$ git pr show -t 8255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8255.diff">https://git.openjdk.java.net/jdk/pull/8255.diff</a>

</details>
