### PR TITLE
JDK-8285756: clean up use of bad arguments for `@clean` in langtools tests

### DIFF
--- a/test/langtools/tools/javac/6257443/T6257443.java
+++ b/test/langtools/tools/javac/6257443/T6257443.java
@@ -29,7 +29,7 @@
  * @compile package-info.java
  * @run main/othervm T6257443 -yes foo/package-info.class
  *
- * @clean foo.package-info
+ * @clean foo.*
  *
  * @compile -printsource package-info.java
  * @run main/othervm T6257443 -no foo/package-info.class

--- a/test/langtools/tools/javac/jvm/ClassRefDupInConstantPoolTest.java
+++ b/test/langtools/tools/javac/jvm/ClassRefDupInConstantPoolTest.java
@@ -26,7 +26,7 @@
  * @bug 8015927
  * @summary Class reference duplicates in constant pool
  * @modules jdk.jdeps/com.sun.tools.classfile
- * @clean ClassRefDupInConstantPoolTest$Duplicates.class
+ * @clean ClassRefDupInConstantPoolTest$Duplicates
  * @run main ClassRefDupInConstantPoolTest
  */
 

--- a/test/langtools/tools/javac/warnings/suppress/PackageInfo.java
+++ b/test/langtools/tools/javac/warnings/suppress/PackageInfo.java
@@ -25,6 +25,6 @@
  * @test
  * @bug 8021112
  * @summary Verify that deprecated warnings are printed correctly for package-info.java
- * @clean pack.package-info pack.DeprecatedClass
+ * @clean pack.*
  * @compile/ref=PackageInfo.out -source 8 -XDrawDiagnostics -Xlint:deprecation,-options pack/package-info.java pack/DeprecatedClass.java
  */


### PR DESCRIPTION
Please review a trivial test fix to fix some bad/unsupported forms of `@clean` tags in some java tests.

Previously, these bad args were not detected and effectively had no effect.  Now, an upcoming new jtreg version will detect and give errors for these forms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285756](https://bugs.openjdk.java.net/browse/JDK-8285756): clean up use of bad arguments for `@clean` in langtools tests


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8435/head:pull/8435` \
`$ git checkout pull/8435`

Update a local copy of the PR: \
`$ git checkout pull/8435` \
`$ git pull https://git.openjdk.java.net/jdk pull/8435/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8435`

View PR using the GUI difftool: \
`$ git pr show -t 8435`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8435.diff">https://git.openjdk.java.net/jdk/pull/8435.diff</a>

</details>
