### PR TITLE
8285445: cannot open file "NUL:"

### DIFF
--- a/src/java.base/windows/classes/java/io/WinNTFileSystem.java
+++ b/src/java.base/windows/classes/java/io/WinNTFileSystem.java
@@ -48,16 +48,15 @@ class WinNTFileSystem extends FileSystem {
 
     // Whether to enable alternative data streams (ADS) by suppressing
     // checking the path for invalid characters, in particular ":".
-    // ADS support will be enabled if and only if the property is set and
-    // is the empty string or is equal, ignoring case, to the string "true".
-    // By default ADS support is disabled.
+    // By default, ADS support is enabled and will be disabled if and
+    // only if the property is set, ignoring case, to the string "false".
     private static final boolean ENABLE_ADS;
     static {
         String enableADS = GetPropertyAction.privilegedGetProperty("jdk.io.File.enableADS");
         if (enableADS != null) {
-            ENABLE_ADS = "".equals(enableADS) || Boolean.parseBoolean(enableADS);
+            ENABLE_ADS = !enableADS.equalsIgnoreCase(Boolean.FALSE.toString());
         } else {
-            ENABLE_ADS = false;
+            ENABLE_ADS = true;
         }
     }
 

--- a/test/jdk/java/io/FileOutputStream/OpenNUL.java
+++ b/test/jdk/java/io/FileOutputStream/OpenNUL.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8285445
+ * @requires (os.family == "windows")
+ * @summary Verify behavior of opening "NUL:" with ADS enabled and disabled.
+ * @run main/othervm -Djdk.io.File.enableADS OpenNUL
+ * @run main/othervm -Djdk.io.File.enableADS=true OpenNUL
+ */
+
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+public class OpenNUL {
+    public static void main(String args[]) throws IOException {
+        String enableADS = System.getProperty("jdk.io.File.enableADS");
+        boolean fails = enableADS.equalsIgnoreCase(Boolean.FALSE.toString());
+
+        FileOutputStream fos;
+        try {
+            fos = new FileOutputStream("NUL:");
+            if (fails)
+                throw new RuntimeException("Should have failed");
+        } catch (FileNotFoundException fnfe) {
+            if (!fails)
+                throw new RuntimeException("Should not have failed");
+        }
+    }
+}


### PR DESCRIPTION
Change the default value of the `jdk.io.File.enableADS` property to `true`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8285445](https://bugs.openjdk.java.net/browse/JDK-8285445): cannot open file "NUL:"
 * [JDK-8285500](https://bugs.openjdk.java.net/browse/JDK-8285500): cannot open file "NUL:" (**CSR**)


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8373/head:pull/8373` \
`$ git checkout pull/8373`

Update a local copy of the PR: \
`$ git checkout pull/8373` \
`$ git pull https://git.openjdk.java.net/jdk pull/8373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8373`

View PR using the GUI difftool: \
`$ git pr show -t 8373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8373.diff">https://git.openjdk.java.net/jdk/pull/8373.diff</a>

</details>
