### PR TITLE
8287353: Use snippet tag instead of pre tag in Javadoc of InterruptedException

### DIFF
--- a/src/java.base/share/classes/java/lang/InterruptedException.java
+++ b/src/java.base/share/classes/java/lang/InterruptedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/InterruptedException.java
+++ b/src/java.base/share/classes/java/lang/InterruptedException.java
@@ -32,10 +32,10 @@ package java.lang;
  * thread has been interrupted, and if so, to immediately throw
  * this exception.  The following code can be used to achieve
  * this effect:
- * <pre>
- *  if (Thread.interrupted())  // Clears interrupted status!
- *      throw new InterruptedException();
- * </pre>
+ * {@snippet:
+ * if (Thread.interrupted())  // Clears interrupted status!
+ *     throw new InterruptedException();
+ * }
  *
  * @author  Frank Yellin
  * @see     java.lang.Object#wait()

--- a/src/java.base/share/classes/java/lang/InterruptedException.java
+++ b/src/java.base/share/classes/java/lang/InterruptedException.java
@@ -32,7 +32,7 @@ package java.lang;
  * thread has been interrupted, and if so, to immediately throw
  * this exception.  The following code can be used to achieve
  * this effect:
- * {@snippet:
+ * {@snippet lang=java :
  * if (Thread.interrupted())  // Clears interrupted status!
  *     throw new InterruptedException();
  * }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287353](https://bugs.openjdk.java.net/browse/JDK-8287353): Use snippet tag instead of pre tag in Javadoc of InterruptedException


### Reviewers
 * [Jaikiran Pai](https://openjdk.java.net/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8400/head:pull/8400` \
`$ git checkout pull/8400`

Update a local copy of the PR: \
`$ git checkout pull/8400` \
`$ git pull https://git.openjdk.java.net/jdk pull/8400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8400`

View PR using the GUI difftool: \
`$ git pr show -t 8400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8400.diff">https://git.openjdk.java.net/jdk/pull/8400.diff</a>

</details>
