### PR TITLE
8208565: [TEST_BUG] javax\swing\PopupFactory\6276087\NonOpaquePopupMenuTest.java throws NPE

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -716,7 +716,6 @@ javax/swing/text/DefaultCaret/HidingSelection/HidingSelectionTest.java 8194048 w
 javax/swing/text/DefaultCaret/HidingSelection/MultiSelectionTest.java 8213562 linux-all
 javax/swing/JFileChooser/6798062/bug6798062.java 8146446 windows-all
 javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all,linux-all
-javax/swing/PopupFactory/6276087/NonOpaquePopupMenuTest.java 8065099,8208565 macosx-all,linux-all
 javax/swing/dnd/8139050/NativeErrorsInTableDnD.java 8202765  macosx-all,linux-all
 javax/swing/Popup/TaskbarPositionTest.java 8065097 macosx-all,linux-all
 javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all

--- a/test/jdk/javax/swing/PopupFactory/6276087/NonOpaquePopupMenuTest.java
+++ b/test/jdk/javax/swing/PopupFactory/6276087/NonOpaquePopupMenuTest.java
@@ -30,7 +30,7 @@
 import java.awt.Point;
 import java.awt.Dimension;
 import java.awt.Robot;
-import java.awt.event.*;
+import java.awt.event.InputEvent;
 
 import javax.swing.JFrame;
 import javax.swing.JMenu;

--- a/test/jdk/javax/swing/PopupFactory/6276087/NonOpaquePopupMenuTest.java
+++ b/test/jdk/javax/swing/PopupFactory/6276087/NonOpaquePopupMenuTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,71 +25,88 @@
  * @test
  * @key headful
  * @bug 6276087
- * @author Romain Guy
  * @summary Tests opacity of a popup menu.
  */
-import java.awt.*;
+import java.awt.Point;
+import java.awt.Dimension;
+import java.awt.Robot;
 import java.awt.event.*;
 
-import javax.swing.*;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
 import static javax.swing.UIManager.LookAndFeelInfo;
 import static javax.swing.UIManager.getInstalledLookAndFeels;
 import static javax.swing.UIManager.setLookAndFeel;
 
-public class NonOpaquePopupMenuTest extends JFrame {
+public class NonOpaquePopupMenuTest {
 
     private static JMenu fileMenu;
+    private static JFrame frame;
     private static final String AQUALAF="com.apple.laf.AquaLookAndFeel";
+    private volatile static Point p;
+    private volatile static Dimension size;
 
-    public NonOpaquePopupMenuTest() {
-        getContentPane().setBackground(java.awt.Color.RED);
+    private static void createUI() {
+        frame = new JFrame();
+        frame.getContentPane().setBackground(java.awt.Color.RED);
         JMenuBar menuBar = new JMenuBar();
         fileMenu = new JMenu("File");
         JMenuItem menuItem = new JMenuItem("New");
         menuBar.add(fileMenu);
-        setJMenuBar(menuBar);
+        frame.setJMenuBar(menuBar);
 
         fileMenu.add(menuItem);
         fileMenu.getPopupMenu().setOpaque(false);
 
-        setSize(new Dimension(640, 480));
-        setLocationRelativeTo(null);
-        setVisible(true);
+        frame.setSize(new Dimension(640, 480));
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
     }
 
     public static void main(String[] args) throws Throwable {
         LookAndFeelInfo[] lookAndFeelInfoArray = getInstalledLookAndFeels();
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
 
         for (LookAndFeelInfo lookAndFeelInfo : lookAndFeelInfoArray) {
-            System.out.println(lookAndFeelInfo.getClassName());
-            if ( AQUALAF == lookAndFeelInfo.getClassName()) {
-                System.out.println("This test scenario is not applicable for" +
-                        " Aqua LookandFeel and hence skipping the validation");
-                continue;
-            }
-            setLookAndFeel(lookAndFeelInfo.getClassName());
-            Robot robot = new Robot();
-            robot.setAutoDelay(250);
-
-            SwingUtilities.invokeAndWait(new Runnable() {
-
-                @Override
-                public void run() {
-                    new NonOpaquePopupMenuTest();
+            try {
+                System.out.println(lookAndFeelInfo.getClassName());
+                if ( AQUALAF == lookAndFeelInfo.getClassName()) {
+                    System.out.println("This test scenario is not applicable for" +
+                            " Aqua LookandFeel and hence skipping the validation");
+                    continue;
                 }
-            });
+                robot.delay(1000);
+                setLookAndFeel(lookAndFeelInfo.getClassName());
 
-            robot.waitForIdle();
+                SwingUtilities.invokeAndWait(() -> createUI());
 
-            Point p = getMenuClickPoint();
-            robot.mouseMove(p.x, p.y);
-            robot.mousePress(InputEvent.BUTTON1_MASK);
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+                robot.waitForIdle();
+                robot.delay(1000);
 
-            robot.waitForIdle();
+                SwingUtilities.invokeAndWait(() -> {
+                    p = fileMenu.getLocationOnScreen();
+                    size = fileMenu.getSize();
+                });
+                robot.mouseMove(p.x + size.width / 2, p.y + size.height / 2);
+                robot.waitForIdle();
+                robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
 
-            if (isParentOpaque()) {
-                throw new RuntimeException("Popup menu parent is opaque");
+                robot.waitForIdle();
+
+                if (isParentOpaque()) {
+                    throw new RuntimeException("Popup menu parent is opaque");
+                }
+            } finally {
+                SwingUtilities.invokeAndWait(() -> {
+                    if (frame != null) {
+                        frame.dispose();
+                    }
+                });
             }
         }
     }
@@ -106,24 +123,5 @@ public class NonOpaquePopupMenuTest extends JFrame {
         });
 
         return result[0];
-    }
-
-    private static Point getMenuClickPoint() throws Exception {
-        final Point[] result = new Point[1];
-
-        SwingUtilities.invokeAndWait(new Runnable() {
-
-            @Override
-            public void run() {
-                Point p = fileMenu.getLocationOnScreen();
-                Dimension size = fileMenu.getSize();
-
-                result[0] = new Point(p.x + size.width / 2,
-                        p.y + size.height / 2);
-            }
-        });
-
-        return result[0];
-
     }
 }


### PR DESCRIPTION
Test was failing in the past owing to NPE while accessing JMenu probably owing to fact the test did not wait for UI to be visible before starting the test, so added a delay after the frame is made visible. Also, added disposal of frame.
Also, it seems JDK-8213535 fix might be having a positive impact on this test.

Several iterations of this test in all platforms have passed (link in JBS).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8208565](https://bugs.openjdk.java.net/browse/JDK-8208565): [TEST_BUG] javax\swing\PopupFactory\6276087\NonOpaquePopupMenuTest.java throws NPE
 * [JDK-8065099](https://bugs.openjdk.java.net/browse/JDK-8065099): [macos] javax/swing/PopupFactory/6276087/NonOpaquePopupMenuTest.java fails: no background shine through


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8282/head:pull/8282` \
`$ git checkout pull/8282`

Update a local copy of the PR: \
`$ git checkout pull/8282` \
`$ git pull https://git.openjdk.java.net/jdk pull/8282/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8282`

View PR using the GUI difftool: \
`$ git pr show -t 8282`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8282.diff">https://git.openjdk.java.net/jdk/pull/8282.diff</a>

</details>
