### PR TITLE
8285011: gc/arguments/TestUseCompressedOopsFlagsWithUlimit.java fails after JDK-8280761

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -79,7 +79,6 @@ compiler/codecache/TestStressCodeBuffers.java 8272094 generic-aarch64
 
 # :hotspot_gc
 
-gc/arguments/TestUseCompressedOopsFlagsWithUlimit.java 8285011 generic-all
 gc/epsilon/TestMemoryMXBeans.java 8206434 generic-all
 gc/g1/humongousObjects/objectGraphTest/TestObjectGraphAfterGC.java 8156755 generic-all
 gc/g1/logging/TestG1LoggingFailure.java 8169634 generic-all

--- a/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsFlagsWithUlimit.java
+++ b/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsFlagsWithUlimit.java
@@ -31,7 +31,8 @@ package gc.arguments;
  * @library /test/lib
  * @library /
  * @requires vm.bits == "64"
- * @requires os.family != "aix" & os.family != "windows"
+ * @requires os.family == "linux"
+ * @requires vm.gc != "Z"
  * @run driver gc.arguments.TestUseCompressedOopsFlagsWithUlimit
  */
 


### PR DESCRIPTION
Hi all,

  can I get reviews for this little test fix that avoids running that test with collectors/platforms where either compressed oops are not supported (ZGC) or the `ulimit -v` call isn't (OSX)?

Testing: tier1, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285011](https://bugs.openjdk.java.net/browse/JDK-8285011): gc/arguments/TestUseCompressedOopsFlagsWithUlimit.java fails after JDK-8280761


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Leo Korinth](https://openjdk.java.net/census#lkorinth) (@lkorinth - **Reviewer**)


### Contributors
 * Albert Mingkun Yang `<ayang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8401/head:pull/8401` \
`$ git checkout pull/8401`

Update a local copy of the PR: \
`$ git checkout pull/8401` \
`$ git pull https://git.openjdk.java.net/jdk pull/8401/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8401`

View PR using the GUI difftool: \
`$ git pr show -t 8401`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8401.diff">https://git.openjdk.java.net/jdk/pull/8401.diff</a>

</details>
