### PR TITLE
JDK-8242888: Convert dynamic proxy to hidden classes

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -1671,6 +1671,15 @@ abstract class MethodHandleImpl {
             public Class<?>[] exceptionTypes(MethodHandle handle) {
                 return VarHandles.exceptionTypes(handle);
             }
+
+            @Override
+            public Lookup injectLookup(Class<?> clazz) {
+                try {
+                    return MethodHandles.privateLookupIn(clazz, IMPL_LOOKUP);
+                } catch (IllegalAccessException ex) {
+                    throw new InternalError(ex);
+                }
+            }
         });
     }
 

--- a/src/java.base/share/classes/java/lang/reflect/Proxy.java
+++ b/src/java.base/share/classes/java/lang/reflect/Proxy.java
@@ -612,7 +612,6 @@ public class Proxy implements java.io.Serializable {
         private final List<Class<?>> interfaces;
         private final ProxyContext context;
 
-        private enum ProxyKind { PACKAGE, NON_EXPORTED, EXPORTED }
         private record ProxyContext(Module module, String pkg, boolean packagePrivate, MethodHandles.Lookup lookup) {}
 
         ProxyBuilder(ClassLoader loader, List<Class<?>> interfaces) {
@@ -770,8 +769,8 @@ public class Proxy implements java.io.Serializable {
          * Reads edge and qualified exports are added for dynamic module to access.
          */
         private static ProxyContext determineContext(ClassLoader loader,
-                                               List<Class<?>> interfaces,
-                                               Set<Class<?>> refTypes) {
+                                                     List<Class<?>> interfaces,
+                                                     Set<Class<?>> refTypes) {
             Map<Class<?>, Module> packagePrivateTypes = new HashMap<>();
             boolean nonExported = false;
             for (Class<?> intf : interfaces) {

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
@@ -188,4 +188,12 @@ public interface JavaLangInvokeAccess {
      * @return an array of exceptions, or {@code null}.
      */
     Class<?>[] exceptionTypes(MethodHandle handle);
+
+    /**
+     * Return a full-privileged lookup for a given class.
+     *
+     * @param clazz the class
+     * @return the lookup
+     */
+    Lookup injectLookup(Class<?> clazz);
 }

--- a/test/langtools/jdk/jshell/ExceptionsTest.java
+++ b/test/langtools/jdk/jshell/ExceptionsTest.java
@@ -227,7 +227,6 @@ public class ExceptionsTest extends KullaTesting {
         assertExceptionMatch(se,
                 new ExceptionInfo(IllegalStateException.class, message,
                         newStackTraceElement("", "lambda$do_it$$0", se.snippet(), 1),
-                        new StackTraceElement("jdk.proxy1.$Proxy0", "hashCode", null, -1),
                         newStackTraceElement("", "", se.snippet(), 1)));
     }
 


### PR DESCRIPTION
Convert dynamic proxies to hidden classes. Modifies the serialization of proxies (requires change in "Java Object Serialization Specification"). Makes the proxies hidden in stack traces. Removes duplicate logic in proxy building.

The main compatibility changes and their rationales are:
1. Modification to the serialization specification: In the "An instance of the class is allocated... The contents restored appropriately" section, I propose explicitly state that handling of proxies are unspecified as to allow implementation freedom, though I've seen deliberate attempts for proxies to implement interfaces with `readResolve` in order to control their serialization behavior.
   - This is for the existing generated constructor accessor is bytecode-based, which cannot refer to hidden classes.
   - An alternative is to preserve the behavior, where the serialization constructor calls `invokespecial` on the closest serializable superclass' no-arg constructor, like in #1830 by @DasBrain.
   - My rationale against preservation is such super calls are unsafe and should be discouraged in the long term. Calling the existing constructor with a dummy argument, as in my implementation, would be more safe.
2. The disappearance of proxies in stack traces.
   - Same behavior exists in lambda expressions: For instance, in `((Runnable) () -> { throw new Error(); }).run();`, the `run` method, implemented by the lambda, will not appear in the stack trace, and isn't too problematic.

A summary of the rest of the changes:
1. Merged the two passes of determining module and package of the proxy into one. This reduced a lot of code and allowed anchor class (for hidden class creation) selection be done together as well.
2. Exposed internal API for obtaining a full-privileged lookup to the rest of `java.base`. This API is intended for implementation of legacy (pre `MethodHandles.Lookup`) caller sensitive public APIs so they don't need more complex tricks to obtain proper permissions as lookups.
3. Implements [8229959](https://bugs.openjdk.java.net/browse/JDK-8229959): passes methods computed by proxy generator as class data to the hidden proxy class to reduce generated proxy class size and improve performance.

In addition, since this change is somewhat large, should we keep the old proxy generator as well and have it toggled through a command-line flag (like the old v49 proxy generator or the old reflection implementation)?

Please feel free to comment or review. This change definitely requires a CSR, but I have yet to determine what specifications should be changed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed
- [ ] Change requires a CSR request to be approved

### Issue
 * [JDK-8242888](https://bugs.openjdk.java.net/browse/JDK-8242888): Convert dynamic proxy to hidden classes


### Contributors
 * Johannes Kuhn `<jkuhn@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8278/head:pull/8278` \
`$ git checkout pull/8278`

Update a local copy of the PR: \
`$ git checkout pull/8278` \
`$ git pull https://git.openjdk.java.net/jdk pull/8278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8278`

View PR using the GUI difftool: \
`$ git pr show -t 8278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8278.diff">https://git.openjdk.java.net/jdk/pull/8278.diff</a>

</details>
