### PR TITLE
8285477: Add a PRECISION public static field to j.l.Float and j.l.Double

### DIFF
--- a/src/java.base/share/classes/java/lang/Double.java
+++ b/src/java.base/share/classes/java/lang/Double.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/Double.java
+++ b/src/java.base/share/classes/java/lang/Double.java
@@ -206,13 +206,29 @@ public final class Double extends Number
     public static final double MIN_VALUE = 0x0.0000000000001P-1022; // 4.9e-324
 
     /**
+     * The number of bits used to represent a {@code double} value.
+     *
+     * @since 1.5
+     */
+    public static final int SIZE = 64;
+
+    /**
+     * The number of bits in the significand of a {@code double} value.
+     * This is the parameter N in section {@jls 4.2.3} of
+     * <em>The Java Language Specification</em>.
+     *
+     * @since 19
+     */
+    public static final int PRECISION = 53;
+
+    /**
      * Maximum exponent a finite {@code double} variable may have.
      * It is equal to the value returned by
      * {@code Math.getExponent(Double.MAX_VALUE)}.
      *
      * @since 1.6
      */
-    public static final int MAX_EXPONENT = 1023;
+    public static final int MAX_EXPONENT = (1 << (SIZE - PRECISION - 1)) - 1;
 
     /**
      * Minimum exponent a normalized {@code double} variable may
@@ -221,14 +237,7 @@ public final class Double extends Number
      *
      * @since 1.6
      */
-    public static final int MIN_EXPONENT = -1022;
-
-    /**
-     * The number of bits used to represent a {@code double} value.
-     *
-     * @since 1.5
-     */
-    public static final int SIZE = 64;
+    public static final int MIN_EXPONENT = 1 - MAX_EXPONENT;
 
     /**
      * The number of bytes used to represent a {@code double} value.

--- a/src/java.base/share/classes/java/lang/Double.java
+++ b/src/java.base/share/classes/java/lang/Double.java
@@ -215,7 +215,7 @@ public final class Double extends Number
     /**
      * The number of bits in the significand of a {@code double} value.
      * This is the parameter N in section {@jls 4.2.3} of
-     * <em>The Java Language Specification</em>.
+     * <cite>The Java Language Specification</cite>.
      *
      * @since 19
      */
@@ -228,7 +228,7 @@ public final class Double extends Number
      *
      * @since 1.6
      */
-    public static final int MAX_EXPONENT = (1 << (SIZE - PRECISION - 1)) - 1;
+    public static final int MAX_EXPONENT = (1 << (SIZE - PRECISION - 1)) - 1; // 1023
 
     /**
      * Minimum exponent a normalized {@code double} variable may
@@ -237,7 +237,7 @@ public final class Double extends Number
      *
      * @since 1.6
      */
-    public static final int MIN_EXPONENT = 1 - MAX_EXPONENT;
+    public static final int MIN_EXPONENT = 1 - MAX_EXPONENT; // -1022
 
     /**
      * The number of bytes used to represent a {@code double} value.

--- a/src/java.base/share/classes/java/lang/Float.java
+++ b/src/java.base/share/classes/java/lang/Float.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/Float.java
+++ b/src/java.base/share/classes/java/lang/Float.java
@@ -125,7 +125,7 @@ public final class Float extends Number
     /**
      * The number of bits in the significand of a {@code float} value.
      * This is the parameter N in section {@jls 4.2.3} of
-     * <em>The Java Language Specification</em>.
+     * <cite>The Java Language Specification</cite>.
      *
      * @since 19
      */
@@ -138,7 +138,7 @@ public final class Float extends Number
      *
      * @since 1.6
      */
-    public static final int MAX_EXPONENT = (1 << (SIZE - PRECISION - 1)) - 1;
+    public static final int MAX_EXPONENT = (1 << (SIZE - PRECISION - 1)) - 1; // 127
 
     /**
      * Minimum exponent a normalized {@code float} variable may have.
@@ -147,7 +147,7 @@ public final class Float extends Number
      *
      * @since 1.6
      */
-    public static final int MIN_EXPONENT = 1 - MAX_EXPONENT;
+    public static final int MIN_EXPONENT = 1 - MAX_EXPONENT; // -126
 
     /**
      * The number of bytes used to represent a {@code float} value.

--- a/src/java.base/share/classes/java/lang/Float.java
+++ b/src/java.base/share/classes/java/lang/Float.java
@@ -116,13 +116,29 @@ public final class Float extends Number
     public static final float MIN_VALUE = 0x0.000002P-126f; // 1.4e-45f
 
     /**
+     * The number of bits used to represent a {@code float} value.
+     *
+     * @since 1.5
+     */
+    public static final int SIZE = 32;
+
+    /**
+     * The number of bits in the significand of a {@code float} value.
+     * This is the parameter N in section {@jls 4.2.3} of
+     * <em>The Java Language Specification</em>.
+     *
+     * @since 19
+     */
+    public static final int PRECISION = 24;
+
+    /**
      * Maximum exponent a finite {@code float} variable may have.  It
      * is equal to the value returned by {@code
      * Math.getExponent(Float.MAX_VALUE)}.
      *
      * @since 1.6
      */
-    public static final int MAX_EXPONENT = 127;
+    public static final int MAX_EXPONENT = (1 << (SIZE - PRECISION - 1)) - 1;
 
     /**
      * Minimum exponent a normalized {@code float} variable may have.
@@ -131,14 +147,7 @@ public final class Float extends Number
      *
      * @since 1.6
      */
-    public static final int MIN_EXPONENT = -126;
-
-    /**
-     * The number of bits used to represent a {@code float} value.
-     *
-     * @since 1.5
-     */
-    public static final int SIZE = 32;
+    public static final int MIN_EXPONENT = 1 - MAX_EXPONENT;
 
     /**
      * The number of bytes used to represent a {@code float} value.


### PR DESCRIPTION
Add useful constants specified in IEEE 754.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8285477](https://bugs.openjdk.java.net/browse/JDK-8285477): Add a PRECISION public static field to j.l.Float and j.l.Double
 * [JDK-8285241](https://bugs.openjdk.java.net/browse/JDK-8285241): Add a PRECISION public static field to j.l.Float and j.l.Double (**CSR**)


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8362/head:pull/8362` \
`$ git checkout pull/8362`

Update a local copy of the PR: \
`$ git checkout pull/8362` \
`$ git pull https://git.openjdk.java.net/jdk pull/8362/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8362`

View PR using the GUI difftool: \
`$ git pr show -t 8362`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8362.diff">https://git.openjdk.java.net/jdk/pull/8362.diff</a>

</details>
