### PR TITLE
8284993: Replace System.exit call in swing tests with RuntimeException

### DIFF
--- a/test/jdk/javax/swing/JComboBox/8019180/Test8019180.java
+++ b/test/jdk/javax/swing/JComboBox/8019180/Test8019180.java
@@ -43,7 +43,7 @@ public class Test8019180 implements Runnable {
         try {
             SwingUtilities.invokeLater(new Test8019180());
             LATCH.await();
-	} finally {
+        } finally {
             SwingUtilities.invokeAndWait(() -> {
                 if (frame != null) {
                     frame.dispose();

--- a/test/jdk/javax/swing/JComboBox/8019180/Test8019180.java
+++ b/test/jdk/javax/swing/JComboBox/8019180/Test8019180.java
@@ -37,10 +37,19 @@ import javax.swing.SwingUtilities;
 public class Test8019180 implements Runnable {
     private static final CountDownLatch LATCH = new CountDownLatch(1);
     private static final String[] ITEMS = {"First", "Second", "Third", "Fourth"};
+    private static JFrame frame;
 
-    public static void main(String[] args) throws InterruptedException {
-        SwingUtilities.invokeLater(new Test8019180());
-        LATCH.await();
+    public static void main(String[] args) throws Exception {
+        try {
+            SwingUtilities.invokeLater(new Test8019180());
+            LATCH.await();
+	} finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
     }
 
     private JComboBox<String> test;
@@ -50,8 +59,9 @@ public class Test8019180 implements Runnable {
         if (this.test == null) {
             this.test = new JComboBox<>(ITEMS);
             this.test.addActionListener(this.test);
-            JFrame frame = new JFrame();
+            frame = new JFrame();
             frame.add(test);
+            frame.setLocationRelativeTo(null);
             frame.pack();
             frame.setVisible(true);
             SwingUtilities.invokeLater(this);
@@ -62,7 +72,6 @@ public class Test8019180 implements Runnable {
                 System.err.println("ERROR: no selection");
                 throw new RuntimeException("Combobox not selected");
             }
-            SwingUtilities.getWindowAncestor(this.test).dispose();
             LATCH.countDown();
         }
     }

--- a/test/jdk/javax/swing/JComboBox/8019180/Test8019180.java
+++ b/test/jdk/javax/swing/JComboBox/8019180/Test8019180.java
@@ -38,11 +38,16 @@ public class Test8019180 implements Runnable {
     private static final CountDownLatch LATCH = new CountDownLatch(1);
     private static final String[] ITEMS = {"First", "Second", "Third", "Fourth"};
     private static JFrame frame;
+    private static boolean selectionFail = false;
 
     public static void main(String[] args) throws Exception {
         try {
             SwingUtilities.invokeLater(new Test8019180());
             LATCH.await();
+	    System.out.println("selectionFail " + selectionFail);
+	    if (selectionFail) {
+                throw new RuntimeException("Combobox not selected");
+            }
         } finally {
             SwingUtilities.invokeAndWait(() -> {
                 if (frame != null) {
@@ -56,25 +61,22 @@ public class Test8019180 implements Runnable {
 
     @Override
     public void run() {
-        try {
-            if (this.test == null) {
-                this.test = new JComboBox<>(ITEMS);
-                this.test.addActionListener(this.test);
-                frame = new JFrame();
-                frame.add(test);
-                frame.setLocationRelativeTo(null);
-                frame.pack();
-                frame.setVisible(true);
-                SwingUtilities.invokeLater(this);
-            } else {
-                int index = this.test.getSelectedIndex();
-                this.test.setSelectedIndex(1 + index);
-                if (0 > this.test.getSelectedIndex()) {
-                    System.err.println("ERROR: no selection");
-                    throw new RuntimeException("Combobox not selected");
-                }
+        if (this.test == null) {
+            this.test = new JComboBox<>(ITEMS);
+            this.test.addActionListener(this.test);
+            frame = new JFrame();
+            frame.add(test);
+            frame.setLocationRelativeTo(null);
+            frame.pack();
+            frame.setVisible(true);
+            SwingUtilities.invokeLater(this);
+        } else {
+            int index = this.test.getSelectedIndex();
+            this.test.setSelectedIndex(1 + index);
+            if (0 > this.test.getSelectedIndex()) {
+                System.err.println("ERROR: no selection");
+                selectionFail = true;
             }
-        } finally {
             LATCH.countDown();
         }
     }

--- a/test/jdk/javax/swing/JComboBox/8019180/Test8019180.java
+++ b/test/jdk/javax/swing/JComboBox/8019180/Test8019180.java
@@ -60,7 +60,7 @@ public class Test8019180 implements Runnable {
             this.test.setSelectedIndex(1 + index);
             if (0 > this.test.getSelectedIndex()) {
                 System.err.println("ERROR: no selection");
-                System.exit(8019180);
+                throw new RuntimeException("Combobox not selected");
             }
             SwingUtilities.getWindowAncestor(this.test).dispose();
             LATCH.countDown();

--- a/test/jdk/javax/swing/JComboBox/8019180/Test8019180.java
+++ b/test/jdk/javax/swing/JComboBox/8019180/Test8019180.java
@@ -44,8 +44,8 @@ public class Test8019180 implements Runnable {
         try {
             SwingUtilities.invokeLater(new Test8019180());
             LATCH.await();
-	    System.out.println("selectionFail " + selectionFail);
-	    if (selectionFail) {
+            System.out.println("selectionFail " + selectionFail);
+            if (selectionFail) {
                 throw new RuntimeException("Combobox not selected");
             }
         } finally {

--- a/test/jdk/javax/swing/JComboBox/8019180/Test8019180.java
+++ b/test/jdk/javax/swing/JComboBox/8019180/Test8019180.java
@@ -56,22 +56,25 @@ public class Test8019180 implements Runnable {
 
     @Override
     public void run() {
-        if (this.test == null) {
-            this.test = new JComboBox<>(ITEMS);
-            this.test.addActionListener(this.test);
-            frame = new JFrame();
-            frame.add(test);
-            frame.setLocationRelativeTo(null);
-            frame.pack();
-            frame.setVisible(true);
-            SwingUtilities.invokeLater(this);
-        } else {
-            int index = this.test.getSelectedIndex();
-            this.test.setSelectedIndex(1 + index);
-            if (0 > this.test.getSelectedIndex()) {
-                System.err.println("ERROR: no selection");
-                throw new RuntimeException("Combobox not selected");
+        try {
+            if (this.test == null) {
+                this.test = new JComboBox<>(ITEMS);
+                this.test.addActionListener(this.test);
+                frame = new JFrame();
+                frame.add(test);
+                frame.setLocationRelativeTo(null);
+                frame.pack();
+                frame.setVisible(true);
+                SwingUtilities.invokeLater(this);
+            } else {
+                int index = this.test.getSelectedIndex();
+                this.test.setSelectedIndex(1 + index);
+                if (0 > this.test.getSelectedIndex()) {
+                    System.err.println("ERROR: no selection");
+                    throw new RuntimeException("Combobox not selected");
+                }
             }
+        } finally {
             LATCH.countDown();
         }
     }

--- a/test/jdk/javax/swing/JFileChooser/8013442/Test8013442.java
+++ b/test/jdk/javax/swing/JFileChooser/8013442/Test8013442.java
@@ -118,6 +118,6 @@ public class Test8013442 extends FileFilter implements Runnable, Thread.Uncaught
 
     public void uncaughtException(Thread thread, Throwable throwable) {
         throwable.printStackTrace();
-        System.exit(1);
+        throw new RuntimeException(throwable);
     }
 }

--- a/test/jdk/javax/swing/plaf/basic/BasicTabbedPaneUI/Test6943780.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicTabbedPaneUI/Test6943780.java
@@ -41,7 +41,7 @@ public class Test6943780 implements Runnable, Thread.UncaughtExceptionHandler {
     @Override
     public void uncaughtException(Thread thread, Throwable throwable) {
         throwable.printStackTrace();
-        System.exit(1);
+        throw new RuntimeException(throwable);
     }
 
     @Override

--- a/test/jdk/javax/swing/plaf/synth/Test8015926.java
+++ b/test/jdk/javax/swing/plaf/synth/Test8015926.java
@@ -94,6 +94,6 @@ public class Test8015926 implements TreeModelListener, Runnable, Thread.Uncaught
     @Override
     public void uncaughtException(Thread thread, Throwable exception) {
         exception.printStackTrace();
-        System.exit(1);
+        throw new RuntimeException(exception);
     }
 }

--- a/test/jdk/javax/swing/text/AbstractDocument/6968363/Test6968363.java
+++ b/test/jdk/javax/swing/text/AbstractDocument/6968363/Test6968363.java
@@ -68,7 +68,7 @@ public class Test6968363 implements Runnable, Thread.UncaughtExceptionHandler {
     @Override
     public void uncaughtException(Thread thread, Throwable throwable) {
         throwable.printStackTrace();
-	throw new RuntimeException(throwable);
+        throw new RuntimeException(throwable);
     }
 
     @Override

--- a/test/jdk/javax/swing/text/AbstractDocument/6968363/Test6968363.java
+++ b/test/jdk/javax/swing/text/AbstractDocument/6968363/Test6968363.java
@@ -68,7 +68,7 @@ public class Test6968363 implements Runnable, Thread.UncaughtExceptionHandler {
     @Override
     public void uncaughtException(Thread thread, Throwable throwable) {
         throwable.printStackTrace();
-        System.exit(1);
+	throw new RuntimeException(throwable);
     }
 
     @Override

--- a/test/jdk/javax/swing/text/html/parser/Test8017492.java
+++ b/test/jdk/javax/swing/text/html/parser/Test8017492.java
@@ -65,7 +65,7 @@ public class Test8017492 {
             @Override
             public void uncaughtException(Thread thread, Throwable throwable) {
                 throwable.printStackTrace();
-                System.exit(1);
+                throw new RuntimeException(throwable);
             }
         });
         thread.start();


### PR DESCRIPTION
Few swing tests call System.exit() which might stop the test harness from executing further tests if any of the test fail. We should replace with RuntimeException.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284993](https://bugs.openjdk.java.net/browse/JDK-8284993): Replace System.exit call in swing tests with RuntimeException


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**) ⚠️ Review applies to 2c8508a65dd18c340bc101ad5f82f06b7f284c1d


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8293/head:pull/8293` \
`$ git checkout pull/8293`

Update a local copy of the PR: \
`$ git checkout pull/8293` \
`$ git pull https://git.openjdk.java.net/jdk pull/8293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8293`

View PR using the GUI difftool: \
`$ git pr show -t 8293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8293.diff">https://git.openjdk.java.net/jdk/pull/8293.diff</a>

</details>
