### PR TITLE
8286063: check compiler queue after calling AbstractCompiler::on_empty_queue

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -443,6 +443,11 @@ CompileTask* CompileQueue::get(CompilerThread* thread) {
     AbstractCompiler* compiler = thread->compiler();
     guarantee(compiler != nullptr, "Compiler object must exist");
     compiler->on_empty_queue(this, thread);
+    if (_first != nullptr) {
+      // The call to on_empty_queue may have temporarily unlocked the MCQ lock
+      // so check again whether any tasks were added to the queue.
+      break;
+    }
 
     // If there are no compilation tasks and we can compile new jobs
     // (i.e., there is enough free space in the code cache) there is


### PR DESCRIPTION
[JDK-8242440](https://bugs.openjdk.java.net/browse/JDK-8242440) added support for a JIT compiler to be notified when a `CompilerThread` has an empty compilation queue. It's possible for an implementation of `AbstractCompiler::on_empty_queue` to temporarily release `MethodCompileQueue_lock` (e.g. [here](https://github.com/openjdk/jdk/blob/357b1b18c20233f16fba872b79237e9459f5ba43/src/hotspot/share/jvmci/jvmciCompiler.cpp#L174)). This means a non-CompilerThread has a chance to enqueue a new compilation task. As such, the `CompilerThread` should check for this after calling `AbstractCompiler::on_empty_queue`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [JDK-8286063](https://bugs.openjdk.java.net/browse/JDK-8286063): check compiler queue after calling AbstractCompiler::on_empty_queue


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8517/head:pull/8517` \
`$ git checkout pull/8517`

Update a local copy of the PR: \
`$ git checkout pull/8517` \
`$ git pull https://git.openjdk.java.net/jdk pull/8517/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8517`

View PR using the GUI difftool: \
`$ git pr show -t 8517`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8517.diff">https://git.openjdk.java.net/jdk/pull/8517.diff</a>

</details>
