### PR TITLE
8285938: ProblemList jdk/jshell/HighlightUITest.java on linux-x64

### DIFF
--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -34,7 +34,7 @@
 jdk/jshell/UserJdiUserRemoteTest.java                                           8173079    linux-all
 jdk/jshell/UserInputTest.java                                                   8169536    generic-all
 jdk/jshell/ToolBasicTest.java                                                   8265357    macosx-aarch64
-jdk/jshell/HighlightUITest.java                                                 8284144    generic-aarch64,macosx-x64
+jdk/jshell/HighlightUITest.java                                                 8284144    generic-aarch64,macosx-x64,linux-x64
 
 ###########################################################################
 #


### PR DESCRIPTION
A trivial fix to ProblemList jdk/jshell/HighlightUITest.java on linux-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285938](https://bugs.openjdk.java.net/browse/JDK-8285938): ProblemList jdk/jshell/HighlightUITest.java on linux-x64


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8470/head:pull/8470` \
`$ git checkout pull/8470`

Update a local copy of the PR: \
`$ git checkout pull/8470` \
`$ git pull https://git.openjdk.java.net/jdk pull/8470/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8470`

View PR using the GUI difftool: \
`$ git pr show -t 8470`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8470.diff">https://git.openjdk.java.net/jdk/pull/8470.diff</a>

</details>
