### PR TITLE
8285851: Cleanup C2AtomicParseAccess::needs_pinning()

### DIFF
--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
@@ -388,9 +388,6 @@ void C2Access::fixup_decorators() {
 //--------------------------- atomic operations---------------------------------
 
 void BarrierSetC2::pin_atomic_op(C2AtomicParseAccess& access) const {
-  if (!access.needs_pinning()) {
-    return;
-  }
   // SCMemProjNodes represent the memory state of a LoadStore. Their
   // main role is to prevent LoadStore nodes from being optimized away
   // when their results aren't used.

--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
@@ -168,22 +168,19 @@ public:
 class C2AtomicParseAccess: public C2ParseAccess {
   Node* _memory;
   uint  _alias_idx;
-  bool  _needs_pinning;
 
 public:
   C2AtomicParseAccess(GraphKit* kit, DecoratorSet decorators, BasicType type,
                  Node* base, C2AccessValuePtr& addr, uint alias_idx) :
     C2ParseAccess(kit, decorators, type, base, addr),
     _memory(NULL),
-    _alias_idx(alias_idx),
-    _needs_pinning(true) {}
+    _alias_idx(alias_idx) {}
 
   // Set the memory node based on the current memory slice.
   virtual void set_memory();
 
   Node* memory() const       { return _memory; }
   uint alias_idx() const     { return _alias_idx; }
-  bool needs_pinning() const { return _needs_pinning; }
 };
 
 // C2Access for optimization time calls to the BarrierSetC2 backend.


### PR DESCRIPTION
It returns `true` by default, and the setter for it was removed by [JDK-8235653](https://bugs.openjdk.java.net/browse/JDK-8235653).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285851](https://bugs.openjdk.java.net/browse/JDK-8285851): Cleanup C2AtomicParseAccess::needs_pinning()


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8455/head:pull/8455` \
`$ git checkout pull/8455`

Update a local copy of the PR: \
`$ git checkout pull/8455` \
`$ git pull https://git.openjdk.java.net/jdk pull/8455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8455`

View PR using the GUI difftool: \
`$ git pr show -t 8455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8455.diff">https://git.openjdk.java.net/jdk/pull/8455.diff</a>

</details>
