### PR TITLE
8285915: failure_handler: gather the contents of /etc/hosts file

### DIFF
--- a/test/failure_handler/src/share/conf/linux.properties
+++ b/test/failure_handler/src/share/conf/linux.properties
@@ -77,7 +77,7 @@ environment=\
         memory.vmstat.slabinfo memory.vmstat.disk \
   files \
   locks \
-  net.sockets net.statistics net.ifconfig \
+  net.sockets net.statistics net.ifconfig net.hostsfile \
   screenshot
 ################################################################################
 users.current.app=id
@@ -123,6 +123,9 @@ net.statistics.app=netstat
 net.statistics.args=-sv
 net.ifconfig.app=ifconfig
 net.ifconfig.args=-a
+
+net.hostsfile.app=cat
+net.hostsfile.args=/etc/hosts
 
 screenshot.app=bash
 screenshot.args=-c\0\

--- a/test/failure_handler/src/share/conf/mac.properties
+++ b/test/failure_handler/src/share/conf/mac.properties
@@ -83,7 +83,7 @@ environment=\
   process.ps process.top \
   memory.vmstat \
   files \
-  net.netstat.av net.netstat.aL net.netstat.m net.netstat.s net.ifconfig \
+  net.netstat.av net.netstat.aL net.netstat.m net.netstat.s net.ifconfig net.hostsfile \
   scutil.nwi scutil.proxy \
   screenshot
 ################################################################################
@@ -124,6 +124,9 @@ net.netstat.m.args=-mm
 net.netstat.s.args=-s
 net.ifconfig.app=ifconfig
 net.ifconfig.args=-a
+
+net.hostsfile.app=cat
+net.hostsfile.args=/etc/hosts
 
 scutil.app=scutil
 scutil.nwi.args=--nwi

--- a/test/failure_handler/src/share/conf/windows.properties
+++ b/test/failure_handler/src/share/conf/windows.properties
@@ -72,7 +72,7 @@ environment=\
   memory.free memory.vmstat.default memory.vmstat.statistics \
         memory.vmstat.slabinfo memory.vmstat.disk \
   files \
-  net.sockets net.statistics net.ipconfig \
+  net.sockets net.statistics net.ipconfig net.hostsfile \
   screenshot
 ################################################################################
 users.current.app=id
@@ -120,6 +120,10 @@ net.statistics.app=netstat
 net.statistics.args=-s -e
 net.ipconfig.app=ipconfig
 net.ipconfig.args=/all
+
+net.hostsfile.app=bash
+net.hostsfile.args.delimiter=\0
+net.hostsfile.args=-c\0cat $WINDIR/System32/drivers/etc/hosts
 
 screenshot.app=bash
 screenshot.args=-c\0\


### PR DESCRIPTION
Can I please get a review of this change which addresses https://bugs.openjdk.java.net/browse/JDK-8285915?

With this change, the environment details collected by the failure handler will now include the contents of the `/etc/hosts/` file, which can be useful in certain cases when debugging network tests that fail.

Testing done (on macOS):

```
cd test/failure_handler 
make test
```
Then verified that the generated environment.html had the `/etc/hosts` file content

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285915](https://bugs.openjdk.java.net/browse/JDK-8285915): failure_handler: gather the contents of /etc/hosts file


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to 673fd0bdedc8555862d1c9079e8f0539e72d0488
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8466/head:pull/8466` \
`$ git checkout pull/8466`

Update a local copy of the PR: \
`$ git checkout pull/8466` \
`$ git pull https://git.openjdk.java.net/jdk pull/8466/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8466`

View PR using the GUI difftool: \
`$ git pr show -t 8466`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8466.diff">https://git.openjdk.java.net/jdk/pull/8466.diff</a>

</details>
