### PR TITLE
JDK-8202790: DnD test DisposeFrameOnDragTest.java does not clean up

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -469,7 +469,6 @@ java/awt/image/VolatileImage/GradientPaints.java 8199003 linux-all
 java/awt/JAWT/JAWT.sh 8197798 windows-all,linux-all
 java/awt/Robot/RobotWheelTest/RobotWheelTest.java 8129827 generic-all
 java/awt/datatransfer/ConstructFlavoredObjectTest/ConstructFlavoredObjectTest.java 8202860 linux-all
-java/awt/dnd/DisposeFrameOnDragCrash/DisposeFrameOnDragTest.java 8202790 macosx-all,linux-all
 java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java 8202882 linux-all
 java/awt/dnd/MissingDragExitEventTest/MissingDragExitEventTest.java 8030121 macosx-all,linux-all
 java/awt/Choice/ChoicePopupLocation/ChoicePopupLocation.java 8202931 macosx-all,linux-all

--- a/test/jdk/java/awt/dnd/DisposeFrameOnDragCrash/DisposeFrameOnDragTest.java
+++ b/test/jdk/java/awt/dnd/DisposeFrameOnDragCrash/DisposeFrameOnDragTest.java
@@ -49,6 +49,7 @@ import test.java.awt.regtesthelpers.Util;
 public class DisposeFrameOnDragTest {
 
     private static JTextArea textArea;
+    private static JFrame background;
 
     public static void main(String[] args) throws Throwable {
 
@@ -77,9 +78,15 @@ public class DisposeFrameOnDragTest {
         Util.waitForIdle(testRobot);
 
         testRobot.delay(200);
+        background.dispose();
     }
 
     private static void constructTestUI() {
+        background = new JFrame("Background");
+        background.setBounds(100, 100, 100, 100);
+        background.setUndecorated(true);
+        background.setVisible(true);
+
         final JFrame frame = new JFrame("Test frame");
         textArea = new JTextArea("Drag Me!");
         try {

--- a/test/jdk/java/awt/dnd/DisposeFrameOnDragCrash/DisposeFrameOnDragTest.java
+++ b/test/jdk/java/awt/dnd/DisposeFrameOnDragCrash/DisposeFrameOnDragTest.java
@@ -73,7 +73,7 @@ public class DisposeFrameOnDragTest {
         Util.drag(testRobot,
                 new Point((int) loc.x + 3, (int) loc.y + 3),
                 new Point((int) loc.x + 40, (int) loc.y + 40),
-                InputEvent.BUTTON1_MASK);
+                InputEvent.BUTTON1_DOWN_MASK);
 
         Util.waitForIdle(testRobot);
 


### PR DESCRIPTION
Added a background to the test to prevent the file from dragging onto the desktop and creating an extra file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8202790](https://bugs.openjdk.java.net/browse/JDK-8202790): DnD test DisposeFrameOnDragTest.java does not clean up


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to e9dace84d32da4ca0c940ab940d30facf1e05c88
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8370/head:pull/8370` \
`$ git checkout pull/8370`

Update a local copy of the PR: \
`$ git checkout pull/8370` \
`$ git pull https://git.openjdk.java.net/jdk pull/8370/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8370`

View PR using the GUI difftool: \
`$ git pr show -t 8370`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8370.diff">https://git.openjdk.java.net/jdk/pull/8370.diff</a>

</details>
