### PR TITLE
8278367: JNI critical region violation in CTextPipe.m:363

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CTextPipe.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CTextPipe.m
@@ -354,14 +354,21 @@ static inline void doDrawGlyphsPipe_checkForPerGlyphTransforms
     if (g_gtiTransformsArray == NULL) {
         return;
     }
-    jdouble *g_gvTransformsAsDoubles = (*env)->GetPrimitiveArrayCritical(env, g_gtiTransformsArray, NULL);
-    if (g_gvTransformsAsDoubles == NULL) {
+
+    DECLARE_FIELD(jm_StandardGlyphVector_GlyphTransformInfo_indices, jc_StandardGlyphVector_GlyphTransformInfo, "indices", "[I");
+    jintArray g_gtiTXIndicesArray = (*env)->GetObjectField(env, gti, jm_StandardGlyphVector_GlyphTransformInfo_indices);
+    if (g_gtiTXIndicesArray == NULL) {
         (*env)->DeleteLocalRef(env, g_gtiTransformsArray);
         return;
     }
 
-    DECLARE_FIELD(jm_StandardGlyphVector_GlyphTransformInfo_indices, jc_StandardGlyphVector_GlyphTransformInfo, "indices", "[I");
-    jintArray g_gtiTXIndicesArray = (*env)->GetObjectField(env, gti, jm_StandardGlyphVector_GlyphTransformInfo_indices);
+    jdouble *g_gvTransformsAsDoubles = (*env)->GetPrimitiveArrayCritical(env, g_gtiTransformsArray, NULL);
+    if (g_gvTransformsAsDoubles == NULL) {
+        (*env)->DeleteLocalRef(env, g_gtiTransformsArray);
+        (*env)->DeleteLocalRef(env, g_gtiTXIndicesArray);
+        return;
+    }
+
     jint *g_gvTXIndicesAsInts = (*env)->GetPrimitiveArrayCritical(env, g_gtiTXIndicesArray, NULL);
     if (g_gvTXIndicesAsInts == NULL) {
         (*env)->ReleasePrimitiveArrayCritical(env, g_gtiTransformsArray, g_gvTransformsAsDoubles, JNI_ABORT);


### PR DESCRIPTION
This re-jigs some lines of code so that we do all the lookups of the arrays before calling the GetPrimitiveArrayCritical on both of them together. Thereby avoiding warnings about calling those other methods in that context.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8278367](https://bugs.openjdk.java.net/browse/JDK-8278367): JNI critical region violation in CTextPipe.m:363


### Reviewers
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.java.net/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8506/head:pull/8506` \
`$ git checkout pull/8506`

Update a local copy of the PR: \
`$ git checkout pull/8506` \
`$ git pull https://git.openjdk.java.net/jdk pull/8506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8506`

View PR using the GUI difftool: \
`$ git pr show -t 8506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8506.diff">https://git.openjdk.java.net/jdk/pull/8506.diff</a>

</details>
