### PR TITLE
8285976: compiler/exceptions/OptimizeImplicitExceptions.java can't pass with -XX:+DeoptimizeALot

### DIFF
--- a/test/hotspot/jtreg/compiler/exceptions/OptimizeImplicitExceptions.java
+++ b/test/hotspot/jtreg/compiler/exceptions/OptimizeImplicitExceptions.java
@@ -195,6 +195,16 @@ public class OptimizeImplicitExceptions {
             return;
         }
 
+        // The following options are both develop, getBooleanVMFlag() returns NULL in product build.
+        // If they are set in debug build, disable them for more test stability.
+        if (WB.getBooleanVMFlag("DeoptimizeALot")) {
+            WB.setBooleanVMFlag("DeoptimizeALot", false);
+        }
+
+        if (WB.getBooleanVMFlag("DeoptimizeRandom")) {
+            WB.setBooleanVMFlag("DeoptimizeRandom", false);
+        }
+
         // Initialize global deopt counts to zero.
         for (ImplicitException impExcp : ImplicitException.values()) {
             oldDeoptCountReason.put(impExcp.getReason(), 0);

--- a/test/hotspot/jtreg/compiler/exceptions/OptimizeImplicitExceptions.java
+++ b/test/hotspot/jtreg/compiler/exceptions/OptimizeImplicitExceptions.java
@@ -195,15 +195,10 @@ public class OptimizeImplicitExceptions {
             return;
         }
 
-        // The following options are both develop, getBooleanVMFlag() returns NULL in product build.
-        // If they are set in debug build, disable them for more test stability.
-        if (WB.getBooleanVMFlag("DeoptimizeALot")) {
-            WB.setBooleanVMFlag("DeoptimizeALot", false);
-        }
-
-        if (WB.getBooleanVMFlag("DeoptimizeRandom")) {
-            WB.setBooleanVMFlag("DeoptimizeRandom", false);
-        }
+        // The following options are both develop, or nops in product build.
+        // If they are set, disable them for test stability. It's fine because we use /othervm above.
+        WB.setBooleanVMFlag("DeoptimizeALot", false);
+        WB.setBooleanVMFlag("DeoptimizeRandom", false);
 
         // Initialize global deopt counts to zero.
         for (ImplicitException impExcp : ImplicitException.values()) {


### PR DESCRIPTION
Disable DeoptimizeALot and DeoptimizeRandom, 2 develop options when run this test for stability.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [JDK-8285976](https://bugs.openjdk.java.net/browse/JDK-8285976): compiler/exceptions/OptimizeImplicitExceptions.java can't pass with -XX:+DeoptimizeALot


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [131a4ad1](https://git.openjdk.java.net/jdk/pull/8513/files/131a4ad187716297c38d7b1eb5da4dbfe9cd205c)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Volker Simonis](https://openjdk.java.net/census#simonis) (@simonis - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8513/head:pull/8513` \
`$ git checkout pull/8513`

Update a local copy of the PR: \
`$ git checkout pull/8513` \
`$ git pull https://git.openjdk.java.net/jdk pull/8513/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8513`

View PR using the GUI difftool: \
`$ git pr show -t 8513`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8513.diff">https://git.openjdk.java.net/jdk/pull/8513.diff</a>

</details>
