### PR TITLE
8285032: vmTestbase/nsk/jdi/EventSet/suspendPolicy/suspendpolicy008/ fails with "eventSet.suspendPolicy() != policyExpected"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/suspendPolicy/suspendpolicy008.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/suspendPolicy/suspendpolicy008.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -247,8 +247,8 @@ public class suspendpolicy008 extends JDIBase {
         getEventSet();
         cpRequest.disable();
 
-        ClassPrepareEvent event = (ClassPrepareEvent) eventIterator.next();
-        debuggeeClass = event.referenceType();
+        ClassPrepareEvent cpEvent = (ClassPrepareEvent) eventIterator.next();
+        debuggeeClass = cpEvent.referenceType();
 
         if (!debuggeeClass.name().equals(debuggeeName))
            throw new JDITestRuntimeException("** Unexpected ClassName for ClassPrepareEvent **");
@@ -371,13 +371,14 @@ public class suspendpolicy008 extends JDIBase {
             }
 
             mainThread.resume();
-            getEventSet();
+            getEventSetForThreadStartDeath("thread" + i);
 
-            if ( !(eventIterator.nextEvent() instanceof ThreadStartEvent)) {
-                 log3("ERROR: new event is not ThreadStartEvent");
+            Event event = eventIterator.nextEvent();
+            if (!(event instanceof ThreadStartEvent)) {
+                log3("ERROR: new event is not ThreadStartEvent: " + event);
                  testExitCode = FAILED;
             } else {
-                log2("......got : instanceof ThreadStartEvent");
+                log2("......got : instanceof ThreadStartEvent: " + event);
                 policy = eventSet.suspendPolicy();
                 if (policy != policyExpected[i]) {
                     log3("ERROR: eventSet.suspendPolicy() != policyExpected");
@@ -418,8 +419,6 @@ public class suspendpolicy008 extends JDIBase {
             throws JDITestRuntimeException {
         try {
             ThreadStartRequest tsr = eventRManager.createThreadStartRequest();
-//            tsr.addThreadFilter(mainThread);
-            tsr.addCountFilter(1);
             tsr.setSuspendPolicy(suspendPolicy);
             tsr.putProperty("number", property);
             return tsr;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/EventFilters.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/EventFilters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -335,6 +335,9 @@ public class EventFilters
             return true;
 
         if (event.toString().contains("JFR request timer"))
+            return true;
+
+        if (event.toString().contains("ForkJoinPool"))
             return true;
 
         return false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/EventFilters.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/EventFilters.java
@@ -337,6 +337,7 @@ public class EventFilters
         if (event.toString().contains("JFR request timer"))
             return true;
 
+        // Filter out any carrier thread that starts while running the test.
         if (event.toString().contains("ForkJoinPool"))
             return true;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/JDIBase.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/JDIBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -165,18 +165,21 @@ public class JDIBase {
             Event event = eventIterator.nextEvent();
             if (event instanceof ThreadStartEvent evt) {
                 if (evt.thread().name().equals(threadName)) {
+                    log2("Got ThreadStartEvent for '" + evt.thread().name());
                     break;
                 }
                 log2("Got ThreadStartEvent for '" + evt.thread().name()
                         + "' instead of '" + threadName + "', skipping");
             } else if (event instanceof ThreadDeathEvent evt) {
                 if (evt.thread().name().equals(threadName)) {
+                    log2("Got ThreadDeathEvent for '" + evt.thread().name());
                     break;
                 }
                 log2("Got ThreadDeathEvent for '" + evt.thread().name()
                         + "' instead of '" + threadName + "', skipping");
             } else {
                 // not ThreadStartEvent nor ThreadDeathEvent
+                log2("Did't get ThreadStartEvent or ThreadDeathEvent: " + event);
                 break;
             }
             eventSet.resume();
@@ -188,15 +191,22 @@ public class JDIBase {
     protected void breakpointForCommunication() throws JDITestRuntimeException {
 
         log2("breakpointForCommunication");
-        getEventSet();
+        while (true) {
+            getEventSet();
 
-        Event event = eventIterator.nextEvent();
-        if (event instanceof BreakpointEvent) {
-            bpEvent = (BreakpointEvent) event;
-            return;
+            Event event = eventIterator.nextEvent();
+            if (event instanceof BreakpointEvent) {
+                bpEvent = (BreakpointEvent) event;
+                return;
+            }
+
+            if (EventFilters.filtered(event)) {
+                // We filter out spurious ThreadStartEvents
+                continue;
+            }
+
+            throw new JDITestRuntimeException("** event '" + event + "' IS NOT a breakpoint **");
         }
-
-        throw new JDITestRuntimeException("** event '" + event + "' IS NOT a breakpoint **");
     }
 
     // Similar to breakpointForCommunication, but skips Locatable events from unexpected locations.


### PR DESCRIPTION
The test is testing that EventSets for ThreadStartEvents have the proper suspendPolicy. When there is more than one ThreadStartRequest and a thread is started, each ThreadStartRequest results in a ThreadStartEvent being created, and they all are grouped into the same EventSet. The suspendPolicy on this EventSet should come from the ThreadStartRequest suspend policy that suspends the most threads. The test is testing for all possible combinations of the 3 suspend polices (NONE, THREAD, and ALL). For example, if NONE and ALL are used, the resulting suspend policy should be ALL.

The following 3 issues are being addressed. These all turned up in loom as a result of carrier threads being created while the test was running, but potentially could happen with other threads that the jvm starts up.

1. When the test calls getEventSet() for the next ThreadStartEvent, it sometimes gets one that is for a carrier thread. In general this is not a problem because the test will accept any thread, but sometimes this carrier thread is generated between setting up two different `ThreadStartRequests`, and as a result has the wrong suspend policy, so the test fails with:

 nsk.share.TestFailure: ##> debugger: ERROR: eventSet.suspendPolicy() != policyExpected 

This is fixed by using getEventSetForThreadStartDeath(<threadName>) instead of getEventSet(), so carrier threads (and any other spuriously created thread) can be ignored.

2. The ThreadStartRequests used a filterCount of 1, which meant they would only produce one ThreadStartEvent. This meant that after fix (1) was in place, I started seeing issues with not even seeing the expected ThreadStartEvent, because the 1 count was used up by the carrier thread starting. I don't see any reason for this filterCount (other than the issue described in 3), so I just removed it.

3. After (1) and (2) were in place, I then noticed issues with sometimes getting a ThreadStartEvent when the BreakpointEvent was expected. This is because sometime a carrier thread was being created after receiving the expected ThreadStartEvent, but before the ThreadStartRequests could be disabled (this is the result of getting rid of the counterFiler). This was fixed by having breakpointForCommunication() filter out unexpected ThreadStartEvents by calling EventFilters.filtered(). I also had to add carrier threads that EventFilters.filtered() filters out.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285032](https://bugs.openjdk.java.net/browse/JDK-8285032): vmTestbase/nsk/jdi/EventSet/suspendPolicy/suspendpolicy008/ fails with "eventSet.suspendPolicy() != policyExpected"


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to 8445f3285dc22091dbb66aa6bc7edfbd4411e62d
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8350/head:pull/8350` \
`$ git checkout pull/8350`

Update a local copy of the PR: \
`$ git checkout pull/8350` \
`$ git pull https://git.openjdk.java.net/jdk pull/8350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8350`

View PR using the GUI difftool: \
`$ git pr show -t 8350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8350.diff">https://git.openjdk.java.net/jdk/pull/8350.diff</a>

</details>
