### PR TITLE
8287181: Avoid redundant HashMap.containsKey calls in InternalLocaleBuilder.setExtension

### DIFF
--- a/src/java.base/share/classes/sun/util/locale/InternalLocaleBuilder.java
+++ b/src/java.base/share/classes/sun/util/locale/InternalLocaleBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -184,7 +184,7 @@ public final class InternalLocaleBuilder {
                     ukeywords.clear();
                 }
             } else {
-                if (extensions != null && extensions.containsKey(key)) {
+                if (extensions != null) {
                     extensions.remove(key);
                 }
             }


### PR DESCRIPTION
No need to separately perform `HashMap.containsKey` before `HashMap.remove` call. If key is present - it will be removed anyway. If it's not present, nothing will be deleted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287181](https://bugs.openjdk.java.net/browse/JDK-8287181): Avoid redundant HashMap.containsKey calls in InternalLocaleBuilder.setExtension


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8488/head:pull/8488` \
`$ git checkout pull/8488`

Update a local copy of the PR: \
`$ git checkout pull/8488` \
`$ git pull https://git.openjdk.java.net/jdk pull/8488/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8488`

View PR using the GUI difftool: \
`$ git pr show -t 8488`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8488.diff">https://git.openjdk.java.net/jdk/pull/8488.diff</a>

</details>
