### PR TITLE
8285956: (fs) Excessive default poll interval in PollingWatchService

### DIFF
--- a/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
+++ b/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
@@ -61,6 +61,8 @@ import java.util.concurrent.TimeUnit;
 class PollingWatchService
     extends AbstractWatchService
 {
+    // Wait between polling thread creation and first poll (seconds)
+    private static final int POLLING_INIT_DELAY = 1;
     // Default time between polls (seconds)
     private static final int DEFAULT_POLLING_INTERVAL = 2;
 
@@ -250,9 +252,6 @@ class PollingWatchService
      * directory and queue keys when entries are added, modified, or deleted.
      */
     private class PollingWatchKey extends AbstractWatchKey {
-
-        // Wait between thread creation and first poll (seconds)
-        private static final int POLLING_INIT_DELAY = 1;
 
         private final Object fileKey;
 

--- a/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
+++ b/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
@@ -310,7 +310,7 @@ class PollingWatchService
                 // update the events
                 this.events = events;
 
-                // create the periodic task with initialDelay set to the default sensitivity
+                // create the periodic task with initialDelay set to the specified constant
                 Runnable thunk = new Runnable() { public void run() { poll(); }};
                 this.poller = scheduledExecutor
                     .scheduleAtFixedRate(thunk, POLLING_INIT_DELAY, period, TimeUnit.SECONDS);

--- a/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
+++ b/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
@@ -61,6 +61,7 @@ import java.util.concurrent.TimeUnit;
 class PollingWatchService
     extends AbstractWatchService
 {
+    // Default time between polls (seconds)
     private static final int DEFAULT_POLLING_INTERVAL = 2;
 
     // map of registrations
@@ -250,6 +251,7 @@ class PollingWatchService
      */
     private class PollingWatchKey extends AbstractWatchKey {
 
+        // Wait between thread creation and first poll (seconds)
         private static final int POLLING_INIT_DELAY = 1;
 
         private final Object fileKey;

--- a/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
+++ b/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
@@ -61,7 +61,7 @@ import java.util.concurrent.TimeUnit;
 class PollingWatchService
     extends AbstractWatchService
 {
-    private static final int DEFAULT_POLLING_INTERVAL = 1;
+    private static final int DEFAULT_POLLING_INTERVAL = 2;
 
     // map of registrations
     private final Map<Object, PollingWatchKey> map = new HashMap<>();

--- a/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
+++ b/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
@@ -61,6 +61,8 @@ import java.util.concurrent.TimeUnit;
 class PollingWatchService
     extends AbstractWatchService
 {
+    private static final int DEFAULT_POLLING_INTERVAL = 1;
+
     // map of registrations
     private final Map<Object, PollingWatchKey> map = new HashMap<>();
 
@@ -115,7 +117,7 @@ class PollingWatchService
             throw new IllegalArgumentException("No events to register");
 
         // Extended modifiers may be used to specify the sensitivity level
-        int sensitivity = 1;
+        int sensitivity = DEFAULT_POLLING_INTERVAL;
         if (modifiers.length > 0) {
             for (WatchEvent.Modifier modifier: modifiers) {
                 if (modifier == null)
@@ -247,6 +249,9 @@ class PollingWatchService
      * directory and queue keys when entries are added, modified, or deleted.
      */
     private class PollingWatchKey extends AbstractWatchKey {
+
+        private static final int POLLING_INIT_DELAY = 1;
+
         private final Object fileKey;
 
         // current event set
@@ -308,7 +313,7 @@ class PollingWatchService
                 // create the periodic task
                 Runnable thunk = new Runnable() { public void run() { poll(); }};
                 this.poller = scheduledExecutor
-                    .scheduleAtFixedRate(thunk, 1 /*init wait*/, period, TimeUnit.SECONDS);
+                    .scheduleAtFixedRate(thunk, POLLING_INIT_DELAY, period, TimeUnit.SECONDS);
             }
         }
 

--- a/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
+++ b/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
@@ -115,7 +115,7 @@ class PollingWatchService
             throw new IllegalArgumentException("No events to register");
 
         // Extended modifiers may be used to specify the sensitivity level
-        int sensitivity = 10;
+        int sensitivity = 1;
         if (modifiers.length > 0) {
             for (WatchEvent.Modifier modifier: modifiers) {
                 if (modifier == null)
@@ -308,7 +308,7 @@ class PollingWatchService
                 // create the periodic task
                 Runnable thunk = new Runnable() { public void run() { poll(); }};
                 this.poller = scheduledExecutor
-                    .scheduleAtFixedRate(thunk, period, period, TimeUnit.SECONDS);
+                    .scheduleAtFixedRate(thunk, 1 /*init wait*/, period, TimeUnit.SECONDS);
             }
         }
 

--- a/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
+++ b/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
@@ -310,7 +310,7 @@ class PollingWatchService
                 // update the events
                 this.events = events;
 
-                // create the periodic task
+                // create the periodic task with initialDelay set to the default sensitivity
                 Runnable thunk = new Runnable() { public void run() { poll(); }};
                 this.poller = scheduledExecutor
                     .scheduleAtFixedRate(thunk, POLLING_INIT_DELAY, period, TimeUnit.SECONDS);


### PR DESCRIPTION
PollingWatchService.java contains the WatchService and WatchKey implementation for AIX and BSD. When a Path is [register](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/file/Path.html#register(java.nio.file.WatchService,java.nio.file.WatchEvent.Kind...))ed this implementation creates a  polling thread to monitor for file system changes. Currently, this thread waits 10 seconds before it's first poll, and then waits 10 seconds between subsequent polls. This interval leads to sluggish performance.

This PR makes the following changes:
- Sets the initial interval to 1 second regardless of the period.
- Change the default period to 1 second.

All tests in `test/jdk/java/nio/file/WatchService` passing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [JDK-8285956](https://bugs.openjdk.java.net/browse/JDK-8285956): (fs) Excessive default poll interval in PollingWatchService


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [6328307a](https://git.openjdk.java.net/jdk/pull/8479/files/6328307a38624404137fb74a03343b9b65a4c284)
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to [6328307a](https://git.openjdk.java.net/jdk/pull/8479/files/6328307a38624404137fb74a03343b9b65a4c284)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8479/head:pull/8479` \
`$ git checkout pull/8479`

Update a local copy of the PR: \
`$ git checkout pull/8479` \
`$ git pull https://git.openjdk.java.net/jdk pull/8479/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8479`

View PR using the GUI difftool: \
`$ git pr show -t 8479`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8479.diff">https://git.openjdk.java.net/jdk/pull/8479.diff</a>

</details>
