### PR TITLE
JDK-8285728: Alpine Linux build fails with busybox tar

### DIFF
--- a/make/autoconf/basic_tools.m4
+++ b/make/autoconf/basic_tools.m4
@@ -269,6 +269,8 @@ AC_DEFUN([BASIC_CHECK_TAR],
     TAR_TYPE="bsd"
   elif test "x$($TAR -v | $GREP "bsdtar")" != "x"; then
     TAR_TYPE="bsd"
+  elif test "x$($TAR --version | $GREP "busybox")" != "x"; then
+    TAR_TYPE="busybox"
   elif test "x$OPENJDK_BUILD_OS" = "xaix"; then
     TAR_TYPE="aix"
   fi
@@ -280,8 +282,11 @@ AC_DEFUN([BASIC_CHECK_TAR],
     TAR_SUPPORTS_TRANSFORM="true"
   elif test "x$TAR_TYPE" = "aix"; then
     # -L InputList of aix tar: name of file listing the files and directories
-    # that need to be   archived or extracted
+    # that need to be archived or extracted
     TAR_INCLUDE_PARAM="L"
+    TAR_SUPPORTS_TRANSFORM="false"
+  elif test "x$TAR_TYPE" = "xbusybox"; then
+    TAR_INCLUDE_PARAM="T"
     TAR_SUPPORTS_TRANSFORM="false"
   else
     TAR_INCLUDE_PARAM="I"


### PR DESCRIPTION
Currently , in target "product-bundles" , the Alpine Linux build fails when BusyBox tar is used.
Error is :
/bin/tar: unrecognized option: I
BusyBox v1.34.1 (2022-04-04 10:19:27 UTC) multi-call binary
Usage: tar c|x|t [-ZzJjahmvokO] [-f TARFILE] [-C DIR] [-T FILE] [-X FILE] [LONGOPT]... [FILE]...

Seems this is coming from a wrong setting of TAR_INCLUDE_PARAM in autoconf/basic_tools.m4 (I is set, seems T is needed) .

The change adjusts the tar-type check.