### PR TITLE
8274597: Some of the dnd tests time out and fail intermittently

### DIFF
--- a/test/jdk/java/awt/dnd/AcceptDropMultipleTimes/AcceptDropMultipleTimes.java
+++ b/test/jdk/java/awt/dnd/AcceptDropMultipleTimes/AcceptDropMultipleTimes.java
@@ -35,16 +35,30 @@
 
 import test.java.awt.regtesthelpers.Util;
 
-import javax.swing.*;
-import java.awt.*;
-import java.awt.datatransfer.*;
-import java.awt.dnd.*;
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.datatransfer.StringSelection;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureEvent;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetAdapter;
+import java.awt.dnd.DropTargetDropEvent;
 import java.awt.event.InputEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.swing.SwingUtilities;
 
 public class AcceptDropMultipleTimes {
 
     private static final int FRAME_SIZE = 100;
     private static final int FRAME_LOCATION = 100;
+    private static CountDownLatch dropCompleteLatch = new CountDownLatch(1);
 
     private static volatile Frame f;
 
@@ -63,11 +77,12 @@ public class AcceptDropMultipleTimes {
                 dtde.acceptDrop(DnDConstants.ACTION_MOVE);
 
                 dtde.dropComplete(true);
+                dropCompleteLatch.countDown();
             }
         });
         dragSource.setDropTarget(dt);
         f.add(dragSource);
-
+        f.setAlwaysOnTop(true);
         f.setVisible(true);
     }
 
@@ -83,6 +98,9 @@ public class AcceptDropMultipleTimes {
                     new Point(FRAME_LOCATION + FRAME_SIZE / 3 * 2, FRAME_LOCATION + FRAME_SIZE / 3 * 2),
                     InputEvent.BUTTON1_MASK);
             Util.waitForIdle(r);
