### PR TITLE
8042380: Test javax/swing/JFileChooser/4524490/bug4524490.java fails with InvocationTargetException

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -706,7 +706,6 @@ javax/swing/JWindow/ShapedAndTranslucentWindows/TranslucentJComboBox.java 802462
 javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all
 javax/swing/JTree/4633594/JTreeFocusTest.java 8173125 macosx-all
 javax/swing/AbstractButton/6711682/bug6711682.java 8060765 windows-all,macosx-all
-javax/swing/JFileChooser/4524490/bug4524490.java 8042380 generic-all
 javax/swing/JFileChooser/6396844/TwentyThousandTest.java 8198003 generic-all
 javax/swing/JPopupMenu/6580930/bug6580930.java 7124313 macosx-all
 javax/swing/JPopupMenu/6800513/bug6800513.java 7184956 macosx-all

--- a/test/jdk/javax/swing/JFileChooser/4524490/bug4524490.java
+++ b/test/jdk/javax/swing/JFileChooser/4524490/bug4524490.java
@@ -45,7 +45,7 @@ public class bug4524490 {
 
     public static void main(String[] args) throws Exception {
         Robot robot = new Robot();
-        robot.setAutoDelay(50);
+        robot.setAutoDelay(100);
 
         UIManager.setLookAndFeel("com.sun.java.swing.plaf.motif.MotifLookAndFeel");
 


### PR DESCRIPTION
This test used to fail in nightly testing few years back and it seems it fails because we used to run in samevm mode at that time.
Several iterations of this test pass in CI testing in all platforms (link in JBS) so removing from Problemlist.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8042380](https://bugs.openjdk.java.net/browse/JDK-8042380): Test javax/swing/JFileChooser/4524490/bug4524490.java fails with InvocationTargetException


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8257/head:pull/8257` \
`$ git checkout pull/8257`

Update a local copy of the PR: \
`$ git checkout pull/8257` \
`$ git pull https://git.openjdk.java.net/jdk pull/8257/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8257`

View PR using the GUI difftool: \
`$ git pr show -t 8257`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8257.diff">https://git.openjdk.java.net/jdk/pull/8257.diff</a>

</details>
