### PR TITLE
8286105: SourceRevision.gmk should respect GIT variable

### DIFF
--- a/make/SourceRevision.gmk
+++ b/make/SourceRevision.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -50,8 +50,8 @@ else ifneq ($(and $(GIT), $(wildcard $(TOPDIR)/.git)), )
   USE_SCM := true
   SCM_DIR := .git
   ID_COMMAND := $(PRINTF) "git:%s%s\n" \
-      "$$(git log -n1 --format=%H | cut -c1-12)" \
-      "$$(if test -n "$$(git status --porcelain)"; then printf '+'; fi)"
+      "$$($(GIT) log -n1 --format=%H | cut -c1-12)" \
+      "$$(if test -n "$$($(GIT) status --porcelain)"; then printf '+'; fi)"
 endif
 
 ifeq ($(USE_SCM), true)


### PR DESCRIPTION
We can specify `git` binary via `GIT` in configure script, but it does not affect in SourceRevision.gmk .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [JDK-8286105](https://bugs.openjdk.java.net/browse/JDK-8286105): SourceRevision.gmk should respect GIT variable


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8526/head:pull/8526` \
`$ git checkout pull/8526`

Update a local copy of the PR: \
`$ git checkout pull/8526` \
`$ git pull https://git.openjdk.java.net/jdk pull/8526/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8526`

View PR using the GUI difftool: \
`$ git pr show -t 8526`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8526.diff">https://git.openjdk.java.net/jdk/pull/8526.diff</a>

</details>
