### PR TITLE
JDK-8267690: Revisit (Doc)Tree search implemented by throwing an exception

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/source/util/DocTreePath.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/DocTreePath.java
@@ -59,38 +59,45 @@ public class DocTreePath implements Iterable<DocTree> {
      * @return a path identifying the target node
      */
     public static DocTreePath getPath(DocTreePath path, DocTree target) {
-        Objects.requireNonNull(path); //null check
-        Objects.requireNonNull(target); //null check
+        Objects.requireNonNull(path);
+        Objects.requireNonNull(target);
 
-        class Result extends Error {
-            static final long serialVersionUID = -5942088234594905625L;
-            @SuppressWarnings("serial") // Type of field is not Serializable
-            DocTreePath path;
-            Result(DocTreePath path) {
-                this.path = path;
+        class PathFinder extends DocTreePathScanner<DocTreePath, DocTree> {
+            private DocTreePath result;
+
+            @Override
+            public DocTreePath scan(DocTreePath path, DocTree docTree) {
+                super.scan(path, docTree);
+                return result;
             }
-        }
 
-        class PathFinder extends DocTreePathScanner<DocTreePath,DocTree> {
             @Override
             public DocTreePath scan(DocTree tree, DocTree target) {
-                if (tree == target) {
-                    throw new Result(new DocTreePath(getCurrentPath(), target));
+                if (result == null) {
+                    if (tree == target) {
+                        result = new DocTreePath(getCurrentPath(), target);
+                    } else {
+                        super.scan(tree, target);
+                    }
                 }
-                return super.scan(tree, target);
+                return result;
+            }
+
+            @Override
+            public DocTreePath scan(Iterable<? extends DocTree> nodes, DocTree docTree) {
+                if (nodes != null) {
+                    for (DocTree node : nodes) {
+                        scan(node, docTree);
+                        if (result != null) {
+                            break;
+                        }
+                    }
+                }
+                return result;
             }
         }
-
-        if (path.getLeaf() == target) {
-            return path;
-        }
-
-        try {
-            new PathFinder().scan(path, target);
-        } catch (Result result) {
-            return result.path;
-        }
-        return null;
+        return path.getLeaf() == target ? path
+                : new PathFinder().scan(path, target);
     }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/source/util/DocTreePath.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/DocTreePath.java
@@ -85,7 +85,7 @@ public class DocTreePath implements Iterable<DocTree> {
 
             @Override
             public DocTreePath scan(Iterable<? extends DocTree> nodes, DocTree docTree) {
-                if (nodes != null) {
+                if (nodes != null && result == null) {
                     for (DocTree node : nodes) {
                         scan(node, docTree);
                         if (result != null) {

--- a/src/jdk.compiler/share/classes/com/sun/source/util/DocTreePath.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/DocTreePath.java
@@ -66,8 +66,8 @@ public class DocTreePath implements Iterable<DocTree> {
             private DocTreePath result;
 
             @Override
-            public DocTreePath scan(DocTreePath path, DocTree docTree) {
-                super.scan(path, docTree);
+            public DocTreePath scan(DocTreePath path, DocTree target) {
+                super.scan(path, target);
                 return result;
             }
 
@@ -84,10 +84,10 @@ public class DocTreePath implements Iterable<DocTree> {
             }
 
             @Override
-            public DocTreePath scan(Iterable<? extends DocTree> nodes, DocTree docTree) {
+            public DocTreePath scan(Iterable<? extends DocTree> nodes, DocTree target) {
                 if (nodes != null && result == null) {
                     for (DocTree node : nodes) {
-                        scan(node, docTree);
+                        scan(node, target);
                         if (result != null) {
                             break;
                         }

--- a/src/jdk.compiler/share/classes/com/sun/source/util/TreePath.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/TreePath.java
@@ -66,8 +66,8 @@ public class TreePath implements Iterable<Tree> {
 
 
             @Override
-            public TreePath scan(TreePath path, Tree docTree) {
-                super.scan(path, docTree);
+            public TreePath scan(TreePath path, Tree target) {
+                super.scan(path, target);
                 return result;
             }
 
@@ -84,10 +84,10 @@ public class TreePath implements Iterable<Tree> {
             }
 
             @Override
-            public TreePath scan(Iterable<? extends Tree> nodes, Tree tree) {
+            public TreePath scan(Iterable<? extends Tree> nodes, Tree target) {
                 if (nodes != null && result == null) {
                     for (Tree node : nodes) {
-                        scan(node, tree);
+                        scan(node, target);
                         if (result != null) {
                             break;
                         }

--- a/src/jdk.compiler/share/classes/com/sun/source/util/TreePath.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/TreePath.java
@@ -85,7 +85,7 @@ public class TreePath implements Iterable<Tree> {
 
             @Override
             public TreePath scan(Iterable<? extends Tree> nodes, Tree tree) {
-                if (nodes != null) {
+                if (nodes != null && result == null) {
                     for (Tree node : nodes) {
                         scan(node, tree);
                         if (result != null) {

--- a/src/jdk.compiler/share/classes/com/sun/source/util/TreePath.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/TreePath.java
@@ -61,34 +61,44 @@ public class TreePath implements Iterable<Tree> {
         Objects.requireNonNull(path);
         Objects.requireNonNull(target);
 
-        class Result extends Error {
-            static final long serialVersionUID = -5942088234594905625L;
-            @SuppressWarnings("serial") // Type of field is not Serializable
-            TreePath path;
-            Result(TreePath path) {
-                this.path = path;
-            }
-        }
-
         class PathFinder extends TreePathScanner<TreePath,Tree> {
+            private TreePath result;
+
+
+            @Override
+            public TreePath scan(TreePath path, Tree docTree) {
+                super.scan(path, docTree);
+                return result;
+            }
+
+            @Override
             public TreePath scan(Tree tree, Tree target) {
-                if (tree == target) {
-                    throw new Result(new TreePath(getCurrentPath(), target));
+                if (result == null) {
+                    if (tree == target) {
+                        result = new TreePath(getCurrentPath(), target);
+                    } else {
+                        super.scan(tree, target);
+                    }
                 }
-                return super.scan(tree, target);
+                return result;
+            }
+
+            @Override
+            public TreePath scan(Iterable<? extends Tree> nodes, Tree tree) {
+                if (nodes != null) {
+                    for (Tree node : nodes) {
+                        scan(node, tree);
+                        if (result != null) {
+                            break;
+                        }
+                    }
+                }
+                return result;
             }
         }
 
-        if (path.getLeaf() == target) {
-            return path;
-        }
-
-        try {
-            new PathFinder().scan(path, target);
-        } catch (Result result) {
-            return result.path;
-        }
-        return null;
+        return path.getLeaf() == target ? path
+                : new PathFinder().scan(path, target);
     }
 
     /**


### PR DESCRIPTION
Please review a moderately simple cleanup change, to eliminate using an exception to terminate scanning a `Tree` or `DocTree` in `(Doc)TreePath.getPath`.

The change is to set a field with the intended result, and once that field is set, do "best-effort" to eliminate any additional scanning.

It is easy enough to stop scanning items in a list, but it is not practical to totally stop scanning the subsequent sibling nodes, but we can substantially reduce the cost of scanning those nodes, and can definitely avoid scanning any children of those nodes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267690](https://bugs.openjdk.java.net/browse/JDK-8267690): Revisit (Doc)Tree search implemented by throwing an exception


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**) ⚠️ Review applies to 32aab7f0b116992b813a3759ebf44e8d8e3cbdb8
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8369/head:pull/8369` \
`$ git checkout pull/8369`

Update a local copy of the PR: \
`$ git checkout pull/8369` \
`$ git pull https://git.openjdk.java.net/jdk pull/8369/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8369`

View PR using the GUI difftool: \
`$ git pr show -t 8369`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8369.diff">https://git.openjdk.java.net/jdk/pull/8369.diff</a>

</details>
