### PR TITLE
8284697: Avoid parsing the doc comment of an element that is not documented

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberTable.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/VisibleMemberTable.java
@@ -463,7 +463,8 @@ public class VisibleMemberTable {
     }
 
     private boolean mustDocument(Element e) {
-        return !utils.hasHiddenTag(e) && utils.shouldDocument(e);
+        // these checks are ordered in a particular way to avoid parsing unless absolutely necessary
+        return utils.shouldDocument(e) && !utils.hasHiddenTag(e);
     }
 
     private boolean allowInheritedMembers(Element e, Kind kind, LocalMemberTable lmt) {


### PR DESCRIPTION
We shouldn't parse comments that are going to be thrown away.

Although the change is simple, I have no idea on how to test it. So I'm tempted to affix the "noreg-other" or "noreg-hard" label on the JBS issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284697](https://bugs.openjdk.java.net/browse/JDK-8284697): Avoid parsing the doc comment of an element that is not documented


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8266/head:pull/8266` \
`$ git checkout pull/8266`

Update a local copy of the PR: \
`$ git checkout pull/8266` \
`$ git pull https://git.openjdk.java.net/jdk pull/8266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8266`

View PR using the GUI difftool: \
`$ git pr show -t 8266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8266.diff">https://git.openjdk.java.net/jdk/pull/8266.diff</a>

</details>
