### PR TITLE
8285885: Replay compilation fails with assert(is_valid()) failed: check invoke

### DIFF
--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -398,7 +398,12 @@ class CompileReplay : public StackObj {
 
       ik->link_class(CHECK_NULL);
 
-      Bytecode_invoke bytecode(caller, bci);
+      Bytecode_invoke bytecode = Bytecode_invoke_check(caller, bci);
+      if (!Bytecodes::is_defined(bytecode.code()) || !bytecode.is_valid()) {
+        report_error("no invoke found at bci");
+        return NULL;
+      }
+      bytecode.verify();
       int index = bytecode.index();
 
       ConstantPoolCacheEntry* cp_cache_entry = NULL;


### PR DESCRIPTION
This change makes replay more tolerant so it will fail gracefully instead of assert if it can't find an invoke bytecode at the desired bci.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [JDK-8285885](https://bugs.openjdk.java.net/browse/JDK-8285885): Replay compilation fails with assert(is_valid()) failed: check invoke


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8514/head:pull/8514` \
`$ git checkout pull/8514`

Update a local copy of the PR: \
`$ git checkout pull/8514` \
`$ git pull https://git.openjdk.java.net/jdk pull/8514/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8514`

View PR using the GUI difftool: \
`$ git pr show -t 8514`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8514.diff">https://git.openjdk.java.net/jdk/pull/8514.diff</a>

</details>
