### PR TITLE
8286117: Remove unnecessary indirection and unused code in UL

### DIFF
--- a/src/hotspot/share/logging/log.hpp
+++ b/src/hotspot/share/logging/log.hpp
@@ -107,8 +107,6 @@ class LogTargetImpl;
 template <LogTagType T0, LogTagType T1 = LogTag::__NO_TAG, LogTagType T2 = LogTag::__NO_TAG, LogTagType T3 = LogTag::__NO_TAG,
           LogTagType T4 = LogTag::__NO_TAG, LogTagType GuardTag = LogTag::__NO_TAG>
 class LogImpl {
- private:
-  static const size_t LogBufferSize = 512;
  public:
   // Make sure no more than the maximum number of tags have been given.
   // The GuardTag allows this to be detected if/when it happens. If the GuardTag
@@ -183,7 +181,7 @@ public:
   }
 
   static bool is_enabled() {
-    return LogImpl<T0, T1, T2, T3, T4, GuardTag>::is_level(level);
+    return LogTagSetMapping<T0, T1, T2, T3, T4, GuardTag>::tagset().is_level(level);
   }
 
   static bool develop_is_enabled() {
@@ -194,7 +192,7 @@ public:
   static void print(const char* fmt, ...) ATTRIBUTE_PRINTF(1, 2) {
     va_list args;
     va_start(args, fmt);
-    LogImpl<T0, T1, T2, T3, T4, GuardTag>::vwrite(level, fmt, args);
+    LogTagSetMapping<T0, T1, T2, T3, T4, GuardTag>::tagset().vwrite(level, fmt, args);
     va_end(args);
   }
 

--- a/src/hotspot/share/logging/logHandle.hpp
+++ b/src/hotspot/share/logging/logHandle.hpp
@@ -32,7 +32,7 @@
 // polluting the surrounding API with template functions.
 class LogHandle {
 private:
-  LogTagSet* _tagset;
+  LogTagSet* const _tagset;
 
 public:
   template <LogTagType T0, LogTagType T1, LogTagType T2, LogTagType T3, LogTagType T4, LogTagType GuardTag>
@@ -43,7 +43,7 @@ public:
     return _tagset->is_level(level);
   }
 
-  LogTagSet* tagset() const {
+  LogTagSet* const tagset() const {
     return _tagset;
   }
 
@@ -73,10 +73,10 @@ public:
 class LogTargetHandle {
 private:
   const LogLevelType _level;
-  LogTagSet*         _tagset;
+  LogTagSet* const   _tagset;
 
 public:
-  LogTargetHandle(LogLevelType level, LogTagSet* tagset) : _level(level), _tagset(tagset) {}
+  LogTargetHandle(LogLevelType level, LogTagSet* const tagset) : _level(level), _tagset(tagset) {}
 
   template <LogLevelType level, LogTagType T0, LogTagType T1, LogTagType T2, LogTagType T3, LogTagType T4, LogTagType GuardTag>
   LogTargetHandle(const LogTargetImpl<level, T0, T1, T2, T3, T4, GuardTag>& type_carrier) :

--- a/src/hotspot/share/logging/logMessage.hpp
+++ b/src/hotspot/share/logging/logMessage.hpp
@@ -63,10 +63,12 @@ template <LogTagType T0, LogTagType T1 = LogTag::__NO_TAG, LogTagType T2 = LogTa
 class LogMessageImpl : public LogMessageBuffer {
  private:
   bool _has_content;
-
+  LogTagSet& _tagset;
  public:
-  LogMessageImpl() : _has_content(false) {
-  }
+  LogMessageImpl() :
+    _has_content(false),
+    _tagset(LogTagSetMapping<T0, T1, T2, T3, T4, GuardTag>::tagset())
+  {}
 
   ~LogMessageImpl() {
     if (_has_content) {
@@ -75,7 +77,7 @@ class LogMessageImpl : public LogMessageBuffer {
   }
 
   void flush() {
-    LogTagSetMapping<T0, T1, T2, T3, T4, GuardTag>::tagset().log(*this);
+    _tagset.log(*this);
     reset();
   }
 
@@ -95,7 +97,7 @@ class LogMessageImpl : public LogMessageBuffer {
 
 #define LOG_LEVEL(level, name) \
   bool is_##name() const { \
-    return LogTagSetMapping<T0, T1, T2, T3, T4, GuardTag>::tagset().is_level(LogLevel::level); \
+    return _tagset.is_level(LogLevel::level); \
   }
   LOG_LEVEL_LIST
 #undef LOG_LEVEL

--- a/src/hotspot/share/logging/logMessage.hpp
+++ b/src/hotspot/share/logging/logMessage.hpp
@@ -62,7 +62,6 @@ template <LogTagType T0, LogTagType T1 = LogTag::__NO_TAG, LogTagType T2 = LogTa
           LogTagType T3 = LogTag::__NO_TAG, LogTagType T4 = LogTag::__NO_TAG, LogTagType GuardTag = LogTag::__NO_TAG>
 class LogMessageImpl : public LogMessageBuffer {
  private:
-  LogImpl<T0, T1, T2, T3, T4, GuardTag> _log;
   bool _has_content;
 
  public:
@@ -76,7 +75,7 @@ class LogMessageImpl : public LogMessageBuffer {
   }
 
   void flush() {
-    _log.write(*this);
+    LogTagSetMapping<T0, T1, T2, T3, T4, GuardTag>::tagset().log(*this);
     reset();
   }
 
@@ -96,7 +95,7 @@ class LogMessageImpl : public LogMessageBuffer {
 
 #define LOG_LEVEL(level, name) \
   bool is_##name() const { \
-    return _log.is_level(LogLevel::level); \
+    return LogTagSetMapping<T0, T1, T2, T3, T4, GuardTag>::tagset().is_level(LogLevel::level); \
   }
   LOG_LEVEL_LIST
 #undef LOG_LEVEL

--- a/src/hotspot/share/logging/logStream.hpp
+++ b/src/hotspot/share/logging/logStream.hpp
@@ -64,16 +64,16 @@ public:
   // Constructor to support creation from a LogTarget instance.
   //
   // LogTarget(Debug, gc) log;
-  // LogStreamBase(log) stream;
+  // LogStream(log) stream;
   template <LogLevelType level, LogTagType T0, LogTagType T1, LogTagType T2, LogTagType T3, LogTagType T4, LogTagType GuardTag>
   LogStream(const LogTargetImpl<level, T0, T1, T2, T3, T4, GuardTag>& type_carrier) :
       _log_handle(level, &LogTagSetMapping<T0, T1, T2, T3, T4>::tagset()) {}
 
   // Constructor to support creation from typed (likely NULL) pointer. Mostly used by the logging framework.
   //
-  // LogStreamBase stream(log.debug());
+  // LogStream stream(log.debug());
   //  or
-  // LogStreamBase stream((LogTargetImpl<level, T0, T1, T2, T3, T4, GuardTag>*)NULL);
+  // LogStream stream((LogTargetImpl<level, T0, T1, T2, T3, T4, GuardTag>*)NULL);
   template <LogLevelType level, LogTagType T0, LogTagType T1, LogTagType T2, LogTagType T3, LogTagType T4, LogTagType GuardTag>
   LogStream(const LogTargetImpl<level, T0, T1, T2, T3, T4, GuardTag>* type_carrier) :
       _log_handle(level, &LogTagSetMapping<T0, T1, T2, T3, T4>::tagset()) {}
@@ -85,13 +85,13 @@ public:
   //
   // LogTarget(Debug, gc) log;
   // LogTargetHandle(log) handle;
-  // LogStreamBase stream(handle);
+  // LogStream stream(handle);
   LogStream(LogTargetHandle handle) : _log_handle(handle) {}
 
   // Constructor to support creation from a log level and tagset.
   //
-  // LogStreamBase(level, tageset);
-  LogStream(LogLevelType level, LogTagSet* tagset) : _log_handle(level, tagset) {}
+  // LogStream(level, tageset);
+  LogStream(LogLevelType level, LogTagSet* const tagset) : _log_handle(level, tagset) {}
 
   bool is_enabled() const {
     return _log_handle.is_enabled();

--- a/src/hotspot/share/logging/logTagSet.hpp
+++ b/src/hotspot/share/logging/logTagSet.hpp
@@ -165,7 +165,7 @@ public:
 // will instantiate the LogTagSetMapping template, which in turn creates the static field for that
 // tagset. This _tagset contains the configuration for those tags.
 template <LogTagType T0, LogTagType T1, LogTagType T2, LogTagType T3, LogTagType T4, LogTagType GuardTag>
-LogTagSet LogTagSetMapping<T0, T1, T2, T3, T4, GuardTag>::_tagset(&LogPrefix<T0, T1, T2, T3, T4>::prefix, T0, T1, T2, T3, T4);
+LogTagSet LogTagSetMapping<T0, T1, T2, T3, T4, GuardTag>::_tagset{&LogPrefix<T0, T1, T2, T3, T4>::prefix, T0, T1, T2, T3, T4};
 
 extern const size_t vwrite_buffer_size;
 #endif // SHARE_LOGGING_LOGTAGSET_HPP


### PR DESCRIPTION
This PR cleans up some minor annoyances in the UL code.

Note that the change from `LogImpl` to `LogTagSet` is equivalent, we're essentially inlining the calls that `LogImpl` would have made. This simplifies understanding ("why do we need `LogImpl` here?" was my question, answer: We don't!)'

*Edit:* Passes tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286117](https://bugs.openjdk.java.net/browse/JDK-8286117): Remove unnecessary indirection and unused code in UL


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - **Reviewer**)
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8541/head:pull/8541` \
`$ git checkout pull/8541`

Update a local copy of the PR: \
`$ git checkout pull/8541` \
`$ git pull https://git.openjdk.java.net/jdk pull/8541/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8541`

View PR using the GUI difftool: \
`$ git pr show -t 8541`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8541.diff">https://git.openjdk.java.net/jdk/pull/8541.diff</a>

</details>
