### PR TITLE
8285396: Do not fill in the stacktrace of an internal exception

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/source/util/DocTreePath.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/DocTreePath.java
@@ -67,6 +67,7 @@ public class DocTreePath implements Iterable<DocTree> {
             @SuppressWarnings("serial") // Type of field is not Serializable
             DocTreePath path;
             Result(DocTreePath path) {
+                super(null, null, true, false);
                 this.path = path;
             }
         }

--- a/src/jdk.compiler/share/classes/com/sun/source/util/DocTreePath.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/DocTreePath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/source/util/TreePath.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/TreePath.java
@@ -66,6 +66,7 @@ public class TreePath implements Iterable<Tree> {
             @SuppressWarnings("serial") // Type of field is not Serializable
             TreePath path;
             Result(TreePath path) {
+                super(null, null, true, false);
                 this.path = path;
             }
         }

--- a/src/jdk.compiler/share/classes/com/sun/source/util/TreePath.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/TreePath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocPretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocPretty.java
@@ -26,6 +26,7 @@
 package com.sun.tools.javac.tree;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.util.List;
 
@@ -115,14 +116,6 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     /* ************************************************************************
      * Traversal methods
      *************************************************************************/
-
-    /** Exception to propagate IOException through visitXYZ methods */
-    private static final class UncheckedIOException extends Error {
-        static final long serialVersionUID = -4032692679158424751L;
-        UncheckedIOException(IOException e) {
-            super(e.getMessage(), e, true, false);
-        }
-    }
 
     @Override @DefinedBy(Api.COMPILER_TREE)
     public Void visitAttribute(AttributeTree node, Void p) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocPretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocPretty.java
@@ -117,10 +117,10 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
      *************************************************************************/
 
     /** Exception to propagate IOException through visitXYZ methods */
-    private static class UncheckedIOException extends Error {
+    private static final class UncheckedIOException extends Error {
         static final long serialVersionUID = -4032692679158424751L;
         UncheckedIOException(IOException e) {
-            super(e.getMessage(), e);
+            super(e.getMessage(), e, true, false);
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocPretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocPretty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
@@ -171,10 +171,10 @@ public class Pretty extends JCTree.Visitor {
      *************************************************************************/
 
     /** Exception to propagate IOException through visitXYZ methods */
-    private static class UncheckedIOException extends Error {
+    private static final class UncheckedIOException extends Error {
         static final long serialVersionUID = -4032692679158424751L;
         UncheckedIOException(IOException e) {
-            super(e.getMessage(), e);
+            super(e.getMessage(), e, true, false);
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
@@ -170,14 +170,6 @@ public class Pretty extends JCTree.Visitor {
      * Traversal methods
      *************************************************************************/
 
-    /** Exception to propagate IOException through visitXYZ methods */
-    private static final class UncheckedIOException extends Error {
-        static final long serialVersionUID = -4032692679158424751L;
-        UncheckedIOException(IOException e) {
-            super(e.getMessage(), e, true, false);
-        }
-    }
-
     /** Visitor argument: the current precedence level.
      */
     int prec;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
@@ -805,9 +805,10 @@ public class TreeInfo {
     public static List<JCTree> pathFor(final JCTree node, final JCCompilationUnit unit) {
         class Result extends Error {
             static final long serialVersionUID = -5942088234594905625L;
-            @SuppressWarnings("serial") // List not statically Serilizable
+            @SuppressWarnings("serial") // List not statically Serializable
             List<JCTree> path;
             Result(List<JCTree> path) {
+                super(null, null, true, false);
                 this.path = path;
             }
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jshell/share/classes/jdk/jshell/ExpressionToTypeInfo.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/ExpressionToTypeInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jshell/share/classes/jdk/jshell/ExpressionToTypeInfo.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/ExpressionToTypeInfo.java
@@ -147,13 +147,14 @@ class ExpressionToTypeInfo {
     }
 
     // return mechanism and other general structure from TreePath.getPath()
-    private static class Result extends Error {
+    private static final class Result extends Error {
 
         static final long serialVersionUID = -5942088234594905629L;
         @SuppressWarnings("serial") // Not statically typed as Serializable
         final TreePath expressionPath;
 
         Result(TreePath path) {
+            super(null, null, true, false);
             this.expressionPath = path;
         }
     }


### PR DESCRIPTION
Sometimes an exception is retrofitted into control flow to interrupt it in a way that it wasn't originally designed to be interrupted. Such an exception is an implementation detail. Once the exception is caught internally, it is discarded.

An exception has a stacktrace. Filling in a stacktrace is not free. Filling in a stacktrace that won't be used seems like a waste.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8285396](https://bugs.openjdk.java.net/browse/JDK-8285396): Do not fill in the stacktrace of an internal exception


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8347/head:pull/8347` \
`$ git checkout pull/8347`

Update a local copy of the PR: \
`$ git checkout pull/8347` \
`$ git pull https://git.openjdk.java.net/jdk pull/8347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8347`

View PR using the GUI difftool: \
`$ git pr show -t 8347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8347.diff">https://git.openjdk.java.net/jdk/pull/8347.diff</a>

</details>
