### PR TITLE
8285305: Create an automated test for JDK-4495286

### DIFF
--- a/test/jdk/javax/accessibility/4495286/AccessibleJTableSelectionTest.java
+++ b/test/jdk/javax/accessibility/4495286/AccessibleJTableSelectionTest.java
@@ -4,7 +4,6 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
-
  * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT

--- a/test/jdk/javax/accessibility/4495286/AccessibleJTableSelectionTest.java
+++ b/test/jdk/javax/accessibility/4495286/AccessibleJTableSelectionTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key headful
+ * @bug 4495286
+ * @summary AccessibleJTable.setAccessibleSelction should
+ * select rows/cols if getCellSelectionEnabled() is false
+ * @run main AccessibleJTableSelectionTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Robot;
+
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.ListSelectionModel;
+import javax.swing.SwingUtilities;
+
+public final class AccessibleJTableSelectionTest {
+
+    private static JTable jTable;
+    private static JFrame jFrame;
+
+    private static Robot robot;
+
+    private static void createGUI() {
+
+        Object[][] rowData = { { "RowData1", Integer.valueOf(1) },
+            { "RowData2", Integer.valueOf(2) },
+            { "RowData3", Integer.valueOf(3) } };
+        Object[] columnData = { "Column One", "Column Two" };
+
+        jTable = new JTable(rowData, columnData);
+        jTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        jTable.setRowSelectionAllowed(false);
+        jTable.setColumnSelectionAllowed(false);
+        jTable.setCellSelectionEnabled(true);
+
+        jFrame = new JFrame();
+        jFrame.add(new JScrollPane(jTable), BorderLayout.CENTER);
+        jFrame.setSize(200, 200);
+        jFrame.setLocationRelativeTo(null);
+        jFrame.setVisible(true);
+    }
+
+    private static void doTest() throws Exception {
+        SwingUtilities.invokeAndWait(() -> createGUI());
+
+        robot = new Robot();
+        robot.waitForIdle();
+        SwingUtilities.invokeAndWait(() -> {
+            jTable.requestFocus();
+            jTable.getAccessibleContext().getAccessibleSelection()
+            .addAccessibleSelection(1);
+        });
+
+        robot.waitForIdle();
+        SwingUtilities.invokeAndWait(() -> {
+            if (!jTable.isRowSelected(0) || !jTable.isColumnSelected(1)) {
+                throw new RuntimeException(
+                    "Unexpected selection state of "
+                    + "Table Row & Column");
+            }
+        });
+
+        robot.waitForIdle();
+        SwingUtilities.invokeAndWait(() -> {
+            jTable.setRowSelectionAllowed(true);
+            jTable.setColumnSelectionAllowed(false);
+            jTable.setCellSelectionEnabled(false);
+            jTable.requestFocus();
+            jTable.getAccessibleContext().getAccessibleSelection()
+            .addAccessibleSelection(3);
+        });
+
+        robot.waitForIdle();
+        SwingUtilities.invokeAndWait(() -> {
+            if (!jTable.isRowSelected(1)) {
+                throw new RuntimeException(
+                    "Unexpected selection state of "
+                    + "Table Row & Column");
+            }
+        });
+
+        robot.waitForIdle();
+        SwingUtilities.invokeAndWait(() -> {
+            jTable.setRowSelectionAllowed(false);
+            jTable.setColumnSelectionAllowed(true);
+            jTable.setCellSelectionEnabled(false);
+            jTable.requestFocus();
+            jTable.getAccessibleContext().getAccessibleSelection()
+            .addAccessibleSelection(4);
+        });
+
+        robot.waitForIdle();
+        SwingUtilities.invokeAndWait(() -> {
+            if (!jTable.isColumnSelected(0)) {
+                throw new RuntimeException(
+                    "Unexpected selection state of "
+                    + "Table Row & Column");
+            }
+        });
+
+        robot.waitForIdle();
+        SwingUtilities.invokeAndWait(() -> {
+            jTable.setRowSelectionAllowed(true);
+            jTable.setColumnSelectionAllowed(true);
+            jTable.setCellSelectionEnabled(false);
+            jTable.requestFocus();
+            jTable.getAccessibleContext().getAccessibleSelection()
+            .addAccessibleSelection(5);
+        });
+
+        robot.waitForIdle();
+        SwingUtilities.invokeAndWait(() -> {
+            if (!(jTable.isRowSelected(2) && jTable.isColumnSelected(1))) {
+                throw new RuntimeException(
+                    "Unexpected selection state of "
+                    + "Table Row & Column");
+            }
+        });
+
+        robot.waitForIdle();
+        SwingUtilities.invokeAndWait(() -> {
+            jTable.setCellSelectionEnabled(true);
+            jTable.setColumnSelectionAllowed(true);
+            jTable.setRowSelectionAllowed(true);
+            jTable.requestFocus();
+            jTable.getAccessibleContext().getAccessibleSelection()
+            .addAccessibleSelection(4);
+        });
+
+        robot.waitForIdle();
+        SwingUtilities.invokeAndWait(() -> {
+            if (!(jTable.isRowSelected(2) && jTable.isColumnSelected(0)
+                && jTable.isCellSelected(2, 0))) {
+                throw new RuntimeException(
+                    "Unexpected selection state of "
+                    + "Table Row & Column");
+            }
+        });
+    }
+
+    public static void main(final String[] argv) throws Exception {
+        doTest();
+        SwingUtilities.invokeAndWait(() -> jFrame.dispose());
+        System.out.println("Test Passed.");
+    }
+}
+

--- a/test/jdk/javax/accessibility/AccessibleJTableSelectionTest.java
+++ b/test/jdk/javax/accessibility/AccessibleJTableSelectionTest.java
@@ -25,8 +25,8 @@
  * @test
  * @key headful
  * @bug 4495286
- * @summary AccessibleJTable.setAccessibleSelction should
- * select rows/cols if getCellSelectionEnabled() is false
+ * @summary Verify that AccessibleJTable.setAccessibleSelction
+ * selects rows/cols if getCellSelectionEnabled() is false
  * @run main AccessibleJTableSelectionTest
  */
 


### PR DESCRIPTION
Create an automated test for [JDK-4495286](https://bugs.openjdk.java.net/browse/JDK-4495286)

AccessibleJTable.setAccessibleSelction should select rows/cols when cell selection.
When cell selection is not enabled, there is no way, using
accessibility, to select rows or columns. It seems logical that selecting a cell
using accessibility should have the same effect as clicking on a cell with the
mouse. That is, if row or column selection is enabled, then selecting a cell
should instead cause the row or column to be selected.
 The proposed test verifies that the above behavior is fixed.

This review is for migrating tests from a closed test suite to open.

Testing:
The test ran successfully on Mach5 with multiple runs (40) on windows-x64, linux-x64 and macos-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285305](https://bugs.openjdk.java.net/browse/JDK-8285305): Create an automated test for JDK-4495286


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8333/head:pull/8333` \
`$ git checkout pull/8333`

Update a local copy of the PR: \
`$ git checkout pull/8333` \
`$ git pull https://git.openjdk.java.net/jdk pull/8333/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8333`

View PR using the GUI difftool: \
`$ git pr show -t 8333`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8333.diff">https://git.openjdk.java.net/jdk/pull/8333.diff</a>

</details>
