### PR TITLE
8284922: Fix some doc-comment issues on methods with package access in JDK API

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -5876,6 +5876,7 @@ System.out.println((int) f0.invokeExact("x", "y")); // 2
      * V adapter(A... a, B... b) {
      *     T t = target(a...);
      *     return filter(b..., t);
+     * }
      * }</pre></blockquote>
      * <p>
      * If the filter handle is a unary function, then this method behaves like {@link #filterReturnValue(MethodHandle, MethodHandle)}.

--- a/src/java.base/share/classes/java/util/MissingResourceException.java
+++ b/src/java.base/share/classes/java/util/MissingResourceException.java
@@ -76,7 +76,7 @@ public class MissingResourceException extends RuntimeException {
      *        the key for the missing resource.
      * @param cause
      *        the cause (which is saved for later retrieval by the
-     *        {@link Throwable.getCause()} method). (A null value is
+     *        {@link Throwable#getCause()} method). (A null value is
      *        permitted, and indicates that the cause is nonexistent
      *        or unknown.)
      */

--- a/src/java.base/share/classes/java/util/MissingResourceException.java
+++ b/src/java.base/share/classes/java/util/MissingResourceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.sql/share/classes/java/sql/JDBCType.java
+++ b/src/java.sql/share/classes/java/sql/JDBCType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.sql/share/classes/java/sql/JDBCType.java
+++ b/src/java.sql/share/classes/java/sql/JDBCType.java
@@ -209,9 +209,9 @@ public enum JDBCType implements SQLType {
     private final Integer type;
 
     /**
-     * Constructor to specify the data type value from {@code Types) for
+     * Constructor to specify the data type value from {@code Types} for
      * this data type.
-     * @param type The value from {@code Types) for this data type
+     * @param type The value from {@code Types} for this data type
      */
     JDBCType(final Integer type) {
         this.type = type;


### PR DESCRIPTION
People rarely include JDK elements with package access in a javadoc run. That is why bugs in those elements' doc comments tend to remain unnoticed.

There are many more bugs in the doc comments of the JDK elements with the package access than are addressed by this PR; I only included the simplest ones.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284922](https://bugs.openjdk.java.net/browse/JDK-8284922): Fix some doc-comment issues on methods with package access in JDK API


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8267/head:pull/8267` \
`$ git checkout pull/8267`

Update a local copy of the PR: \
`$ git checkout pull/8267` \
`$ git pull https://git.openjdk.java.net/jdk pull/8267/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8267`

View PR using the GUI difftool: \
`$ git pr show -t 8267`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8267.diff">https://git.openjdk.java.net/jdk/pull/8267.diff</a>

</details>
