### PR TITLE
8285431: Assertion in NativeGSSContext constructor

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/NativeGSSContext.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/NativeGSSContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -237,7 +237,7 @@ class NativeGSSContext implements GSSContextSpi {
     // Constructor for imported context
     // Warning: called by NativeUtil.c
     NativeGSSContext(long pCtxt, GSSLibStub stub) throws GSSException {
-        assert(pContext != 0);
+        assert(pCtxt != 0);
         pContext = pCtxt;
         cStub = stub;
 


### PR DESCRIPTION
Hi,

May I have the simple update reviewed.

In the NativeGSSContext constructor for imported context, the assert is use on the object field, instead of the input parameters. As in a constructor, `'this'` object does not exist yet, this looks like an obvious issue.  The fix is straightforward as well. 

```
    NativeGSSContext(long pCtxt, GSSLibStub stub) throws GSSException {
-       assert(pContext != 0);
+       assert(pCtxt != 0);
        pContext = pCtxt;
        ...

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285431](https://bugs.openjdk.java.net/browse/JDK-8285431): Assertion in NativeGSSContext constructor


### Reviewers
 * [Daniel Jeliński](https://openjdk.java.net/census#djelinski) (@djelinski - Committer)
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8355/head:pull/8355` \
`$ git checkout pull/8355`

Update a local copy of the PR: \
`$ git checkout pull/8355` \
`$ git pull https://git.openjdk.java.net/jdk pull/8355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8355`

View PR using the GUI difftool: \
`$ git pr show -t 8355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8355.diff">https://git.openjdk.java.net/jdk/pull/8355.diff</a>

</details>
