### PR TITLE
8286163: micro-optimize Instant.plusSeconds

### DIFF
--- a/src/java.base/share/classes/java/time/Instant.java
+++ b/src/java.base/share/classes/java/time/Instant.java
@@ -878,7 +878,11 @@ public final class Instant
      * @throws ArithmeticException if numeric overflow occurs
      */
     public Instant plusSeconds(long secondsToAdd) {
-        return plus(secondsToAdd, 0);
+        if (secondsToAdd == 0) {
+            return this;
+        }
+        long epochSec = Math.addExact(seconds, secondsToAdd);
+        return create(epochSec, nanos);
     }
 
     /**

--- a/test/micro/org/openjdk/bench/java/time/InstantBench.java
+++ b/test/micro/org/openjdk/bench/java/time/InstantBench.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.time;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Examine Instant.plusSeconds operations
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
+@State(Scope.Benchmark)
+public class InstantBench {
+
+    private Instant[] INSTANTS;
+    private int[] SECONDS;
+
+    private long[] RESULT;
+
+    @Setup
+    public void createInstants() {
+        // Various instants during the same day
+        final Instant loInstant = Instant.EPOCH.plus(Duration.ofDays(365*50)); // 2020-01-01
+        final Instant hiInstant = loInstant.plus(Duration.ofDays(1));
+        final long maxOffsetNanos = Duration.between(loInstant, hiInstant).toNanos();
+        final Random random = new Random(0);
+        INSTANTS = IntStream
+                .range(0, 1_000)
+                .mapToObj(ignored -> {
+                    final long offsetNanos = (long) Math.floor(random.nextDouble() * maxOffsetNanos);
+                    return loInstant.plus(offsetNanos, ChronoUnit.NANOS);
+                })
+                .toArray(Instant[]::new);
+        SECONDS = IntStream
+                .range(0, INSTANTS.length)
+                .map(ignored -> random.nextInt(1000))
+                .toArray();
+        RESULT = new long[INSTANTS.length];
+    }
+
+    @Benchmark
+    public long[] plusSecondsDropNanos() {
+        for (int i = 0; i < INSTANTS.length; i++) {
+            RESULT[i] = INSTANTS[i].plusSeconds(SECONDS[i]).getEpochSecond();
+        }
+        return RESULT;
+    }
+}


### PR DESCRIPTION
Provide micro-benchmark for comparison

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286163](https://bugs.openjdk.java.net/browse/JDK-8286163): micro-optimize Instant.plusSeconds


### Reviewers
 * [Stephen Colebourne](https://openjdk.java.net/census#scolebourne) (@jodastephen - Author)
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - **Reviewer**)
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8542/head:pull/8542` \
`$ git checkout pull/8542`

Update a local copy of the PR: \
`$ git checkout pull/8542` \
`$ git pull https://git.openjdk.java.net/jdk pull/8542/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8542`

View PR using the GUI difftool: \
`$ git pr show -t 8542`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8542.diff">https://git.openjdk.java.net/jdk/pull/8542.diff</a>

</details>
