### PR TITLE
8287603: Avoid redundant HashMap.containsKey calls in NimbusDefaults.getDerivedColor

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/Defaults.template
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/Defaults.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,14 +50,12 @@ import java.awt.image.BufferedImage;
 import static java.awt.image.BufferedImage.*;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.lang.ref.WeakReference;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.WeakHashMap;
 import javax.swing.border.Border;
 import javax.swing.plaf.UIResource;
@@ -682,7 +680,7 @@ ${UI_DEFAULT_INIT}
      * Get a derived color, derived colors are shared instances and will be
      * updated when its parent UIDefault color changes.
      *
-     * @param uiDefaultParentName The parent UIDefault key
+     * @param parentUin The parent UIDefault key
      * @param hOffset The hue offset
      * @param sOffset The saturation offset
      * @param bOffset The brightness offset
@@ -712,10 +710,10 @@ ${UI_DEFAULT_INIT}
                 bOffset, aOffset);
         }
 
-        if (derivedColors.containsKey(color)) {
-            return derivedColors.get(color);
+        DerivedColor prev = derivedColors.putIfAbsent(color, color);
+        if (prev != null) {
+            return prev;
         } else {
-            derivedColors.put(color, color);
             color.rederiveColor(); /// move to ARP.decodeColor() ?
             colorTree.addColor(uin, color);
             return color;


### PR DESCRIPTION
The method `javax.swing.plaf.nimbus.NimbusDefaults#getDerivedColor(String,String,float,float,float,int,boolean)` could be improved by usage of Map.putIfAbsent instead of separate `containsKey`/`get`/`put` calls. We known that HashMap `javax.swing.plaf.nimbus.NimbusDefaults#derivedColors` can contain only non-null values. And to check if `putIfAbsent` was successful or not, we can just compare result with `null`.
https://github.com/openjdk/jdk/blob/97bd4c255a319ce626a316ed211ef1fd7d0f1e14/src/java.desktop/share/classes/javax/swing/plaf/nimbus/Defaults.template#L713-L720
It makes code a bit cleaner and faster.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287603](https://bugs.openjdk.org/browse/JDK-8287603): Avoid redundant HashMap.containsKey calls in NimbusDefaults.getDerivedColor


### Reviewers
 * [Attila Szegedi](https://openjdk.org/census#attila) (@szegedi - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk pull/8482/head:pull/8482` \
`$ git checkout pull/8482`

Update a local copy of the PR: \
`$ git checkout pull/8482` \
`$ git pull https://git.openjdk.org/jdk pull/8482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8482`

View PR using the GUI difftool: \
`$ git pr show -t 8482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/8482.diff">https://git.openjdk.org/jdk/pull/8482.diff</a>

</details>
