### PR TITLE
8285683: Missing @ since 11 in java.security.spec.MGF1ParameterSpec fields

### DIFF
--- a/src/java.base/share/classes/java/security/spec/MGF1ParameterSpec.java
+++ b/src/java.base/share/classes/java/security/spec/MGF1ParameterSpec.java
@@ -65,38 +65,37 @@ package java.security.spec;
 public class MGF1ParameterSpec implements AlgorithmParameterSpec {
 
     /**
-     * The <code>MGF1ParameterSpec</code> which uses a "SHA-1" message digest.
+     * The {@code MGF1ParameterSpec} uses a "SHA-1" message digest.
      */
     public static final MGF1ParameterSpec SHA1 =
         new MGF1ParameterSpec("SHA-1");
 
     /**
-     * The <code>MGF1ParameterSpec</code> which uses a "SHA-224" message digest.
+     * The {@code MGF1ParameterSpec} uses a "SHA-224" message digest.
      */
     public static final MGF1ParameterSpec SHA224 =
         new MGF1ParameterSpec("SHA-224");
 
     /**
-     * The <code>MGF1ParameterSpec</code> which uses a "SHA-256" message digest.
+     * The {@code MGF1ParameterSpec} uses a "SHA-256" message digest.
      */
     public static final MGF1ParameterSpec SHA256 =
         new MGF1ParameterSpec("SHA-256");
 
     /**
-     * The <code>MGF1ParameterSpec</code> which uses a "SHA-384" message digest.
+     * The {@code MGF1ParameterSpec} uses a "SHA-384" message digest.
      */
     public static final MGF1ParameterSpec SHA384 =
         new MGF1ParameterSpec("SHA-384");
 
     /**
-     * The <code>MGF1ParameterSpec</code> which uses a "SHA-512" message digest.
+     * The {@code MGF1ParameterSpec} uses a "SHA-512" message digest.
      */
     public static final MGF1ParameterSpec SHA512 =
         new MGF1ParameterSpec("SHA-512");
 
     /**
-     * The <code>MGF1ParameterSpec</code> which uses a "SHA-512/224"
-     * message digest.
+     * The {@code MGF1ParameterSpec} uses a "SHA-512/224" message digest.
      *
      * @since 11
      */
@@ -104,8 +103,7 @@ public class MGF1ParameterSpec implements AlgorithmParameterSpec {
         new MGF1ParameterSpec("SHA-512/224");
 
     /**
-     * The <code>MGF1ParameterSpec</code> which uses a "SHA-512/256"
-     * message digest.
+     * The {@code MGF1ParameterSpec} uses a "SHA-512/256" message digest.
      *
      * @since 11
      */
@@ -113,8 +111,7 @@ public class MGF1ParameterSpec implements AlgorithmParameterSpec {
         new MGF1ParameterSpec("SHA-512/256");
 
     /**
-     * The <code>MGF1ParameterSpec</code> which uses a "SHA3-224"
-     * message digest.
+     * The {@code MGF1ParameterSpec} uses a "SHA3-224" message digest.
      *
      * @since 16
      */
@@ -122,8 +119,7 @@ public class MGF1ParameterSpec implements AlgorithmParameterSpec {
         new MGF1ParameterSpec("SHA3-224");
 
     /**
-     * The <code>MGF1ParameterSpec</code> which uses a "SHA3-256"
-     * message digest.
+     * The {@code MGF1ParameterSpec} uses a "SHA3-256" message digest.
      *
      * @since 16
      */
@@ -131,8 +127,7 @@ public class MGF1ParameterSpec implements AlgorithmParameterSpec {
         new MGF1ParameterSpec("SHA3-256");
 
     /**
-     * The <code>MGF1ParameterSpec</code> which uses a "SHA3-384"
-     * message digest.
+     * The {@code MGF1ParameterSpec} uses a "SHA3-384" message digest.
      *
      * @since 16
      */
@@ -140,8 +135,7 @@ public class MGF1ParameterSpec implements AlgorithmParameterSpec {
         new MGF1ParameterSpec("SHA3-384");
 
     /**
-     * The <code>MGF1ParameterSpec</code> which uses a "SHA3-512"
-     * message digest.
+     * The {@code MGF1ParameterSpec} uses a "SHA3-512" message digest.
      *
      * @since 16
      */

--- a/src/java.base/share/classes/java/security/spec/MGF1ParameterSpec.java
+++ b/src/java.base/share/classes/java/security/spec/MGF1ParameterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,12 +96,16 @@ public class MGF1ParameterSpec implements AlgorithmParameterSpec {
 
     /**
      * The MGF1ParameterSpec which uses SHA-512/224 message digest
+     *
+     * @since 11
      */
     public static final MGF1ParameterSpec SHA512_224 =
         new MGF1ParameterSpec("SHA-512/224");
 
     /**
      * The MGF1ParameterSpec which uses SHA-512/256 message digest
+     *
+     * @since 11
      */
     public static final MGF1ParameterSpec SHA512_256 =
         new MGF1ParameterSpec("SHA-512/256");

--- a/src/java.base/share/classes/java/security/spec/MGF1ParameterSpec.java
+++ b/src/java.base/share/classes/java/security/spec/MGF1ParameterSpec.java
@@ -65,37 +65,38 @@ package java.security.spec;
 public class MGF1ParameterSpec implements AlgorithmParameterSpec {
 
     /**
-     * The MGF1ParameterSpec which uses "SHA-1" message digest
+     * The <code>MGF1ParameterSpec</code> which uses "SHA-1" message digest.
      */
     public static final MGF1ParameterSpec SHA1 =
         new MGF1ParameterSpec("SHA-1");
 
     /**
-     * The MGF1ParameterSpec which uses "SHA-224" message digest
+     * The <code>MGF1ParameterSpec</code> which uses "SHA-224" message digest.
      */
     public static final MGF1ParameterSpec SHA224 =
         new MGF1ParameterSpec("SHA-224");
 
     /**
-     * The MGF1ParameterSpec which uses "SHA-256" message digest
+     * The <code>MGF1ParameterSpec</code> which uses "SHA-256" message digest.
      */
     public static final MGF1ParameterSpec SHA256 =
         new MGF1ParameterSpec("SHA-256");
 
     /**
-     * The MGF1ParameterSpec which uses "SHA-384" message digest
+     * The <code>MGF1ParameterSpec</code> which uses "SHA-384" message digest.
      */
     public static final MGF1ParameterSpec SHA384 =
         new MGF1ParameterSpec("SHA-384");
 
     /**
-     * The MGF1ParameterSpec which uses SHA-512 message digest
+     * The <code>MGF1ParameterSpec</code> which uses "SHA-512" message digest.
      */
     public static final MGF1ParameterSpec SHA512 =
         new MGF1ParameterSpec("SHA-512");
 
     /**
-     * The MGF1ParameterSpec which uses SHA-512/224 message digest
+     * The <code>MGF1ParameterSpec</code> which uses "SHA-512/224"
+     * message digest.
      *
      * @since 11
      */
@@ -103,7 +104,8 @@ public class MGF1ParameterSpec implements AlgorithmParameterSpec {
         new MGF1ParameterSpec("SHA-512/224");
 
     /**
-     * The MGF1ParameterSpec which uses SHA-512/256 message digest
+     * The <code>MGF1ParameterSpec</code> which uses "SHA-512/256"
+     * message digest.
      *
      * @since 11
      */
@@ -111,28 +113,31 @@ public class MGF1ParameterSpec implements AlgorithmParameterSpec {
         new MGF1ParameterSpec("SHA-512/256");
 
     /**
-     * The MGF1ParameterSpec which uses SHA3-224 message digest
+     * The <code>MGF1ParameterSpec</code> which uses "SHA3-224" message digest.
+     *
      * @since 16
      */
     public static final MGF1ParameterSpec SHA3_224 =
         new MGF1ParameterSpec("SHA3-224");
 
     /**
-     * The MGF1ParameterSpec which uses SHA3-256 message digest
+     * The <code>MGF1ParameterSpec</code> which uses "SHA3-256" message digest.
+     *
      * @since 16
      */
     public static final MGF1ParameterSpec SHA3_256 =
         new MGF1ParameterSpec("SHA3-256");
 
     /**
-     * The MGF1ParameterSpec which uses SHA3-384 message digest
+     * The <code>MGF1ParameterSpec</code> which uses "SHA3-384" message digest.
+     *
      * @since 16
      */
     public static final MGF1ParameterSpec SHA3_384 =
         new MGF1ParameterSpec("SHA3-384");
 
     /**
-     * The MGF1ParameterSpec which uses SHA3-512 message digest
+     * The <code>MGF1ParameterSpec</code> which uses "SHA3-512" message digest.
      * @since 16
      */
     public static final MGF1ParameterSpec SHA3_512 =

--- a/src/java.base/share/classes/java/security/spec/MGF1ParameterSpec.java
+++ b/src/java.base/share/classes/java/security/spec/MGF1ParameterSpec.java
@@ -65,37 +65,37 @@ package java.security.spec;
 public class MGF1ParameterSpec implements AlgorithmParameterSpec {
 
     /**
-     * The <code>MGF1ParameterSpec</code> which uses "SHA-1" message digest.
+     * The <code>MGF1ParameterSpec</code> which uses a "SHA-1" message digest.
      */
     public static final MGF1ParameterSpec SHA1 =
         new MGF1ParameterSpec("SHA-1");
 
     /**
-     * The <code>MGF1ParameterSpec</code> which uses "SHA-224" message digest.
+     * The <code>MGF1ParameterSpec</code> which uses a "SHA-224" message digest.
      */
     public static final MGF1ParameterSpec SHA224 =
         new MGF1ParameterSpec("SHA-224");
 
     /**
-     * The <code>MGF1ParameterSpec</code> which uses "SHA-256" message digest.
+     * The <code>MGF1ParameterSpec</code> which uses a "SHA-256" message digest.
      */
     public static final MGF1ParameterSpec SHA256 =
         new MGF1ParameterSpec("SHA-256");
 
     /**
-     * The <code>MGF1ParameterSpec</code> which uses "SHA-384" message digest.
+     * The <code>MGF1ParameterSpec</code> which uses a "SHA-384" message digest.
      */
     public static final MGF1ParameterSpec SHA384 =
         new MGF1ParameterSpec("SHA-384");
 
     /**
-     * The <code>MGF1ParameterSpec</code> which uses "SHA-512" message digest.
+     * The <code>MGF1ParameterSpec</code> which uses a "SHA-512" message digest.
      */
     public static final MGF1ParameterSpec SHA512 =
         new MGF1ParameterSpec("SHA-512");
 
     /**
-     * The <code>MGF1ParameterSpec</code> which uses "SHA-512/224"
+     * The <code>MGF1ParameterSpec</code> which uses a "SHA-512/224"
      * message digest.
      *
      * @since 11
@@ -104,7 +104,7 @@ public class MGF1ParameterSpec implements AlgorithmParameterSpec {
         new MGF1ParameterSpec("SHA-512/224");
 
     /**
-     * The <code>MGF1ParameterSpec</code> which uses "SHA-512/256"
+     * The <code>MGF1ParameterSpec</code> which uses a "SHA-512/256"
      * message digest.
      *
      * @since 11
@@ -113,7 +113,8 @@ public class MGF1ParameterSpec implements AlgorithmParameterSpec {
         new MGF1ParameterSpec("SHA-512/256");
 
     /**
-     * The <code>MGF1ParameterSpec</code> which uses "SHA3-224" message digest.
+     * The <code>MGF1ParameterSpec</code> which uses a "SHA3-224"
+     * message digest.
      *
      * @since 16
      */
@@ -121,7 +122,8 @@ public class MGF1ParameterSpec implements AlgorithmParameterSpec {
         new MGF1ParameterSpec("SHA3-224");
 
     /**
-     * The <code>MGF1ParameterSpec</code> which uses "SHA3-256" message digest.
+     * The <code>MGF1ParameterSpec</code> which uses a "SHA3-256"
+     * message digest.
      *
      * @since 16
      */
@@ -129,7 +131,8 @@ public class MGF1ParameterSpec implements AlgorithmParameterSpec {
         new MGF1ParameterSpec("SHA3-256");
 
     /**
-     * The <code>MGF1ParameterSpec</code> which uses "SHA3-384" message digest.
+     * The <code>MGF1ParameterSpec</code> which uses a "SHA3-384"
+     * message digest.
      *
      * @since 16
      */
@@ -137,7 +140,9 @@ public class MGF1ParameterSpec implements AlgorithmParameterSpec {
         new MGF1ParameterSpec("SHA3-384");
 
     /**
-     * The <code>MGF1ParameterSpec</code> which uses "SHA3-512" message digest.
+     * The <code>MGF1ParameterSpec</code> which uses a "SHA3-512"
+     * message digest.
+     *
      * @since 16
      */
     public static final MGF1ParameterSpec SHA3_512 =

--- a/src/java.base/share/classes/java/security/spec/MGF1ParameterSpec.java
+++ b/src/java.base/share/classes/java/security/spec/MGF1ParameterSpec.java
@@ -143,7 +143,7 @@ public class MGF1ParameterSpec implements AlgorithmParameterSpec {
     public static final MGF1ParameterSpec SHA3_512 =
         new MGF1ParameterSpec("SHA3-512");
 
-    private String mdName;
+    private final String mdName;
 
     /**
      * Constructs a parameter set for mask generation function MGF1


### PR DESCRIPTION
Two new constant fields `MGF1ParameterSpec.SHA512_224` and `MGF1ParameterSpec.SHA512_256` didn't have `@since 11` tag added as part of [JDK-8146293](https://bugs.openjdk.java.net/browse/JDK-8146293). 

This bug addresses this issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285683](https://bugs.openjdk.java.net/browse/JDK-8285683): Missing @ since 11 in java.security.spec.MGF1ParameterSpec fields


### Reviewers
 * [Hai-May Chao](https://openjdk.java.net/census#hchao) (@haimaychao - Committer) ⚠️ Review applies to 8f3981c1fd3e0ea0693bf49ea5fb1bf840315123
 * [Valerie Peng](https://openjdk.java.net/census#valeriep) (@valeriepeng - **Reviewer**) ⚠️ Review applies to 8f3981c1fd3e0ea0693bf49ea5fb1bf840315123
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**) ⚠️ Review applies to 8f3981c1fd3e0ea0693bf49ea5fb1bf840315123
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**) ⚠️ Review applies to 00edca0d05ff79c59eabe1be7f2fde647d4f0ad8


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8411/head:pull/8411` \
`$ git checkout pull/8411`

Update a local copy of the PR: \
`$ git checkout pull/8411` \
`$ git pull https://git.openjdk.java.net/jdk pull/8411/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8411`

View PR using the GUI difftool: \
`$ git pr show -t 8411`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8411.diff">https://git.openjdk.java.net/jdk/pull/8411.diff</a>

</details>
