### PR TITLE
8283705: Make javax.sound.midi.Track a final class

### DIFF
--- a/src/java.desktop/share/classes/javax/sound/midi/Track.java
+++ b/src/java.desktop/share/classes/javax/sound/midi/Track.java
@@ -60,7 +60,7 @@ import com.sun.media.sound.MidiUtils;
  * @see Sequencer#setTrackMute
  * @see Sequencer#setTrackSolo
  */
-public class Track {
+public final class Track {
 
     // TODO: use arrays for faster access
 


### PR DESCRIPTION
This is the straggler from several PRs which were around making JDK classes sealed.
There's nothing to be sealed here, but the same query pointed out that this class has
no public or protected constructor (as well as no sub-classes) and so can be made final

CSR for review here https://bugs.openjdk.java.net/browse/JDK-8285978

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issues
 * [JDK-8283705](https://bugs.openjdk.java.net/browse/JDK-8283705): Make javax.sound.midi.Track a final class
 * [JDK-8285978](https://bugs.openjdk.java.net/browse/JDK-8285978): Make javax.sound.midi.Track a final class (**CSR**)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8492/head:pull/8492` \
`$ git checkout pull/8492`

Update a local copy of the PR: \
`$ git checkout pull/8492` \
`$ git pull https://git.openjdk.java.net/jdk pull/8492/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8492`

View PR using the GUI difftool: \
`$ git pr show -t 8492`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8492.diff">https://git.openjdk.java.net/jdk/pull/8492.diff</a>

</details>
