### PR TITLE
8285658: Fix two typos in the spec of j.u.random.RandomGenerator

### DIFF
--- a/src/java.base/share/classes/java/util/random/RandomGenerator.java
+++ b/src/java.base/share/classes/java/util/random/RandomGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/random/RandomGenerator.java
+++ b/src/java.base/share/classes/java/util/random/RandomGenerator.java
@@ -55,7 +55,8 @@ import java.util.stream.Stream;
  * possible values of the type. In the case of {@code float} and {@code double}
  * values, first a value is always chosen uniformly from the set of
  * 2<sup><i>w</i></sup> values between 0.0 (inclusive) and 1.0 (exclusive),
- * where <i>w</i> is 23 for {@code float} values and 52 for {@code double}
+ * where <i>w</i> is {@link Float#PRECISION} for {@code float} values
+ * and {@link Double#PRECISION} for {@code double}
  * values, such that adjacent values differ by 2<sup>&minus;<i>w</i></sup>
  * (notice that this set is a <i>subset</i> of the set of
  * <i>all representable floating-point values</i> between 0.0 (inclusive) and 1.0 (exclusive));
@@ -496,11 +497,11 @@ public interface RandomGenerator {
      *
      * @return a pseudorandom {@code float} value between zero (inclusive) and one (exclusive)
      *
-     * @implSpec The default implementation uses the 24 high-order bits from a call to
-     * {@link RandomGenerator#nextInt() nextInt}().
+     * @implSpec The default implementation uses the {@link Float#PRECISION}
+     * high-order bits from a call to {@link RandomGenerator#nextInt() nextInt}().
      */
     default float nextFloat() {
-        return (nextInt() >>> 8) * 0x1.0p-24f;
+        return (nextInt() >>> (Float.SIZE - Float.PRECISION)) * 0x1.0p-24f;
     }
 
     /**
@@ -562,11 +563,11 @@ public interface RandomGenerator {
      * @return a pseudorandom {@code double} value between zero (inclusive)
      *         and one (exclusive)
      *
-     * @implSpec The default implementation uses the 53 high-order bits from a call to
-     * {@link RandomGenerator#nextLong nextLong}().
+     * @implSpec The default implementation uses the {@link Double#PRECISION}
+     * high-order bits from a call to {@link RandomGenerator#nextLong nextLong}().
      */
     default double nextDouble() {
-        return (nextLong() >>> 11) * 0x1.0p-53;
+        return (nextLong() >>> (Double.SIZE - Double.PRECISION)) * 0x1.0p-53;
     }
 
     /**

--- a/src/java.base/share/classes/java/util/random/RandomGenerator.java
+++ b/src/java.base/share/classes/java/util/random/RandomGenerator.java
@@ -498,7 +498,7 @@ public interface RandomGenerator {
      * @return a pseudorandom {@code float} value between zero (inclusive) and one (exclusive)
      *
      * @implSpec The default implementation uses the {@link Float#PRECISION}
-     * high-order bits from a call to {@link RandomGenerator#nextInt() nextInt}().
+     * high-order bits from a call to {@link RandomGenerator#nextInt() nextInt()}.
      */
     default float nextFloat() {
         return (nextInt() >>> (Float.SIZE - Float.PRECISION)) * 0x1.0p-24f;
@@ -564,7 +564,7 @@ public interface RandomGenerator {
      *         and one (exclusive)
      *
      * @implSpec The default implementation uses the {@link Double#PRECISION}
-     * high-order bits from a call to {@link RandomGenerator#nextLong nextLong}().
+     * high-order bits from a call to {@link RandomGenerator#nextLong() nextLong()}.
      */
     default double nextDouble() {
         return (nextLong() >>> (Double.SIZE - Double.PRECISION)) * 0x1.0p-53;


### PR DESCRIPTION
The spec of the interface `java.util.random.RandomGenerator` is slightly incorrect when it discusses `float` and `double` random values.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8285658](https://bugs.openjdk.java.net/browse/JDK-8285658): Fix two typos in the spec of j.u.random.RandomGenerator
 * [JDK-8285641](https://bugs.openjdk.java.net/browse/JDK-8285641): Fix two typos in the spec of j.u.random.RandomGenerator (**CSR**)


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to 8d4388bd8ebfab0672e28709d0bad388f8d3ddf6


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8404/head:pull/8404` \
`$ git checkout pull/8404`

Update a local copy of the PR: \
`$ git checkout pull/8404` \
`$ git pull https://git.openjdk.java.net/jdk pull/8404/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8404`

View PR using the GUI difftool: \
`$ git pr show -t 8404`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8404.diff">https://git.openjdk.java.net/jdk/pull/8404.diff</a>

</details>
