### PR TITLE
8283324: CLDRConverter run time increased by 3x

### DIFF
--- a/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
@@ -847,19 +847,24 @@ public class CLDRConverter {
         "DateTimePatternChars",
         "PluralRules",
         "DayPeriodRules",
-        "DateFormatItem",
+        "DateFormatItemInputRegions.allowed",
+        "DateFormatItemInputRegions.preferred",
     };
+
+    static final Set<String> availableSkeletons = new HashSet<>();
 
     private static Map<String, Object> extractFormatData(Map<String, Object> map, String id) {
         Map<String, Object> formatData = new LinkedHashMap<>();
         for (CalendarType calendarType : CalendarType.values()) {
             String prefix = calendarType.keyElementName();
             Arrays.stream(FORMAT_DATA_ELEMENTS)
-                .flatMap(elem -> map.keySet().stream().filter(k -> k.startsWith(prefix + elem)))
-                .forEach(key -> {
+                .forEach(elem -> {
+                    var key = prefix + elem;
                     copyIfPresent(map, "java.time." + key, formatData);
                     copyIfPresent(map, key, formatData);
                 });
+            availableSkeletons.forEach(s ->
+                copyIfPresent(map, prefix + "DateFormatItem." + s, formatData));
         }
 
         for (String key : map.keySet()) {

--- a/make/jdk/src/classes/build/tools/cldrconverter/LDMLParseHandler.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/LDMLParseHandler.java
@@ -768,9 +768,14 @@ class LDMLParseHandler extends AbstractLDMLHandler<Object> {
         case "dateFormatItem":
             {
                 // for FormatData
-                prefix = (currentCalendarType == null) ? "" : currentCalendarType.keyElementName();
-                pushStringEntry(qName, attributes,
-                        prefix + Bundle.DATEFORMATITEM_KEY_PREFIX + attributes.getValue("id"));
+                if (currentCalendarType != null) {
+                    var skeleton = attributes.getValue("id");
+                    CLDRConverter.availableSkeletons.add(skeleton);
+                    pushStringEntry(qName, attributes,
+                            currentCalendarType.keyElementName() + Bundle.DATEFORMATITEM_KEY_PREFIX + skeleton);
+                } else {
+                    pushIgnoredContainer(qName);
+                }
             }
             break;
 


### PR DESCRIPTION
Fixing performance regression caused by the fix to https://bugs.openjdk.java.net/browse/JDK-8176706. The fix introduced extra looping through the resource map multiple times which was not necessary. The execution time of the tool now got back on par with close to JDK18.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283324](https://bugs.openjdk.java.net/browse/JDK-8283324): CLDRConverter run time increased by 3x


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.java.net/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8288/head:pull/8288` \
`$ git checkout pull/8288`

Update a local copy of the PR: \
`$ git checkout pull/8288` \
`$ git pull https://git.openjdk.java.net/jdk pull/8288/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8288`

View PR using the GUI difftool: \
`$ git pr show -t 8288`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8288.diff">https://git.openjdk.java.net/jdk/pull/8288.diff</a>

</details>
