### PR TITLE
8285690: CloneableReference subtest should not throw CloneNotSupportedException

### DIFF
--- a/test/jdk/java/lang/ref/ReferenceClone.java
+++ b/test/jdk/java/lang/ref/ReferenceClone.java
@@ -47,7 +47,9 @@ public class ReferenceClone {
         CloneableReference ref = new CloneableReference(o);
         try {
             ref.clone();
-        } catch (CloneNotSupportedException e) {}
+        } catch (CloneNotSupportedException e) {
+            throw new RuntimeException("CloneableReference::clone should not throw CloneNotSupportedException");
+        }
     }
 
     private void assertCloneNotSupported(CloneableRef ref) {


### PR DESCRIPTION
Please review this fix to test/jdk/java/lang/ref/ReferenceClone.java.  It was
passing if CloneableReference::clone were to throw CloneNotSupportedException.
That should be a failure.

Testing:
Locally (linux-x64) verified test still passes.  Temporarily changed
CloneableReference::clone to throw and verified the expected failure gets
reported, unlike before.
