### PR TITLE
8285793: C2: optimization  of mask checks in counted loops fail in the presence of cast nodes

### DIFF
--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -1759,6 +1759,10 @@ bool MulNode::AndIL_shift_and_mask_is_always_zero(PhaseGVN* phase, Node* shift, 
   if (mask == NULL || shift == NULL) {
     return false;
   }
+  shift = shift->uncast();
+  if (shift == NULL) {
+    return false;
+  }
   const TypeInteger* mask_t = phase->type(mask)->isa_integer(bt);
   const TypeInteger* shift_t = phase->type(shift)->isa_integer(bt);
   if (mask_t == NULL || shift_t == NULL) {
@@ -1768,6 +1772,10 @@ bool MulNode::AndIL_shift_and_mask_is_always_zero(PhaseGVN* phase, Node* shift, 
   if (bt == T_LONG && shift->Opcode() == Op_ConvI2L) {
     bt = T_INT;
     Node* val = shift->in(1);
+    if (val == NULL) {
+      return false;
+    }
+    val = val->uncast();
     if (val == NULL) {
       return false;
     }

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestShiftAndMask.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestShiftAndMask.java
@@ -344,7 +344,7 @@ public class TestShiftAndMask {
     public static int shiftMaskIntCheckIndex(int i, int length) {
         return Objects.checkIndex(i << 2, length) & 3; // transformed to: return 0;
     }
-    
+
     @Run(test = "shiftMaskIntCheckIndex")
     public static void shiftMaskIntCheckIndex_runner() {
         int i = RANDOM.nextInt((Integer.MAX_VALUE - 1) >> 2);
@@ -359,7 +359,7 @@ public class TestShiftAndMask {
     public static long shiftMaskLongCheckIndex(long i, long length) {
         return Objects.checkIndex(i << 2, length) & 3; // transformed to: return 0;
     }
-    
+
     @Run(test = "shiftMaskLongCheckIndex")
     public static void shiftMaskLongCheckIndex_runner() {
         long i = RANDOM.nextInt((Integer.MAX_VALUE - 1) >> 2);

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestShiftAndMask.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestShiftAndMask.java
@@ -26,10 +26,11 @@ package compiler.c2.irTests;
 import compiler.lib.ir_framework.*;
 import jdk.test.lib.Utils;
 import java.util.Random;
+import java.util.Objects;
 
 /*
  * @test
- * @bug 8277850 8278949
+ * @bug 8277850 8278949 8285793
  * @summary C2: optimize mask checks in counted loops
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestShiftAndMask
@@ -274,7 +275,7 @@ public class TestShiftAndMask {
 
     @Test
     @Arguments({Argument.RANDOM_EACH})
-    @IR(failOn = { IRNode.AND_L, IRNode.LSHIFT_I })
+    @IR(failOn = { IRNode.AND_L, IRNode.LSHIFT_I, IRNode.CONV_I2L })
     public static long shiftConvMask(int i) {
         return ((long)(i << 2)) & 3; // transformed to: return 0;
     }
@@ -288,7 +289,7 @@ public class TestShiftAndMask {
 
     @Test
     @Arguments({Argument.RANDOM_EACH, Argument.BOOLEAN_TOGGLE_FIRST_TRUE})
-    @IR(failOn = { IRNode.AND_L, IRNode.LSHIFT_L })
+    @IR(failOn = { IRNode.AND_L, IRNode.LSHIFT_I, IRNode.CONV_I2L })
     public static long shiftNotConstConvMask(int i, boolean flag) {
         long mask;
         if (flag) {
@@ -326,13 +327,158 @@ public class TestShiftAndMask {
 
     @Test
     @Arguments({Argument.RANDOM_EACH, Argument.RANDOM_EACH})
-    @IR(failOn = { IRNode.AND_L, IRNode.ADD_L, IRNode.LSHIFT_L })
+    @IR(failOn = { IRNode.AND_L, IRNode.ADD_L, IRNode.LSHIFT_I, IRNode.CONV_I2L })
     public static long addShiftConvMask2(int i, int j) {
         return (((long)(j << 2)) + ((long)(i << 2))) & 3; // transformed to: return 0;
     }
 
     @Check(test = "addShiftConvMask2")
     public static void checkAddShiftConvMask2(long res) {
+        if (res != 0) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+
+    @Test
+    @IR(failOn = { IRNode.AND_I })
+    public static int shiftMaskIntCheckIndex(int i, int length) {
+        return Objects.checkIndex(i << 2, length) & 3; // transformed to: return 0;
+    }
+    
+    @Run(test = "shiftMaskIntCheckIndex")
+    public static void shiftMaskIntCheckIndex_runner() {
+        int i = RANDOM.nextInt((Integer.MAX_VALUE - 1) >> 2);
+        int res = shiftMaskIntCheckIndex(i, (i << 2) + 1);
+        if (res != 0) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+
+    @Test
+    @IR(failOn = { IRNode.AND_L })
+    public static long shiftMaskLongCheckIndex(long i, long length) {
+        return Objects.checkIndex(i << 2, length) & 3; // transformed to: return 0;
+    }
+    
+    @Run(test = "shiftMaskLongCheckIndex")
+    public static void shiftMaskLongCheckIndex_runner() {
+        long i = RANDOM.nextInt((Integer.MAX_VALUE - 1) >> 2);
+        long res = shiftMaskLongCheckIndex(i, (i << 2) + 1);
+        if (res != 0) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+
+    @Test
+    @IR(counts = { IRNode.AND_I, "1" })
+    @IR(failOn = { IRNode.ADD_I })
+    public static int addShiftMaskIntCheckIndex(int i, int j, int length) {
+        return (j + Objects.checkIndex(i << 2, length)) & 3; // transformed to: return j & 3;
+    }
+
+    @Run(test = "addShiftMaskIntCheckIndex")
+    public static void addShiftMaskIntCheckIndex_runner() {
+        int i = RANDOM.nextInt((Integer.MAX_VALUE - 1) >> 2);
+        int j = RANDOM.nextInt();
+        int res = addShiftMaskIntCheckIndex(i, j, (i << 2) + 1);
+        if (res != (j & 3)) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+
+    @Test
+    @IR(counts = { IRNode.AND_L, "1" })
+    @IR(failOn = { IRNode.ADD_L })
+    public static long addShiftMaskLongCheckIndex(long i, long j, long length) {
+        return (j + Objects.checkIndex(i << 2, length)) & 3; // transformed to: return j & 3;
+    }
+
+    @Run(test = "addShiftMaskLongCheckIndex")
+    public static void addShiftMaskLongCheckIndex_runner() {
+        long i = RANDOM.nextInt((Integer.MAX_VALUE - 1) >> 2);
+        long j = RANDOM.nextLong();
+        long res = addShiftMaskLongCheckIndex(i, j, (i << 2) + 1);
+        if (res != (j & 3)) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+
+    @Test
+    @IR(failOn = { IRNode.AND_I, IRNode.ADD_I })
+    public static int addShiftMaskIntCheckIndex2(int i, int j, int length) {
+        return (Objects.checkIndex(j << 2, length) + Objects.checkIndex(i << 2, length)) & 3; // transformed to: return 0;
+    }
+
+
+    @Run(test = "addShiftMaskIntCheckIndex2")
+    public static void addShiftMaskIntCheckIndex2_runner() {
+        int i = RANDOM.nextInt((Integer.MAX_VALUE - 1) >> 2);
+        int j = RANDOM.nextInt((Integer.MAX_VALUE - 1) >> 2);
+        int res = addShiftMaskIntCheckIndex2(i, j, (Integer.max(i, j) << 2) + 1);
+        if (res != 0) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+
+    @Test
+    @IR(failOn = { IRNode.AND_L, IRNode.ADD_L })
+    public static long addShiftMaskLongCheckIndex2(long i, long j, long length) {
+        return (Objects.checkIndex(j << 2, length) + Objects.checkIndex(i << 2, length)) & 3; // transformed to: return 0;
+    }
+
+    @Run(test = "addShiftMaskLongCheckIndex2")
+    public static void addShiftMaskLongCheckIndex2_runner() {
+        long i = RANDOM.nextInt((Integer.MAX_VALUE - 1) >> 2);
+        long j = RANDOM.nextInt((Integer.MAX_VALUE - 1) >> 2);
+        long res = addShiftMaskLongCheckIndex2(i, j, (Long.max(i, j) << 2) + 1);
+        if (res != 0) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+
+    @Test
+    @IR(failOn = { IRNode.AND_L, IRNode.CONV_I2L })
+    public static long shiftConvMaskCheckIndex(int i, int length) {
+        return ((long)Objects.checkIndex(i << 2, length)) & 3; // transformed to: return 0;
+    }
+
+    @Run(test = "shiftConvMaskCheckIndex")
+    public static void shiftConvMaskCheckIndex_runner() {
+        int i = RANDOM.nextInt((Integer.MAX_VALUE - 1) >> 2);
+        long res = shiftConvMaskCheckIndex(i, (i << 2) + 1);
+        if (res != 0) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+
+    @Test
+    @IR(counts = { IRNode.AND_L, "1" })
+    @IR(failOn = { IRNode.ADD_L, IRNode.CONV_I2L })
+    public static long addShiftConvMaskCheckIndex(int i, long j, int length) {
+        return (j + Objects.checkIndex(i << 2, length)) & 3; // transformed to: return j & 3;
+    }
+
+    @Run(test = "addShiftConvMaskCheckIndex")
+    public static void addShiftConvMaskCheckIndex_runner() {
+        int i = RANDOM.nextInt((Integer.MAX_VALUE - 1) >> 2);
+        long j = RANDOM.nextLong();
+        long res = addShiftConvMaskCheckIndex(i, j, (i << 2) + 1);
+        if (res != (j & 3)) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+
+    @Test
+    @IR(failOn = { IRNode.AND_L, IRNode.ADD_L })
+    public static long addShiftConvMaskCheckIndex2(int i, int j, int length) {
+        return (((long)Objects.checkIndex(j << 2, length)) + ((long)Objects.checkIndex(i << 2, length))) & 3; // transformed to: return 0;
+    }
+
+    @Run(test = "addShiftConvMaskCheckIndex2")
+    public static void addShiftConvMaskCheckIndex2_runner() {
+        int i = RANDOM.nextInt((Integer.MAX_VALUE - 1) >> 2);
+        int j = RANDOM.nextInt((Integer.MAX_VALUE - 1) >> 2);
+        long res = addShiftConvMaskCheckIndex2(i, j, (Integer.max(i, j) << 2) + 1);
         if (res != 0) {
             throw new RuntimeException("incorrect result: " + res);
         }


### PR DESCRIPTION
This showed up when working with a panama micro benchmark. Optimization of:

if ((base + (offset << 2)) & 3) != 0) {
}

into:

if ((base & 3) != 0) {

fails if the subgraph contains cast nodes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285793](https://bugs.openjdk.java.net/browse/JDK-8285793): C2: optimization  of mask checks in counted loops fail in the presence of cast nodes


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8447/head:pull/8447` \
`$ git checkout pull/8447`

Update a local copy of the PR: \
`$ git checkout pull/8447` \
`$ git pull https://git.openjdk.java.net/jdk pull/8447/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8447`

View PR using the GUI difftool: \
`$ git pr show -t 8447`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8447.diff">https://git.openjdk.java.net/jdk/pull/8447.diff</a>

</details>
