### PR TITLE
8285646: Add test that checks IP_DONTFRAGMENT is a supported option

### DIFF
--- a/test/jdk/jdk/net/ExtendedSocketOption/DontFragmentTest.java
+++ b/test/jdk/jdk/net/ExtendedSocketOption/DontFragmentTest.java
@@ -58,6 +58,9 @@ public class DontFragmentTest {
     public static void testDatagramChannel() throws IOException {
         try (DatagramChannel c1 = DatagramChannel.open()) {
 
+            if (!c1.supportedOptions().contains(IP_DONTFRAGMENT)) {
+                throw new RuntimeException("IP_DONTFRAGMENT not supported");
+            }
             if (c1.getOption(IP_DONTFRAGMENT)) {
                 throw new RuntimeException("IP_DONTFRAGMENT should not be set");
             }
@@ -75,6 +78,9 @@ public class DontFragmentTest {
     public static void testDatagramChannel(String[] args, ProtocolFamily fam) throws IOException {
         try (DatagramChannel c1 = DatagramChannel.open(fam)) {
 
+            if (!c1.supportedOptions().contains(IP_DONTFRAGMENT)) {
+                throw new RuntimeException("IP_DONTFRAGMENT not supported");
+            }
             if (c1.getOption(IP_DONTFRAGMENT)) {
                 throw new RuntimeException("IP_DONTFRAGMENT should not be set");
             }
@@ -90,6 +96,9 @@ public class DontFragmentTest {
     }
 
     public static void testDatagramSocket(DatagramSocket c1) throws IOException {
+        if (!c1.supportedOptions().contains(IP_DONTFRAGMENT)) {
+            throw new RuntimeException("IP_DONTFRAGMENT not supported");
+        }
         if (c1.getOption(IP_DONTFRAGMENT)) {
             throw new RuntimeException("IP_DONTFRAGMENT should not be set");
         }


### PR DESCRIPTION
Hi,

Could I get the following small test update reviewed please?
It includes a test scenario that should have been included with JDK-8284890

Thanks,
Michael

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8285646](https://bugs.openjdk.java.net/browse/JDK-8285646): Add test that checks IP_DONTFRAGMENT is a supported option


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8405/head:pull/8405` \
`$ git checkout pull/8405`

Update a local copy of the PR: \
`$ git checkout pull/8405` \
`$ git pull https://git.openjdk.java.net/jdk pull/8405/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8405`

View PR using the GUI difftool: \
`$ git pr show -t 8405`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8405.diff">https://git.openjdk.java.net/jdk/pull/8405.diff</a>

</details>
