### PR TITLE
8285872: JFR: Remove finalize() methods

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/ChunkInputStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/ChunkInputStream.java
@@ -110,11 +110,4 @@ final class ChunkInputStream extends InputStream {
             }
         }
     }
-
-    @Override
-    @SuppressWarnings("removal")
-    protected void finalize() throws Throwable {
-        super.finalize();
-        close();
-    }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/ChunksChannel.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/ChunksChannel.java
@@ -135,11 +135,4 @@ final class ChunksChannel implements ReadableByteChannel {
     public boolean isOpen() {
         return channel != null;
     }
-
-    @Override
-    @SuppressWarnings("removal")
-    protected void finalize() throws Throwable {
-        super.finalize();
-        close();
-    }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/RepositoryChunk.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/RepositoryChunk.java
@@ -133,20 +133,6 @@ final class RepositoryChunk {
         }
     }
 
-    @Override
-    @SuppressWarnings("removal")
-    protected void finalize() {
-        boolean destroy = false;
-        synchronized (this) {
-            if (refCount > 0) {
-                destroy = true;
-            }
-        }
-        if (destroy) {
-            destroy();
-        }
-    }
-
     public long getSize() {
         return size;
     }


### PR DESCRIPTION
Hi,

Could I have review of a fix that removes the finalize() methods in the jdk.jfr module.

Chunks are reference counted so finalizers are not needed. To verify this, I added checks to the finalize() methods to make sure resources were not released when the finalizer was run. 

Testing: jdk/jdk/jfr multiple times

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8285872](https://bugs.openjdk.java.net/browse/JDK-8285872): JFR: Remove finalize() methods


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8510/head:pull/8510` \
`$ git checkout pull/8510`

Update a local copy of the PR: \
`$ git checkout pull/8510` \
`$ git pull https://git.openjdk.java.net/jdk pull/8510/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8510`

View PR using the GUI difftool: \
`$ git pr show -t 8510`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8510.diff">https://git.openjdk.java.net/jdk/pull/8510.diff</a>

</details>
