### PR TITLE
8285523: Improve test java/io/FileOutputStream/OpenNUL.java

### DIFF
--- a/test/jdk/java/io/FileOutputStream/OpenNUL.java
+++ b/test/jdk/java/io/FileOutputStream/OpenNUL.java
@@ -26,7 +26,9 @@
  * @bug 8285445
  * @requires (os.family == "windows")
  * @summary Verify behavior of opening "NUL:" with ADS enabled and disabled.
+ * @run main/othervm OpenNUL
  * @run main/othervm -Djdk.io.File.enableADS OpenNUL
+ * @run main/othervm -Djdk.io.File.enableADS=FalsE OpenNUL
  * @run main/othervm -Djdk.io.File.enableADS=true OpenNUL
  */
 
@@ -36,7 +38,7 @@ import java.io.IOException;
 
 public class OpenNUL {
     public static void main(String args[]) throws IOException {
-        String enableADS = System.getProperty("jdk.io.File.enableADS");
+        String enableADS = System.getProperty("jdk.io.File.enableADS", "true");
         boolean fails = enableADS.equalsIgnoreCase(Boolean.FALSE.toString());
 
         FileOutputStream fos;


### PR DESCRIPTION
The new test added as part of the [JDK-8285445](https://bugs.openjdk.java.net/browse/JDK-8285445) cannot trigger that bug and pass w/ and w/o fix.

An updated test validates the "default" case when the `jdk.io.File.enableADS` property is not set, in this case the ADS should be [accepted](https://github.com/openjdk/jdk/blob/9d9f4e502f6ddc3116ed9b80f7168a1edfce839e/src/java.base/windows/classes/java/io/WinNTFileSystem.java#L59).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285523](https://bugs.openjdk.java.net/browse/JDK-8285523): Improve test java/io/FileOutputStream/OpenNUL.java


### Reviewers
 * [Andrew John Hughes](https://openjdk.java.net/census#andrew) (@gnu-andrew - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8379/head:pull/8379` \
`$ git checkout pull/8379`

Update a local copy of the PR: \
`$ git checkout pull/8379` \
`$ git pull https://git.openjdk.java.net/jdk pull/8379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8379`

View PR using the GUI difftool: \
`$ git pr show -t 8379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8379.diff">https://git.openjdk.java.net/jdk/pull/8379.diff</a>

</details>
