### PR TITLE
8285699: riscv: Provide information when hitting a HaltNode

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -425,7 +425,7 @@ public:
 
   // Emit an illegal instruction that's known to trap, with 32 read-only CSR
   // to choose as the input operand.
-  // Acording to the RISC-V Assembly Programmer's Manual, a de facto implementation
+  // According to the RISC-V Assembly Programmer's Manual, a de facto implementation
   // of this instruction is the UNIMP pseduo-instruction, 'CSRRW x0, cycle, x0',
   // attempting to write zero to a read-only CSR 'cycle' (0xC00).
   // RISC-V ISAs provide a set of up to 32 read-only CSR registers 0xC00-0xC1F,

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -425,9 +425,9 @@ public:
 
   // Emit an illegal instruction that's known to trap, with 32 read-only CSR
   // to choose as the input operand.
-  // Acording RISC-V asembler manual, a de facto implementation of this instruction
-  // is the UNIMP pseduo-instruction, 'CSRRW x0, cycle, x0', attempting to write
-  // zero to a read-only CSR 'cycle' (0xC00).
+  // Acording to the RISC-V Assembly Programmer's Manual, a de facto implementation
+  // of this instruction is the UNIMP pseduo-instruction, 'CSRRW x0, cycle, x0',
+  // attempting to write zero to a read-only CSR 'cycle' (0xC00).
   // RISC-V ISAs provide a set of up to 32 read-only CSR registers 0xC00-0xC1F,
   // and an attempt to write into any read-only CSR (whether it exists or not)
   // will generate an illegal instruction exception.

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -388,8 +388,51 @@ public:
     emit_int32((jint)insn);
   }
 
-  void _halt() {
-    emit_int32(0);
+  enum csr {
+    cycle = 0xc00,
+    time,
+    instret,
+    hpmcounter3,
+    hpmcounter4,
+    hpmcounter5,
+    hpmcounter6,
+    hpmcounter7,
+    hpmcounter8,
+    hpmcounter9,
+    hpmcounter10,
+    hpmcounter11,
+    hpmcounter12,
+    hpmcounter13,
+    hpmcounter14,
+    hpmcounter15,
+    hpmcounter16,
+    hpmcounter17,
+    hpmcounter18,
+    hpmcounter19,
+    hpmcounter20,
+    hpmcounter21,
+    hpmcounter22,
+    hpmcounter23,
+    hpmcounter24,
+    hpmcounter25,
+    hpmcounter26,
+    hpmcounter27,
+    hpmcounter28,
+    hpmcounter29,
+    hpmcounter30,
+    hpmcounter31 = 0xc1f
+  };
+
+  // Emit an illegal instruction that's known to trap, with 32 read-only CSR
+  // to choose as the input operand.
+  // Acording RISC-V asembler manual, a de facto implementation of this instruction
+  // is the UNIMP pseduo-instruction, 'CSRRW x0, cycle, x0', attempting to write
+  // zero to a read-only CSR 'cycle' (0xC00).
+  // RISC-V ISAs provide a set of up to 32 read-only CSR registers 0xC00-0xC1F,
+  // and an attempt to write into any read-only CSR (whether it exists or not)
+  // will generate an illegal instruction exception.
+  void illegal_instruction(csr csr_reg) {
+    csrrw(x0, (unsigned)csr_reg, x0);
   }
 
 // Register Instruction
@@ -2851,20 +2894,6 @@ public:
   }
 
   INSN(ebreak);
-
-#undef INSN
-
-#define INSN(NAME)                                                      \
-  void NAME() {                                                         \
-    /* The illegal instruction in RVC is presented by a 16-bit 0. */    \
-    if (do_compress()) {                                                \
-      emit_int16(0);                                                    \
-      return;                                                           \
-    }                                                                   \
-    _halt();                                                            \
-  }
-
-  INSN(halt);
 
 #undef INSN
 

