### PR TITLE
8225777: java/awt/Mixing/MixingOnDialog.java fails on Ubuntu

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -176,7 +176,6 @@ java/awt/Mixing/AWT_Mixing/JTextFieldInGlassPaneOverlapping.java 8158801 windows
 java/awt/Mixing/AWT_Mixing/JTextFieldOverlapping.java 8158801 windows-all
 java/awt/Mixing/AWT_Mixing/JToggleButtonInGlassPaneOverlapping.java 8158801 windows-all
 java/awt/Mixing/AWT_Mixing/JToggleButtonOverlapping.java 8158801 windows-all
-java/awt/Mixing/MixingOnDialog.java 8225777 linux-all
 java/awt/Mixing/NonOpaqueInternalFrame.java 7124549 macosx-all
 java/awt/Focus/ActualFocusedWindowTest/ActualFocusedWindowRetaining.java 6829264 generic-all
 java/awt/datatransfer/DragImage/MultiResolutionDragImageTest.java 8080982 generic-all

--- a/test/jdk/java/awt/Mixing/MixingOnDialog.java
+++ b/test/jdk/java/awt/Mixing/MixingOnDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,9 +39,14 @@
  * summary:  Tests whether awt.Button and swing.JButton mix correctly
  */
 
-import java.awt.*;
-import java.awt.event.*;
-import javax.swing.*;
+import java.awt.Button;
+import java.awt.Dialog;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import javax.swing.JButton;
+
 import test.java.awt.regtesthelpers.Util;
 
 
@@ -76,14 +81,14 @@ public class MixingOnDialog
                 );
 
         // Overlap the buttons
-        heavy.setBounds(30, 30, 200, 200);
-        light.setBounds(10, 10, 50, 50);
+        heavy.setBounds(230, 230, 200, 200);
+        light.setBounds(210, 210, 50, 50);
 
         // Put the components into the frame
         d.setLayout(null);
         d.add(light);
         d.add(heavy);
-        d.setBounds(50, 50, 400, 400);
+        d.setBounds(250, 250, 400, 400);
         d.setVisible(true);
 
 
@@ -98,8 +103,8 @@ public class MixingOnDialog
         robot.mouseMove(heavyLoc.x + 5, heavyLoc.y + 5);
 
         // Now perform the click at this point
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         Util.waitForIdle(robot);
 
         // If the buttons are correctly mixed, the test sequence