+            if(!dropCompleteLatch.await(10, TimeUnit.SECONDS)) {
+                throw new RuntimeException("Waited too long, but the drop is not completed");
+            }
         } finally {
             if (f != null) {
                 f.dispose();

--- a/test/jdk/java/awt/dnd/AcceptDropMultipleTimes/AcceptDropMultipleTimes.java
+++ b/test/jdk/java/awt/dnd/AcceptDropMultipleTimes/AcceptDropMultipleTimes.java
@@ -37,10 +37,13 @@ import test.java.awt.regtesthelpers.Util;
 
 import java.awt.Color;
 import java.awt.Cursor;
+import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.Panel;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.Robot;
+import java.awt.Toolkit;
 import java.awt.datatransfer.StringSelection;
 import java.awt.dnd.DnDConstants;
 import java.awt.dnd.DragGestureEvent;
@@ -50,21 +53,26 @@ import java.awt.dnd.DropTarget;
 import java.awt.dnd.DropTargetAdapter;
 import java.awt.dnd.DropTargetDropEvent;
 import java.awt.event.InputEvent;
+import java.io.File;
+import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.imageio.ImageIO;
 import javax.swing.SwingUtilities;
 
 public class AcceptDropMultipleTimes {
 
     private static final int FRAME_SIZE = 100;
-    private static final int FRAME_LOCATION = 100;
     private static CountDownLatch dropCompleteLatch = new CountDownLatch(1);
 
     private static volatile Frame f;
 
     private static void initAndShowUI() {
         f = new Frame("Test frame");
-        f.setBounds(FRAME_LOCATION, FRAME_LOCATION, FRAME_SIZE, FRAME_SIZE);
+        f.setSize(FRAME_SIZE, FRAME_SIZE);
+        f.setLocationRelativeTo(null);
+        f.setUndecorated(true);
 
         final DraggablePanel dragSource = new DraggablePanel();
         dragSource.setBackground(Color.yellow);
@@ -92,13 +100,18 @@ public class AcceptDropMultipleTimes {
             SwingUtilities.invokeAndWait(() -> initAndShowUI());
 
             Robot r = new Robot();
+            r.setAutoDelay(50);
             Util.waitForIdle(r);
+            final AtomicReference<Point> frameLoc = new AtomicReference<>();
+            SwingUtilities.invokeAndWait(() -> frameLoc.set(f.getLocationOnScreen()));
+            Point loc = frameLoc.get();
             Util.drag(r,
-                    new Point(FRAME_LOCATION + FRAME_SIZE / 3, FRAME_LOCATION + FRAME_SIZE / 3),
-                    new Point(FRAME_LOCATION + FRAME_SIZE / 3 * 2, FRAME_LOCATION + FRAME_SIZE / 3 * 2),
-                    InputEvent.BUTTON1_MASK);
+                    new Point(loc.x + FRAME_SIZE / 3, loc.y + FRAME_SIZE / 3),
+                    new Point(loc.x + FRAME_SIZE / 3 * 2, loc.y + FRAME_SIZE / 3 * 2),
+                    InputEvent.BUTTON1_DOWN_MASK);
             Util.waitForIdle(r);
             if(!dropCompleteLatch.await(10, TimeUnit.SECONDS)) {
+                captureScreen(r);
                 throw new RuntimeException("Waited too long, but the drop is not completed");
             }
         } finally {
@@ -107,7 +120,17 @@ public class AcceptDropMultipleTimes {
             }
         }
     }
-
+    private static void captureScreen(Robot r) {
+        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+        try {
+            ImageIO.write(
+                    r.createScreenCapture(new Rectangle(0, 0, screenSize.width, screenSize.height)),
+                    "png",
+                    new File("FailedScreenImage.png")
+                         );
+        } catch (IOException ignore) {
+        }
+    }
     private static class DraggablePanel extends Panel implements DragGestureListener {
 
         public DraggablePanel() {

--- a/test/jdk/java/awt/dnd/DropTargetEnterExitTest/ExtraDragEnterTest.java
+++ b/test/jdk/java/awt/dnd/DropTargetEnterExitTest/ExtraDragEnterTest.java
@@ -35,8 +35,13 @@
 
 import test.java.awt.regtesthelpers.Util;
 
-import javax.swing.*;
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
 import java.awt.datatransfer.StringSelection;
 import java.awt.dnd.DnDConstants;
 import java.awt.dnd.DragGestureEvent;
@@ -47,23 +52,27 @@ import java.awt.dnd.DropTargetAdapter;
 import java.awt.dnd.DropTargetDragEvent;
 import java.awt.dnd.DropTargetDropEvent;
 import java.awt.event.InputEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.swing.SwingUtilities;
 
 public class ExtraDragEnterTest {
 
     private static final int FRAME_SIZE = 100;
-    private static final int FRAME_LOCATION = 100;
 
     private static AtomicInteger dragEnterCalled = new AtomicInteger(0);
 
     private static volatile Panel mainPanel;
     private static volatile Frame f;
+    private static CountDownLatch dropCompleteLatch = new CountDownLatch(1);
 
     private static void initAndShowUI() {
         f = new Frame("Test frame");
-        f.setBounds(FRAME_LOCATION,FRAME_LOCATION,FRAME_SIZE,FRAME_SIZE);
+        f.setLocationRelativeTo(null);
+        f.setSize(FRAME_SIZE,FRAME_SIZE);
         mainPanel = new Panel();
-        mainPanel.setBounds(0, 0, FRAME_SIZE, FRAME_SIZE);
+        mainPanel.setSize(FRAME_SIZE, FRAME_SIZE);
         mainPanel.setBackground(Color.black);
         mainPanel.setLayout(new GridLayout(2, 1));
 
@@ -75,7 +84,10 @@ public class ExtraDragEnterTest {
         Panel dropTarget = new Panel();
         dropTarget.setBackground(Color.red);
         DropTarget dt = new DropTarget(dropTarget, new DropTargetAdapter() {
-            @Override public void drop(DropTargetDropEvent dtde) { }
+            @Override public void drop(DropTargetDropEvent dtde) {
+                System.out.println("Drop complete");
+                dropCompleteLatch.countDown();
+            }
 
             @Override
             public void dragEnter(DropTargetDragEvent dtde) {
@@ -86,6 +98,7 @@ public class ExtraDragEnterTest {
         mainPanel.add(dropTarget);
 
         f.add(mainPanel);
+        f.setAlwaysOnTop(true);
         f.setVisible(true);
     }
 
@@ -112,6 +125,9 @@ public class ExtraDragEnterTest {
             int called = dragEnterCalled.get();
             if (called != 1) {
                 throw new RuntimeException("Failed. Drag enter called " + called + " times. Expected 1" );
+            }
+            if(!dropCompleteLatch.await(10, TimeUnit.SECONDS)) {
+                throw new RuntimeException("Waited too long, but the drop is not completed");
             }
         } finally {
             if (f != null) {

--- a/test/jdk/java/awt/dnd/DropTargetEnterExitTest/MissedDragExitTest.java
+++ b/test/jdk/java/awt/dnd/DropTargetEnterExitTest/MissedDragExitTest.java
@@ -35,8 +35,12 @@
 
 import test.java.awt.regtesthelpers.Util;
 
-import javax.swing.*;
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
 import java.awt.datatransfer.StringSelection;
 import java.awt.dnd.DnDConstants;
 import java.awt.dnd.DragGestureEvent;
@@ -48,15 +52,17 @@ import java.awt.dnd.DropTargetDragEvent;
 import java.awt.dnd.DropTargetDropEvent;
 import java.awt.dnd.DropTargetEvent;
 import java.awt.event.InputEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.swing.SwingUtilities;
 
 public class MissedDragExitTest {
 
     private static final int FRAME_SIZE = 100;
     private static final int FRAME_LOCATION = 100;
 
-    private static volatile boolean dragExitCalled = false;
-
     private static volatile Frame f;
+    private static CountDownLatch dragLatch = new CountDownLatch(2);
 
     private static void initAndShowUI() {
         f = new Frame("Test frame");
@@ -70,21 +76,30 @@ public class MissedDragExitTest {
 
             @Override
             public void dragExit(DropTargetEvent dte) {
-                dragExitCalled = true;
+                System.out.println("Drag Exit");
+                dragLatch.countDown();
             }
 
             @Override
             public void dragOver(DropTargetDragEvent dtde) {
-                Panel newDropTarget = new Panel();
-                newDropTarget.setDropTarget(new DropTarget());
-                newDropTarget.setBackground(Color.red);
-                newDropTarget.setBounds(0, 0, FRAME_SIZE, FRAME_SIZE);
-                dragSource.add(newDropTarget);
+                Panel newDropTargetPanel = new Panel();
+                final DropTarget dropTarget = new DropTarget(null,new DropTargetAdapter() {
+                    @Override
+                    public void drop(DropTargetDropEvent dtde) {
+                        System.out.println("Drop complete");
+                        dragLatch.countDown();
+                    }
+                });
+                newDropTargetPanel.setDropTarget(dropTarget);
+                newDropTargetPanel.setBackground(Color.red);
+                newDropTargetPanel.setSize(FRAME_SIZE, FRAME_SIZE);
+                dragSource.add(newDropTargetPanel);
             }
         });
         dragSource.setDropTarget(dt);
         f.add(dragSource);
 
+        f.setAlwaysOnTop(true);
         f.setVisible(true);
     }
 
@@ -105,8 +120,7 @@ public class MissedDragExitTest {
                     new Point(FRAME_LOCATION + FRAME_SIZE / 3 * 2, FRAME_LOCATION + FRAME_SIZE / 3 * 2),
                     InputEvent.BUTTON1_DOWN_MASK);
             Util.waitForIdle(r);
-
-            if (!dragExitCalled) {
+            if(!dragLatch.await(10, TimeUnit.SECONDS)) {
                 throw new RuntimeException("Failed. Drag exit was not called" );
             }
         } finally {

--- a/test/jdk/java/awt/regtesthelpers/Util.java
+++ b/test/jdk/java/awt/regtesthelpers/Util.java
@@ -661,4 +661,3 @@ public final class Util {
     }
 
 }
-

--- a/test/jdk/java/awt/regtesthelpers/Util.java
+++ b/test/jdk/java/awt/regtesthelpers/Util.java
@@ -318,20 +318,12 @@ public final class Util {
             throw new IllegalArgumentException("invalid mouse button");
         }
 
-        boolean autoDelaySet = false;
-        if(robot.getAutoDelay() == 0) {
-            robot.setAutoDelay(100);
-            autoDelaySet = true;
-        }
         robot.mouseMove(startPoint.x, startPoint.y);
         robot.mousePress(button);
         try {
             mouseMove(robot, startPoint, endPoint);
         } finally {
             robot.mouseRelease(button);
-            if(autoDelaySet) {
-                robot.setAutoDelay(0);
-            }
         }
     }
 

--- a/test/jdk/java/awt/regtesthelpers/Util.java
+++ b/test/jdk/java/awt/regtesthelpers/Util.java
@@ -669,3 +669,4 @@ public final class Util {
     }
 
 }
+

--- a/test/jdk/java/awt/regtesthelpers/Util.java
+++ b/test/jdk/java/awt/regtesthelpers/Util.java
@@ -318,12 +318,20 @@ public final class Util {
             throw new IllegalArgumentException("invalid mouse button");
         }
 
+        boolean autoDelaySet = false;
+        if(robot.getAutoDelay() == 0) {
+            robot.setAutoDelay(100);
+            autoDelaySet = true;
+        }
         robot.mouseMove(startPoint.x, startPoint.y);
         robot.mousePress(button);
         try {
             mouseMove(robot, startPoint, endPoint);
         } finally {
             robot.mouseRelease(button);
+            if(autoDelaySet) {
+                robot.setAutoDelay(0);
+            }
         }
     }
 


### PR DESCRIPTION
These dnd tests fails with a time out intermittently in some machines(mostly Windows 11) which creates frequent noise in CI.
1. java/awt/dnd/AcceptDropMultipleTimes/AcceptDropMultipleTimes.java
2. java/awt/dnd/DropTargetEnterExitTest/MissedDragExitTest.java
3. java/awt/dnd/DropTargetEnterExitTest/ExtraDragEnterTest.java
4. java/awt/dnd/MissingDragExitEventTest/MissingDragExitEventTest.java

Issue :
This doesn't seem to be a deadlock. When there is no sufficient delay after the mouse release(dragged mouse pointer release to drop the content), the frame is getting disposed even before the drop() method gets called. So it waits for the drop() method which will never happen as the frame has been already disposed and the test times out after some time.

Fix:
Waiting for the drop() method to get called before disposing the frame.

Testing: 
1. All the four tests are run 10 times per platform and got all pass
2. All the four tests are run 10 times on Windows 11 and got all pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8274597](https://bugs.openjdk.java.net/browse/JDK-8274597): Some of the dnd tests time out and fail intermittently
 * [JDK-8028998](https://bugs.openjdk.java.net/browse/JDK-8028998): [TEST_BUG] [macosx] java/awt/dnd/DropTargetEnterExitTest/MissedDragExitTest.java failed


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to fae1d36a9ec1b1a28f60f4855267e4f4d5782750


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8316/head:pull/8316` \
`$ git checkout pull/8316`

Update a local copy of the PR: \
`$ git checkout pull/8316` \
`$ git pull https://git.openjdk.java.net/jdk pull/8316/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8316`

View PR using the GUI difftool: \
`$ git pr show -t 8316`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8316.diff">https://git.openjdk.java.net/jdk/pull/8316.diff</a>

</details>
