### PR TITLE
8283577: SSLEngine.unwrap on read-only input ByteBuffer

### DIFF
--- a/src/java.base/share/classes/javax/crypto/Cipher.java
+++ b/src/java.base/share/classes/javax/crypto/Cipher.java
@@ -25,27 +25,47 @@
 
 package javax.crypto;
 
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.regex.*;
+import sun.security.jca.GetInstance;
+import sun.security.jca.JCAUtil;
+import sun.security.jca.ServiceId;
+import sun.security.util.Debug;
+import sun.security.util.KnownOIDs;
 
-
-import java.security.*;
-import java.security.Provider.Service;
-import java.security.spec.AlgorithmParameterSpec;
-import java.security.spec.InvalidParameterSpecException;
-import java.security.cert.Certificate;
-import java.security.cert.X509Certificate;
-
-import javax.crypto.spec.*;
-
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.PBEParameterSpec;
+import javax.crypto.spec.RC2ParameterSpec;
+import javax.crypto.spec.RC5ParameterSpec;
 import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
-
-import sun.security.util.Debug;
-import sun.security.jca.*;
-import sun.security.util.KnownOIDs;
+import java.security.AlgorithmParameters;
+import java.security.GeneralSecurityException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.InvalidParameterException;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Provider;
+import java.security.Provider.Service;
+import java.security.ProviderException;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.InvalidParameterSpecException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.regex.Pattern;
 
 /**
  * This class provides the functionality of a cryptographic cipher for
@@ -2837,5 +2857,235 @@ public class Cipher {
         }
         sb.append(", algorithm from: ").append(getProviderName());
         return sb.toString();
+    }
+
+    /**
+     * fdsafsdafsdafda
+     * @return dsfasfa
+     */
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    /**
+     * fdsafsafsda
+     */
+    public static class Builder {
+        Cipher cyfr;
+        String algorithm;
+        Key key = null;
+        Certificate cert = null;
+        AlgorithmParameters ap = null;
+        AlgorithmParameterSpec aps = null;
+        SecureRandom random = null;
+        int op = Cipher.ENCRYPT_MODE;
+        Provider provider;
+        String provStr;
+        String keygenStr = null;
+
+        /**
+         * fdsafsdafda
+         */
+        public Builder() {
+            super();
+        }
+
+        /**
+         * fsdafd afdfasd
+         * @return fdsafsda
+         * @throws GeneralSecurityException blah
+         */
+        public Cipher build() throws GeneralSecurityException {
+            if (random == null) {
+                JCAUtil.getDefSecureRandom();
+            }
+            try {
+                if (provider == null && provStr == null) {
+                    cyfr = Cipher.getInstance(algorithm);
+                } else if (provider != null) {
+                    cyfr = Cipher.getInstance(algorithm, provider);
+                } else if (provStr != null) {
+                    cyfr = Cipher.getInstance(algorithm, provStr);
+                }
+
+                if (key == null && keygenStr != null) {
+                    KeyGenerator kg;
+                    if (cyfr.provider == null) {
+                         kg = KeyGenerator.getInstance(keygenStr);
+                    } else {
+                        kg = KeyGenerator.getInstance(keygenStr, cyfr.provider);
+                    }
+                    key = kg.generateKey();
+                }
+
+                if (aps != null) {
+                    cyfr.init(op, key, aps, random);
+                } else if (ap != null) {
+                    cyfr.init(op, key, ap, random);
+                } else if (cert != null) {
+                    cyfr.init(op, cert, random);
+                } else {
+                    cyfr.init(op, key, random);
+                }
+
+            } catch (Exception e) {
+                throw new GeneralSecurityException(e);
+            }
+            return cyfr;
+        }
+
+        /**
+         * Build a cipher object with the provided algorithm transformation
+         * @param algorithm - algorithm transformation
+         * @return the builder object
+         */
+        public Builder with(String algorithm) {
+            this.algorithm = algorithm;
+            return this;
+        }
+
+        /**
+         * Build a cipher object with the provided Key object
+         * @param key secret key object
+         * @return the builder object
+         */
+        public Builder with(Key key) {
+            this.key = key;
+            return this;
+        }
+
+        /**
+         * Build a cipher object with the provided Certificate object
+         * @param cert certificate object
+         * @return the builder object
+         * @throws GeneralSecurityException exception thrown if other builder
+         * methods were called that conflict with this method
+         */
+        public Builder with(Certificate cert) throws GeneralSecurityException {
+            if (aps != null) {
+                throw new GeneralSecurityException("AlgorithmParameterSpec " +
+                    "cannot be specified when using a certificate");
+            }
+            if (ap != null) {
+                throw new GeneralSecurityException("AlgorithmParameters " +
+                    "cannot be specified when using a certificate");
+            }
+            this.cert = cert;
+            return this;
+        }
+
+        /**
+         * Build a cipher object with the provided AlgorithmParameterSpec object
+         * @param params AlgorithmParameterSpec
+         * @return the builder object
+         * @throws GeneralSecurityException exception thrown if other builder
+         * methods were called that conflict with this method
+         */
+        Builder with(AlgorithmParameterSpec params) throws GeneralSecurityException {
+            if (cert != null) {
+                throw new GeneralSecurityException("AlgorithmParameterSpec " +
+                    "cannot be specified when using a certificate");
+            }
+            if (ap != null) {
+                throw new GeneralSecurityException("AlgorithmParameterSpec " +
+                    "cannot be specified after using an " +
+                    "AlgorithmParameters");
+            }            aps = params;
+            return this;
+        }
+
+        /**
+         * Build a cipher object with the provided AlgorithmParameters object
+         * @param params AlgorithmParameterSpec
+         * @return the builder object
+         * @throws GeneralSecurityException exception thrown if other builder
+         * methods were called that conflict with this method
+         */
+        public Builder with(AlgorithmParameters params) throws GeneralSecurityException {
+            if (cert != null) {
+                throw new GeneralSecurityException("AlgorithmParameters " +
+                    "cannot be specified when using a certificate");
+            }
+            if (aps != null) {
+                throw new GeneralSecurityException("AlgorithmParameters " +
+                    "cannot be specified after using an " +
+                    "AlgorithmParameterSpec");
+            }
+            ap = params;
+            return this;
+        }
+
+        /**
+         * Build a cipher object for encryption
+         * @return the builder object
+         */
+        public Builder encrypt() {
+            op = Cipher.ENCRYPT_MODE;
+            return this;
+        }
+
+        /**
+         * Build a cipher object for decrypt
+         * @return the builder object
+         */
+        public Builder decrypt() {
+            op = Cipher.DECRYPT_MODE;
+            return this;
+        }
+
+        /**
+         * Build a cipher object that will generate a key, using {@code KeyGenerator} with the given key type.
+         * If the builder has a specified provider, it will use that provider to generate the key.
+         * @param kgStr String of the key type
+         * @return the builder object
+         */
+        public Builder generate(String kgStr) {
+            keygenStr = kgStr;
+            return this;
+        }
+
+        /**
+         * Build a cipher object that will do all it's operations with the given provider
+         * @param prov Provider class
+         * @return the builder object
+         * @throws GeneralSecurityException throws if the provider has already been specified by another method
+         */
+        public Builder provider(Provider prov) throws GeneralSecurityException {
+            if (provStr != null) {
+                throw new GeneralSecurityException(
+                    "Provider already specified");
+            }
+            provider = prov;
+            return this;
+        }
+
+        /**
+         * Build a cipher object that will do all it's operations with the
+         * given provider
+         * @param prov Provider name as a string
+         * @return the builder object
+         * @throws GeneralSecurityException throws if the provider has already
+         * been specified by another method
+         */
+        public Builder provider(String prov) throws GeneralSecurityException {
+            if (provider != null) {
+                throw new GeneralSecurityException(
+                    "Provider already specified");
+            }
+            provStr = prov;
+            return this;
+        }
+
+        /**
+         * Return the key used in the cipher object.
+         * @return This method is for returning the {@code Key} when
+         * {@code generate()} has been used.  This must be used after the
+         * {@code build()} is called. If {@code generate()} was not called
+         * and {@code with(Key)} is called, this will return that key object,
+         * otherwise {@code null} will be returned
+         */
+        public Key getKey() {
+            return key;
+        }
     }
 }

