### PR TITLE
8286013: Incorrect test configurations for compiler/stable/TestStableShort.java

### DIFF
--- a/test/hotspot/jtreg/compiler/stable/TestStableShort.java
+++ b/test/hotspot/jtreg/compiler/stable/TestStableShort.java
@@ -37,18 +37,18 @@
  * @run main/bootclasspath/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xcomp
  *                                 -XX:CompileOnly=::get,::get1,::get2,::get3,::get4
  *                                 -XX:-TieredCompilation
- *                                 -XX:+FoldStableValues
+ *                                 -XX:-FoldStableValues
  *                                 compiler.stable.TestStableShort
  *
  * @run main/bootclasspath/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xcomp
  *                                 -XX:CompileOnly=::get,::get1,::get2,::get3,::get4
- *                                 -XX:-TieredCompilation
+ *                                 -XX:+TieredCompilation -XX:TieredStopAtLevel=1
  *                                 -XX:+FoldStableValues
  *                                 compiler.stable.TestStableShort
  * @run main/bootclasspath/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xcomp
  *                                 -XX:CompileOnly=::get,::get1,::get2,::get3,::get4
- *                                 -XX:-TieredCompilation
- *                                 -XX:+FoldStableValues
+ *                                 -XX:+TieredCompilation -XX:TieredStopAtLevel=1
+ *                                 -XX:-FoldStableValues
  *                                 compiler.stable.TestStableShort
  */
 


### PR DESCRIPTION
Hi all,

The four test configurations for `compiler/stable/TestStableShort.java` are the same.
```
/*
 * @test TestStableShort
 * @summary tests on stable fields and arrays
 * @library /test/lib /
 * @modules java.base/jdk.internal.misc
 * @modules java.base/jdk.internal.vm.annotation
 * @build sun.hotspot.WhiteBox
 *
 * @run main/bootclasspath/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xcomp
 *                                 -XX:CompileOnly=::get,::get1,::get2,::get3,::get4
 *                                 -XX:-TieredCompilation
 *                                 -XX:+FoldStableValues
 *                                 compiler.stable.TestStableShort
 * @run main/bootclasspath/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xcomp
 *                                 -XX:CompileOnly=::get,::get1,::get2,::get3,::get4
 *                                 -XX:-TieredCompilation
 *                                 -XX:+FoldStableValues
 *                                 compiler.stable.TestStableShort
 *
 * @run main/bootclasspath/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xcomp
 *                                 -XX:CompileOnly=::get,::get1,::get2,::get3,::get4
 *                                 -XX:-TieredCompilation
 *                                 -XX:+FoldStableValues
 *                                 compiler.stable.TestStableShort
 * @run main/bootclasspath/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xcomp
 *                                 -XX:CompileOnly=::get,::get1,::get2,::get3,::get4
 *                                 -XX:-TieredCompilation
 *                                 -XX:+FoldStableValues
 *                                 compiler.stable.TestStableShort
 */
```

I believe this is a copy-paste mistake.
Let's fix it.

The patch just follows the test configurations in TestStable{Byte/Char/Int/Long/Float/Double/Object}.java

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8286013](https://bugs.openjdk.java.net/browse/JDK-8286013): Incorrect test configurations for compiler/stable/TestStableShort.java


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8503/head:pull/8503` \
`$ git checkout pull/8503`

Update a local copy of the PR: \
`$ git checkout pull/8503` \
`$ git pull https://git.openjdk.java.net/jdk pull/8503/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8503`

View PR using the GUI difftool: \
`$ git pr show -t 8503`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8503.diff">https://git.openjdk.java.net/jdk/pull/8503.diff</a>

</details>
