### PR TITLE
JDK-8282772: JButton text set as HTML content has unwanted padding

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicButtonUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicButtonUI.java
@@ -25,22 +25,40 @@
 
 package javax.swing.plaf.basic;
 
-import sun.swing.SwingUtilities2;
 import sun.awt.AppContext;
-
-import java.awt.*;
-import java.awt.event.*;
-import java.io.Serializable;
-import javax.swing.*;
-import javax.swing.border.*;
-import java.awt.*;
-import java.awt.event.*;
+import sun.swing.SwingUtilities2;
+import java.awt.AWTKeyStroke;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Insets;
+import java.awt.KeyboardFocusManager;
+import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.awt.event.MouseMotionListener;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
+
+import javax.swing.AbstractAction;
+import javax.swing.AbstractButton;
+import javax.swing.ButtonGroup;
+import javax.swing.ButtonModel;
+import javax.swing.DefaultButtonModel;
+import javax.swing.Icon;
+import javax.swing.JComponent;
+import javax.swing.JRadioButton;
+import javax.swing.JToggleButton;
+import javax.swing.KeyStroke;
+import javax.swing.LookAndFeel;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 import javax.swing.plaf.ButtonUI;
-import javax.swing.plaf.UIResource;
 import javax.swing.plaf.ComponentUI;
+import javax.swing.plaf.UIResource;
 import javax.swing.text.View;
 
 /**
@@ -580,7 +598,15 @@ public class BasicButtonUI extends ButtonUI{
 
     private String layout(AbstractButton b, FontMetrics fm,
                           int width, int height) {
-        Insets i = b.getInsets();
+        Insets i;
+
+        final View v = (View)b.getClientProperty(BasicHTML.propertyKey);
+        if (v != null) {
+            i = new Insets(0, 0, 0, 0);
+        } else {
+            i = b.getInsets();
+        }
+
         viewRect.x = i.left;
         viewRect.y = i.top;
         viewRect.width = width - (i.right + viewRect.x);

--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
@@ -268,7 +268,7 @@
       </uiComponent>
       <uiComponent opaque="false" type="javax.swing.JButton" name="Button" ui="ButtonUI" subregion="false">
          <stateTypes/>
-         <contentMargins top="6" bottom="6" left="0" right="0"/>
+         <contentMargins top="6" bottom="6" left="14" right="14"/>
          <style>
             <textForeground/>
             <textBackground/>

--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
@@ -268,7 +268,7 @@
       </uiComponent>
       <uiComponent opaque="false" type="javax.swing.JButton" name="Button" ui="ButtonUI" subregion="false">
          <stateTypes/>
-         <contentMargins top="6" bottom="6" left="14" right="14"/>
+         <contentMargins top="6" bottom="6" left="0" right="0"/>
          <style>
             <textForeground/>
             <textBackground/>

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthGraphicsUtils.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthGraphicsUtils.java
@@ -24,13 +24,24 @@
  */
 package javax.swing.plaf.synth;
 
-import sun.swing.SwingUtilities2;
 import sun.swing.MenuItemLayoutHelper;
+import sun.swing.SwingUtilities2;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Insets;
+import java.awt.Rectangle;
 
-import java.awt.*;
-import javax.swing.*;
+import javax.swing.ButtonModel;
+import javax.swing.Icon;
+import javax.swing.JComponent;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
 import javax.swing.plaf.basic.BasicHTML;
-import javax.swing.text.*;
+import javax.swing.text.View;
 
 /**
  * Wrapper for primitive graphics calls.
@@ -380,10 +391,18 @@ public class SynthGraphicsUtils {
         FontMetrics fm = SwingUtilities2.getFontMetrics(c, g);
         Insets insets = SynthLookAndFeel.getPaintingInsets(ss, paintInsets);
 
-        paintViewR.x = insets.left;
-        paintViewR.y = insets.top;
-        paintViewR.width = c.getWidth() - (insets.left + insets.right);
-        paintViewR.height = c.getHeight() - (insets.top + insets.bottom);
+        final View v = (View)c.getClientProperty(BasicHTML.propertyKey);
+        if (v != null) {
+            paintViewR.x = 0;
+            paintViewR.y = 0;
+            paintViewR.width = c.getWidth();
+            paintViewR.height = c.getHeight();
+        } else {
+            paintViewR.x = insets.left;
+            paintViewR.y = insets.top;
+            paintViewR.width = c.getWidth() - (insets.left + insets.right);
+            paintViewR.height = c.getHeight() - (insets.top + insets.bottom);
+        }
 
         paintIconR.x = paintIconR.y = paintIconR.width = paintIconR.height = 0;
         paintTextR.x = paintTextR.y = paintTextR.width = paintTextR.height = 0;
@@ -409,8 +428,6 @@ public class SynthGraphicsUtils {
         }
 
         if (text != null) {
-            View v = (View) c.getClientProperty(BasicHTML.propertyKey);
-
             if (v != null) {
                 v.paint(g, paintTextR);
             } else {

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthGraphicsUtils.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthGraphicsUtils.java
@@ -37,6 +37,7 @@ import java.awt.Rectangle;
 
 import javax.swing.ButtonModel;
 import javax.swing.Icon;
+import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JMenuItem;
 import javax.swing.SwingUtilities;
@@ -392,7 +393,8 @@ public class SynthGraphicsUtils {
         Insets insets = SynthLookAndFeel.getPaintingInsets(ss, paintInsets);
 
         final View v = (View)c.getClientProperty(BasicHTML.propertyKey);
-        if (v != null) {
+
+        if (c instanceof JButton && v != null) {
             paintViewR.x = 0;
             paintViewR.y = 0;
             paintViewR.width = c.getWidth();

--- a/test/jdk/javax/swing/JButton/HtmlButtonImageTest/HtmlButtonImageTest.java
+++ b/test/jdk/javax/swing/JButton/HtmlButtonImageTest/HtmlButtonImageTest.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8015854
- * @summary Tests HTML image as JButton text for unwanted padding on macOS Aqua LAF
+ * @summary Tests HTML image as JButton text for unwanted padding
  * @run main HtmlButtonImageTest
  */
 


### PR DESCRIPTION
The insets for buttons were incorrect for L&Fs except for Aqua when the text is set to HTML. This was fixed in Aqua by adding a conditional to check for the BasicHTML property key in the button component. This same logic can be used to fix Metal & Motif L&Fs in BasicButtonUI, but Nimbus is not fixed by this. Nimbus gets its default values from a skin.laf file, and when the defaults here are set to have left & right insets to 0 for ButtonUI, the issue is fixed. I also tested for non-HTML text after the changes, and the changes do not affect normal text.

The HtmlButtonImageTest has been changed to cycle through all L&Fs available on a device.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8282772](https://bugs.openjdk.java.net/browse/JDK-8282772): JButton text set as HTML content has unwanted padding


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [05bd9a42](https://git.openjdk.java.net/jdk/pull/8407/files/05bd9a42e4e625a4dd3ec60101036a9de43568eb)
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8407/head:pull/8407` \
`$ git checkout pull/8407`

Update a local copy of the PR: \
`$ git checkout pull/8407` \
`$ git pull https://git.openjdk.java.net/jdk pull/8407/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8407`

View PR using the GUI difftool: \
`$ git pr show -t 8407`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8407.diff">https://git.openjdk.java.net/jdk/pull/8407.diff</a>

</details>
