### PR TITLE
8129778: Few awt test fail for Solaris 11 with RuntimeException

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -192,10 +192,7 @@ java/awt/Focus/6981400/Test1.java 8029675 windows-all,macosx-all
 java/awt/Focus/6981400/Test3.java 8173264 generic-all
 java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java 8169476 windows-all,macosx-all
 java/awt/event/KeyEvent/KeyChar/KeyCharTest.java 8169474,8224055 macosx-all,windows-all
-java/awt/event/KeyEvent/ExtendedModifiersTest/ExtendedModifiersTest.java 8129778 generic-all
-java/awt/event/KeyEvent/KeyMaskTest/KeyMaskTest.java 8129778 generic-all
 java/awt/event/KeyEvent/KeyTyped/CtrlASCII.java 8252713 linux-all
-java/awt/event/MouseEvent/MouseButtonsAndKeyMasksTest/MouseButtonsAndKeyMasksTest.java 8129778 generic-all
 
 java/awt/dnd/URIListToFileListBetweenJVMsTest/URIListToFileListBetweenJVMsTest.java 8194947 generic-all
 java/awt/Frame/FramesGC/FramesGC.java 8079069 macosx-all

--- a/test/jdk/java/awt/event/KeyEvent/ExtendedModifiersTest/ExtendedModifiersTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/ExtendedModifiersTest/ExtendedModifiersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@
  * @build LWButton
  * @build LWList
  * @build ExtendedRobot
- * @run main/timeout=600 ExtendedModifiersTest
+ * @run main/timeout=300 ExtendedModifiersTest
  */
 import java.awt.Button;
 import java.awt.Color;
@@ -71,7 +71,7 @@ public class ExtendedModifiersTest implements KeyListener {
 
     private final ExtendedRobot robot;
     private static final int WAIT_DELAY = 5000;
-    private static final int KEY_DELAY = 500;
+    private static final int KEY_DELAY = 100;
     private final Object lock;
 
     private boolean keyPressedFlag;
@@ -106,6 +106,7 @@ public class ExtendedModifiersTest implements KeyListener {
         frame = new Frame();
         frame.setTitle("ExtendedModifiersTest");
         frame.setLayout(new GridLayout(1, 6));
+        frame.setLocationRelativeTo(null);
 
         button = new Button();
         button.addKeyListener(this);

--- a/test/jdk/java/awt/event/KeyEvent/KeyMaskTest/KeyMaskTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/KeyMaskTest/KeyMaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,11 +35,20 @@
  * @build LWButton
  * @build LWList
  * @build ExtendedRobot
- * @run main/timeout=600 KeyMaskTest
+ * @run main/timeout=300 KeyMaskTest
  */
 
 
-import java.awt.*;
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.List;
+import java.awt.Point;
+import java.awt.TextArea;
+import java.awt.TextField;
 import java.awt.event.InputEvent;
 
 import java.awt.event.KeyAdapter;
@@ -47,7 +56,8 @@ import java.awt.event.KeyEvent;
 
 import java.util.ArrayList;
 
-import static jdk.test.lib.Asserts.*;
+import static jdk.test.lib.Asserts.assertEQ;
+import static jdk.test.lib.Asserts.assertTrue;
 
 import test.java.awt.event.helpers.lwcomponents.LWButton;
 import test.java.awt.event.helpers.lwcomponents.LWList;
@@ -65,12 +75,9 @@ public class KeyMaskTest extends KeyAdapter {
     List      list;
     LWList    listLW;
 
-    int buttonPressedNumber;
-    int buttonReleasedNumber;
-
     ExtendedRobot robot;
 
-    private final static int robotDelay = 1500;
+    private final static int robotDelay = 500;
     private final static int waitDelay  = 3500;
 
     final Object lock;
@@ -89,6 +96,7 @@ public class KeyMaskTest extends KeyAdapter {
         frame = new Frame();
         frame.setTitle("KeyMaskTest");
         frame.setLayout(new GridLayout(1, 6));
+        frame.setLocationRelativeTo(null);
 
         button = new Button();
         button.addKeyListener(this);

--- a/test/jdk/java/awt/event/MouseEvent/MouseButtonsAndKeyMasksTest/MouseButtonsAndKeyMasksTest.java
+++ b/test/jdk/java/awt/event/MouseEvent/MouseButtonsAndKeyMasksTest/MouseButtonsAndKeyMasksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,8 +22,16 @@
  */
 
 
-import java.awt.*;
-
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.List;
+import java.awt.Point;
+import java.awt.TextArea;
+import java.awt.TextField;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
@@ -31,7 +39,8 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.util.ArrayList;
 
-import static jdk.test.lib.Asserts.*;
+import static jdk.test.lib.Asserts.assertEQ;
+import static jdk.test.lib.Asserts.assertTrue;
 
 
 import test.java.awt.event.helpers.lwcomponents.LWButton;
@@ -52,7 +61,7 @@ import test.java.awt.event.helpers.lwcomponents.LWList;
  * @build LWButton
  * @build LWList
  * @build ExtendedRobot
- * @run main/timeout=600 MouseButtonsAndKeyMasksTest
+ * @run main/timeout=300 MouseButtonsAndKeyMasksTest
  */
 
 public class MouseButtonsAndKeyMasksTest implements MouseListener, KeyListener {
@@ -68,11 +77,11 @@ public class MouseButtonsAndKeyMasksTest implements MouseListener, KeyListener {
 
     ExtendedRobot robot;
 
-    private final static int robotDelay = 1500;
-    private final static int   keyDelay =  500;
+    private final static int robotDelay = 500;
+    private final static int   keyDelay =  100;
     private final static int  waitDelay = 5000;
 
-    int modMouse = 0, modMouseEx = 0, modKey = 0, modAction = 0;
+    int modMouse = 0, modMouseEx = 0, modKey = 0;
 
     boolean mousePressFired = false;
     boolean keyPressFired = false;
@@ -90,6 +99,7 @@ public class MouseButtonsAndKeyMasksTest implements MouseListener, KeyListener {
         frame = new Frame();
         frame.setTitle("MouseButtonsAndKeysTest");
         frame.setLayout(new GridLayout(1, 6));
+        frame.setLocationRelativeTo(null);
 
         button = new Button();
         button.addKeyListener(this);


### PR DESCRIPTION
Those tests were failing on Solaris, which is no longer supported.

They pass as they are, but decreasing of delays reduce execution time significantly:

e.g. proposed changes drops execution time from ~5min to ~2 min 
for MouseButtonsAndKeyMasksTest on my machine.

Testing is green on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8129778](https://bugs.openjdk.java.net/browse/JDK-8129778): Few  awt test fail for Solaris 11 with RuntimeException


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8339/head:pull/8339` \
`$ git checkout pull/8339`

Update a local copy of the PR: \
`$ git checkout pull/8339` \
`$ git pull https://git.openjdk.java.net/jdk pull/8339/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8339`

View PR using the GUI difftool: \
`$ git pr show -t 8339`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8339.diff">https://git.openjdk.java.net/jdk/pull/8339.diff</a>

</details>
