### PR TITLE
8284930: Re-examine FilterInputStream mark/reset

### DIFF
--- a/src/java.base/share/classes/java/io/FilterInputStream.java
+++ b/src/java.base/share/classes/java/io/FilterInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -204,7 +204,7 @@ public class FilterInputStream extends InputStream {
      * @see     java.io.FilterInputStream#reset()
      */
     @Override
-    public synchronized void mark(int readlimit) {
+    public void mark(int readlimit) {
         in.mark(readlimit);
     }
 
@@ -230,7 +230,7 @@ public class FilterInputStream extends InputStream {
      * @see        java.io.FilterInputStream#mark(int)
      */
     @Override
-    public synchronized void reset() throws IOException {
+    public void reset() throws IOException {
         in.reset();
     }
 

--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -683,7 +683,7 @@ public abstract class InputStream implements Closeable {
      *                      the mark position becomes invalid.
      * @see     java.io.InputStream#reset()
      */
-    public synchronized void mark(int readlimit) {}
+    public void mark(int readlimit) {}
 
     /**
      * Repositions this stream to the position at the time the
@@ -729,7 +729,7 @@ public abstract class InputStream implements Closeable {
      * @see     java.io.InputStream#mark(int)
      * @see     java.io.IOException
      */
-    public synchronized void reset() throws IOException {
+    public void reset() throws IOException {
         throw new IOException("mark/reset not supported");
     }
 


### PR DESCRIPTION
Remove the `synchronized` keyword from the `mark(int)` and `reset()` methods of `java.io.FilterInputStream`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8284930](https://bugs.openjdk.java.net/browse/JDK-8284930): Re-examine FilterInputStream mark/reset
 * [JDK-8285286](https://bugs.openjdk.java.net/browse/JDK-8285286): Re-examine FilterInputStream mark/reset (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.java.net/census#jpai) (@jaikiran - Committer)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8309/head:pull/8309` \
`$ git checkout pull/8309`

Update a local copy of the PR: \
`$ git checkout pull/8309` \
`$ git pull https://git.openjdk.java.net/jdk pull/8309/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8309`

View PR using the GUI difftool: \
`$ git pr show -t 8309`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8309.diff">https://git.openjdk.java.net/jdk/pull/8309.diff</a>

</details>
