### PR TITLE
8262004: Classpath separator: Man page says semicolon; should be colon on Linux

### DIFF
--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -467,7 +467,7 @@ and file name of the library.
 .RE
 .TP
 .B \f[CB]\-\-class\-path\f[R] \f[I]classpath\f[R], \f[CB]\-classpath\f[R] \f[I]classpath\f[R], or \f[CB]\-cp\f[R] \f[I]classpath\f[R]
-A semicolon (\f[CB];\f[R]) separated list of directories, JAR archives,
+A colon (\f[CB]:\f[R]) separated list of directories, JAR archives,
 and ZIP archives to search for class files.
 .RS
 .PP
@@ -522,13 +522,13 @@ invoked.
 .RE
 .TP
 .B \f[CB]\-\-module\-path\f[R] \f[I]modulepath\f[R]... or \f[CB]\-p\f[R] \f[I]modulepath\f[R]
-A semicolon (\f[CB];\f[R]) separated list of directories in which each
+A colon (\f[CB]:\f[R]) separated list of directories in which each
 directory is a directory of modules.
 .RS
 .RE
 .TP
 .B \f[CB]\-\-upgrade\-module\-path\f[R] \f[I]modulepath\f[R]...
-A semicolon (\f[CB];\f[R]) separated list of directories in which each
+A colon (\f[CB]:\f[R]) separated list of directories in which each
 directory is a directory of modules that replace upgradeable modules in
 the runtime image.
 .RS

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -471,9 +471,8 @@ Specifies a list of directories, JAR archives, and ZIP archives to search
 for class files.
 .RS
 .PP
-\f[B]Linux and macOS:\f[R] Colons (\f[CB]:\f[R]) separate entities in this list.
-.PP
-\f[B]Windows:\f[R] Semicolons (\f[CB];\f[R]) separate entities in this list.
+On Windows, semicolons (\f[CB];\f[R]) separate entities in this list;
+on other platforms it is a colon (\f[CB]:\f[R]).
 .PP
 Specifying \f[I]classpath\f[R] overrides any setting of the
 \f[CB]CLASSPATH\f[R] environment variable.
@@ -530,9 +529,8 @@ Specifies a list of directories in which each directory is a directory
 of modules.
 .RS
 .PP
-\f[B]Linux and macOS:\f[R] Colons (\f[CB]:\f[R]) separate directories in this list.
-.PP
-\f[B]Windows:\f[R] Semicolons (\f[CB];\f[R]) separate directories in this list.
+On Windows, semicolons (\f[CB];\f[R]) separate directories in this list;
+on other platforms it is a colon (\f[CB]:\f[R]).
 .RE
 .TP
 .B \f[CB]\-\-upgrade\-module\-path\f[R] \f[I]modulepath\f[R]...
@@ -540,9 +538,8 @@ Specifies a list of directories in which each directory is a directory
 of modules that replace upgradeable modules in the runtime image.
 .RS
 .PP
-\f[B]Linux and macOS:\f[R] Colons (\f[CB]:\f[R]) separate directories in this list.
-.PP
-\f[B]Windows:\f[R] Semicolons (\f[CB];\f[R]) separate directories in this list.
+On Windows, semicolons (\f[CB];\f[R]) separate directories in this list;
+on other platforms it is a colon (\f[CB]:\f[R]).
 .RE
 .TP
 .B \f[CB]\-\-add\-modules\f[R] \f[I]module\f[R][\f[CB],\f[R]\f[I]module\f[R]...]
@@ -805,11 +802,8 @@ Specifies a list of directories, JAR files, and ZIP archives to append
 to the end of the default bootstrap class path.
 .RS
 .PP
-\f[B]Linux and macOS:\f[R] Colons (\f[CB]:\f[R]) separate entities in this
-list.
-.PP
-\f[B]Windows:\f[R] Semicolons (\f[CB];\f[R]) separate entities in this
-list.
+On Windows, semicolons (\f[CB];\f[R]) separate entities in this list;
+on other platforms it is a colon (\f[CB]:\f[R]).
 .RE
 .TP
 .B \f[CB]\-Xcheck:jni\f[R]

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -467,9 +467,13 @@ and file name of the library.
 .RE
 .TP
 .B \f[CB]\-\-class\-path\f[R] \f[I]classpath\f[R], \f[CB]\-classpath\f[R] \f[I]classpath\f[R], or \f[CB]\-cp\f[R] \f[I]classpath\f[R]
-A colon (\f[CB]:\f[R]) separated list of directories, JAR archives,
-and ZIP archives to search for class files.
+Specifies a list of directories, JAR archives, and ZIP archives to search
+for class files.
 .RS
+.PP
+\f[B]Linux and macOS:\f[R] Colons (\f[CB]:\f[R]) separate entities in this list.
+.PP
+\f[B]Windows:\f[R] Semicolons (\f[CB];\f[R]) separate entities in this list.
 .PP
 Specifying \f[I]classpath\f[R] overrides any setting of the
 \f[CB]CLASSPATH\f[R] environment variable.
@@ -522,16 +526,23 @@ invoked.
 .RE
 .TP
 .B \f[CB]\-\-module\-path\f[R] \f[I]modulepath\f[R]... or \f[CB]\-p\f[R] \f[I]modulepath\f[R]
-A colon (\f[CB]:\f[R]) separated list of directories in which each
-directory is a directory of modules.
+Specifies a list of directories in which each directory is a directory
+of modules.
 .RS
+.PP
+\f[B]Linux and macOS:\f[R] Colons (\f[CB]:\f[R]) separate directories in this list.
+.PP
+\f[B]Windows:\f[R] Semicolons (\f[CB];\f[R]) separate directories in this list.
 .RE
 .TP
 .B \f[CB]\-\-upgrade\-module\-path\f[R] \f[I]modulepath\f[R]...
-A colon (\f[CB]:\f[R]) separated list of directories in which each
-directory is a directory of modules that replace upgradeable modules in
-the runtime image.
+Specifies a list of directories in which each directory is a directory
+of modules that replace upgradeable modules in the runtime image.
 .RS
+.PP
+\f[B]Linux and macOS:\f[R] Colons (\f[CB]:\f[R]) separate directories in this list.
+.PP
+\f[B]Windows:\f[R] Semicolons (\f[CB];\f[R]) separate directories in this list.
 .RE
 .TP
 .B \f[CB]\-\-add\-modules\f[R] \f[I]module\f[R][\f[CB],\f[R]\f[I]module\f[R]...]


### PR DESCRIPTION
Man file for the java command in JDK, the arguments such as -classpath, --module-path and --upgrade-module-path say "A semicolon (;) separated list of directories"

Please review this fix correcting the text to "A colon (:) separated list of directories".

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8262004](https://bugs.openjdk.java.net/browse/JDK-8262004): Classpath separator: Man page says semicolon; should be colon on Linux


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8530/head:pull/8530` \
`$ git checkout pull/8530`

Update a local copy of the PR: \
`$ git checkout pull/8530` \
`$ git pull https://git.openjdk.java.net/jdk pull/8530/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8530`

View PR using the GUI difftool: \
`$ git pr show -t 8530`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8530.diff">https://git.openjdk.java.net/jdk/pull/8530.diff</a>

</details>
