### PR TITLE
8266246: Swing test PressedIconTest.java sometimes fails on macOS 11 ARM

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -721,7 +721,6 @@ javax/swing/dnd/8139050/NativeErrorsInTableDnD.java 8202765  macosx-all,linux-al
 javax/swing/Popup/TaskbarPositionTest.java 8065097 macosx-all,linux-all
 javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
-javax/swing/JButton/8151303/PressedIconTest.java 8266246 macosx-aarch64
 javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java 8273573 macosx-all
 
 # Several tests which fail on some hidpi systems/macosx12-aarch64 system


### PR DESCRIPTION
javax/swing/JButton/8151303/PressedIconTest.java was failing few times in macos M1 system owing t color profile issue.
```
java.lang.RuntimeException: Colors are different!
at PressedIconTest.main(PressedIconTest.java:88) 
```

Test is now passing in all mac M1 systems in CI (link in jBS) so can be removed from problemlist.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266246](https://bugs.openjdk.java.net/browse/JDK-8266246): Swing test PressedIconTest.java sometimes fails on macOS 11 ARM


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8261/head:pull/8261` \
`$ git checkout pull/8261`

Update a local copy of the PR: \
`$ git checkout pull/8261` \
`$ git pull https://git.openjdk.java.net/jdk pull/8261/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8261`

View PR using the GUI difftool: \
`$ git pr show -t 8261`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8261.diff">https://git.openjdk.java.net/jdk/pull/8261.diff</a>

</details>
