### PR TITLE
8285397: JNI exception pending in CUPSfuncs.c:250

### DIFF
--- a/src/java.desktop/unix/native/common/awt/CUPSfuncs.c
+++ b/src/java.desktop/unix/native/common/awt/CUPSfuncs.c
@@ -246,6 +246,7 @@ Java_sun_print_CUPSPrinter_getCupsDefaultPrinters(JNIEnv *env,
     for (i = 0; i < num_dests; i++) {
             utf_str = JNU_NewStringPlatform(env, dests[i].name);
             if (utf_str == NULL) {
+                (*env)->ExceptionClear(env);
                 for (j = i - 1; j >= 0; j--) {
                     utf_str = (*env)->GetObjectArrayElement(env, nameArray, j);
                     (*env)->SetObjectArrayElement(env, nameArray, j, NULL);


### PR DESCRIPTION
A tool checking for JNI errors complains that the call to JNU_NewStringPlatform(..)
might throw an exception and subsequent JNI code isn't making sure of that.
Clear the exception so the error handling code can do its thing.