### PR TITLE
8266247: Swing test bug7154030.java sometimes fails on macOS 11 ARM

### DIFF
--- a/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
+++ b/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
@@ -74,6 +74,8 @@ public class bug7154030 {
                 @Override
                 public void run() {
                     JDesktopPane desktop = new JDesktopPane();
+                    desktop.setBackground(Color.WHITE);
+                    desktop.setForeground(Color.BLACK);
                     button = new JButton("button");
                     frame = new JFrame();
                     frame.setUndecorated(true);


### PR DESCRIPTION
Change background and foreground colors to white and black to avoid color shift problems.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266247](https://bugs.openjdk.java.net/browse/JDK-8266247): Swing test bug7154030.java sometimes fails on macOS 11 ARM


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8313/head:pull/8313` \
`$ git checkout pull/8313`

Update a local copy of the PR: \
`$ git checkout pull/8313` \
`$ git pull https://git.openjdk.java.net/jdk pull/8313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8313`

View PR using the GUI difftool: \
`$ git pr show -t 8313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8313.diff">https://git.openjdk.java.net/jdk/pull/8313.diff</a>

</details>
