### PR TITLE
8285436: riscv: Fix broken MacroAssembler::debug64

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -530,7 +530,7 @@ void MacroAssembler::resolve_jobject(Register value, Register thread, Register t
 
 void MacroAssembler::stop(const char* msg) {
   address ip = pc();
-  pusha();
+  push_reg(0xffffffff, sp);
   // The length of the instruction sequence emitted should be independent
   // of the values of msg and ip so that the size of mach nodes for scratch
   // emit and normal emit matches.

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -578,7 +578,7 @@ class StubGenerator: public StubCodeGenerator {
     __ bind(error);
     __ pop_reg(0x3000, sp);   // pop c_rarg2 and c_rarg3
 
-    __ pusha();
+    __ push_reg(0xffffffff, sp);
     // debug(char* msg, int64_t pc, int64_t regs[])
     __ mv(c_rarg0, t0);             // pass address of error message
     __ mv(c_rarg1, ra);             // pass return address


### PR DESCRIPTION
`MacroAssembler::stop()`[1] and `StubGenerator::generate_verify_oop()`[2] would first push all regs (calling `MacroAssembler::pusha()`[3]) onto the stack and then call `MacroAssembler::debug64()`[4] to print the pushed regs. But `MacroAssembler::pusha()`[3] won't push x0~x4 so the result of `MacroAssembler::debug64()` is broken.

Tested by manually adding a `__ verify_oop(x1)` and option `-XX:+VerifyOops -XX:+ShowMessageBoxOnError` to deliberately crash the VM to make sure the new result matches the fact. Also a hotspot tier1.

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp#L533
[2] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp#L581
[3] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp#L1126-L1130
[4] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp#L473-L503

Thanks,
Xiaolin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8285436](https://bugs.openjdk.java.net/browse/JDK-8285436): riscv: Fix broken MacroAssembler::debug64


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8357/head:pull/8357` \
`$ git checkout pull/8357`

Update a local copy of the PR: \
`$ git checkout pull/8357` \
`$ git pull https://git.openjdk.java.net/jdk pull/8357/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8357`

View PR using the GUI difftool: \
`$ git pr show -t 8357`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8357.diff">https://git.openjdk.java.net/jdk/pull/8357.diff</a>

</details>
