### PR TITLE
8285404: RSA signature verification should reject non-DER OCTET STRING

### DIFF
--- a/src/java.base/share/classes/sun/security/rsa/RSASignature.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSASignature.java
@@ -213,10 +213,12 @@ abstract class RSASignature extends SignatureSpi {
                     RSACore.getByteLength(publicKey));
             }
             byte[] digest = getDigestValue();
+            // https://www.rfc-editor.org/rfc/rfc8017.html#section-8.2.2
+            // Step 4: Compare the encoded message, not the decoded.
+            byte[] encoded = RSAUtil.encodeSignature(digestOID, digest);
             byte[] decrypted = RSACore.rsa(sigBytes, publicKey);
             byte[] unpadded = padding.unpad(decrypted);
-            byte[] decodedDigest = RSAUtil.decodeSignature(digestOID, unpadded);
-            return MessageDigest.isEqual(digest, decodedDigest);
+            return MessageDigest.isEqual(unpadded, encoded);
         } catch (javax.crypto.BadPaddingException e) {
             // occurs if the app has used the wrong RSA public key
             // or if sigBytes is invalid

--- a/src/java.base/share/classes/sun/security/rsa/RSAUtil.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAUtil.java
@@ -28,6 +28,7 @@ package sun.security.rsa;
 import java.io.IOException;
 import java.security.*;
 import java.security.spec.*;
+import sun.security.util.DerInputStream;
 import sun.security.util.DerOutputStream;
 import sun.security.util.DerValue;
 import sun.security.util.ObjectIdentifier;
@@ -177,5 +178,32 @@ public class RSAUtil {
         DerValue result =
             new DerValue(DerValue.tag_Sequence, out.toByteArray());
         return result.toByteArray();
+    }
+
+    /**
+     * Decode the signature data. Verify that the object identifier matches
+     * and return the message digest.
+     */
+    public static byte[] decodeSignature(ObjectIdentifier oid, byte[] sig)
+            throws IOException {
+        // Enforce strict DER checking for signatures
+        DerInputStream in = new DerInputStream(sig, 0, sig.length, false);
+        DerValue[] values = in.getSequence(2);
+        if ((values.length != 2) || (in.available() != 0)) {
+            throw new IOException("SEQUENCE length error");
+        }
+        AlgorithmId algId = AlgorithmId.parse(values[0]);
+        if (algId.getOID().equals(oid) == false) {
+            throw new IOException("ObjectIdentifier mismatch: "
+                + algId.getOID());
+        }
+        if (algId.getEncodedParams() != null) {
+            throw new IOException("Unexpected AlgorithmId parameters");
+        }
+        if (values[1].isConstructed()) {
+            throw new IOException("Unexpected constructed digest value");
+        }
+        byte[] digest = values[1].getOctetString();
+        return digest;
     }
 }

--- a/src/java.base/share/classes/sun/security/rsa/RSAUtil.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAUtil.java
@@ -28,7 +28,6 @@ package sun.security.rsa;
 import java.io.IOException;
 import java.security.*;
 import java.security.spec.*;
-import sun.security.util.DerInputStream;
 import sun.security.util.DerOutputStream;
 import sun.security.util.DerValue;
 import sun.security.util.ObjectIdentifier;
@@ -178,29 +177,5 @@ public class RSAUtil {
         DerValue result =
             new DerValue(DerValue.tag_Sequence, out.toByteArray());
         return result.toByteArray();
-    }
-
-    /**
-     * Decode the signature data. Verify that the object identifier matches
-     * and return the message digest.
-     */
-    public static byte[] decodeSignature(ObjectIdentifier oid, byte[] sig)
-            throws IOException {
-        // Enforce strict DER checking for signatures
-        DerInputStream in = new DerInputStream(sig, 0, sig.length, false);
-        DerValue[] values = in.getSequence(2);
-        if ((values.length != 2) || (in.available() != 0)) {
-            throw new IOException("SEQUENCE length error");
-        }
-        AlgorithmId algId = AlgorithmId.parse(values[0]);
-        if (algId.getOID().equals(oid) == false) {
-            throw new IOException("ObjectIdentifier mismatch: "
-                + algId.getOID());
-        }
-        if (algId.getEncodedParams() != null) {
-            throw new IOException("Unexpected AlgorithmId parameters");
-        }
-        byte[] digest = values[1].getOctetString();
-        return digest;
     }
 }


### PR DESCRIPTION
Compare encoded instead of decoded digest in RSA signature verification.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285404](https://bugs.openjdk.java.net/browse/JDK-8285404): RSA signature verification should reject non-DER OCTET STRING


### Reviewers
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8365/head:pull/8365` \
`$ git checkout pull/8365`

Update a local copy of the PR: \
`$ git checkout pull/8365` \
`$ git pull https://git.openjdk.java.net/jdk pull/8365/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8365`

View PR using the GUI difftool: \
`$ git pr show -t 8365`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8365.diff">https://git.openjdk.java.net/jdk/pull/8365.diff</a>

</details>
