### PR TITLE
8213531: Test javax/swing/border/TestTitledBorderLeak.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -657,7 +657,6 @@ javax/sound/midi/Sequencer/Looping.java 8136897 generic-all
 
 javax/swing/plaf/basic/BasicTextUI/8001470/bug8001470.java 8233177 linux-all,windows-all
 
-javax/swing/border/TestTitledBorderLeak.java 8213531 linux-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/ShapedTranslucentPerPixelTranslucentGradient.java 8233582 linux-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/ShapedPerPixelTranslucentGradient.java 8233582 linux-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/PerPixelTranslucentSwing.java 8194128 macosx-all

--- a/test/jdk/javax/swing/border/TestTitledBorderLeak.java
+++ b/test/jdk/javax/swing/border/TestTitledBorderLeak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,22 +57,19 @@ public class TestTitledBorderLeak {
                 frame[i] = new JFrame("Borders");
                 JPanel panel = new JPanel();
                 panel.add(label);
-                frame[i].setContentPane(panel);
-                frame[i].setVisible(true);
-
             }
         });
         if (TOTAL_TITLEDBORDER != weakRefArrTB.size()) {
             System.err.println("TOTAL_TITLEDBORDER != weakRefArrTB.size()");
         }
-        Thread.sleep(3000);
+        Thread.sleep(1000);
         SwingUtilities.invokeAndWait(() -> {
             for (int i = 0; i < TOTAL_TITLEDBORDER; i++) {
                 frame[i].dispose();
                 frame[i] = null;
             }
         });
