### PR TITLE
8285246: AArch64: remove overflow check from InterpreterMacroAssembler::increment_mdp_data_at

### DIFF
--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -961,35 +961,15 @@ void InterpreterMacroAssembler::increment_mdp_data_at(Register mdp_in,
   }
 
   if (decrement) {
-    // Decrement the register.  Set condition codes.
-    // Intel does this
-    // addptr(data, (int32_t) -DataLayout::counter_increment);
-    // If the decrement causes the counter to overflow, stay negative
-    // Label L;
-    // jcc(Assembler::negative, L);
-    // addptr(data, (int32_t) DataLayout::counter_increment);
-    // so we do this
+    // Decrement the register.  No point checking for 64-bit underflow.
     ldr(rscratch1, addr);
-    subs(rscratch1, rscratch1, (unsigned)DataLayout::counter_increment);
-    Label L;
-    br(Assembler::LO, L);       // skip store if counter underflow
+    sub(rscratch1, rscratch1, (unsigned)DataLayout::counter_increment);
     str(rscratch1, addr);
-    bind(L);
   } else {
-    assert(DataLayout::counter_increment == 1,
-           "flow-free idiom only works with 1");
-    // Intel does this
-    // Increment the register.  Set carry flag.
-    // addptr(data, DataLayout::counter_increment);
-    // If the increment causes the counter to overflow, pull back by 1.
-    // sbbptr(data, (int32_t)0);
-    // so we do this
+    // Increment the register.  No point checking for 64-bit overflow.
     ldr(rscratch1, addr);
-    adds(rscratch1, rscratch1, DataLayout::counter_increment);
-    Label L;
-    br(Assembler::CS, L);       // skip store if counter overflow
+    add(rscratch1, rscratch1, DataLayout::counter_increment);
     str(rscratch1, addr);
-    bind(L);
   }
 }
 
@@ -1075,17 +1055,9 @@ void InterpreterMacroAssembler::profile_taken_branch(Register mdp,
     //increment_mdp_data_at(mdp, in_bytes(JumpData::taken_offset()));
     Address data(mdp, in_bytes(JumpData::taken_offset()));
     ldr(bumped_count, data);
-    assert(DataLayout::counter_increment == 1,
-            "flow-free idiom only works with 1");
-    // Intel does this to catch overflow
-    // addptr(bumped_count, DataLayout::counter_increment);
-    // sbbptr(bumped_count, 0);
-    // so we do this
-    adds(bumped_count, bumped_count, DataLayout::counter_increment);
-    Label L;
-    br(Assembler::CS, L);       // skip store if counter overflow
+    add(bumped_count, bumped_count, DataLayout::counter_increment);
     str(bumped_count, data);
-    bind(L);
+
     // The method data pointer needs to be updated to reflect the new target.
     update_mdp_by_offset(mdp, in_bytes(JumpData::displacement_offset()));
     bind(profile_continue);


### PR DESCRIPTION
Several reasons to do this:

- A 64-bit counter is realistically never going to overflow in the interpreter.  The PPC64 port also doesn't check for overflow for this reason.

- It's inconsistent with C1 which does not check for overflow.  (See e.g. `LIRGenerator::profile_branch()` which does `__ leal(...)` to add and explicitly doesn't set the flags.)

- We're checking for 64-bit overflow as the MDO cells are word-sized but accessors like `BranchData::taken()` silently truncate to uint which is 32 bit.  So I don't think this check is doing anything useful.

- I'd like to experiment with using LSE far atomics to update the MDO counters here, but the overflow check prevents that.

Tested jtreg tier1-3 and also verified that the counters for a particular test method were the same before and after when run with -Xbatch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8285246](https://bugs.openjdk.java.net/browse/JDK-8285246): AArch64: remove overflow check from InterpreterMacroAssembler::increment_mdp_data_at


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8363/head:pull/8363` \
`$ git checkout pull/8363`

Update a local copy of the PR: \
`$ git checkout pull/8363` \
`$ git pull https://git.openjdk.java.net/jdk pull/8363/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8363`

View PR using the GUI difftool: \
`$ git pr show -t 8363`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8363.diff">https://git.openjdk.java.net/jdk/pull/8363.diff</a>

</details>
