### PR TITLE
8285437: riscv: Fix MachNode size mismatch for MacroAssembler::verify_oops*

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -378,7 +378,7 @@ void MacroAssembler::verify_oop(Register reg, const char* s) {
   push_reg(RegSet::of(ra, t0, t1, c_rarg0), sp);
 
   mv(c_rarg0, reg); // c_rarg0 : x10
-  li(t0, (uintptr_t)(address)b);
+  mv(t0, (address)b);
 
   // call indirectly to solve generation ordering problem
   int32_t offset = 0;
@@ -414,7 +414,7 @@ void MacroAssembler::verify_oop_addr(Address addr, const char* s) {
     ld(x10, addr);
   }
 
-  li(t0, (uintptr_t)(address)b);
+  mv(t0, (address)b);
 
   // call indirectly to solve generation ordering problem
   int32_t offset = 0;

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -378,6 +378,9 @@ void MacroAssembler::verify_oop(Register reg, const char* s) {
   push_reg(RegSet::of(ra, t0, t1, c_rarg0), sp);
 
   mv(c_rarg0, reg); // c_rarg0 : x10
+  // The length of the instruction sequence emitted should be independent
+  // of the values of the local char buffer address so that the size of mach
+  // nodes for scratch emit and normal emit matches.
   mv(t0, (address)b);
 
   // call indirectly to solve generation ordering problem
@@ -414,6 +417,9 @@ void MacroAssembler::verify_oop_addr(Address addr, const char* s) {
     ld(x10, addr);
   }
 
+  // The length of the instruction sequence emitted should be independent
+  // of the values of the local char buffer address so that the size of mach
+  // nodes for scratch emit and normal emit matches.
   mv(t0, (address)b);
 
   // call indirectly to solve generation ordering problem


### PR DESCRIPTION
Trivial and same as [JDK-8283737](https://bugs.openjdk.java.net/browse/JDK-8283737): in fastdebug build, MacroAssembler::verify_oop is used in match rules encodeHeapOop and decodeHeapOop, which also requires a fixed length.

Logs are inside the JBS issue, and this issue could be reproduced by using `-XX:+VerifyOops`.

Tested using `-XX:+VerifyOops` and a hotspot tier1 on qemu.

Thanks,
Xiaolin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285437](https://bugs.openjdk.java.net/browse/JDK-8285437): riscv: Fix MachNode size mismatch for MacroAssembler::verify_oops*


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to f52442b67de1457dee6c25d82c0d984788d85b08
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8356/head:pull/8356` \
`$ git checkout pull/8356`

Update a local copy of the PR: \
`$ git checkout pull/8356` \
`$ git pull https://git.openjdk.java.net/jdk pull/8356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8356`

View PR using the GUI difftool: \
`$ git pr show -t 8356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8356.diff">https://git.openjdk.java.net/jdk/pull/8356.diff</a>

</details>
