### PR TITLE
8285794: AsyncGetCallTrace might acquire a lock via JavaThread::thread_from_jni_environment

### DIFF
--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -568,7 +568,8 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
   Thread* raw_thread = Thread::current_or_null_safe();
   JavaThread* thread;
 
-  if (trace->env_id == NULL || raw_thread == NULL || !raw_thread->is_Java_thread() || (thread = JavaThread::cast(raw_thread))->is_exiting()) {
+  if (trace->env_id == NULL || raw_thread == NULL || !raw_thread->is_Java_thread() ||
+      (thread = JavaThread::cast(raw_thread))->is_exiting()) {
     // bad env_id, thread has exited or thread is exiting
     trace->num_frames = ticks_thread_exit; // -8
     return;

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -563,10 +563,9 @@ extern "C" {
 JNIEXPORT
 void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
 
-  JavaThread* thread;
+  JavaThread* thread = JavaThread::current();
 
-  if (trace->env_id == NULL ||
-      (thread = JavaThread::thread_from_jni_environment(trace->env_id))->is_exiting()) {
+  if (trace->env_id == NULL || thread->is_terminated() || thread->is_exiting()) {
     // bad env_id, thread has exited or thread is exiting
     trace->num_frames = ticks_thread_exit; // -8
     return;
@@ -578,7 +577,7 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
     return;
   }
 
-  assert(JavaThread::current() == thread,
+  assert(thread == JavaThread::thread_from_jni_environment(trace->env_id),
          "AsyncGetCallTrace must be called by the current interrupted thread");
 
   if (!JvmtiExport::should_post_class_load()) {

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -566,14 +566,13 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
   // Can't use thread_from_jni_environment as it may also perform a VM exit check that is unsafe to
   // do from this context.
   Thread* raw_thread = Thread::current_or_null_safe();
+  JavaThread* thread;
 
-  if (trace->env_id == NULL || raw_thread == NULL || !raw_thread->is_Java_thread() || ((JavaThread*)raw_thread)->is_exiting()) {
+  if (trace->env_id == NULL || raw_thread == NULL || !raw_thread->is_Java_thread() || (thread = JavaThread::cast(raw_thread))->is_exiting()) {
     // bad env_id, thread has exited or thread is exiting
     trace->num_frames = ticks_thread_exit; // -8
     return;
   }
-
-  JavaThread* thread = JavaThread::cast(raw_thread);
 
   if (thread->in_deopt_handler()) {
     // thread is in the deoptimization handler so return no frames

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -32,7 +32,6 @@
 #include "prims/jvmtiExport.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/javaCalls.hpp"
-#include "runtime/thread.hpp"
 #include "runtime/thread.inline.hpp"
 #include "runtime/vframe.inline.hpp"
 #include "runtime/vframeArray.hpp"
@@ -574,7 +573,7 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
     return;
   }
 
-  JavaThread* thread = (JavaThread*)raw_thread;
+  JavaThread* thread = JavaThread::cast(raw_thread);
 
   if (thread->in_deopt_handler()) {
     // thread is in the deoptimization handler so return no frames

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -563,9 +563,9 @@ extern "C" {
 JNIEXPORT
 void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
 
-  JavaThread* thread = JavaThread::current();
+  JavaThread* thread = JavaThread::current_or_null();
 
-  if (trace->env_id == NULL || thread->is_terminated() || thread->is_exiting()) {
+  if (trace->env_id == NULL || thread == NULL || thread->is_terminated() || thread->is_exiting()) {
     // bad env_id, thread has exited or thread is exiting
     trace->num_frames = ticks_thread_exit; // -8
     return;


### PR DESCRIPTION
Calling JavaThread::thread_from_jni_environment for a terminated thread in AsyncGetCallTrace might cause the acquisition of a lock, making AsyncGetCallTrace non-signal-safe. 

AsyncGetCallTrace can only be called for the current threads (there are asserts for that), therefore using JavaThread::current directly and checking the termination status is semantically equivalent.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8285794](https://bugs.openjdk.java.net/browse/JDK-8285794): AsyncGetCallTrace might acquire a lock via JavaThread::thread_from_jni_environment


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [8d4b60eb](https://git.openjdk.java.net/jdk/pull/8446/files/8d4b60eb97f15ee31bad03bf1e63ec38c4fd378e)
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [8d4b60eb](https://git.openjdk.java.net/jdk/pull/8446/files/8d4b60eb97f15ee31bad03bf1e63ec38c4fd378e)
 * [Jaroslav Bachorik](https://openjdk.java.net/census#jbachorik) (@jbachorik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8446/head:pull/8446` \
`$ git checkout pull/8446`

Update a local copy of the PR: \
`$ git checkout pull/8446` \
`$ git pull https://git.openjdk.java.net/jdk pull/8446/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8446`

View PR using the GUI difftool: \
`$ git pr show -t 8446`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8446.diff">https://git.openjdk.java.net/jdk/pull/8446.diff</a>

</details>
