### PR TITLE
8285493: ECC calculation error

### DIFF
--- a/src/java.base/share/classes/sun/security/util/math/intpoly/IntegerPolynomial.java
+++ b/src/java.base/share/classes/sun/security/util/math/intpoly/IntegerPolynomial.java
@@ -558,7 +558,7 @@ public abstract sealed class IntegerPolynomial implements IntegerFieldModuloP
 
         @Override
         public ImmutableElement add(IntegerModuloP genB) {
-
+            assert IntegerPolynomial.this == genB.getField();
             Element b = (Element) genB;
             if (!(isSummand() && b.isSummand())) {
                 throw new ArithmeticException("Not a valid summand");
@@ -596,7 +596,7 @@ public abstract sealed class IntegerPolynomial implements IntegerFieldModuloP
 
         @Override
         public ImmutableElement multiply(IntegerModuloP genB) {
-
+            assert IntegerPolynomial.this == genB.getField();
             Element b = (Element) genB;
 
             long[] newLimbs = new long[limbs.length];
@@ -612,7 +612,7 @@ public abstract sealed class IntegerPolynomial implements IntegerFieldModuloP
         }
 
         public void addModPowerTwo(IntegerModuloP arg, byte[] result) {
-
+            assert IntegerPolynomial.this == arg.getField();
             Element other = (Element) arg;
             if (!(isSummand() && other.isSummand())) {
                 throw new ArithmeticException("Not a valid summand");
@@ -642,7 +642,7 @@ public abstract sealed class IntegerPolynomial implements IntegerFieldModuloP
 
         @Override
         public void conditionalSet(IntegerModuloP b, int set) {
-
+            assert IntegerPolynomial.this == b.getField();
             Element other = (Element) b;
 
             conditionalAssign(set, limbs, other.limbs);
@@ -651,7 +651,7 @@ public abstract sealed class IntegerPolynomial implements IntegerFieldModuloP
 
         @Override
         public void conditionalSwapWith(MutableIntegerModuloP b, int swap) {
-
+            assert IntegerPolynomial.this == b.getField();
             MutableElement other = (MutableElement) b;
 
             conditionalSwap(swap, limbs, other.limbs);
@@ -663,6 +663,7 @@ public abstract sealed class IntegerPolynomial implements IntegerFieldModuloP
 
         @Override
         public MutableElement setValue(IntegerModuloP v) {
+            assert IntegerPolynomial.this == v.getField();
             Element other = (Element) v;
 
             System.arraycopy(other.limbs, 0, limbs, 0, other.limbs.length);
@@ -692,6 +693,7 @@ public abstract sealed class IntegerPolynomial implements IntegerFieldModuloP
 
         @Override
         public MutableElement setProduct(IntegerModuloP genB) {
+            assert IntegerPolynomial.this == genB.getField();
             Element b = (Element) genB;
             mult(limbs, b.limbs, limbs);
             numAdds = 0;
@@ -708,7 +710,7 @@ public abstract sealed class IntegerPolynomial implements IntegerFieldModuloP
 
         @Override
         public MutableElement setSum(IntegerModuloP genB) {
-
+            assert IntegerPolynomial.this == genB.getField();
             Element b = (Element) genB;
             if (!(isSummand() && b.isSummand())) {
                 throw new ArithmeticException("Not a valid summand");
@@ -724,7 +726,7 @@ public abstract sealed class IntegerPolynomial implements IntegerFieldModuloP
 
         @Override
         public MutableElement setDifference(IntegerModuloP genB) {
-
+            assert IntegerPolynomial.this == genB.getField();
             Element b = (Element) genB;
             if (!(isSummand() && b.isSummand())) {
                 throw new ArithmeticException("Not a valid summand");
@@ -747,7 +749,6 @@ public abstract sealed class IntegerPolynomial implements IntegerFieldModuloP
 
         @Override
         public MutableElement setAdditiveInverse() {
-
             for (int i = 0; i < limbs.length; i++) {
                 limbs[i] = -limbs[i];
             }
@@ -756,7 +757,6 @@ public abstract sealed class IntegerPolynomial implements IntegerFieldModuloP
 
         @Override
         public MutableElement setReduced() {
-
             reduce(limbs);
             numAdds = 0;
             return this;

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDSAOperations.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDSAOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import sun.security.util.math.*;
 import static sun.security.ec.ECOperations.IntermediateValueException;
 
 import java.math.BigInteger;
+import java.security.MessageDigest;
 import java.security.ProviderException;
 import java.security.spec.*;
 import java.util.Arrays;
@@ -256,10 +257,8 @@ public class ECDSAOperations {
 
         ecOps.setSum(p1, p2.asAffine());
         IntegerModuloP result = p1.asAffine().getX();
-        result = result.additiveInverse().add(ri);
-
         b2a(result, orderField, temp1);
-        return ECOperations.allZero(temp1);
+        return MessageDigest.isEqual(temp1, r);
     }
 
     public static ImmutableIntegerModuloP b2a(IntegerModuloP b,


### PR DESCRIPTION
Only numbers from the same modular fields can be involved in arithmetic calculations. Add `assert` to guarantee this.

Also, found one broken case and rewrote it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285493](https://bugs.openjdk.java.net/browse/JDK-8285493): ECC calculation error


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)
 * [Anthony Scarpino](https://openjdk.java.net/census#ascarpino) (@ascarpino - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8409/head:pull/8409` \
`$ git checkout pull/8409`

Update a local copy of the PR: \
`$ git checkout pull/8409` \
`$ git pull https://git.openjdk.java.net/jdk pull/8409/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8409`

View PR using the GUI difftool: \
`$ git pr show -t 8409`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8409.diff">https://git.openjdk.java.net/jdk/pull/8409.diff</a>

</details>
