### PR TITLE
8277493: [REDO] Quarantined jpackage apps are labeled as "damaged"

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
@@ -178,6 +178,10 @@ final public class TKit {
         return (OS.contains("mac"));
     }
 
+    public static boolean isArmMac() {
+        return (isOSX() && "aarch64".equals(System.getProperty("os.arch")));
+    }
+
     public static boolean isLinux() {
         return ((OS.contains("nix") || OS.contains("nux")));
     }

--- a/test/jdk/tools/jpackage/macosx/SigningAppImageTest.java
+++ b/test/jdk/tools/jpackage/macosx/SigningAppImageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,8 +22,11 @@
  */
 
 import java.nio.file.Path;
+import java.util.List;
+
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.Annotations.Test;
+import jdk.jpackage.test.Annotations.Parameters;
 import jdk.jpackage.test.AdditionalLauncher;
 
 /**
@@ -58,27 +61,41 @@ import jdk.jpackage.test.AdditionalLauncher;
  */
 public class SigningAppImageTest {
 
+    final boolean doSign;
+
+    public SigningAppImageTest(String flag) {
+        this.doSign = "true".equals(flag);
+    }
+
+    @Parameters
+    public static List<Object[]> data() {
+        return List.of(new Object[][] {{"true"}, {"false"}});
+    }
+
     @Test
-    public static void test() throws Exception {
+    public void test() throws Exception {
         SigningCheck.checkCertificates();
 
         JPackageCommand cmd = JPackageCommand.helloAppImage();
-        cmd.addArguments("--mac-sign", "--mac-signing-key-user-name",
-                SigningBase.DEV_NAME, "--mac-signing-keychain",
-                SigningBase.KEYCHAIN);
-
+        if (doSign) {
+            cmd.addArguments("--mac-sign", "--mac-signing-key-user-name",
+                    SigningBase.DEV_NAME, "--mac-signing-keychain",
+                    SigningBase.KEYCHAIN);
+        }
         AdditionalLauncher testAL = new AdditionalLauncher("testAL");
         testAL.applyTo(cmd);
         cmd.executeAndAssertHelloAppImageCreated();
 
         Path launcherPath = cmd.appLauncherPath();
-        SigningBase.verifyCodesign(launcherPath, true);
+        SigningBase.verifyCodesign(launcherPath, doSign);
 
         Path testALPath = launcherPath.getParent().resolve("testAL");
-        SigningBase.verifyCodesign(testALPath, true);
+        SigningBase.verifyCodesign(testALPath, doSign);
 
         Path appImage = cmd.outputBundle();
-        SigningBase.verifyCodesign(appImage, true);
-        SigningBase.verifySpctl(appImage, "exec");
+        SigningBase.verifyCodesign(appImage, doSign);
+        if (doSign) {
+            SigningBase.verifySpctl(appImage, "exec");
+        }
     }
 }

--- a/test/jdk/tools/jpackage/macosx/SigningAppImageTest.java
+++ b/test/jdk/tools/jpackage/macosx/SigningAppImageTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.Annotations.Test;
-import jdk.jpackage.test.Annotations.Parameters;
+import jdk.jpackage.test.Annotations.Parameter;
 import jdk.jpackage.test.AdditionalLauncher;
 
 /**
@@ -61,19 +61,10 @@ import jdk.jpackage.test.AdditionalLauncher;
  */
 public class SigningAppImageTest {
 
-    final boolean doSign;
-
-    public SigningAppImageTest(String flag) {
-        this.doSign = "true".equals(flag);
-    }
-
-    @Parameters
-    public static List<Object[]> data() {
-        return List.of(new Object[][] {{"true"}, {"false"}});
-    }
-
     @Test
-    public void test() throws Exception {
+    @Parameter("true")
+    @Parameter("false")
+    public void test(boolean doSign) throws Exception {
         SigningCheck.checkCertificates();
 
         JPackageCommand cmd = JPackageCommand.helloAppImage();

--- a/test/jdk/tools/jpackage/share/AppContentTest.java
+++ b/test/jdk/tools/jpackage/share/AppContentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,7 +99,9 @@ public class AppContentTest {
                 }
 
             })
-            .setExpectedExitCode(testPathArgs.contains(TEST_BAD) ? 1 : 0)
+            // On macOS aarch64 we always signing app image and signing will fail, since
+            // test produces invalid app bundle.
+            .setExpectedExitCode(testPathArgs.contains(TEST_BAD) || TKit.isArmMac() ? 1 : 0)
             .run();
         }
 }


### PR DESCRIPTION
- No changes to code provided by original fix.
 - Added ad hoc signing on macOS aarch64, since macOS aarch64 cannot execute unsigned code and code should be at least ad hoc signed.
 - Signing of app bundle produced by AppContentTest.java fails, since it has invalid app bundle structure with added files into Content folder. Thus test is executed but failure is always expected on macOS aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8277493](https://bugs.openjdk.java.net/browse/JDK-8277493): [REDO] Quarantined jpackage apps are labeled as "damaged"


### Reviewers
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8527/head:pull/8527` \
`$ git checkout pull/8527`

Update a local copy of the PR: \
`$ git checkout pull/8527` \
`$ git pull https://git.openjdk.java.net/jdk pull/8527/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8527`

View PR using the GUI difftool: \
`$ git pr show -t 8527`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8527.diff">https://git.openjdk.java.net/jdk/pull/8527.diff</a>

</details>
