### PR TITLE
8285342: Zero build failure with clang due to values not handled in switch

### DIFF
--- a/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
+++ b/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
@@ -619,6 +619,8 @@ int ZeroInterpreter::getter_entry(Method* method, intptr_t UNUSED, TRAPS) {
       stack->alloc(wordSize);
       topOfStack = stack->sp();
       break;
+    default:
+      ;
   }
 
   // Read the field to stack(0)

--- a/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
@@ -2995,7 +2995,7 @@ run:
         MORE_STACK(1);
         break;
       default:
-        ;
+        ShouldNotReachHere();
     }
 
     ts->clr_earlyret_value();

--- a/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
@@ -2994,6 +2994,8 @@ run:
         SET_STACK_OBJECT(ts->earlyret_oop(), 0);
         MORE_STACK(1);
         break;
+      default:
+        ;
     }
 
     ts->clr_earlyret_value();


### PR DESCRIPTION
Hi all,

May I get reviews for this trivial change?

It fixes zero build failure with clang due to values not handled in switch.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285342](https://bugs.openjdk.java.net/browse/JDK-8285342): Zero build failure with clang due to values not handled in switch


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8330/head:pull/8330` \
`$ git checkout pull/8330`

Update a local copy of the PR: \
`$ git checkout pull/8330` \
`$ git pull https://git.openjdk.java.net/jdk pull/8330/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8330`

View PR using the GUI difftool: \
`$ git pr show -t 8330`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8330.diff">https://git.openjdk.java.net/jdk/pull/8330.diff</a>

</details>
