### PR TITLE
8285785: CheckCleanerBound test fails with PasswordCallback object is…

### DIFF
--- a/test/jdk/javax/security/auth/callback/PasswordCallback/CheckCleanerBound.java
+++ b/test/jdk/javax/security/auth/callback/PasswordCallback/CheckCleanerBound.java
@@ -47,6 +47,7 @@ public final class CheckCleanerBound {
         // Wait to trigger the cleanup.
         for (int i = 0; i < 10 && weakHashMap.size() != 0; i++) {
             System.gc();
+            Thread.sleep(100);
         }
 
         // Check if the object has been collected.  The collection will not


### PR DESCRIPTION
Hi,

May I have this test update reviewed?

The javax/security/auth/callback/PasswordCallback/CheckCleanerBound.java test case failed on one of the test setups.  The test runs gc in a loop and expects the GC to have garbage collected contents of a WeakHashMap. The loop runs for 10 iterations. Some delay needs to be added between each iteration to increase the chances of GC garbage collecting the instances.

Thanks,
Xuelei