### PR TITLE
8285745: Re-examine PushbackInputStream mark/reset

### DIFF
--- a/src/java.base/share/classes/java/io/PushbackInputStream.java
+++ b/src/java.base/share/classes/java/io/PushbackInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -345,7 +345,7 @@ public class PushbackInputStream extends FilterInputStream {
      *                      the mark position becomes invalid.
      * @see     java.io.InputStream#reset()
      */
-    public synchronized void mark(int readlimit) {
+    public void mark(int readlimit) {
     }
 
     /**
@@ -360,7 +360,7 @@ public class PushbackInputStream extends FilterInputStream {
      * @see     java.io.InputStream#mark(int)
      * @see     java.io.IOException
      */
-    public synchronized void reset() throws IOException {
+    public void reset() throws IOException {
         throw new IOException("mark/reset not supported");
     }
 


### PR DESCRIPTION
Please review this request to remove the `synchronized` keyword from the `mark(int)` and `reset()` methods of `java.io.PushbackInputStream`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8285745](https://bugs.openjdk.java.net/browse/JDK-8285745): Re-examine PushbackInputStream mark/reset
 * [JDK-8285759](https://bugs.openjdk.java.net/browse/JDK-8285759): Re-examine PushbackInputStream mark/reset (**CSR**)


### Reviewers
 * [Jaikiran Pai](https://openjdk.java.net/census#jpai) (@jaikiran - Committer)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8433/head:pull/8433` \
`$ git checkout pull/8433`

Update a local copy of the PR: \
`$ git checkout pull/8433` \
`$ git pull https://git.openjdk.java.net/jdk pull/8433/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8433`

View PR using the GUI difftool: \
`$ git pr show -t 8433`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8433.diff">https://git.openjdk.java.net/jdk/pull/8433.diff</a>

</details>
