### PR TITLE
8284027: vmTestbase/nsk/jvmti/GetAllThreads/allthr001/ is failing

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetAllThreads/allthr001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetAllThreads/allthr001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,6 @@ public class allthr001 {
         }
     }
 
-    native static void setSysCnt();
     native static void checkInfo(int thr_ind);
     native static int getRes();
 
@@ -64,7 +63,6 @@ public class allthr001 {
         }
         out.println("# Waiting time = " + waitTime + " mins");
 
-        setSysCnt();
         checkInfo(0);
 
         ThreadGroup tg = new ThreadGroup("tg1");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetAllThreads/allthr001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetAllThreads/allthr001/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm/native -agentlib:allthr001 nsk.jvmti.GetAllThreads.allthr001 5
+ * @run main/othervm/native -agentlib:allthr001=printdump nsk.jvmti.GetAllThreads.allthr001 5
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetAllThreads/allthr001/allthr001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetAllThreads/allthr001/allthr001.cpp
@@ -180,8 +180,6 @@ void releaseThreadInfo(JNIEnv *env, jvmtiThreadInfo *info) {
 JNIEXPORT void checkInfo(JNIEnv *env, int ind) {
     jint threadsCount = -1;
     jthread *threads;
-    int i, j;
-    bool found;
     jvmtiError err;
     int expected = 0;
     jvmtiThreadInfo inf;
@@ -227,7 +225,7 @@ JNIEXPORT void checkInfo(JNIEnv *env, int ind) {
     }
 
     // check unexpected threads
-    for (i = 0; i < threadsCount; i++) {
+    for (int i = 0; i < threadsCount; i++) {
         err = jvmti->GetThreadInfo(threads[i], &inf);
         if (err != JVMTI_ERROR_NONE) {
             printf("Failed to get thread info: %s (%d)\n",
@@ -238,7 +236,8 @@ JNIEXPORT void checkInfo(JNIEnv *env, int ind) {
         if (printdump == JNI_TRUE) {
             printf(" >>> %s", inf.name);
         }
-        for (j = 0, found = false; j < thrInfo[ind].unexpected.cnt && !found; j++) {
+        bool found = false;
+        for (int j = 0; j < thrInfo[ind].unexpected.cnt && !found; j++) {
             found = (inf.name != NULL && strcmp(inf.name, thrInfo[ind].unexpected.thrNames[j]) == 0);
         }
         if (found) {
@@ -252,8 +251,9 @@ JNIEXPORT void checkInfo(JNIEnv *env, int ind) {
     }
 
     // verify all expected threads are present
-    for (i = 0; i < thrInfo[ind].expected.cnt; i++) {
-        for (j = 0, found = false; j < threadsCount && !found; j++) {
+    for (int i = 0; i < thrInfo[ind].expected.cnt; i++) {
+        bool found = false;
+        for (int j = 0; j < threadsCount && !found; j++) {
             err = jvmti->GetThreadInfo(threads[j], &inf);
             if (err != JVMTI_ERROR_NONE) {
                 printf("Failed to get thread info: %s (%d)\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetAllThreads/allthr001/allthr001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetAllThreads/allthr001/allthr001.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,18 +39,34 @@ typedef struct {
     const char **thrNames;
 } info;
 
+typedef struct  {
+    info expected;
+    info unexpected;
+} threadInfo;
+
 static jvmtiEnv *jvmti;
 static jrawMonitorID lock1;
 static jrawMonitorID lock2;
 static jboolean printdump = JNI_FALSE;
 static jint result = PASSED;
-static jvmtiThreadInfo inf;
-static int sys_cnt;
-static const char *names0[] = { "main" };
-static const char *names1[] = { "main", "thread1" };
-static const char *names2[] = { "main", "Thread-" };
-static info thrInfo[] = {
-    { 1, names0 }, { 1, names0 }, { 2, names1 }, { 1, names0 }, { 2, names2 }
+
+static const char main_name[] = "main";
+static const char thread1_name[] = "thread1";
+static const char sys_thread_name[] = "SysThread";
+
+static const char *main_only[] = { main_name };
+static const char *thr1_only[] = { thread1_name };
+static const char *sys_only[] = { sys_thread_name };
+static const char *main_thr1[] = { main_name, thread1_name };
+static const char *main_sys[] = { main_name, sys_thread_name };
+static const char *thr1_sys[] = { thread1_name, sys_thread_name };
+
+static threadInfo thrInfo[] = {
+    {{1, main_only},    {2, thr1_sys}},
+    {{1, main_only},    {2, thr1_sys}},
+    {{2, main_thr1},    {1, sys_only}},
+    {{1, main_only},    {2, thr1_sys}},
+    {{2, main_sys},     {1, thr1_only}}
 };
 
 jthread jthr(JNIEnv *env) {
@@ -58,8 +74,10 @@ jthread jthr(JNIEnv *env) {
     jmethodID cid;
     jthread res;
     thrClass = env->FindClass("java/lang/Thread");
-    cid = env->GetMethodID(thrClass, "<init>", "()V");
-    res = env->NewObject(thrClass, cid);
+    cid = env->GetMethodID(thrClass, "<init>", "(Ljava/lang/String;)V");
+    jstring thread_name = env->NewStringUTF(sys_thread_name);
+    res = env->NewObject(thrClass, cid, thread_name);
+    env->DeleteLocalRef(thread_name);
     return res;
 }
 
@@ -149,12 +167,23 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     return JNI_OK;
 }
 
+void release(JNIEnv *env, jvmtiThreadInfo *info) {
+    jvmti->Deallocate((unsigned char *)info->name);
+    if (info->thread_group != NULL) {
+        env->DeleteLocalRef(info->thread_group);
+    }
+    if (info->context_class_loader != NULL) {
+        env->DeleteLocalRef(info->context_class_loader);
+    }
+}
+
 JNIEXPORT void checkInfo(JNIEnv *env, int ind) {
     jint threadsCount = -1;
     jthread *threads;
     int i, j, found;
     jvmtiError err;
-    int num_unexpected = 0;
+    int expected = 0;
+    jvmtiThreadInfo inf;
 
     if (printdump == JNI_TRUE) {
         printf(" >>> Check: %d\n", ind);
@@ -196,20 +225,33 @@ JNIEXPORT void checkInfo(JNIEnv *env, int ind) {
         return;
     }
 
+    // check unexpected threads
     for (i = 0; i < threadsCount; i++) {
-        if (!isThreadExpected(jvmti, threads[i])) {
-            num_unexpected++;
+        err = jvmti->GetThreadInfo(threads[i], &inf);
+        if (err != JVMTI_ERROR_NONE) {
+            printf("Failed to get thread info: %s (%d)\n",
+                   TranslateError(err), err);
+            result = STATUS_FAILED;
+            return;
         }
+        if (printdump == JNI_TRUE) {
+            printf(" >>> %s", inf.name);
+        }
+        for (j = 0, found = 0; j < thrInfo[ind].unexpected.cnt && !found; j++) {
+            found = (inf.name != NULL && strcmp(inf.name, thrInfo[ind].unexpected.thrNames[j]) == 0);
+        }
+        if (found) {
+            printf("Point %d: detected unexpected thread %s\n", ind, inf.name);
+            result = STATUS_FAILED;
+        }
+        release(env, &inf);
+    }
+    if (printdump == JNI_TRUE) {
+        printf("\n");
     }
 
-    if (threadsCount - num_unexpected != thrInfo[ind].cnt + sys_cnt) {
-        printf("Point %d: number of threads expected: %d, got: %d\n",
-            ind, thrInfo[ind].cnt + sys_cnt, threadsCount - num_unexpected);
-        result = STATUS_FAILED;
-        return;
-    }
-
-    for (i = 0; i < thrInfo[ind].cnt; i++) {
+    // verify all expected threads are present
+    for (i = 0; i < thrInfo[ind].expected.cnt; i++) {
         for (j = 0, found = 0; j < threadsCount && !found; j++) {
             err = jvmti->GetThreadInfo(threads[j], &inf);
             if (err != JVMTI_ERROR_NONE) {
@@ -218,20 +260,12 @@ JNIEXPORT void checkInfo(JNIEnv *env, int ind) {
                 result = STATUS_FAILED;
                 return;
             }
-            if (printdump == JNI_TRUE) {
-                printf(" >>> %s", inf.name);
-            }
-            found = (inf.name != NULL &&
-                     strstr(inf.name, thrInfo[ind].thrNames[i]) == inf.name &&
-                     (ind == 4 || strlen(inf.name) ==
-                      strlen(thrInfo[ind].thrNames[i])));
-        }
-        if (printdump == JNI_TRUE) {
-            printf("\n");
+            found = (inf.name != NULL && strcmp(inf.name, thrInfo[ind].expected.thrNames[j]) == 0);
+            release(env, &inf);
         }
         if (!found) {
             printf("Point %d: thread %s not detected\n",
-                   ind, thrInfo[ind].thrNames[i]);
+                   ind, thrInfo[ind].expected.thrNames[i]);
             result = STATUS_FAILED;
         }
     }
@@ -262,33 +296,6 @@ JNIEXPORT void checkInfo(JNIEnv *env, int ind) {
                    TranslateError(err), err);
             result = STATUS_FAILED;
         }
-    }
-}
-
-JNIEXPORT void JNICALL Java_nsk_jvmti_GetAllThreads_allthr001_setSysCnt(JNIEnv *env, jclass cls) {
-    jint threadsCount = -1;
-    jthread *threads;
-    jvmtiError err;
-    int i;
-
-    err = jvmti->GetAllThreads(&threadsCount, &threads);
-    if (err != JVMTI_ERROR_NONE) {
-        printf("Failed to get all threads (count): %s (%d)\n",
-               TranslateError(err), err);
-        result = STATUS_FAILED;
-        return;
-    }
-
-    sys_cnt = threadsCount - 1;
-
-    for (i = 0; i < threadsCount; i++) {
-        if (!isThreadExpected(jvmti, threads[i])) {
-            sys_cnt--;
-        }
-    }
-
-    if (printdump == JNI_TRUE) {
-        printf(" >>> number of system threads: %d\n", sys_cnt);
     }
 }
 


### PR DESCRIPTION
The test counts all "system" threads before the execution and expects that this number remains the same during test execution.
This makes the test fragile - JVM may start internal threads, some threads may end.

The fix updates the test:
- the test checks only test threads, and verify that the live threads are reported by GetAllThreads and terminated threads are not reported;
- dropped "system" thread counting stuff;
- added proper deallocation of GetThreadInfo results.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [JDK-8284027](https://bugs.openjdk.java.net/browse/JDK-8284027): vmTestbase/nsk/jvmti/GetAllThreads/allthr001/ is failing


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8512/head:pull/8512` \
`$ git checkout pull/8512`

Update a local copy of the PR: \
`$ git checkout pull/8512` \
`$ git pull https://git.openjdk.java.net/jdk pull/8512/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8512`

View PR using the GUI difftool: \
`$ git pr show -t 8512`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8512.diff">https://git.openjdk.java.net/jdk/pull/8512.diff</a>

</details>
