### PR TITLE
8284632: runtime/Thread/StopAtExit.java possibly leaking memory again

### DIFF
--- a/src/hotspot/share/runtime/handshake.hpp
+++ b/src/hotspot/share/runtime/handshake.hpp
@@ -52,11 +52,9 @@ class HandshakeClosure : public ThreadClosure, public CHeapObj<mtThread> {
   virtual ~HandshakeClosure()                      {}
   const char* name() const                         { return _name; }
   virtual bool is_async()                          { return false; }
-  virtual bool is_async_installer()                { return false; }
   virtual bool is_suspend()                        { return false; }
   virtual bool is_async_exception()                { return false; }
   virtual bool is_ThreadDeath()                    { return false; }
-  virtual void do_cleanup()                        {}
   virtual void do_thread(Thread* thread) = 0;
 };
 
@@ -128,13 +126,13 @@ class HandshakeState {
 
  public:
   HandshakeState(JavaThread* thread);
+  ~HandshakeState();
 
   void add_operation(HandshakeOperation* op);
 
   bool has_operation() { return !_queue.is_empty(); }
   bool has_operation(bool allow_suspend, bool check_async_exception);
   bool has_async_exception_operation(bool ThreadDeath_only);
-  void clean_async_exception_operation();
 
   bool operation_pending(HandshakeOperation* op);
 

--- a/src/hotspot/share/runtime/handshake.hpp
+++ b/src/hotspot/share/runtime/handshake.hpp
@@ -52,9 +52,11 @@ class HandshakeClosure : public ThreadClosure, public CHeapObj<mtThread> {
   virtual ~HandshakeClosure()                      {}
   const char* name() const                         { return _name; }
   virtual bool is_async()                          { return false; }
+  virtual bool is_async_installer()                { return false; }
   virtual bool is_suspend()                        { return false; }
   virtual bool is_async_exception()                { return false; }
   virtual bool is_ThreadDeath()                    { return false; }
+  virtual void do_cleanup()                        {}
   virtual void do_thread(Thread* thread) = 0;
 };
 
@@ -132,6 +134,7 @@ class HandshakeState {
   bool has_operation() { return !_queue.is_empty(); }
   bool has_operation(bool allow_suspend, bool check_async_exception);
   bool has_async_exception_operation(bool ThreadDeath_only);
+  void clean_async_exception_operation();
 
   bool operation_pending(HandshakeOperation* op);
 

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1375,17 +1375,26 @@ void JavaThread::exit(bool destroy_vm, ExitType exit_type) {
       // implementation specific clean-up by calling Thread.exit(). We prevent any
       // asynchronous exceptions from being delivered while in Thread.exit()
       // to ensure the clean-up is not corrupted.
-      NoAsyncExceptionDeliveryMark _no_async(this);
+      {
+        NoAsyncExceptionDeliveryMark _no_async(this);
 
-      EXCEPTION_MARK;
-      JavaValue result(T_VOID);
-      Klass* thread_klass = vmClasses::Thread_klass();
-      JavaCalls::call_virtual(&result,
-                              threadObj, thread_klass,
-                              vmSymbols::exit_method_name(),
-                              vmSymbols::void_method_signature(),
-                              THREAD);
-      CLEAR_PENDING_EXCEPTION;
+        EXCEPTION_MARK;
+        JavaValue result(T_VOID);
+        Klass* thread_klass = vmClasses::Thread_klass();
+        JavaCalls::call_virtual(&result,
+                                threadObj, thread_klass,
+                                vmSymbols::exit_method_name(),
+                                vmSymbols::void_method_signature(),
+                                THREAD);
+        CLEAR_PENDING_EXCEPTION;
+      }
+
+      // If we have an async exception pending at this point, then it was
+      // queued up while NoAsyncExceptionDeliveryMark was active above so
+      // it could not be processed by this target thread.
+      if (has_async_exception_condition(/* ThreadDeath_only */ false)) {
+        handshake_state()->clean_async_exception_operation();
+      }
     }
 
     // notify JVMTI
@@ -1670,6 +1679,10 @@ class InstallAsyncExceptionHandshake : public HandshakeClosure {
 public:
   InstallAsyncExceptionHandshake(AsyncExceptionHandshake* aeh) :
     HandshakeClosure("InstallAsyncException"), _aeh(aeh) {}
+  virtual bool is_async_installer()                { return true; }
+  void do_cleanup() {
+    delete _aeh;
+  }
   void do_thread(Thread* thr) {
     JavaThread* target = JavaThread::cast(thr);
     target->install_async_exception(_aeh);

--- a/test/hotspot/jtreg/runtime/Thread/StopAtExit.java
+++ b/test/hotspot/jtreg/runtime/Thread/StopAtExit.java
@@ -93,7 +93,15 @@ public class StopAtExit extends Thread {
             // the thread is terminated.
             ThreadGroup myTG = new ThreadGroup("myTG-" + count);
             myTG.setDaemon(true);
-            Throwable myException = new ThreadDeath();
+            Throwable myException;
+            if ((count % 1) == 1) {
+              // Throw RuntimeException before ThreadDeath since a
+              // ThreadDeath can also be queued up when there's already
+              // a non-ThreadDeath async execution queued up.
+              myException = new RuntimeException();
+            } else {
+              myException = new ThreadDeath();
+            }
             int retCode;
             StopAtExit thread = new StopAtExit(myTG, null);
             thread.start();


### PR DESCRIPTION
Throwing async exceptions at exiting JavaThreads can leak the exception:

1) HandshakeOperation::do_handshake() recognizes that the target thread
    might be terminated, but needs to do some cleanup when the operation
    is one that installs an async exception.

2) JavaThread::exit() uses a NoAsyncExceptionDeliveryMark to protect the
    VM's call out to Thread::exit() from async exceptions, but it needs to do
    some cleanup when those async exceptions cannot be delivered because
    the target thread has logically exited.

Also tweaked runtime/Thread/StopAtExit.java to alternate between throwing
RuntimeException and ThreadDeath. The async exception queuing code accepts
any exception, but it recognizes ThreadDeath as special. When a target thread
already has a queued async ThreadDeath exception, then another exception will
not be queued. So the test now throws RuntimeException on odd iterations and
ThreadDeath on even iterations and the target thread will have at most two async
exceptions queued up.

This fix has been tested with Mach5 Tier[1-7] (about to start a Tier8) and I also ran
my StressWrapper_StopAtExit.java test using {release, fastdebug, and slowdebug}
bits for 12 hours per config. No leaks detected. Previously, release bits would
fail with OutOfMemoryException in ~2 minutes with StressWrapper_StopAtExit.java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284632](https://bugs.openjdk.java.net/browse/JDK-8284632): runtime/Thread/StopAtExit.java possibly leaking memory again


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.java.net/census#pchilanomate) (@pchilano - **Reviewer**)
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8388/head:pull/8388` \
`$ git checkout pull/8388`

Update a local copy of the PR: \
`$ git checkout pull/8388` \
`$ git pull https://git.openjdk.java.net/jdk pull/8388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8388`

View PR using the GUI difftool: \
`$ git pr show -t 8388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8388.diff">https://git.openjdk.java.net/jdk/pull/8388.diff</a>

</details>