--- a/test/jdk/java/awt/Mixing/MixingOnDialog.java
+++ b/test/jdk/java/awt/Mixing/MixingOnDialog.java
@@ -50,11 +50,12 @@ import javax.swing.SwingUtilities;
 
 public class MixingOnDialog {
     static volatile boolean lightClicked = false;
+    static Dialog d;
     static Button heavy;
 
     private static void init() {
         // Create components
-        final Dialog d = new Dialog((Frame)null, "Button-JButton mix test");
+        d = new Dialog((Frame)null, "Button-JButton mix test");
         heavy = new Button("  Heavyweight Button  ");
         final JButton light = new JButton("  LW Button  ");
 
@@ -90,6 +91,8 @@ public class MixingOnDialog {
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.waitForIdle();
+
+        SwingUtilities.invokeLater(() -> d.dispose());
 
         if (!lightClicked) {
             throw new RuntimeException("The lightweight component left behind the heavyweight one.");

--- a/test/jdk/java/awt/Mixing/MixingOnDialog.java
+++ b/test/jdk/java/awt/Mixing/MixingOnDialog.java
@@ -27,58 +27,39 @@
   @bug 4811096
   @summary Tests whether mixing works on Dialogs
   @author anthony.petrov@...: area=awt.mixing
-  @library ../regtesthelpers
-  @build Util
   @run main MixingOnDialog
 */
 
 
-/**
+/*
  * MixingOnDialog.java
  *
  * summary:  Tests whether awt.Button and swing.JButton mix correctly
  */
 
+import java.awt.AWTException;
 import java.awt.Button;
 import java.awt.Dialog;
 import java.awt.Frame;
 import java.awt.Point;
 import java.awt.Robot;
 import java.awt.event.InputEvent;
+import java.lang.reflect.InvocationTargetException;
 import javax.swing.JButton;
+import javax.swing.SwingUtilities;
 
-import test.java.awt.regtesthelpers.Util;
-
-
-
-public class MixingOnDialog
-{
-    static volatile boolean heavyClicked = false;
+public class MixingOnDialog {
     static volatile boolean lightClicked = false;
+    static Button heavy;
 
-    private static void init()
-    {
+    private static void init() {
         // Create components
         final Dialog d = new Dialog((Frame)null, "Button-JButton mix test");
-        final Button heavy = new Button("  Heavyweight Button  ");
+        heavy = new Button("  Heavyweight Button  ");
         final JButton light = new JButton("  LW Button  ");
 
         // Actions for the buttons add appropriate number to the test sequence
-        heavy.addActionListener(new java.awt.event.ActionListener()
-                {
-                    public void actionPerformed(java.awt.event.ActionEvent e) {
-                        heavyClicked = true;
-                    }
-                }
-                );
-
-        light.addActionListener(new java.awt.event.ActionListener()
-                {
-                    public void actionPerformed(java.awt.event.ActionEvent e) {
-                        lightClicked = true;
-                    }
-                }
-                );
+        light.addActionListener(e -> lightClicked = true);
 
         // Overlap the buttons
         heavy.setBounds(230, 230, 200, 200);
@@ -90,12 +71,15 @@ public class MixingOnDialog
         d.add(heavy);
         d.setBounds(250, 250, 400, 400);
         d.setVisible(true);
+    }
 
+    public static void main(String[] args) throws InterruptedException, InvocationTargetException, AWTException {
+        SwingUtilities.invokeAndWait(MixingOnDialog::init);
 
-        Robot robot = Util.createRobot();
-        robot.setAutoDelay(20);
-
-        Util.waitForIdle(robot);
+        Robot robot = new Robot();
+        robot.setAutoDelay(50);
+        robot.waitForIdle();
+        robot.delay(500);
 
         // Move the mouse pointer to the position where both
         //    buttons overlap
@@ -105,135 +89,10 @@ public class MixingOnDialog
         // Now perform the click at this point
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-        Util.waitForIdle(robot);
+        robot.waitForIdle();
 
-        // If the buttons are correctly mixed, the test sequence
-        // is equal to the check sequence.
-        if (lightClicked == true) {
-            MixingOnDialog.pass();
-        } else {
-            MixingOnDialog.fail("The lightweight component left behind the heavyweight one.");
+        if (!lightClicked) {
+            throw new RuntimeException("The lightweight component left behind the heavyweight one.");
         }
-    }//End  init()
-
-
-
-    /*****************************************************
-     * Standard Test Machinery Section
-     * DO NOT modify anything in this section -- it's a
-     * standard chunk of code which has all of the
-     * synchronisation necessary for the test harness.
-     * By keeping it the same in all tests, it is easier
-     * to read and understand someone else's test, as
-     * well as insuring that all tests behave correctly
-     * with the test harness.
-     * There is a section following this for test-
-     * classes
-     ******************************************************/
-    private static boolean theTestPassed = false;
-    private static boolean testGeneratedInterrupt = false;
-    private static String failureMessage = "";
-
-    private static Thread mainThread = null;
-
-    private static int sleepTime = 300000;
-
-    // Not sure about what happens if multiple of this test are
-    //  instantiated in the same VM.  Being static (and using
-    //  static vars), it aint gonna work.  Not worrying about
-    //  it for now.
-    public static void main( String args[] ) throws InterruptedException
-    {
-        mainThread = Thread.currentThread();
-        try
-        {
-            init();
-        }
-        catch( TestPassedException e )
-        {
-            //The test passed, so just return from main and harness will
-            // interepret this return as a pass
-            return;
-        }
-        //At this point, neither test pass nor test fail has been
-        // called -- either would have thrown an exception and ended the
-        // test, so we know we have multiple threads.
-
-        //Test involves other threads, so sleep and wait for them to
-        // called pass() or fail()
-        try
-        {
-            Thread.sleep( sleepTime );
-            //Timed out, so fail the test
-            throw new RuntimeException( "Timed out after " + sleepTime/1000 + " seconds" );
-        }
-        catch (InterruptedException e)
-        {
-            //The test harness may have interrupted the test.  If so, rethrow the exception
-            // so that the harness gets it and deals with it.
-            if( ! testGeneratedInterrupt ) throw e;
-
-            //reset flag in case hit this code more than once for some reason (just safety)
-            testGeneratedInterrupt = false;
-
-            if ( theTestPassed == false )
-            {
-                throw new RuntimeException( failureMessage );
-            }
-        }
-
-    }//main
-
-    public static synchronized void setTimeoutTo( int seconds )
-    {
-        sleepTime = seconds * 1000;
     }
-
-    public static synchronized void pass()
-    {
-        System.out.println( "The test passed." );
-        System.out.println( "The test is over, hit  Ctl-C to stop Java VM" );
-        //first check if this is executing in main thread
-        if ( mainThread == Thread.currentThread() )
-        {
-            //Still in the main thread, so set the flag just for kicks,
-            // and throw a test passed exception which will be caught
-            // and end the test.
-            theTestPassed = true;
-            throw new TestPassedException();
-        }
-        theTestPassed = true;
-        testGeneratedInterrupt = true;
-        mainThread.interrupt();
-    }//pass()
-
-    public static synchronized void fail()
-    {
-        //test writer didn't specify why test failed, so give generic
-        fail( "it just plain failed! :-)" );
-    }
-
-    public static synchronized void fail( String whyFailed )
-    {
-        System.out.println( "The test failed: " + whyFailed );
-        System.out.println( "The test is over, hit  Ctl-C to stop Java VM" );
-        //check if this called from main thread
-        if ( mainThread == Thread.currentThread() )
-        {
-            //If main thread, fail now 'cause not sleeping
-            throw new RuntimeException( whyFailed );
-        }
-        theTestPassed = false;
-        testGeneratedInterrupt = true;
-        failureMessage = whyFailed;
-        mainThread.interrupt();
-    }//fail()
-
-}// class MixingOnDialog
-
-//This exception is used to exit from any level of call nesting
-// when it's determined that the test has passed, and immediately
-// end the test.
-class TestPassedException extends RuntimeException
-{
 }

--- a/test/jdk/java/awt/Mixing/MixingOnDialog.java
+++ b/test/jdk/java/awt/Mixing/MixingOnDialog.java
@@ -51,7 +51,7 @@ import javax.swing.SwingUtilities;
 public class MixingOnDialog {
     static volatile boolean lightClicked = false;
     static Dialog d;
-    static Button heavy;
+    static volatile Button heavy;
 
     private static void init() {
         // Create components
@@ -92,7 +92,7 @@ public class MixingOnDialog {
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.waitForIdle();
 
-        SwingUtilities.invokeLater(() -> d.dispose());
+        SwingUtilities.invokeAndWait(() -> d.dispose());
 
         if (!lightClicked) {
             throw new RuntimeException("The lightweight component left behind the heavyweight one.");


### PR DESCRIPTION
The test was failing due to it tried to place windows too close to left top corner, so they got shifted from the dock and top panel on Gnome.

Shifting all test windows fixes the issue.


Testing is green on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8225777](https://bugs.openjdk.java.net/browse/JDK-8225777): java/awt/Mixing/MixingOnDialog.java fails on Ubuntu


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8326/head:pull/8326` \
`$ git checkout pull/8326`

Update a local copy of the PR: \
`$ git checkout pull/8326` \
`$ git pull https://git.openjdk.java.net/jdk pull/8326/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8326`

View PR using the GUI difftool: \
`$ git pr show -t 8326`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8326.diff">https://git.openjdk.java.net/jdk/pull/8326.diff</a>

</details>
