### PR TITLE
8285755: JDK-8285093 changed the default for --with-output-sync

### DIFF
--- a/make/autoconf/basic_tools.m4
+++ b/make/autoconf/basic_tools.m4
@@ -162,7 +162,7 @@ AC_DEFUN([BASIC_CHECK_MAKE_OUTPUT_SYNC],
 [
   # Check if make supports the output sync option and if so, setup using it.
   UTIL_ARG_WITH(NAME: output-sync, TYPE: literal,
-      VALID_VALUES: [none recurse line target], DEFAULT: recurse,
+      VALID_VALUES: [none recurse line target], DEFAULT: none,
       OPTIONAL: true, ENABLED_DEFAULT: true,
       ENABLED_RESULT: OUTPUT_SYNC_SUPPORTED,
       CHECKING_MSG: [for make --output-sync value],


### PR DESCRIPTION
The make option '--output-sync recurse' can be useful in certain situations, especially when dealing with very verbose output from makefiles and you want to parse them after the fact. However, when running make interactively on the command line, it certainly gets in the way, as output from each sub make call is buffered until that make process terminates.

In [JDK-8285093](https://bugs.openjdk.java.net/browse/JDK-8285093), the configure logic for this configuration was changed and, probably by mistake, the default was changes to default "recurse" if available in the supplied GNU make. This is a regression for most users of the build system and needs to be changed back.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285755](https://bugs.openjdk.java.net/browse/JDK-8285755): JDK-8285093 changed the default for --with-output-sync


### Reviewers
 * [Mikael Vidstedt](https://openjdk.java.net/census#mikael) (@vidmik - **Reviewer**)
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8431/head:pull/8431` \
`$ git checkout pull/8431`

Update a local copy of the PR: \
`$ git checkout pull/8431` \
`$ git pull https://git.openjdk.java.net/jdk pull/8431/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8431`

View PR using the GUI difftool: \
`$ git pr show -t 8431`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8431.diff">https://git.openjdk.java.net/jdk/pull/8431.diff</a>

</details>
