### PR TITLE
8284914: Problem list test(s) failing due to extra repaints with D3D pipeline.

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -237,6 +237,7 @@ java/awt/image/multiresolution/MultiresolutionIconTest.java 8169187,8252812 maco
 java/awt/print/Headless/HeadlessPrinterJob.java 8196088 windows-all
 sun/awt/datatransfer/SuplementaryCharactersTransferTest.java 8011371 generic-all
 sun/awt/shell/ShellFolderMemoryLeak.java 8197794 windows-all
+sun/java2d/DirectX/MultiPaintEventTest/MultiPaintEventTest.java 8284825 windows-all
 sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java 8022403 generic-all
 sun/java2d/DirectX/OverriddenInsetsTest/OverriddenInsetsTest.java 8196102 generic-all
 sun/java2d/DirectX/RenderingToCachedGraphicsTest/RenderingToCachedGraphicsTest.java 8196180 windows-all,macosx-all


### PR DESCRIPTION
Problem list a test that fails on D3D systems

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284914](https://bugs.openjdk.java.net/browse/JDK-8284914): Problem list test(s) failing due to extra repaints with D3D pipeline.


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8265/head:pull/8265` \
`$ git checkout pull/8265`

Update a local copy of the PR: \
`$ git checkout pull/8265` \
`$ git pull https://git.openjdk.java.net/jdk pull/8265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8265`

View PR using the GUI difftool: \
`$ git pr show -t 8265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8265.diff">https://git.openjdk.java.net/jdk/pull/8265.diff</a>

</details>
