### PR TITLE
8286138: ProblemList javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java on macosx-aarch64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -692,6 +692,7 @@ sanity/client/SwingSet/src/ScrollPaneDemoTest.java 8225013 linux-all
 sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java 8265770 macosx-all
 javax/swing/JTree/4908142/bug4908142.java 8278348 macosx-all
 javax/swing/JTable/8236907/LastVisibleRow.java 8284619 macosx-all
+javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java 8284888 macosx-aarch64
 
 ############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java on macosx-aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [JDK-8286138](https://bugs.openjdk.java.net/browse/JDK-8286138): ProblemList javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java on macosx-aarch64


### Reviewers
 * [Brian Burkhalter](https://openjdk.java.net/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8538/head:pull/8538` \
`$ git checkout pull/8538`

Update a local copy of the PR: \
`$ git checkout pull/8538` \
`$ git pull https://git.openjdk.java.net/jdk pull/8538/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8538`

View PR using the GUI difftool: \
`$ git pr show -t 8538`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8538.diff">https://git.openjdk.java.net/jdk/pull/8538.diff</a>

</details>
