### PR TITLE
JDK-8285439: remove unused os::fsync

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -663,10 +663,6 @@ jlong os::lseek(int fd, jlong offset, int whence) {
   return (jlong) BSD_ONLY(::lseek) NOT_BSD(::lseek64)(fd, offset, whence);
 }
 
-int os::fsync(int fd) {
-  return ::fsync(fd);
-}
-
 int os::ftruncate(int fd, jlong length) {
    return BSD_ONLY(::ftruncate) NOT_BSD(::ftruncate64)(fd, length);
 }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4977,21 +4977,6 @@ int os::get_fileno(FILE* fp) {
   return _fileno(fp);
 }
 
-// This code is a copy of JDK's sysSync
-// from src/windows/hpi/src/sys_api_md.c
-// except for the legacy workaround for a bug in Win 98
-
-int os::fsync(int fd) {
-  HANDLE handle = (HANDLE)::_get_osfhandle(fd);
-
-  if ((!::FlushFileBuffers(handle)) &&
-      (GetLastError() != ERROR_ACCESS_DENIED)) {
-    // from winerror.h
-    return -1;
-  }
-  return 0;
-}
-
 void os::flockfile(FILE* fp) {
   _lock_file(fp);
 }

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -549,7 +549,6 @@ class os: AllStatic {
   // the input pointer.
   static char* native_path(char *path);
   static int ftruncate(int fd, jlong length);
-  static int fsync(int fd);
   static int get_fileno(FILE* fp);
   static void flockfile(FILE* fp);
   static void funlockfile(FILE* fp);


### PR DESCRIPTION
Please review this small change; it removes the unused os::fsync function .
Thanks, Matthias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285439](https://bugs.openjdk.java.net/browse/JDK-8285439): remove unused os::fsync


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8358/head:pull/8358` \
`$ git checkout pull/8358`

Update a local copy of the PR: \
`$ git checkout pull/8358` \
`$ git pull https://git.openjdk.java.net/jdk pull/8358/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8358`

View PR using the GUI difftool: \
`$ git pr show -t 8358`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8358.diff">https://git.openjdk.java.net/jdk/pull/8358.diff</a>

</details>
