### PR TITLE
8286028: Some -Xlint keys are missing in javac man page

### DIFF
--- a/src/jdk.compiler/share/man/javac.1
+++ b/src/jdk.compiler/share/man/javac.1
@@ -753,8 +753,8 @@ Supported values for \f[I]key\f[R] are:
 .IP \[bu] 2
 \f[CB]all\f[R]: Enables all warnings.
 .IP \[bu] 2
-\f[CB]auxiliaryclass\f[R]: Warns about an auxiliary class that\[aq]s
-hidden in a source file, and is used from other files.
+\f[CB]auxiliaryclass\f[R]: Warns about an auxiliary class that is hidden
+in a source file, and is used from other files.
 .IP \[bu] 2
 \f[CB]cast\f[R]: Warns about the use of unnecessary casts.
 .IP \[bu] 2
@@ -778,6 +778,9 @@ switch statement to the next.
 \f[CB]finally\f[R]: Warns about \f[CB]finally\f[R] clauses that do not
 terminate normally.
 .IP \[bu] 2
+\f[CB]missing\-explicit\-ctor\f[R]: Warns about missing explicit
+constructors in public and protected classes in exported packages.
+.IP \[bu] 2
 \f[CB]module\f[R]: Warns about the module system\-related issues.
 .IP \[bu] 2
 \f[CB]opens\f[R]: Warns about the issues related to module opens.
@@ -789,8 +792,10 @@ options.
 .IP \[bu] 2
 \f[CB]overrides\f[R]: Warns about the issues related to method overrides.
 .IP \[bu] 2
-\f[CB]path\f[R]: Warns about the invalid path elements on the command l
-ine.
+\f[CB]path\f[R]: Warns about the invalid path elements on the command
+line.
+.IP \[bu] 2
+\f[CB]preview\f[R]: Warns about the use of preview language features.
 .IP \[bu] 2
 \f[CB]processing\f[R]: Warns about the issues related to annotation
 processing.
@@ -814,8 +819,17 @@ element.
 \f[CB]static\f[R]: Warns about the accessing a static member using an
 instance.
 .IP \[bu] 2
-\f[CB]try\f[R]: Warns about the issues relating to the use of try blocks (
-that is, try\-with\-resources).
+\f[CB]strictfp\f[R]: Warns about unnecessary use of the \f[CB]strictfp\f[R]
+modifier.
+.IP \[bu] 2
+\f[CB]synchronization\f[R]: Warns about synchronization attempts on
+instances of value\-based classes.
+.IP \[bu] 2
+\f[CB]text\-blocks\f[R]: Warns about inconsistent white space characters
+in text block indentation.
+.IP \[bu] 2
+\f[CB]try\f[R]: Warns about the issues relating to the use of try blocks
+(that is, try\-with\-resources).
 .IP \[bu] 2
 \f[CB]unchecked\f[R]: Warns about the unchecked operations.
 .IP \[bu] 2


### PR DESCRIPTION
Please review an update to the javac man page, derived from the upstream sources, and triggered by PR #7971 by Ethan McCue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [JDK-8286028](https://bugs.openjdk.java.net/browse/JDK-8286028): Some -Xlint keys are missing in javac man page


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Contributors
 * Ethan McCue `<emccue@live.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8507/head:pull/8507` \
`$ git checkout pull/8507`

Update a local copy of the PR: \
`$ git checkout pull/8507` \
`$ git pull https://git.openjdk.java.net/jdk pull/8507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8507`

View PR using the GUI difftool: \
`$ git pr show -t 8507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8507.diff">https://git.openjdk.java.net/jdk/pull/8507.diff</a>

</details>
