### PR TITLE
8279622: C2: miscompilation of map pattern as a vector reduction

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -1931,6 +1931,18 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
         if (can_reshape && igvn != NULL) {
           igvn->_worklist.push(r);
         }
+        if (n != nullptr && n->is_reduction()) {
+          for (unsigned i = 1; i < n->req(); i++) {
+            if (n->in(i) == this) {
+              // Reduction nodes that are both input and output to a phi node
+              // stop being reductions when the dependency cycle is broken, as
+              // per the definition used in PhaseIdealLoop::mark_reductions().
+              n->remove_flag(Node::Flag_is_reduction);
+              assert(r->is_CountedLoop(), "reduction node within a non-counted loop");
+              r->as_CountedLoop()->clear_has_reductions();
+            }
+          }
+        }
         // Nuke it down
         set_req_X(j, top, phase);
         progress = this;        // Record progress

--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -1931,22 +1931,6 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
         if (can_reshape && igvn != NULL) {
           igvn->_worklist.push(r);
         }
-        if (n != nullptr && n->is_reduction()) {
-          for (unsigned i = 1; i < n->req(); i++) {
-            if (n->in(i) == this) {
-              // Reduction nodes that are both input and output to a phi node
-              // stop being reductions when the dependency cycle is broken, as
-              // per the definition used in PhaseIdealLoop::mark_reductions().
-              n->remove_flag(Node::Flag_is_reduction);
-              if (can_reshape && igvn != NULL) {
-                igvn->_worklist.push(n);
-              }
-              assert(r->is_CountedLoop(), "reduction node within a non-counted loop");
-              // The loop node is already added to the IGVN worklist above.
-              r->as_CountedLoop()->clear_has_reductions();
-            }
-          }
-        }
         // Nuke it down
         set_req_X(j, top, phase);
         progress = this;        // Record progress

--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -1938,7 +1938,11 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
               // stop being reductions when the dependency cycle is broken, as
               // per the definition used in PhaseIdealLoop::mark_reductions().
               n->remove_flag(Node::Flag_is_reduction);
+              if (can_reshape && igvn != NULL) {
+                igvn->_worklist.push(n);
+              }
               assert(r->is_CountedLoop(), "reduction node within a non-counted loop");
+              // The loop node is already added to the IGVN worklist above.
               r->as_CountedLoop()->clear_has_reductions();
             }
           }

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -1605,6 +1605,15 @@ void PhaseIdealLoop::insert_pre_post_loops(IdealLoopTree *loop, Node_List &old_n
   set_idom(new_pre_exit, pre_end, dd_main_head);
   set_loop(new_pre_exit, outer_loop->_parent);
 
+  if (peel_only) {
+    // Nodes in the peeled iteration that were marked as reductions within the
+    // original loop might not be reductions within their new outer loop.
+    for (uint i = 0; i < loop->_body.size(); i++) {
+      Node* n = old_new[loop->_body[i]->_idx];
+      n->remove_flag(Node::Flag_is_reduction);
+    }
+  }
+
   // Step B2: Build a zero-trip guard for the main-loop.  After leaving the
   // pre-loop, the main-loop may not execute at all.  Later in life this
   // zero-trip guard will become the minimum-trip guard when we unroll

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -3886,6 +3886,17 @@ uint IdealLoopTree::est_loop_flow_merge_sz() const {
   return 0;
 }
 
+#ifdef ASSERT
+bool IdealLoopTree::has_reduction_nodes() const {
+  for (uint i = 0; i < _body.size(); i++) {
+    if (_body[i]->is_reduction()) {
+      return true;
+    }
+  }
+  return false;
+}
+#endif // ASSERT
+
 #ifndef PRODUCT
 //------------------------------dump_head--------------------------------------
 // Dump 1 liner for loop header info

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -108,7 +108,6 @@ public:
 
   void mark_partial_peel_failed() { _loop_flags |= PartialPeelFailed; }
   void mark_has_reductions() { _loop_flags |= HasReductions; }
-  void clear_has_reductions() { _loop_flags &= ~HasReductions; }
   void mark_was_slp() { _loop_flags |= WasSlpAnalyzed; }
   void mark_passed_slp() { _loop_flags |= PassedSlpAnalysis; }
   void mark_do_unroll_only() { _loop_flags |= DoUnrollOnly; }

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -108,6 +108,7 @@ public:
 
   void mark_partial_peel_failed() { _loop_flags |= PartialPeelFailed; }
   void mark_has_reductions() { _loop_flags |= HasReductions; }
+  void clear_has_reductions() { _loop_flags &= ~HasReductions; }
   void mark_was_slp() { _loop_flags |= WasSlpAnalyzed; }
   void mark_passed_slp() { _loop_flags |= PassedSlpAnalysis; }
   void mark_do_unroll_only() { _loop_flags |= DoUnrollOnly; }
@@ -777,6 +778,11 @@ public:
   bool is_innermost() { return is_loop() && _child == NULL; }
 
   void remove_main_post_loops(CountedLoopNode *cl, PhaseIdealLoop *phase);
+
+#ifdef ASSERT
+  // Tell whether the body contains nodes marked as reductions.
+  bool has_reduction_nodes() const;
+#endif // ASSERT
 
 #ifndef PRODUCT
   void dump_head() const;       // Dump loop head only

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -110,6 +110,8 @@ bool SuperWord::transform_loop(IdealLoopTree* lpt, bool do_optimization) {
     return false; // skip malformed counted loop
   }
 
+  assert(!lpt->has_reduction_nodes() || cl->is_reduction_loop(),
+         "non-reduction loop contains reduction nodes");
   if (cl->is_rce_post_loop() && cl->is_reduction_loop()) {
     // Post loop vectorization doesn't support reductions
     return false;

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestPeeledReductionNode.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestPeeledReductionNode.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8279622
+ * @summary Test that reduction nodes peeled out of an inner loop are not
+ *          vectorized as reductions within the outer loop.
+ * @library /test/lib
+ * @comment The test is run with -XX:LoopUnrollLimit=32 to prevent unrolling
+ *          from fully replacing vectorization.
+ * @run main/othervm -Xbatch -XX:LoopUnrollLimit=32
+ *      compiler.loopopts.superword.TestPeeledReductionNode
+ */
+package compiler.loopopts.superword;
+
+import jdk.test.lib.Asserts;
+
+public class TestPeeledReductionNode {
+    static final int N = 32;
+    static final int M = 65; // Must be odd and >= 65 to trigger the failure.
+    static final int INPUT = 0b0000_0000_0000_0000_0000_0000_0000_0001;
+    static final int MASK  = 0b0000_0000_1000_0000_0000_0000_0000_0000;
+    static final int EXPECTED = (M % 2 == 0 ? INPUT : INPUT ^ MASK);
+    static int mask = 0;
+    public static void main(String[] args) {
+        int r[] = new int[N];
+        for (int i = 0; i < N; i++) {
+            r[i] = INPUT;
+        }
+        // Trigger the relevant OSR compilation and set
+        // TestPeeledReductionNode.mask to MASK.
+        for (int k = 0; k < MASK; k++) {
+            TestPeeledReductionNode.mask++;
+        }
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                // Before the fix, this reduction is peeled out of its loop and
+                // wrongly remains marked as a reduction within the outer loop.
+                r[i] ^= TestPeeledReductionNode.mask;
+            }
+        }
+        for (int i = 0; i < N; i++) {
+            Asserts.assertEquals(r[i], EXPECTED);
+        }
+        return;
+    }
+}


