### PR TITLE
8286002: Add support for intel syntax to capstone hsdis

### DIFF
--- a/src/utils/hsdis/capstone/hsdis-capstone.c
+++ b/src/utils/hsdis/capstone/hsdis-capstone.c
@@ -51,7 +51,6 @@
 
 #include <inttypes.h>
 #include <string.h>
-#include <stdio.h>
 
 #include <capstone.h>
 

--- a/src/utils/hsdis/capstone/hsdis-capstone.c
+++ b/src/utils/hsdis/capstone/hsdis-capstone.c
@@ -89,7 +89,7 @@ typedef struct {
   bool intel_syntax;
 } Options;
 
-static Options parse_options(const char* options) {
+static Options parse_options(const char* options, printf_callback_t printf_callback, void* printf_stream) {
   Options ops;
   // initialize with defaults
   ops.intel_syntax = false;
@@ -107,7 +107,7 @@ static Options parse_options(const char* options) {
       if (end == NULL) {
         end = strchr(cursor, '\0');
       }
-      printf("Unknown PrintAssembly option: %.*s\n", (int) (end - cursor), cursor);
+      print("Unknown PrintAssembly option: %.*s\n", (int) (end - cursor), cursor);
       cursor = end;
     }
   }
@@ -120,9 +120,9 @@ __declspec(dllexport)
 #endif
 void* decode_instructions_virtual(uintptr_t start_va, uintptr_t end_va,
                                   unsigned char* buffer, uintptr_t length,
-                                  void* (*event_callback)(void*, const char*, void*),
+                                  event_callback_t event_callback,
                                   void* event_stream,
-                                  int (*printf_callback)(void*, const char*, ...),
+                                  printf_callback_t printf_callback,
                                   void* printf_stream,
                                   const char* options,
                                   int newline /* bool value for nice new line */) {
@@ -148,7 +148,7 @@ void* decode_instructions_virtual(uintptr_t start_va, uintptr_t end_va,
     return NULL;
   }
 
-  Options ops = parse_options(options);
+  Options ops = parse_options(options, printf_callback, printf_stream);
   cs_option(cs_handle, CS_OPT_SYNTAX, ops.intel_syntax ? CS_OPT_SYNTAX_INTEL : CS_OPT_SYNTAX_ATT);
 
   cs_insn *insn;

--- a/src/utils/hsdis/capstone/hsdis-capstone.c
+++ b/src/utils/hsdis/capstone/hsdis-capstone.c
@@ -91,6 +91,8 @@ typedef struct {
 
 static Options parse_options(const char* options) {
   Options ops;
+  // initialize with defaults
+  ops.intel_syntax = false;
 
   const char* cursor = options;
   while (*cursor != '\0') {


### PR DESCRIPTION
This patch adds support for outputting assembly in intel syntax to capstone hsdis, through the `-XX:PrintAssemblyOptions=intel` flag.

Snippet of example output:

```
[Verified Entry Point]
  # {method} {0x0000021c8a4002d8} 'add' '(II)I' in 'Main'
  # parm0:    rdx       = int
  # parm1:    r8        = int
  #           [sp+0x20]  (sp of caller)
  0x0000021cfa713780:   sub             rsp, 0x18
  0x0000021cfa713787:   mov             qword ptr [rsp + 0x10], rbp
  0x0000021cfa71378c:   mov             eax, edx
  0x0000021cfa71378e:   add             eax, r8d
  0x0000021cfa713791:   add             rsp, 0x10
  0x0000021cfa713795:   pop             rbp
  0x0000021cfa713796:   cmp             rsp, qword ptr [r15 + 0x338]
                                                            ;   {poll_return}
  0x0000021cfa71379d:   ja              0x21cfa7137a4
  0x0000021cfa7137a3:   ret
  0x0000021cfa7137a4:   movabs          r10, 0x21cfa713796  ;   {internal_word}
  0x0000021cfa7137ae:   mov             qword ptr [r15 + 0x350], r10
  0x0000021cfa7137b5:   jmp             0x21cfa6f3400       ;   {runtime_call SafepointBlob}
  ```
  
  Testing: 
  - Manual testing with and without `-XX:PrintAssemblyOptions=intel`, to make sure that both syntaxes work.
  - Manual testing with several different invalid options such as `-XX:PrintAssemblyOptions=asdf,,` to make sure that invalid options are handled correctly.
  
  Thanks,
  Jorn

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286002](https://bugs.openjdk.java.net/browse/JDK-8286002): Add support for intel syntax to capstone hsdis


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8502/head:pull/8502` \
`$ git checkout pull/8502`

Update a local copy of the PR: \
`$ git checkout pull/8502` \
`$ git pull https://git.openjdk.java.net/jdk pull/8502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8502`

View PR using the GUI difftool: \
`$ git pr show -t 8502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8502.diff">https://git.openjdk.java.net/jdk/pull/8502.diff</a>

</details>
