### PR TITLE
8273506: java Robot API did the 'm' keypress and caused /awt/event/KeyEvent/KeyCharTest/KeyCharTest.html is timing out on macOS 12

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
@@ -296,6 +296,11 @@ Java_sun_lwawt_macosx_CRobot_keyEvent
         CGKeyCode keyCode = GetCGKeyCode(javaKeyCode);
         CGEventRef event = CGEventCreateKeyboardEvent(source, keyCode, keyPressed);
         if (event != NULL) {
+            CGEventFlags flags = CGEventSourceFlagsState(kCGEventSourceStateHIDSystemState);
+            if ((flags & kCGEventFlagMaskSecondaryFn) != 0) {
+                flags ^= kCGEventFlagMaskSecondaryFn;
+                CGEventSetFlags(event, flags);
+            }
             CGEventPost(kCGHIDEventTap, event);
             CFRelease(event);
         }

--- a/test/jdk/java/awt/event/KeyEvent/KeyCharTest/KeyCharTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/KeyCharTest/KeyCharTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 5013984
+  @summary Tests KEY_PRESSED has the same KeyChar as KEY_RELEASED
+  @key headful
+  @run main KeyCharTest
+*/
+
+import java.awt.Frame;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.awt.event.MouseEvent;
+import java.util.HashMap;
+
+public class KeyCharTest extends Frame implements KeyListener {
+    HashMap<Integer, Character> transMap = new HashMap();
+
+    public void keyTyped(KeyEvent e){
+    }
+
+    public void keyPressed(KeyEvent e){
+        transMap.put(e.getKeyCode(), e.getKeyChar());
+    }
+
+    public void keyReleased(KeyEvent e){
+        Object value = transMap.get(e.getKeyCode());
+        if (value != null && e.getKeyChar() != ((Character)value).charValue()) {
+            throw new RuntimeException("Wrong KeyChar on KEY_RELEASED "+
+                KeyEvent.getKeyText(e.getKeyCode()));
+        }
+    }
+
+    public void start () {
+        addKeyListener(this);
+        setLocationRelativeTo(null);
+        setSize(200, 200);
+        setVisible(true);
+        requestFocus();
+
+        try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(10);
+            robot.setAutoWaitForIdle(true);
+            robot.delay(100);
+            robot.mouseMove(getLocationOnScreen().x + getWidth()/2,
+                            getLocationOnScreen().y + getHeight()/2);
+
+            robot.mousePress(MouseEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(MouseEvent.BUTTON1_DOWN_MASK);
+
+            for(int vkey = 0x20; vkey < 0x7F; vkey++) {
+                try {
+                    robot.keyPress(vkey);
+                    robot.keyRelease(vkey);
+                    System.out.println(KeyEvent.getKeyText(vkey) + " " + vkey);
+                } catch (RuntimeException e) {
+                }
+            }
+            robot.delay(100);
+        } catch(Exception e){
+            e.printStackTrace();
+            throw new RuntimeException("Exception while performing Robot actions.");
+        }
+   }
+
+    public static void main(String[] args) {
+        KeyCharTest test = new KeyCharTest();
+        try {
+            test.start();
+        } finally {
+            test.setVisible(false);
+            test.dispose();
+        }
+    }
+}
+


### PR DESCRIPTION
Clear the kCGEventFlagMaskSecondaryFn flag if it is set before posting keyboard events to the system queue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [JDK-8273506](https://bugs.openjdk.java.net/browse/JDK-8273506): java Robot API did the 'm' keypress and caused /awt/event/KeyEvent/KeyCharTest/KeyCharTest.html is timing out on macOS 12


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8320/head:pull/8320` \
`$ git checkout pull/8320`

Update a local copy of the PR: \
`$ git checkout pull/8320` \
`$ git pull https://git.openjdk.java.net/jdk pull/8320/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8320`

View PR using the GUI difftool: \
`$ git pr show -t 8320`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8320.diff">https://git.openjdk.java.net/jdk/pull/8320.diff</a>

</details>
