### PR TITLE
8284933: Improve debug in jdk.crypto.cryptoki

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,9 +88,7 @@ final class Config {
     private static final boolean DEBUG = false;
 
     private static void debug(Object o) {
-        if (DEBUG) {
-            System.out.println(o);
-        }
+        System.out.println(o);
     }
 
     // file name containing this configuration
@@ -548,7 +546,9 @@ final class Config {
 
     private int nextToken() throws IOException {
         int token = st.nextToken();
-        debug(st);
+        if (DEBUG)  {
+            debug(st);
+        }
         return token;
     }
 
@@ -595,7 +595,9 @@ final class Config {
         }
         String value = st.sval;
 
-        debug(keyword + ": " + value);
+        if (DEBUG) {
+            debug(keyword + ": " + value);
+        }
         return value;
     }
 
@@ -603,7 +605,9 @@ final class Config {
         checkDup(keyword);
         parseEquals();
         boolean value = parseBoolean();
-        debug(keyword + ": " + value);
+        if (DEBUG) {
+            debug(keyword + ": " + value);
+        }
         return value;
     }
 
@@ -611,7 +615,9 @@ final class Config {
         checkDup(keyword);
         parseEquals();
         int value = decodeNumber(parseWord());
-        debug(keyword + ": " + value);
+        if (DEBUG) {
+            debug(keyword + ": " + value);
+        }
         return value;
     }
 
@@ -716,7 +722,9 @@ final class Config {
             String suffix = lib.substring(i + 5);
             lib = prefix + suffix;
         }
-        debug(keyword + ": " + lib);
+        if (DEBUG) {
+            debug(keyword + ": " + lib);
+        }
 
         // Check to see if full path is specified to prevent the DLL
         // preloading attack
@@ -731,7 +739,9 @@ final class Config {
         checkDup(keyword);
         parseEquals();
         description = parseLine();
-        debug("description: " + description);
+        if (DEBUG) {
+            debug("description: " + description);
+        }
     }
 
     private void parseSlotID(String keyword) throws IOException {
@@ -745,7 +755,9 @@ final class Config {
         parseEquals();
         String slotString = parseWord();
         slotID = decodeNumber(slotString);
-        debug("slot: " + slotID);
+        if (DEBUG) {
+            debug("slot: " + slotID);
+        }
     }
 
     private void parseSlotListIndex(String keyword) throws IOException {
@@ -759,7 +771,9 @@ final class Config {
         parseEquals();
         String slotString = parseWord();
         slotListIndex = decodeNumber(slotString);
-        debug("slotListIndex: " + slotListIndex);
+        if (DEBUG) {
+            debug("slotListIndex: " + slotListIndex);
+        }
     }
 
     private void parseEnabledMechanisms(String keyword) throws IOException {
@@ -1021,7 +1035,9 @@ final class Config {
             throw excToken("Expected quoted string");
         }
         nssArgs = expand(st.sval);
-        debug("nssArgs: " + nssArgs);
+        if (DEBUG) {
+            debug("nssArgs: " + nssArgs);
+        }
     }
 
     private void parseHandleStartupErrors(String keyword) throws IOException {
@@ -1037,7 +1053,9 @@ final class Config {
         } else {
             throw excToken("Invalid value for handleStartupErrors:");
         }
-        debug("handleStartupErrors: " + handleStartupErrors);
+        if (DEBUG) {
+            debug("handleStartupErrors: " + handleStartupErrors);
+        }
     }
 
 }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
@@ -87,10 +87,6 @@ final class Config {
 
     private static final boolean DEBUG = false;
 
-    private static void debug(Object o) {
-        System.out.println(o);
-    }
-
     // file name containing this configuration
     private String filename;
 
@@ -547,7 +543,7 @@ final class Config {
     private int nextToken() throws IOException {
         int token = st.nextToken();
         if (DEBUG)  {
-            debug(st);
+            System.out.println(st);
         }
         return token;
     }
@@ -596,7 +592,7 @@ final class Config {
         String value = st.sval;
 
         if (DEBUG) {
-            debug(keyword + ": " + value);
+            System.out.println(keyword + ": " + value);
         }
         return value;
     }
@@ -606,7 +602,7 @@ final class Config {
         parseEquals();
         boolean value = parseBoolean();
         if (DEBUG) {
-            debug(keyword + ": " + value);
+            System.out.println(keyword + ": " + value);
         }
         return value;
     }
@@ -616,7 +612,7 @@ final class Config {
         parseEquals();
         int value = decodeNumber(parseWord());
         if (DEBUG) {
-            debug(keyword + ": " + value);
+            System.out.println(keyword + ": " + value);
         }
         return value;
     }
@@ -723,7 +719,7 @@ final class Config {
             lib = prefix + suffix;
         }
         if (DEBUG) {
-            debug(keyword + ": " + lib);
+            System.out.println(keyword + ": " + lib);
         }
 
         // Check to see if full path is specified to prevent the DLL
@@ -740,7 +736,7 @@ final class Config {
         parseEquals();
         description = parseLine();
         if (DEBUG) {
-            debug("description: " + description);
+            System.out.println("description: " + description);
         }
     }
 
@@ -756,7 +752,7 @@ final class Config {
         String slotString = parseWord();
         slotID = decodeNumber(slotString);
         if (DEBUG) {
-            debug("slot: " + slotID);
+            System.out.println("slot: " + slotID);
         }
     }
 
@@ -772,7 +768,7 @@ final class Config {
         String slotString = parseWord();
         slotListIndex = decodeNumber(slotString);
         if (DEBUG) {
-            debug("slotListIndex: " + slotListIndex);
+            System.out.println("slotListIndex: " + slotListIndex);
         }
     }
 
@@ -1036,7 +1032,7 @@ final class Config {
         }
         nssArgs = expand(st.sval);
         if (DEBUG) {
-            debug("nssArgs: " + nssArgs);
+            System.out.println("nssArgs: " + nssArgs);
         }
     }
 
@@ -1054,7 +1050,7 @@ final class Config {
             throw excToken("Invalid value for handleStartupErrors:");
         }
         if (DEBUG) {
-            debug("handleStartupErrors: " + handleStartupErrors);
+            System.out.println("handleStartupErrors: " + handleStartupErrors);
         }
     }
 


### PR DESCRIPTION
Hi,

May I have the simple update reviewed?

In the jdk.crypto.cryptoki module implementation, some of the debug information could be calculated even if the debug is not enabled, which is not resource friendly.

Thanks,
Xuelei

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284933](https://bugs.openjdk.java.net/browse/JDK-8284933): Improve debug in jdk.crypto.cryptoki


### Reviewers
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8277/head:pull/8277` \
`$ git checkout pull/8277`

Update a local copy of the PR: \
`$ git checkout pull/8277` \
`$ git pull https://git.openjdk.java.net/jdk pull/8277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8277`

View PR using the GUI difftool: \
`$ git pr show -t 8277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8277.diff">https://git.openjdk.java.net/jdk/pull/8277.diff</a>

</details>
