### PR TITLE
6829250: Reg test: java/awt/Toolkit/ScreenInsetsTest/ScreenInsetsTest.java fails in Windows

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -185,7 +185,6 @@ java/awt/Mixing/NonOpaqueInternalFrame.java 7124549 macosx-all
 java/awt/Focus/ActualFocusedWindowTest/ActualFocusedWindowRetaining.java 6829264 generic-all
 java/awt/datatransfer/DragImage/MultiResolutionDragImageTest.java 8080982 generic-all
 java/awt/datatransfer/SystemFlavorMap/AddFlavorTest.java 8079268 linux-all
-java/awt/Toolkit/ScreenInsetsTest/ScreenInsetsTest.java 6829250 windows-all
 java/awt/Toolkit/RealSync/Test.java 6849383 linux-all
 java/awt/LightweightComponent/LightweightEventTest/LightweightEventTest.java 8159252 windows-all
 java/awt/EventDispatchThread/HandleExceptionOnEDT/HandleExceptionOnEDT.java 8072110 macosx-all

--- a/test/jdk/java/awt/Toolkit/ScreenInsetsTest/ScreenInsetsTest.java
+++ b/test/jdk/java/awt/Toolkit/ScreenInsetsTest/ScreenInsetsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,6 @@ public class ScreenInsetsTest
         GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
         GraphicsDevice[] gds = ge.getScreenDevices();
         for (GraphicsDevice gd : gds) {
-
             GraphicsConfiguration gc = gd.getDefaultConfiguration();
             Rectangle gcBounds = gc.getBounds();
             Insets gcInsets = Toolkit.getDefaultToolkit().getScreenInsets(gc);
@@ -100,7 +99,13 @@ public class ScreenInsetsTest
                                          gcBounds.y + gcBounds.height - fBounds.y - fBounds.height,
                                          gcBounds.x + gcBounds.width - fBounds.x - fBounds.width);
 
-            if (!expected.equals(gcInsets))
+            // On Windows 10 and up system allows undecorated maximized windows
+            // to be placed over the taskbar so calculated insets might
+            // be smaller than reported ones depending on the taskbar position
+            if (gcInsets.top < expected.top
+                    || gcInsets.bottom < expected.bottom
+                    || gcInsets.left < expected.left
+                    || gcInsets.right < expected.right)
             {
                 passed = false;
                 System.err.println("Wrong insets for GraphicsConfig: " + gc);


### PR DESCRIPTION
Only check that insets of the fully expanded undecorated window is not bigger than device insets. They can be smaller, it is a normal situation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-6829250](https://bugs.openjdk.java.net/browse/JDK-6829250): Reg test: java/awt/Toolkit/ScreenInsetsTest/ScreenInsetsTest.java fails in Windows


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8314/head:pull/8314` \
`$ git checkout pull/8314`

Update a local copy of the PR: \
`$ git checkout pull/8314` \
`$ git pull https://git.openjdk.java.net/jdk pull/8314/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8314`

View PR using the GUI difftool: \
`$ git pr show -t 8314`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8314.diff">https://git.openjdk.java.net/jdk/pull/8314.diff</a>

</details>
