### PR TITLE
8030121: java/awt/dnd/MissingDragExitEventTest/MissingDragExitEventTest.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -429,7 +429,6 @@ java/awt/image/VolatileImage/GradientPaints.java 8199003 linux-all
 java/awt/JAWT/JAWT.sh 8197798 windows-all,linux-all
 java/awt/datatransfer/ConstructFlavoredObjectTest/ConstructFlavoredObjectTest.java 8202860 linux-all
 java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java 8202882 linux-all
-java/awt/dnd/MissingDragExitEventTest/MissingDragExitEventTest.java 8030121 macosx-all,linux-all
 java/awt/Choice/ChoicePopupLocation/ChoicePopupLocation.java 8202931 macosx-all,linux-all
 java/awt/Focus/NonFocusableBlockedOwnerTest/NonFocusableBlockedOwnerTest.java 7124275 macosx-all
 java/awt/Focus/TranserFocusToWindow/TranserFocusToWindow.java 6848810 macosx-all,linux-all


### PR DESCRIPTION
Removing MissingDragExitEventTest.java from ProblemList as JDK-8274597 already fixed the test and it's working fine now.

Testing:
MissingDragExitEventTest.java test has been run 10 times on all 3 platforms and got all Pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8030121](https://bugs.openjdk.java.net/browse/JDK-8030121): java/awt/dnd/MissingDragExitEventTest/MissingDragExitEventTest.java fails


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8529/head:pull/8529` \
`$ git checkout pull/8529`

Update a local copy of the PR: \
`$ git checkout pull/8529` \
`$ git pull https://git.openjdk.java.net/jdk pull/8529/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8529`

View PR using the GUI difftool: \
`$ git pr show -t 8529`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8529.diff">https://git.openjdk.java.net/jdk/pull/8529.diff</a>

</details>
