### PR TITLE
8285919: Remove debug printout from JDK-8285093

### DIFF
--- a/make/autoconf/util.m4
+++ b/make/autoconf/util.m4
@@ -702,7 +702,6 @@ UTIL_DEFUN_NAMED([UTIL_ARG_WITH],
   ARG_CHECK_AVAILABLE
 
   # Check if the option should be turned on
-  echo check msg:ARG_CHECKING_MSG:
   AC_MSG_CHECKING(ARG_CHECKING_MSG)
 
   if test x$AVAILABLE = xfalse; then


### PR DESCRIPTION
A debug printout in configure was introduced in JDK-8285093. It should be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285919](https://bugs.openjdk.java.net/browse/JDK-8285919): Remove debug printout from JDK-8285093


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8467/head:pull/8467` \
`$ git checkout pull/8467`

Update a local copy of the PR: \
`$ git checkout pull/8467` \
`$ git pull https://git.openjdk.java.net/jdk pull/8467/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8467`

View PR using the GUI difftool: \
`$ git pr show -t 8467`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8467.diff">https://git.openjdk.java.net/jdk/pull/8467.diff</a>

</details>
