### PR TITLE
8284951: Compile::flatten_alias_type asserts with "indeterminate pointers come only from unsafe ops"

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1294,7 +1294,7 @@ const TypePtr *Compile::flatten_alias_type( const TypePtr *tj ) const {
 
   // Process weird unsafe references.
   if (offset == Type::OffsetBot && (tj->isa_instptr() /*|| tj->isa_klassptr()*/)) {
-    assert(InlineUnsafeOps, "indeterminate pointers come only from unsafe ops");
+    assert(InlineUnsafeOps || StressReflectiveCode, "indeterminate pointers come only from unsafe ops");
     assert(!is_known_inst, "scalarizable allocation should not have unsafe references");
     tj = TypeOopPtr::BOTTOM;
     ptr = tj->ptr();

--- a/test/hotspot/jtreg/compiler/arraycopy/TestCloneWithStressReflectiveCode.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestCloneWithStressReflectiveCode.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8284951
+ * @summary Test clone intrinsic with StressReflectiveCode.
+ * @run main/othervm -XX:-InlineUnsafeOps -XX:-ReduceInitialCardMarks -XX:+StressReflectiveCode -Xbatch -XX:-TieredCompilation
+ *                   -XX:CompileCommand=dontinline,compiler.arraycopy.TestCloneWithStressReflectiveCode::test
+ *                   compiler.arraycopy.TestCloneWithStressReflectiveCode
+ * @run main/othervm -XX:-InlineUnsafeOps -XX:-ReduceInitialCardMarks -XX:+StressReflectiveCode -Xcomp -XX:-TieredCompilation
+ *                   compiler.arraycopy.TestCloneWithStressReflectiveCode
+ */
+
+package compiler.arraycopy;
+
+public class TestCloneWithStressReflectiveCode implements Cloneable {
+
+    public Object test() throws CloneNotSupportedException {
+        return clone();
+    }
+
+    public static void main(String[] args) throws CloneNotSupportedException {
+        TestCloneWithStressReflectiveCode t = new TestCloneWithStressReflectiveCode();
+        for (int i = 0; i < 50_000; ++i) {
+            t.test();
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/arraycopy/TestCloneWithStressReflectiveCode.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestCloneWithStressReflectiveCode.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8284951
  * @summary Test clone intrinsic with StressReflectiveCode.
+ * @requires vm.debug
  * @run main/othervm -XX:-InlineUnsafeOps -XX:-ReduceInitialCardMarks -XX:+StressReflectiveCode -Xbatch -XX:-TieredCompilation
  *                   -XX:CompileCommand=dontinline,compiler.arraycopy.TestCloneWithStressReflectiveCode::test
  *                   compiler.arraycopy.TestCloneWithStressReflectiveCode


### PR DESCRIPTION
The `Object.clone()` intrinsic emits an arraycopy guarded by an array check. With `StressReflectiveCode` the arraycopy is not removed even if the source object is statically known to be a non-array instance. This triggers an assert in `Compile::flatten_alias_type asserts` because the (arraycopy) address type is an instance pointer with bottom offset.

The fix is to disable the assert when `StressReflectiveCode` is enabled.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284951](https://bugs.openjdk.java.net/browse/JDK-8284951): Compile::flatten_alias_type asserts with "indeterminate pointers come only from unsafe ops"


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8381/head:pull/8381` \
`$ git checkout pull/8381`

Update a local copy of the PR: \
`$ git checkout pull/8381` \
`$ git pull https://git.openjdk.java.net/jdk pull/8381/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8381`

View PR using the GUI difftool: \
`$ git pr show -t 8381`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8381.diff">https://git.openjdk.java.net/jdk/pull/8381.diff</a>

</details>
