### PR TITLE
8285378: Remove unnecessary nop for C1 exception and deopt handler

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -378,13 +378,6 @@ int LIR_Assembler::initial_frame_size_in_bytes() const {
 
 
 int LIR_Assembler::emit_exception_handler() {
-  // if the last instruction is a call (typically to do a throw which
-  // is coming at the end after block reordering) the return address
-  // must still point into the code area in order to avoid assertion
-  // failures when searching for the corresponding bci => add a nop
-  // (was bug 5/14/1999 - gri)
-  __ nop();
-
   // generate code for exception handler
   address handler_base = __ start_a_stub(exception_handler_size());
   if (handler_base == NULL) {
@@ -403,7 +396,8 @@ int LIR_Assembler::emit_exception_handler() {
   __ verify_not_null_oop(r0);
 
   // search an exception handler (r0: exception oop, r3: throwing pc)
-  __ far_call(RuntimeAddress(Runtime1::entry_for(Runtime1::handle_exception_from_callee_id)));  __ should_not_reach_here();
+  __ far_call(RuntimeAddress(Runtime1::entry_for(Runtime1::handle_exception_from_callee_id)));
+  __ should_not_reach_here();
   guarantee(code_offset() - offset <= exception_handler_size(), "overflow");
   __ end_a_stub();
 
@@ -471,13 +465,6 @@ int LIR_Assembler::emit_unwind_handler() {
 
 
 int LIR_Assembler::emit_deopt_handler() {
-  // if the last instruction is a call (typically to do a throw which
-  // is coming at the end after block reordering) the return address
-  // must still point into the code area in order to avoid assertion
-  // failures when searching for the corresponding bci => add a nop
-  // (was bug 5/14/1999 - gri)
-  __ nop();
-
   // generate code for exception handler
   address handler_base = __ start_a_stub(deopt_handler_size());
   if (handler_base == NULL) {

--- a/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
@@ -199,9 +199,6 @@ int LIR_Assembler::initial_frame_size_in_bytes() const {
 
 
 int LIR_Assembler::emit_exception_handler() {
-  // TODO: ARM
-  __ nop(); // See comments in other ports
-
   address handler_base = __ start_a_stub(exception_handler_size());
   if (handler_base == NULL) {
     bailout("exception handler overflow");

--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -167,13 +167,6 @@ void LIR_Assembler::osr_entry() {
 
 
 int LIR_Assembler::emit_exception_handler() {
-  // If the last instruction is a call (typically to do a throw which
-  // is coming at the end after block reordering) the return address
-  // must still point into the code area in order to avoid assertion
-  // failures when searching for the corresponding bci => add a nop
-  // (was bug 5/14/1999 - gri).
-  __ nop();
-
   // Generate code for the exception handler.
   address handler_base = __ start_a_stub(exception_handler_size());
 
@@ -247,13 +240,6 @@ int LIR_Assembler::emit_unwind_handler() {
 
 
 int LIR_Assembler::emit_deopt_handler() {
-  // If the last instruction is a call (typically to do a throw which
-  // is coming at the end after block reordering) the return address
-  // must still point into the code area in order to avoid assertion
-  // failures when searching for the corresponding bci => add a nop
-  // (was bug 5/14/1999 - gri).
-  __ nop();
-
   // Generate code for deopt handler.
   address handler_base = __ start_a_stub(deopt_handler_size());
 

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -307,13 +307,6 @@ int LIR_Assembler::initial_frame_size_in_bytes() const {
 }
 
 int LIR_Assembler::emit_exception_handler() {
-  // if the last instruction is a call (typically to do a throw which
-  // is coming at the end after block reordering) the return address
-  // must still point into the code area in order to avoid assertion
-  // failures when searching for the corresponding bci ==> add a nop
-  // (was bug 5/14/1999 -gri)
-  __ nop();
-
   // generate code for exception handler
   address handler_base = __ start_a_stub(exception_handler_size());
   if (handler_base == NULL) {
@@ -399,13 +392,6 @@ int LIR_Assembler::emit_unwind_handler() {
 }
 
 int LIR_Assembler::emit_deopt_handler() {
-  // if the last instruction is a call (typically to do a throw which
-  // is coming at the end after block reordering) the return address
-  // must still point into the code area in order to avoid assertion
-  // failures when searching for the corresponding bck => add a nop
-  // (was bug 5/14/1999 - gri)
-  __ nop();
-
   // generate code for exception handler
   address handler_base = __ start_a_stub(deopt_handler_size());
   if (handler_base == NULL) {

--- a/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
@@ -165,13 +165,6 @@ address LIR_Assembler::emit_call_c(address a) {
 }
 
 int LIR_Assembler::emit_exception_handler() {
-  // If the last instruction is a call (typically to do a throw which
-  // is coming at the end after block reordering) the return address
-  // must still point into the code area in order to avoid assertion
-  // failures when searching for the corresponding bci. => Add a nop.
-  // (was bug 5/14/1999 - gri)
-  __ nop();
-
   // Generate code for exception handler.
   address handler_base = __ start_a_stub(exception_handler_size());
   if (handler_base == NULL) {
@@ -263,13 +256,6 @@ int LIR_Assembler::emit_unwind_handler() {
 }
 
 int LIR_Assembler::emit_deopt_handler() {
-  // If the last instruction is a call (typically to do a throw which
-  // is coming at the end after block reordering) the return address
-  // must still point into the code area in order to avoid assertion
-  // failures when searching for the corresponding bci. => Add a nop.
-  // (was bug 5/14/1999 - gri)
-  __ nop();
-
   // Generate code for exception handler.
   address handler_base = __ start_a_stub(deopt_handler_size());
   if (handler_base == NULL) {

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -398,13 +398,6 @@ int LIR_Assembler::initial_frame_size_in_bytes() const {
 
 
 int LIR_Assembler::emit_exception_handler() {
-  // if the last instruction is a call (typically to do a throw which
-  // is coming at the end after block reordering) the return address
-  // must still point into the code area in order to avoid assertion
-  // failures when searching for the corresponding bci => add a nop
-  // (was bug 5/14/1999 - gri)
-  __ nop();
-
   // generate code for exception handler
   address handler_base = __ start_a_stub(exception_handler_size());
   if (handler_base == NULL) {
@@ -499,13 +492,6 @@ int LIR_Assembler::emit_unwind_handler() {
 
 
 int LIR_Assembler::emit_deopt_handler() {
-  // if the last instruction is a call (typically to do a throw which
-  // is coming at the end after block reordering) the return address
-  // must still point into the code area in order to avoid assertion
-  // failures when searching for the corresponding bci => add a nop
-  // (was bug 5/14/1999 - gri)
-  __ nop();
-
   // generate code for exception handler
   address handler_base = __ start_a_stub(deopt_handler_size());
   if (handler_base == NULL) {


### PR DESCRIPTION
Each C1 method have two nops in the code body. They originally separated the exception/deopt handler block from the code body to fix a "bug 5/14/1999". Now Exception Handler and Deopt Handler are generated in a separate CodeSegment and these nops in the code body don't really help anyone. 

I checked jtreg tests on the following platforms:
- x86
- ppc
- arm32
- aarch64

I would be grateful if someone could check my changes on the riscv and s390 platforms.

```
[Verified Entry Point]
  0x0000ffff7c749d40: nop
  0x0000ffff7c749d44: sub x9, sp, #0x20, lsl #12
  0x0000ffff7c749d48: str xzr, [x9]
  0x0000ffff7c749d4c: sub sp, sp, #0x40
  0x0000ffff7c749d50: stp x29, x30, [sp, #48]
  0x0000ffff7c749d54: and w0, w2, #0x1
  0x0000ffff7c749d58: strb w0, [x1, #12]
  0x0000ffff7c749d5c: dmb ishst
  0x0000ffff7c749d60: ldp x29, x30, [sp, #48]
  0x0000ffff7c749d64: add sp, sp, #0x40
  0x0000ffff7c749d68: ldr x8, [x28, #808] ; {poll_return}
  0x0000ffff7c749d6c: cmp sp, x8
  0x0000ffff7c749d70: b.hi 0x0000ffff7c749d78 // b.pmore
  0x0000ffff7c749d74: ret
# emit_slow_case_stubs
  0x0000ffff7c749d78: adr x8, 0x0000ffff7c749d68 ; {internal_word}
  0x0000ffff7c749d7c: str x8, [x28, #832]
  0x0000ffff7c749d80: b 0x0000ffff7c697480 ; {runtime_call SafepointBlob}
# Excessive nops: Exception Handler and Deopt Handler prolog
  0x0000ffff7c749d84: nop <----------------------------------------------------------------
  0x0000ffff7c749d88: nop <----------------------------------------------------------------
# Unwind handler: the handler to remove the activation from the stack and dispatch to the caller.
  0x0000ffff7c749d8c: ldr x0, [x28, #968]
  0x0000ffff7c749d90: str xzr, [x28, #968]
  0x0000ffff7c749d94: str xzr, [x28, #976]
  0x0000ffff7c749d98: ldp x29, x30, [sp, #48]
  0x0000ffff7c749d9c: add sp, sp, #0x40
  0x0000ffff7c749da0: b 0x0000ffff7c73e000 ; {runtime_call unwind_exception Runtime1 stub}
# Stubs alignment
  0x0000ffff7c749da4: .inst 0x00000000 ; undefined
  0x0000ffff7c749da8: .inst 0x00000000 ; undefined
  0x0000ffff7c749dac: .inst 0x00000000 ; undefined
  0x0000ffff7c749db0: .inst 0x00000000 ; undefined
  0x0000ffff7c749db4: .inst 0x00000000 ; undefined
  0x0000ffff7c749db8: .inst 0x00000000 ; undefined
  0x0000ffff7c749dbc: .inst 0x00000000 ; undefined
[Exception Handler]
  0x0000ffff7c749dc0: bl 0x0000ffff7c740d00 ; {no_reloc}
  0x0000ffff7c749dc4: dcps1 #0xdeae
  0x0000ffff7c749dc8: .inst 0x853828d8 ; undefined
  0x0000ffff7c749dcc: .inst 0x0000ffff ; undefined
[Deopt Handler Code]
  0x0000ffff7c749dd0: adr x30, 0x0000ffff7c749dd0
  0x0000ffff7c749dd4: b 0x0000ffff7c6977c0 ; {runtime_call DeoptimizationBlob} 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [JDK-8285378](https://bugs.openjdk.java.net/browse/JDK-8285378): Remove unnecessary nop for C1 exception and deopt handler


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8341/head:pull/8341` \
`$ git checkout pull/8341`

Update a local copy of the PR: \
`$ git checkout pull/8341` \
`$ git pull https://git.openjdk.java.net/jdk pull/8341/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8341`

View PR using the GUI difftool: \
`$ git pr show -t 8341`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8341.diff">https://git.openjdk.java.net/jdk/pull/8341.diff</a>

</details>
