### PR TITLE
JDK-8285610: TreeInfo.pathFor and its uses appear to be dead code

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTaskImpl.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTaskImpl.java
@@ -489,10 +489,6 @@ public class JavacTaskImpl extends BasicJavacTask {
         return results;
     }
 
-    public Iterable<? extends Tree> pathFor(CompilationUnitTree unit, Tree node) {
-        return TreeInfo.pathFor((JCTree) node, (JCTree.JCCompilationUnit) unit).reverse();
-    }
-
     public void ensureEntered() {
         args.allowEmpty();
         enter(null);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
@@ -793,44 +793,6 @@ public class TreeInfo {
         return s.result;
     }
 
-    public static Env<AttrContext> scopeFor(JCTree node, JCCompilationUnit unit) {
-        return scopeFor(pathFor(node, unit));
-    }
-
-    public static Env<AttrContext> scopeFor(List<JCTree> path) {
-        // TODO: not implemented yet
-        throw new UnsupportedOperationException("not implemented yet");
-    }
-
-    public static List<JCTree> pathFor(final JCTree node, final JCCompilationUnit unit) {
-        class Result extends Error {
-            static final long serialVersionUID = -5942088234594905625L;
-            @SuppressWarnings("serial") // List not statically Serilizable
-            List<JCTree> path;
-            Result(List<JCTree> path) {
-                this.path = path;
-            }
-        }
-        class PathFinder extends TreeScanner {
-            List<JCTree> path = List.nil();
-            public void scan(JCTree tree) {
-                if (tree != null) {
-                    path = path.prepend(tree);
-                    if (tree == node)
-                        throw new Result(path);
-                    super.scan(tree);
-                    path = path.tail;
-                }
-            }
-        }
-        try {
-            new PathFinder().scan(unit);
-        } catch (Result result) {
-            return result.path;
-        }
-        return List.nil();
-    }
-
     /** Return the statement referenced by a label.
      *  If the label refers to a loop or switch, return that switch
      *  otherwise return the labelled statement itself


### PR DESCRIPTION
Please review a trivial change to remove some unused/dead code. 

All tier1 tests pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285610](https://bugs.openjdk.java.net/browse/JDK-8285610): TreeInfo.pathFor and its uses appear to be dead code


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8393/head:pull/8393` \
`$ git checkout pull/8393`

Update a local copy of the PR: \
`$ git checkout pull/8393` \
`$ git pull https://git.openjdk.java.net/jdk pull/8393/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8393`

View PR using the GUI difftool: \
`$ git pr show -t 8393`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8393.diff">https://git.openjdk.java.net/jdk/pull/8393.diff</a>

</details>
