### PR TITLE
8287285: Avoid redundant HashMap.containsKey call in java.util.zip.ZipFile.Source.get

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -1292,13 +1292,12 @@ public class ZipFile implements ZipConstants, Closeable {
             src = new Source(key, toDelete, zc);
 
             synchronized (files) {
-                if (files.containsKey(key)) {    // someone else put in first
-                    src.close();                 // close the newly created one
-                    src = files.get(key);
-                    src.refs++;
-                    return src;
+                Source prev = files.putIfAbsent(key, src);
+                if (prev != null) {    // someone else put in first
+                    src.close();       // close the newly created one
+                    prev.refs++;
+                    return prev;
                 }
-                files.put(key, src);
                 return src;
             }
         }


### PR DESCRIPTION
The method `java.util.zip.ZipFile.Source#get` could be improved by usage of `Map.putIfAbsent` instead of separate `containsKey`/`get`/`put` calls. We known that HashMap `java.util.zip.ZipFile.Source#files` can contain only non-null values. And to check if putIfAbsent was successful or not we can just compare result with `null`.
It makes code a bit cleaner and faster.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287285](https://bugs.openjdk.java.net/browse/JDK-8287285): Avoid redundant HashMap.containsKey call in java.util.zip.ZipFile.Source.get


### Reviewers
 * [Jaikiran Pai](https://openjdk.java.net/census#jpai) (@jaikiran - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8481/head:pull/8481` \
`$ git checkout pull/8481`

Update a local copy of the PR: \
`$ git checkout pull/8481` \
`$ git pull https://git.openjdk.java.net/jdk pull/8481/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8481`

View PR using the GUI difftool: \
`$ git pr show -t 8481`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8481.diff">https://git.openjdk.java.net/jdk/pull/8481.diff</a>

</details>
