### PR TITLE
8285736: JDK-8236128 causes validate-source failures

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/PlatformPackage.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/PlatformPackage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
A trivial fix for JDK-8236128 causes validate-source failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285736](https://bugs.openjdk.java.net/browse/JDK-8285736): JDK-8236128 causes validate-source failures


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8429/head:pull/8429` \
`$ git checkout pull/8429`

Update a local copy of the PR: \
`$ git checkout pull/8429` \
`$ git pull https://git.openjdk.java.net/jdk pull/8429/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8429`

View PR using the GUI difftool: \
`$ git pr show -t 8429`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8429.diff">https://git.openjdk.java.net/jdk/pull/8429.diff</a>

</details>
