### PR TITLE
8285369: C2: emit reduction flag value in node and loop dumps

### DIFF
--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -455,6 +455,9 @@ void IdealGraphPrinter::visit_node(Node *n, bool edges, VectorSet* temp_set) {
     }
     if (flags & Node::Flag_has_call) {
       print_prop("has_call", "true");
+    }
+    if (flags & Node::Flag_is_reduction) {
+      print_prop("is_reduction", "true");
     }
 
     if (C->matcher() != NULL) {

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -2233,6 +2233,7 @@ void CountedLoopNode::dump_spec(outputStream *st) const {
   if (is_pre_loop ()) st->print("pre of N%d" , _main_idx);
   if (is_main_loop()) st->print("main of N%d", _idx);
   if (is_post_loop()) st->print("post of N%d", _main_idx);
+  if (is_reduction_loop()) st->print(" reduction");
   if (is_strip_mined()) st->print(" strip mined");
 }
 #endif
@@ -3934,6 +3935,7 @@ void IdealLoopTree::dump_head() const {
     if (cl->is_pre_loop ()) tty->print(" pre" );
     if (cl->is_main_loop()) tty->print(" main");
     if (cl->is_post_loop()) tty->print(" post");
+    if (cl->is_reduction_loop()) tty->print(" reduction");
     if (cl->is_vectorized_loop()) tty->print(" vector");
     if (cl->range_checks_present()) tty->print(" rc ");
     if (cl->is_multiversioned()) tty->print(" multi ");


### PR DESCRIPTION
This (trivial?) enhancement emits the `LoopNode::HasReductions` flag from `CountedLoopNode::dump_spec()` and `IdealLoopTree::dump_head()`, and `Node::Flag_is_reduction` from `IdealGraphPrinter::print()`. This proved to be useful in the investigation of [JDK-8279622](https://bugs.openjdk.java.net/browse/JDK-8279622).

Tested on linux-x64 (build and hs-tier1).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285369](https://bugs.openjdk.java.net/browse/JDK-8285369): C2: emit reduction flag value in node and loop dumps


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8336/head:pull/8336` \
`$ git checkout pull/8336`

Update a local copy of the PR: \
`$ git checkout pull/8336` \
`$ git pull https://git.openjdk.java.net/jdk pull/8336/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8336`

View PR using the GUI difftool: \
`$ git pr show -t 8336`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8336.diff">https://git.openjdk.java.net/jdk/pull/8336.diff</a>

</details>
