### PR TITLE
JDK-8285614: Fix typo in java.lang.Float

### DIFF
--- a/src/java.base/share/classes/java/lang/Float.java
+++ b/src/java.base/share/classes/java/lang/Float.java
@@ -57,7 +57,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * The class {@code java.lang.Double} has a <a
  * href="Double.html#equivalenceRelation">discussion of equality,
  * equivalence, and comparison of floating-point values</a> that is
- * equality applicable to {@code float} values.
+ * equally applicable to {@code float} values.
  *
  * @author  Lee Boynton
  * @author  Arthur van Hoff


### PR DESCRIPTION
Fix typo introduced in JDK-8261123.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285614](https://bugs.openjdk.java.net/browse/JDK-8285614): Fix typo in java.lang.Float


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8390/head:pull/8390` \
`$ git checkout pull/8390`

Update a local copy of the PR: \
`$ git checkout pull/8390` \
`$ git pull https://git.openjdk.java.net/jdk pull/8390/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8390`

View PR using the GUI difftool: \
`$ git pr show -t 8390`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8390.diff">https://git.openjdk.java.net/jdk/pull/8390.diff</a>

</details>
