### PR TITLE
8284319: Test runtime/cds/appcds/TestParallelGCWithCDS.java fails in repo-loom

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
@@ -114,12 +114,10 @@ public class TestParallelGCWithCDS {
                 if (out.getExitValue() == 0) {
                     out.shouldContain(HELLO);
                 } else {
-                    String output = out.getStdout() + out.getStderr();
-                    String exp1 = "Too small maximum heap";
-                    String exp2 = "GC triggered before VM initialization completed";
-                    if (!output.contains(exp1) && !output.contains(exp2)) {
-                        throw new RuntimeException("Either '" + exp1 + "' or '" + exp2 + "' must be in stdout/stderr \n");
-                    }
+                    String pattern = "((Too small maximum heap)" +
+                                       "|(GC triggered before VM initialization completed)" +
+                                       "|(java.lang.OutOfMemoryError: Java heap space))";
+                    out.shouldMatch(pattern);
                 }
                 n++;
             }


### PR DESCRIPTION
When the TestParallelGCWithCDS.java test is run with the `-Xcomp` and `-XX:MaxRAMPercentage` VM options with loom jdk, an `OutOfMemoryError` could occur early during `initPhase2`.

This change is for adjusting the test to account for the `OutOfMemoryError`.

Ran the test multiple times with the `-Xcomp`, etc. VM options.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284319](https://bugs.openjdk.java.net/browse/JDK-8284319): Test runtime/cds/appcds/TestParallelGCWithCDS.java fails in repo-loom


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8385/head:pull/8385` \
`$ git checkout pull/8385`

Update a local copy of the PR: \
`$ git checkout pull/8385` \
`$ git pull https://git.openjdk.java.net/jdk pull/8385/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8385`

View PR using the GUI difftool: \
`$ git pr show -t 8385`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8385.diff">https://git.openjdk.java.net/jdk/pull/8385.diff</a>

</details>
