### PR TITLE
8285696: AlgorithmConstraints:permits not throwing IllegalArgumentException when 'alg'  is null

### DIFF
--- a/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
@@ -951,6 +951,9 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
     }
 
     private boolean cachedCheckAlgorithm(String algorithm) {
+        if (algorithm == null || algorithm.isEmpty()) {
+            throw new IllegalArgumentException("No algorithm name specified");
+        }
         Map<String, Boolean> cache;
         if ((cache = cacheRef.get()) == null) {
             synchronized (this) {

--- a/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
@@ -160,6 +160,9 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
             throw new IllegalArgumentException("The primitives cannot be null" +
                     " or empty.");
         }
+        if (algorithm == null || algorithm.isEmpty()) {
+            throw new IllegalArgumentException("No algorithm name specified");
+        }
 
         if (!cachedCheckAlgorithm(algorithm)) {
             return false;
@@ -951,9 +954,6 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
     }
 
     private boolean cachedCheckAlgorithm(String algorithm) {
-        if (algorithm == null || algorithm.isEmpty()) {
-            throw new IllegalArgumentException("No algorithm name specified");
-        }
         Map<String, Boolean> cache;
         if ((cache = cacheRef.get()) == null) {
             synchronized (this) {


### PR DESCRIPTION
Please review this follow up to #8349.

As JCK pointed out, `permits` is supposed to throw IAE on null input. However, now that we're looking up the result in a `ConcurrentHashMap`, a `NullPointerException` is thrown. This patch restores the original behavior.

Verified that the JCK test passes with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285696](https://bugs.openjdk.java.net/browse/JDK-8285696): AlgorithmConstraints:permits not throwing IllegalArgumentException when 'alg'  is null


### Reviewers
 * [Jaikiran Pai](https://openjdk.java.net/census#jpai) (@jaikiran - Committer) ⚠️ Review applies to 35361a3148b2d1029648c57ddc6286e4efc8a537
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8427/head:pull/8427` \
`$ git checkout pull/8427`

Update a local copy of the PR: \
`$ git checkout pull/8427` \
`$ git pull https://git.openjdk.java.net/jdk pull/8427/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8427`

View PR using the GUI difftool: \
`$ git pr show -t 8427`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8427.diff">https://git.openjdk.java.net/jdk/pull/8427.diff</a>

</details>
