### PR TITLE
[PATCH] Avoid redundant Hashtable.containsKey call in PKCS9Attributes

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs/PKCS9Attributes.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS9Attributes.java
@@ -158,13 +158,12 @@ public class PKCS9Attributes {
         ObjectIdentifier oid;
         for (int i=0; i < attribs.length; i++) {
             oid = attribs[i].getOID();
-            if (attributes.containsKey(oid))
+            if (attributes.putIfAbsent(oid, attribs[i]) != null)
                 throw new IllegalArgumentException(
                           "PKCSAttribute " + attribs[i].getOID() +
                           " duplicated while constructing " +
                           "PKCS9Attributes.");
 
-            attributes.put(oid, attribs[i]);
         }
         derEncoding = generateDerEncoding();
         permittedAttributes = null;


### PR DESCRIPTION
`Hashtable` doesn't allow `null` values. And instead of pair method calls `containsKey`+`put` we can use `putIfAbsent` instead.
It's clearer and a bit faster.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8485/head:pull/8485` \
`$ git checkout pull/8485`

Update a local copy of the PR: \
`$ git checkout pull/8485` \
`$ git pull https://git.openjdk.java.net/jdk pull/8485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8485`

View PR using the GUI difftool: \
`$ git pr show -t 8485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8485.diff">https://git.openjdk.java.net/jdk/pull/8485.diff</a>

</details>