--- a/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
@@ -673,6 +673,9 @@ public abstract class SSLEngine {
      * @throws  IllegalStateException if the client/server mode
      *          has not yet been set.
      * @see     #unwrap(ByteBuffer, ByteBuffer[], int, int)
+     *
+     * @implNote The data in {@code src} may be modified during the decryption
+     * process.
      */
     public SSLEngineResult unwrap(ByteBuffer src,
             ByteBuffer dst) throws SSLException {
@@ -710,6 +713,9 @@ public abstract class SSLEngine {
      * @throws  IllegalStateException if the client/server mode
      *          has not yet been set.
      * @see     #unwrap(ByteBuffer, ByteBuffer[], int, int)
+     *
+     * @implNote The data in {@code src} may be modified during the decryption
+     * process
      */
     public SSLEngineResult unwrap(ByteBuffer src,
             ByteBuffer [] dsts) throws SSLException {
@@ -798,6 +804,9 @@ public abstract class SSLEngine {
      * @see     java.nio.channels.ScatteringByteChannel
      * @see     java.nio.channels.ScatteringByteChannel#read(
      *              ByteBuffer[], int, int)
+     *
+     * @implNote The data in {@code src} may be modified during the decryption
+     * process
      */
     public abstract SSLEngineResult unwrap(ByteBuffer src,
             ByteBuffer [] dsts, int offset, int length) throws SSLException;

--- a/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,16 @@
 
 package sun.security.ssl;
 
+import sun.security.ssl.Authenticator.MAC;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.ShortBufferException;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
 import java.nio.ByteBuffer;
 import java.security.AccessController;
 import java.security.GeneralSecurityException;
@@ -41,17 +51,17 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import javax.crypto.BadPaddingException;
-import javax.crypto.Cipher;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.NoSuchPaddingException;
-import javax.crypto.SecretKey;
-import javax.crypto.ShortBufferException;
-import javax.crypto.spec.GCMParameterSpec;
-import javax.crypto.spec.IvParameterSpec;
-import sun.security.ssl.Authenticator.MAC;
-import static sun.security.ssl.CipherType.*;
-import static sun.security.ssl.JsseJce.*;
+
+import static sun.security.ssl.CipherType.AEAD_CIPHER;
+import static sun.security.ssl.CipherType.BLOCK_CIPHER;
+import static sun.security.ssl.CipherType.NULL_CIPHER;
+import static sun.security.ssl.CipherType.STREAM_CIPHER;
+import static sun.security.ssl.JsseJce.CIPHER_3DES;
+import static sun.security.ssl.JsseJce.CIPHER_AES;
+import static sun.security.ssl.JsseJce.CIPHER_AES_GCM;
+import static sun.security.ssl.JsseJce.CIPHER_CHACHA20_POLY1305;
+import static sun.security.ssl.JsseJce.CIPHER_DES;
+import static sun.security.ssl.JsseJce.CIPHER_RC4;
 
 enum SSLCipher {
     // exportable ciphers
@@ -881,39 +891,43 @@ enum SSLCipher {
             public Plaintext decrypt(byte contentType, ByteBuffer bb,
                     byte[] sequence) throws GeneralSecurityException {
                 int len = bb.remaining();
-                int pos = bb.position();
-                ByteBuffer dup = bb.duplicate();
+                int pos;
+                // Do in-place with the ct buffer if it's not read-only
+                ByteBuffer pt;
+                if (!bb.isReadOnly()) {
+                    pt = bb.duplicate();
+                    pos = bb.position();
+                } else {
+                    pt = ByteBuffer.allocate(bb.remaining());
+                    pos = 0;
+                }
                 try {
-                    if (len != cipher.update(dup, bb)) {
+                    if (len != cipher.update(bb, pt)) {
                         // catch BouncyCastle buffering error
                         throw new RuntimeException(
                                 "Unexpected number of plaintext bytes");
-                    }
-                    if (bb.position() != dup.position()) {
-                        throw new RuntimeException(
-                                "Unexpected ByteBuffer position");
                     }
                 } catch (ShortBufferException sbe) {
                     // catch BouncyCastle buffering error
                     throw new RuntimeException("Cipher buffering error in " +
                         "JCE provider " + cipher.getProvider().getName(), sbe);
                 }
-                bb.position(pos);
+                pt.position(pos);
                 if (SSLLogger.isOn && SSLLogger.isOn("plaintext")) {
                     SSLLogger.fine(
-                            "Plaintext after DECRYPTION", bb.duplicate());
+                            "Plaintext after DECRYPTION", pt.duplicate());
                 }
 
                 MAC signer = (MAC)authenticator;
                 if (signer.macAlg().size != 0) {
-                    checkStreamMac(signer, bb, contentType, sequence);
+                    checkStreamMac(signer, pt, contentType, sequence);
                 } else {
                     authenticator.increaseSequenceNumber();
                 }
 
                 return new Plaintext(contentType,
                         ProtocolVersion.NONE.major, ProtocolVersion.NONE.minor,
-                        -1, -1L, bb.slice());
+                        -1, -1L, pt.slice());
             }
 
             @Override
@@ -1066,18 +1080,21 @@ enum SSLCipher {
                 }
                 // decryption
                 int len = bb.remaining();
-                int pos = bb.position();
-                ByteBuffer dup = bb.duplicate();
+                int pos;
+                // Do in-place with the ct buffer if it's not read-only
+                ByteBuffer pt;
+                if (!bb.isReadOnly()) {
+                    pt = bb.duplicate();
+                    pos = bb.position();
+                } else {
+                    pt = ByteBuffer.allocate(bb.remaining());
+                    pos = 0;
+                }
                 try {
-                    if (len != cipher.update(dup, bb)) {
+                    if (len != cipher.update(bb, pt)) {
                         // catch BouncyCastle buffering error
                         throw new RuntimeException(
                                 "Unexpected number of plaintext bytes");
-                    }
-
-                    if (bb.position() != dup.position()) {
-                        throw new RuntimeException(
-                                "Unexpected ByteBuffer position");
                     }
                 } catch (ShortBufferException sbe) {
                     // catch BouncyCastle buffering error
@@ -1088,14 +1105,14 @@ enum SSLCipher {
                 if (SSLLogger.isOn && SSLLogger.isOn("plaintext")) {
                     SSLLogger.fine(
                             "Padded plaintext after DECRYPTION",
-                            bb.duplicate().position(pos));
+                            pt.duplicate().position(pos));
                 }
 
                 // remove the block padding
                 int blockSize = cipher.getBlockSize();
-                bb.position(pos);
+                pt.position(pos);
                 try {
-                    removePadding(bb, tagLen, blockSize, protocolVersion);
+                    removePadding(pt, tagLen, blockSize, protocolVersion);
                 } catch (BadPaddingException bpe) {
                     if (reservedBPE == null) {
                         reservedBPE = bpe;
@@ -1106,7 +1123,7 @@ enum SSLCipher {
                 // block cipher suites.
                 try {
                     if (tagLen != 0) {
-                        checkCBCMac(signer, bb,
+                        checkCBCMac(signer, pt,
                                 contentType, cipheredLength, sequence);
                     } else {
                         authenticator.increaseSequenceNumber();
@@ -1124,7 +1141,7 @@ enum SSLCipher {
 
                 return new Plaintext(contentType,
                         ProtocolVersion.NONE.major, ProtocolVersion.NONE.minor,
-                        -1, -1L, bb.slice());
+                        -1, -1L, pt.slice());
             }
 
             @Override
@@ -1338,18 +1355,22 @@ enum SSLCipher {
 
                 // decryption
                 int len = bb.remaining();
-                int pos = bb.position();
-                ByteBuffer dup = bb.duplicate();
+                int pos;
+                // Do in-place with the ct buffer if it's not read-only
+                ByteBuffer pt;
+                if (!bb.isReadOnly()) {
+                    pt = bb.duplicate();
+                    pos = bb.position();
+                } else {
+                    pt = ByteBuffer.allocate(bb.remaining());
+                    pos = 0;
+                }
+
                 try {
-                    if (len != cipher.update(dup, bb)) {
+                    if (len != cipher.update(bb, pt)) {
                         // catch BouncyCastle buffering error
                         throw new RuntimeException(
                                 "Unexpected number of plaintext bytes");
-                    }
-
-                    if (bb.position() != dup.position()) {
-                        throw new RuntimeException(
-                                "Unexpected ByteBuffer position");
                     }
                 } catch (ShortBufferException sbe) {
                     // catch BouncyCastle buffering error
@@ -1358,20 +1379,20 @@ enum SSLCipher {
                 }
 
                 if (SSLLogger.isOn && SSLLogger.isOn("plaintext")) {
-                    SSLLogger.fine(
-                            "Padded plaintext after DECRYPTION",
-                            bb.duplicate().position(pos));
+                    SSLLogger.fine("Padded plaintext after DECRYPTION",
+                        pt.duplicate().position(pos));
                 }
 
+                //bb.position(pos);
+
                 // Ignore the explicit nonce.
-                bb.position(pos + cipher.getBlockSize());
-                pos = bb.position();
+                int blockSize = cipher.getBlockSize();
+                pos += blockSize;
+                pt.position(pos);
 
                 // remove the block padding
-                int blockSize = cipher.getBlockSize();
-                bb.position(pos);
                 try {
-                    removePadding(bb, tagLen, blockSize, protocolVersion);
+                    removePadding(pt, tagLen, blockSize, protocolVersion);
                 } catch (BadPaddingException bpe) {
                     if (reservedBPE == null) {
                         reservedBPE = bpe;
@@ -1382,7 +1403,7 @@ enum SSLCipher {
                 // block cipher suites.
                 try {
                     if (tagLen != 0) {
-                        checkCBCMac(signer, bb,
+                        checkCBCMac(signer, pt,
                                 contentType, cipheredLength, sequence);
                     } else {
                         authenticator.increaseSequenceNumber();
@@ -1400,7 +1421,7 @@ enum SSLCipher {
 
                 return new Plaintext(contentType,
                         ProtocolVersion.NONE.major, ProtocolVersion.NONE.minor,
-                        -1, -1L, bb.slice());
+                        -1, -1L, pt.slice());
             }
 
             @Override
@@ -1655,10 +1676,19 @@ enum SSLCipher {
 
                 // DON'T decrypt the nonce_explicit for AEAD mode. The buffer
                 // position has moved out of the nonce_explicit range.
-                int len, pos = bb.position();
-                ByteBuffer dup = bb.duplicate();
+
+                int len, pos;
+                // Do in-place with the ct buffer if it's not read-only
+                ByteBuffer pt;
+                if (!bb.isReadOnly()) {
+                    pt = bb.duplicate();
+                    pos = bb.position();
+                } else {
+                    pt = ByteBuffer.allocate(bb.remaining());
+                    pos = 0;
+                }
                 try {
-                    len = cipher.doFinal(dup, bb);
+                    len = cipher.doFinal(bb, pt);
                 } catch (IllegalBlockSizeException ibse) {
                     // unlikely to happen
                     throw new RuntimeException(
@@ -1670,17 +1700,17 @@ enum SSLCipher {
                         "JCE provider " + cipher.getProvider().getName(), sbe);
                 }
                 // reset the limit to the end of the decrypted data
-                bb.position(pos);
-                bb.limit(pos + len);
+                pt.position(pos);
+                pt.limit(pos + len);
 
                 if (SSLLogger.isOn && SSLLogger.isOn("plaintext")) {
                     SSLLogger.fine(
-                            "Plaintext after DECRYPTION", bb.duplicate());
+                            "Plaintext after DECRYPTION", pt.duplicate());
                 }
 
                 return new Plaintext(contentType,
                         ProtocolVersion.NONE.major, ProtocolVersion.NONE.minor,
-                        -1, -1L, bb.slice());
+                        -1, -1L, pt.slice());
             }
 
             @Override
@@ -1929,10 +1959,18 @@ enum SSLCipher {
                                         contentType, bb.remaining(), sn);
                 cipher.updateAAD(aad);
 
-                int len, pos = bb.position();
-                ByteBuffer dup = bb.duplicate();
+                int len, pos;
+                // Do in-place with the ct buffer if it's not read-only
+                ByteBuffer pt;
+                if (!bb.isReadOnly()) {
+                    pt = bb.duplicate();
+                    pos = bb.position();
+                } else {
+                    pt = ByteBuffer.allocate(bb.remaining());
+                    pos = 0;
+                }
                 try {
-                    len = cipher.doFinal(dup, bb);
+                    len = cipher.doFinal(bb, pt);
                 } catch (IllegalBlockSizeException ibse) {
                     // unlikely to happen
                     throw new RuntimeException(
@@ -1943,25 +1981,24 @@ enum SSLCipher {
                     throw new RuntimeException("Cipher buffering error in " +
                         "JCE provider " + cipher.getProvider().getName(), sbe);
                 }
+                pt.position(pos);
                 // reset the limit to the end of the decrypted data
-                bb.position(pos);
-                bb.limit(pos + len);
+                pt.limit(pos + len);
 
                 // remove inner plaintext padding
-                int i = bb.limit() - 1;
-                for (; i > 0 && bb.get(i) == 0; i--) {
-                    // blank
-                }
+                int i = pt.limit() - 1;
+                for (; i > 0 && pt.get(i) == 0; i--);
+
                 if (i < (pos + 1)) {
                     throw new BadPaddingException(
                             "Incorrect inner plaintext: no content type");
                 }
-                contentType = bb.get(i);
-                bb.limit(i);
+                contentType = pt.get(i);
+                pt.limit(i);
 
                 if (SSLLogger.isOn && SSLLogger.isOn("plaintext")) {
                     SSLLogger.fine(
-                            "Plaintext after DECRYPTION", bb.duplicate());
+                            "Plaintext after DECRYPTION", pt.duplicate());
                 }
                 if (keyLimitEnabled) {
                     keyLimitCountdown -= len;
@@ -1969,7 +2006,7 @@ enum SSLCipher {
 
                 return new Plaintext(contentType,
                         ProtocolVersion.NONE.major, ProtocolVersion.NONE.minor,
-                        -1, -1L, bb.slice());
+                        -1, -1L, pt.slice());
             }
 
             @Override
@@ -2203,11 +2240,19 @@ enum SSLCipher {
 
                 // DON'T decrypt the nonce_explicit for AEAD mode. The buffer
                 // position has moved out of the nonce_explicit range.
-                int len;
-                int pos = bb.position();
-                ByteBuffer dup = bb.duplicate();
+
+                int len, pos;
+                // Do in-place with the ct buffer if it's not read-only
+                ByteBuffer pt;
+                if (!bb.isReadOnly()) {
+                    pt = bb.duplicate();
+                    pos = bb.position();
+                } else {
+                    pt = ByteBuffer.allocate(bb.remaining());
+                    pos = 0;
+                }
                 try {
-                    len = cipher.doFinal(dup, bb);
+                    len = cipher.doFinal(bb, pt);
                 } catch (IllegalBlockSizeException ibse) {
                     // unlikely to happen
                     throw new RuntimeException(
@@ -2219,17 +2264,17 @@ enum SSLCipher {
                         "JCE provider " + cipher.getProvider().getName(), sbe);
                 }
                 // reset the limit to the end of the decrypted data
-                bb.position(pos);
-                bb.limit(pos + len);
+                pt.position(pos);
+                pt.limit(pos + len);
 
                 if (SSLLogger.isOn && SSLLogger.isOn("plaintext")) {
                     SSLLogger.fine(
-                            "Plaintext after DECRYPTION", bb.duplicate());
+                            "Plaintext after DECRYPTION", pt.duplicate());
                 }
 
                 return new Plaintext(contentType,
                         ProtocolVersion.NONE.major, ProtocolVersion.NONE.minor,
-                        -1, -1L, bb.slice());
+                        -1, -1L, pt.slice());
             }
 
             @Override
@@ -2473,11 +2518,18 @@ enum SSLCipher {
                                         contentType, bb.remaining(), sn);
                 cipher.updateAAD(aad);
 
-                int len;
-                int pos = bb.position();
-                ByteBuffer dup = bb.duplicate();
+                 int len, pos;
+                // Do in-place with the ct buffer if it's not read-only
+                ByteBuffer pt;
+                if (!bb.isReadOnly()) {
+                    pt = bb.duplicate();
+                    pos = bb.position();
+                } else {
+                    pt = ByteBuffer.allocate(bb.remaining());
+                    pos = 0;
+                }
                 try {
-                    len = cipher.doFinal(dup, bb);
+                    len = cipher.doFinal(bb, pt);
                 } catch (IllegalBlockSizeException ibse) {
                     // unlikely to happen
                     throw new RuntimeException(
@@ -2489,29 +2541,29 @@ enum SSLCipher {
                         "JCE provider " + cipher.getProvider().getName(), sbe);
                 }
                 // reset the limit to the end of the decrypted data
-                bb.position(pos);
-                bb.limit(pos + len);
+                pt.position(pos);
+                pt.limit(pos + len);
 
                 // remove inner plaintext padding
-                int i = bb.limit() - 1;
-                for (; i > 0 && bb.get(i) == 0; i--) {
+                int i = pt.limit() - 1;
+                for (; i > 0 && pt.get(i) == 0; i--) {
                     // blank
                 }
                 if (i < (pos + 1)) {
                     throw new BadPaddingException(
                             "Incorrect inner plaintext: no content type");
                 }
-                contentType = bb.get(i);
-                bb.limit(i);
+                contentType = pt.get(i);
+                pt.limit(i);
 
                 if (SSLLogger.isOn && SSLLogger.isOn("plaintext")) {
                     SSLLogger.fine(
-                            "Plaintext after DECRYPTION", bb.duplicate());
+                            "Plaintext after DECRYPTION", pt.duplicate());
                 }
 
                 return new Plaintext(contentType,
                         ProtocolVersion.NONE.major, ProtocolVersion.NONE.minor,
-                        -1, -1L, bb.slice());
+                        -1, -1L, pt.slice());
             }
 
             @Override

--- a/test/jdk/javax/crypto/Cipher/BuilderTest.java
+++ b/test/jdk/javax/crypto/Cipher/BuilderTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Arrays;
+
+/**
+ * @test
+ */
+public class BuilderTest {
+    static Cipher c;
+
+    public static void main(String[] args) throws Exception {
+        byte[] keydata = new byte[16];
+        byte[] pt = "FISH".getBytes();
+
+        //SecretKeySpec key = new SecretKeySpec(keydata, "AES");
+        Cipher.Builder cb = Cipher.newBuilder();
+        c = cb.with("AES/GCM/NoPadding").generate("AES").build();
+        SecretKeySpec key = (SecretKeySpec) cb.getKey();
+        byte[] ct = c.doFinal(pt);
+        c = Cipher.newBuilder().decrypt().with("AES/GCM/NoPadding").with(key).with(c.getParameters()).build();
+        ct = c.doFinal(ct);
+        assert(Arrays.compare(pt, ct) != 0);
+    }
+}

--- a/test/jdk/javax/net/ssl/SSLSession/ReadOnlyEngine.java
+++ b/test/jdk/javax/net/ssl/SSLSession/ReadOnlyEngine.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @library /javax/net/ssl/templates
+ * @bug 8283577
+ * @summary Test SSLEngine to use read-only input bytebuffers
+ * @run main/othervm ReadOnlyEngine
+ */
+
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLEngineResult;
+import javax.net.ssl.SSLEngineResult.HandshakeStatus;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.FileInputStream;
+import java.nio.ByteBuffer;
+import java.security.KeyStore;
+import java.security.Security;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class ReadOnlyEngine {
+
+    private static String pathToStores = "../etc";
+    private static String keyStoreFile = "keystore";
+    private static String trustStoreFile = "truststore";
+    private static char[] passwd = "passphrase".toCharArray();
+
+    private static String keyFilename =
+        System.getProperty("test.src", "./") + "/" + pathToStores +
+            "/" + keyStoreFile;
+    private static String trustFilename =
+        System.getProperty("test.src", "./") + "/" + pathToStores +
+            "/" + trustStoreFile;
+
+    SSLEngine server;
+    SSLEngine client;
+    static ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    HandshakeStatus doHandshake(SSLEngine engine, ByteBuffer in, ByteBuffer out) {
+        HandshakeStatus status;
+        status = engine.getHandshakeStatus();
+        while (status != SSLEngineResult.HandshakeStatus.FINISHED &&
+            status != SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING) {
+            out.clear();
+            switch (status) {
+                case NEED_UNWRAP:
+                    try {
+                        return receive(engine, in, out);
+                    } catch (SSLException e) {
+                        e.printStackTrace();
+                    }
+                    break;
+                case NEED_WRAP:
+                    try {
+                        return send(engine, in, out);
+                    } catch (SSLException e) {
+                        e.printStackTrace();
+                    }
+                    break;
+                case NEED_TASK:
+                    Runnable task;
+                    while ((task = engine.getDelegatedTask()) != null) {
+                        executor.execute(task);
+                    }
+                    status = engine.getHandshakeStatus();
+                    break;
+                case FINISHED:
+                    break;
+                case NOT_HANDSHAKING:
+                    break;
+                default:
+                    throw new IllegalStateException("Invalid SSL status: " + status);
+            }
+        }
+        return status;
+    }
+
+    HandshakeStatus send(SSLEngine engine, ByteBuffer in, ByteBuffer out) throws SSLException {
+        SSLEngineResult status = engine.wrap(in, out);
+        out.flip();
+        return status.getHandshakeStatus();
+    }
+
+    HandshakeStatus receive(SSLEngine engine, ByteBuffer in, ByteBuffer out) throws SSLException {
+        SSLEngineResult status = engine.unwrap(in, out);
+        out.flip();
+        return status.getHandshakeStatus();
+    }
+
+    ReadOnlyEngine(SSLContext sslc, String ciphersuite) throws Exception {
+        System.err.println("==== Test Protocol: " + sslc.getProtocol() +
+            ", CipherSuite: " + ciphersuite);
+        KeyStore ks = KeyStore.getInstance("PKCS12");
+        KeyStore ts = KeyStore.getInstance("PKCS12");
+
+        ks.load(new FileInputStream(keyFilename), passwd);
+        ts.load(new FileInputStream(trustFilename), passwd);
+
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+        kmf.init(ks, passwd);
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
+        tmf.init(ts);
+
+        sslc.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+        client = sslc.createSSLEngine("client", 1);
+        client.setUseClientMode(true);
+        server = sslc.createSSLEngine("server", 2);
+        if (ciphersuite != null) {
+            server.setEnabledCipherSuites(new String[] { ciphersuite });
+        }
+        server.setUseClientMode(false);
+
+        SSLSession session = server.getSession();
+        int maxData = session.getPacketBufferSize();
+
+        ByteBuffer in = ByteBuffer.allocate(maxData);
+        ByteBuffer out = ByteBuffer.allocate(maxData);
+
+        HandshakeStatus statusClient, statusServer;
+        client.beginHandshake();
+        server.beginHandshake();
+        do {
+            statusClient = doHandshake(client, out, in);
+            statusServer = doHandshake(server, in, out);
+        }
+        while ((statusClient != HandshakeStatus.FINISHED && statusClient != HandshakeStatus.NOT_HANDSHAKING)
+            || (statusServer != HandshakeStatus.FINISHED && statusServer != HandshakeStatus.NOT_HANDSHAKING));
+
+        System.err.println("done");
+
+        in.clear();
+        out.clear();
+        in.put("FISH".getBytes()).flip();
+        send(client, in.asReadOnlyBuffer(), out);
+        in.clear();
+        receive(server, out.asReadOnlyBuffer(), in);
+    }
+
+    public static void main(String[] args) throws Exception {
+        Security.setProperty("jdk.tls.disabledAlgorithms", "");
+        new ReadOnlyEngine(SSLContext.getInstance("TLSv1.3"), "TLS_AES_256_GCM_SHA384");
+        new ReadOnlyEngine(SSLContext.getInstance("TLSv1.3"), "TLS_CHACHA20_POLY1305_SHA256");
+        new ReadOnlyEngine(SSLContext.getInstance("TLSv1.2"), "TLS_RSA_WITH_AES_128_GCM_SHA256");
+        new ReadOnlyEngine(SSLContext.getInstance("TLSv1.2"), "TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256");
+        new ReadOnlyEngine(SSLContext.getInstance("TLSv1.1"), "TLS_RSA_WITH_AES_128_CBC_SHA");
+        new ReadOnlyEngine(SSLContext.getInstance("TLSv1"), "TLS_RSA_WITH_AES_128_CBC_SHA");
+    }
+}


### PR DESCRIPTION
Hi,

I need a review of this fix to allow a read-only 'src' buffer to be used with SSLEngine.unwrap().  A temporary read-write buffer is created in the SSLCipher operation when a read-only buffer is passed.  If the 'src' is read-write, there is no effect on the current operation

The PR also includes a CSR for an API implementation note to the SSLEngine.unwrap.  The 'src' buffer may be modified during the decryption operation.  'unwrap()' has had this behavior forever, so there is no compatibility issue with this note.  Using the 'src' buffer for in-place decryption was a performance decision.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issues
 * [JDK-8283577](https://bugs.openjdk.java.net/browse/JDK-8283577): SSLEngine.unwrap on read-only input ByteBuffer
 * [JDK-8285603](https://bugs.openjdk.java.net/browse/JDK-8285603): SSLEngine.unwrap modifies input ByteBuffer (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8461/head:pull/8461` \
`$ git checkout pull/8461`

Update a local copy of the PR: \
`$ git checkout pull/8461` \
`$ git pull https://git.openjdk.java.net/jdk pull/8461/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8461`

View PR using the GUI difftool: \
`$ git pr show -t 8461`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8461.diff">https://git.openjdk.java.net/jdk/pull/8461.diff</a>

</details>
