### PR TITLE
8283022: com/sun/crypto/provider/Cipher/AEAD/GCMBufferTest.java failing with -Xcomp after 8273297

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
@@ -86,7 +86,7 @@ abstract class GaloisCounterMode extends CipherSpi {
     // data size when buffer is divided up to aid in intrinsics
     private static final int TRIGGERLEN = 65536;  // 64k
     // x86-64 parallel intrinsic data size
-    private static final int PARALLEL_LEN = 8192;
+    private static final int PARALLEL_LEN = 7680;
     // max data size for x86-64 intrinsic
     private static final int SPLIT_LEN = 1048576;  // 1MB
 


### PR DESCRIPTION
When input length provided to the intrinsic is 8192, only 7680 bytes are processed as the intrinsic operates on multiples of 768 bytes.
In implGCMCrypt(ByteBuffer src, ByteBuffer dst) method, 
dst.put(bout, 0, PARALLEL_LEN) statement caused the ciphertext mismatch as PARALLEL_LEN was set to 8192. 
Since the intrinsic only processed 7680 bytes, the rest output was incorrect.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283022](https://bugs.openjdk.java.net/browse/JDK-8283022): com/sun/crypto/provider/Cipher/AEAD/GCMBufferTest.java failing with -Xcomp after 8273297


### Reviewers
 * [Anthony Scarpino](https://openjdk.java.net/census#ascarpino) (@ascarpino - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8280/head:pull/8280` \
`$ git checkout pull/8280`

Update a local copy of the PR: \
`$ git checkout pull/8280` \
`$ git pull https://git.openjdk.java.net/jdk pull/8280/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8280`

View PR using the GUI difftool: \
`$ git pr show -t 8280`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8280.diff">https://git.openjdk.java.net/jdk/pull/8280.diff</a>

</details>
