### PR TITLE
JDK-8285987: executing shell scripts without #! fails on Alpine linux

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -486,15 +486,15 @@ public class Basic {
                             equal(run(pb).exitValue(),
                                   False.exitValue());
                             // Traditional shell scripts without #!
-                            setFileContents(prog, "exec /bin/true\n");
-                            prog.setExecutable(true);
-                            equal(run(pb).exitValue(),
-                                  True.exitValue());
-                            prog.delete();
-                            setFileContents(prog, "exec /bin/false\n");
-                            prog.setExecutable(true);
-                            equal(run(pb).exitValue(),
-                                  False.exitValue());
+                            if (!(Platform.isLinux() && Platform.isMusl())) {
+                                setFileContents(prog, "exec /bin/true\n");
+                                prog.setExecutable(true);
+                                equal(run(pb).exitValue(), True.exitValue());
+                                prog.delete();
+                                setFileContents(prog, "exec /bin/false\n");
+                                prog.setExecutable(true);
+                                equal(run(pb).exitValue(), False.exitValue());
+                            }
                             prog.delete();
                         }
 
@@ -511,14 +511,16 @@ public class Basic {
                         pb.command(cmd);
 
                         // Test traditional shell scripts without #!
-                        setFileContents(dir1Prog, "/bin/echo \"$@\"\n");
-                        pb.command(new String[] {"prog", "hello", "world"});
-                        checkPermissionDenied(pb);
-                        dir1Prog.setExecutable(true);
-                        equal(run(pb).out(), "hello world\n");
-                        equal(run(pb).exitValue(), True.exitValue());
-                        dir1Prog.delete();
-                        pb.command(cmd);
+                        if (!(Platform.isLinux() && Platform.isMusl())) {
+                            setFileContents(dir1Prog, "/bin/echo \"$@\"\n");
+                            pb.command(new String[] {"prog", "hello", "world"});
+                            checkPermissionDenied(pb);
+                            dir1Prog.setExecutable(true);
+                            equal(run(pb).out(), "hello world\n");
+                            equal(run(pb).exitValue(), True.exitValue());
+                            dir1Prog.delete();
+                            pb.command(cmd);
+                        }
 
                         // If prog found on both parent and child's PATH,
                         // parent's is used.

--- a/test/langtools/jdk/jshell/ExternalEditorTest.java
+++ b/test/langtools/jdk/jshell/ExternalEditorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
  * @test
  * @summary Testing external editor.
  * @bug 8143955 8080843 8163816 8143006 8169828 8171130 8162989 8210808
+ * @comment musl/Alpine has problems executing some shell scripts, see 8285987
+ * @requires !vm.musl
  * @modules jdk.jshell/jdk.internal.jshell.tool
  * @build ReplToolTesting CustomEditor EditorTestBase
  * @run testng ExternalEditorTest

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -189,6 +189,19 @@ public class Platform {
         return vmVersion;
     }
 
+    public static boolean isMusl() {
+        try {
+            ProcessBuilder pb = new ProcessBuilder("ldd", "--version");
+            pb.redirectErrorStream(true);
+            Process p = pb.start();
+            BufferedReader b = new BufferedReader(new InputStreamReader(p.getInputStream()));
+            String l = b.readLine();
+            if (l != null && l.contains("musl")) { return true; }
+        } catch(Exception e) {
+        }
+        return false;
+    }
+
     public static boolean isAArch64() {
         return isArch("aarch64");
     }


### PR DESCRIPTION
A couple a tests like java/lang/ProcessBuilder/Basic.java#id0.Basic_id0 and jdk/jshell/ExternalEditorTest.java.ExternalEditorTest try to start small shell scripts without #! at the first line of the script. This fails with error=8, Exec format error when running on Alpine 3.15 .
Looks like this is a known issue on musl / Alpine, see also
https://www.openwall.com/lists/musl/2018/03/09/2
and
https://github.com/scala-steward-org/scala-steward/issues/1374
(we see it on Alpine 3.15).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [JDK-8285987](https://bugs.openjdk.java.net/browse/JDK-8285987): executing shell scripts without #! fails on Alpine linux


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8535/head:pull/8535` \
`$ git checkout pull/8535`

Update a local copy of the PR: \
`$ git checkout pull/8535` \
`$ git pull https://git.openjdk.java.net/jdk pull/8535/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8535`

View PR using the GUI difftool: \
`$ git pr show -t 8535`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8535.diff">https://git.openjdk.java.net/jdk/pull/8535.diff</a>

</details>
