### PR TITLE
8285012: Problemlist gc/arguments/TestUseCompressedOopsFlagsWithUlimit.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -79,6 +79,7 @@ compiler/codecache/TestStressCodeBuffers.java 8272094 generic-aarch64
 
 # :hotspot_gc
 
+gc/arguments/TestUseCompressedOopsFlagsWithUlimit.java 8285011 generic-all
 gc/epsilon/TestMemoryMXBeans.java 8206434 generic-all
 gc/g1/humongousObjects/objectGraphTest/TestObjectGraphAfterGC.java 8156755 generic-all
 gc/g1/logging/TestG1LoggingFailure.java 8169634 generic-all


### PR DESCRIPTION
Hi all,

  please review this problemlisting of the test `gc/arguments/TestUseCompressedOopsFlagsWithUlimit.java` since it causes lots of noise.

Thanks,
  Thomas