### PR TITLE
8286029: Add classpath exemption to globals_vectorApiSupport_***.S.inc

### DIFF
--- a/src/jdk.incubator.vector/linux/native/libjsvml/globals_vectorApiSupport_linux.S.inc
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/globals_vectorApiSupport_linux.S.inc
@@ -4,7 +4,9 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.incubator.vector/linux/native/libjsvml/globals_vectorApiSupport_linux.S.inc
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/globals_vectorApiSupport_linux.S.inc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.incubator.vector/windows/native/libjsvml/globals_vectorApiSupport_windows.S.inc
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/globals_vectorApiSupport_windows.S.inc
@@ -1,4 +1,4 @@
-; Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+; Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.incubator.vector/windows/native/libjsvml/globals_vectorApiSupport_windows.S.inc
+++ b/src/jdk.incubator.vector/windows/native/libjsvml/globals_vectorApiSupport_windows.S.inc
@@ -3,7 +3,9 @@
 ;
 ; This code is free software; you can redistribute it and/or modify it
 ; under the terms of the GNU General Public License version 2 only, as
-; published by the Free Software Foundation.
+; published by the Free Software Foundation.  Oracle designates this
+; particular file as subject to the "Classpath" exception as provided
+; by Oracle in the LICENSE file that accompanied this code.
 ;
 ; This code is distributed in the hope that it will be useful, but WITHOUT
 ; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or


### PR DESCRIPTION
Adds missing classpath exception to the header of two GPLv2 files.

Requested [here](https://mail.openjdk.java.net/pipermail/jdk-updates-dev/2022-April/013988.html).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [JDK-8286029](https://bugs.openjdk.java.net/browse/JDK-8286029): Add classpath exemption to globals_vectorApiSupport_***.S.inc


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.java.net/census#sviswanathan) (@sviswa7 - **Reviewer**) ⚠️ Review applies to [72f74f0e](https://git.openjdk.java.net/jdk/pull/8508/files/72f74f0eea68189bd089db82ab07f4642ebc5973)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8508/head:pull/8508` \
`$ git checkout pull/8508`

Update a local copy of the PR: \
`$ git checkout pull/8508` \
`$ git pull https://git.openjdk.java.net/jdk pull/8508/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8508`

View PR using the GUI difftool: \
`$ git pr show -t 8508`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8508.diff">https://git.openjdk.java.net/jdk/pull/8508.diff</a>

</details>
