### PR TITLE
8285370: Fix typo in jdk.charsets

### DIFF
--- a/src/jdk.charsets/share/classes/sun/nio/cs/ext/IBM942C.java.template
+++ b/src/jdk.charsets/share/classes/sun/nio/cs/ext/IBM942C.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,7 @@ public class IBM942C extends Charset implements HistoricallyNamedCharset
         static final char[] c2bIndex;
 
         static {
-            // the mappings need udpate are
+            // the mappings that need updating are
             //    u+001a  <-> 0x1a
             //    u+001c  <-> 0x1c
             //    u+005c  <-> 0x5c


### PR DESCRIPTION
`codespell` could just find a single typo in the files covered by the i18n alias. Just fixing the typo did not make the comment more readable, so I rewrote it slightly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285370](https://bugs.openjdk.java.net/browse/JDK-8285370): Fix typo in jdk.charsets


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8335/head:pull/8335` \
`$ git checkout pull/8335`

Update a local copy of the PR: \
`$ git checkout pull/8335` \
`$ git pull https://git.openjdk.java.net/jdk pull/8335/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8335`

View PR using the GUI difftool: \
`$ git pr show -t 8335`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8335.diff">https://git.openjdk.java.net/jdk/pull/8335.diff</a>

</details>
