### PR TITLE
8285828: runtime/execstack/TestCheckJDK.java fails with zipped debug symbols

### DIFF
--- a/test/hotspot/jtreg/runtime/execstack/TestCheckJDK.java
+++ b/test/hotspot/jtreg/runtime/execstack/TestCheckJDK.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class TestCheckJDK {
     static void checkExecStack(Path file) {
         String filename = file.toString();
         Path parent = file.getParent();
-        if (parent.endsWith("bin") || filename.endsWith(".so")) {
+        if ((parent.endsWith("bin") && !filename.endsWith(".diz")) || filename.endsWith(".so")) {
             if (!WB.checkLibSpecifiesNoexecstack(filename)) {
                 System.out.println("Library does not have the noexecstack bit set: " + filename);
                 testPassed = false;


### PR DESCRIPTION
Hi all,

If we configure and build the jdk with `--with-native-debug-symbols=zipped`, `runtime/execstack/TestCheckJDK.java` fails on Linux.

The failure was caused by the following zipped debug symbols files, which aren't ELF files at all.
```
~/jdk/build/linux-x86_64-server-release/images/jdk/bin]$ ls *.diz
jar.diz        java.diz     jcmd.diz      jdeprscan.diz  jhsdb.diz   jlink.diz  jpackage.diz    jshell.diz  jstat.diz       rmiregistry.diz
jarsigner.diz  javadoc.diz  jconsole.diz  jdeps.diz      jimage.diz  jmap.diz   jps.diz         jstack.diz  jwebserver.diz  serialver.diz
javac.diz      javap.diz    jdb.diz       jfr.diz        jinfo.diz   jmod.diz   jrunscript.diz  jstatd.diz  keytool.diz
```

The fix just skips these non-elf `*.diz` files when checking the linking attributes.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285828](https://bugs.openjdk.java.net/browse/JDK-8285828): runtime/execstack/TestCheckJDK.java fails with zipped debug symbols


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8451/head:pull/8451` \
`$ git checkout pull/8451`

Update a local copy of the PR: \
`$ git checkout pull/8451` \
`$ git pull https://git.openjdk.java.net/jdk pull/8451/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8451`

View PR using the GUI difftool: \
`$ git pr show -t 8451`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8451.diff">https://git.openjdk.java.net/jdk/pull/8451.diff</a>

</details>
