### PR TITLE
JDK-8285921: serviceability/dcmd/jvmti/AttachFailed/AttachReturnError.java fails on Alpine

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/jvmti/AttachFailed/AttachReturnError.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/jvmti/AttachFailed/AttachReturnError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@ import jdk.test.lib.process.OutputAnalyzer;
 /*
  * @test
  * @bug 8165736 8252657
+ * @comment muslc dlclose is a no-op, see 8285921
+ * @requires !vm.musl
  * @library /test/lib
  * @run testng AttachReturnError
  */


### PR DESCRIPTION
The test  serviceability/dcmd/jvmti/AttachFailed/AttachReturnError.java fails on Alpine Linux using musl.
Reason is the difference how dlclose is done 
https://wiki.musl-libc.org/functional-differences-from-glibc.html
"musl’s dynamic loader loads libraries permanently for the lifetime of the process, until it exits or calls exec. dlclose is a no-op. "

This leads to "libReturnError.so found in stdout" when running the test on Alpine/musl , unlike on other Linux versions without musl.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [JDK-8285921](https://bugs.openjdk.java.net/browse/JDK-8285921): serviceability/dcmd/jvmti/AttachFailed/AttachReturnError.java fails on Alpine


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8515/head:pull/8515` \
`$ git checkout pull/8515`

Update a local copy of the PR: \
`$ git checkout pull/8515` \
`$ git pull https://git.openjdk.java.net/jdk pull/8515/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8515`

View PR using the GUI difftool: \
`$ git pr show -t 8515`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8515.diff">https://git.openjdk.java.net/jdk/pull/8515.diff</a>

</details>
