### PR TITLE
8285970: gc/arguments/TestUseCompressedOopsFlagsWithUlimit.java still fails after JDK-8285011

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsFlagsWithUlimit.java
+++ b/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsFlagsWithUlimit.java
@@ -33,6 +33,7 @@ package gc.arguments;
  * @requires vm.bits == "64"
  * @requires os.family == "linux"
  * @requires vm.gc != "Z"
+ * @requires vm.opt.UseCompressedOops == null
  * @run driver gc.arguments.TestUseCompressedOopsFlagsWithUlimit
  */
 


### PR DESCRIPTION
Hi all,

  please review this test fix that disables running that test when the user provided the `UseCompressedOops` flag on the command line. I intentionally did not change the `createTestJvm` call to `createJavaProcessBuilder` or similar to allow running with other collectors than the default, which should work.

Testing: local testing with and without `-XX:-UseCompressedOops` on the jtreg command line

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285970](https://bugs.openjdk.java.net/browse/JDK-8285970): gc/arguments/TestUseCompressedOopsFlagsWithUlimit.java still fails after JDK-8285011


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8499/head:pull/8499` \
`$ git checkout pull/8499`

Update a local copy of the PR: \
`$ git checkout pull/8499` \
`$ git pull https://git.openjdk.java.net/jdk pull/8499/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8499`

View PR using the GUI difftool: \
`$ git pr show -t 8499`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8499.diff">https://git.openjdk.java.net/jdk/pull/8499.diff</a>

</details>
