### PR TITLE
8285308: Win: Japanese logical fonts are drawn with wrong size

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
+++ b/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
@@ -135,7 +135,7 @@ public abstract class FontConfiguration {
         osVersion = System.getProperty("os.version");
     }
 
-    protected void setEncoding() {
+    private void setEncoding() {
         encoding = Charset.defaultCharset().name();
         startupLocale = SunToolkit.getStartupLocale();
     }

--- a/src/java.desktop/windows/classes/sun/awt/windows/WFontConfiguration.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WFontConfiguration.java
@@ -102,16 +102,6 @@ public final class WFontConfiguration extends FontConfiguration {
         }
     }
 
-    @Override
-    protected void setEncoding() {
-        String nativeEncoding = System.getProperty("native.encoding");
-        Charset cs = (nativeEncoding != null) ?
-                     Charset.forName(nativeEncoding) :
-                     Charset.defaultCharset();
-        encoding = cs.name();
-        startupLocale = sun.awt.SunToolkit.getStartupLocale();
-    }
-
     // overrides FontConfiguration.getFallbackFamilyName
     @Override
     public String getFallbackFamilyName(String fontName, String defaultFallback) {
@@ -218,7 +208,8 @@ public final class WFontConfiguration extends FontConfiguration {
         subsetEncodingMap.put("arabic", "windows-1256");
         subsetEncodingMap.put("chinese-ms936", "GBK");
         subsetEncodingMap.put("chinese-gb18030", "GB18030");
-        if ("x-MS950-HKSCS".equals(defaultEncoding)) {
+        if ("x-MS950-HKSCS".equals(defaultEncoding) ||
+            "HK".equals(startupLocale.getCountry())) {
             subsetEncodingMap.put("chinese-ms950", "x-MS950-HKSCS");
         } else {
             subsetEncodingMap.put("chinese-ms950", "x-windows-950"); //MS950
@@ -235,32 +226,23 @@ public final class WFontConfiguration extends FontConfiguration {
         subsetEncodingMap.put("symbol", "sun.awt.Symbol");
         subsetEncodingMap.put("thai", "x-windows-874");
 
-        if ("windows-1256".equals(defaultEncoding)) {
-            textInputCharset = "ARABIC_CHARSET";
-        } else if ("GBK".equals(defaultEncoding)) {
-            textInputCharset = "GB2312_CHARSET";
-        } else if ("GB18030".equals(defaultEncoding)) {
-            textInputCharset = "GB2312_CHARSET";
-        } else if ("x-windows-950".equals(defaultEncoding)) {
-            textInputCharset = "CHINESEBIG5_CHARSET";
-        } else if ("x-MS950-HKSCS".equals(defaultEncoding)) {
-            textInputCharset = "CHINESEBIG5_CHARSET";
-        } else if ("windows-1251".equals(defaultEncoding)) {
-            textInputCharset = "RUSSIAN_CHARSET";
-        } else if ("UTF-8".equals(defaultEncoding)) {
-            textInputCharset = "DEFAULT_CHARSET";
-        } else if ("windows-1253".equals(defaultEncoding)) {
-            textInputCharset = "GREEK_CHARSET";
-        } else if ("windows-1255".equals(defaultEncoding)) {
-            textInputCharset = "HEBREW_CHARSET";
-        } else if ("windows-31j".equals(defaultEncoding)) {
-            textInputCharset = "SHIFTJIS_CHARSET";
-        } else if ("x-windows-949".equals(defaultEncoding)) {
-            textInputCharset = "HANGEUL_CHARSET";
-        } else if ("x-windows-874".equals(defaultEncoding)) {
-            textInputCharset = "THAI_CHARSET";
-        } else {
-            textInputCharset = "DEFAULT_CHARSET";
-        }
+        textInputCharset = switch(startupLocale.getLanguage()) {
+            case "ar" -> "ARABIC_CHARSET";
+            case "zh" -> {
+                String country = startupLocale.getCountry();
+                if (country.equals("TW") || country.equals("HK")) {
+                    yield "CHINESEBIG5_CHARSET";
+                } else {
+                    yield "GB2312_CHARSET";
+                }
+            }
+            case "ru" -> "RUSSIAN_CHARSET";
+            case "el" -> "GREEK_CHARSET";
+            case "iw" -> "HEBREW_CHARSET";
+            case "ja" -> "SHIFTJIS_CHARSET";
+            case "ko" -> "HANGEUL_CHARSET";
+            case "th" -> "THAI_CHARSET";
+            default -> "DEFAULT_CHARSET";
+        };
     }
 }


### PR DESCRIPTION
Japanese logical fonts are drawn with wrong size since Java 18.
It's triggered by JEP 400, UTF-8 by Default. `sun.awt.FontConfiguration` (and `sun.awt.windows.WFontConfiguration`) seems to expect the native encoding instead of the default encoding. This patch changes to use native encoding.

Tested: jdk_desktop on Windows, Linux, and macOS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [JDK-8285308](https://bugs.openjdk.java.net/browse/JDK-8285308): Win: Japanese logical fonts are drawn with wrong size


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8329/head:pull/8329` \
`$ git checkout pull/8329`

Update a local copy of the PR: \
`$ git checkout pull/8329` \
`$ git pull https://git.openjdk.java.net/jdk pull/8329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8329`

View PR using the GUI difftool: \
`$ git pr show -t 8329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8329.diff">https://git.openjdk.java.net/jdk/pull/8329.diff</a>

</details>
