### PR TITLE
8285389: EdDSA trimming zeros

### DIFF
--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAOperations.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSAOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -134,6 +134,11 @@ public class EdDSAOperations {
         if (signature == null) {
             throw new SignatureException("signature was null");
         }
+
+        if (params.getKeyLength() * 2 != signature.length) {
+            throw new SignatureException("signature length invalid");
+        }
+
         byte[] encR = Arrays.copyOf(signature, signature.length / 2);
         byte[] encS = Arrays.copyOfRange(signature, signature.length / 2,
             signature.length);


### PR DESCRIPTION
Hi,

I'd like a code review of this change to EdDSA. ed25519 and ed448 internally was trimming extra zeros off the end of the signature before processing. This can result in some verify testing failures which are strict about the signature length passed into the operation. 

thanks

Tony