### PR TITLE
8265360: several compiler/whitebox tests fail with "private compiler.whitebox.SimpleTestCaseHelper(int) must be compiled"

### DIFF
--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -191,7 +191,7 @@ CompileTask* CompilationPolicy::select_task_helper(CompileQueue* compile_queue) 
 
 // Simple methods are as good being compiled with C1 as C2.
 // Determine if a given method is such a case.
-bool CompilationPolicy::is_trivial(Method* method) {
+bool CompilationPolicy::is_trivial(const methodHandle& method) {
   if (method->is_accessor() ||
       method->is_constant_getter()) {
     return true;
@@ -596,7 +596,7 @@ CompLevel CompilationPolicy::initial_compile_level(const methodHandle& method) {
 }
 
 // Set carry flags on the counters if necessary
-void CompilationPolicy::handle_counter_overflow(Method* method) {
+void CompilationPolicy::handle_counter_overflow(const methodHandle& method) {
   MethodCounters *mcs = method->method_counters();
   if (mcs != NULL) {
     mcs->invocation_counter()->set_carry_on_overflow();
@@ -619,21 +619,25 @@ CompileTask* CompilationPolicy::select_task(CompileQueue* compile_queue) {
   // Iterate through the queue and find a method with a maximum rate.
   for (CompileTask* task = compile_queue->first(); task != NULL;) {
     CompileTask* next_task = task->next();
-    Method* method = task->method();
     // If a method was unloaded or has been stale for some time, remove it from the queue.
     // Blocking tasks and tasks submitted from whitebox API don't become stale
-    if (task->is_unloaded() || (task->can_become_stale() && is_stale(t, TieredCompileTaskTimeout, method) && !is_old(method))) {
-      if (!task->is_unloaded()) {
-        if (PrintTieredEvents) {
-          print_event(REMOVE_FROM_QUEUE, method, method, task->osr_bci(), (CompLevel) task->comp_level());
-        }
-        method->clear_queued_for_compilation();
-      }
+    if (task->is_unloaded()) {
       compile_queue->remove_and_mark_stale(task);
       task = next_task;
       continue;
     }
-    update_rate(t, method);
+    Method* method = task->method();
+    methodHandle mh(Thread::current(), method);
+    if (task->can_become_stale() && is_stale(t, TieredCompileTaskTimeout, mh) && !is_old(mh)) {
+      if (PrintTieredEvents) {
+        print_event(REMOVE_FROM_QUEUE, method, method, task->osr_bci(), (CompLevel) task->comp_level());
+      }
+      method->clear_queued_for_compilation();
+      compile_queue->remove_and_mark_stale(task);
+      task = next_task;
+      continue;
+    }
+    update_rate(t, mh);
     if (max_task == NULL || compare_methods(method, max_method)) {
       // Select a method with the highest rate
       max_task = task;
@@ -711,9 +715,9 @@ nmethod* CompilationPolicy::event(const methodHandle& method, const methodHandle
     return NULL;
   }
 
-  handle_counter_overflow(method());
+  handle_counter_overflow(method);
   if (method() != inlinee()) {
-    handle_counter_overflow(inlinee());
+    handle_counter_overflow(inlinee);
   }
 
   if (bci == InvocationEntryBci) {
@@ -792,43 +796,43 @@ void CompilationPolicy::compile(const methodHandle& mh, int bci, CompLevel level
       print_event(COMPILE, mh(), mh(), bci, level);
     }
     int hot_count = (bci == InvocationEntryBci) ? mh->invocation_count() : mh->backedge_count();
-    update_rate(nanos_to_millis(os::javaTimeNanos()), mh());
+    update_rate(nanos_to_millis(os::javaTimeNanos()), mh);
     CompileBroker::compile_method(mh, bci, level, mh, hot_count, CompileTask::Reason_Tiered, THREAD);
   }
 }
 
 // update_rate() is called from select_task() while holding a compile queue lock.
-void CompilationPolicy::update_rate(jlong t, Method* m) {
+void CompilationPolicy::update_rate(jlong t, const methodHandle& method) {
   // Skip update if counters are absent.
   // Can't allocate them since we are holding compile queue lock.
-  if (m->method_counters() == NULL)  return;
+  if (method->method_counters() == NULL)  return;
 
-  if (is_old(m)) {
+  if (is_old(method)) {
     // We don't remove old methods from the queue,
     // so we can just zero the rate.
-    m->set_rate(0);
+    method->set_rate(0);
     return;
   }
 
   // We don't update the rate if we've just came out of a safepoint.
   // delta_s is the time since last safepoint in milliseconds.
   jlong delta_s = t - SafepointTracing::end_of_last_safepoint_ms();
-  jlong delta_t = t - (m->prev_time() != 0 ? m->prev_time() : start_time()); // milliseconds since the last measurement
+  jlong delta_t = t - (method->prev_time() != 0 ? method->prev_time() : start_time()); // milliseconds since the last measurement
   // How many events were there since the last time?
-  int event_count = m->invocation_count() + m->backedge_count();
-  int delta_e = event_count - m->prev_event_count();
+  int event_count = method->invocation_count() + method->backedge_count();
+  int delta_e = event_count - method->prev_event_count();
 
   // We should be running for at least 1ms.
   if (delta_s >= TieredRateUpdateMinTime) {
     // And we must've taken the previous point at least 1ms before.
     if (delta_t >= TieredRateUpdateMinTime && delta_e > 0) {
-      m->set_prev_time(t);
-      m->set_prev_event_count(event_count);
-      m->set_rate((float)delta_e / (float)delta_t); // Rate is events per millisecond
+      method->set_prev_time(t);
+      method->set_prev_event_count(event_count);
+      method->set_rate((float)delta_e / (float)delta_t); // Rate is events per millisecond
     } else {
       if (delta_t > TieredRateUpdateMaxTime && delta_e == 0) {
         // If nothing happened for 25ms, zero the rate. Don't modify prev values.
-        m->set_rate(0);
+        method->set_rate(0);
       }
     }
   }
@@ -836,12 +840,12 @@ void CompilationPolicy::update_rate(jlong t, Method* m) {
 
 // Check if this method has been stale for a given number of milliseconds.
 // See select_task().
-bool CompilationPolicy::is_stale(jlong t, jlong timeout, Method* m) {
+bool CompilationPolicy::is_stale(jlong t, jlong timeout, const methodHandle& method) {
   jlong delta_s = t - SafepointTracing::end_of_last_safepoint_ms();
-  jlong delta_t = t - m->prev_time();
+  jlong delta_t = t - method->prev_time();
   if (delta_t > timeout && delta_s > timeout) {
-    int event_count = m->invocation_count() + m->backedge_count();
-    int delta_e = event_count - m->prev_event_count();
+    int event_count = method->invocation_count() + method->backedge_count();
+    int delta_e = event_count - method->prev_event_count();
     // Return true if there were no events.
     return delta_e == 0;
   }
@@ -850,13 +854,16 @@ bool CompilationPolicy::is_stale(jlong t, jlong timeout, Method* m) {
 
 // We don't remove old methods from the compile queue even if they have
 // very low activity. See select_task().
-bool CompilationPolicy::is_old(Method* method) {
-  return method->invocation_count() > 50000 || method->backedge_count() > 500000;
+bool CompilationPolicy::is_old(const methodHandle& method) {
+  int i = method->invocation_count();
+  int b = method->backedge_count();
+  double k = TieredOldPercentage / 100.0;
+
+  return CallPredicate::apply_scaled(method, CompLevel_none, i, b, k) || LoopPredicate::apply_scaled(method, CompLevel_none, i, b, k);
 }
 
 double CompilationPolicy::weight(Method* method) {
-  return (double)(method->rate() + 1) *
-    (method->invocation_count() + 1) * (method->backedge_count() + 1);
+  return (double)(method->rate() + 1) * (method->invocation_count() + 1) * (method->backedge_count() + 1);
 }
 
 // Apply heuristics and return true if x should be compiled before y
@@ -909,7 +916,7 @@ bool CompilationPolicy::should_create_mdo(const methodHandle& method, CompLevel 
   if (cur_level != CompLevel_none || force_comp_at_level_simple(method) || CompilationModeFlag::quick_only() || !ProfileInterpreter) {
     return false;
   }
-  if (is_old(method())) {
+  if (is_old(method)) {
     return true;
   }
   int i = method->invocation_count();
@@ -918,7 +925,7 @@ bool CompilationPolicy::should_create_mdo(const methodHandle& method, CompLevel 
 
   // If the top level compiler is not keeping up, delay profiling.
   if (CompileBroker::queue_size(CompLevel_full_optimization) <= Tier0Delay * compiler_count(CompLevel_full_optimization)) {
-    return CallPredicate::apply_scaled(method, CompLevel_full_profile, i, b, k) || LoopPredicate::apply_scaled(method, CompLevel_full_profile, i, b, k);
+    return CallPredicate::apply_scaled(method, CompLevel_none, i, b, k) || LoopPredicate::apply_scaled(method, CompLevel_none, i, b, k);
   }
   return false;
 }
@@ -1008,7 +1015,7 @@ CompLevel CompilationPolicy::common(const methodHandle& method, CompLevel cur_le
   if (force_comp_at_level_simple(method)) {
     next_level = CompLevel_simple;
   } else {
-    if (is_trivial(method())) {
+    if (is_trivial(method)) {
       next_level = CompilationModeFlag::disable_intermediate() ? CompLevel_full_optimization : CompLevel_simple;
     } else {
       switch(cur_level) {
@@ -1086,7 +1093,7 @@ CompLevel CompilationPolicy::common(const methodHandle& method, CompLevel cur_le
 // Determine if a method should be compiled with a normal entry point at a different level.
 CompLevel CompilationPolicy::call_event(const methodHandle& method, CompLevel cur_level, Thread* thread) {
   CompLevel osr_level = MIN2((CompLevel) method->highest_osr_comp_level(), common<LoopPredicate>(method, cur_level, true));
-  CompLevel next_level = common<CallPredicate>(method, cur_level, is_old(method()));
+  CompLevel next_level = common<CallPredicate>(method, cur_level, is_old(method));
 
   // If OSR method level is greater than the regular method level, the levels should be
   // equalized by raising the regular method level in order to avoid OSRs during each

--- a/src/hotspot/share/compiler/compilationPolicy.hpp
+++ b/src/hotspot/share/compiler/compilationPolicy.hpp
@@ -169,7 +169,7 @@ class CompilationPolicy : AllStatic {
   static double _increase_threshold_at_ratio;
 
   // Set carry flags in the counters (in Method* and MDO).
-  inline static void handle_counter_overflow(Method* method);
+  inline static void handle_counter_overflow(const methodHandle& method);
   // Verify that a level is consistent with the compilation mode
   static bool verify_level(CompLevel level);
   // Clamp the request level according to various constraints.
@@ -188,17 +188,17 @@ class CompilationPolicy : AllStatic {
   // Has a method been long around?
   // We don't remove old methods from the compile queue even if they have
   // very low activity (see select_task()).
-  inline static bool is_old(Method* method);
+  inline static bool is_old(const methodHandle& method);
   // Was a given method inactive for a given number of milliseconds.
   // If it is, we would remove it from the queue (see select_task()).
-  inline static bool is_stale(jlong t, jlong timeout, Method* m);
+  inline static bool is_stale(jlong t, jlong timeout, const methodHandle& method);
   // Compute the weight of the method for the compilation scheduling
   inline static double weight(Method* method);
   // Apply heuristics and return true if x should be compiled before y
   inline static bool compare_methods(Method* x, Method* y);
   // Compute event rate for a given method. The rate is the number of event (invocations + backedges)
   // per millisecond.
-  inline static void update_rate(jlong t, Method* m);
+  inline static void update_rate(jlong t, const methodHandle& method);
   // Compute threshold scaling coefficient
   inline static double threshold_scale(CompLevel level, int feedback_k);
   // If a method is old enough and is still in the interpreter we would want to
@@ -219,7 +219,7 @@ class CompilationPolicy : AllStatic {
   static void compile(const methodHandle& mh, int bci, CompLevel level, TRAPS);
   // Simple methods are as good being compiled with C1 as C2.
   // This function tells if it's such a function.
-  inline static bool is_trivial(Method* method);
+  inline static bool is_trivial(const methodHandle& method);
   // Force method to be compiled at CompLevel_simple?
   inline static bool force_comp_at_level_simple(const methodHandle& method);
 

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -267,12 +267,11 @@ void CompilerConfig::set_legacy_emulation_flags() {
         FLAG_SET_ERGO(Tier0BackedgeNotifyFreqLog, MAX2<intx>(10, osr_threshold_log));
       }
       // Adjust the tiered policy flags to approximate the legacy behavior.
-      if (CompilerConfig::is_c1_only()) {
-        FLAG_SET_ERGO(Tier3InvocationThreshold, threshold);
-        FLAG_SET_ERGO(Tier3MinInvocationThreshold, threshold);
-        FLAG_SET_ERGO(Tier3CompileThreshold, threshold);
-        FLAG_SET_ERGO(Tier3BackEdgeThreshold, osr_threshold);
-      } else {
+      FLAG_SET_ERGO(Tier3InvocationThreshold, threshold);
+      FLAG_SET_ERGO(Tier3MinInvocationThreshold, threshold);
+      FLAG_SET_ERGO(Tier3CompileThreshold, threshold);
+      FLAG_SET_ERGO(Tier3BackEdgeThreshold, osr_threshold);
+      if (CompilerConfig::is_c2_or_jvmci_compiler_only()) {
         FLAG_SET_ERGO(Tier4InvocationThreshold, threshold);
         FLAG_SET_ERGO(Tier4MinInvocationThreshold, threshold);
         FLAG_SET_ERGO(Tier4CompileThreshold, threshold);
@@ -338,6 +337,20 @@ void CompilerConfig::set_compilation_policy_flags() {
     if (FLAG_IS_DEFAULT(Tier4BackEdgeThreshold)) {
       FLAG_SET_DEFAULT(Tier4BackEdgeThreshold, 15000);
     }
+
+    if (FLAG_IS_DEFAULT(Tier3InvocationThreshold)) {
+      FLAG_SET_DEFAULT(Tier3InvocationThreshold, Tier4InvocationThreshold);
+    }
+    if (FLAG_IS_DEFAULT(Tier3MinInvocationThreshold)) {
+      FLAG_SET_DEFAULT(Tier3MinInvocationThreshold, Tier4MinInvocationThreshold);
+    }
+    if (FLAG_IS_DEFAULT(Tier3CompileThreshold)) {
+      FLAG_SET_DEFAULT(Tier3CompileThreshold, Tier4CompileThreshold);
+    }
+    if (FLAG_IS_DEFAULT(Tier3BackEdgeThreshold)) {
+      FLAG_SET_DEFAULT(Tier3BackEdgeThreshold, Tier4BackEdgeThreshold);
+    }
+
   }
 
   // Scale tiered compilation thresholds.

--- a/src/hotspot/share/compiler/compiler_globals.hpp
+++ b/src/hotspot/share/compiler/compiler_globals.hpp
@@ -217,6 +217,12 @@
           "do not start profiling in the interpreter")                      \
           range(0, max_jint)                                                \
                                                                             \
+  product(intx, TieredOldPercentage, 1000, DIAGNOSTIC,                      \
+          "Percentage over tier 3 thresholds after which a method is "      \
+          "considered old (turns off parts of prioritization based on "     \
+          "compile queue length)")                                          \
+          range(0, max_jint)                                                \
+                                                                            \
   product(intx, Tier3DelayOn, 5,                                            \
           "If C2 queue size grows over this amount per compiler thread "    \
           "stop compiling at tier 3 and start compiling at tier 2")         \
@@ -248,8 +254,7 @@
                                                                             \
   product(intx, Tier0ProfilingStartPercentage, 200,                         \
           "Start profiling in interpreter if the counters exceed the "      \
-          "specified percentage of tier 3 thresholds (tier 4 thresholds "   \
-          "with CompilationMode=high-only|high-only-quick-internal)")       \
+          "specified percentage of tier 3 thresholds")                      \
           range(0, max_jint)                                                \
                                                                             \
   product(uintx, IncreaseFirstTierCompileThresholdAt, 50,                   \

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -67,10 +67,6 @@ compiler/rtm/print/TestPrintPreciseRTMLockingStatistics.java 8183263 generic-x64
 
 compiler/c2/Test8004741.java 8235801 generic-all
 
-compiler/whitebox/ClearMethodStateTest.java 8265360 macosx-all
-compiler/whitebox/EnqueueMethodForCompilationTest.java 8265360 macosx-all
-compiler/whitebox/MakeMethodNotCompilableTest.java 8265360 macosx-all
-
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-all
 compiler/codecache/TestStressCodeBuffers.java 8272094 generic-aarch64
 


### PR DESCRIPTION
The compilation policy uses the length of the queues as a feedback mechanism that gives us information about the compilation speed. In some places it makes decisions based on the queue length length alone without looking at the invocation counters. That can cause a starvation effect. For example when running in a C2-only mode it may delay profiling in the interpreter if the C2 queue is too long. The solution to this is detect "old" methods (that is method that have been used a lot) and force putting them into the queue and let the queue prioritization deal with it.

I also did some cleanup for things that got in the way.
Testing looks clean.