### PR TITLE
8284995: G1: Do not mark through Closed Archive regions during concurrent mark

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1898,6 +1898,7 @@ G1ConcurrentMark::claim_region(uint worker_id) {
       assert(_finger >= end, "the finger should have moved forward");
 
       if (limit > bottom) {
+        assert(!curr_region->is_closed_archive(), "CA regions should be skipped");
         return curr_region;
       } else {
         assert(limit == bottom,

--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -242,7 +242,11 @@ inline void HeapRegion::update_bot_for_obj(HeapWord* obj_start, size_t obj_size)
 
 inline void HeapRegion::note_start_of_marking() {
   _next_marked_bytes = 0;
-  _next_top_at_mark_start = top();
+  if (!is_closed_archive()) {
+    _next_top_at_mark_start = top();
+  } else {
+    assert(next_top_at_mark_start() == bottom(), "CA region's nTAMS must alawys be at bottom");
+  }
   _gc_efficiency = -1.0;
 }
 

--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -244,9 +244,8 @@ inline void HeapRegion::note_start_of_marking() {
   _next_marked_bytes = 0;
   if (!is_closed_archive()) {
     _next_top_at_mark_start = top();
-  } else {
-    assert(next_top_at_mark_start() == bottom(), "CA region's nTAMS must alawys be at bottom");
   }
+  assert(!is_closed_archive() || next_top_at_mark_start() == bottom(), "CA region's nTAMS must always be at bottom");
   _gc_efficiency = -1.0;
 }
 


### PR DESCRIPTION
Hi all,

  please review this change that skips CA regions during concurrent mark. This is achieved by keeping the ntams at bottom for these regions.
G1 Full GC already skips marking of CA regions.

Testing: tier1-5

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284995](https://bugs.openjdk.java.net/browse/JDK-8284995): G1: Do not mark through Closed Archive regions during concurrent mark


### Reviewers
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8315/head:pull/8315` \
`$ git checkout pull/8315`

Update a local copy of the PR: \
`$ git checkout pull/8315` \
`$ git pull https://git.openjdk.java.net/jdk pull/8315/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8315`

View PR using the GUI difftool: \
`$ git pr show -t 8315`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8315.diff">https://git.openjdk.java.net/jdk/pull/8315.diff</a>

</details>
