### PR TITLE
JDK-8283807: Handle CompileThreshold the same as other thresholds when scaled with -XX:CompileThresholdScaling

### DIFF
--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -27,6 +27,7 @@
 #include "runtime/arguments.hpp"
 #include "runtime/flags/jvmFlag.hpp"
 #include "runtime/flags/jvmFlagAccess.hpp"
+#include "runtime/flags/jvmFlagConstraintsCompiler.hpp"
 #include "runtime/flags/jvmFlagLimit.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/globals_extension.hpp"
@@ -286,7 +287,10 @@ void CompilerConfig::set_legacy_emulation_flags() {
   // Scale CompileThreshold
   // CompileThresholdScaling == 0.0 is equivalent to -Xint and leaves CompileThreshold unchanged.
   if (!FLAG_IS_DEFAULT(CompileThresholdScaling) && CompileThresholdScaling > 0.0 && CompileThreshold > 0) {
-    FLAG_SET_ERGO(CompileThreshold, scaled_compile_threshold(CompileThreshold));
+    intx scaled_value = scaled_compile_threshold(CompileThreshold);
+    if (CompileThresholdConstraintFunc(scaled_value, true) != JVMFlag::VIOLATES_CONSTRAINT) {
+      FLAG_SET_ERGO(CompileThreshold, scaled_value);
+    }
   }
 }
 

--- a/test/hotspot/jtreg/compiler/arguments/TestCompileThresholdScaling.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestCompileThresholdScaling.java
@@ -48,25 +48,25 @@ public class TestCompileThresholdScaling {
     }
 
     static void checkCompileThresholdScaling(double value, boolean fail) throws Throwable {
-      OutputAnalyzer out = ProcessTools.executeTestJvm("-XX:CompileThresholdScaling=" + value, "--version");
-      out.shouldHaveExitValue(0);
-      String output = out.getOutput();
+        OutputAnalyzer out = ProcessTools.executeTestJvm("-XX:CompileThresholdScaling=" + value, "--version");
+        out.shouldHaveExitValue(0);
+        String output = out.getOutput();
 
-      List<String> thresholdList = List.of(
-      "Tier0InvokeNotifyFreqLog", "Tier0BackedgeNotifyFreqLog", "Tier3InvocationThreshold",
-      "Tier3MinInvocationThreshold", "Tier3CompileThreshold", "Tier3BackEdgeThreshold",
-      "Tier2InvokeNotifyFreqLog", "Tier2BackedgeNotifyFreqLog", "Tier3InvokeNotifyFreqLog",
-      "Tier3BackedgeNotifyFreqLog", "Tier23InlineeNotifyFreqLog", "Tier4InvocationThreshold",
-      "Tier4MinInvocationThreshold", "Tier4CompileThreshold", "Tier4BackEdgeThreshold");
+        List<String> thresholdList = List.of(
+        "Tier0InvokeNotifyFreqLog", "Tier0BackedgeNotifyFreqLog", "Tier3InvocationThreshold",
+        "Tier3MinInvocationThreshold", "Tier3CompileThreshold", "Tier3BackEdgeThreshold",
+        "Tier2InvokeNotifyFreqLog", "Tier2BackedgeNotifyFreqLog", "Tier3InvokeNotifyFreqLog",
+        "Tier3BackedgeNotifyFreqLog", "Tier23InlineeNotifyFreqLog", "Tier4InvocationThreshold",
+        "Tier4MinInvocationThreshold", "Tier4CompileThreshold", "Tier4BackEdgeThreshold");
 
-      String pattern = ".*CompileThreshold .* must be between .* and .*";
-      boolean found = Pattern.compile(pattern).matcher(output).find();
-      Asserts.assertEquals(found, fail, "Unexpected result");
+        String pattern = ".*CompileThreshold .* must be between .* and .*";
+        boolean found = Pattern.compile(pattern).matcher(output).find();
+        Asserts.assertEquals(found, fail, "Unexpected result");
 
-      for (String threshold : thresholdList) {
-          pattern = ".*" + threshold + "=.* is outside the allowed range";
-          Asserts.assertEquals(found, fail, "Unexpected result");
-      }
+        for (String threshold : thresholdList) {
+            pattern = ".*" + threshold + "=.* is outside the allowed range";
+            Asserts.assertEquals(found, fail, "Unexpected result");
+        }
     }
 
 }

