### PR TITLE
[PATCH] Avoid redundant TreeMap.containsKey call in PolicyParser

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/PolicyParser.java
+++ b/src/java.base/share/classes/sun/security/provider/PolicyParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -202,9 +202,7 @@ public class PolicyParser {
                 DomainEntry de = parseDomainEntry();
                 if (de != null) {
                     String domainName = de.getName();
-                    if (!domainEntries.containsKey(domainName)) {
-                        domainEntries.put(domainName, de);
-                    } else {
+                    if (domainEntries.putIfAbsent(domainName, de) != null) {
                         LocalizedMessage localizedMsg = new LocalizedMessage(
                             "duplicate.keystore.domain.name");
                         Object[] source = {domainName};


### PR DESCRIPTION
Instead of pair `TreeMap.containsKey`/`TreeMap.put` method calls, we can use single call `TreeMap.putIfAbsent` and check result for nullness.