### PR TITLE
8285711: riscv: RVC: Support disassembler show-bytes option

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -266,12 +266,27 @@ class InternalAddress: public Address {
 class Assembler : public AbstractAssembler {
 public:
 
-  enum { instruction_size = 4 };
+  enum {
+    instruction_size = 4,
+    compressed_instruction_size = 2,
+  };
+
+  // instruction must start at passed address
+  static bool is_compressed_instr(address instr) {
+    if (UseRVC && (((uint16_t *)instr)[0] & 0b11) != 0b11) {
+      // 16-bit instructions end with 0b00, 0b01, and 0b10
+      return true;
+    }
+    // 32-bit instructions end with 0b11
+    return false;
+  }
 
   //---<  calculate length of instruction  >---
   // We just use the values set above.
   // instruction must start at passed address
-  static unsigned int instr_len(unsigned char *instr) { return instruction_size; }
+  static unsigned int instr_len(address instr) {
+    return is_compressed_instr(instr) ? compressed_instruction_size : instruction_size;
+  }
 
   //---<  longest instructions  >---
   static unsigned int instr_maxlen() { return instruction_size; }

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -273,11 +273,16 @@ public:
 
   // instruction must start at passed address
   static bool is_compressed_instr(address instr) {
+    // The RISC-V ISA Manual, Section 'Base Instruction-Length Encoding':
+    // Instructions are stored in memory as a sequence of 16-bit little-endian parcels, regardless of
+    // memory system endianness. Parcels forming one instruction are stored at increasing halfword
+    // addresses, with the lowest-addressed parcel holding the lowest-numbered bits in the instruction
+    // specification.
     if (UseRVC && (((uint16_t *)instr)[0] & 0b11) != 0b11) {
-      // 16-bit instructions end with 0b00, 0b01, and 0b10
+      // 16-bit instructions' lowest two bits are 0b00, 0b01, and 0b10
       return true;
     }
-    // 32-bit instructions end with 0b11
+    // 32-bit instructions' lowest two bits are 0b11
     return false;
   }
 

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -279,10 +279,10 @@ public:
     // addresses, with the lowest-addressed parcel holding the lowest-numbered bits in the instruction
     // specification.
     if (UseRVC && (((uint16_t *)instr)[0] & 0b11) != 0b11) {
-      // 16-bit instructions' lowest two bits are 0b00, 0b01, and 0b10
+      // 16-bit instructions have their lowest two bits equal to 0b00, 0b01, or 0b10
       return true;
     }
-    // 32-bit instructions' lowest two bits are 0b11
+    // 32-bit instructions have their lowest two bits set to 0b11
     return false;
   }
 


### PR DESCRIPTION
When RVC (under which instruction size could become 2-byte) is enabled currently, the disassembler 'show-bytes' output is not right, for `Assembler::instr_len` doesn't get adjusted.

Using `-XX:+UnlockExperimentalVMOptions -XX:+UseRVC -XX:+UnlockDiagnosticVMOptions -XX:+PrintAssembly -XX:PrintAssemblyOptions=no-aliases,numeric,show-bytes -XX:+PrintAssembly`

Before: (wrong)
```
...
0x000000401354f9bc: 9722 4107  | auipc  x5,0x7412                               ;   {runtime_call handle_exception_from_callee Runtime1 stub}
  0x000000401354f9c0: e780 4210  | jalr  x1,260(x5) # 0x000000401a961ac0
  0x000000401354f9c4: 1571 06e0  | c.addi16sp  x2,-224
  0x000000401354f9c6: 06e0 16e4  | c.sdsp  x1,0(x2)
  0x000000401354f9c8: 16e4 1ae8  | c.sdsp  x5,8(x2)
  0x000000401354f9ca: 1ae8 1eec  | c.sdsp  x6,16(x2)
  0x000000401354f9cc: 1eec 22f0  | c.sdsp  x7,24(x2)
  0x000000401354f9ce: 22f0 26f4  | c.sdsp  x8,32(x2)
  0x000000401354f9d0: 26f4 2af8  | c.sdsp  x9,40(x2)
...
```

After: (right)
```
0x0000004013546c2c: 97a2 4107  | auipc  x5,0x741a                               ;   {runtime_call handle_exception_from_callee Runtime1 stub}
  0x0000004013546c30: e780 42b9  | jalr  x1,-1132(x5) # 0x000000401a9607c0
  0x0000004013546c34: 1571    | c.addi16sp  x2,-224
  0x0000004013546c36: 06e0    | c.sdsp  x1,0(x2)
  0x0000004013546c38: 16e4    | c.sdsp  x5,8(x2)
  0x0000004013546c3a: 1ae8    | c.sdsp  x6,16(x2)
  0x0000004013546c3c: 1eec    | c.sdsp  x7,24(x2)
  0x0000004013546c3e: 22f0    | c.sdsp  x8,32(x2)
  0x0000004013546c40: 26f4    | c.sdsp  x9,40(x2)
```

The [RISC-V ISA manual](https://github.com/riscv/riscv-isa-manual/blob/04cc07bccea63f6587371b6c75b228af3e5ebb02/src/intro.tex#L630-L635) reads, 
> We have to fix the order in which instruction parcels are stored in memory, independent of memory system endianness, to ensure that **the length-encoding bits always appear first in halfword address order**. This allows the length of a variable-length instruction to be quickly determined by an instruction-fetch unit by examining only the first few bits of the first 16-bit instruction parcel.

Instructions are stored in little-endian order, and in that only the first 16-bit matters, we could just check if the lowest 2 bits of it to detect the instruction length. 
(48-bit and 64-bit instructions are not supported yet in the current backend)
(extracting an `is_compressed_instr`, for this might get used in the future)

Thanks,
Xiaolin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285711](https://bugs.openjdk.java.net/browse/JDK-8285711): riscv: RVC: Support disassembler show-bytes option


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**) ⚠️ Review applies to 20d8f09b390e080c2574294544ff687434649989


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8421/head:pull/8421` \
`$ git checkout pull/8421`

Update a local copy of the PR: \
`$ git checkout pull/8421` \
`$ git pull https://git.openjdk.java.net/jdk pull/8421/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8421`

View PR using the GUI difftool: \
`$ git pr show -t 8421`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8421.diff">https://git.openjdk.java.net/jdk/pull/8421.diff</a>

</details>
