### PR TITLE
8285266: compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnUnsupportedCPU.java fails after JDK-8284563

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -308,7 +308,7 @@ void VM_Version::initialize() {
     UseMD5Intrinsics = true;
   }
 
-  if (VM_Version::supports_sha1() || VM_Version::supports_sha2() ||
+  if (VM_Version::supports_sha1() || VM_Version::supports_sha256() ||
       VM_Version::supports_sha3() || VM_Version::supports_sha512()) {
     if (FLAG_IS_DEFAULT(UseSHA)) {
       FLAG_SET_DEFAULT(UseSHA, true);
@@ -327,7 +327,7 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseSHA1Intrinsics, false);
   }
 
-  if (UseSHA && VM_Version::supports_sha2()) {
+  if (UseSHA && VM_Version::supports_sha256()) {
     if (FLAG_IS_DEFAULT(UseSHA256Intrinsics)) {
       FLAG_SET_DEFAULT(UseSHA256Intrinsics, true);
     }

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -107,7 +107,7 @@ public:
     decl(AES,           aes,           3)     \
     decl(PMULL,         pmull,         4)     \
     decl(SHA1,          sha1,          5)     \
-    decl(SHA2,          sha2,          6)     \
+    decl(SHA2,          sha256,        6)     \
     decl(CRC32,         crc32,         7)     \
     decl(LSE,           lse,           8)     \
     decl(DCPOP,         dcpop,         16)    \


### PR DESCRIPTION
Changes for #8258 renamed `sha256` aarch64 feature to `sha2`. Unfortunately this name is used by testing to determine if a feature is supported: [IntrinsicPredicates.java#L78](https://github.com/openjdk/jdk/blob/master/test/hotspot/jtreg/compiler/testlibrary/sha/predicate/IntrinsicPredicates.java#L78)

I reverted the name back to fix the issue. Tested tier1-3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285266](https://bugs.openjdk.java.net/browse/JDK-8285266): compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnUnsupportedCPU.java fails after JDK-8284563


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8324/head:pull/8324` \
`$ git checkout pull/8324`

Update a local copy of the PR: \
`$ git checkout pull/8324` \
`$ git pull https://git.openjdk.java.net/jdk pull/8324/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8324`

View PR using the GUI difftool: \
`$ git pr show -t 8324`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8324.diff">https://git.openjdk.java.net/jdk/pull/8324.diff</a>

</details>
