### PR TITLE
8285361: ClassCastExceptionForInvalidSurface.java has an incorrect copyright header

### DIFF
--- a/test/jdk/sun/java2d/ClassCastExceptionForInvalidSurface.java
+++ b/test/jdk/sun/java2d/ClassCastExceptionForInvalidSurface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Can I please get a review for this trivial fix to the copyright header?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285361](https://bugs.openjdk.java.net/browse/JDK-8285361): ClassCastExceptionForInvalidSurface.java has an incorrect copyright header


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8331/head:pull/8331` \
`$ git checkout pull/8331`

Update a local copy of the PR: \
`$ git checkout pull/8331` \
`$ git pull https://git.openjdk.java.net/jdk pull/8331/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8331`

View PR using the GUI difftool: \
`$ git pr show -t 8331`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8331.diff">https://git.openjdk.java.net/jdk/pull/8331.diff</a>

</details>
