### PR TITLE
8286115: G1: G1RemSetArrayOfCardsEntriesBase off-by-one error

### DIFF
--- a/src/hotspot/share/gc/g1/g1Arguments.cpp
+++ b/src/hotspot/share/gc/g1/g1Arguments.cpp
@@ -137,7 +137,7 @@ void G1Arguments::initialize_card_set_configuration() {
   if (FLAG_IS_DEFAULT(G1RemSetArrayOfCardsEntries)) {
     uint max_cards_in_inline_ptr = G1CardSetConfiguration::max_cards_in_inline_ptr(HeapRegion::LogOfHRGrainBytes - CardTable::card_shift());
     FLAG_SET_ERGO(G1RemSetArrayOfCardsEntries, MAX2(max_cards_in_inline_ptr * 2,
-                                                    G1RemSetArrayOfCardsEntriesBase * (1u << (region_size_log_mb + 1))));
+                                                    G1RemSetArrayOfCardsEntriesBase << region_size_log_mb));
   }
 
   // Round to next 8 byte boundary for array to maximize space usage.


### PR DESCRIPTION
Simple fix for an off-by-one error around the G1 remset array container capacity.

Test: tier1, manually verifying `-XX:+PrintFlagsFinal` prints the correct value

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [JDK-8286115](https://bugs.openjdk.java.net/browse/JDK-8286115): G1: G1RemSetArrayOfCardsEntriesBase off-by-one error


### Reviewers
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8531/head:pull/8531` \
`$ git checkout pull/8531`

Update a local copy of the PR: \
`$ git checkout pull/8531` \
`$ git pull https://git.openjdk.java.net/jdk pull/8531/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8531`

View PR using the GUI difftool: \
`$ git pr show -t 8531`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8531.diff">https://git.openjdk.java.net/jdk/pull/8531.diff</a>

</details>
