### PR TITLE
[PATCH] Cleanup Map usage in AuthenticationInfo.requestAuthentication

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/http/AuthenticationInfo.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/AuthenticationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@ public abstract class AuthenticationInfo extends AuthCacheValue implements Clone
     @java.io.Serial
     static final long serialVersionUID = -2588378268010453259L;
 
-    // Constants saying what kind of authroization this is.  This determines
+    // Constants saying what kind of authorization this is.  This determines
     // the namespace in the hash table lookup.
     public static final char SERVER_AUTHENTICATION = 's';
     public static final char PROXY_AUTHENTICATION = 'p';
@@ -152,14 +152,9 @@ public abstract class AuthenticationInfo extends AuthCacheValue implements Clone
 
             // Otherwise, if no request is in progress, record this
             // thread as performing authentication and returns null.
-            Thread t, c;
-            c = Thread.currentThread();
-            if ((t = requests.get(key)) == null) {
-                requests.put (key, c);
-                assert cached == null;
-                return cached;
-            }
-            if (t == c) {
+            Thread c = Thread.currentThread();
+            Thread t = requests.putIfAbsent(key, c);
+            if (t == null || t == c) {
                 assert cached == null;
                 return cached;
             }


### PR DESCRIPTION
`AuthenticationInfo.requestAuthentication` uses separate `HashMap`'s `get` +`put` calls.
```
            Thread t, c;
            c = Thread.currentThread();
            if ((t = requests.get(key)) == null) {
                requests.put (key, c);
                assert cached == null;
                return cached;
            }
            if (t == c) {
                assert cached == null;
                return cached;
            }
```

Instead we can use the `HashMap.putIfAbsent` to make code a bit easier to follow. We know that `requests` can contain only non-null values.