### PR TITLE
8285979: G1: G1SegmentedArraySegment::header_size() is incorrect since JDK-8283368

### DIFF
--- a/src/hotspot/share/gc/g1/g1SegmentedArray.cpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArray.cpp
@@ -32,9 +32,9 @@
 G1SegmentedArraySegment::G1SegmentedArraySegment(uint slot_size, uint num_slots, G1SegmentedArraySegment* next, MEMFLAGS flag) :
   _slot_size(slot_size),
   _num_slots(num_slots),
-  _mem_flag(flag),
   _next(next),
-  _next_allocate(0) {
+  _next_allocate(0),
+  _mem_flag(flag) {
   _bottom = ((char*) this) + header_size();
 }
 

--- a/src/hotspot/share/gc/g1/g1SegmentedArray.hpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArray.hpp
@@ -36,17 +36,17 @@
 class G1SegmentedArraySegment {
   const uint _slot_size;
   const uint _num_slots;
-  const MEMFLAGS _mem_flag;
   G1SegmentedArraySegment* volatile _next;
   // Index into the next free slot to allocate into. Full if equal (or larger)
   // to _num_slots (can be larger because we atomically increment this value and
   // check only afterwards if the allocation has been successful).
   uint volatile _next_allocate;
+  const MEMFLAGS _mem_flag;
 
   char* _bottom;  // Actual data.
   // Do not add class member variables beyond this point
 
-  static size_t header_size() { return align_up(offset_of(G1SegmentedArraySegment, _bottom), DEFAULT_CACHE_LINE_SIZE); }
+  static size_t header_size() { return align_up(offset_of(G1SegmentedArraySegment, _bottom) + sizeof(_bottom), DEFAULT_CACHE_LINE_SIZE); }
 
   static size_t payload_size(uint slot_size, uint num_slots) {
     // The cast (size_t) is required to guard against overflow wrap around.

--- a/src/hotspot/share/gc/g1/g1SegmentedArray.hpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArray.hpp
@@ -46,7 +46,7 @@ class G1SegmentedArraySegment {
   char* _bottom;  // Actual data.
   // Do not add class member variables beyond this point
 
-  static size_t header_size() { return align_up(offset_of(G1SegmentedArraySegment, _bottom) + sizeof(_bottom), DEFAULT_CACHE_LINE_SIZE); }
+  static size_t header_size() { return align_up(sizeof(G1SegmentedArraySegment), DEFAULT_CACHE_LINE_SIZE); }
 
   static size_t payload_size(uint slot_size, uint num_slots) {
     // The cast (size_t) is required to guard against overflow wrap around.


### PR DESCRIPTION
Hi all,

`G1SegmentedArraySegment::header_size()` is incorrect if `DEFAULT_CACHE_LINE_SIZE <= 32`.
This bug can be easily reproduced by running `gc/g1` with VM configured and built with `--with-jvm-features=-compiler2`.

The reason is that there are paddings in the layout of `G1SegmentedArraySegment`.
```
  const uint _slot_size;                   // offset 0-byte
  const uint _num_slots;                   // offset 4-byte
  const MEMFLAGS _mem_flag;                // offset 8-byte
    // --- padding 4 bytes
  G1SegmentedArraySegment* volatile _next; // offset 16-byte
  uint volatile _next_allocate;            // offset 24
    // --- padding 4 bytes
  char* _bottom;                           // offset 32-byte
```

So if we calculate `header_size()` like this, it will return 32 bytes when `DEFAULT_CACHE_LINE_SIZE=32`, which should be at least 40 bytes actually.
```
static size_t header_size() { return align_up(offset_of(G1SegmentedArraySegment, _bottom) + sizeof(_bottom), DEFAULT_CACHE_LINE_SIZE); }
```

Two changes are made in this patch:
- Fix the implementation of `header_size()`.
- Fix the layout of `G1SegmentedArraySegment` to eliminate paddings.

Testing:
- tier1~3 on Linux/x64, no regression
- gc/g1 with `--with-jvm-features=-compiler2` on Linux/x64, all passed

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285979](https://bugs.openjdk.java.net/browse/JDK-8285979): G1: G1SegmentedArraySegment::header_size() is incorrect since JDK-8283368


### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8494/head:pull/8494` \
`$ git checkout pull/8494`

Update a local copy of the PR: \
`$ git checkout pull/8494` \
`$ git pull https://git.openjdk.java.net/jdk pull/8494/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8494`

View PR using the GUI difftool: \
`$ git pr show -t 8494`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8494.diff">https://git.openjdk.java.net/jdk/pull/8494.diff</a>

</details>
