### PR TITLE
8285980: Several tests in compiler/c2/irTests miss @requires vm.compiler2.enabled

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestCountedLoopSafepoint.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestCountedLoopSafepoint.java
@@ -30,6 +30,7 @@ import compiler.lib.ir_framework.*;
  * bug 8281322
  * @summary check counted loop is properly constructed with/without safepoint
  * @library /test/lib /
+ * @requires vm.compiler2.enabled
  * @run driver compiler.c2.irTests.TestCountedLoopSafepoint
  */
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestDuplicateBackedge.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestDuplicateBackedge.java
@@ -31,6 +31,7 @@ import java.util.Objects;
  * @bug 8279888
  * @summary Local variable independently used by multiple loops can interfere with loop optimizations
  * @library /test/lib /
+ * @requires vm.compiler2.enabled
  * @run driver compiler.c2.irTests.TestDuplicateBackedge
  */
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestFewIterationsCountedLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestFewIterationsCountedLoop.java
@@ -30,6 +30,7 @@ import compiler.lib.ir_framework.*;
  * @bug 8262721
  * @summary Add Tests to verify single iteration loops are properly optimized
  * @library /test/lib /
+ * @requires vm.compiler2.enabled
  * @run driver compiler.c2.irTests.TestFewIterationsCountedLoop
  */
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestIRAddIdealNotXPlusC.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestIRAddIdealNotXPlusC.java
@@ -32,6 +32,7 @@ import compiler.lib.ir_framework.*;
  * @summary Test that transformation from ~x + c to (c - 1) - x and
  *          from ~(x + c) to (-c - 1) - x works as intended.
  * @library /test/lib /
+ * @requires vm.compiler2.enabled
  * @run driver compiler.c2.irTests.TestIRAddIdealNotXPlusC
  */
 public class TestIRAddIdealNotXPlusC {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestIRLShiftIdeal_XPlusX_LShiftC.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestIRLShiftIdeal_XPlusX_LShiftC.java
@@ -31,6 +31,7 @@ import compiler.lib.ir_framework.*;
  * @bug 8278114
  * @summary Test that transformation from (x + x) >> c to x >> (c + 1) works as intended.
  * @library /test/lib /
+ * @requires vm.compiler2.enabled
  * @run driver compiler.c2.irTests.TestIRLShiftIdeal_XPlusX_LShiftC
  */
 public class TestIRLShiftIdeal_XPlusX_LShiftC {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestLongRangeChecks.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestLongRangeChecks.java
@@ -31,6 +31,7 @@ import java.util.Objects;
  * @bug 8259609 8276116
  * @summary C2: optimize long range checks in long counted loops
  * @library /test/lib /
+ * @requires vm.compiler2.enabled
  * @run driver compiler.c2.irTests.TestLongRangeChecks
  */
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestSkeletonPredicates.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestSkeletonPredicates.java
@@ -32,6 +32,7 @@ import java.util.Random;
  * @bug 8278228
  * @summary C2: Improve identical back-to-back if elimination
  * @library /test/lib /
+ * @requires vm.compiler2.enabled
  * @run driver compiler.c2.irTests.TestSkeletonPredicates
  */
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestStripMiningDropsSafepoint.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestStripMiningDropsSafepoint.java
@@ -30,6 +30,7 @@ import compiler.lib.ir_framework.*;
  * @bug 8282045
  * @summary When loop strip mining fails, safepoints are removed from loop anyway
  * @library /test/lib /
+ * @requires vm.compiler2.enabled
  * @run driver compiler.c2.irTests.TestStripMiningDropsSafepoint
  */
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestSuperwordFailsUnrolling.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestSuperwordFailsUnrolling.java
@@ -32,6 +32,7 @@ import sun.hotspot.WhiteBox;
  * @summary C2: loop candidate for superword not always unrolled fully if superword fails
  * @library /test/lib /
  * @build sun.hotspot.WhiteBox
+ * @requires vm.compiler2.enabled
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -DSkipWhiteBoxInstall=true -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI compiler.c2.irTests.TestSuperwordFailsUnrolling
  */


### PR DESCRIPTION
Hi all,

Several tests in compiler/c2/irTests fail if C2 is not available.

The following 7 tests use C2-only VM falgs.
```
compiler/c2/irTests/TestSkeletonPredicates.java
compiler/c2/irTests/TestFewIterationsCountedLoop.java
compiler/c2/irTests/TestDuplicateBackedge.java
compiler/c2/irTests/TestStripMiningDropsSafepoint.java
compiler/c2/irTests/TestCountedLoopSafepoint.java
compiler/c2/irTests/TestLongRangeChecks.java
compiler/c2/irTests/TestSuperwordFailsUnrolling.java
```

The following two tests assert that C2 must be available.
```
compiler/c2/irTests/TestIRLShiftIdeal_XPlusX_LShiftC.java   
compiler/c2/irTests/TestIRAddIdealNotXPlusC.java
```

It would be better to add `@requires vm.compiler2.enabled` to these tests.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285980](https://bugs.openjdk.java.net/browse/JDK-8285980): Several tests in compiler/c2/irTests miss @requires vm.compiler2.enabled


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8495/head:pull/8495` \
`$ git checkout pull/8495`

Update a local copy of the PR: \
`$ git checkout pull/8495` \
`$ git pull https://git.openjdk.java.net/jdk pull/8495/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8495`

View PR using the GUI difftool: \
`$ git pr show -t 8495`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8495.diff">https://git.openjdk.java.net/jdk/pull/8495.diff</a>

</details>
