### PR TITLE
8285934: Remove unimplemented MemTracker::init_tracking_level

### DIFF
--- a/src/hotspot/share/services/memTracker.hpp
+++ b/src/hotspot/share/services/memTracker.hpp
@@ -231,7 +231,6 @@ class MemTracker : AllStatic {
   static void tuning_statistics(outputStream* out);
 
  private:
-  static NMT_TrackingLevel init_tracking_level();
   static void report(bool summary_only, outputStream* output, size_t scale);
 
  private:


### PR DESCRIPTION
Trivial change of removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285934](https://bugs.openjdk.java.net/browse/JDK-8285934): Remove unimplemented MemTracker::init_tracking_level


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8469/head:pull/8469` \
`$ git checkout pull/8469`

Update a local copy of the PR: \
`$ git checkout pull/8469` \
`$ git pull https://git.openjdk.java.net/jdk pull/8469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8469`

View PR using the GUI difftool: \
`$ git pr show -t 8469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8469.diff">https://git.openjdk.java.net/jdk/pull/8469.diff</a>

</details>
