### PR TITLE
8284900: Check InitialHeapSize and container memory limits before startup

### DIFF
--- a/src/hotspot/share/gc/shared/gcArguments.cpp
+++ b/src/hotspot/share/gc/shared/gcArguments.cpp
@@ -143,8 +143,8 @@ void GCArguments::initialize_heap_flags_and_sizes() {
 
 #if defined(LINUX)
   if (OSContainer::is_containerized() && FLAG_IS_CMDLINE(InitialHeapSize)) {
-    jlong memswBytes = OSContainer::memory_and_swap_limit_in_bytes();
-    if ((memswBytes > 0) && (InitialHeapSize >= (julong) memswBytes)) {
+    jlong limit = OSContainer::memory_and_swap_limit_in_bytes();
+    if ((limit > 0) && (InitialHeapSize >= (julong) limit)) {
       vm_exit_during_initialization("Initial heap size set to a larger value than the container memory & swap limit");
     }
   }

--- a/src/hotspot/share/gc/shared/gcArguments.cpp
+++ b/src/hotspot/share/gc/shared/gcArguments.cpp
@@ -130,9 +130,11 @@ void GCArguments::initialize_heap_flags_and_sizes() {
     }
   }
   #if defined(LINUX)
-  if (OSContainer::is_containerized() && (OSContainer::memory_and_swap_limit_in_bytes() > 0) &&
-      FLAG_IS_CMDLINE(InitialHeapSize) && (InitialHeapSize >= (julong) OSContainer::memory_and_swap_limit_in_bytes())) {
-    vm_exit_during_initialization("Initial heap size set to a larger value than the container memory & swap limit");
+  if (OSContainer::is_containerized()) {
+    jlong memswBytes = OSContainer::memory_and_swap_limit_in_bytes();
+    if ((memswBytes > 0) && FLAG_IS_CMDLINE(InitialHeapSize) && (InitialHeapSize >= (julong) memswBytes)) {
+      vm_exit_during_initialization("Initial heap size set to a larger value than the container memory & swap limit");
+    }
   }
   #endif
   // Check heap parameter properties

--- a/src/hotspot/share/gc/shared/gcArguments.cpp
+++ b/src/hotspot/share/gc/shared/gcArguments.cpp
@@ -30,10 +30,10 @@
 #include "runtime/arguments.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/globals_extension.hpp"
+#include "utilities/macros.hpp"
 #if defined(LINUX)
 #include "osContainer_linux.hpp"
 #endif
-#include "utilities/macros.hpp"
 
 size_t HeapAlignment = 0;
 size_t SpaceAlignment = 0;
@@ -129,14 +129,7 @@ void GCArguments::initialize_heap_flags_and_sizes() {
       vm_exit_during_initialization("Incompatible minimum and maximum heap sizes specified");
     }
   }
-#if defined(LINUX)
-  if (OSContainer::is_containerized() && FLAG_IS_CMDLINE(InitialHeapSize)) {
-    jlong memswBytes = OSContainer::memory_and_swap_limit_in_bytes();
-    if ((memswBytes > 0) && (InitialHeapSize >= (julong) memswBytes)) {
-      vm_exit_during_initialization("Initial heap size set to a larger value than the container memory & swap limit");
-    }
-  }
-#endif
+
   // Check heap parameter properties
   if (MaxHeapSize < 2 * M) {
     vm_exit_during_initialization("Too small maximum heap");
@@ -147,6 +140,15 @@ void GCArguments::initialize_heap_flags_and_sizes() {
   if (MinHeapSize < M) {
     vm_exit_during_initialization("Too small minimum heap");
   }
+
+#if defined(LINUX)
+  if (OSContainer::is_containerized() && FLAG_IS_CMDLINE(InitialHeapSize)) {
+    jlong memswBytes = OSContainer::memory_and_swap_limit_in_bytes();
+    if ((memswBytes > 0) && (InitialHeapSize >= (julong) memswBytes)) {
+      vm_exit_during_initialization("Initial heap size set to a larger value than the container memory & swap limit");
+    }
+  }
+#endif
 
   // User inputs from -Xmx and -Xms must be aligned
   // Write back to flags if the values changed

--- a/src/hotspot/share/gc/shared/gcArguments.cpp
+++ b/src/hotspot/share/gc/shared/gcArguments.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, Red Hat, Inc. and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -30,6 +30,7 @@
 #include "runtime/arguments.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/globals_extension.hpp"
+#include "osContainer_linux.hpp"
 #include "utilities/macros.hpp"
 
 size_t HeapAlignment = 0;
@@ -127,8 +128,9 @@ void GCArguments::initialize_heap_flags_and_sizes() {
     }
   }
 
-  if (FLAG_IS_CMDLINE(InitialHeapSize) && InitialHeapSize >= os::physical_memory()) {
-    vm_exit_during_initialization("Initial heap size set to a larger value than the os or container memory");
+  if (OSContainer::is_containerized() && (OSContainer::memory_and_swap_limit_in_bytes() > 0) &&
+      FLAG_IS_CMDLINE(InitialHeapSize) && (InitialHeapSize >= (julong) OSContainer::memory_and_swap_limit_in_bytes())) {
+    vm_exit_during_initialization("Initial heap size set to a larger value than the container memory & swap limit");
   }
 
   // Check heap parameter properties

--- a/src/hotspot/share/gc/shared/gcArguments.cpp
+++ b/src/hotspot/share/gc/shared/gcArguments.cpp
@@ -129,14 +129,14 @@ void GCArguments::initialize_heap_flags_and_sizes() {
       vm_exit_during_initialization("Incompatible minimum and maximum heap sizes specified");
     }
   }
-  #if defined(LINUX)
-  if (OSContainer::is_containerized()) {
+#if defined(LINUX)
+  if (OSContainer::is_containerized() && FLAG_IS_CMDLINE(InitialHeapSize)) {
     jlong memswBytes = OSContainer::memory_and_swap_limit_in_bytes();
-    if ((memswBytes > 0) && FLAG_IS_CMDLINE(InitialHeapSize) && (InitialHeapSize >= (julong) memswBytes)) {
+    if ((memswBytes > 0) && (InitialHeapSize >= (julong) memswBytes)) {
       vm_exit_during_initialization("Initial heap size set to a larger value than the container memory & swap limit");
     }
   }
-  #endif
+#endif
   // Check heap parameter properties
   if (MaxHeapSize < 2 * M) {
     vm_exit_during_initialization("Too small maximum heap");

--- a/src/hotspot/share/gc/shared/gcArguments.cpp
+++ b/src/hotspot/share/gc/shared/gcArguments.cpp
@@ -127,6 +127,10 @@ void GCArguments::initialize_heap_flags_and_sizes() {
     }
   }
 
+  if (FLAG_IS_CMDLINE(InitialHeapSize) && InitialHeapSize >= os::physical_memory()) {
+    vm_exit_during_initialization("Initial heap size set to a larger value than the os or container memory");
+  }
+
   // Check heap parameter properties
   if (MaxHeapSize < 2 * M) {
     vm_exit_during_initialization("Too small maximum heap");

--- a/src/hotspot/share/gc/shared/gcArguments.cpp
+++ b/src/hotspot/share/gc/shared/gcArguments.cpp
@@ -143,7 +143,7 @@ void GCArguments::initialize_heap_flags_and_sizes() {
 
 #if defined(LINUX)
   if (OSContainer::is_containerized() && FLAG_IS_CMDLINE(InitialHeapSize)) {
-    jlong limit = OSContainer::memory_and_swap_limit_in_bytes();
+    jlong limit = os::physical_memory();
     if ((limit > 0) && (InitialHeapSize >= (julong) limit)) {
       vm_exit_during_initialization("Initial heap size set to a larger value than the container memory & swap limit");
     }

--- a/src/hotspot/share/gc/shared/gcArguments.cpp
+++ b/src/hotspot/share/gc/shared/gcArguments.cpp
@@ -30,7 +30,9 @@
 #include "runtime/arguments.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/globals_extension.hpp"
+#if defined(LINUX)
 #include "osContainer_linux.hpp"
+#endif
 #include "utilities/macros.hpp"
 
 size_t HeapAlignment = 0;
@@ -127,12 +129,12 @@ void GCArguments::initialize_heap_flags_and_sizes() {
       vm_exit_during_initialization("Incompatible minimum and maximum heap sizes specified");
     }
   }
-
+  #if defined(LINUX)
   if (OSContainer::is_containerized() && (OSContainer::memory_and_swap_limit_in_bytes() > 0) &&
       FLAG_IS_CMDLINE(InitialHeapSize) && (InitialHeapSize >= (julong) OSContainer::memory_and_swap_limit_in_bytes())) {
     vm_exit_during_initialization("Initial heap size set to a larger value than the container memory & swap limit");
   }
-
+  #endif
   // Check heap parameter properties
   if (MaxHeapSize < 2 * M) {
     vm_exit_during_initialization("Too small maximum heap");

--- a/src/hotspot/share/gc/shared/genArguments.cpp
+++ b/src/hotspot/share/gc/shared/genArguments.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@
 #include "logging/log.hpp"
 #include "runtime/globals_extension.hpp"
 #include "runtime/java.hpp"
+#include "runtime/os.hpp"
 #include "utilities/align.hpp"
 #include "utilities/globalDefinitions.hpp"
 

--- a/src/hotspot/share/gc/shared/genArguments.cpp
+++ b/src/hotspot/share/gc/shared/genArguments.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
 #include "logging/log.hpp"
 #include "runtime/globals_extension.hpp"
 #include "runtime/java.hpp"
-#include "runtime/os.hpp"
 #include "utilities/align.hpp"
 #include "utilities/globalDefinitions.hpp"
 

--- a/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
@@ -61,6 +61,8 @@ public class TestMemoryAwareness {
             testMemorySoftLimit("500m", "524288000");
             testMemorySoftLimit("1g", "1073741824");
 
+            testMemorySwapLimit("100m", "100m");
+
             // Add extra 10 Mb to allocator limit, to be sure to cause OOM
             testOOM("256m", 256 + 10);
 
@@ -173,6 +175,19 @@ public class TestMemoryAwareness {
         } catch(RuntimeException ex) {
             out.shouldMatch("OperatingSystemMXBean\\.getFreeSwapSpaceSize: 0");
         }
+    }
+
+    private static void testMemorySwapLimit(String dockerMemSwapLimit, String initialHeapSize) throws Exception {
+        Common.logNewTestCase("Check initial heap size with memory and swap limit");
+
+        DockerRunOptions opts = Common.newOpts(imageName, "CheckInitialHeapSize")
+            .addDockerOpts("--memory", dockerMemSwapLimit, "--memory-swap", dockerMemSwapLimit)
+            .addJavaOptsAppended("-Xms" + initialHeapSize);
+
+        OutputAnalyzer out = DockerTestUtils.dockerRunJava(opts);
+        out.shouldContain("Error occurred during initialization of VM")
+           .shouldContain("Initial heap size set to a larger value than the container memory & swap limit");
+
     }
 
 }


### PR DESCRIPTION
Check InitialHeapSize and container memory limits before startup

```
Operating System Metrics:
    Provider: cgroupv1
    Effective CPU Count: 8
    CPU Period: 100000us
    CPU Quota: -1
    CPU Shares: -1
    List of Processors, 8 total: 
    0 1 2 3 4 5 6 7 
    List of Effective Processors: N/A
    List of Memory Nodes, 1 total: 
    0 
    List of Available Memory Nodes: N/A
    Memory Limit: 50.00M
    Memory Soft Limit: Unlimited
    Memory & Swap Limit: 60.00M
    Maximum Processes Limit: 4194305
```
command:-Xms60m -XshowSettings:system -version 




When the memory limit is exceeded, the startup fail with message


```
Error occurred during initialization of VM
Initial heap size set to a larger value than the container memory & swap limit
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8284900](https://bugs.openjdk.java.net/browse/JDK-8284900): Check InitialHeapSize and container memory limits before startup


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8256/head:pull/8256` \
`$ git checkout pull/8256`

Update a local copy of the PR: \
`$ git checkout pull/8256` \
`$ git pull https://git.openjdk.java.net/jdk pull/8256/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8256`

View PR using the GUI difftool: \
`$ git pr show -t 8256`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8256.diff">https://git.openjdk.java.net/jdk/pull/8256.diff</a>

</details>
