### PR TITLE
8285890: Fix some @param tags

### DIFF
--- a/src/java.base/share/classes/java/lang/Shutdown.java
+++ b/src/java.base/share/classes/java/lang/Shutdown.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,11 +70,11 @@ class Shutdown {
      * be added to the delete on exit list by the application shutdown
      * hooks.
      *
-     * @params slot  the slot in the shutdown hook array, whose element
-     *               will be invoked in order during shutdown
-     * @params registerShutdownInProgress true to allow the hook
-     *               to be registered even if the shutdown is in progress.
-     * @params hook  the hook to be registered
+     * @param slot  the slot in the shutdown hook array, whose element
+     *              will be invoked in order during shutdown
+     * @param registerShutdownInProgress true to allow the hook
+     *              to be registered even if the shutdown is in progress.
+     * @param hook  the hook to be registered
      *
      * @throws IllegalStateException
      *         if registerShutdownInProgress is false and shutdown is in progress; or

--- a/src/java.base/share/classes/java/lang/StackStreamFactory.java
+++ b/src/java.base/share/classes/java/lang/StackStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -376,8 +376,8 @@ final class StackStreamFactory {
         /*
          * Fetches stack frames.
          *
-         * @params batchSize number of elements of the frame  buffers for this batch
-         * @returns number of frames fetched in this batch
+         * @param batchSize number of elements of the frame buffers for this batch
+         * @return number of frames fetched in this batch
          */
         private int fetchStackFrames(int batchSize) {
             int startIndex = frameBuffer.startIndex();

--- a/src/java.base/share/classes/java/lang/ref/PhantomReference.java
+++ b/src/java.base/share/classes/java/lang/ref/PhantomReference.java
@@ -45,7 +45,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * phantom reference always returns {@code null}.
  * The {@link #refersTo(Object) refersTo} method can be used to test
  * whether some object is the referent of a phantom reference.
- * @param<T> the type of the referent
+ * @param <T> the type of the referent
  *
  * @author   Mark Reinhold
  * @since    1.2

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -36,7 +36,7 @@ import jdk.internal.ref.Cleaner;
  * operations common to all reference objects.  Because reference objects are
  * implemented in close cooperation with the garbage collector, this class may
  * not be subclassed directly.
- * @param<T> the type of the referent
+ * @param <T> the type of the referent
  *
  * @author   Mark Reinhold
  * @since    1.2

--- a/src/java.base/share/classes/java/lang/ref/ReferenceQueue.java
+++ b/src/java.base/share/classes/java/lang/ref/ReferenceQueue.java
@@ -31,7 +31,7 @@ import jdk.internal.misc.VM;
 /**
  * Reference queues, to which registered reference objects are appended by the
  * garbage collector after the appropriate reachability changes are detected.
- * @param<T> the type of the reference object
+ * @param <T> the type of the reference object
  *
  * @author   Mark Reinhold
  * @since    1.2

--- a/src/java.base/share/classes/java/lang/ref/SoftReference.java
+++ b/src/java.base/share/classes/java/lang/ref/SoftReference.java
@@ -56,7 +56,7 @@ package java.lang.ref;
  * prevent its most recently used entries from being discarded by keeping
  * strong referents to those entries, leaving the remaining entries to be
  * discarded at the discretion of the garbage collector.
- * @param<T> the type of the referent
+ * @param <T> the type of the referent
  *
  * @author   Mark Reinhold
  * @since    1.2

--- a/src/java.base/share/classes/java/lang/ref/WeakReference.java
+++ b/src/java.base/share/classes/java/lang/ref/WeakReference.java
@@ -40,7 +40,7 @@ package java.lang.ref;
  * weakly-reachable objects to be finalizable.  At the same time or at some
  * later time it will enqueue those newly-cleared weak references that are
  * registered with reference queues.
- * @param<T> the type of the referent
+ * @param <T> the type of the referent
  *
  * @author   Mark Reinhold
  * @since    1.2

--- a/src/java.security.jgss/share/classes/sun/security/jgss/GSSHeader.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/GSSHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -280,7 +280,7 @@ public class GSSHeader {
     /**
      * Put the encoding of the length in the specified stream.
      *
-     * @params len the length of the attribute.
+     * @param len the length of the attribute.
      * @param out the outputstream to write the length to
      * @return the number of bytes written
      * @exception IOException on writing errors.


### PR DESCRIPTION
* Syntactically improves a few cases from 8285676 (https://github.com/openjdk/jdk/pull/8410)
* Fixes a few misspelled `@param` tags for elements that, although are not included in the API Documentation, are visible in and processed by IDEs

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285890](https://bugs.openjdk.java.net/browse/JDK-8285890): Fix some @param tags


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)
 * [Bradford Wetmore](https://openjdk.java.net/census#wetmore) (@bradfordwetmore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8465/head:pull/8465` \
`$ git checkout pull/8465`

Update a local copy of the PR: \
`$ git checkout pull/8465` \
`$ git pull https://git.openjdk.java.net/jdk pull/8465/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8465`

View PR using the GUI difftool: \
`$ git pr show -t 8465`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8465.diff">https://git.openjdk.java.net/jdk/pull/8465.diff</a>

</details>
