### PR TITLE
8285447: StackWalker minimal batch size should be optimized for getCallerClass

### DIFF
--- a/src/java.base/share/classes/java/lang/StackStreamFactory.java
+++ b/src/java.base/share/classes/java/lang/StackStreamFactory.java
@@ -65,10 +65,15 @@ final class StackStreamFactory {
     // lazily add subclasses when they are loaded.
     private static final Set<Class<?>> stackWalkImplClasses = init();
 
-    private static final int SMALL_BATCH       = 8;
+    // Minimum batch size for any walker. The shortest walk is for getCallerClass,
+    // which would need to skip a few of StackWalker own frames.
+    private static final int MIN_BATCH_SIZE    = 4;
+
+    // Heuristic sizes to balance the stack walk costs, for both smaller and
+    // larger stacks.
+    private static final int SMALL_BATCH       = MIN_BATCH_SIZE;
     private static final int BATCH_SIZE        = 32;
     private static final int LARGE_BATCH_SIZE  = 256;
-    private static final int MIN_BATCH_SIZE    = SMALL_BATCH;
 
     // These flags must match the values maintained in the VM
     @Native private static final int DEFAULT_MODE              = 0x0;


### PR DESCRIPTION
In a simple benchmark like:

```
@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
@Fork(value = 3, jvmArgsAppend = {"-Xmx1g", "-Xms1g"})
@State(Scope.Benchmark)
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.MICROSECONDS)
public class CallerClassBench {
    static final StackWalker INST = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);

    @Benchmark
    public Class<?> stackWalker() {
        return INST.getCallerClass();
    }
} 
```

...it becomes quickly evident that `MIN_BATCH_SIZE` of `8` is too much, since we only reach for 4-th frame on the stack. Dropping it to 4 like this improves the `getCallerClass` performance significantly:

```
 before: 0.884 ± 0.036 us/op
 after:  0.461 ± 0.012 us/op ; +92%
```

While this improvement targets `getCallerClass`, we can also keep `SMALL_BATCH` equal to new `MIN_BATCH_SIZE`, which effectively drops it to `4` as well, and brings related improvements for general cases as well. That said, we can limit the effect on this patch to `MIN_BATCH_SIZE` only, and still reap the benefits for `getCallerClass` alone.

Existing microbenchmarks show these improvements and regressions:

```
o.o.b.j.lang.StackWalkBench.getCallerClass:
 @depth=4, +20%
 @depth=100, +18%

o.o.b.j.lang.StackWalkBench.walk_filterCallerClass:
 @depth=4, +20%
 @depth=100, +15%

o.o.b.j.lang.StackWalkBench.walk_filterCallerClassHalfStack:
 @depth=4, -9% [regression: StackWalker does two batches instead of one now]
 @depth=100, +13%

o.o.b.j.util.logging.LoggingRuntimeMicros.testLoggingInferCaller:
 @depth=4, +10%
 @depth=100, +11%
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8285447](https://bugs.openjdk.java.net/browse/JDK-8285447): StackWalker minimal batch size should be optimized for getCallerClass


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8366/head:pull/8366` \
`$ git checkout pull/8366`

Update a local copy of the PR: \
`$ git checkout pull/8366` \
`$ git pull https://git.openjdk.java.net/jdk pull/8366/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8366`

View PR using the GUI difftool: \
`$ git pr show -t 8366`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8366.diff">https://git.openjdk.java.net/jdk/pull/8366.diff</a>

</details>
