### PR TITLE
8285011: gc/arguments/TestUseCompressedOopsFlagsWithUlimit.java fails after JDK-8280761

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsFlagsWithUlimit.java
+++ b/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsFlagsWithUlimit.java
@@ -32,6 +32,7 @@ package gc.arguments;
  * @library /
  * @requires vm.bits == "64"
  * @requires os.family != "aix" & os.family != "windows"
+ * @requires vm.gc != "Z"
  * @run driver gc.arguments.TestUseCompressedOopsFlagsWithUlimit
  */
 


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that fixes a test to not run with ZGC? The issue is that the test expects that UseCompressedOops is set after invocation, but ZGC does not support compressed oops at all.

The suggested fix is to not run this test with ZGC.

Testing: local jtreg testing with "-a -XX:+UseZGC" before and after, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8285011](https://bugs.openjdk.java.net/browse/JDK-8285011): gc/arguments/TestUseCompressedOopsFlagsWithUlimit.java fails after JDK-8280761


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8298/head:pull/8298` \
`$ git checkout pull/8298`

Update a local copy of the PR: \
`$ git checkout pull/8298` \
`$ git pull https://git.openjdk.java.net/jdk pull/8298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8298`

View PR using the GUI difftool: \
`$ git pr show -t 8298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8298.diff">https://git.openjdk.java.net/jdk/pull/8298.diff</a>

</details>
