### PR TITLE
8285827: Describe the keystore.pkcs12.legacy system property in the java.security file

### DIFF
--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -1171,6 +1171,19 @@ jceks.key.serialFilter = java.base/java.lang.Enum;java.base/java.security.KeyRep
 # name, an exception will be thrown when the property is used.
 # If the property is not set or empty, a default value will be used.
 #
+# For compatibility, the system property "keystore.pkcs12.legacy" can be set
+# which will override the properties defined here with weaker algorithms.
+# This system property is equivalent to
+#   -Dkeystore.pkcs12.certProtectionAlgorithm=PBEWithSHA1AndRC2_40
+#   -Dkeystore.pkcs12.keyProtectionAlgorithm=PBEWithSHA1AndDESede
+#   -Dkeystore.pkcs12.macAlgorithm=HmacPBESHA1
+#   -Dkeystore.pkcs12.certPbeIterationCount=50000
+#   -Dkeystore.pkcs12.keyPbeIterationCount=50000
+#   -Dkeystore.pkcs12.macIterationCount=100000
+# This system property should be used at your own risk. Please note there is
+# no value defined for this system property, i.e. "-Dkeystore.pkcs12.legacy"
+# has the same effect as "-Dkeystore.pkcs12.legacy=<any value>".
+#
 # Note: These properties are currently used by the JDK Reference implementation.
 # They are not guaranteed to be examined and used by other implementations.
 

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -1166,23 +1166,30 @@ jceks.key.serialFilter = java.base/java.lang.Enum;java.base/java.security.KeyRep
 # If a system property of the same name is also specified, it supersedes the
 # security property value defined here.
 #
-# If the property is set to an illegal value,
-# an iteration count that is not a positive integer, or an unknown algorithm
-# name, an exception will be thrown when the property is used.
-# If the property is not set or empty, a default value will be used.
+# If the property is set to an illegal value, an iteration count that is not
+# a positive integer, or an unknown algorithm name, an exception will be thrown
+# when the property is used. If the property is not set or empty, a default
+# value will be used.
 #
-# For compatibility, the system property "keystore.pkcs12.legacy" can be set
-# which will override the properties defined here with weaker algorithms.
-# This system property is equivalent to
+# Some PKCS12 tools and libraries may not support algorithms based on PBES2
+# and AES. To create a PKCS12 keystore which they can load, set the system
+# property "keystore.pkcs12.legacy" which overrides the values of the properties
+# defined below with legacy algorithms. Setting this system property (which can
+# only be enabled and has no value) is equivalent to
+#
 #   -Dkeystore.pkcs12.certProtectionAlgorithm=PBEWithSHA1AndRC2_40
 #   -Dkeystore.pkcs12.keyProtectionAlgorithm=PBEWithSHA1AndDESede
 #   -Dkeystore.pkcs12.macAlgorithm=HmacPBESHA1
 #   -Dkeystore.pkcs12.certPbeIterationCount=50000
 #   -Dkeystore.pkcs12.keyPbeIterationCount=50000
 #   -Dkeystore.pkcs12.macIterationCount=100000
-# This system property should be used at your own risk. Please note there is
-# no value defined for this system property, i.e. "-Dkeystore.pkcs12.legacy"
-# has the same effect as "-Dkeystore.pkcs12.legacy=<any value>".
+#
+# Also, you can downgrade an existing PKCS12 keystore created with stronger
+# algorithms to legacy algorithms with
+#
+#    keytool -J-Dkeystore.pkcs12.legacy -importkeystore -srckeystore ks -destkeystore ks
+#
+# This system property should be used at your own risk.
 #
 # Note: These properties are currently used by the JDK Reference implementation.
 # They are not guaranteed to be examined and used by other implementations.


### PR DESCRIPTION
We added a new system property back in https://bugs.openjdk.java.net/browse/JDK-8153005 but it's better to describe it in the `java.security` file as well.

Please review the text. I especially added the last sentence so that people won't set `-Dkeystore.pkcs12.legacy=false`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285827](https://bugs.openjdk.java.net/browse/JDK-8285827): Describe the keystore.pkcs12.legacy system property in the java.security file


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8452/head:pull/8452` \
`$ git checkout pull/8452`

Update a local copy of the PR: \
`$ git checkout pull/8452` \
`$ git pull https://git.openjdk.java.net/jdk pull/8452/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8452`

View PR using the GUI difftool: \
`$ git pr show -t 8452`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8452.diff">https://git.openjdk.java.net/jdk/pull/8452.diff</a>

</details>
