### PR TITLE
8285710: Miscalculation of G1CardSetAllocator unused memory size

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
@@ -61,9 +61,8 @@ size_t G1CardSetAllocator::mem_size() const {
 }
 
 size_t G1CardSetAllocator::unused_mem_size() const {
-  uint num_unused_slots = _segmented_array.num_total_slots() -
-                          _segmented_array.num_allocated_slots() -
-                          (uint)_free_slots_list.pending_count();
+  uint num_unused_slots = (_segmented_array.num_total_slots() - _segmented_array.num_allocated_slots()) +
+                          (uint)_free_slots_list.free_count();
   return num_unused_slots * _segmented_array.slot_size();
 }
 


### PR DESCRIPTION
when calculating the wasted memory size of G1CardSetAllocator, the code erroneously substracted both _segmented_array.num_allocated_slots() and _free_slots_list.pending_count() from _segmented_array.num_available_slots().

The correct formula should be: num_wasted_slots = _segmented_array.num_available_slots() - (_segmented_array.num_allocated_slots() - (uint)_free_slots_list.pending_count()).

This can potentially leads to an arithmetic overflow and misleading information will be displayed when G1SummarizeRSetStatsPeriod is set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8285710](https://bugs.openjdk.java.net/browse/JDK-8285710): Miscalculation of G1CardSetAllocator unused memory size


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [14d8a471](https://git.openjdk.java.net/jdk/pull/8424/files/14d8a471fc8f52610cdfe37d038a5d9e68d59aa1)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8424/head:pull/8424` \
`$ git checkout pull/8424`

Update a local copy of the PR: \
`$ git checkout pull/8424` \
`$ git pull https://git.openjdk.java.net/jdk pull/8424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8424`

View PR using the GUI difftool: \
`$ git pr show -t 8424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8424.diff">https://git.openjdk.java.net/jdk/pull/8424.diff</a>

</details>
