### PR TITLE
JDK-8286153: Remove redundant casts and other cleanup

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassUseWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassUseWriter.java
@@ -169,18 +169,13 @@ public class ClassUseWriter extends SubWriterHolderWriter {
 
     private Map<PackageElement, List<Element>> pkgDivide(Map<TypeElement, ? extends List<? extends Element>> classMap) {
         Map<PackageElement, List<Element>> map = new HashMap<>();
-        List<? extends Element> elements = (List<? extends Element>) classMap.get(typeElement);
+        List<? extends Element> elements = classMap.get(typeElement);
         if (elements != null) {
             elements.sort(comparators.makeClassUseComparator());
             for (Element e : elements) {
                 PackageElement pkg = utils.containingPackage(e);
                 pkgSet.add(pkg);
-                List<Element> inPkg = map.get(pkg);
-                if (inPkg == null) {
-                    inPkg = new ArrayList<>();
-                    map.put(pkg, inPkg);
-                }
-                inPkg.add(e);
+                map.computeIfAbsent(pkg, k -> new ArrayList<>()).add(e);
             }
         }
         return map;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DocFilesHandlerImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DocFilesHandlerImpl.java
@@ -30,7 +30,6 @@ import com.sun.source.doctree.EndElementTree;
 import com.sun.source.doctree.StartElementTree;
 import com.sun.source.util.DocTreeFactory;
 import jdk.javadoc.internal.doclets.formats.html.markup.BodyContents;
-import jdk.javadoc.internal.doclets.formats.html.markup.ContentBuilder;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlTree;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 import jdk.javadoc.internal.doclets.toolkit.DocFileElement;
@@ -77,22 +76,23 @@ public class DocFilesHandlerImpl implements DocFilesHandler {
         this.element = element;
 
         switch (element.getKind()) {
-            case MODULE:
-                ModuleElement mdle = (ModuleElement)element;
+            case MODULE -> {
+                ModuleElement mdle = (ModuleElement) element;
                 location = configuration.utils.getLocationForModule(mdle);
                 source = DocPaths.DOC_FILES;
-                break;
-            case PACKAGE:
-                PackageElement pkg = (PackageElement)element;
+            }
+
+            case PACKAGE -> {
+                PackageElement pkg = (PackageElement) element;
                 location = configuration.utils.getLocationForPackage(pkg);
                 // Note, given that we have a module-specific location,
                 // we want a module-relative path for the source, and not the
                 // standard path that may include the module directory
                 source = DocPath.create(pkg.getQualifiedName().toString().replace('.', '/'))
                         .resolve(DocPaths.DOC_FILES);
-                break;
-            default:
-                throw new AssertionError("unsupported element " + element);
+            }
+
+            default -> throw new AssertionError("unsupported element " + element);
         }
     }
 
@@ -110,17 +110,11 @@ public class DocFilesHandlerImpl implements DocFilesHandler {
             if (!srcdir.isDirectory()) {
                 continue;
             }
-            DocPath path = null;
-            switch (this.element.getKind()) {
-                case MODULE:
-                    path = DocPaths.forModule((ModuleElement)this.element);
-                    break;
-                case PACKAGE:
-                    path = configuration.docPaths.forPackage((PackageElement)this.element);
-                    break;
-                default:
-                    throw new AssertionError("unknown kind:" + this.element.getKind());
-            }
+            DocPath path = switch (this.element.getKind()) {
+                case MODULE -> DocPaths.forModule((ModuleElement) this.element);
+                case PACKAGE -> configuration.docPaths.forPackage((PackageElement) this.element);
+                default -> throw new AssertionError("unknown kind:" + this.element.getKind());
+            };
             copyDirectory(srcdir, path.resolve(DocPaths.DOC_FILES), first);
             first = false;
         }
@@ -128,7 +122,7 @@ public class DocFilesHandlerImpl implements DocFilesHandler {
 
     @Override
     public List<DocPath> getStylesheets() throws DocFileIOException {
-        List<DocPath> stylesheets = new ArrayList<DocPath>();
+        var stylesheets = new ArrayList<DocPath>();
         for (DocFile srcdir : DocFile.list(configuration, location, source)) {
             for (DocFile srcFile : srcdir.list()) {
                 if (srcFile.getName().endsWith(".css"))

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -294,7 +294,7 @@ public class HtmlDocletWriter {
         ExecutableElement overriddenMethod = utils.overriddenMethod(method);
         VisibleMemberTable vmt = configuration.getVisibleMemberTable(enclosing);
         // Check whether there is any implementation or overridden info to be
-        // printed. If no overridden or implementation info needs to be
+        // printed. If not overridden or implementation info needs to be
         // printed, do not print this section.
         if ((!intfacs.isEmpty()
                 && !vmt.getImplementedMethods(method).isEmpty())
@@ -2322,7 +2322,7 @@ public class HtmlDocletWriter {
                 case PACKAGE, MODULE ->
                         ((QualifiedNameable) forWhat).getQualifiedName();
                 case CONSTRUCTOR ->
-                        ((TypeElement) forWhat.getEnclosingElement()).getSimpleName();
+                        forWhat.getEnclosingElement().getSimpleName();
                 default -> forWhat.getSimpleName();
             }).toString();
             var nameCode = HtmlTree.CODE(Text.of(name));

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -294,7 +294,7 @@ public class HtmlDocletWriter {
         ExecutableElement overriddenMethod = utils.overriddenMethod(method);
         VisibleMemberTable vmt = configuration.getVisibleMemberTable(enclosing);
         // Check whether there is any implementation or overridden info to be
-        // printed. If not overridden or implementation info needs to be
+        // printed. If no overridden or implementation info needs to be
         // printed, do not print this section.
         if ((!intfacs.isEmpty()
                 && !vmt.getImplementedMethods(method).isEmpty())

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/ClassUseMapper.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/ClassUseMapper.java
@@ -221,7 +221,7 @@ public class ClassUseMapper {
             for (VariableElement fd : fields) {
                 mapTypeParameters(classToFieldTypeParam, fd, fd);
                 mapAnnotations(annotationToField, fd, fd);
-                 var stv = new SimpleTypeVisitor9<Void, VariableElement>() {
+                var stv = new SimpleTypeVisitor9<Void, VariableElement>() {
                     @Override
                     public Void visitArray(ArrayType t, VariableElement p) {
                         return visit(t.getComponentType(), p);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/ClassUseMapper.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/ClassUseMapper.java
@@ -205,7 +205,7 @@ public class ClassUseMapper {
             subclasses(te);
         }
         for (TypeElement intfc : classtree.baseInterfaces()) {
-            // does subinterfacing as side-effect
+            // does subinterfacing as a side-effect
             implementingClasses(intfc);
         }
         // Map methods, fields, constructors using a class.
@@ -221,7 +221,7 @@ public class ClassUseMapper {
             for (VariableElement fd : fields) {
                 mapTypeParameters(classToFieldTypeParam, fd, fd);
                 mapAnnotations(annotationToField, fd, fd);
-                SimpleTypeVisitor9<Void, VariableElement> stv = new SimpleTypeVisitor9<Void, VariableElement>() {
+                 var stv = new SimpleTypeVisitor9<Void, VariableElement>() {
                     @Override
                     public Void visitArray(ArrayType t, VariableElement p) {
                         return visit(t.getComponentType(), p);
@@ -232,6 +232,7 @@ public class ClassUseMapper {
                         add(classToField, (TypeElement) t.asElement(), p);
                         return null;
                     }
+
                     @Override
                     public Void visitTypeVariable(TypeVariable t, VariableElement p) {
                         return visit(typeUtils.erasure(t), p);
@@ -252,7 +253,7 @@ public class ClassUseMapper {
                 mapExecutable(method);
                 mapTypeParameters(classToMethodTypeParam, method, method);
                 mapAnnotations(classToMethodAnnotations, method, method);
-                SimpleTypeVisitor9<Void, ExecutableElement> stv = new SimpleTypeVisitor9<Void, ExecutableElement>() {
+                var stv = new SimpleTypeVisitor9<Void, ExecutableElement>() {
                     @Override
                     public Void visitArray(ArrayType t, ExecutableElement p) {
                         TypeMirror componentType = t.getComponentType();
@@ -385,7 +386,7 @@ public class ClassUseMapper {
 
         }
         for (TypeMirror anException : ee.getThrownTypes()) {
-            SimpleTypeVisitor9<Void, ExecutableElement> stv = new SimpleTypeVisitor9<Void, ExecutableElement>() {
+            var stv = new SimpleTypeVisitor9<Void, ExecutableElement>() {
 
                 @Override
                 public Void visitArray(ArrayType t, ExecutableElement p) {
@@ -418,12 +419,7 @@ public class ClassUseMapper {
     }
 
     private <T> List<T> refList(Map<TypeElement, List<T>> map, TypeElement element) {
-        List<T> list = map.get(element);
-        if (list == null) {
-            list = new ArrayList<>();
-            map.put(element, list);
-        }
-        return list;
+        return map.computeIfAbsent(element, k -> new ArrayList<>());
     }
 
     private Set<PackageElement> packageSet(TypeElement te) {
@@ -449,9 +445,9 @@ public class ClassUseMapper {
         refList(map, te).add(ref);
         // add ref's package to package map and class map
         packageSet(te).add(elementUtils.getPackageOf(ref));
-        TypeElement entry = (utils.isField((Element) ref)
-                || utils.isConstructor((Element) ref)
-                || utils.isMethod((Element) ref))
+        TypeElement entry = (utils.isField(ref)
+                || utils.isConstructor(ref)
+                || utils.isMethod(ref))
                 ? (TypeElement) ref.getEnclosingElement()
                 : (TypeElement) ref;
         classSet(te).add(entry);
@@ -483,50 +479,49 @@ public class ClassUseMapper {
     private <T extends Element> void mapTypeParameters(final Map<TypeElement, List<T>> map,
             Element element, final T holder) {
 
-        SimpleElementVisitor14<Void, Void> elementVisitor
-                = new SimpleElementVisitor14<Void, Void>() {
+        var elementVisitor = new SimpleElementVisitor14<Void, Void>() {
 
-                    private void addParameters(TypeParameterElement e) {
-                        for (TypeMirror type : utils.getBounds(e)) {
-                            addTypeParameterToMap(map, type, holder);
-                        }
-                    }
+            private void addParameters(TypeParameterElement e) {
+                for (TypeMirror type : utils.getBounds(e)) {
+                    addTypeParameterToMap(map, type, holder);
+                }
+            }
 
-                    @Override
-                    public Void visitType(TypeElement e, Void p) {
-                        for (TypeParameterElement param : e.getTypeParameters()) {
-                            addParameters(param);
-                        }
-                        return null;
-                    }
+            @Override
+            public Void visitType(TypeElement e, Void p) {
+                for (TypeParameterElement param : e.getTypeParameters()) {
+                    addParameters(param);
+                }
+                return null;
+            }
 
-                    @Override
-                    public Void visitExecutable(ExecutableElement e, Void p) {
-                        for (TypeParameterElement param : e.getTypeParameters()) {
-                            addParameters(param);
-                        }
-                        return null;
-                    }
+            @Override
+            public Void visitExecutable(ExecutableElement e, Void p) {
+                for (TypeParameterElement param : e.getTypeParameters()) {
+                    addParameters(param);
+                }
+                return null;
+            }
 
-                    @Override
-                    protected Void defaultAction(Element e, Void p) {
-                        mapTypeParameters(map, e.asType(), holder);
-                        return null;
-                    }
+            @Override
+            protected Void defaultAction(Element e, Void p) {
+                mapTypeParameters(map, e.asType(), holder);
+                return null;
+            }
 
-                    @Override
-                    public Void visitTypeParameter(TypeParameterElement e, Void p) {
-                        addParameters(e);
-                        return null;
-                    }
-                };
+            @Override
+            public Void visitTypeParameter(TypeParameterElement e, Void p) {
+                addParameters(e);
+                return null;
+            }
+        };
         elementVisitor.visit(element);
     }
 
     private <T extends Element> void mapTypeParameters(final Map<TypeElement, List<T>> map,
             TypeMirror aType, final T holder) {
 
-        SimpleTypeVisitor9<Void, Void> tv = new SimpleTypeVisitor9<Void, Void>() {
+        var tv = new SimpleTypeVisitor9<Void, Void>() {
 
             @Override
             public Void visitWildcard(WildcardType t, Void p) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/MetaKeywords.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/MetaKeywords.java
@@ -70,7 +70,7 @@ public class MetaKeywords {
      * definitions are on separate pages.
      */
     public List<String> getMetaKeywords(TypeElement typeElement) {
-        ArrayList<String> results = new ArrayList<>();
+        var results = new ArrayList<String>();
 
         // Add field and method keywords only if -keywords option is used
         if (options.keywords()) {
@@ -83,26 +83,22 @@ public class MetaKeywords {
     }
 
     /**
-     * Get the current class for a meta tag keyword, as the first
-     * and only element of an array list.
+     * Get the current class for a meta tag keyword, as a singleton list.
      */
     protected List<String> getClassKeyword(TypeElement typeElement) {
-        ArrayList<String> metakeywords = new ArrayList<>(1);
         String cltypelower = utils.isPlainInterface(typeElement) ? "interface" : "class";
-        metakeywords.add(utils.getFullyQualifiedName(typeElement) + " " + cltypelower);
-        return metakeywords;
+        return List.of(utils.getFullyQualifiedName(typeElement) + " " + cltypelower);
     }
 
     /**
      * Get the package keywords.
      */
     public List<String> getMetaKeywords(PackageElement packageElement) {
-        List<String> result = new ArrayList<>(1);
         if (options.keywords()) {
-            String pkgName = utils.getPackageName(packageElement);
-            result.add(pkgName + " " + "package");
+            return List.of(utils.getPackageName(packageElement) + " " + "package");
+        } else {
+            return List.of();
         }
-        return result;
     }
 
     /**
@@ -122,16 +118,16 @@ public class MetaKeywords {
      * Get the overview keywords.
      */
     public List<String> getOverviewMetaKeywords(String title, String docTitle) {
-        List<String> result = new ArrayList<>(1);
         if (options.keywords()) {
             String windowOverview = resources.getText(title);
             if (docTitle.length() > 0) {
-                result.add(windowOverview + ", " + docTitle);
+                return List.of(windowOverview + ", " + docTitle);
             } else {
-                result.add(windowOverview);
+                return List.of(windowOverview);
             }
+        } else {
+            return List.of();
         }
-        return result;
     }
 
     /**
@@ -144,13 +140,13 @@ public class MetaKeywords {
      * @param members  array of members to be added to keywords
      */
     protected List<String> getMemberKeywords(List<? extends Element> members) {
-        ArrayList<String> results = new ArrayList<>();
+        var results = new ArrayList<String>();
         for (Element member : members) {
-            String membername = utils.isMethod(member)
+            String memberName = utils.isMethod(member)
                     ? utils.getSimpleName(member) + "()"
                     : utils.getSimpleName(member);
-            if (!results.contains(membername)) {
-                results.add(membername);
+            if (!results.contains(memberName)) {
+                results.add(memberName);
             }
         }
         results.trimToSize();

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/MetaKeywords.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/MetaKeywords.java
@@ -78,7 +78,7 @@ public class MetaKeywords {
             results.addAll(getMemberKeywords(utils.getFields(typeElement)));
             results.addAll(getMemberKeywords(utils.getMethods(typeElement)));
         }
-        ((ArrayList)results).trimToSize();
+        results.trimToSize();
         return results;
     }
 
@@ -122,7 +122,7 @@ public class MetaKeywords {
      * Get the overview keywords.
      */
     public List<String> getOverviewMetaKeywords(String title, String docTitle) {
-         List<String> result = new ArrayList<>(1);
+        List<String> result = new ArrayList<>(1);
         if (options.keywords()) {
             String windowOverview = resources.getText(title);
             if (docTitle.length() > 0) {
@@ -153,7 +153,7 @@ public class MetaKeywords {
                 results.add(membername);
             }
         }
-        ((ArrayList)results).trimToSize();
+        results.trimToSize();
         return results;
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -1235,18 +1235,17 @@ public class Utils {
         for (int i = 0; i < textLength; i++) {
             char ch = text.charAt(i);
             switch (ch) {
-                case '\n': case '\r':
-                    lineLength = 0;
-                    break;
-                case '\t':
+                case '\n', '\r' -> lineLength = 0;
+
+                case '\t' -> {
                     result.append(text, pos, i);
                     int spaceCount = tabLength - lineLength % tabLength;
                     result.append(whitespace, 0, spaceCount);
                     lineLength += spaceCount;
                     pos = i + 1;
-                    break;
-                default:
-                    lineLength++;
+                }
+
+                default -> lineLength++;
             }
         }
         result.append(text, pos, textLength);
@@ -1261,18 +1260,18 @@ public class Utils {
         for (int i = 0; i < textLength; i++) {
             char ch = text.charAt(i);
             switch (ch) {
-                case '\n':
+                case '\n' -> {
                     sb.append(text, pos, i);
                     sb.append(NL);
                     pos = i + 1;
-                    break;
-                case '\r':
+                }
+                case '\r' -> {
                     sb.append(text, pos, i);
                     sb.append(NL);
                     if (i + 1 < textLength && text.charAt(i + 1) == '\n')
                         i++;
                     pos = i + 1;
-                    break;
+                }
             }
         }
         sb.append(text, pos, textLength);
@@ -1493,28 +1492,26 @@ public class Utils {
         loop:
         for (DocTree dt : preamble) {
             switch (dt.getKind()) {
-                case START_ELEMENT:
-                    StartElementTree nodeStart = (StartElementTree)dt;
+                case START_ELEMENT -> {
+                    StartElementTree nodeStart = (StartElementTree) dt;
                     if (Utils.toLowerCase(nodeStart.getName().toString()).equals("title")) {
                         titleFound = true;
                     }
-                    break;
-
-                case END_ELEMENT:
-                    EndElementTree nodeEnd = (EndElementTree)dt;
+                }
+                case END_ELEMENT -> {
+                    EndElementTree nodeEnd = (EndElementTree) dt;
                     if (Utils.toLowerCase(nodeEnd.getName().toString()).equals("title")) {
                         break loop;
                     }
-                    break;
-
-                case TEXT:
-                    TextTree nodeText = (TextTree)dt;
+                }
+                case TEXT -> {
+                    TextTree nodeText = (TextTree) dt;
                     if (titleFound)
                         sb.append(nodeText.getBody());
-                    break;
-
-                default:
-                    // do nothing
+                }
+                default -> {
+                }
+                // do nothing
             }
         }
         return sb.toString().trim();
@@ -1528,8 +1525,9 @@ public class Utils {
             instance = createCollator(locale);
             instance.setStrength(strength);
 
-            keys = new LinkedHashMap<String, CollationKey>(MAX_SIZE + 1, 0.75f, true) {
+            keys = new LinkedHashMap<>(MAX_SIZE + 1, 0.75f, true) {
                 private static final long serialVersionUID = 1L;
+
                 @Override
                 protected boolean removeEldestEntry(Entry<String, CollationKey> eldest) {
                     return size() > MAX_SIZE;
@@ -1916,7 +1914,7 @@ public class Utils {
 
     public boolean shouldDocument(Element e) {
         if (shouldDocumentVisitor == null) {
-            shouldDocumentVisitor = new SimpleElementVisitor14<Boolean, Void>() {
+            shouldDocumentVisitor = new SimpleElementVisitor14<>() {
                 private boolean hasSource(TypeElement e) {
                     return configuration.docEnv.getFileKind(e) ==
                             javax.tools.JavaFileObject.Kind.SOURCE;
@@ -1925,7 +1923,7 @@ public class Utils {
                 // handle types
                 @Override
                 public Boolean visitType(TypeElement e, Void p) {
-                    // treat inner classes etc as members
+                    // treat inner classes etc. as members
                     if (e.getNestingKind().isNested()) {
                         return defaultAction(e, p);
                     }
@@ -2547,7 +2545,7 @@ public class Utils {
             return prev == null ? null : prev.get();
         }
 
-        public CommentHelper get(Object key) {
+        public CommentHelper get(Element key) {
             SoftReference<CommentHelper> value = map.get(key);
             return value == null ? null : value.get();
         }
@@ -2855,7 +2853,7 @@ public class Utils {
     }
 
     public interface PreviewFlagProvider {
-        public boolean isPreview(Element el);
+        boolean isPreview(Element el);
     }
 
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ElementsTable.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ElementsTable.java
@@ -1217,10 +1217,10 @@ public class ElementsTable {
 
         static EnumSet<AccessKind> getFilterSet(AccessKind accessValue) {
             return switch (accessValue) {
-                case PUBLIC -> EnumSet.of(AccessKind.PUBLIC);
+                case PUBLIC    -> EnumSet.of(AccessKind.PUBLIC);
                 case PROTECTED -> EnumSet.of(AccessKind.PUBLIC, AccessKind.PROTECTED);
-                case PACKAGE -> EnumSet.of(AccessKind.PUBLIC, AccessKind.PROTECTED, AccessKind.PACKAGE);
-                case PRIVATE -> EnumSet.allOf(AccessKind.class);
+                case PACKAGE   -> EnumSet.of(AccessKind.PUBLIC, AccessKind.PROTECTED, AccessKind.PACKAGE);
+                case PRIVATE   -> EnumSet.allOf(AccessKind.class);
             };
         }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ElementsTable.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ElementsTable.java
@@ -239,12 +239,10 @@ public class ElementsTable {
      * @return the module documentation level mode
      */
     public ModuleMode getModuleMode() {
-        switch(accessFilter.getAccessValue(ElementKind.MODULE)) {
-            case PACKAGE: case PRIVATE:
-                return DocletEnvironment.ModuleMode.ALL;
-            default:
-                return DocletEnvironment.ModuleMode.API;
-        }
+        return switch (accessFilter.getAccessValue(ElementKind.MODULE)) {
+            case PACKAGE, PRIVATE -> ModuleMode.ALL;
+            default -> ModuleMode.API;
+        };
     }
 
     private Set<Element> specifiedElements = null;
@@ -272,7 +270,7 @@ public class ElementsTable {
      * A module is fully included,
      *   - is specified on the command line --module
      *   - is derived from the module graph, that is, by expanding the
-     *     requires directive, based on --expand-requires
+     *     'requires' directive, based on --expand-requires
      *
      * A module is included if an enclosed package or type is
      * specified on the command line.
@@ -653,7 +651,7 @@ public class ElementsTable {
                 String binaryName = fm.inferBinaryName(msymloc, fo);
                 String pn = getPackageName(binaryName);
                 PackageSymbol psym = syms.enterPackage(msym, names.fromString(pn));
-                result.add((PackageElement) psym);
+                result.add(psym);
             }
         }
         return result;
@@ -993,7 +991,7 @@ public class ElementsTable {
             return false;
         }
         if (visibleElementVisitor == null) {
-            visibleElementVisitor = new SimpleElementVisitor14<Boolean, Void>() {
+            visibleElementVisitor = new SimpleElementVisitor14<>() {
                 @Override
                 public Boolean visitType(TypeElement e, Void p) {
                     if (!accessFilter.checkModifier(e)) {
@@ -1061,14 +1059,11 @@ public class ElementsTable {
                 }
                 Element enclosing = e.getEnclosingElement();
                 if (enclosing != null) {
-                    switch(enclosing.getKind()) {
-                        case PACKAGE:
-                            return specifiedPackageElements.contains((PackageElement)enclosing);
-                        case CLASS: case INTERFACE: case ENUM: case ANNOTATION_TYPE:
-                            return visit((TypeElement) enclosing);
-                        default:
-                            throw new AssertionError("unknown element: " + enclosing);
-                    }
+                    return switch (enclosing.getKind()) {
+                        case CLASS, ENUM, RECORD, INTERFACE, ANNOTATION_TYPE -> visit(enclosing);
+                        case PACKAGE -> specifiedPackageElements.contains((PackageElement) enclosing);
+                        default -> throw new AssertionError("unknown element: " + enclosing);
+                    };
                 }
             }
             return false;
@@ -1080,14 +1075,14 @@ public class ElementsTable {
             if (includedCache.contains(e))
                 return true;
             if (visit(e.getEnclosingElement()) && isSelected(e)) {
-                switch(e.getKind()) {
-                    case ANNOTATION_TYPE: case CLASS: case ENUM: case INTERFACE:
-                    case MODULE: case OTHER: case PACKAGE:
-                        throw new AssertionError("invalid element for this operation: " + e);
-                    default:
+                switch (e.getKind()) {
+                    case CLASS, ENUM, RECORD, INTERFACE, ANNOTATION_TYPE,
+                            MODULE, OTHER, PACKAGE -> throw new AssertionError("invalid element for this operation: " + e);
+                    default -> {
                         // the only allowed kinds in the cache are "members"
                         includedCache.add(e);
                         return true;
+                    }
                 }
             }
             return false;
@@ -1208,40 +1203,25 @@ public class ElementsTable {
 
             AccessKind accessValue = null;
             for (ElementKind kind : ALLOWED_KINDS) {
-                switch (kind) {
-                    case METHOD:
-                        accessValue  = options.showMembersAccess();
-                        break;
-                    case CLASS:
-                        accessValue  = options.showTypesAccess();
-                        break;
-                    case PACKAGE:
-                        accessValue  = options.showPackagesAccess();
-                        break;
-                    case MODULE:
-                        accessValue  = options.showModuleContents();
-                        break;
-                    default:
-                        throw new AssertionError("unknown element: " + kind);
-
-                }
+                accessValue = switch (kind) {
+                    case METHOD  -> options.showMembersAccess();
+                    case CLASS   -> options.showTypesAccess();
+                    case PACKAGE -> options.showPackagesAccess();
+                    case MODULE  -> options.showModuleContents();
+                    default -> throw new AssertionError("unknown element: " + kind);
+                };
                 accessMap.put(kind, accessValue);
                 filterMap.put(kind, getFilterSet(accessValue));
             }
         }
 
         static EnumSet<AccessKind> getFilterSet(AccessKind accessValue) {
-            switch (accessValue) {
-                case PUBLIC:
-                    return EnumSet.of(AccessKind.PUBLIC);
-                case PROTECTED:
-                default:
-                    return EnumSet.of(AccessKind.PUBLIC, AccessKind.PROTECTED);
-                case PACKAGE:
-                    return EnumSet.of(AccessKind.PUBLIC, AccessKind.PROTECTED, AccessKind.PACKAGE);
-                case PRIVATE:
-                    return EnumSet.allOf(AccessKind.class);
-            }
+            return switch (accessValue) {
+                case PUBLIC -> EnumSet.of(AccessKind.PUBLIC);
+                case PROTECTED -> EnumSet.of(AccessKind.PUBLIC, AccessKind.PROTECTED);
+                case PACKAGE -> EnumSet.of(AccessKind.PUBLIC, AccessKind.PROTECTED, AccessKind.PACKAGE);
+                case PRIVATE -> EnumSet.allOf(AccessKind.class);
+            };
         }
 
         public AccessKind getAccessValue(ElementKind kind) {
@@ -1273,19 +1253,13 @@ public class ElementsTable {
 
         // convert a requested element kind to an allowed access kind
         private ElementKind getAllowedKind(ElementKind kind) {
-            switch (kind) {
-                case CLASS: case METHOD: case MODULE: case PACKAGE:
-                    return kind;
-                case RECORD: case ANNOTATION_TYPE: case ENUM: case INTERFACE:
-                    return ElementKind.CLASS;
-                case CONSTRUCTOR: case ENUM_CONSTANT: case EXCEPTION_PARAMETER:
-                case FIELD: case INSTANCE_INIT: case LOCAL_VARIABLE: case PARAMETER:
-                case RESOURCE_VARIABLE: case STATIC_INIT: case TYPE_PARAMETER:
-                case RECORD_COMPONENT:
-                    return ElementKind.METHOD;
-                default:
-                    throw new AssertionError("unsupported kind: " + kind);
-            }
+            return switch (kind) {
+                case CLASS, METHOD, MODULE, PACKAGE -> kind;
+                case RECORD, ANNOTATION_TYPE, ENUM, INTERFACE -> ElementKind.CLASS;
+                case CONSTRUCTOR, ENUM_CONSTANT, EXCEPTION_PARAMETER, FIELD, INSTANCE_INIT, LOCAL_VARIABLE,
+                        PARAMETER, RESOURCE_VARIABLE, STATIC_INIT, TYPE_PARAMETER, RECORD_COMPONENT -> ElementKind.METHOD;
+                default -> throw new AssertionError("unsupported kind: " + kind);
+            };
         }
     } // end ModifierFilter
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/Start.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/Start.java
@@ -209,7 +209,7 @@ public class Start {
     }
 
     private void showToolOptions(ToolOption.Kind kind) {
-        Comparator<ToolOption> comp = new Comparator<ToolOption>() {
+        var comp = new Comparator<ToolOption>() {
             final Collator collator = Collator.getInstance(Locale.US);
             { collator.setStrength(Collator.PRIMARY); }
 
@@ -250,7 +250,7 @@ public class Start {
         }
         showLinesUsingKey("main.doclet.usage.header", name);
 
-        Comparator<Doclet.Option> comp = new Comparator<Doclet.Option>() {
+        var comp = new Comparator<Doclet.Option>() {
             final Collator collator = Collator.getInstance(Locale.US);
             { collator.setStrength(Collator.PRIMARY); }
 


### PR DESCRIPTION
Please review some cleanup updates to address issues reported by an IDE.

The seeds for the change were a series of redundant casts, that have now all been removed.  Various other warnings and suggestions were made by the IDE for the affected files. There were a number of places with redundant type arguments, for which the general fix was in favor of using `var` instead of `<>`.

Some `switch` statements were converted to the enhanced `switch` form, which also revealed a couple of places where `RECORD` should have been added alongside `ENUM`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286153](https://bugs.openjdk.java.net/browse/JDK-8286153): Remove redundant casts and other cleanup


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**) ⚠️ Review applies to [6ad78546](https://git.openjdk.java.net/jdk/pull/8543/files/6ad785461550707572be064d5d07a354b173f79a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8543/head:pull/8543` \
`$ git checkout pull/8543`

Update a local copy of the PR: \
`$ git checkout pull/8543` \
`$ git pull https://git.openjdk.java.net/jdk pull/8543/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8543`

View PR using the GUI difftool: \
`$ git pr show -t 8543`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8543.diff">https://git.openjdk.java.net/jdk/pull/8543.diff</a>

</details>
