### PR TITLE
8285394: Compiler blackholes can be eliminated due to stale ciMethod::intrinsic_id()

### DIFF
--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -82,7 +82,6 @@ ciMethod::ciMethod(const methodHandle& h_m, ciInstanceKlass* holder) :
   _max_stack          = h_m->max_stack();
   _max_locals         = h_m->max_locals();
   _code_size          = h_m->code_size();
-  _intrinsic_id       = h_m->intrinsic_id();
   _handler_count      = h_m->exception_table_length();
   _size_of_parameters = h_m->size_of_parameters();
   _uses_monitors      = h_m->access_flags().has_monitor_bytecodes();
@@ -101,6 +100,10 @@ ciMethod::ciMethod(const methodHandle& h_m, ciInstanceKlass* holder) :
   _flow               = NULL;
   _bcea               = NULL;
 #endif // COMPILER2
+
+  // Check for blackhole intrinsic and then populate the intrinsic ID.
+  CompilerOracle::tag_blackhole_if_possible(h_m);
+  _intrinsic_id       = h_m->intrinsic_id();
 
   ciEnv *env = CURRENT_ENV;
   if (env->jvmti_can_hotswap_or_post_breakpoint()) {
@@ -157,8 +160,6 @@ ciMethod::ciMethod(const methodHandle& h_m, ciInstanceKlass* holder) :
     ciReplay::initialize(this);
   }
 #endif
-
-  CompilerOracle::tag_blackhole_if_possible(h_m);
 }
 
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/blackhole/BlackholeHotInlineTest.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/blackhole/BlackholeHotInlineTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8285394
+ * @requires vm.compiler2.enabled
+ * @summary Blackholes should work when hot inlined
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.blackhole.BlackholeHotInlineTest
+ */
+
+package compiler.c2.irTests.blackhole;
+
+import compiler.lib.ir_framework.*;
+import jdk.test.lib.Asserts;
+
+public class BlackholeHotInlineTest {
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags(
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:CompileThreshold=100",
+            "-XX:-TieredCompilation",
+            "-XX:CompileCommand=blackhole,compiler.c2.irTests.blackhole.BlackholeHotInlineTest::blackhole",
+            "-XX:CompileCommand=dontinline,compiler.c2.irTests.blackhole.BlackholeHotInlineTest::dontinline"
+        );
+    }
+
+    static long x, y;
+
+    /*
+     * Baseline test: check that dontinline method does not allow the elimination.
+     */
+
+    @Test
+    @IR(counts = {IRNode.MUL_L, "1"})
+    static void testDontline() {
+        dontinline(x * y);
+    }
+
+    static void dontinline(long x) {}
+
+    @Run(test = "testDontline")
+    static void runDontinline() {
+        testDontline();
+    }
+
+    /*
+     * Positive test: check that blackhole method does not allow the elimination either.
+     */
+
+    @Test
+    @IR(counts = {IRNode.MUL_L, "1"})
+    static void testBlackholed() {
+        blackhole(x * y);
+    }
+
+    static void blackhole(long x) {}
+
+    @Run(test = "testBlackholed")
+    static void runBlackholed() {
+        testBlackholed();
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/c2/irTests/blackhole/BlackholeHotInlineTest.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/blackhole/BlackholeHotInlineTest.java
@@ -50,13 +50,29 @@ public class BlackholeHotInlineTest {
     static long x, y;
 
     /*
-     * Baseline test: check that dontinline method does not allow the elimination.
+     * Negative test: check that dangling expression is eliminated
+     */
+
+    @Test
+    @IR(failOn = IRNode.MUL_L)
+    static void testNothing() {
+        long r = x * y;
+    }
+
+    @Run(test = "testNothing")
+    static void runNothing() {
+        testNothing();
+    }
+
+    /*
+     * Auxiliary test: check that dontinline method does not allow the elimination.
      */
 
     @Test
     @IR(counts = {IRNode.MUL_L, "1"})
     static void testDontline() {
-        dontinline(x * y);
+        long r = x * y;
+        dontinline(r);
     }
 
     static void dontinline(long x) {}
@@ -73,7 +89,8 @@ public class BlackholeHotInlineTest {
     @Test
     @IR(counts = {IRNode.MUL_L, "1"})
     static void testBlackholed() {
-        blackhole(x * y);
+        long r = x * y;
+        blackhole(r);
     }
 
     static void blackhole(long x) {}


### PR DESCRIPTION
This is seen in some tests: if blackhole method is deemed hot for inlining, then at least C2 would inline it without looking back at its intrinsic status. Which silently breaks blackholes.

The cause is that there are *two* places where intrinsic ID is recorded. Current blackhole code only writes down blackhole intrinsic ID in `Method::intrinsic_id()`, but we should also set it in `ciMethod::intrinsic_id()`, which is used from C2 inlining code. `ciMethod` is normally populated from `Method::intrinsic_id()`, but it happens too early, before setting up blackhole intrinsic. 

Additional testing:
 - [x] Linux x86_64 {fastdebug,release}, wew test fails before the patch, passes with it
 - [x] Linux x86_64 {fastdebug,release} `compiler/blackhole`
 - [x] Linux x86_64 fastdebug, sanity microbenchmark corpus run with the patch

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285394](https://bugs.openjdk.java.net/browse/JDK-8285394): Compiler blackholes can be eliminated due to stale ciMethod::intrinsic_id()


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8344/head:pull/8344` \
`$ git checkout pull/8344`

Update a local copy of the PR: \
`$ git checkout pull/8344` \
`$ git pull https://git.openjdk.java.net/jdk pull/8344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8344`

View PR using the GUI difftool: \
`$ git pr show -t 8344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8344.diff">https://git.openjdk.java.net/jdk/pull/8344.diff</a>

</details>
