### PR TITLE
8285962: NimbusDefaults has a typo in a L&F property

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
@@ -16238,7 +16238,7 @@
                <uiProperty name="tileWidth" type="INT" value="27"/>
                <uiProperty name="paintOutsideClip" type="BOOLEAN" value="true"/>
                <uiProperty name="rotateText" type="BOOLEAN" value="true"/>
-               <uiProperty name="vertictalSize" type="DIMENSION">
+               <uiProperty name="verticalSize" type="DIMENSION">
                   <dimension width="19" height="150"/>
                </uiProperty>
                <uiProperty name="horizontalSize" type="DIMENSION">


### PR DESCRIPTION
BasicLookAndFeel, BasicProgressBarUI, GTKLookAndFeel tries to find property by "ProgressBar.verticalSize" but the property defined in NimbusDefaults has a typo "vertictalSize ".
Rectified the typo.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8285962](https://bugs.openjdk.java.net/browse/JDK-8285962): NimbusDefaults has a typo in a L&F property


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8504/head:pull/8504` \
`$ git checkout pull/8504`

Update a local copy of the PR: \
`$ git checkout pull/8504` \
`$ git pull https://git.openjdk.java.net/jdk pull/8504/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8504`

View PR using the GUI difftool: \
`$ git pr show -t 8504`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8504.diff">https://git.openjdk.java.net/jdk/pull/8504.diff</a>

</details>