-        Thread.sleep(3000);
+        Thread.sleep(1000);
         attemptGCTitledBorder();
         if (TOTAL_TITLEDBORDER != getCleanedUpTitledBorderCount()) {
             throw new RuntimeException("Expected Total TitledBorder to be freed : " + TOTAL_TITLEDBORDER +
@@ -85,7 +82,6 @@ public class TestTitledBorderLeak {
         // Attempt gc GC_ATTEMPTS times
         for (int i = 0; i < GC_ATTEMPTS; i++) {
             System.gc();
-            System.runFinalization();
             if (getCleanedUpTitledBorderCount() == TOTAL_TITLEDBORDER) {
                 break;
             }

--- a/test/jdk/javax/swing/border/TestTitledBorderLeak.java
+++ b/test/jdk/javax/swing/border/TestTitledBorderLeak.java
@@ -57,6 +57,7 @@ public class TestTitledBorderLeak {
                 frame[i] = new JFrame("Borders");
                 JPanel panel = new JPanel();
                 panel.add(label);
+                frame[i].setContentPane(panel);
             }
         });
         if (TOTAL_TITLEDBORDER != weakRefArrTB.size()) {

--- a/test/jdk/javax/swing/border/TestTitledBorderLeak.java
+++ b/test/jdk/javax/swing/border/TestTitledBorderLeak.java
@@ -21,86 +21,45 @@
  * questions.
  */
 
-import java.lang.ref.WeakReference;
-import java.util.ArrayList;
 import javax.swing.border.TitledBorder;
-import javax.swing.JFrame;
-import javax.swing.JPanel;
-import javax.swing.JLabel;
-import javax.swing.SwingUtilities;
 
-/**
+/*
  * @test
- * @key headful
  * @bug 8204963
  * @summary Verifies TitledBorder's memory leak
- * @run main TestTitledBorderLeak
+ * @run main/othervm -Xmx10M TestTitledBorderLeak
  */
-
 public class TestTitledBorderLeak {
-
-    final static int TOTAL_TITLEDBORDER = 10;
-    final static int GC_ATTEMPTS = 10;
-    static ArrayList<WeakReference<TitledBorder>> weakRefArrTB =
-                                         new ArrayList(TOTAL_TITLEDBORDER);
-
     public static void main(String[] args) throws Exception {
+        int max = 100000;
+        long initialFreeMemory = 0L;
+        long currentFreeMemory;
+        try {
+            for (int i = 1; i <= max; i++) {
+                new TitledBorder("");
+                if ((i % 1000) == 0) {
+                    System.gc();
+                    currentFreeMemory = dumpMemoryStatus("After " + i);
+                    if(initialFreeMemory == 0L) {
+                        initialFreeMemory = currentFreeMemory;
+                    } else if( currentFreeMemory < initialFreeMemory/2) {
+                        throw new RuntimeException("Memory halved: there's a leak");
+                    }
 
-        JFrame frame[] = new JFrame[TOTAL_TITLEDBORDER];
-
-        SwingUtilities.invokeAndWait(() -> {
-            for (int i = 0; i < TOTAL_TITLEDBORDER; i++) {
-                TitledBorder tb = new TitledBorder("");
-                weakRefArrTB.add(i, new WeakReference<TitledBorder>(tb));
-                JLabel label = new JLabel("TitledBorder");
-                label.setBorder(tb);
-                frame[i] = new JFrame("Borders");
-                JPanel panel = new JPanel();
-                panel.add(label);
-                frame[i].setContentPane(panel);
+                }
             }
-        });
-        if (TOTAL_TITLEDBORDER != weakRefArrTB.size()) {
-            System.err.println("TOTAL_TITLEDBORDER != weakRefArrTB.size()");
-        }
-        Thread.sleep(1000);
-        SwingUtilities.invokeAndWait(() -> {
-            for (int i = 0; i < TOTAL_TITLEDBORDER; i++) {
-                frame[i].dispose();
-                frame[i] = null;
-            }
-        });
-        Thread.sleep(1000);
-        attemptGCTitledBorder();
-        if (TOTAL_TITLEDBORDER != getCleanedUpTitledBorderCount()) {
-            throw new RuntimeException("Expected Total TitledBorder to be freed : " + TOTAL_TITLEDBORDER +
-                           " Freed " + getCleanedUpTitledBorderCount());
-        }
-        System.out.println("OK");
-    }
-
-    private static void attemptGCTitledBorder() {
-        // Attempt gc GC_ATTEMPTS times
-        for (int i = 0; i < GC_ATTEMPTS; i++) {
+        }catch(OutOfMemoryError e) {
+            // Don't think it would work; should not happen
             System.gc();
-            if (getCleanedUpTitledBorderCount() == TOTAL_TITLEDBORDER) {
-                break;
-            }
-            try {
-                Thread.sleep(500);
-            } catch (InterruptedException e) {
-                System.err.println("InterruptedException occurred during Thread.sleep()");
-            }
+            throw new RuntimeException("There was OOM");
         }
+        System.out.println("Passed");
     }
-
-    private static int getCleanedUpTitledBorderCount() {
-        int count = 0;
-        for (WeakReference<TitledBorder> ref : weakRefArrTB) {
-            if (ref.get() == null) {
-                count++;
-            }
-        }
-        return count;
+    private static long dumpMemoryStatus(String msg) {
+        Runtime rt = Runtime.getRuntime();
+        long freeMem = rt.freeMemory();
+        System.out.println(msg + ": " + freeMem + " free");
+        return freeMem;
     }
 }
+


### PR DESCRIPTION
Test was failing in linux citing `java.lang.RuntimeException: Expected Total TitledBorder to be freed : 10 Freed 9 `
As per the fix done in JDK-8204963 http://hg.openjdk.java.net/jdk/jdk/rev/cd7d2f9154fd
there was no platform specific code done for the fix and logs in `TitledBorder.installPropertyChangeListeners` shows it was called 10 times for the test but `CleanerFactory.cleaner().register` action was only called 9 times in linux causing it to fail.

Modified the test to not show the frame which cause the problem to go away and also it can still be used as 8204963 regression test as it still fails without the fix and pass with it. Modified test has passed in all platforms for several iterations.

Also removed the deprecated `System.runFinalization`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8213531](https://bugs.openjdk.java.net/browse/JDK-8213531): Test javax/swing/border/TestTitledBorderLeak.java fails


### Reviewers
 * @kristylee88 (no known github.com user name / role)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8450/head:pull/8450` \
`$ git checkout pull/8450`

Update a local copy of the PR: \
`$ git checkout pull/8450` \
`$ git pull https://git.openjdk.java.net/jdk pull/8450/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8450`

View PR using the GUI difftool: \
`$ git pr show -t 8450`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8450.diff">https://git.openjdk.java.net/jdk/pull/8450.diff</a>

</details>
