### PR TITLE
8285399: JNI exception pending in awt_GraphicsEnv.c:1432

### DIFF
--- a/src/java.desktop/unix/native/common/awt/awt.h
+++ b/src/java.desktop/unix/native/common/awt/awt.h
@@ -85,6 +85,9 @@ extern void awt_output_flush();
 
 #define AWT_LOCK_IMPL() \
     do { \
+        if ((*env)->ExceptionCheck(env)) { \
+            (*env)->ExceptionClear(env); \
+        } \
         (*env)->CallStaticVoidMethod(env, tkClass, awtLockMID); \
         if ((*env)->ExceptionCheck(env)) { \
             (*env)->ExceptionClear(env); \

--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
@@ -1425,6 +1425,9 @@ Java_sun_awt_X11GraphicsDevice_getDoubleBufferVisuals(JNIEnv *env,
     AWT_FLUSH_UNLOCK();
     for (i = 0; i < visScreenInfo->count; i++) {
         XdbeVisualInfo* visInfo = visScreenInfo->visinfo;
+        if ((*env)->ExceptionCheck(env)) {
+            break;
+        }
         (*env)->CallVoidMethod(env, this, midAddVisual, (visInfo[i]).visual);
         if ((*env)->ExceptionCheck(env)) {
             break;

--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
@@ -1429,9 +1429,6 @@ Java_sun_awt_X11GraphicsDevice_getDoubleBufferVisuals(JNIEnv *env,
             break;
         }
         (*env)->CallVoidMethod(env, this, midAddVisual, (visInfo[i]).visual);
-        if ((*env)->ExceptionCheck(env)) {
-            break;
-        }
     }
     AWT_LOCK();
     XdbeFreeVisualInfo(visScreenInfo);


### PR DESCRIPTION
This is a theoretical/potential case of calling JNI methods with a possible execption pending.
As noted in the eval of the bug report, we no longer follow the practice that AWT_LOCK is
called only at the start of a native method and AWT_UNLOCK at the end, if indeed we ever did.
But it seems to be implied in how they are handling exceptions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8285399](https://bugs.openjdk.java.net/browse/JDK-8285399): JNI exception pending in awt_GraphicsEnv.c:1432


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8493/head:pull/8493` \
`$ git checkout pull/8493`

Update a local copy of the PR: \
`$ git checkout pull/8493` \
`$ git pull https://git.openjdk.java.net/jdk pull/8493/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8493`

View PR using the GUI difftool: \
`$ git pr show -t 8493`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8493.diff">https://git.openjdk.java.net/jdk/pull/8493.diff</a>

</details>
