### PR TITLE
JDK-8285712: LogMessageBuffer doesn't check vsnprintf return value

### DIFF
--- a/src/hotspot/share/logging/logMessageBuffer.cpp
+++ b/src/hotspot/share/logging/logMessageBuffer.cpp
@@ -110,7 +110,14 @@ void LogMessageBuffer::vwrite(LogLevelType level, const char* fmt, va_list args)
 
     va_list copy;
     va_copy(copy, args);
-    written += (size_t)os::vsnprintf(current_buffer_position, remaining_buffer_length, fmt, copy) + 1;
+    int ret = os::vsnprintf(current_buffer_position, remaining_buffer_length, fmt, copy);
+    assert(ret >= 0, "Log message buffer issue.");
+    if (ret < 0) {
+      // Encoding error occurred, bail.
+      va_end(copy);
+      return;
+    }
+    written += (size_t)ret + 1;
     va_end(copy);
     if (written > _message_buffer_capacity - _message_buffer_size) {
       assert(attempts == 0, "Second attempt should always have a sufficiently large buffer (resized to fit).");

--- a/src/hotspot/share/logging/logMessageBuffer.cpp
+++ b/src/hotspot/share/logging/logMessageBuffer.cpp
@@ -111,14 +111,13 @@ void LogMessageBuffer::vwrite(LogLevelType level, const char* fmt, va_list args)
     va_list copy;
     va_copy(copy, args);
     int ret = os::vsnprintf(current_buffer_position, remaining_buffer_length, fmt, copy);
+    va_end(copy);
     assert(ret >= 0, "Log message buffer issue.");
     if (ret < 0) {
       // Encoding error occurred, bail.
-      va_end(copy);
       return;
     }
     written += (size_t)ret + 1;
-    va_end(copy);
     if (written > _message_buffer_capacity - _message_buffer_size) {
       assert(attempts == 0, "Second attempt should always have a sufficiently large buffer (resized to fit).");
       grow(_message_buffer, _message_buffer_capacity, _message_buffer_size + written);

--- a/src/hotspot/share/logging/logMessageBuffer.cpp
+++ b/src/hotspot/share/logging/logMessageBuffer.cpp
@@ -112,9 +112,9 @@ void LogMessageBuffer::vwrite(LogLevelType level, const char* fmt, va_list args)
     va_copy(copy, args);
     int ret = os::vsnprintf(current_buffer_position, remaining_buffer_length, fmt, copy);
     va_end(copy);
-    assert(ret >= 0, "Log message buffer issue.");
+    assert(ret >= 0, "Log message buffer issue");
     if (ret < 0) {
-      // Encoding error occurred, bail.
+      this->write(level, "%s", "Log message buffer issue");
       return;
     }
     written += (size_t)ret + 1;


### PR DESCRIPTION
os::vsnprintf can return a negative value on encoding error. A negative return value will cause wraparound when cast to size_t. This in turn causes LogMessageBuffer::grow() to attempt a large memory allocation. Instead of accepting this we bail on the logging.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285712](https://bugs.openjdk.java.net/browse/JDK-8285712): LogMessageBuffer doesn't check vsnprintf return value


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to bbe720cd143b7a8efa2eff0a9091e63fe0707a40
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8423/head:pull/8423` \
`$ git checkout pull/8423`

Update a local copy of the PR: \
`$ git checkout pull/8423` \
`$ git pull https://git.openjdk.java.net/jdk pull/8423/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8423`

View PR using the GUI difftool: \
`$ git pr show -t 8423`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8423.diff">https://git.openjdk.java.net/jdk/pull/8423.diff</a>

</details>
