### PR TITLE
8278109: gc/metaspace/TestPerfCountersAndMemoryPools.java fails with Used out of sync: expected 1028976 to equal 1029224

### DIFF
--- a/test/hotspot/jtreg/gc/metaspace/TestPerfCountersAndMemoryPools.java
+++ b/test/hotspot/jtreg/gc/metaspace/TestPerfCountersAndMemoryPools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,8 +39,8 @@ import gc.testlibrary.PerfCounters;
  * @modules java.base/jdk.internal.misc
  *          java.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops -XX:-UseCompressedClassPointers -XX:+UseSerialGC -XX:+UsePerfData -Xint gc.metaspace.TestPerfCountersAndMemoryPools
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:+UseSerialGC -XX:+UsePerfData -Xint gc.metaspace.TestPerfCountersAndMemoryPools
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xlog:class+load,class+unload=trace -XX:-UseCompressedOops -XX:-UseCompressedClassPointers -XX:+UseSerialGC -XX:+UsePerfData -Xint gc.metaspace.TestPerfCountersAndMemoryPools
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xlog:class+load,class+unload=trace -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:+UseSerialGC -XX:+UsePerfData -Xint gc.metaspace.TestPerfCountersAndMemoryPools
  */
 public class TestPerfCountersAndMemoryPools {
     public static void main(String[] args) throws Exception {
@@ -80,10 +80,19 @@ public class TestPerfCountersAndMemoryPools {
         System.gc();
         assertEQ(getMinCapacity(perfNS), pool.getUsage().getInit(), "MinCapacity out of sync");
 
-        // Adding a second GC due to metadata allocations caused by getting the
-        // initial size from the pool. This is needed when running with -Xcomp.
-        System.gc();
-        assertEQ(getUsed(perfNS), pool.getUsage().getUsed(), "Used out of sync");
+        long usedPerfCounters;
+        long usedMXBean;
+
+        // the pool.getUsage().getUsed() might load additional classes intermittently
+        // so first verify that perfCounters are not changed, call System.gc() to reset them
+        do {
+            System.gc();
+            usedPerfCounters = getUsed(perfNS);
+            usedMXBean = pool.getUsage().getUsed();
+            System.gc();
+        } while (usedPerfCounters != getUsed(perfNS));
+        assertEQ(usedPerfCounters, usedMXBean, "Used out of sync");
+
         assertEQ(getCapacity(perfNS), pool.getUsage().getCommitted(), "Committed out of sync");
     }
 


### PR DESCRIPTION
The test is updated to don't fail if 'MemoryPoolMXBean::getUsage().getUsed()' allocate new classes intermittently.

The problem was reproduced in repo-loom only. However it makes sense to push this fix into jdk/jdk separately to reduce overall push and increase test stability.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278109](https://bugs.openjdk.java.net/browse/JDK-8278109): gc/metaspace/TestPerfCountersAndMemoryPools.java fails with Used out of sync: expected 1028976 to equal 1029224


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8408/head:pull/8408` \
`$ git checkout pull/8408`

Update a local copy of the PR: \
`$ git checkout pull/8408` \
`$ git pull https://git.openjdk.java.net/jdk pull/8408/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8408`

View PR using the GUI difftool: \
`$ git pr show -t 8408`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8408.diff">https://git.openjdk.java.net/jdk/pull/8408.diff</a>

</details>
