### PR TITLE
8285007: Use correct lookup mode for MethodHandleStatics.UNSAFE

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
@@ -896,11 +896,11 @@ sealed class DirectMethodHandle extends MethodHandle {
                 case NF_constructorMethod:
                     return getNamedFunction("constructorMethod", OBJ_OBJ_TYPE);
                 case NF_UNSAFE:
-                    MemberName member = new MemberName(MethodHandleStatics.class, "UNSAFE", Unsafe.class, REF_getField);
+                    MemberName member = new MemberName(MethodHandleStatics.class, "UNSAFE", Unsafe.class, REF_getStatic);
                     return new NamedFunction(
                             MemberName.getFactory().resolveOrFail(REF_getField, member,
                                                                   DirectMethodHandle.class, LM_TRUSTED,
-                                                                  NoSuchMethodException.class));
+                                                                  NoSuchFieldException.class));
                 case NF_checkReceiver:
                     member = new MemberName(DirectMethodHandle.class, "checkReceiver", OBJ_OBJ_TYPE, REF_invokeVirtual);
                     return new NamedFunction(

--- a/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
@@ -898,7 +898,7 @@ sealed class DirectMethodHandle extends MethodHandle {
                 case NF_UNSAFE:
                     MemberName member = new MemberName(MethodHandleStatics.class, "UNSAFE", Unsafe.class, REF_getStatic);
                     return new NamedFunction(
-                            MemberName.getFactory().resolveOrFail(REF_getField, member,
+                            MemberName.getFactory().resolveOrFail(REF_getStatic, member,
                                                                   DirectMethodHandle.class, LM_TRUSTED,
                                                                   NoSuchFieldException.class));
                 case NF_checkReceiver:


### PR DESCRIPTION
Trivially fix the resolution of the `NF_UNSAFE` named function to use the appropriate lookup mode.

In [JDK-8187826](https://bugs.openjdk.java.net/browse/JDK-8187826) we changed from regular reflection to use a `NamedFunction` for this field, but it appears the lookup mode came out wrong. This mismatch appears to be benign and ignored by HotSpot, but a user implementing an experimental JVM ran into some issues (and additionally noticed the resolve throws the wrong exception). 

This patch is a point fix to this particular issue, but I think we should consider following up with a stronger assertion or test for proper staticness of fields somewhere when resolving fields via `MemberName.getFactory().resolveOrNull(..)`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285007](https://bugs.openjdk.java.net/browse/JDK-8285007): Use correct lookup mode for MethodHandleStatics.UNSAFE


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to fa10026af6141a211c78b5495230c74832c4e510
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8297/head:pull/8297` \
`$ git checkout pull/8297`

Update a local copy of the PR: \
`$ git checkout pull/8297` \
`$ git pull https://git.openjdk.java.net/jdk pull/8297/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8297`

View PR using the GUI difftool: \
`$ git pr show -t 8297`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8297.diff">https://git.openjdk.java.net/jdk/pull/8297.diff</a>

</details>