--- a/test/hotspot/jtreg/compiler/arguments/TestCompileThresholdScaling.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestCompileThresholdScaling.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test TestCompileThresholdScaling
+ * @bug 8283807
+ * @summary With a very large value of CompileThresholdScaling all scaled
+ *          thresholds should be outside the allowed range
+ * @library /test/lib
+ * @run driver compiler.arguments.TestCompileThresholdScaling
+ */
+
+package compiler.arguments;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.util.List;
+
+public class TestCompileThresholdScaling {
+
+    public static void main(String args[]) throws Throwable {
+        checkCompileThresholdScaling(Double.MAX_VALUE, true);
+        checkCompileThresholdScaling(Double.valueOf(Integer.MAX_VALUE), true);
+        checkCompileThresholdScaling(1.0, false);
+    }
+
+    static void checkCompileThresholdScaling(double value, boolean fail) throws Throwable {
+      OutputAnalyzer out = ProcessTools.executeTestJvm("-XX:CompileThresholdScaling=" + value, "--version");
+      out.shouldHaveExitValue(0);
+      String output = out.getOutput();
+
+      List<String> thresholdList = List.of(
+      "Tier0InvokeNotifyFreqLog", "Tier0BackedgeNotifyFreqLog", "Tier3InvocationThreshold",
+      "Tier3MinInvocationThreshold", "Tier3CompileThreshold", "Tier3BackEdgeThreshold",
+      "Tier2InvokeNotifyFreqLog", "Tier2BackedgeNotifyFreqLog", "Tier3InvokeNotifyFreqLog",
+      "Tier3BackedgeNotifyFreqLog", "Tier23InlineeNotifyFreqLog", "Tier4InvocationThreshold",
+      "Tier4MinInvocationThreshold", "Tier4CompileThreshold", "Tier4BackEdgeThreshold");
+
+      String pattern = ".*CompileThreshold .* must be between .* and .*";
+      boolean found = Pattern.compile(pattern).matcher(output).find();
+      Asserts.assertEquals(found, fail, "Unexpected result");
+
+      for (String threshold : thresholdList) {
+          pattern = ".*" + threshold + "=.* is outside the allowed range";
+          Asserts.assertEquals(found, fail, "Unexpected result");
+      }
+    }
+
+}

--- a/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/TestOptionsWithRanges.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/TestOptionsWithRanges.java
@@ -259,8 +259,9 @@ public class TestOptionsWithRanges {
 
         /*
          * Exclude CompileThresholdScaling from max range testing, because
-         * it is expected to print "outside the allowed range" warnings for
-         * the scaled flags
+         * it is expected to print "outside the allowed range" warnings for the
+         * scaled flag and the "outside the allowed range" warning does not
+         * refer to CompileThresholdScaling itself.
          */
         excludeTestMaxRange("CompileThresholdScaling");
 

--- a/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/TestOptionsWithRanges.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/TestOptionsWithRanges.java
@@ -257,6 +257,13 @@ public class TestOptionsWithRanges {
         excludeTestMaxRange("NonNMethodCodeHeapSize");
         excludeTestMaxRange("CodeCacheExpansionSize");
 
+        /*
+         * Exclude CompileThresholdScaling from max range testing, because
+         * it is expected to print "outside the allowed range" warnings for
+         * the scaled flags
+         */
+        excludeTestMaxRange("CompileThresholdScaling");
+
         List<JVMOption> testSubset = getTestSubset(args);
 
         Asserts.assertGT(testSubset.size(), 0, "Options with ranges not found!");

--- a/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/common/optionsvalidation/DoubleJVMOption.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/common/optionsvalidation/DoubleJVMOption.java
@@ -127,10 +127,7 @@ public class DoubleJVMOption extends JVMOption {
             validValues.add(formatValue(min));
         }
         if (testMaxRange) {
-            if (!name.equals("CompileThresholdScaling")) {
-                // See JDK-8283807: Max range for -XX:CompileThresholdScaling is too large
-                validValues.add(formatValue(max));
-            }
+            validValues.add(formatValue(max));
         }
 
         if (testMinRange) {


### PR DESCRIPTION
`CompileThresholdScaling` scales several compiler thresholds. If the scaled threshold value is outside of the allowed range, a warning is printed and the default value is kept. But when scaling `CompileThreshold` we do not check the scaled value because it is not a ranged flag. Later when verifying flags with a constraint function `OnStackReplacePercentageConstraintFunc` which calls `CompileThresholdConstraintFunc` fails because `CompileThreshold` is outside of the allowed range. This stops the VM from being created. 

The fix is to call `CompileThresholdConstraintFunc` when scaling `CompileThreshold` with `CompileThresholdScaling`. If `CompileThresholdConstraintFunc` fails we print a warning and keep the default value of `CompileThreshold`. This behaviour is then consistent with the other 15 other thresholds where the VM just prints a warning if the scaled value is too large and then keeps the current value.

We also have to exclude `CompileThresholdScaling` from max. range testing in `TestOptionsWithRanges.java`, because
it is expected to print "outside the allowed range" warnings for the scaled flag and the "outside the allowed range" warning does not refer to `CompileThresholdScaling` itself. 

One question that remains it why `CompileThresholdScaling` takes the default value when a scaled threshold is too large instead of the max. value?  Because now we can have the case where some compiler thresholds are scaled to almost their max. value and others that are already larger than the maximum are default again (which can be the minimum value in some cases). I suggest to address this issue in a separate RFE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [JDK-8283807](https://bugs.openjdk.java.net/browse/JDK-8283807): Handle CompileThreshold the same as other thresholds when scaled with -XX:CompileThresholdScaling


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [834cfcfb](https://git.openjdk.java.net/jdk/pull/8501/files/834cfcfbebcf07b0338e61694e1f68b861297a68)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8501/head:pull/8501` \
`$ git checkout pull/8501`

Update a local copy of the PR: \
`$ git checkout pull/8501` \
`$ git pull https://git.openjdk.java.net/jdk pull/8501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8501`

View PR using the GUI difftool: \
`$ git pr show -t 8501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8501.diff">https://git.openjdk.java.net/jdk/pull/8501.diff</a>

</details>
