### PR TITLE
8285386: java/util/HashMap/WhiteBoxResizeTest.java fails in tier7 after JDK-8186958

### DIFF
--- a/test/jdk/java/util/HashMap/WhiteBoxResizeTest.java
+++ b/test/jdk/java/util/HashMap/WhiteBoxResizeTest.java
@@ -51,7 +51,7 @@ import static org.testng.Assert.assertNull;
  * @bug 8186958 8210280 8281631
  * @modules java.base/java.util:open
  * @summary White box tests for HashMap-related internals around table sizing
- * @run testng WhiteBoxResizeTest
+ * @run testng/othervm -Xmx2g WhiteBoxResizeTest
  */
 public class WhiteBoxResizeTest {
 

--- a/test/jdk/java/util/HashMap/WhiteBoxResizeTest.java
+++ b/test/jdk/java/util/HashMap/WhiteBoxResizeTest.java
@@ -48,7 +48,7 @@ import static org.testng.Assert.assertNull;
 
 /*
  * @test
- * @bug 8186958 8210280 8281631
+ * @bug 8186958 8210280 8281631 8285386
  * @modules java.base/java.util:open
  * @summary White box tests for HashMap-related internals around table sizing
  * @run testng/othervm -Xmx2g WhiteBoxResizeTest


### PR DESCRIPTION
Adds `othervm` and `-Xmx2g` options to this test, because the default heap of 768m isn't enough.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285386](https://bugs.openjdk.java.net/browse/JDK-8285386): java/util/HashMap/WhiteBoxResizeTest.java fails in tier7 after JDK-8186958


### Reviewers
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8352/head:pull/8352` \
`$ git checkout pull/8352`

Update a local copy of the PR: \
`$ git checkout pull/8352` \
`$ git pull https://git.openjdk.java.net/jdk pull/8352/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8352`

View PR using the GUI difftool: \
`$ git pr show -t 8352`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8352.diff">https://git.openjdk.java.net/jdk/pull/8352.diff</a>

</details>
