### PR TITLE
8285693: Create an automated test for JDK-4702199

### DIFF
--- a/test/jdk/javax/accessibility/4702199/AccessibleExtendedTextTest.java
+++ b/test/jdk/javax/accessibility/4702199/AccessibleExtendedTextTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key headful
+ * @bug 4702199
+ * @summary AccessibleExtendedText and related classes for
+ * missing accessibility support
+ * @run main AccessibleExtendedTextTest
+ */
+
+public class AccessibleExtendedTextTest {
+
+    public static void doTest() throws Exception {
+        try {
+            Class[] param = { int.class, int.class };
+            Class accessibleExtendedText =
+                Class.forName("javax.accessibility.AccessibleExtendedText");
+            accessibleExtendedText.getDeclaredField("LINE");
+            accessibleExtendedText.getDeclaredField("ATTRIBUTE_RUN");
+            accessibleExtendedText.getDeclaredMethod("getTextRange", param);
+            accessibleExtendedText.getDeclaredMethod("getTextSequenceAt",
+                param);
+            accessibleExtendedText.getDeclaredMethod("getTextSequenceAfter",
+                param);
+            accessibleExtendedText.getDeclaredMethod("getTextSequenceBefore",
+                param);
+            accessibleExtendedText.getDeclaredMethod("getTextBounds", param);
+        } catch (Exception e) {
+            throw new Exception(
+                "Failures in Interface AccessibleExtendedText");
+        }
+
+        try {
+            Class accessibleTextSequence =
+                Class.forName("javax.accessibility.AccessibleTextSequence");
+            accessibleTextSequence.getDeclaredField("startIndex");
+            accessibleTextSequence.getDeclaredField("endIndex");
+            accessibleTextSequence.getDeclaredField("text");
+        } catch (Exception e) {
+            throw new Exception(
+                "Failures in Interface AccessibleTextSequence");
+        }
+
+        try {
+            Class accessibleTextAttributeSequence = Class
+                .forName("javax.accessibility.AccessibleAttributeSequence");
+            accessibleTextAttributeSequence.getDeclaredField("startIndex");
+            accessibleTextAttributeSequence.getDeclaredField("endIndex");
+            accessibleTextAttributeSequence.getDeclaredField("attributes");
+        } catch (Exception e) {
+            throw new Exception(
+                "Failures in Interface AccessibleAttributeSequence");
+        }
+
+        try {
+            Class accessibleContext =
+                Class.forName("javax.accessibility.AccessibleContext");
+            accessibleContext
+            .getDeclaredField("ACCESSIBLE_INVALIDATE_CHILDREN");
+            accessibleContext
+            .getDeclaredField("ACCESSIBLE_TEXT_ATTRIBUTES_CHANGED");
+            accessibleContext
+            .getDeclaredField("ACCESSIBLE_COMPONENT_BOUNDS_CHANGED");
+        } catch (Exception e) {
+            throw new Exception(
+                "Failures in Interface AccessibleContext");
+        }
+        System.out.println("Test Passed");
+    }
+
+    public static void main(String[] args) throws Exception {
+        doTest();
+    }
+}


### PR DESCRIPTION
reate an automated test for [JDK-4702199](https://bugs.openjdk.java.net/browse/JDK-4702199)

In order for spatial Braille to work and screen reader "review mode", we need bounding rectangle information for all text on the screen, and also the ability to get text substrings. StarOffice 6.1, Netscape and GNOME accessibility also require this new interface for describing text in their applications. This new interface is required for accessibility to StarOffice 6.1, Netscape and GNOME applications as required by Section 508

The solution is to define a new interface and related two helper classes.
AccessibleExtendedText,
AccessibleTextSequence.
AccessibleAttributeSequence

The test validates the public fields of the above classes.
This review is for migrating tests from a closed test suite to open.

Testing:
The test ran successfully on Mach5 with multiple runs (30) on windows-x64, linux-x64 and macos-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285693](https://bugs.openjdk.java.net/browse/JDK-8285693): Create an automated test for JDK-4702199


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8416/head:pull/8416` \
`$ git checkout pull/8416`

Update a local copy of the PR: \
`$ git checkout pull/8416` \
`$ git pull https://git.openjdk.java.net/jdk pull/8416/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8416`

View PR using the GUI difftool: \
`$ git pr show -t 8416`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8416.diff">https://git.openjdk.java.net/jdk/pull/8416.diff</a>

</details>
