### PR TITLE
8278348: [macos12] javax/swing/JTree/4908142/bug4908142.java fails in macos12

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -684,13 +684,9 @@ java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64
 java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 8274106 macosx-aarch64
 javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8274106 macosx-aarch64
 
-# macos12 failure
-javax/swing/JMenu/4515762/bug4515762.java 8276074 macosx-all
-
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8225012 windows-all,macosx-all
 sanity/client/SwingSet/src/ScrollPaneDemoTest.java 8225013 linux-all
 sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java 8265770 macosx-all
-javax/swing/JTree/4908142/bug4908142.java 8278348 macosx-all
 javax/swing/JTable/8236907/LastVisibleRow.java 8284619 macosx-all
 
 ############################################################################


### PR DESCRIPTION
2 open tests were seen to be failing in macos12 which happen to have same root cause as 
8273506: java Robot API did the 'm' keypress and caused /awt/event/Ke....

With that fix being committed, testing on intended macos12 systems are not able to reproduce this failures so we can remove from Problemlist. CI jobs links are in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8278348](https://bugs.openjdk.java.net/browse/JDK-8278348): [macos12] javax/swing/JTree/4908142/bug4908142.java fails in macos12


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8532/head:pull/8532` \
`$ git checkout pull/8532`

Update a local copy of the PR: \
`$ git checkout pull/8532` \
`$ git pull https://git.openjdk.java.net/jdk pull/8532/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8532`

View PR using the GUI difftool: \
`$ git pr show -t 8532`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8532.diff">https://git.openjdk.java.net/jdk/pull/8532.diff</a>

</details>
