### PR TITLE
8023814: Test java/awt/im/memoryleak/InputContextMemoryLeakTest.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -483,7 +483,6 @@ java/awt/Toolkit/DesktopProperties/rfe4758438.java 8193547 linux-all
 java/awt/Toolkit/ToolkitPropertyTest/ToolkitPropertyTest_Enable.java 6847163
 java/awt/xembed/server/RunTestXEmbed.java 7034201 linux-all
 java/awt/Modal/ModalFocusTransferTests/FocusTransferDialogsDocModalTest.java 8164473 linux-all
-java/awt/im/memoryleak/InputContextMemoryLeakTest.java 8023814 linux-all
 java/awt/Frame/DisposeParentGC/DisposeParentGC.java 8079786 macosx-all
 
 java/awt/GraphicsDevice/DisplayModes/CycleDMImage.java 7099223,8274106 macosx-aarch64,linux-all,windows-all

--- a/test/jdk/java/awt/im/memoryleak/InputContextMemoryLeakTest.java
+++ b/test/jdk/java/awt/im/memoryleak/InputContextMemoryLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,6 @@
 
 import java.awt.FlowLayout;
 import java.awt.Robot;
-import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
@@ -88,7 +87,12 @@ public class InputContextMemoryLeakTest {
         //After the next caret blink it automatically TextField references
         Thread.sleep(text.get().getCaret().getBlinkRate() * 2);
         Util.waitForIdle(null);
-        assertGC();
+
+        try {
+            assertGC();
+        } finally {
+            SwingUtilities.invokeAndWait(() -> frame.dispose());
+        }
     }
 
       public static void assertGC() throws Throwable {


### PR DESCRIPTION
Removing the test from problem list, since I am unable to reproduce the issue even with old Ubuntu distros with jdk8.
Bug filed against Solaris initially, but I did not test on it, since it is no longer supported.

Multiple mach5 testing is green.

`dispose` added for convenience if test is executed without jtreg.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8023814](https://bugs.openjdk.java.net/browse/JDK-8023814): Test java/awt/im/memoryleak/InputContextMemoryLeakTest.java fails


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8295/head:pull/8295` \
`$ git checkout pull/8295`

Update a local copy of the PR: \
`$ git checkout pull/8295` \
`$ git pull https://git.openjdk.java.net/jdk pull/8295/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8295`

View PR using the GUI difftool: \
`$ git pr show -t 8295`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8295.diff">https://git.openjdk.java.net/jdk/pull/8295.diff</a>

</details>
