### PR TITLE
8285677: ProblemList two tests from JDK-8285671 on macosx-x64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -597,6 +597,9 @@ java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc6
 
 java/nio/channels/DatagramChannel/ManySourcesAndTargets.java    8264385 macosx-aarch64
 
+java/nio/channels/etc/PrintSupportedOptions.java                8285671 macosx-x64
+java/nio/channels/DatagramChannel/AfterDisconnect.java          8285671 macosx-x64
+
 ############################################################################
 
 # jdk_rmi


### PR DESCRIPTION
A trivial fix to ProblemList two tests from JDK-8285671 on macosx-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285677](https://bugs.openjdk.java.net/browse/JDK-8285677): ProblemList two tests from JDK-8285671 on macosx-x64


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8406/head:pull/8406` \
`$ git checkout pull/8406`

Update a local copy of the PR: \
`$ git checkout pull/8406` \
`$ git pull https://git.openjdk.java.net/jdk pull/8406/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8406`

View PR using the GUI difftool: \
`$ git pr show -t 8406`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8406.diff">https://git.openjdk.java.net/jdk/pull/8406.diff</a>

</details>
