### PR TITLE
8285633: Take better advantage of generic MethodType cache

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -622,7 +622,7 @@ class LambdaForm {
         for (int i = 0; i < arity; ++i) {
             ptypes[i] = parameterType(i).btClass;
         }
-        return MethodType.makeImpl(returnType().btClass, ptypes, true);
+        return MethodType.methodType(returnType().btClass, ptypes, true);
     }
 
     /** Return ABC_Z, where the ABC are parameter type characters, and Z is the return type character. */

--- a/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -153,7 +153,7 @@ final class MemberName implements Member, Cloneable {
             } else if (type instanceof Object[] typeInfo) {
                 Class<?>[] ptypes = (Class<?>[]) typeInfo[1];
                 Class<?> rtype = (Class<?>) typeInfo[0];
-                MethodType res = MethodType.makeImpl(rtype, ptypes, true);
+                MethodType res = MethodType.methodType(rtype, ptypes, true);
                 type = res;
             }
             // Make sure type is a MethodType for racing threads.

--- a/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -323,7 +323,7 @@ abstract class MethodHandleImpl {
                 for (int pos : positions) {
                     ptypes[pos - 1] = newType;
                 }
-                midType = MethodType.makeImpl(midType.rtype(), ptypes, true);
+                midType = MethodType.methodType(midType.rtype(), ptypes, true);
             }
             LambdaForm form2;
             if (positions.length > 1) {

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
@@ -393,7 +393,7 @@ class MethodHandleNatives {
      * The JVM wants a pointer to a MethodType.  Oblige it by finding or creating one.
      */
     static MethodType findMethodHandleType(Class<?> rtype, Class<?>[] ptypes) {
-        return MethodType.makeImpl(rtype, ptypes, true);
+        return MethodType.methodType(rtype, ptypes, true);
     }
 
     /**
@@ -561,7 +561,7 @@ class MethodHandleNatives {
             }
             // Access descriptor at end
             guardParams[guardParams.length - 1] = VarHandle.AccessDescriptor.class;
-            MethodType guardType = MethodType.makeImpl(guardReturnType, guardParams, true);
+            MethodType guardType = MethodType.methodType(guardReturnType, guardParams, true);
 
             MemberName linker = new MemberName(
                     VarHandleGuards.class, getVarHandleGuardMethodName(guardType),

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -5601,7 +5601,7 @@ assertEquals("XY", (String) f2.invokeExact("x", "y")); // XY
         for (int pos : positions) {
             ptypes[pos - 1] = newParamType;
         }
-        MethodType newType = MethodType.makeImpl(targetType.rtype(), ptypes, true);
+        MethodType newType = MethodType.methodType(targetType.rtype(), ptypes, true);
 
         LambdaForm lform = result.editor().filterRepeatedArgumentForm(BasicType.basicType(newParamType), positions);
         return result.copyWithExtendL(newType, lform, filter);

--- a/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -240,7 +240,7 @@ class MethodType
      * @throws IllegalArgumentException if any element of {@code ptypes} is {@code void.class}
      */
     public static MethodType methodType(Class<?> rtype, Class<?>[] ptypes) {
-        return makeImpl(rtype, ptypes, false);
+        return methodType(rtype, ptypes, false);
     }
 
     /**
@@ -254,7 +254,7 @@ class MethodType
      */
     public static MethodType methodType(Class<?> rtype, List<Class<?>> ptypes) {
         boolean notrust = false;  // random List impl. could return evil ptypes array
-        return makeImpl(rtype, listToArray(ptypes), notrust);
+        return methodType(rtype, listToArray(ptypes), notrust);
     }
 
     private static Class<?>[] listToArray(List<Class<?>> ptypes) {
@@ -275,9 +275,23 @@ class MethodType
      * @throws IllegalArgumentException if {@code ptype0} or {@code ptypes} or any element of {@code ptypes} is {@code void.class}
      */
     public static MethodType methodType(Class<?> rtype, Class<?> ptype0, Class<?>... ptypes) {
-        Class<?>[] ptypes1 = new Class<?>[1+ptypes.length];
+        int len = ptypes.length;
+        if (rtype == Object.class && ptype0 == Object.class) {
+            if (len == 0) {
+                return genericMethodType(1, false);
+            }
+            if (isAllObject(ptypes, len - 1)) {
+                Class<?> lastParam = ptypes[len - 1];
+                if (lastParam == Object.class) {
+                    return genericMethodType(len + 1, false);
+                } else if (lastParam == Object[].class) {
+                    return genericMethodType(len, true);
+                }
+            }
+        }
+        Class<?>[] ptypes1 = new Class<?>[1 + len];
         ptypes1[0] = ptype0;
-        System.arraycopy(ptypes, 0, ptypes1, 1, ptypes.length);
+        System.arraycopy(ptypes, 0, ptypes1, 1, len);
         return makeImpl(rtype, ptypes1, true);
     }
 
@@ -290,6 +304,9 @@ class MethodType
      * @throws NullPointerException if {@code rtype} is null
      */
     public static MethodType methodType(Class<?> rtype) {
+        if (rtype == Object.class) {
+            return genericMethodType(0, false);
+        }
         return makeImpl(rtype, NO_PTYPES, true);
     }
 
@@ -304,6 +321,13 @@ class MethodType
      * @throws IllegalArgumentException if {@code ptype0} is {@code void.class}
      */
     public static MethodType methodType(Class<?> rtype, Class<?> ptype0) {
+        if (rtype == Object.class) {
+            if (ptype0 == Object.class) {
+                return genericMethodType(1, false);
+            } else if (ptype0 == Object[].class) {
+                return genericMethodType(0, true);
+            }
+        }
         return makeImpl(rtype, new Class<?>[]{ ptype0 }, true);
     }
 
@@ -318,7 +342,35 @@ class MethodType
      * @throws NullPointerException if {@code rtype} or {@code ptypes} is null
      */
     public static MethodType methodType(Class<?> rtype, MethodType ptypes) {
-        return makeImpl(rtype, ptypes.ptypes, true);
+        return methodType(rtype, ptypes.ptypes, true);
+    }
+
+    private static boolean isAllObject(Class<?>[] ptypes, int to) {
+        for (int i = 0; i < to; i++) {
+            if (ptypes[i] != Object.class) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /*trusted*/
+    static MethodType methodType(Class<?> rtype, Class<?>[] ptypes, boolean trusted) {
+        if (rtype == Object.class) {
+            int last = ptypes.length - 1;
+            if (last < 0) {
+                return genericMethodType(0, false);
+            }
+            if (isAllObject(ptypes, last)) {
+                Class<?> lastParam = ptypes[last];
+                if (lastParam == Object.class) {
+                    return genericMethodType(last + 1, false);
+                } else if (lastParam == Object[].class) {
+                    return genericMethodType(last, true);
+                }
+            }
+        }
+        return makeImpl(rtype, ptypes, trusted);
     }
 
     /**
@@ -332,8 +384,7 @@ class MethodType
      * @throws IllegalArgumentException if any element of {@code ptypes} is {@code void.class}
      * @return the unique method type of the desired structure
      */
-    /*trusted*/
-    static MethodType makeImpl(Class<?> rtype, Class<?>[] ptypes, boolean trusted) {
+    private static MethodType makeImpl(Class<?> rtype, Class<?>[] ptypes, boolean trusted) {
         if (ptypes.length == 0) {
             ptypes = NO_PTYPES; trusted = true;
         }
@@ -629,7 +680,7 @@ class MethodType
                 System.arraycopy(ptypes, end, nptypes, start, tail);
             }
         }
-        return makeImpl(rtype, nptypes, true);
+        return methodType(rtype, nptypes, true);
     }
 
     /**
@@ -641,7 +692,7 @@ class MethodType
      */
     public MethodType changeReturnType(Class<?> nrtype) {
         if (returnType() == nrtype)  return this;
-        return makeImpl(nrtype, ptypes, true);
+        return methodType(nrtype, ptypes, true);
     }
 
     /**
@@ -1164,7 +1215,7 @@ class MethodType
         List<Class<?>> types = BytecodeDescriptor.parseMethod(descriptor, loader);
         Class<?> rtype = types.remove(types.size() - 1);
         Class<?>[] ptypes = listToArray(types);
-        return makeImpl(rtype, ptypes, true);
+        return methodType(rtype, ptypes, true);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/invoke/MethodTypeForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodTypeForm.java
@@ -194,7 +194,7 @@ final class MethodTypeForm {
             this.lambdaForms   = new SoftReference[LF_LIMIT];
             this.methodHandles = new SoftReference[MH_LIMIT];
         } else {
-            this.basicType = MethodType.makeImpl(basicReturnType, basicPtypes, true);
+            this.basicType = MethodType.methodType(basicReturnType, basicPtypes, true);
             // fill in rest of data from the basic type:
             MethodTypeForm that = this.basicType.form();
             assert(this != that);
@@ -250,7 +250,7 @@ final class MethodTypeForm {
         // Find the erased version of the method type:
         if (rtypeCanonical == null)  rtypeCanonical = rtype;
         if (ptypesCanonical == null)  ptypesCanonical = ptypes;
-        return MethodType.makeImpl(rtypeCanonical, ptypesCanonical, true);
+        return MethodType.methodType(rtypeCanonical, ptypesCanonical, true);
     }
 
     /** Canonicalize the given return or param type.

--- a/src/java.base/share/classes/java/lang/invoke/MethodTypeForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodTypeForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeAcquire.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeAcquire.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeAcquire.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeAcquire.java
@@ -24,11 +24,14 @@ package org.openjdk.bench.java.lang.invoke;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodType;
 import java.util.concurrent.TimeUnit;
@@ -39,6 +42,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
+@Warmup(iterations = 10, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(3)
 public class MethodTypeAcquire {
 
     private MethodType pTypes;
@@ -69,6 +75,16 @@ public class MethodTypeAcquire {
     }
 
     @Benchmark
+    public MethodType testGenericObject() {
+        return MethodType.genericMethodType(1);
+    }
+
+    @Benchmark
+    public MethodType testObjectObject() {
+        return MethodType.methodType(Object.class, Object.class);
+    }
+
+    @Benchmark
     public MethodType testSinglePType() {
         return MethodType.methodType(void.class, int.class);
     }
@@ -76,6 +92,16 @@ public class MethodTypeAcquire {
     @Benchmark
     public MethodType testMultiPType() {
         return MethodType.methodType(void.class, A.class, B.class);
+    }
+
+    @Benchmark
+    public MethodType testMultiPType_ObjectAndA() {
+        return MethodType.methodType(Object.class, Object.class, Object.class, Object.class, Object.class, A.class, B.class);
+    }
+
+    @Benchmark
+    public MethodType testMultiPType_ObjectOnly() {
+        return MethodType.methodType(Object.class, Object.class, Object.class, Object.class, Object.class, Object.class, Object.class);
     }
 
     @Benchmark


### PR DESCRIPTION
The `MethodType.genericMethodType` methods provide convenience methods for certain common method types and also provide `@Stable` cache that allows for constant folding. This patch enhances the more generic `methodType` methods to take advantage of this cache, when possible. This allows calls like `MethodType.methodType(Object.class, Object.class, ...)` to constant fold, making them 50x+ faster and allocation-free.

Baseline:
```
Benchmark                                    Mode  Cnt   Score   Error  Units
MethodTypeAcquire.baselineRaw                avgt    5   0.673 ? 0.036  ns/op
MethodTypeAcquire.testGenericObject          avgt    5   0.520 ? 0.162  ns/op
MethodTypeAcquire.testMultiPType             avgt    5  47.922 ? 1.778  ns/op
MethodTypeAcquire.testMultiPType_Arg         avgt    5  28.992 ? 0.949  ns/op
MethodTypeAcquire.testMultiPType_ObjectAndA  avgt    5  56.698 ? 0.879  ns/op
MethodTypeAcquire.testMultiPType_ObjectOnly  avgt    5  55.705 ? 0.854  ns/op
MethodTypeAcquire.testObjectObject           avgt    5  31.729 ? 2.204  ns/op
MethodTypeAcquire.testReturnInt              avgt    5  26.171 ? 0.141  ns/op
MethodTypeAcquire.testReturnObject           avgt    5  24.340 ? 0.868  ns/op
MethodTypeAcquire.testReturnVoid             avgt    5  24.793 ? 2.816  ns/op
MethodTypeAcquire.testSinglePType            avgt    5  32.653 ? 1.082  ns/op
```

Patched:
```
Benchmark                                    Mode  Cnt   Score   Error  Units
MethodTypeAcquire.baselineRaw                avgt    5   0.727 ? 0.382  ns/op
MethodTypeAcquire.testGenericObject          avgt    5   0.658 ? 0.655  ns/op
MethodTypeAcquire.testMultiPType             avgt    5  48.066 ? 1.187  ns/op
MethodTypeAcquire.testMultiPType_Arg         avgt    5  27.097 ? 0.745  ns/op
MethodTypeAcquire.testMultiPType_ObjectAndA  avgt    5  58.074 ? 6.299  ns/op
MethodTypeAcquire.testMultiPType_ObjectOnly  avgt    5   0.538 ? 0.195  ns/op
MethodTypeAcquire.testObjectObject           avgt    5   0.520 ? 0.162  ns/op
MethodTypeAcquire.testReturnInt              avgt    5  28.093 ? 0.235  ns/op
MethodTypeAcquire.testReturnObject           avgt    5   0.540 ? 0.204  ns/op
MethodTypeAcquire.testReturnVoid             avgt    5  24.746 ? 0.706  ns/op
MethodTypeAcquire.testSinglePType            avgt    5  32.662 ? 1.924  ns/op
```

The cost on method types that don't match are in the noise (0-2ns/op). Even on a test I constructed to act as a worst case (`testMultiPType_ObjectAndA`) there's barely any appreciable cost.