### PR TITLE
8284926: Share the certificate NamedGroup in SignatureScheme::getSignerOfPreferableAlgorithm

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/ECDHClientKeyExchange.java
+++ b/src/java.base/share/classes/sun/security/ssl/ECDHClientKeyExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -269,22 +269,9 @@ final class ECDHClientKeyExchange {
                     "No expected EC server cert for ECDH client key exchange");
             }
 
-            // Determine which NamedGroup we'll be using, then use
-            // the creator functions.
-            NamedGroup namedGroup = null;
-
             // Iteratively determine the X509Possession type's ParameterSpec.
             ECParameterSpec ecParams = x509Possession.getECParameterSpec();
-            NamedParameterSpec namedParams = null;
-            if (ecParams != null) {
-                namedGroup = NamedGroup.valueOf(ecParams);
-            }
-
-            // Wasn't EC, try XEC.
-            if (ecParams == null) {
-                namedParams = x509Possession.getXECParameterSpec();
-                namedGroup = NamedGroup.nameOf(namedParams.getName());
-            }
+            NamedParameterSpec namedParams = x509Possession.getXECParameterSpec();
 
             // Can't figure this out, bail.
             if ((ecParams == null) && (namedParams == null)) {
@@ -292,6 +279,10 @@ final class ECDHClientKeyExchange {
                 throw shc.conContext.fatal(Alert.ILLEGAL_PARAMETER,
                     "Not EC/XDH server cert for ECDH client key exchange");
             }
+
+            // Determine which NamedGroup we'll be using, then use
+            // the creator functions.
+            NamedGroup namedGroup = x509Possession.getNamedGroup();
 
             // unlikely, have been checked during cipher suite negotiation.
             if (namedGroup == null) {

--- a/src/java.base/share/classes/sun/security/ssl/ECDHClientKeyExchange.java
+++ b/src/java.base/share/classes/sun/security/ssl/ECDHClientKeyExchange.java
@@ -269,17 +269,6 @@ final class ECDHClientKeyExchange {
                     "No expected EC server cert for ECDH client key exchange");
             }
 
-            // Iteratively determine the X509Possession type's ParameterSpec.
-            ECParameterSpec ecParams = x509Possession.getECParameterSpec();
-            NamedParameterSpec namedParams = x509Possession.getXECParameterSpec();
-
-            // Can't figure this out, bail.
-            if ((ecParams == null) && (namedParams == null)) {
-                // unlikely, have been checked during cipher suite negotiation.
-                throw shc.conContext.fatal(Alert.ILLEGAL_PARAMETER,
-                    "Not EC/XDH server cert for ECDH client key exchange");
-            }
-
             // Determine which NamedGroup we'll be using, then use
             // the creator functions.
             NamedGroup namedGroup = x509Possession.getNamedGroup();
@@ -289,6 +278,13 @@ final class ECDHClientKeyExchange {
                 throw shc.conContext.fatal(Alert.ILLEGAL_PARAMETER,
                     "Unknown named group in server cert for " +
                         "ECDH client key exchange");
+            }
+
+            // unlikely, have been checked during cipher suite negotiation.
+            if (namedGroup.spec != NamedGroup.NamedGroupSpec.NAMED_GROUP_ECDHE
+                    && namedGroup.spec != NamedGroup.NamedGroupSpec.NAMED_GROUP_XDH) {
+                throw shc.conContext.fatal(Alert.ILLEGAL_PARAMETER,
+                    "Not EC/XDH server cert for ECDH client key exchange");
             }
 
             SSLKeyExchange ke = SSLKeyExchange.valueOf(

--- a/src/java.base/share/classes/sun/security/ssl/ECDHKeyExchange.java
+++ b/src/java.base/share/classes/sun/security/ssl/ECDHKeyExchange.java
@@ -297,7 +297,7 @@ final class ECDHKeyExchange {
                     continue;
                 }
 
-                NamedGroup ng = NamedGroup.valueOf(params);
+                NamedGroup ng = ((X509Possession)poss).getECNamedGroup();
                 if (ng == null) {
                     // unlikely, have been checked during cipher suite
                     // negotiation.

--- a/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
+++ b/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
@@ -474,8 +474,7 @@ enum SignatureScheme {
         PrivateKey signingKey = x509Possession.popPrivateKey;
 
         ECParameterSpec params = x509Possession.getECParameterSpec();
-        NamedGroup namedGroup = params != null
-                ? NamedGroup.valueOf(params) : null;
+        NamedGroup namedGroup = x509Possession.getECNamedGroup();
 
         String keyAlgorithm = signingKey.getAlgorithm();
         int keySize;

--- a/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
+++ b/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
@@ -473,7 +473,6 @@ enum SignatureScheme {
 
         PrivateKey signingKey = x509Possession.popPrivateKey;
 
-        ECParameterSpec params = x509Possession.getECParameterSpec();
         NamedGroup namedGroup = x509Possession.getECNamedGroup();
 
         String keyAlgorithm = signingKey.getAlgorithm();
@@ -503,7 +502,8 @@ enum SignatureScheme {
                             SSLLogger.isOn("ssl,handshake,verbose")) {
                         SSLLogger.finest(
                             "Ignore the signature algorithm (" + ss +
-                            "), unsupported EC parameter spec: " + params);
+                            "), unsupported EC parameter spec: " +
+                            x509Possession.getECParameterSpec());
                     }
                 } else if ("EC".equals(ss.keyAlgorithm)) {
                     // Must be a legacy signature algorithm, which does not
@@ -527,7 +527,8 @@ enum SignatureScheme {
                             SSLLogger.isOn("ssl,handshake,verbose")) {
                         SSLLogger.finest(
                             "Ignore the legacy signature algorithm (" + ss +
-                            "), unsupported EC parameter spec: " + params);
+                            "), unsupported EC parameter spec: " +
+                            x509Possession.getECParameterSpec());
                     }
                 } else {
                     Signature signer = ss.getSigner(signingKey);

--- a/src/java.base/share/classes/sun/security/ssl/X509Authentication.java
+++ b/src/java.base/share/classes/sun/security/ssl/X509Authentication.java
@@ -122,10 +122,10 @@ enum X509Authentication implements SSLAuthentication {
         final X509Certificate[]   popCerts;
         final PrivateKey          popPrivateKey;
 
-        private final ECParameterSpec     ecParams;
+        private final ECParameterSpec     ecParamSpec;
         private final NamedGroup          ecNamedGroup;
 
-        private final NamedParameterSpec  xecParams;
+        private final NamedParameterSpec  xecParamSpec;
         private final NamedGroup          xecNamedGroup;
 
         X509Possession(PrivateKey popPrivateKey,
@@ -133,28 +133,28 @@ enum X509Authentication implements SSLAuthentication {
             this.popCerts = popCerts;
             this.popPrivateKey = popPrivateKey;
 
-            ecParams = getECParams();
+            ecParamSpec = getECParamSpec();
 
-            if (ecParams != null) {
-                ecNamedGroup = NamedGroup.valueOf(ecParams);
+            if (ecParamSpec != null) {
+                ecNamedGroup = NamedGroup.valueOf(ecParamSpec);
 
-                xecParams = null;
+                xecParamSpec = null;
                 xecNamedGroup = null;
             } else {
                 ecNamedGroup = null;
 
                 // Wasn't EC, try XEC.
-                xecParams = getXECParams();
-                xecNamedGroup = xecParams != null
-                        ? NamedGroup.nameOf(xecParams.getName()) : null;
+                xecParamSpec = getXECParamSpec();
+                xecNamedGroup = xecParamSpec != null
+                        ? NamedGroup.nameOf(xecParamSpec.getName()) : null;
             }
         }
 
         ECParameterSpec getECParameterSpec() {
-            return ecParams;
+            return ecParamSpec;
         }
 
-        private ECParameterSpec getECParams() {
+        private ECParameterSpec getECParamSpec() {
             if (popPrivateKey == null ||
                     !"EC".equals(popPrivateKey.getAlgorithm())) {
                 return null;
@@ -175,11 +175,11 @@ enum X509Authentication implements SSLAuthentication {
         }
 
         NamedParameterSpec getXECParameterSpec() {
-            return xecParams;
+            return xecParamSpec;
         }
 
         // Similar to above, but for XEC.
-        private NamedParameterSpec getXECParams() {
+        private NamedParameterSpec getXECParamSpec() {
             if (popPrivateKey == null ||
                     !"XEC".equals(popPrivateKey.getAlgorithm())) {
                 return null;


### PR DESCRIPTION
It would not to generate the certificate's ECParameterSpec and NamedGroup multiple times in method `SignatureScheme::getSignerOfPreferableAlgorithm`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8284926](https://bugs.openjdk.java.net/browse/JDK-8284926): Share the certificate NamedGroup in SignatureScheme::getSignerOfPreferableAlgorithm


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8271/head:pull/8271` \
`$ git checkout pull/8271`

Update a local copy of the PR: \
`$ git checkout pull/8271` \
`$ git pull https://git.openjdk.java.net/jdk pull/8271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8271`

View PR using the GUI difftool: \
`$ git pr show -t 8271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8271.diff">https://git.openjdk.java.net/jdk/pull/8271.diff</a>

</details>
