### PR TITLE
8178969: [TESTBUG] Wrong reporting of gc/g1/humongousObjects/TestHeapCounters test.

### DIFF
--- a/test/hotspot/jtreg/gc/g1/humongousObjects/TestHeapCounters.java
+++ b/test/hotspot/jtreg/gc/g1/humongousObjects/TestHeapCounters.java
@@ -162,7 +162,7 @@ public class TestHeapCounters {
             if (gcCountNow == gcCountBefore) {
                 // We should allocate at least allocation.expectedSize
                 Asserts.assertGreaterThanOrEqual(usedMemoryAfter - usedMemoryBefore, expectedAllocationSize,
-                        "Counter of type " + memoryCounter.getClass().getSimpleName() +
+                        "Counter of type " + memoryCounter.toString() +
                                 " returned wrong allocation size");
             } else {
                 System.out.println("GC happened during allocation so the check is skipped");
@@ -184,7 +184,7 @@ public class TestHeapCounters {
             // We should free at least allocation.expectedSize * ALLOCATION_SIZE_TOLERANCE_FACTOR
             Asserts.assertGreaterThanOrEqual(usedMemoryBefore - usedMemoryAfter,
                     (long) (allocation.expectedSize * ALLOCATION_SIZE_TOLERANCE_FACTOR),
-                    "Counter of type " + memoryCounter.getClass().getSimpleName() + " returned wrong allocation size");
+                    "Counter of type " + memoryCounter.toString() + " returned wrong allocation size");
         });
     }
 }


### PR DESCRIPTION
Hi all,

Please review this small fix on the error message. The `getSimpleName()` returns an empty string for anonymous classes, and in this case, the enum values are objects of anonymous classes. 

Thanks
Ivan

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8178969](https://bugs.openjdk.java.net/browse/JDK-8178969): [TESTBUG] Wrong reporting of gc/g1/humongousObjects/TestHeapCounters test.


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8415/head:pull/8415` \
`$ git checkout pull/8415`

Update a local copy of the PR: \
`$ git checkout pull/8415` \
`$ git pull https://git.openjdk.java.net/jdk pull/8415/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8415`

View PR using the GUI difftool: \
`$ git pr show -t 8415`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8415.diff">https://git.openjdk.java.net/jdk/pull/8415.diff</a>

</details>
