### PR TITLE
8129827: [TEST_BUG] Test java/awt/Robot/RobotWheelTest/RobotWheelTest.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -464,7 +464,6 @@ java/awt/font/TextLayout/LigatureCaretTest.java 8266312  generic-all
 java/awt/image/VolatileImage/CustomCompositeTest.java 8199002 windows-all,linux-all
 java/awt/image/VolatileImage/GradientPaints.java 8199003 linux-all
 java/awt/JAWT/JAWT.sh 8197798 windows-all,linux-all
-java/awt/Robot/RobotWheelTest/RobotWheelTest.java 8129827 generic-all
 java/awt/datatransfer/ConstructFlavoredObjectTest/ConstructFlavoredObjectTest.java 8202860 linux-all
 java/awt/dnd/DisposeFrameOnDragCrash/DisposeFrameOnDragTest.java 8202790 macosx-all,linux-all
 java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java 8202882 linux-all

--- a/test/jdk/java/awt/Robot/RobotWheelTest/RobotWheelTest.java
+++ b/test/jdk/java/awt/Robot/RobotWheelTest/RobotWheelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,10 +20,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 import java.awt.Button;
 import java.awt.Frame;
 import java.awt.Rectangle;
 import java.awt.Robot;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import jdk.test.lib.Platform;
 
@@ -40,22 +42,46 @@ import jdk.test.lib.Platform;
 public class RobotWheelTest {
 
     private static final int NUMTESTS = 20;
-    private static volatile int wheelRotation;
+
+    private static AtomicInteger wheelRotation = new AtomicInteger();
+    private static int wheelSign = Platform.isOSX() ? -1 : 1;
+
+    static Robot robot;
+
+    static void waitTillSuccess(int i) {
+        boolean success = false;
+
+        for (int t = 0; t < 5; t++) {
+            if (i == wheelSign * wheelRotation.get()) {
+                success = true;
+                break;
+            }
+            System.out.printf(
+                    "attempt #%d failed. wheelRotation = %d, expected value = %d\n",
+                    t, wheelRotation.get(), i
+            );
+            robot.delay(100);
+        }
+
+        if (!success) {
+            throw new RuntimeException("wheelRotation = " + wheelRotation.get()
+                    + ", expected value = " + i);
+        }
+    }
 
     public static void main(String[] args) throws Exception {
+        robot = new Robot();
 
         Frame frame = null;
         try {
-            int wheelSign = Platform.isOSX() ? -1 : 1;
-
             frame = new Frame();
             frame.setSize(200, 200);
             Button button = new Button("WheelButton");
-            button.addMouseWheelListener(e -> wheelRotation = e.getWheelRotation());
+            button.addMouseWheelListener(e -> wheelRotation.addAndGet(e.getWheelRotation()));
             frame.add(button);
+            frame.setLocationRelativeTo(null);
             frame.setVisible(true);
 
-            Robot robot = new Robot();
             robot.setAutoDelay(100);
             robot.waitForIdle();
 
@@ -69,12 +95,13 @@ public class RobotWheelTest {
                 if (i == 0) {
                     continue;
                 }
+
+                wheelRotation.set(0);
+
                 robot.mouseWheel(i);
                 robot.waitForIdle();
-                if (i != wheelSign * wheelRotation) {
-                    throw new RuntimeException("wheelRotation = " + wheelRotation
-                            + ", expected value = " + i);
-                }
+
+                waitTillSuccess(i);
             }
         } finally {
             if (frame != null) {


### PR DESCRIPTION
Test was written based on assumption that we will receive only one `mouseWheelMoved` event with `getWheelRotation() == 20` after `robot.mouseWheel(20)` call, but we can receive 20  events with `getWheelRotation == 1` instead.

So the test is modified to accumulate wheel rotation values before checking.

Testing is green on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8129827](https://bugs.openjdk.java.net/browse/JDK-8129827): [TEST_BUG] Test java/awt/Robot/RobotWheelTest/RobotWheelTest.java fails


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8305/head:pull/8305` \
`$ git checkout pull/8305`

Update a local copy of the PR: \
`$ git checkout pull/8305` \
`$ git pull https://git.openjdk.java.net/jdk pull/8305/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8305`

View PR using the GUI difftool: \
`$ git pr show -t 8305`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8305.diff">https://git.openjdk.java.net/jdk/pull/8305.diff</a>

</details>
