### PR TITLE
[PATCH] Avoid redundant HashMap.containsKey calls in ZoneName

### DIFF
--- a/src/java.base/share/classes/java/time/format/ZoneName.java.template
+++ b/src/java.base/share/classes/java/time/format/ZoneName.java.template
@@ -40,15 +40,16 @@ class ZoneName {
 
     public static String toZid(String zid, Locale locale) {
         String mzone = zidToMzone.get(zid);
-        if (mzone == null && aliases.containsKey(zid)) {
-            zid = aliases.get(zid);
-            mzone = zidToMzone.get(zid);
+        if (mzone == null) {
+            String alias = aliases.get(zid);
+            if (alias != null) {
+                zid = alias;
+                mzone = zidToMzone.get(zid);
+            }
         }
         if (mzone != null) {
             Map<String, String> map = mzoneToZidL.get(mzone);
-            if (map != null && map.containsKey(locale.getCountry())) {
-                zid = map.get(locale.getCountry());
-            } else {
+            if (map == null || ((zid = map.get(locale.getCountry())) == null)) {
                 zid = mzoneToZid.get(mzone);
             }
         }
@@ -56,10 +57,7 @@ class ZoneName {
     }
 
     public static String toZid(String zid) {
-        if (aliases.containsKey(zid)) {
-            return aliases.get(zid);
-        }
-        return zid;
+        return aliases.getOrDefault(zid, zid);
     }
 
     private static final String[] zidMap = new String[] {


### PR DESCRIPTION
Map.containsKey after used unnecessary, when it's known that Map doesn't contain `null` values.
Instead we can just use Map.get and compare result with `null`.
I found one of such place, where Map.containsKey calls could be eliminated - `java.time.format.ZoneName`.
it gives a bit of performance for `toZid`.

```
Benchmark                             Mode  Cnt   Score   Error  Units
ZoneNamesBench.useExistingCountry     avgt    5  10,738 ± 0,065  ns/op
ZoneNamesBench.useExistingCountryOld  avgt    5  13,679 ± 0,089  ns/op
```

<details>
<summary>Benchmark</summary>

```
@BenchmarkMode(value = Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
@Fork(1)
@State(Scope.Benchmark)
public class ZoneNamesBench {

    @Benchmark
    public String useExistingCountry() {
        return ZoneName.toZid("Africa/Tunis", Locale.ITALY);
    }

    @Benchmark
    public String useExistingCountryOld() {
        return ZoneName.toZidOld("Africa/Tunis", Locale.ITALY);
    }
}
```

```
    public static String toZid(String zid, Locale locale) {
        String mzone = zidToMzone.get(zid);
        if (mzone == null) {
            String alias = aliases.get(zid);
            if (alias != null) {
                zid = alias;
                mzone = zidToMzone.get(zid);
            }
        }
        if (mzone != null) {
            Map<String, String> map = mzoneToZidL.get(mzone);
            if (map == null || ((zid = map.get(locale.getCountry())) == null)) {
                zid = mzoneToZid.get(mzone);
            }
        }
        return toZid(zid);
    }

    public static String toZid(String zid) {
        return aliases.getOrDefault(zid, zid);
    }

    public static String toZidOld(String zid, Locale locale) {
        String mzone = zidToMzone.get(zid);
        if (mzone == null && aliases.containsKey(zid)) {
            zid = aliases.get(zid);
            mzone = zidToMzone.get(zid);
        }
        if (mzone != null) {
            Map<String, String> map = mzoneToZidL.get(mzone);
            if (map != null && map.containsKey(locale.getCountry())) {
                zid = map.get(locale.getCountry());
            } else {
                zid = mzoneToZid.get(mzone);
            }
        }
        return toZidOld(zid);
    }

    public static String toZidOld(String zid) {
        if (aliases.containsKey(zid)) {
            return aliases.get(zid);
        }
        return zid;
    }
```
</details>