### PR TITLE
8284779: Test java/util/logging/Logger/logrb/TestLogrbResourceBundle.java fails intermittently with vthreads wrapper

### DIFF
--- a/test/jdk/java/util/logging/Logger/logrb/TestLogrbResourceBundle.java
+++ b/test/jdk/java/util/logging/Logger/logrb/TestLogrbResourceBundle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+import java.lang.ref.Reference;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Objects;
@@ -316,6 +317,11 @@ public class TestLogrbResourceBundle {
             // Now we're going to the same thing, but with a logger which
             // has an inherited resource bundle.
             Logger foobaz = Logger.getLogger("foo.bar.baz");
+
+            // keep "foo.bar" logger alive until its child has
+            // been created. A child logger has a strong
+            // reference to its first parent.
+            Reference.reachabilityFence(foobar);
 
             // check that foobaz has no bundle set locally.
             if (foobaz.getResourceBundle() != null) {

--- a/test/jdk/java/util/logging/Logger/logrb/TestLogrbResourceBundle.java
+++ b/test/jdk/java/util/logging/Logger/logrb/TestLogrbResourceBundle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Hi,

Please find enclosed a patch to fix a rare intermittent failure that was detected while testing virtual threads.
The issue has nothing to do with virtual threads, the test is simply missing a reachability fence to make sure that the parent logger is not garbage collected until its child logger is created.

best regards,

-- daniel

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284779](https://bugs.openjdk.java.net/browse/JDK-8284779): Test java/util/logging/Logger/logrb/TestLogrbResourceBundle.java fails intermittently with vthreads wrapper


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8382/head:pull/8382` \
`$ git checkout pull/8382`

Update a local copy of the PR: \
`$ git checkout pull/8382` \
`$ git pull https://git.openjdk.java.net/jdk pull/8382/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8382`

View PR using the GUI difftool: \
`$ git pr show -t 8382`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8382.diff">https://git.openjdk.java.net/jdk/pull/8382.diff</a>

</details>
