### PR TITLE
JDK-8286114: [test] show real exception in bomb call in sun/rmi/runtime/Log/checkLogging/CheckLogging.java

### DIFF
--- a/test/jdk/sun/rmi/runtime/Log/checkLogging/CheckLogging.java
+++ b/test/jdk/sun/rmi/runtime/Log/checkLogging/CheckLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,7 +107,7 @@ public class CheckLogging {
             REGISTRY_PORT = TestLibrary.getRegistryPort(registry);
             LOCATION = "rmi://localhost:" + REGISTRY_PORT + "/";
         } catch (Exception e) {
-            TestLibrary.bomb("could not create registry");
+            TestLibrary.bomb("could not create registry", e);
         }
     }
 


### PR DESCRIPTION
There is one TestLibrary.bomb call in sun/rmi/runtime/Log/checkLogging/CheckLogging.java that is not passing the exception to bomb, that should be improved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [JDK-8286114](https://bugs.openjdk.java.net/browse/JDK-8286114): [test] show real exception in bomb call in sun/rmi/runtime/Log/checkLogging/CheckLogging.java


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8533/head:pull/8533` \
`$ git checkout pull/8533`

Update a local copy of the PR: \
`$ git checkout pull/8533` \
`$ git pull https://git.openjdk.java.net/jdk pull/8533/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8533`

View PR using the GUI difftool: \
`$ git pr show -t 8533`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8533.diff">https://git.openjdk.java.net/jdk/pull/8533.diff</a>

</details>
