### PR TITLE
8285611: Retrofit (Doc)Pretty with java.io.UncheckedIOException

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocPretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/DocPretty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package com.sun.tools.javac.tree;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.util.List;
 
@@ -64,7 +65,7 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
                 tree.accept(this, null);
             }
         } catch (UncheckedIOException ex) {
-            throw new IOException(ex.getMessage(), ex);
+            throw ex.getCause();
         }
     }
 
@@ -115,14 +116,6 @@ public class DocPretty implements DocTreeVisitor<Void,Void> {
     /* ************************************************************************
      * Traversal methods
      *************************************************************************/
-
-    /** Exception to propagate IOException through visitXYZ methods */
-    private static class UncheckedIOException extends Error {
-        static final long serialVersionUID = -4032692679158424751L;
-        UncheckedIOException(IOException e) {
-            super(e.getMessage(), e);
-        }
-    }
 
     @Override @DefinedBy(Api.COMPILER_TREE)
     public Void visitAttribute(AttributeTree node, Void p) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
@@ -170,14 +170,6 @@ public class Pretty extends JCTree.Visitor {
      * Traversal methods
      *************************************************************************/
 
-    /** Exception to propagate IOException through visitXYZ methods */
-    private static class UncheckedIOException extends Error {
-        static final long serialVersionUID = -4032692679158424751L;
-        UncheckedIOException(IOException e) {
-            super(e.getMessage(), e);
-        }
-    }
-
     /** Visitor argument: the current precedence level.
      */
     int prec;
@@ -194,7 +186,7 @@ public class Pretty extends JCTree.Visitor {
                 tree.accept(this);
             }
         } catch (UncheckedIOException ex) {
-            throw new IOException(ex.getMessage(), ex);
+            throw ex.getCause();
         } finally {
             this.prec = prevPrec;
         }


### PR DESCRIPTION
Standard `java.io.UncheckedIOException` is more convenient than older ad-hoc `com.sun.tools.javac.tree.(Doc)Pretty.UncheckedIOException`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285611](https://bugs.openjdk.java.net/browse/JDK-8285611): Retrofit (Doc)Pretty with java.io.UncheckedIOException


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8387/head:pull/8387` \
`$ git checkout pull/8387`

Update a local copy of the PR: \
`$ git checkout pull/8387` \
`$ git pull https://git.openjdk.java.net/jdk pull/8387/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8387`

View PR using the GUI difftool: \
`$ git pr show -t 8387`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8387.diff">https://git.openjdk.java.net/jdk/pull/8387.diff</a>

</details>
