### PR TITLE
8285279: ArgumentsTest.set_numeric_flag_double_vm fails on some locales (again)

### DIFF
--- a/test/hotspot/gtest/runtime/test_arguments.cpp
+++ b/test/hotspot/gtest/runtime/test_arguments.cpp
@@ -593,13 +593,13 @@ TEST_VM_F(ArgumentsTest, set_numeric_flag_double) {
   for (uint i = 0; i < ARRAY_SIZE(more_test_strings); i++) {
     const char* str = more_test_strings[i];
 
-    char* dummy;
+    char* end;
     errno = 0;
-    double expected = strtod(str, &dummy);
-    if (errno == 0) {
+    double expected = strtod(str, &end);
+    if (errno == 0 && end != NULL && *end == '\0') {
       ASSERT_TRUE(ArgumentsTest::parse_argument(flag->name(), str))
         << "Test string '" <<
-        str << "' did not parse for type " << flag->type_string() << ".";
+        str << "' did not parse for type " << flag->type_string() << ". (Expected value = " << expected << ")";
       double d = flag->get_double();
       ASSERT_TRUE(d == expected)
         << "Parsed number " << d << " is not the same as expected " << expected;


### PR DESCRIPTION
Please review this trivial fix for ArgumentsTest.set_numeric_flag_double_vm. If an input string is only partially accepted by `strtod()` under the current locale , `end` will point to a non-empty character. In this case, the test should treat the input as invalid.

Thanks to @tstuefe for providing the test scenario.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285279](https://bugs.openjdk.java.net/browse/JDK-8285279): ArgumentsTest.set_numeric_flag_double_vm fails on some locales (again)


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8386/head:pull/8386` \
`$ git checkout pull/8386`

Update a local copy of the PR: \
`$ git checkout pull/8386` \
`$ git pull https://git.openjdk.java.net/jdk pull/8386/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8386`

View PR using the GUI difftool: \
`$ git pr show -t 8386`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8386.diff">https://git.openjdk.java.net/jdk/pull/8386.diff</a>

</details>
