### PR TITLE
8285518: CDS assert: visibility cannot change between dump time and runtime

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1006,14 +1006,6 @@ bool SystemDictionary::is_shared_class_visible_impl(Symbol* class_name,
   assert(!ik->is_shared_unregistered_class(), "this function should be called for built-in classes only");
   assert(scp_index >= 0, "must be");
   SharedClassPathEntry* scp_entry = FileMapInfo::shared_path(scp_index);
-
-  if (UseNewCode && class_name->equals("jdk/internal/ref/Cleaner")) {
-    while (!Universe::is_module_initialized()) {
-      tty->print_cr("Cleaner: wait for Universe::is_module_initialized(), pkg_entry = %p", pkg_entry);
-      os::naked_short_sleep(200);
-    }
-  }
-
   if (!Universe::is_module_initialized()) {
     assert(scp_entry != NULL && scp_entry->is_modules_image(),
            "Loading non-bootstrap classes before the module system is initialized");
@@ -1021,7 +1013,7 @@ bool SystemDictionary::is_shared_class_visible_impl(Symbol* class_name,
     return true;
   }
 
-  if (UseNewCode2 && pkg_entry == NULL) {
+  if (pkg_entry == NULL) {
     // We might have looked up pkg_entry before the module system was initialized.
     // Need to reload it now.
     TempNewSymbol pkg_name = ClassLoader::package_from_class_name(class_name);
@@ -1291,9 +1283,6 @@ InstanceKlass* SystemDictionary::load_instance_class_impl(Symbol* class_name, Ha
 #if INCLUDE_CDS
     if (UseSharedSpaces)
     {
-      if (UseNewCode && class_name->equals("jdk/internal/ref/Cleaner")) {
-        tty->print_cr("Cleaner pkg_entry = %p", pkg_entry);
-      }
       PerfTraceTime vmtimer(ClassLoader::perf_shared_classload_time());
       InstanceKlass* ik = SystemDictionaryShared::find_builtin_class(class_name);
       if (ik != NULL && ik->is_shared_boot_class() && !ik->shared_loading_failed()) {

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -191,7 +191,7 @@ public abstract sealed class Reference<T>
     /* High-priority thread to enqueue pending References
      */
     private static class ReferenceHandler extends Thread {
-        private static final boolean DEBUG = true;
+
         private static void ensureClassInitialized(Class<?> clazz) {
             try {
                 Class.forName(clazz.getName(), true, clazz.getClassLoader());
@@ -204,7 +204,7 @@ public abstract sealed class Reference<T>
             // pre-load and initialize Cleaner class so that we don't
             // get into trouble later in the run loop if there's
             // memory shortage while loading/initializing it lazily.
-            if (!DEBUG) ensureClassInitialized(Cleaner.class);
+            ensureClassInitialized(Cleaner.class);
         }
 
         ReferenceHandler(ThreadGroup g, String name) {
@@ -212,7 +212,6 @@ public abstract sealed class Reference<T>
         }
 
         public void run() {
-            if (DEBUG) ensureClassInitialized(Cleaner.class);
             while (true) {
                 processPendingReferences();
             }

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -191,7 +191,7 @@ public abstract sealed class Reference<T>
     /* High-priority thread to enqueue pending References
      */
     private static class ReferenceHandler extends Thread {
-
+        private static final boolean DEBUG = true;
         private static void ensureClassInitialized(Class<?> clazz) {
             try {
                 Class.forName(clazz.getName(), true, clazz.getClassLoader());
@@ -204,7 +204,7 @@ public abstract sealed class Reference<T>
             // pre-load and initialize Cleaner class so that we don't
             // get into trouble later in the run loop if there's
             // memory shortage while loading/initializing it lazily.
-            ensureClassInitialized(Cleaner.class);
+            if (!DEBUG) ensureClassInitialized(Cleaner.class);
         }
 
         ReferenceHandler(ThreadGroup g, String name) {
@@ -212,6 +212,7 @@ public abstract sealed class Reference<T>
         }
 
         public void run() {
+            if (DEBUG) ensureClassInitialized(Cleaner.class);
             while (true) {
                 processPendingReferences();
             }


### PR DESCRIPTION
This PR fixes a timing hole in the CDS class loading code. The bug happens with the `jdk/internal/ref/Cleaner` class, which is loaded by the boot classloader.

- The loading of `Cleaner` is initiated
- We look up the `pkg_entry` for this class
- At this point, the module system is not yet fully initialized, so package information is not yet available, and we get `pkg_entry == NULL`
- Later, in `SystemDictionary::is_shared_class_visible_impl`, we try to check the visbility of this class, but now the module system is fully initialized, so the NULL `pkg_entry` is no longer valid.

The fix is to always reload the  `pkg_entry` if it's NULL. This should happen very rarely because  `pkg_entry`  for archived classes are usually non-null.

This timing hole existed before but has been triggered (once) only after Loom changed the bootstrap sequence of the reference thread. Nonetheless we should backport to older JDKs since there's still a theoretical chance this it may happen, and the fix is simple.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8285518](https://bugs.openjdk.java.net/browse/JDK-8285518): CDS assert: visibility cannot change between dump time and runtime


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8392/head:pull/8392` \
`$ git checkout pull/8392`

Update a local copy of the PR: \
`$ git checkout pull/8392` \
`$ git pull https://git.openjdk.java.net/jdk pull/8392/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8392`

View PR using the GUI difftool: \
`$ git pr show -t 8392`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8392.diff">https://git.openjdk.java.net/jdk/pull/8392.diff</a>

</details>
