### PR TITLE
8285094: Test java/awt/Frame/InvisibleOwner/InvisibleOwner.java failing on Linux

### DIFF
--- a/test/jdk/java/awt/Frame/GetGraphicsStressTest/GetGraphicsStressTest.java
+++ b/test/jdk/java/awt/Frame/GetGraphicsStressTest/GetGraphicsStressTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * @test
- * @bug 8235638 8235739
+ * @bug 8235638 8235739 8285094
  * @key headful
  */
 public final class GetGraphicsStressTest {
@@ -44,6 +44,11 @@ public final class GetGraphicsStressTest {
             endtime = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
             test();
         }
+        /*
+         * This test needs to give the desktop time to recover to avoid
+         * destabilising other tests.
+         */
+        Thread.sleep(10000);
     }
 
     private static void test() throws Exception {

--- a/test/jdk/java/awt/Frame/InvisibleOwner/InvisibleOwner.java
+++ b/test/jdk/java/awt/Frame/InvisibleOwner/InvisibleOwner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,99 +24,159 @@
 /*
   @test
   @key headful
-  @bug 7154177
+  @bug 7154177 8285094
   @summary An invisible owner frame should never become visible
-  @author anthony.petrov@oracle.com: area=awt.toplevel
-  @library ../../regtesthelpers
-  @build Util
   @run main InvisibleOwner
 */
 
-import java.awt.*;
-import java.awt.event.*;
-import java.util.*;
-import test.java.awt.regtesthelpers.Util;
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.Window;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 
 public class InvisibleOwner {
+
     private static volatile boolean invisibleOwnerClicked = false;
     private static volatile boolean backgroundClicked = false;
 
-    private static final int F_X = 40, F_Y = 40, F_W = 200, F_H = 200;
+    private static final int F_X = 200, F_Y = 200, F_W = 200, F_H = 200;
+    private static final int H_X = F_X - 10, H_Y = F_Y - 10, H_W = F_W + 20, H_H = F_H + 20;
+    private static final int C_X = F_X + F_W / 2, C_Y = F_Y + F_H / 2;
+    static final Color helperFrameBgColor = Color.blue;
+    static final Color invisibleFrameBgColor = Color.green;
+    static Frame invisibleFrame;
+    static Frame helperFrame;
+    static Window ownedWindow;
+    static Robot robot;
 
-    public static void main(String[] args) throws AWTException {
-        // A background frame to compare a pixel color against
-        Frame helperFrame = new Frame("Background frame");
-        helperFrame.setBackground(Color.BLUE);
-        helperFrame.setBounds(F_X - 10, F_Y - 10, F_W + 20, F_H + 20);
-        helperFrame.addMouseListener(new MouseAdapter() {
+    static void createUI() {
+        /* A background frame to compare a pixel color against
+         * It should be centered in the same location as the invisible
+         * frame but extend beyond its bounds.
+         */ 
+        helperFrame = new Frame("Background frame");
+        helperFrame.setBackground(helperFrameBgColor);
+        helperFrame.setLocation(H_X, H_Y);
+        helperFrame.setSize(H_W, H_H);
+        System.out.println("Helper requested bounds : x=" +
+                           H_X + " y="+ H_Y +" w="+ H_W +" h="+ H_H);
+        helperFrame.addMouseListener(new MouseAdapter() {        
             @Override
             public void mouseClicked(MouseEvent ev) {
-                backgroundClicked= true;
+                System.out.println("Background helper frame clicked");
+                backgroundClicked = true;
             }
         });
         helperFrame.setVisible(true);
 
-        // An owner frame that should stay invisible
-        Frame frame = new Frame("Invisible Frame");
-        frame.setBackground(Color.GREEN);
-        frame.setLocation(F_X, F_Y);
-        frame.setSize(F_W, F_H);
-        frame.addMouseListener(new MouseAdapter() {
+        /* An owner frame that should stay invisible but theoretical
+         * bounds are within the helper frame.
+         */
+        invisibleFrame = new Frame("Invisible Frame");
+        invisibleFrame.setBackground(invisibleFrameBgColor);
+        invisibleFrame.setLocation(F_X, F_Y);
+        invisibleFrame.setSize(F_W, F_H);
+        invisibleFrame.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent ev) {
+                System.out.println("Invisible owner clicked");
                 invisibleOwnerClicked = true;
             }
         });
 
-        // An owned window
-        final Window window = new Window(frame);
-        window.setBackground(Color.RED);
-        window.setSize(200, 200);
-        window.setLocation(300, 300);
-        window.setVisible(true);
-        try { Thread.sleep(1000); } catch (Exception ex) {}
+        /* An owned window of the invisible frame that is located 
+         * such that it does not overlap either the helper or
+         * the invisisible frame.
+         */
+        ownedWindow = new Window(invisibleFrame);
+        ownedWindow.setBackground(Color.RED);
+        ownedWindow.setLocation(H_X+H_W+100, H_Y+H_W+100);
+        ownedWindow.setSize(100, 100);
+        ownedWindow.setVisible(true);
+ 
+        Toolkit.getDefaultToolkit().sync();
+    }
 
-        Robot robot = new Robot();
+    static void captureScreen() throws Exception {
+        System.out.println("Writing screen capture");
+        Rectangle screenRect = helperFrame.getGraphicsConfiguration().getBounds(); 
+        java.awt.image.BufferedImage bi = robot.createScreenCapture(screenRect);
+        javax.imageio.ImageIO.write(bi, "png", new java.io.File("screen_IO.png"));
+    }
+        
+    public static void main(String[] args) throws Exception {
 
-        // Clicking the owned window shouldn't make its owner visible
-        Util.clickOnComp(window, robot);
-        try { Thread.sleep(500); } catch (Exception ex) {}
+        try {
+            EventQueue.invokeAndWait(() -> createUI());
+            robot = new Robot();
+            robot.waitForIdle();
+            robot.setAutoDelay(100);
+            robot.setAutoWaitForIdle(true);
 
+            Rectangle helperBounds = helperFrame.getBounds();
+            System.out.println("helperFrame bounds = " + helperBounds);
+            if (!helperBounds.contains(C_X, C_Y)) {
+                System.out.println("Helper not positioned where it needs to be");
+                return;
+            }
 
-        // Assume the location and size are applied to the frame as expected.
-        // This should work fine on the Mac. We can't call getLocationOnScreen()
-        // since from Java perspective the frame is invisible anyway.
+            // Clicking the owned window shouldn't make its owner visible
+            Rectangle ownedWindowBounds = ownedWindow.getBounds();
+            robot.mouseMove(ownedWindowBounds.x + ownedWindowBounds.width / 2,
+                            ownedWindowBounds.y + ownedWindowBounds.height / 2);
+            robot.mousePress(InputEvent.BUTTON1_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            robot.delay(1000);
+             
+            // 1. Check the color at the center of the invisible & helper frame location
+            Color c = robot.getPixelColor(C_X, C_Y);
+            System.out.println("Sampled pixel at " + C_X +"," + C_Y);
+            System.out.println("Pixel color: " + c);
+            if (c == null) {
+                captureScreen();
+                throw new RuntimeException("Robot.getPixelColor() failed");
+            }
+            if (c.equals(invisibleFrameBgColor)) {
+                captureScreen();
+                throw new RuntimeException("The invisible frame has become visible");
+            }
+            if (!c.equals(helperFrameBgColor)) {
+                captureScreen();
+                throw new RuntimeException(
+                    "Background frame was covered by something unexpected");
+            }
 
-        // 1. Check the color at the center of the owner frame
-        Color c = robot.getPixelColor(F_X + F_W / 2, F_Y + F_H / 2);
-        System.err.println("Pixel color: " + c);
-        if (c == null) {
-            throw new RuntimeException("Robot.getPixelColor() failed");
+            // 2. Try to click it - event should be delivered to the
+            // helper frame, not the invisible frame.
+            robot.mouseMove(C_X, C_Y);
+            robot.mousePress(InputEvent.BUTTON1_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            robot.delay(1000);
+
+            if (invisibleOwnerClicked) {
+                captureScreen();
+                throw new RuntimeException(
+                    "The invisible owner frame got clicked. Looks like it became visible.");
+            }
+            if (!backgroundClicked) {
+                captureScreen();
+                throw new RuntimeException(
+                    "The background helper frame hasn't been clicked");
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (ownedWindow != null) ownedWindow.dispose();
+                if (invisibleFrame != null) invisibleFrame.dispose();
+                if (helperFrame != null) helperFrame.dispose();
+            });
         }
-        if (c.equals(frame.getBackground())) {
-            throw new RuntimeException("The invisible frame has become visible");
-        }
-        if (!c.equals(helperFrame.getBackground())) {
-            throw new RuntimeException("The background helper frame has been covered by something unexpected");
-        }
 
-        // 2. Try to click it
-        robot.mouseMove(F_X + F_W / 2, F_Y + F_H / 2);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
-        try { Thread.sleep(500); } catch (Exception ex) {}
-
-        // Cleanup
-        window.dispose();
-        frame.dispose();
-        helperFrame.dispose();
-
-        // Final checks
-        if (invisibleOwnerClicked) {
-            throw new RuntimeException("An invisible owner frame got clicked. Looks like it became visible.");
-        }
-        if (!backgroundClicked) {
-            throw new RuntimeException("The background helper frame hasn't been clciked");
-        }
     }
 }

--- a/test/jdk/java/awt/Frame/InvisibleOwner/InvisibleOwner.java
+++ b/test/jdk/java/awt/Frame/InvisibleOwner/InvisibleOwner.java
@@ -155,8 +155,8 @@ public class InvisibleOwner {
             // 2. Try to click it - event should be delivered to the
             // helper frame, not the invisible frame.
             robot.mouseMove(C_X, C_Y);
-            robot.mousePress(InputEvent.BUTTON1_MASK);
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.delay(1000);
 
             if (invisibleOwnerClicked) {

--- a/test/jdk/java/awt/Frame/InvisibleOwner/InvisibleOwner.java
+++ b/test/jdk/java/awt/Frame/InvisibleOwner/InvisibleOwner.java
@@ -60,14 +60,14 @@ public class InvisibleOwner {
         /* A background frame to compare a pixel color against
          * It should be centered in the same location as the invisible
          * frame but extend beyond its bounds.
-         */ 
+         */
         helperFrame = new Frame("Background frame");
         helperFrame.setBackground(helperFrameBgColor);
         helperFrame.setLocation(H_X, H_Y);
         helperFrame.setSize(H_W, H_H);
         System.out.println("Helper requested bounds : x=" +
                            H_X + " y="+ H_Y +" w="+ H_W +" h="+ H_H);
-        helperFrame.addMouseListener(new MouseAdapter() {        
+        helperFrame.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent ev) {
                 System.out.println("Background helper frame clicked");
@@ -91,7 +91,7 @@ public class InvisibleOwner {
             }
         });
 
-        /* An owned window of the invisible frame that is located 
+        /* An owned window of the invisible frame that is located
          * such that it does not overlap either the helper or
          * the invisisible frame.
          */
@@ -100,17 +100,17 @@ public class InvisibleOwner {
         ownedWindow.setLocation(H_X+H_W+100, H_Y+H_W+100);
         ownedWindow.setSize(100, 100);
         ownedWindow.setVisible(true);
- 
+
         Toolkit.getDefaultToolkit().sync();
     }
 
     static void captureScreen() throws Exception {
         System.out.println("Writing screen capture");
-        Rectangle screenRect = helperFrame.getGraphicsConfiguration().getBounds(); 
+        Rectangle screenRect = helperFrame.getGraphicsConfiguration().getBounds();
         java.awt.image.BufferedImage bi = robot.createScreenCapture(screenRect);
         javax.imageio.ImageIO.write(bi, "png", new java.io.File("screen_IO.png"));
     }
-        
+
     public static void main(String[] args) throws Exception {
 
         try {
@@ -134,7 +134,7 @@ public class InvisibleOwner {
             robot.mousePress(InputEvent.BUTTON1_MASK);
             robot.mouseRelease(InputEvent.BUTTON1_MASK);
             robot.delay(1000);
-             
+
             // 1. Check the color at the center of the invisible & helper frame location
             Color c = robot.getPixelColor(C_X, C_Y);
             System.out.println("Sampled pixel at " + C_X +"," + C_Y);

--- a/test/jdk/java/awt/Frame/InvisibleOwner/InvisibleOwner.java
+++ b/test/jdk/java/awt/Frame/InvisibleOwner/InvisibleOwner.java
@@ -32,7 +32,6 @@
 import java.awt.Color;
 import java.awt.EventQueue;
 import java.awt.Frame;
-import java.awt.Graphics;
 import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.Toolkit;
@@ -131,8 +130,8 @@ public class InvisibleOwner {
             Rectangle ownedWindowBounds = ownedWindow.getBounds();
             robot.mouseMove(ownedWindowBounds.x + ownedWindowBounds.width / 2,
                             ownedWindowBounds.y + ownedWindowBounds.height / 2);
-            robot.mousePress(InputEvent.BUTTON1_MASK);
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.delay(1000);
 
             // 1. Check the color at the center of the invisible & helper frame location


### PR DESCRIPTION
As discussed in https://bugs.openjdk.java.net/browse/JDK-8285094 it seems that the test
java/awt/Frame/GetGraphicsStressTest/GetGraphicsStressTest.java destabilises the Xserver.
This causes java/awt/Frame/InvisibleOwner/InvisibleOwner.java to fail and even before that
other tests which do  pass are not visibly behaving as expected.

I didn't find any Xserver logs of "bad stuff" happening so it just seems like the Xserver was
having trouble keeping up and JDK was behaving correctly as it could despite the Xserver sending
lots of requests to repaint.

Just the "sleep" at the end of GetGraphicsStressTest.java seems to be enough but I'd already
reworked InvisibleOwner.java and I'd like to think it is a bit better than before.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285094](https://bugs.openjdk.java.net/browse/JDK-8285094): Test java/awt/Frame/InvisibleOwner/InvisibleOwner.java failing on Linux


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**) ⚠️ Review applies to 160b4eaea65d73841c35945d7734bfe70210d334
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to 160b4eaea65d73841c35945d7734bfe70210d334


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8312/head:pull/8312` \
`$ git checkout pull/8312`

Update a local copy of the PR: \
`$ git checkout pull/8312` \
`$ git pull https://git.openjdk.java.net/jdk pull/8312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8312`

View PR using the GUI difftool: \
`$ git pr show -t 8312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8312.diff">https://git.openjdk.java.net/jdk/pull/8312.diff</a>

</details>
