### PR TITLE
8286366: (cs) Charset.put can use putIfAbsent instead of containsKey+put

### DIFF
--- a/src/java.base/share/classes/java/nio/charset/Charset.java
+++ b/src/java.base/share/classes/java/nio/charset/Charset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -566,8 +566,7 @@ public abstract class Charset
     private static void put(Iterator<Charset> i, Map<String,Charset> m) {
         while (i.hasNext()) {
             Charset cs = i.next();
-            if (!m.containsKey(cs.name()))
-                m.put(cs.name(), cs);
+            m.putIfAbsent(cs.name(), cs);
         }
     }
 


### PR DESCRIPTION
The method `Charset.put(Iterator<Charset> i, Map<String,Charset> m)` could be improved by usage of `Map.putIfAbsent` instead of pair `containsKey`+`put`. This method is called only with `TreeMap` as an argument and `TreeMap` has an effective implementation of `putIfAbsent` which avoid traversal Tree twice.
According to [JDK-8176894](https://bugs.openjdk.java.net/browse/JDK-8176894) usage of `TreeMap.putIfAbsent` could improve performance by 40%-100% compared with previous approach.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286366](https://bugs.openjdk.java.net/browse/JDK-8286366): (cs) Charset.put can use putIfAbsent instead of containsKey+put


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8480/head:pull/8480` \
`$ git checkout pull/8480`

Update a local copy of the PR: \
`$ git checkout pull/8480` \
`$ git pull https://git.openjdk.java.net/jdk pull/8480/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8480`

View PR using the GUI difftool: \
`$ git pr show -t 8480`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8480.diff">https://git.openjdk.java.net/jdk/pull/8480.diff</a>

</details>
