### PR TITLE
8225433: Clarify behavior of PKIXParameters.setRevocationEnabled when PKIXRevocationChecker is used

### DIFF
--- a/src/java.base/share/classes/java/security/cert/PKIXParameters.java
+++ b/src/java.base/share/classes/java/security/cert/PKIXParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -321,8 +321,10 @@ public class PKIXParameters implements CertPathParameters {
     /**
      * Sets the RevocationEnabled flag. If this flag is true, the default
      * revocation checking mechanism of the underlying PKIX service provider
-     * will be used. If this flag is false, the default revocation checking
-     * mechanism will be disabled (not used).
+     * will be used, unless a {@link PKIXRevocationChecker} is passed in
+     * as a {@code CertPathChecker} (see below for further explanation). If
+     * this flag is false, the default revocation checking mechanism will be
+     * disabled (not used).
      * <p>
      * When a {@code PKIXParameters} object is created, this flag is set
      * to true. This setting reflects the most common strategy for checking
@@ -333,6 +335,11 @@ public class PKIXParameters implements CertPathParameters {
      * revocation checking mechanism is to be substituted (by also calling the
      * {@link #addCertPathChecker addCertPathChecker} or {@link
      * #setCertPathCheckers setCertPathCheckers} methods).
+     * <p>
+     * However, if a {@code PKIXRevocationChecker} is passed in as a parameter
+     * via the {@code addCertPathChecker} or {@code setCertPathCheckers}
+     * methods, it will be used to check revocation irrespective of the setting
+     * of the RevocationEnabled flag.
      *
      * @param val the new value of the RevocationEnabled flag
      */
@@ -343,8 +350,9 @@ public class PKIXParameters implements CertPathParameters {
     /**
      * Checks the RevocationEnabled flag. If this flag is true, the default
      * revocation checking mechanism of the underlying PKIX service provider
-     * will be used. If this flag is false, the default revocation checking
-     * mechanism will be disabled (not used). See the {@link
+     * will be used, unless a {@link PKIXRevocationChecker} is passed in as
+     * a {@code CertPathChecker}. If this flag is false, the default revocation
+     * checking mechanism will be disabled (not used). See the {@link
      * #setRevocationEnabled setRevocationEnabled} method for more details on
      * setting the value of this flag.
      *

--- a/src/java.base/share/classes/java/security/cert/PKIXParameters.java
+++ b/src/java.base/share/classes/java/security/cert/PKIXParameters.java
@@ -336,10 +336,10 @@ public class PKIXParameters implements CertPathParameters {
      * {@link #addCertPathChecker addCertPathChecker} or {@link
      * #setCertPathCheckers setCertPathCheckers} methods).
      * <p>
-     * However, if a {@code PKIXRevocationChecker} is passed in as a parameter
-     * via the {@code addCertPathChecker} or {@code setCertPathCheckers}
-     * methods, it will be used to check revocation irrespective of the setting
-     * of the RevocationEnabled flag.
+     * Note that when a {@code PKIXRevocationChecker} is passed in as a
+     * parameter via the {@code addCertPathChecker} or
+     * {@code setCertPathCheckers} methods, it will be used to check
+     * revocation irrespective of the setting of the RevocationEnabled flag.
      *
      * @param val the new value of the RevocationEnabled flag
      */

--- a/src/java.base/share/classes/java/security/cert/PKIXRevocationChecker.java
+++ b/src/java.base/share/classes/java/security/cert/PKIXRevocationChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,9 +66,10 @@ import java.util.Set;
  * to be validated to the {@link CertPathValidator#validate validate} method
  * of a PKIX {@code CertPathValidator}. When supplying a revocation checker in
  * this manner, it will be used to check revocation irrespective of the setting
- * of the {@link PKIXParameters#isRevocationEnabled RevocationEnabled} flag.
- * Similarly, a {@code PKIXRevocationChecker} may be added to a
- * {@code PKIXBuilderParameters} object for use with a PKIX
+ * of the {@link PKIXParameters#isRevocationEnabled RevocationEnabled} flag,
+ * and will override the default revocation checking mechanism of the PKIX
+ * service provider. Similarly, a {@code PKIXRevocationChecker} may be added
+ * to a {@code PKIXBuilderParameters} object for use with a PKIX
  * {@code CertPathBuilder}.
  *
  * <p>Note that when a {@code PKIXRevocationChecker} is added to


### PR DESCRIPTION
This change improves the specification for the case when a `PKIXRevocationChecker` is supplied as one of the `CertPathChecker` parameters. Specifically, it makes it more clear that a `PKIXRevocationChecker` overrides the default revocation checking mechanism of a PKIX service provider, and will be used to check revocation irrespective of the setting of the RevocationEnabled parameter.

Will also file a CSR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8225433](https://bugs.openjdk.java.net/browse/JDK-8225433): Clarify behavior of PKIXParameters.setRevocationEnabled when PKIXRevocationChecker is used
 * [JDK-8285262](https://bugs.openjdk.java.net/browse/JDK-8285262): Clarify behavior of PKIXParameters.setRevocationEnabled when PKIXRevocationChecker is used (**CSR**)


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**) ⚠️ Review applies to 36a0ff132e8a67b9006075438dc190768df73639
 * [Hai-May Chao](https://openjdk.java.net/census#hchao) (@haimaychao - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8287/head:pull/8287` \
`$ git checkout pull/8287`

Update a local copy of the PR: \
`$ git checkout pull/8287` \
`$ git pull https://git.openjdk.java.net/jdk pull/8287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8287`

View PR using the GUI difftool: \
`$ git pr show -t 8287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8287.diff">https://git.openjdk.java.net/jdk/pull/8287.diff</a>

</details>
