### PR TITLE
8285521: Minor improvements in java.net.URI

### DIFF
--- a/src/java.base/share/classes/java/net/URI.java
+++ b/src/java.base/share/classes/java/net/URI.java
@@ -2005,13 +2005,12 @@ public final class URI
             if (authority.startsWith("[")) {
                 // authority should (but may not) contain an embedded IPv6 address
                 int end = authority.indexOf(']');
-                String doquote = authority, dontquote = "";
+                String doquote = authority;
                 if (end != -1 && authority.indexOf(':') != -1) {
                     // the authority contains an IPv6 address
-                    dontquote = authority.substring(0 , end + 1);
+                    sb.append(authority, 0, end + 1);
                     doquote = authority.substring(end + 1);
                 }
-                sb.append(dontquote);
                 sb.append(quote(doquote,
                             L_REG_NAME | L_SERVER,
                             H_REG_NAME | H_SERVER));

--- a/src/java.base/share/classes/java/net/URI.java
+++ b/src/java.base/share/classes/java/net/URI.java
@@ -1852,7 +1852,17 @@ public final class URI
     // US-ASCII only
     private static boolean equalIgnoringCase(String s, String t) {
         if (s == t) return true;
-        return s != null && s.equalsIgnoreCase(t);
+        if ((s != null) && (t != null)) {
+            int n = s.length();
+            if (t.length() != n)
+                return false;
+            for (int i = 0; i < n; i++) {
+                if (toLower(s.charAt(i)) != toLower(t.charAt(i)))
+                    return false;
+            }
+            return true;
+        }
+        return false;
     }
 
     private static int hash(int hash, String s) {
@@ -1956,7 +1966,15 @@ public final class URI
         if (s == t) return 0;
         if (s != null) {
             if (t != null) {
-                return s.compareToIgnoreCase(t);
+                int sn = s.length();
+                int tn = t.length();
+                int n = sn < tn ? sn : tn;
+                for (int i = 0; i < n; i++) {
+                    int c = toLower(s.charAt(i)) - toLower(t.charAt(i));
+                    if (c != 0)
+                        return c;
+                }
+                return sn - tn;
             }
             return +1;
         } else {


### PR DESCRIPTION
- use `String.equalsIgnoreCase()` instead of hand-written code relying on `String.charAt()`
- use `String.compareToIgnoreCase()` instead of hand-written code relying on `String.charAt()`
- drop branches that are never executed
- drop unused argument from `URI.resolvePath()`
- simplify String-related operations

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285521](https://bugs.openjdk.org/browse/JDK-8285521): Minor improvements in java.net.URI


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/8397/head:pull/8397` \
`$ git checkout pull/8397`

Update a local copy of the PR: \
`$ git checkout pull/8397` \
`$ git pull https://git.openjdk.org/jdk pull/8397/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8397`

View PR using the GUI difftool: \
`$ git pr show -t 8397`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/8397.diff">https://git.openjdk.org/jdk/pull/8397.diff</a>

</details>
