### PR TITLE
8284585: PushPromiseContinuation test fails intermittently in timeout

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -761,7 +761,7 @@ class Http2Connection  {
             }
 
             Stream<?> stream = getStream(streamid);
-            if (stream == null) {
+            if (stream == null && pushContinuationState == null) {
                 // Should never receive a frame with unknown stream id
 
                 if (frame instanceof HeaderFrame) {
@@ -801,7 +801,11 @@ class Http2Connection  {
             if (pushContinuationState != null) {
                 if (frame instanceof ContinuationFrame cf) {
                     try {
-                        handlePushContinuation(stream, cf);
+                        if (streamid == pushContinuationState.pushContFrame.streamid())
+                            handlePushContinuation(stream, cf);
+                        else
+                            protocolError(ErrorFrame.PROTOCOL_ERROR, "Received a Continuation Frame with an " +
+                                    "unexpected stream id");
                     } catch (UncheckedIOException e) {
                         debug.log("Error handling Push Promise with Continuation: " + e.getMessage(), e);
                         protocolError(ErrorFrame.PROTOCOL_ERROR, e.getMessage());
@@ -864,9 +868,19 @@ class Http2Connection  {
         // always decode the headers as they may affect connection-level HPACK
         // decoding state
         assert pushContinuationState == null;
+        int promisedStreamid = pp.getPromisedStream();
+        if (promisedStreamid != nextPushStream) {
+            resetStream(promisedStreamid, ResetFrame.PROTOCOL_ERROR);
+            return;
+        } else if (!reserveStream(false)) {
+            resetStream(promisedStreamid, ResetFrame.REFUSED_STREAM);
+            return;
+        } else {
+            nextPushStream += 2;
+        }
+
         HeaderDecoder decoder = new HeaderDecoder();
         decodeHeaders(pp, decoder);
-        int promisedStreamid = pp.getPromisedStream();
         if (pp.endHeaders()) {
             completePushPromise(promisedStreamid, parent, decoder.headers());
         } else {
@@ -888,19 +902,7 @@ class Http2Connection  {
 
     private <T> void completePushPromise(int promisedStreamid, Stream<T> parent, HttpHeaders headers)
             throws IOException {
-        // Perhaps the following checks could be moved to handlePushPromise()
-        // to reset the PushPromise stream earlier?
         HttpRequestImpl parentReq = parent.request;
-        if (promisedStreamid != nextPushStream) {
-            resetStream(promisedStreamid, ResetFrame.PROTOCOL_ERROR);
-            return;
-        } else if (!reserveStream(false)) {
-            resetStream(promisedStreamid, ResetFrame.REFUSED_STREAM);
-            return;
-        } else {
-            nextPushStream += 2;
-        }
-
         HttpRequestImpl pushReq = HttpRequestImpl.createPushRequest(parentReq, headers);
         Exchange<T> pushExch = new Exchange<>(pushReq, parent.exchange.multi);
         Stream.PushedStream<T> pushStream = createPushStream(parent, pushExch);
@@ -944,6 +946,7 @@ class Http2Connection  {
         } finally {
             decrementStreamsCount(streamid);
             closeStream(streamid);
+            System.err.println("closeStream");
         }
     }
 

--- a/test/jdk/java/net/httpclient/http2/PushPromiseContinuation.java
+++ b/test/jdk/java/net/httpclient/http2/PushPromiseContinuation.java
@@ -248,9 +248,7 @@ public class PushPromiseContinuation {
             HttpHeaders pushPromiseHeaders = pushPromiseHeadersBuilder.build();
             testHeaders = testHeadersBuilder.build();
             // Create the Push Promise Frame
-            OutgoingPushPromise pp = new OutgoingPushPromise(streamid, uri, pushPromiseHeaders, content);
-            if (!cfs.isEmpty())
-                cfs.forEach(pp::addContinuation);
+            OutgoingPushPromise pp = new OutgoingPushPromise(streamid, uri, pushPromiseHeaders, content, cfs);
 
             // Indicates to the client that a continuation should be expected
             pp.setFlag(0x0);

--- a/test/jdk/java/net/httpclient/http2/PushPromiseContinuation.java
+++ b/test/jdk/java/net/httpclient/http2/PushPromiseContinuation.java
@@ -61,12 +61,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiPredicate;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.*;
 
 public class PushPromiseContinuation {
 
@@ -97,7 +98,7 @@ public class PushPromiseContinuation {
 
         // Need to have a custom exchange supplier to manage the server's push
         // promise with continuation flow
-        server.setExchangeSupplier(Http2LPPTestExchangeImpl::new);
+        server.setExchangeSupplier(Http2PushPromiseContinuationExchangeImpl::new);
 
         System.err.println("PushPromiseContinuation: Server listening on port " + server.getAddress().getPort());
         server.start();
@@ -166,6 +167,31 @@ public class PushPromiseContinuation {
         verify(resp);
     }
 
+    @Test
+    public void testSendHeadersOnPushPromiseStream() throws Exception {
+        // This test server sends a push promise that should be followed by a continuation but
+        // incorrectly sends on Response Headers while the client awaits the continuation.
+        Http2TestServer faultyServer = new Http2TestServer(false, 0);
+        faultyServer.addHandler(new ServerPushHandler(), "/");
+        faultyServer.setExchangeSupplier(Http2PushPromiseHeadersExchangeImpl::new);
+        System.err.println("PushPromiseContinuation: FaultyServer listening on port " + faultyServer.getAddress().getPort());
+        faultyServer.start();
+
+        int faultyPort = faultyServer.getAddress().getPort();
+        URI faultyUri = new URI("http://localhost:" + faultyPort + "/");
+
+        HttpClient client = HttpClient.newHttpClient();
+        // Server is making a request to an incorrect URI
+        HttpRequest hreq = HttpRequest.newBuilder(faultyUri).version(HttpClient.Version.HTTP_2).GET().build();
+        CompletableFuture<HttpResponse<String>> cf =
+                client.sendAsync(hreq, HttpResponse.BodyHandlers.ofString(UTF_8), pph);
+
+        CompletionException t = expectThrows(CompletionException.class, () -> cf.join());
+        assertEquals(t.getCause().getClass(), IOException.class, "Expected an IOException but got " + t.getCause());
+        System.err.println("Client received the following expected exception: " + t.getCause());
+        faultyServer.stop();
+    }
+
     private void verify(HttpResponse<String> resp) {
         assertEquals(resp.statusCode(), 200);
         assertEquals(resp.body(), mainResponseBody);
@@ -186,15 +212,46 @@ public class PushPromiseContinuation {
         }
     }
 
-    static class Http2LPPTestExchangeImpl extends Http2TestExchangeImpl {
+    static class Http2PushPromiseHeadersExchangeImpl extends Http2TestExchangeImpl {
+
+        Http2PushPromiseHeadersExchangeImpl(int streamid, String method, HttpHeaders reqheaders, HttpHeadersBuilder rspheadersBuilder, URI uri, InputStream is, SSLSession sslSession, BodyOutputStream os, Http2TestServerConnection conn, boolean pushAllowed) {
+            super(streamid, method, reqheaders, rspheadersBuilder, uri, is, sslSession, os, conn, pushAllowed);
+        }
+
+
+        @Override
+        public void serverPush(URI uri, HttpHeaders headers, InputStream content) {
+            HttpHeadersBuilder headersBuilder = new HttpHeadersBuilder();
+            headersBuilder.setHeader(":method", "GET");
+            headersBuilder.setHeader(":scheme", uri.getScheme());
+            headersBuilder.setHeader(":authority", uri.getAuthority());
+            headersBuilder.setHeader(":path", uri.getPath());
+            for (Map.Entry<String,List<String>> entry : headers.map().entrySet()) {
+                for (String value : entry.getValue())
+                    headersBuilder.addHeader(entry.getKey(), value);
+            }
+            HttpHeaders combinedHeaders = headersBuilder.build();
+            OutgoingPushPromise pp = new OutgoingPushPromise(streamid, uri, combinedHeaders, content);
+            // Indicates to the client that a continuation should be expected
+            pp.setFlag(0x0);
+            try {
+                conn.outputQ.put(pp);
+                // writeLoop will spin up thread to read the InputStream
+            } catch (IOException ex) {
+                System.err.println("TestServer: pushPromise exception: " + ex);
+            }
+        }
+    }
+
+    static class Http2PushPromiseContinuationExchangeImpl extends Http2TestExchangeImpl {
 
         HttpHeadersBuilder pushPromiseHeadersBuilder;
         List<ContinuationFrame> cfs;
 
-        Http2LPPTestExchangeImpl(int streamid, String method, HttpHeaders reqheaders,
-                                 HttpHeadersBuilder rspheadersBuilder, URI uri, InputStream is,
-                                 SSLSession sslSession, BodyOutputStream os,
-                                 Http2TestServerConnection conn, boolean pushAllowed) {
+        Http2PushPromiseContinuationExchangeImpl(int streamid, String method, HttpHeaders reqheaders,
+                                                 HttpHeadersBuilder rspheadersBuilder, URI uri, InputStream is,
+                                                 SSLSession sslSession, BodyOutputStream os,
+                                                 Http2TestServerConnection conn, boolean pushAllowed) {
             super(streamid, method, reqheaders, rspheadersBuilder, uri, is, sslSession, os, conn, pushAllowed);
         }
 

--- a/test/jdk/java/net/httpclient/http2/PushPromiseContinuation.java
+++ b/test/jdk/java/net/httpclient/http2/PushPromiseContinuation.java
@@ -249,6 +249,9 @@ public class PushPromiseContinuation {
             testHeaders = testHeadersBuilder.build();
             // Create the Push Promise Frame
             OutgoingPushPromise pp = new OutgoingPushPromise(streamid, uri, pushPromiseHeaders, content);
+            if (!cfs.isEmpty())
+                cfs.forEach(pp::addContinuation);
+
             // Indicates to the client that a continuation should be expected
             pp.setFlag(0x0);
 
@@ -256,10 +259,6 @@ public class PushPromiseContinuation {
                 // Schedule push promise and continuation for sending
                 conn.outputQ.put(pp);
                 System.err.println("Server: Scheduled a Push Promise to Send");
-                for (ContinuationFrame cf : cfs) {
-                    conn.outputQ.put(cf);
-                    System.err.println("Server: Scheduled a Continuation to Send");
-                }
             } catch (IOException ex) {
                 System.err.println("Server: pushPromise exception: " + ex);
             }

--- a/test/jdk/java/net/httpclient/http2/server/Http2TestServerConnection.java
+++ b/test/jdk/java/net/httpclient/http2/server/Http2TestServerConnection.java
@@ -22,6 +22,7 @@
  */
 
 import jdk.internal.net.http.common.HttpHeadersBuilder;
+import jdk.internal.net.http.frame.ContinuationFrame;
 import jdk.internal.net.http.frame.DataFrame;
 import jdk.internal.net.http.frame.ErrorFrame;
 import jdk.internal.net.http.frame.FramesDecoder;
@@ -945,6 +946,12 @@ public class Http2TestServerConnection {
         nextPushStreamId += 2;
         pp.streamid(op.parentStream);
         writeFrame(pp);
+        if (pp.getFlags() != HeadersFrame.END_HEADERS && op.hasContinuations()) {
+            LinkedList<ContinuationFrame> continuations = new LinkedList<>(op.getContinuations());
+            while (!continuations.isEmpty()) {
+                writeFrame(continuations.pop());
+            }
+        }
         final InputStream ii = op.is;
         final BodyOutputStream oo = new BodyOutputStream(
                 promisedStreamid,

--- a/test/jdk/java/net/httpclient/http2/server/Http2TestServerConnection.java
+++ b/test/jdk/java/net/httpclient/http2/server/Http2TestServerConnection.java
@@ -22,7 +22,6 @@
  */
 
 import jdk.internal.net.http.common.HttpHeadersBuilder;
-import jdk.internal.net.http.frame.ContinuationFrame;
 import jdk.internal.net.http.frame.DataFrame;
 import jdk.internal.net.http.frame.ErrorFrame;
 import jdk.internal.net.http.frame.FramesDecoder;
@@ -946,10 +945,11 @@ public class Http2TestServerConnection {
         nextPushStreamId += 2;
         pp.streamid(op.parentStream);
         writeFrame(pp);
-        if (pp.getFlags() != HeadersFrame.END_HEADERS) {
-            for (ContinuationFrame cf : op.getContinuations())
-                writeFrame(cf);
-        }
+        // No need to check for END_HEADERS flag here to allow for tests to simulate bad server side
+        // behavior i.e Continuation Frames included with END_HEADERS flag set
+        for (Http2Frame cf : op.getContinuations())
+            writeFrame(cf);
+
         final InputStream ii = op.is;
         final BodyOutputStream oo = new BodyOutputStream(
                 promisedStreamid,

--- a/test/jdk/java/net/httpclient/http2/server/Http2TestServerConnection.java
+++ b/test/jdk/java/net/httpclient/http2/server/Http2TestServerConnection.java
@@ -946,11 +946,9 @@ public class Http2TestServerConnection {
         nextPushStreamId += 2;
         pp.streamid(op.parentStream);
         writeFrame(pp);
-        if (pp.getFlags() != HeadersFrame.END_HEADERS && op.hasContinuations()) {
-            LinkedList<ContinuationFrame> continuations = new LinkedList<>(op.getContinuations());
-            while (!continuations.isEmpty()) {
-                writeFrame(continuations.pop());
-            }
+        if (pp.getFlags() != HeadersFrame.END_HEADERS) {
+            for (ContinuationFrame cf : op.getContinuations())
+                writeFrame(cf);
         }
         final InputStream ii = op.is;
         final BodyOutputStream oo = new BodyOutputStream(

--- a/test/jdk/java/net/httpclient/http2/server/OutgoingPushPromise.java
+++ b/test/jdk/java/net/httpclient/http2/server/OutgoingPushPromise.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,9 @@
 import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpHeaders;
+import java.util.LinkedList;
+
+import jdk.internal.net.http.frame.ContinuationFrame;
 import jdk.internal.net.http.frame.Http2Frame;
 
 // will be converted to a PushPromiseFrame in the writeLoop
@@ -33,6 +36,7 @@ class OutgoingPushPromise extends Http2Frame {
     final URI uri;
     final InputStream is;
     final int parentStream; // not the pushed streamid
+    private LinkedList<ContinuationFrame> continuations;
 
     public OutgoingPushPromise(int parentStream,
                                URI uri,
@@ -45,4 +49,17 @@ class OutgoingPushPromise extends Http2Frame {
         this.parentStream = parentStream;
     }
 
+    public void addContinuation(ContinuationFrame cf) {
+        if (continuations == null)
+            continuations = new LinkedList<>();
+        continuations.add(cf);
+    }
+
+    public boolean hasContinuations() {
+        return !continuations.isEmpty();
+    }
+
+    public LinkedList<ContinuationFrame> getContinuations() {
+        return continuations;
+    }
 }

--- a/test/jdk/java/net/httpclient/http2/server/OutgoingPushPromise.java
+++ b/test/jdk/java/net/httpclient/http2/server/OutgoingPushPromise.java
@@ -25,8 +25,10 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpHeaders;
 import java.util.LinkedList;
+import java.util.List;
 
 import jdk.internal.net.http.frame.ContinuationFrame;
+import jdk.internal.net.http.frame.HeaderFrame;
 import jdk.internal.net.http.frame.Http2Frame;
 
 // will be converted to a PushPromiseFrame in the writeLoop
@@ -36,7 +38,7 @@ class OutgoingPushPromise extends Http2Frame {
     final URI uri;
     final InputStream is;
     final int parentStream; // not the pushed streamid
-    private LinkedList<ContinuationFrame> continuations;
+    private final List<ContinuationFrame> continuations;
 
     public OutgoingPushPromise(int parentStream,
                                URI uri,
@@ -47,19 +49,24 @@ class OutgoingPushPromise extends Http2Frame {
         this.headers = headers;
         this.is = is;
         this.parentStream = parentStream;
+        this.continuations = null;
     }
 
-    public void addContinuation(ContinuationFrame cf) {
-        if (continuations == null)
-            continuations = new LinkedList<>();
-        continuations.add(cf);
+    public OutgoingPushPromise(int parentStream,
+                               URI uri,
+                               HttpHeaders headers,
+                               InputStream is,
+                               List<ContinuationFrame> continuations) {
+        super(0,0);
+        assert flags != HeaderFrame.END_HEADERS;
+        this.uri = uri;
+        this.headers = headers;
+        this.is = is;
+        this.parentStream = parentStream;
+        this.continuations = List.copyOf(continuations);
     }
 
-    public boolean hasContinuations() {
-        return !continuations.isEmpty();
-    }
-
-    public LinkedList<ContinuationFrame> getContinuations() {
+    public List<ContinuationFrame> getContinuations() {
         return continuations;
     }
 }

--- a/test/jdk/java/net/httpclient/http2/server/OutgoingPushPromise.java
+++ b/test/jdk/java/net/httpclient/http2/server/OutgoingPushPromise.java
@@ -24,11 +24,9 @@
 import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpHeaders;
-import java.util.LinkedList;
 import java.util.List;
 
 import jdk.internal.net.http.frame.ContinuationFrame;
-import jdk.internal.net.http.frame.HeaderFrame;
 import jdk.internal.net.http.frame.Http2Frame;
 
 // will be converted to a PushPromiseFrame in the writeLoop
@@ -38,18 +36,13 @@ class OutgoingPushPromise extends Http2Frame {
     final URI uri;
     final InputStream is;
     final int parentStream; // not the pushed streamid
-    private final List<ContinuationFrame> continuations;
+    private final List<Http2Frame> continuations;
 
     public OutgoingPushPromise(int parentStream,
                                URI uri,
                                HttpHeaders headers,
                                InputStream is) {
-        super(0,0);
-        this.uri = uri;
-        this.headers = headers;
-        this.is = is;
-        this.parentStream = parentStream;
-        this.continuations = null;
+        this(parentStream, uri, headers, is, List.of());
     }
 
     public OutgoingPushPromise(int parentStream,
@@ -58,7 +51,6 @@ class OutgoingPushPromise extends Http2Frame {
                                InputStream is,
                                List<ContinuationFrame> continuations) {
         super(0,0);
-        assert flags != HeaderFrame.END_HEADERS;
         this.uri = uri;
         this.headers = headers;
         this.is = is;
@@ -66,7 +58,7 @@ class OutgoingPushPromise extends Http2Frame {
         this.continuations = List.copyOf(continuations);
     }
 
-    public List<ContinuationFrame> getContinuations() {
+    public List<Http2Frame> getContinuations() {
         return continuations;
     }
 }


### PR DESCRIPTION
**Issue**
A recent fix for [JDK-8263031](https://bugs.openjdk.java.net/browse/JDK-8263031), which addressed the httpclient being unable to properly process Http/2 PushPromise frames followed by continuations caused intermittent failures of the test. This was cause by two seperate problems. 

- Firstly, on the client side, `Http2Connection.processFrame` did not a check for whether or not a Continuation was to be expected early on in the method resulting in frames other than the expected Continuation Frame being incorrectly processed. In Http/2, when a Continuation Frame is expected, no other type of frame should be processed without a connection error of type PROTOCOL_ERROR being thrown.
- Secondly, `Http2TestConnection.handlePush` had no guards around response headers and data frames being sent before a continuation is sent which resulted in the intermittent nature of this timeout. 

**Proposed Solution**
The test class `OutgoingPushPromise` was modified to contain a list of Continuation Frames as required rather than the Continuations being scheduled to send in the test itself. This prevents the situation of unexpected frames being sent before a Continuation Frame was meant to arrive. 

In addition to the above, Http2Connection was modified to ensure that a connection error of type PROTOCOL_ERROR is thrown if a frame other than a Continuation arrives at the client unexpectedly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8284585](https://bugs.openjdk.java.net/browse/JDK-8284585): PushPromiseContinuation test fails intermittently in timeout


### Reviewers
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8518/head:pull/8518` \
`$ git checkout pull/8518`

Update a local copy of the PR: \
`$ git checkout pull/8518` \
`$ git pull https://git.openjdk.java.net/jdk pull/8518/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8518`

View PR using the GUI difftool: \
`$ git pr show -t 8518`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8518.diff">https://git.openjdk.java.net/jdk/pull/8518.diff</a>

</details>
