### PR TITLE
8286092: Remove dead windows stack code

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -554,13 +554,6 @@ static unsigned __stdcall thread_native_entry(Thread* thread) {
 
   log_info(os, thread)("Thread finished (tid: " UINTX_FORMAT ").", os::current_thread_id());
 
-  // One less thread is executing
-  // When the VMThread gets here, the main thread may have already exited
-  // which frees the CodeHeap containing the Atomic::add code
-  if (thread != VMThread::vm_thread() && VMThread::vm_thread() != NULL) {
-    Atomic::dec(&os::win32::_os_thread_count);
-  }
-
   // Thread must not return from exit_process_or_thread(), but if it does,
   // let it proceed to exit normally
   return (unsigned)os::win32::exit_process_or_thread(os::win32::EPT_THREAD, res);
@@ -774,8 +767,6 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
     delete osthread;
     return false;
   }
-
-  Atomic::inc(&os::win32::_os_thread_count);
 
   // Store info on the Win32 thread into the OSThread
   osthread->set_thread_handle(thread_handle);
@@ -3876,9 +3867,6 @@ int    os::win32::_processor_type            = 0;
 int    os::win32::_processor_level           = 0;
 julong os::win32::_physical_memory           = 0;
 
-intx          os::win32::_os_thread_limit    = 0;
-volatile intx os::win32::_os_thread_count    = 0;
-
 bool   os::win32::_is_windows_server         = false;
 
 // 6573254
@@ -4288,27 +4276,6 @@ jint os::init_2(void) {
   if (set_minimum_stack_sizes() == JNI_ERR) {
     return JNI_ERR;
   }
-
-  size_t actual_reserve_size = JavaThread::stack_size_at_create();
-  if (actual_reserve_size == 0) {
-    // -Xss or -XX:ThreadStackSize were not given, use the current stack size.
-    actual_reserve_size = current_stack_size();
-  }
-
-  // Calculate theoretical max. size of Threads to guard against artificial
-  // out-of-memory situations, where all available address-space has been
-  // reserved by thread stacks.
-  assert(actual_reserve_size != 0, "Must have a stack");
-
-  // Calculate the thread limit when we should start doing Virtual Memory
-  // banging. Currently when the threads will have used all but 200Mb of space.
-  //
-  // TODO: consider performing a similar calculation for commit size instead
-  // as reserve size, since on a 64-bit platform we'll run into that more
-  // often than running out of virtual memory space.  We can use the
-  // lower value of the two calculations as the os_thread_limit.
-  size_t max_address_space = ((size_t)1 << (BitsPerWord - 1)) - (200 * K * K);
-  win32::_os_thread_limit = (intx)(max_address_space / actual_reserve_size);
 
   // at exit methods are called in the reverse order of their registration.
   // there is no limit to the number of functions registered. atexit does

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -82,10 +82,6 @@ class win32 {
  public:
   // Generic interface:
 
-  // Trace number of created threads
-  static          intx  _os_thread_limit;
-  static volatile intx  _os_thread_count;
-
   // Tells whether this is a server version of Windows
   static bool is_windows_server() { return _is_windows_server; }
 


### PR DESCRIPTION
In reviewing JDK-[8285832](https://bugs.openjdk.java.net/browse/JDK-8285832) @iklam noticed the code following the minimum stack size calculation is dead.  This change removes the dead code, plus an unused os_thread_counter nearby.
This code predates mercurial.
Tested with tier1 on windows-x64 and windows-x64-debug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [JDK-8286092](https://bugs.openjdk.java.net/browse/JDK-8286092): Remove dead windows stack code


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8524/head:pull/8524` \
`$ git checkout pull/8524`

Update a local copy of the PR: \
`$ git checkout pull/8524` \
`$ git pull https://git.openjdk.java.net/jdk pull/8524/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8524`

View PR using the GUI difftool: \
`$ git pr show -t 8524`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8524.diff">https://git.openjdk.java.net/jdk/pull/8524.diff</a>

</details>