--- a/src/hotspot/cpu/riscv/frame_riscv.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.hpp
@@ -106,10 +106,12 @@
  public:
   enum {
     pc_return_offset                                 =  0,
+
     // All frames
     link_offset                                      = -2,
     return_addr_offset                               = -1,
     sender_sp_offset                                 =  0,
+
     // Interpreter frames
     interpreter_frame_oop_temp_offset                =  1, // for native calls only
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -379,7 +379,7 @@ void MacroAssembler::_verify_oop(Register reg, const char* s, const char* file, 
 
   mv(c_rarg0, reg); // c_rarg0 : x10
   // The length of the instruction sequence emitted should be independent
-  // of the values of the local char buffer address so that the size of mach
+  // of the value of the local char buffer address so that the size of mach
   // nodes for scratch emit and normal emit matches.
   mv(t0, (address)b);
 
@@ -418,7 +418,7 @@ void MacroAssembler::_verify_oop_addr(Address addr, const char* s, const char* f
   }
 
   // The length of the instruction sequence emitted should be independent
-  // of the values of the local char buffer address so that the size of mach
+  // of the value of the local char buffer address so that the size of mach
   // nodes for scratch emit and normal emit matches.
   mv(t0, (address)b);
 
@@ -535,17 +535,9 @@ void MacroAssembler::resolve_jobject(Register value, Register thread, Register t
 }
 
 void MacroAssembler::stop(const char* msg) {
-  address ip = pc();
-  pusha();
-  // The length of the instruction sequence emitted should be independent
-  // of the values of msg and ip so that the size of mach nodes for scratch
-  // emit and normal emit matches.
-  mv(c_rarg0, (address)msg);
-  mv(c_rarg1, (address)ip);
-  mv(c_rarg2, sp);
-  mv(c_rarg3, CAST_FROM_FN_PTR(address, MacroAssembler::debug64));
-  jalr(c_rarg3);
-  ebreak();
+  BLOCK_COMMENT(msg);
+  illegal_instruction(Assembler::csr::time);
+  emit_int64((uintptr_t)msg);
 }
 
 void MacroAssembler::unimplemented(const char* what) {
@@ -1117,18 +1109,6 @@ void MacroAssembler::pop_call_clobbered_registers_except(RegSet exclude) {
   addi(sp, sp, wordSize * 20);
 
   pop_reg(RegSet::of(x7) + RegSet::range(x10, x17) + RegSet::range(x28, x31) - exclude, sp);
-}
-
-// Push all the integer registers, except zr(x0) & sp(x2) & gp(x3) & tp(x4).
-void MacroAssembler::pusha() {
-  CompressibleRegion cr(this);
-  push_reg(0xffffffe2, sp);
-}
-
-// Pop all the integer registers, except zr(x0) & sp(x2) & gp(x3) & tp(x4).
-void MacroAssembler::popa() {
-  CompressibleRegion cr(this);
-  pop_reg(0xffffffe2, sp);
 }
 
 void MacroAssembler::push_CPU_state(bool save_vectors, int vector_size_in_bytes) {
@@ -2936,9 +2916,7 @@ address MacroAssembler::emit_trampoline_stub(int insts_call_instruction_offset,
   // with the call instruction at insts_call_instruction_offset in the
   // instructions code-section.
 
-  // make sure 4 byte aligned here, so that the destination address would be
-  // 8 byte aligned after 3 instructions
-  // when we reach here we may get a 2-byte alignment so need to align it
+  // Make sure the address of destination 8-byte aligned after 3 instructions.
   align(wordSize, NativeCallTrampolineStub::data_offset);
 
   relocate(trampoline_stub_Relocation::spec(code()->insts()->start() +

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -512,8 +512,6 @@ class MacroAssembler: public Assembler {
     pop_call_clobbered_registers_except(RegSet());
   }
 
-  void pusha();
-  void popa();
   void push_CPU_state(bool save_vectors = false, int vector_size_in_bytes = 0);
   void pop_CPU_state(bool restore_vectors = false, int vector_size_in_bytes = 0);
 

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -339,7 +339,7 @@ void NativeIllegalInstruction::insert(address code_pos) {
 }
 
 bool NativeInstruction::is_stop() {
-  return uint_at(0) == 0xffffffff; // an illegal instruction
+  return uint_at(0) == 0xc0101073; // an illegal instruction, 'csrrw x0, time, x0'
 }
 
 //-------------------------------------------------------------------

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -10565,9 +10565,8 @@ instruct ShouldNotReachHere() %{
   format %{ "#@ShouldNotReachHere" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     if (is_reachable()) {
-      __ halt();
+      __ stop(_halt_reason);
     }
   %}
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -578,7 +578,7 @@ class StubGenerator: public StubCodeGenerator {
     __ bind(error);
     __ pop_reg(0x3000, sp);   // pop c_rarg2 and c_rarg3
 
-    __ pusha();
+    __ push_reg(RegSet::range(x0, x31), sp);
     // debug(char* msg, int64_t pc, int64_t regs[])
     __ mv(c_rarg0, t0);             // pass address of error message
     __ mv(c_rarg1, ra);             // pass return address

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -1228,11 +1228,11 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
     __ addi(t1, zr, (u1)StackOverflow::stack_guard_yellow_reserved_disabled);
     __ bne(t0, t1, no_reguard);
 
-    __ pusha(); // only save smashed registers
+    __ push_call_clobbered_registers();
     __ mv(c_rarg0, xthread);
     __ mv(t1, CAST_FROM_FN_PTR(address, SharedRuntime::reguard_yellow_pages));
     __ jalr(t1);
-    __ popa(); // only restore smashed registers
+    __ pop_call_clobbered_registers();
     __ bind(no_reguard);
   }
 

--- a/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
@@ -354,7 +354,7 @@ void os::print_context(outputStream *st, const void *context) {
   // point to garbage if entry point in an nmethod is corrupted. Leave
   // this at the end, and hope for the best.
   address pc = os::Posix::ucontext_get_pc(uc);
-  print_instructions(st, pc, sizeof(char));
+  print_instructions(st, pc, UseRVC ? sizeof(char) : 4/*non-compressed native instruction size*/);
   st->cr();
 }
 


### PR DESCRIPTION
The code generated in MacroAssembler::stop is indeed grossly bloated with pusha()/popa() and a native call. We would like to follow the implementation in aarch64 port [JDK-8245986](https://bugs.openjdk.java.net/browse/JDK-8245986), and provide a halt reason when hitting a C2 HaltNode on riscv, and implement it by triggering illegal instruction exceptions.

hs_err_pid log BEFORE:
```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGILL (0x4) at pc=0x0000003fdd049cd0, pid=2203593, tid=2203614
#
# JRE version: OpenJDK Runtime Environment (19.0) (fastdebug build 19-internal-adhoc.wangyadong.jdk)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 19-internal-adhoc.wangyadong.jdk, compiled mode, compressed oops, compressed class ptrs, g1 gc, linux-riscv64)
# Problematic frame:
# J 20 c2 compiler.unsafe.TestUnsafeLoadWithZeroAddress.main([Ljava/lang/String;)V (13 bytes) @ 0x0000003fdd049cd0 [0x0000003fdd049c40+0x0000000000000090]
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
#

---------------  S U M M A R Y ------------

Command Line: -Dtest.vm.opts= -Dtest.tool.vm.opts= -Dtest.compiler.opts= -Dtest.java.opts= -Dtest.jdk=/home/wangyadong/openjdk-19-internal-before -Dcompile.jdk=/home/wangyadong/openjdk-19-internal-before -Dtest.timeout.factor=1.0 -Dtest.root=/home/wangyadong/riscv-port/test/hotspot/jtreg -Dtest.name=compiler/unsafe/TestUnsafeLoadWithZeroAddress.java -Dtest.file=/home/wangyadong/riscv-port/test/hotspot/jtreg/compiler/unsafe/TestUnsafeLoadWithZeroAddress.java -Dtest.src=/home/wangyadong/riscv-port/test/hotspot/jtreg/compiler/unsafe -Dtest.src.path=/home/wangyadong/riscv-port/test/hotspot/jtreg/compiler/unsafe -Dtest.classes=/home/wangyadong/riscv-port/JTwork/classes/compiler/unsafe/TestUnsafeLoadWithZeroAddress.d -Dtest.class.path=/home/wangyadong/riscv-port/JTwork/classes/compiler/unsafe/TestUnsafeLoadWithZeroAddress.d -Dtest.modules=java.base/jdk.internal.misc:+open --add-modules=java.base --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED -Xcomp -Xbatch -XX:-TieredCompilation -XX:+AlwaysIncrementalInline -XX:CompileCommand=compileonly,compiler.unsafe.TestUnsafeLoadWithZeroAddress::* com.sun.javatest.regtest.agent.MainWrapper /home/wangyadong/riscv-port/JTwork/compiler/unsafe/TestUnsafeLoadWithZeroAddress.d/main.0.jta

Host: ubuntu, RISCV64, 4 cores, 15G, Ubuntu 21.04
Time: Thu Apr 28 00:00:50 2022 CST elapsed time: 4.374528 seconds (0d 0h 0m 4s)

---------------  T H R E A D  ---------------

Current thread (0x0000003fe8471060):  JavaThread "MainThread" [_thread_in_Java, id=2203614, stack(0x0000003fc47a4000,0x0000003fc49a4000)]

Stack: [0x0000003fc47a4000,0x0000003fc49a4000],  sp=0x0000003fc49a1f00,  free space=2039k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
J 20 c2 compiler.unsafe.TestUnsafeLoadWithZeroAddress.main([Ljava/lang/String;)V (13 bytes) @ 0x0000003fdd049cd0 [0x0000003fdd049c40+0x0000000000000090]
j  java.lang.invoke.LambdaForm$DMH+0x0000000800080800.invokeStatic(Ljava/lang/Object;Ljava/lang/Object;)V+10 java.base@19-internal
j  java.lang.invoke.LambdaForm$MH+0x0000000800081c00.invoke(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;+33 java.base@19-internal
j  java.lang.invoke.Invokers$Holder.invokeExact_MT(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;+20 java.base@19-internal
j  jdk.internal.reflect.DirectMethodHandleAccessor.invokeImpl(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;+55 java.base@19-internal
j  jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;+23 java.base@19-internal
j  java.lang.reflect.Method.invoke(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;+102 java.base@19-internal
j  com.sun.javatest.regtest.agent.MainWrapper$MainThread.run()V+172
j  java.lang.Thread.run()V+11 java.base@19-internal
v  ~StubRoutines::call_stub
V  [libjvm.so+0xa8a0fe]  JavaCalls::call_helper(JavaValue*, methodHandle const&, JavaCallArguments*, JavaThread*)+0x4cc
V  [libjvm.so+0xa8a674]  JavaCalls::call_virtual(JavaValue*, Klass*, Symbol*, Symbol*, JavaCallArguments*, JavaThread*)+0x3e0
V  [libjvm.so+0xa8aa02]  JavaCalls::call_virtual(JavaValue*, Handle, Klass*, Symbol*, Symbol*, JavaThread*)+0x60
V  [libjvm.so+0xbcf9b4]  thread_entry(JavaThread*, JavaThread*)+0x88
V  [libjvm.so+0x1299d94]  JavaThread::thread_main_inner()+0x24e
V  [libjvm.so+0x12a0cd4]  Thread::call_run()+0xd4
V  [libjvm.so+0xf3c52e]  thread_native_entry(Thread*)+0xee
C  [libpthread.so.0+0x7460]  start_thread+0xb4
C  [libc.so.6+0xa7362]
```
hs_err_pid log AFTER:
```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (0xe0000000), pid=2178405, tid=2178428
#  stop: unsafe off-heap access with zero address
#
# JRE version: OpenJDK Runtime Environment (19.0) (fastdebug build 19-internal-adhoc.wangyadong.jdk)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 19-internal-adhoc.wangyadong.jdk, compiled mode, compressed oops, compressed class ptrs, g1 gc, linux-riscv64)
# Problematic frame:
# J 20 c2 compiler.unsafe.TestUnsafeLoadWithZeroAddress.main([Ljava/lang/String;)V (13 bytes) @ 0x0000003fe0f4c5d0 [0x0000003fe0f4c540+0x0000000000000090]
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
#

---------------  S U M M A R Y ------------

Command Line: -Dtest.vm.opts= -Dtest.tool.vm.opts= -Dtest.compiler.opts= -Dtest.java.opts= -Dtest.jdk=/home/wangyadong/openjdk-19-internal-fastdebug -Dcompile.jdk=/home/wangyadong/openjdk-19-internal-fastdebug -Dtest.timeout.factor=1.0 -Dtest.root=/home/wangyadong/riscv-port/test/hotspot/jtreg -Dtest.name=compiler/unsafe/TestUnsafeLoadWithZeroAddress.java -Dtest.file=/home/wangyadong/riscv-port/test/hotspot/jtreg/compiler/unsafe/TestUnsafeLoadWithZeroAddress.java -Dtest.src=/home/wangyadong/riscv-port/test/hotspot/jtreg/compiler/unsafe -Dtest.src.path=/home/wangyadong/riscv-port/test/hotspot/jtreg/compiler/unsafe -Dtest.classes=/home/wangyadong/riscv-port/JTwork/classes/compiler/unsafe/TestUnsafeLoadWithZeroAddress.d -Dtest.class.path=/home/wangyadong/riscv-port/JTwork/classes/compiler/unsafe/TestUnsafeLoadWithZeroAddress.d -Dtest.modules=java.base/jdk.internal.misc:+open --add-modules=java.base --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED -Xcomp -Xbatch -XX:-TieredCompilation -XX:+AlwaysIncrementalInline -XX:CompileCommand=compileonly,compiler.unsafe.TestUnsafeLoadWithZeroAddress::* com.sun.javatest.regtest.agent.MainWrapper /home/wangyadong/riscv-port/JTwork/compiler/unsafe/TestUnsafeLoadWithZeroAddress.d/main.0.jta

Host: ubuntu, RISCV64, 4 cores, 15G, Ubuntu 21.04
Time: Wed Apr 27 23:41:11 2022 CST elapsed time: 4.469731 seconds (0d 0h 0m 4s)

---------------  T H R E A D  ---------------

Current thread (0x0000003fec45d7a0):  JavaThread "MainThread" [_thread_in_Java, id=2178428, stack(0x0000003fc91fe000,0x0000003fc93fe000)]

Stack: [0x0000003fc91fe000,0x0000003fc93fe000],  sp=0x0000003fc93fbf00,  free space=2039k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
J 20 c2 compiler.unsafe.TestUnsafeLoadWithZeroAddress.main([Ljava/lang/String;)V (13 bytes) @ 0x0000003fe0f4c5d0 [0x0000003fe0f4c540+0x0000000000000090]
j  java.lang.invoke.LambdaForm$DMH+0x00000008000c0000.invokeStatic(Ljava/lang/Object;Ljava/lang/Object;)V+10 java.base@19-internal
j  java.lang.invoke.LambdaForm$MH+0x00000008000c1400.invoke(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;+33 java.base@19-internal
j  java.lang.invoke.Invokers$Holder.invokeExact_MT(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;+20 java.base@19-internal
j  jdk.internal.reflect.DirectMethodHandleAccessor.invokeImpl(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;+55 java.base@19-internal
j  jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;+23 java.base@19-internal
j  java.lang.reflect.Method.invoke(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;+102 java.base@19-internal
j  com.sun.javatest.regtest.agent.MainWrapper$MainThread.run()V+172
j  java.lang.Thread.run()V+11 java.base@19-internal
v  ~StubRoutines::call_stub
V  [libjvm.so+0xa8a0d2]  JavaCalls::call_helper(JavaValue*, methodHandle const&, JavaCallArguments*, JavaThread*)+0x4cc
V  [libjvm.so+0xa8a648]  JavaCalls::call_virtual(JavaValue*, Klass*, Symbol*, Symbol*, JavaCallArguments*, JavaThread*)+0x3e0
V  [libjvm.so+0xa8a9d6]  JavaCalls::call_virtual(JavaValue*, Handle, Klass*, Symbol*, Symbol*, JavaThread*)+0x60
V  [libjvm.so+0xbcf988]  thread_entry(JavaThread*, JavaThread*)+0x88
V  [libjvm.so+0x1299ca6]  JavaThread::thread_main_inner()+0x24e
V  [libjvm.so+0x12a0be6]  Thread::call_run()+0xd4
V  [libjvm.so+0xf3c294]  thread_native_entry(Thread*)+0xee
C  [libpthread.so.0+0x7460]  start_thread+0xb4
C  [libc.so.6+0xa7362]
```

This patch passes hotspot and jdk tiere1 on unmatched, and all jtreg tests are tested on Qemu without new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285699](https://bugs.openjdk.java.net/browse/JDK-8285699): riscv: Provide information when hitting a HaltNode


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8442/head:pull/8442` \
`$ git checkout pull/8442`

Update a local copy of the PR: \
`$ git checkout pull/8442` \
`$ git pull https://git.openjdk.java.net/jdk pull/8442/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8442`

View PR using the GUI difftool: \
`$ git pr show -t 8442`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8442.diff">https://git.openjdk.java.net/jdk/pull/8442.diff</a>

</details>
