### PR TITLE
JDK-8284994: -Xdoclint:all returns warning for records, even when documented properly

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
@@ -187,7 +187,7 @@ public class Checker extends DocTreePathScanner<Void, Void> {
                     if (isNormalClass(p.getParentPath())) {
                         reportMissing("dc.default.constructor");
                     }
-                } else if (!isOverridingMethod && !isSynthetic() && !isAnonymous()) {
+                } else if (!isOverridingMethod && !isSynthetic() && !isAnonymous() && !isRecordComponentOrField()) {
                     reportMissing("dc.missing.comment");
                 }
                 return null;
@@ -248,26 +248,28 @@ public class Checker extends DocTreePathScanner<Void, Void> {
 
         scan(new DocTreePath(p, tree), null);
 
-        if (!isOverridingMethod) {
-            switch (env.currElement.getKind()) {
-                case METHOD:
-                case CONSTRUCTOR: {
-                    ExecutableElement ee = (ExecutableElement) env.currElement;
-                    checkParamsDocumented(ee.getTypeParameters());
-                    checkParamsDocumented(ee.getParameters());
-                    switch (ee.getReturnType().getKind()) {
-                        case VOID:
-                        case NONE:
-                            break;
-                        default:
-                            if (!foundReturn
-                                    && !foundInheritDoc
-                                    && !env.types.isSameType(ee.getReturnType(), env.java_lang_Void)) {
-                                reportMissing("dc.missing.return");
-                            }
+        // the following checks are made after the scan, which will record @param tags
+        if (isDeclaredType()) {
+            TypeElement te = (TypeElement) env.currElement;
+            // checkParamsDocumented(te.getTypeParameters()); // See JDK-8285496
+            checkParamsDocumented(te.getRecordComponents());
+        } else if (isExecutable()) {
+            if (!isOverridingMethod) {
+                ExecutableElement ee = (ExecutableElement) env.currElement;
+                checkParamsDocumented(ee.getTypeParameters());
+                checkParamsDocumented(ee.getParameters());
+                switch (ee.getReturnType().getKind()) {
+                    case VOID, NONE -> {
                     }
-                    checkThrowsDocumented(ee.getThrownTypes());
+                    default -> {
+                        if (!foundReturn
+                                && !foundInheritDoc
+                                && !env.types.isSameType(ee.getReturnType(), env.java_lang_Void)) {
+                            reportMissing("dc.missing.return");
+                        }
+                    }
                 }
+                checkThrowsDocumented(ee.getThrownTypes());
             }
         }
 
@@ -1205,6 +1207,26 @@ public class Checker extends DocTreePathScanner<Void, Void> {
                 return env.getPos(p) == env.getPos(p.getParentPath());
         }
         return false;
+    }
+
+    private boolean isDeclaredType() {
+        ElementKind ek = env.currElement.getKind();
+        return ek.isClass() || ek.isInterface();
+    }
+
+    private boolean isExecutable() {
+        ElementKind ek = env.currElement.getKind();
+        return switch (ek) {
+            case CONSTRUCTOR, METHOD -> true;
+            default -> false;
+        };
+    }
+
+    private boolean isRecordComponentOrField() {
+        return env.currElement.getKind() == ElementKind.RECORD_COMPONENT
+            || env.currElement.getEnclosingElement() != null
+                && env.currElement.getEnclosingElement().getKind() == ElementKind.RECORD
+                && env.currElement.getKind() == ElementKind.FIELD;
     }
 
     private boolean isNormalClass(TreePath p) {

--- a/test/langtools/tools/doclint/MissingRecordParamsTest.java
+++ b/test/langtools/tools/doclint/MissingRecordParamsTest.java
@@ -1,0 +1,12 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8004832 8284994
+ * @summary Add new doclint package
+ * @modules jdk.javadoc/jdk.javadoc.internal.doclint
+ * @build DocLintTester
+ * @run main DocLintTester -Xmsgs:-missing MissingRecordParamsTest.java
+ * @run main DocLintTester -Xmsgs:missing -ref MissingRecordParamsTest.out MissingRecordParamsTest.java
+ */
+
+/** . */
+public record MissingRecordParamsTest(int x) {  }

--- a/test/langtools/tools/doclint/MissingRecordParamsTest.out
+++ b/test/langtools/tools/doclint/MissingRecordParamsTest.out
@@ -1,0 +1,4 @@
+MissingRecordParamsTest.java:12: warning: no @param for x
+public record MissingRecordParamsTest(int x) {  }
+       ^
+1 warning

--- a/test/langtools/tools/doclint/RecordParamsTest.java
+++ b/test/langtools/tools/doclint/RecordParamsTest.java
@@ -1,0 +1,16 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8004832 8284994
+ * @summary Add new doclint package
+ * @modules jdk.javadoc/jdk.javadoc.internal.doclint
+ * @build DocLintTester
+ * @run main DocLintTester -Xmsgs:all -ref RecordParamsTest.out RecordParamsTest.java
+ */
+
+/**
+ * Comment.
+ * @param a aaa
+ * @param a aaa
+ * @param z zzz
+ */
+public record RecordParamsTest(int a, int b, int c) {  }

--- a/test/langtools/tools/doclint/RecordParamsTest.out
+++ b/test/langtools/tools/doclint/RecordParamsTest.out
@@ -1,0 +1,14 @@
+RecordParamsTest.java:13: warning: @param "a" has already been specified
+ * @param a aaa
+   ^
+RecordParamsTest.java:14: error: invalid use of @param
+ * @param z zzz
+   ^
+RecordParamsTest.java:16: warning: no @param for b
+public record RecordParamsTest(int a, int b, int c) {  }
+       ^
+RecordParamsTest.java:16: warning: no @param for c
+public record RecordParamsTest(int a, int b, int c) {  }
+       ^
+1 error
+3 warnings


### PR DESCRIPTION
Please review a small fix to address issues with records in DocLint when invoked from javac. Bottom line, record components or their fields should never have direct documentation comments (and so the absence of comments should not be reported as "missing") ... they should be documented with `@param` tags in the doc comment for the record itself.

In the course of this work, it was observed that DocLint does not check for `@param` tags for type parameters on a class or interface declaration. Fixing that uncovers issues in the JDK API documentation, so that part of the fix is disabled for now, and a followup bug has been filed. [JDK-8285496](https://bugs.openjdk.java.net/browse/JDK-8285496)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284994](https://bugs.openjdk.java.net/browse/JDK-8284994): -Xdoclint:all returns warning for records, even when documented properly


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8375/head:pull/8375` \
`$ git checkout pull/8375`

Update a local copy of the PR: \
`$ git checkout pull/8375` \
`$ git pull https://git.openjdk.java.net/jdk pull/8375/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8375`

View PR using the GUI difftool: \
`$ git pr show -t 8375`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8375.diff">https://git.openjdk.java.net/jdk/pull/8375.diff</a>

</details>
