### PR TITLE
8155701: The compiler fails with an AssertionError: typeSig ERROR

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -2419,7 +2419,7 @@ public class Resolve {
      *                   (a subset of VAL, TYP, PCK).
      */
     Symbol findIdent(DiagnosticPosition pos, Env<AttrContext> env, Name name, KindSelector kind) {
-        return checkRestrictedType(pos, findIdentInternal(env, name, kind), name);
+        return checkNonExistentType(checkRestrictedType(pos, findIdentInternal(env, name, kind), name));
     }
 
     Symbol findIdentInternal(Env<AttrContext> env, Name name, KindSelector kind) {
@@ -2455,7 +2455,7 @@ public class Resolve {
     Symbol findIdentInPackage(DiagnosticPosition pos,
                               Env<AttrContext> env, TypeSymbol pck,
                               Name name, KindSelector kind) {
-        return checkRestrictedType(pos, findIdentInPackageInternal(env, pck, name, kind), name);
+        return checkNonExistentType(checkRestrictedType(pos, findIdentInPackageInternal(env, pck, name, kind), name));
     }
 
     Symbol findIdentInPackageInternal(Env<AttrContext> env, TypeSymbol pck,
@@ -2492,7 +2492,17 @@ public class Resolve {
     Symbol findIdentInType(DiagnosticPosition pos,
                            Env<AttrContext> env, Type site,
                            Name name, KindSelector kind) {
-        return checkRestrictedType(pos, findIdentInTypeInternal(env, site, name, kind), name);
+        return checkNonExistentType(checkRestrictedType(pos, findIdentInTypeInternal(env, site, name, kind), name));
+    }
+
+    private Symbol checkNonExistentType(Symbol symbol) {
+        /*  Guard against returning a type is not on the class path of the current compilation,
+         *  but *was* on the class path of a separate compilation that produced a class file
+         *  that is on the class path of the current compilation. Such a type will fail completion
+         *  but the completion failure may have been silently swallowed (e.g. missing annotation types)
+         *  with an error stub symbol lingering in the symbol tables.
+         */
+        return symbol instanceof ClassSymbol c && c.type.isErroneous() && c.classfile == null ? typeNotFound : symbol;
     }
 
     Symbol findIdentInTypeInternal(Env<AttrContext> env, Type site,

--- a/test/langtools/tools/javac/annotations/MissingAnnotationClassFile.java
+++ b/test/langtools/tools/javac/annotations/MissingAnnotationClassFile.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8155701
+ * @summary Ensure that compiler surfaces diagnostics about inaccessible class
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ * @run main MissingAnnotationClassFile
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+
+import javax.tools.JavaCompiler;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+
+import toolbox.*;
+
+public class MissingAnnotationClassFile {
+
+    public static void main(String [] args) throws Exception {
+
+        ToolBox tb = new ToolBox();
+        Path base = Paths.get(".");
+        Path testSrc = base.resolve("test-src");
+        tb.createDirectories(testSrc);
+        Path libSrc = testSrc.resolve("lib-src");
+        tb.createDirectories(libSrc);
+        tb.writeJavaFiles(libSrc, "package lib;\n" +
+                                  "public @interface I {\n" +
+                                  "    String value();\n" +
+                                  "}\n",
+
+                                  "package lib;\n" +
+                                  "@I(\"Foo\")\n" +
+                                  "public class Foo {}\n");
+        Path libClasses = base.resolve("lib-classes");
+        tb.createDirectories(libClasses);
+        new JavacTask(tb).outdir(libClasses.toString())
+                         .sourcepath(libSrc.toString())
+                         .files(tb.findJavaFiles(libSrc))
+                         .run()
+                         .writeAll();
+
+        Files.delete(libClasses.resolve("lib/I.class"));
+
+        tb.writeJavaFiles(testSrc, "import lib.Foo;\n" +
+                                   "public class Bar {\n" +
+                                   "@lib.I(\"Bar\")\n" +
+                                   "public void bar() {}\n" +
+                                   "}\n");
+        Path testClasses = base.resolve("test-classes");
+        tb.createDirectories(testClasses);
+
+        Path bar = testSrc.resolve("Bar.java");
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        List<String> errors = new ArrayList<>();
+
+        try (StandardJavaFileManager fm = compiler.getStandardFileManager(null, null, null)) {
+            com.sun.source.util.JavacTask task = (com.sun.source.util.JavacTask)
+                    compiler.getTask(null,
+                                     null,
+                                     d -> errors.add(d.getCode()),
+                                     Arrays.asList("-XDrawDiagnostics",
+                                                   "-classpath",
+                                                   libClasses.toString()),
+                                     null,
+                                     fm.getJavaFileObjects(bar));
+            task.parse();
+            task.analyze();
+            task.generate();
+        }
+
+        List<String> expected = Arrays.asList("compiler.err.cant.resolve.location");
+
+        if (!expected.equals(errors)) {
+            throw new IllegalStateException("Expected error not found!");
+        }
+    }
+}


### PR DESCRIPTION
Make sure javac issues suitable diagnostics for types not found in the class path

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8155701](https://bugs.openjdk.java.net/browse/JDK-8155701): The compiler fails with an AssertionError: typeSig ERROR


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8414/head:pull/8414` \
`$ git checkout pull/8414`

Update a local copy of the PR: \
`$ git checkout pull/8414` \
`$ git pull https://git.openjdk.java.net/jdk pull/8414/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8414`

View PR using the GUI difftool: \
`$ git pr show -t 8414`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8414.diff">https://git.openjdk.java.net/jdk/pull/8414.diff</a>

</details>
