### PR TITLE
8285630: Fix a configure error in RISC-V cross build

### DIFF
--- a/make/autoconf/build-aux/config.sub
+++ b/make/autoconf/build-aux/config.sub
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,13 @@ fi
 # Allow msys2
 if echo $* | grep pc-msys >/dev/null ; then
     echo $*
+    exit
+fi
+
+# Canonicalize for riscv64 which autoconf-config.sub doesn't handle
+if echo $* | grep '^riscv64-linux' >/dev/null ; then
+    result=`echo $@ | sed 's/^riscv64-linux/riscv64-unknown-linux/'`
+    echo $result
     exit
 fi
 

--- a/make/autoconf/build-aux/config.sub
+++ b/make/autoconf/build-aux/config.sub
@@ -46,9 +46,9 @@ if echo $* | grep pc-msys >/dev/null ; then
     exit
 fi
 
-# Canonicalize for riscv64 which autoconf-config.sub doesn't handle
-if echo $* | grep '^riscv64-linux' >/dev/null ; then
-    result=`echo $@ | sed 's/^riscv64-linux/riscv64-unknown-linux/'`
+# Canonicalize for riscv which autoconf-config.sub doesn't handle
+if echo $* | grep '^riscv\(32\|64\)-linux' >/dev/null ; then
+    result=`echo $@ | sed 's/linux/unknown-linux/'`
     echo $result
     exit
 fi
@@ -85,4 +85,3 @@ result=`echo $result | sed "s/^arm-/aarch64-/"`
 
 echo $result
 exit $exitcode
-


### PR DESCRIPTION
We are trying to cross build a RISC-V version of OpenJDK. We specified
`--openjdk-target=riscv64-linux-gnu` after `bash configure` but got an
error message.

```
configure: error: /usr/bin/bash /home/ent-user/jdk_src/make/autoconf/build-aux/config.sub riscv64-linux-gnu failed
configure exiting with result code 1
```

It shows the processing of `riscv64-linux-gnu` in script `config.sub`
fails. We see `config.sub` calls another script `autoconf-config.sub`
to validate and canonicalize a configuration type. The validation fails
here because `autoconf-config.sub` is a quite old version and has no
RISC-V support inside. Comments in those scripts tell us patching the
autoconf script is not a good idea so we add a fix in `config.sub` in
this patch.

We have verified RISC-V cross build succeeds after this change. As we
are not quite familiar with the build system, please let us know if this
is the best way to fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285630](https://bugs.openjdk.java.net/browse/JDK-8285630): Fix a configure error in RISC-V cross build


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)
 * [Feilong Jiang](https://openjdk.java.net/census#fjiang) (@feilongjiang - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8420/head:pull/8420` \
`$ git checkout pull/8420`

Update a local copy of the PR: \
`$ git checkout pull/8420` \
`$ git pull https://git.openjdk.java.net/jdk pull/8420/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8420`

View PR using the GUI difftool: \
`$ git pr show -t 8420`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8420.diff">https://git.openjdk.java.net/jdk/pull/8420.diff</a>

</details>
