### PR TITLE
JDK-8285675: Temporary fix for arm32 SafeFetch

### DIFF
--- a/src/hotspot/share/runtime/safefetch.hpp
+++ b/src/hotspot/share/runtime/safefetch.hpp
@@ -34,10 +34,11 @@
 #ifdef _WIN32
   // Windows uses Structured Exception Handling
   #include "safefetch_windows.hpp"
-#elif defined(ZERO) || defined (_AIX)
+#elif defined(ZERO) || defined (_AIX) || defined (ARM32)
   // These platforms implement safefetch via Posix sigsetjmp/longjmp.
   // This is slower than the other methods and uses more thread stack,
   // but its safe and portable.
+  // (arm32 uses sigsetjmp/longjmp as long as JDK-8284997 is not solved)
   #include "safefetch_sigjmp.hpp"
   #define SAFEFETCH_METHOD_SIGSETJMP
 #else


### PR DESCRIPTION
[JDK-8283326](https://bugs.openjdk.java.net/browse/JDK-8283326) reworked the SafeFetch implementation and, on most platforms, switched to static assembly.

On arm (32-bit), this change led to strange crashes ([JDK-8284997](https://bugs.openjdk.java.net/browse/JDK-8284997)). These problems are time consuming to analyze (among other things they only occur when building natively on a Rasberry Pi with one particular Docker setup).

As a temporary workaround I'd like to switch SafeFetch to the sigjmp method for arm, until I find time to analyze these problems in more detail.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285675](https://bugs.openjdk.java.net/browse/JDK-8285675): Temporary fix for arm32 SafeFetch


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8399/head:pull/8399` \
`$ git checkout pull/8399`

Update a local copy of the PR: \
`$ git checkout pull/8399` \
`$ git pull https://git.openjdk.java.net/jdk pull/8399/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8399`

View PR using the GUI difftool: \
`$ git pr show -t 8399`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8399.diff">https://git.openjdk.java.net/jdk/pull/8399.diff</a>

</details>
