### PR TITLE
JDK-8285496: DocLint does not check for missing `@param` tags for type parameters on classes and interfaces

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
@@ -251,7 +251,7 @@ public class Checker extends DocTreePathScanner<Void, Void> {
         // the following checks are made after the scan, which will record @param tags
         if (isDeclaredType()) {
             TypeElement te = (TypeElement) env.currElement;
-            // checkParamsDocumented(te.getTypeParameters()); // See JDK-8285496
+            checkParamsDocumented(te.getTypeParameters());
             checkParamsDocumented(te.getRecordComponents());
         } else if (isExecutable()) {
             if (!isOverridingMethod) {

--- a/test/langtools/tools/doclint/MissingParamsTest.java
+++ b/test/langtools/tools/doclint/MissingParamsTest.java
@@ -1,6 +1,6 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 8004832
+ * @bug 8004832 8285496
  * @summary Add new doclint package
  * @modules jdk.javadoc/jdk.javadoc.internal.doclint
  * @build DocLintTester
@@ -21,4 +21,7 @@ public class MissingParamsTest {
 
     /** . */
     <T> void missingTyparam() { }
+
+    /** . */
+    public class MissingTyparam<T> { /** . */ MissingTyparam() { } }
 }

--- a/test/langtools/tools/doclint/MissingParamsTest.out
+++ b/test/langtools/tools/doclint/MissingParamsTest.out
@@ -10,5 +10,8 @@ MissingParamsTest.java:20: warning: no @param for param
 MissingParamsTest.java:23: warning: no @param for <T>
     <T> void missingTyparam() { }
              ^
-4 warnings
+MissingParamsTest.java:26: warning: no @param for <T>
+    public class MissingTyparam<T> { /** . */ MissingTyparam() { } }
+           ^
+5 warnings
 


### PR DESCRIPTION
Please review a trivial update for doclint, to check for `@param` tags for type parameters of classes and interfaces.

The bug was discovered recently, while making an update for record components, but this part of the fix was effectively blocked by the presence of missing tags in API documentation.

As well as a minor update to an existing test, the change has been tested by running `make docs`, `make docs-javase` and `make docs-reference`, all of which succeed without any warnings about missing tags.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285496](https://bugs.openjdk.java.net/browse/JDK-8285496): DocLint does not check for missing `@param` tags for type parameters on classes and interfaces


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8458/head:pull/8458` \
`$ git checkout pull/8458`

Update a local copy of the PR: \
`$ git checkout pull/8458` \
`$ git pull https://git.openjdk.java.net/jdk pull/8458/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8458`

View PR using the GUI difftool: \
`$ git pr show -t 8458`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8458.diff">https://git.openjdk.java.net/jdk/pull/8458.diff</a>

</details>
