### PR TITLE
8283839: [JVMCI] add support for querying indy bootstrap method target and arguments

### DIFF
--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -336,6 +336,8 @@
   template(findMethodHandleType_signature,       "(Ljava/lang/Class;[Ljava/lang/Class;)Ljava/lang/invoke/MethodType;") \
   template(invokeExact_name,                          "invokeExact")                              \
   template(linkMethodHandleConstant_name,             "linkMethodHandleConstant")                 \
+  template(asFixedArity_name,                         "asFixedArity")                             \
+  template(asFixedArity_signature,                    "()Ljava/lang/invoke/MethodHandle;")        \
   template(linkMethodHandleConstant_signature, "(Ljava/lang/Class;ILjava/lang/Class;Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/invoke/MethodHandle;") \
   template(linkMethod_name,                           "linkMethod")                               \
   template(linkMethod_signature, "(Ljava/lang/Class;ILjava/lang/Class;Ljava/lang/String;Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/invoke/MemberName;") \

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -295,11 +295,9 @@ final class CompilerToVM {
     native void resolveInvokeDynamicInPool(HotSpotConstantPool constantPool, int cpi);
 
     /**
-     * If {@code cpi} denotes an entry representing a
-     * <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-2.html#jvms-2.9">signature
-     * polymorphic</a> method, this method ensures that the type referenced by the entry is loaded
-     * and initialized. It {@code cpi} does not denote a signature polymorphic method, this method
-     * does nothing.
+     * If {@code cpi} denotes an entry representing a signature polymorphic method ({@jvms 2.9}),
+     * this method ensures that the type referenced by the entry is loaded and initialized. It
+     * {@code cpi} does not denote a signature polymorphic method, this method does nothing.
      */
     native void resolveInvokeHandleInPool(HotSpotConstantPool constantPool, int cpi);
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -283,8 +283,6 @@ final class CompilerToVM {
      */
     native HotSpotResolvedJavaMethodImpl lookupMethodInPool(HotSpotConstantPool constantPool, int cpi, byte opcode);
 
-    // TODO resolving JVM_CONSTANT_Dynamic
-
     /**
      * Ensures that the type referenced by the specified {@code JVM_CONSTANT_InvokeDynamic} entry at
      * index {@code cpi} in {@code constantPool} is loaded and initialized.
@@ -293,6 +291,30 @@ final class CompilerToVM {
      * {@code JVM_CONSTANT_InvokeDynamic} entry.
      */
     native void resolveInvokeDynamicInPool(HotSpotConstantPool constantPool, int cpi);
+
+    /**
+     * Resolves the details for invoking the bootstrap method associated with the
+     * {@code CONSTANT_Dynamic_info} or @{code CONSTANT_InvokeDynamic_info} entry at {@code cpi} in
+     * {@code constant pool}.
+     *
+     * The return value encodes the details in an object array that is described by the pseudo Java
+     * object {@code info} below:
+     *
+     * <pre>
+     *     bsm_invocation = [
+     *         ResolvedJavaMethod[] method,
+     *         String name,
+     *         Object type,             // JavaConstant: reference to Class (condy) or MethodType (indy)
+     *         Object staticArguments,  // null: no static arguments
+     *                                  // JavaConstant: single static argument
+     *                                  // JavaConstant[]: multiple static arguments
+     *                                  // int[]: static arguments to be resolved via BootstrapCallInfo
+     *     ]
+     * </pre>
+     *
+     * @return bootstrap method invocation details as encoded above
+     */
+    native Object[] resolveBootstrapMethod(HotSpotConstantPool constantPool, int cpi);
 
     /**
      * If {@code cpi} denotes an entry representing a signature polymorphic method ({@jvms 2.9}),

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/VMIntrinsicMethod.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/VMIntrinsicMethod.java
@@ -30,9 +30,9 @@ import jdk.vm.ci.meta.Signature;
 public final class VMIntrinsicMethod {
 
     /**
-     * The name of the class declaring the intrinsified method. The name is in
-     * <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.2.1">class
-     * file format</a> (e.g., {@code "java/lang/Thread"} instead of {@code "java.lang.Thread"}).
+     * The name of the class declaring the intrinsified method. The name is in class file format
+     * (see JVMS {@jvms 4.2.1}). For example, {@code "java/lang/Thread"} instead of
+     * {@code "java.lang.Thread"}.
      */
     public final String declaringClass;
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/ConstantPool.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/ConstantPool.java
@@ -22,6 +22,9 @@
  */
 package jdk.vm.ci.meta;
 
+import java.lang.invoke.MethodType;
+import java.util.List;
+
 /**
  * Represents the runtime representation of the constant pool that is used by the compiler when
  * parsing bytecode. Provides methods to look up a constant pool entry without performing
@@ -83,6 +86,65 @@ public interface ConstantPool {
      * @throws ClassFormatError if the entry at {@code cpi} is not a method
      */
     JavaMethod lookupMethod(int cpi, int opcode);
+
+    /**
+     * The details for invoking a bootstrap method associated with a {@code CONSTANT_Dynamic_info}
+     * or {@code CONSTANT_InvokeDynamic_info} pool entry .
+     *
+     * @jvms 4.4.10 The {@code CONSTANT_Dynamic_info} and {@code CONSTANT_InvokeDynamic_info}
+     *       Structures
+     * @jvms 4.7.23 The {@code BootstrapMethods} Attribute
+     */
+    interface BootstrapMethodInvocation {
+        /**
+         * Gets the bootstrap method that will be invoked.
+         */
+        ResolvedJavaMethod getMethod();
+
+        /**
+         * Returns {@code true} if this bootstrap method invocation is for a
+         * {@code CONSTANT_InvokeDynamic_info} pool entry, {@code false} if it is for a
+         * {@code CONSTANT_Dynamic_info} entry.
+         */
+        boolean isInvokeDynamic();
+
+        /**
+         * Gets the name of the pool entry.
+         */
+        String getName();
+
+        /**
+         * Returns a reference to the {@link MethodType} ({@code this.isInvokeDynamic() == true}) or
+         * {@link Class} ({@code this.isInvokeDynamic() == false}) resolved for the descriptor of
+         * the pool entry.
+         */
+        JavaConstant getType();
+
+        /**
+         * Gets the static arguments with which the bootstrap method will be invoked.
+         *
+         * @jvms 5.4.3.6
+         */
+        List<JavaConstant> getStaticArguments();
+    }
+
+    /**
+     * Gets the details for invoking a bootstrap method associated with the
+     * {@code CONSTANT_Dynamic_info} or {@code CONSTANT_InvokeDynamic_info} pool entry {@code cpi}
+     * in the constant pool.
+     *
+     * @param cpi a constant pool index
+     * @param opcode the opcode of the instruction that has {@code cpi} as an operand or -1 if
+     *            {@code cpi} was not decoded from an instruction stream
+     * @return the bootstrap method invocation details or {@code null} if the entry at {@code cpi}
+     *         is not a {@code CONSTANT_Dynamic_info} or @{code CONSTANT_InvokeDynamic_info}
+     * @throws IllegalArgumentException if the bootstrap method invocation makes use of
+     *             {@code java.lang.invoke.BootstrapCallInfo}
+     * @jvms 4.7.23 The {@code BootstrapMethods} Attribute
+     */
+    default BootstrapMethodInvocation lookupBootstrapMethodInvocation(int cpi, int opcode) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Looks up a reference to a type. If {@code opcode} is non-negative, then resolution checks

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/JavaKind.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/JavaKind.java
@@ -101,10 +101,9 @@ public enum JavaKind {
 
     /**
      * Returns the name of the kind as a single upper case character. For the void and primitive
-     * kinds, this is the <i>FieldType</i> term in
-     * <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.3.2-200">
-     * table 4.3-A</a> of the JVM Specification. For {@link #Object}, the character {@code 'A'} is
-     * returned and for {@link #Illegal}, {@code '-'} is returned.
+     * kinds, this is the <i>FieldType</i> term in table 4.3-A of JVMS {@jvms 4.3.2}. For
+     * {@link #Object}, the character {@code 'A'} is returned and for {@link #Illegal}, {@code '-'}
+     * is returned.
      */
     public char getTypeChar() {
         return typeChar;

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/LineNumberTable.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/LineNumberTable.java
@@ -25,7 +25,7 @@ package jdk.vm.ci.meta;
 /**
  * Maps bytecode indexes to source line numbers.
  *
- * @see "https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.12"
+ * @jvms 4.7.12
  */
 public class LineNumberTable {
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/LocalVariableTable.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/LocalVariableTable.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * Describes the {@link Local}s for a Java method.
  *
- * @see "https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.13"
+ * @jvms 4.7.13
  */
 public class LocalVariableTable {
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/MetaAccessProvider.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/MetaAccessProvider.java
@@ -83,9 +83,7 @@ public interface MetaAccessProvider {
     long getMemorySize(JavaConstant constant);
 
     /**
-     * Parses a
-     * <a href="http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.3.3">method
-     * descriptor</a> into a {@link Signature}.
+     * Parses a method descriptor ({@jvms 4.3.3}) into a {@link Signature}.
      *
      * @throws IllegalArgumentException if the method descriptor is not well formed
      */

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/ResolvedJavaMethod.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/ResolvedJavaMethod.java
@@ -85,20 +85,18 @@ public interface ResolvedJavaMethod extends JavaMethod, InvokeTarget, ModifiersP
     boolean isSynthetic();
 
     /**
-     * Checks that the method is a
-     * <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.6">varargs</a>
-     * method.
+     * Checks if the method is a varargs method.
      *
      * @return whether the method is a varargs method
+     * @jvms 4.6
      */
     boolean isVarArgs();
 
     /**
-     * Checks that the method is a
-     * <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.6">bridge</a>
-     * method.
+     * Checks if the method is a bridge method.
      *
      * @return whether the method is a bridge method
+     * @jvms 4.6
      */
     boolean isBridge();
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/Signature.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/Signature.java
@@ -25,8 +25,7 @@ package jdk.vm.ci.meta;
 /**
  * Represents a method signature provided by the runtime.
  *
- * @see <a href="http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.3.3">Method
- *      Descriptors</a>
+ * @jvms 4.3.3
  */
 public interface Signature {
 
@@ -84,9 +83,7 @@ public interface Signature {
     }
 
     /**
-     * Gets the
-     * <a href="http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.3.3">method
-     * descriptor</a> corresponding to this signature. For example:
+     * Gets the method descriptor ({@jvms 4.3.3}) corresponding to this signature. For example:
      *
      * <pre>
      * (ILjava/lang/String;D)V


### PR DESCRIPTION
This PR adds support to JVMCI for obtaining the call info for the bootstrap method associated with an invokedynamic or constantdynamic constant pool entry.

In the context of Native Image, this is necessary to be able to defer execution of select bootstrap methods to image run time (as opposed to executing the bootstrap method during Native Image build time).

I've also included a minor change to adopt use of the `jvms` javadoc tag in JVMCI Java code. This is preferable to the HTML links previously used in that the latter refer to a specific JDK release.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283839](https://bugs.openjdk.java.net/browse/JDK-8283839): [JVMCI] add support for querying indy bootstrap method target and arguments


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8273/head:pull/8273` \
`$ git checkout pull/8273`

Update a local copy of the PR: \
`$ git checkout pull/8273` \
`$ git pull https://git.openjdk.java.net/jdk pull/8273/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8273`

View PR using the GUI difftool: \
`$ git pr show -t 8273`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8273.diff">https://git.openjdk.java.net/jdk/pull/8273.diff</a>

</details>
