### PR TITLE
8287053: Avoid redundant HashMap.containsKey calls in ZoneInfoFile.getZoneInfo0

### DIFF
--- a/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
+++ b/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -125,10 +125,7 @@ public final class ZoneInfoFile {
             if (zi != null) {
                 return zi;
             }
-            String zid = zoneId;
-            if (aliases.containsKey(zoneId)) {
-                zid = aliases.get(zoneId);
-            }
+            String zid = aliases.getOrDefault(zoneId, zoneId);
             int index = Arrays.binarySearch(regions, zid);
             if (index < 0) {
                 return null;
@@ -335,7 +332,7 @@ public final class ZoneInfoFile {
             }
         }
         // remove the following ids from the map, they
-        // are exclued from the "old" ZoneInfo
+        // are excluded from the "old" ZoneInfo
         zones.remove("ROC");
         for (int i = 0; i < versionCount; i++) {
             int aliasCount = dis.readShort();


### PR DESCRIPTION
Instead of pair `HashMap.containsKey`/`HashMap.get` method calls, we can use single call `HashMap.getOrDefault`.
It's faster and clearer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287053](https://bugs.openjdk.java.net/browse/JDK-8287053): Avoid redundant HashMap.containsKey calls in ZoneInfoFile.getZoneInfo0


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8487/head:pull/8487` \
`$ git checkout pull/8487`

Update a local copy of the PR: \
`$ git checkout pull/8487` \
`$ git pull https://git.openjdk.java.net/jdk pull/8487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8487`

View PR using the GUI difftool: \
`$ git pr show -t 8487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8487.diff">https://git.openjdk.java.net/jdk/pull/8487.diff</a>

</details>
