### PR TITLE
8285595: Assert frame anchor doesn't change in safepoints/handshakes

### DIFF
--- a/src/hotspot/share/runtime/safepointMechanism.cpp
+++ b/src/hotspot/share/runtime/safepointMechanism.cpp
@@ -112,6 +112,7 @@ void SafepointMechanism::update_poll_values(JavaThread* thread) {
 }
 
 void SafepointMechanism::process(JavaThread *thread, bool allow_suspend, bool check_async_exception) {
+  DEBUG_ONLY(intptr_t* sp_before = thread->last_Java_sp();)
   // Read global poll and has_handshake after local poll
   OrderAccess::loadload();
 
@@ -140,6 +141,7 @@ void SafepointMechanism::process(JavaThread *thread, bool allow_suspend, bool ch
 
   update_poll_values(thread);
   OrderAccess::cross_modify_fence();
+  assert(sp_before == thread->last_Java_sp(), "Anchor has changed");
 }
 
 void SafepointMechanism::initialize_header(JavaThread* thread) {


### PR DESCRIPTION
Hi.
Please review this change that asserts that the frame anchor is not changed by safepoints/handshakes.

Passes tier1

— Ron

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285595](https://bugs.openjdk.java.net/browse/JDK-8285595): Assert frame anchor doesn't change in safepoints/handshakes


### Reviewers
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8402/head:pull/8402` \
`$ git checkout pull/8402`

Update a local copy of the PR: \
`$ git checkout pull/8402` \
`$ git pull https://git.openjdk.java.net/jdk pull/8402/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8402`

View PR using the GUI difftool: \
`$ git pr show -t 8402`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8402.diff">https://git.openjdk.java.net/jdk/pull/8402.diff</a>

</details>