### PR DESCRIPTION
The node reduction flag (`Node::Flag_is_reduction`) is only valid as long as the node remains within the reduction loop in which it was originally marked. This changeset ensures that reduction nodes are unmarked as such if they are extracted out of their associated reduction loop by the peel/main/post loop transformation (`PhaseIdealLoop::insert_pre_post_loops()`). This prevents SLP from wrongly vectorizing, as parallel reductions, outer non-reduction loops to which reduction nodes have been extracted. A more detailed analysis of the failure is available in the [JBS bug report](https://bugs.openjdk.java.net/browse/JDK-8279622).

The issue could be alternatively fixed at the IGVN level by unmarking reduction nodes as soon as they are decoupled from their corresponding phi and counted loop nodes, but the fix proposed here is simpler and less intrusive.

The changeset also introduces an assertion at the use point (`SuperWord::transform_loop()`) to check that loops containing reduction nodes are marked as reductions. This invariant could be alternatively placed together with other assertions under `-XX:+VerifyLoopOptimizations`, but [this option is known to be broken](https://bugs.openjdk.java.net/browse/JDK-8173709).

IR verification using the IR test framework is not feasible for the proposed test case, since the failure is triggered on a OSR compilation, [for which IR verification does not seem to be supported](https://github.com/openjdk/jdk/blob/e7c3b9de649d4b28ba16844e042afcf3c89323e5/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/Line.java#L56-L58). The assertion described above compensates this limitation.

#### Testing

##### Functionality

- hs-tier1-3 (windows-x64, linux-x64, linux-aarch64, and macosx-x64; release and debug mode).
- hs-tier4-7 (linux-x64; debug mode).

##### Performance

- No significant regression on a set of standard benchmark suites (DaCapo, SPECjbb2015, SPECjvm2008, ...) and on windows-x64, linux-x64, linux-aarch64, and macosx-x64.
- No significant difference in generated number of vector instructions when comparing the output of `compiler/vectorization` and `compiler/loopopts/superword` tests using `-XX:+TraceNewVectors` on linux-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279622](https://bugs.openjdk.java.net/browse/JDK-8279622): C2: miscompilation of map pattern as a vector reduction


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8464/head:pull/8464` \
`$ git checkout pull/8464`

Update a local copy of the PR: \
`$ git checkout pull/8464` \
`$ git pull https://git.openjdk.java.net/jdk pull/8464/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8464`

View PR using the GUI difftool: \
`$ git pr show -t 8464`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8464.diff">https://git.openjdk.java.net/jdk/pull/8464.diff</a>

</details>
