### PR TITLE
8284050: [vectorapi] Optimize masked store for non-predicated architectures

### DIFF
--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -946,6 +946,7 @@ class methodHandle;
                                              "J"                                                                                               \
                                              "Ljdk/internal/vm/vector/VectorSupport$Vector;"                                                   \
                                              "Ljdk/internal/vm/vector/VectorSupport$VectorMask;"                                               \
+                                             "I"                                                                                               \
                                              "Ljava/lang/Object;"                                                                              \
                                              "I"                                                                                               \
                                              "Ljdk/internal/vm/vector/VectorSupport$StoreVectorMaskedOperation;)"                              \

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -1148,7 +1148,7 @@ bool LibraryCallKit::inline_vector_mem_operation(bool is_store) {
 //  E>
 // void storeMasked(Class<? extends V> vectorClass, Class<M> maskClass, Class<E> elementType,
 //                  int length, Object base, long offset,
-//                  V v, M m,
+//                  V v, M m, int offsetInRange,
 //                  C container, int index,  // Arguments for default implementation
 //                  StoreVectorMaskedOperation<C, V, M, E> defaultImpl) {
 //
@@ -1229,28 +1229,22 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
   // If current arch does not support the predicated operations, we have to bail
   // out when current case uses the predicate feature.
   if (!supports_predicate) {
-    bool use_predicate = false;
-    if (is_store) {
-      // Masked vector store always uses the predicated store.
-      use_predicate = true;
-    } else {
-      // Masked vector load with IOOBE always uses the predicated load.
-      const TypeInt* offset_in_range = gvn().type(argument(8))->isa_int();
-      if (!offset_in_range->is_con()) {
-        if (C->print_intrinsics()) {
-          tty->print_cr("  ** missing constant: offsetInRange=%s",
-                        NodeClassNames[argument(8)->Opcode()]);
-        }
-        set_map(old_map);
-        set_sp(old_sp);
-        return false;
+    const TypeInt* offset_in_range = gvn().type(is_store ? argument(9) : argument(8))->isa_int();
+    if (!offset_in_range->is_con()) {
+      if (C->print_intrinsics()) {
+        tty->print_cr("  ** missing constant: offsetInRange=%s",
+                      is_store ? NodeClassNames[argument(9)->Opcode()]
+                               : NodeClassNames[argument(8)->Opcode()]);
       }
-      use_predicate = (offset_in_range->get_con() == 0);
+      set_map(old_map);
+      set_sp(old_sp);
+      return false;
     }
 
-    if (use_predicate) {
+    // Masked vector load/store with IOOBE always use the predicated load/store instruction.
+    if (offset_in_range->get_con() == 0) {
       if (C->print_intrinsics()) {
-        tty->print_cr("  ** not supported: op=%s vlen=%d etype=%s using_byte_array=%d",
+        tty->print_cr("  ** not supported: op=%s vlen=%d etype=%s using_byte_array=%d offset_in_range=0",
                       is_store ? "storeMasked" : "loadMasked",
                       num_elem, type2name(elem_bt), using_byte_array ? 1 : 0);
       }
@@ -1260,17 +1254,20 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
     }
   }
 
-  // This only happens for masked vector load. If predicate is not supported, then check whether
-  // the normal vector load and blend operations are supported by backend.
-  if (!supports_predicate && (!arch_supports_vector(Op_LoadVector, mem_num_elem, mem_elem_bt, VecMaskNotUsed) ||
-      !arch_supports_vector(Op_VectorBlend, mem_num_elem, mem_elem_bt, VecMaskUseLoad))) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: op=loadMasked vlen=%d etype=%s using_byte_array=%d",
-                    num_elem, type2name(elem_bt), using_byte_array ? 1 : 0);
+  // Check whether the vector blend pattern is supported or not if predicate is not supported.
+  if (!supports_predicate) {
+    if ((is_store && !arch_supports_vector(Op_StoreVector, mem_num_elem, mem_elem_bt, VecMaskNotUsed)) ||
+        !arch_supports_vector(Op_LoadVector, mem_num_elem, mem_elem_bt, VecMaskNotUsed) ||
+        !arch_supports_vector(Op_VectorBlend, mem_num_elem, mem_elem_bt, VecMaskUseLoad)) {
+      if (C->print_intrinsics()) {
+        tty->print_cr("  ** not supported: op=%s vlen=%d etype=%s using_byte_array=%d",
+                      is_store ? "storeMasked" : "loadMasked", num_elem,
+                      type2name(elem_bt), using_byte_array ? 1 : 0);
+      }
+      set_map(old_map);
+      set_sp(old_sp);
+      return false;
     }
-    set_map(old_map);
-    set_sp(old_sp);
-    return false;
   }
 
   // Since we are using byte array, we need to double check that the vector reinterpret operation
@@ -1313,6 +1310,20 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
   const TypeInstPtr* vbox_type = TypeInstPtr::make_exact(TypePtr::NotNull, vbox_klass);
   const TypeInstPtr* mbox_type = TypeInstPtr::make_exact(TypePtr::NotNull, mbox_klass);
 
+  Node* val = NULL;
+  if (is_store) {
+    val = unbox_vector(argument(7), vbox_type, elem_bt, num_elem);
+    if (val == NULL) {
+      if (C->print_intrinsics()) {
+        tty->print_cr("  ** unbox failed vector=%s",
+                      NodeClassNames[argument(7)->Opcode()]);
+      }
+      set_map(old_map);
+      set_sp(old_sp);
+      return false; // operand unboxing failed
+    }
+  }
+
   Node* mask = unbox_vector(is_store ? argument(8) : argument(7), mbox_type, elem_bt, num_elem);
   if (mask == NULL) {
     if (C->print_intrinsics()) {
@@ -1324,45 +1335,42 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
     set_sp(old_sp);
     return false;
   }
+  if (using_byte_array) {
+    // Reinterpret the vector mask to byte type.
+    const TypeVect* from_mask_type = TypeVect::makemask(elem_bt, num_elem);
+    const TypeVect* to_mask_type = TypeVect::makemask(mem_elem_bt, mem_num_elem);
+    mask = gvn().transform(new VectorReinterpretNode(mask, from_mask_type, to_mask_type));
+  }
+
+  const TypeVect* vt = TypeVect::make(elem_bt, num_elem);
+  const TypeVect* mem_vt = TypeVect::make(mem_elem_bt, mem_num_elem);
 
   if (is_store) {
-    Node* val = unbox_vector(argument(7), vbox_type, elem_bt, num_elem);
-    if (val == NULL) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** unbox failed vector=%s",
-                      NodeClassNames[argument(7)->Opcode()]);
-      }
-      set_map(old_map);
-      set_sp(old_sp);
-      return false; // operand unboxing failed
-    }
     set_all_memory(reset_memory());
 
     if (using_byte_array) {
       // Reinterpret the incoming vector to byte vector.
-      const TypeVect* to_vect_type = TypeVect::make(mem_elem_bt, mem_num_elem);
-      val = gvn().transform(new VectorReinterpretNode(val, val->bottom_type()->is_vect(), to_vect_type));
-      // Reinterpret the vector mask to byte type.
-      const TypeVect* from_mask_type = TypeVect::makemask(elem_bt, num_elem);
-      const TypeVect* to_mask_type = TypeVect::makemask(mem_elem_bt, mem_num_elem);
-      mask = gvn().transform(new VectorReinterpretNode(mask, from_mask_type, to_mask_type));
+      val = gvn().transform(new VectorReinterpretNode(val, val->bottom_type()->is_vect(), mem_vt));
     }
-    Node* vstore = gvn().transform(new StoreVectorMaskedNode(control(), memory(addr), addr, val, addr_type, mask));
+
+    Node* vstore = NULL;
+    if (supports_predicate) {
+      // Generate masked store vector node if predicate feature is supported.
+      vstore = gvn().transform(new StoreVectorMaskedNode(control(), memory(addr), addr, val, addr_type, mask));
+    } else {
+      // Use the vector blend to implement the masked store. The biased elements are the original
+      // values in the memory.
+      Node* mem_val = gvn().transform(LoadVectorNode::make(0, control(), memory(addr), addr, addr_type, mem_num_elem, mem_elem_bt));
+      val = gvn().transform(new VectorBlendNode(mem_val, val, mask));
+      vstore = gvn().transform(new StoreVectorNode(control(), memory(addr), addr, addr_type, val));
+    }
     set_memory(vstore, addr_type);
   } else {
     Node* vload = NULL;
 
-    if (using_byte_array) {
-      // Reinterpret the vector mask to byte type.
-      const TypeVect* from_mask_type = TypeVect::makemask(elem_bt, num_elem);
-      const TypeVect* to_mask_type = TypeVect::makemask(mem_elem_bt, mem_num_elem);
-      mask = gvn().transform(new VectorReinterpretNode(mask, from_mask_type, to_mask_type));
-    }
-
     if (supports_predicate) {
       // Generate masked load vector node if predicate feature is supported.
-      const TypeVect* vt = TypeVect::make(mem_elem_bt, mem_num_elem);
-      vload = gvn().transform(new LoadVectorMaskedNode(control(), memory(addr), addr, addr_type, vt, mask));
+      vload = gvn().transform(new LoadVectorMaskedNode(control(), memory(addr), addr, addr_type, mem_vt, mask));
     } else {
       // Use the vector blend to implement the masked load vector. The biased elements are zeros.
       Node* zero = gvn().transform(gvn().zerocon(mem_elem_bt));
@@ -1372,8 +1380,7 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
     }
 
     if (using_byte_array) {
-      const TypeVect* to_vect_type = TypeVect::make(elem_bt, num_elem);
-      vload = gvn().transform(new VectorReinterpretNode(vload, vload->bottom_type()->is_vect(), to_vect_type));
+      vload = gvn().transform(new VectorReinterpretNode(vload, vload->bottom_type()->is_vect(), vt));
     }
 
     Node* box = box_vector(vload, vbox_type, elem_bt, num_elem);

--- a/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
+++ b/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
@@ -517,14 +517,14 @@ public class ScopedMemoryAccess {
     public static
     <V extends VectorSupport.Vector<E>, E, M extends VectorSupport.VectorMask<E>>
     void storeIntoByteBufferMasked(Class<? extends V> vmClass, Class<M> maskClass, Class<E> e,
-                                   int length, V v, M m,
+                                   int length, V v, M m, boolean offsetInRange,
                                    ByteBuffer bb, int offset,
                                    VectorSupport.StoreVectorMaskedOperation<ByteBuffer, V, M> defaultImpl) {
         try {
             storeIntoByteBufferMaskedScoped(
                     BufferAccess.scope(bb),
                     vmClass, maskClass, e, length,
-                    v, m,
+                    v, m, offsetInRange,
                     bb, offset,
                     defaultImpl);
         } catch (ScopedMemoryAccess.Scope.ScopedAccessError ex) {
@@ -538,7 +538,7 @@ public class ScopedMemoryAccess {
     <V extends VectorSupport.Vector<E>, E, M extends VectorSupport.VectorMask<E>>
     void storeIntoByteBufferMaskedScoped(ScopedMemoryAccess.Scope scope,
                                          Class<? extends V> vmClass, Class<M> maskClass,
-                                         Class<E> e, int length, V v, M m,
+                                         Class<E> e, int length, V v, M m, boolean offsetInRange,
                                          ByteBuffer bb, int offset,
                                          VectorSupport.StoreVectorMaskedOperation<ByteBuffer, V, M> defaultImpl) {
         try {
@@ -546,11 +546,19 @@ public class ScopedMemoryAccess {
                 scope.checkValidState();
             }
 
-            VectorSupport.storeMasked(vmClass, maskClass, e, length,
-                    BufferAccess.bufferBase(bb), BufferAccess.bufferAddress(bb, offset),
-                    v, m,
-                    bb, offset,
-                    defaultImpl);
+            if (offsetInRange) {
+                VectorSupport.storeMasked(vmClass, maskClass, e, length,
+                        BufferAccess.bufferBase(bb), BufferAccess.bufferAddress(bb, offset),
+                        v, m, /* offsetInRange */ 1,
+                        bb, offset,
+                        defaultImpl);
+            } else {
+                VectorSupport.storeMasked(vmClass, maskClass, e, length,
+                        BufferAccess.bufferBase(bb), BufferAccess.bufferAddress(bb, offset),
+                        v, m, /* offsetInRange */ 0,
+                        bb, offset,
+                        defaultImpl);
+            }
         } finally {
             Reference.reachabilityFence(scope);
         }

--- a/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
+++ b/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
@@ -469,7 +469,7 @@ public class VectorSupport {
     void storeMasked(Class<? extends V> vClass, Class<M> mClass, Class<E> eClass,
                      int length,
                      Object base, long offset,
-                     V v, M m, C container, int index,
+                     V v, M m, int offsetInRange, C container, int index,
                      StoreVectorMaskedOperation<C, V, M> defaultImpl) {
         assert isNonCapturingLambda(defaultImpl) : defaultImpl;
         defaultImpl.store(container, index, v, m);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
@@ -911,16 +911,16 @@ final class Byte128Vector extends ByteVector {
     @ForceInline
     @Override
     final
-    void intoArray0(byte[] a, int offset, VectorMask<Byte> m) {
-        super.intoArray0Template(Byte128Mask.class, a, offset, (Byte128Mask) m);
+    void intoArray0(byte[] a, int offset, VectorMask<Byte> m, boolean offsetInRange) {
+        super.intoArray0Template(Byte128Mask.class, a, offset, (Byte128Mask) m, offsetInRange);
     }
 
 
     @ForceInline
     @Override
     final
-    void intoBooleanArray0(boolean[] a, int offset, VectorMask<Byte> m) {
-        super.intoBooleanArray0Template(Byte128Mask.class, a, offset, (Byte128Mask) m);
+    void intoBooleanArray0(boolean[] a, int offset, VectorMask<Byte> m, boolean offsetInRange) {
+        super.intoBooleanArray0Template(Byte128Mask.class, a, offset, (Byte128Mask) m, offsetInRange);
     }
 
     @ForceInline
@@ -933,15 +933,15 @@ final class Byte128Vector extends ByteVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Byte> m) {
-        super.intoByteArray0Template(Byte128Mask.class, a, offset, (Byte128Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Byte> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Byte128Mask.class, a, offset, (Byte128Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Byte> m) {
-        super.intoByteBuffer0Template(Byte128Mask.class, bb, offset, (Byte128Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Byte> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Byte128Mask.class, bb, offset, (Byte128Mask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
@@ -943,16 +943,16 @@ final class Byte256Vector extends ByteVector {
     @ForceInline
     @Override
     final
-    void intoArray0(byte[] a, int offset, VectorMask<Byte> m) {
-        super.intoArray0Template(Byte256Mask.class, a, offset, (Byte256Mask) m);
+    void intoArray0(byte[] a, int offset, VectorMask<Byte> m, boolean offsetInRange) {
+        super.intoArray0Template(Byte256Mask.class, a, offset, (Byte256Mask) m, offsetInRange);
     }
 
 
     @ForceInline
     @Override
     final
-    void intoBooleanArray0(boolean[] a, int offset, VectorMask<Byte> m) {
-        super.intoBooleanArray0Template(Byte256Mask.class, a, offset, (Byte256Mask) m);
+    void intoBooleanArray0(boolean[] a, int offset, VectorMask<Byte> m, boolean offsetInRange) {
+        super.intoBooleanArray0Template(Byte256Mask.class, a, offset, (Byte256Mask) m, offsetInRange);
     }
 
     @ForceInline
@@ -965,15 +965,15 @@ final class Byte256Vector extends ByteVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Byte> m) {
-        super.intoByteArray0Template(Byte256Mask.class, a, offset, (Byte256Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Byte> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Byte256Mask.class, a, offset, (Byte256Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Byte> m) {
-        super.intoByteBuffer0Template(Byte256Mask.class, bb, offset, (Byte256Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Byte> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Byte256Mask.class, bb, offset, (Byte256Mask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
@@ -1007,16 +1007,16 @@ final class Byte512Vector extends ByteVector {
     @ForceInline
     @Override
     final
-    void intoArray0(byte[] a, int offset, VectorMask<Byte> m) {
-        super.intoArray0Template(Byte512Mask.class, a, offset, (Byte512Mask) m);
+    void intoArray0(byte[] a, int offset, VectorMask<Byte> m, boolean offsetInRange) {
+        super.intoArray0Template(Byte512Mask.class, a, offset, (Byte512Mask) m, offsetInRange);
     }
 
 
     @ForceInline
     @Override
     final
-    void intoBooleanArray0(boolean[] a, int offset, VectorMask<Byte> m) {
-        super.intoBooleanArray0Template(Byte512Mask.class, a, offset, (Byte512Mask) m);
+    void intoBooleanArray0(boolean[] a, int offset, VectorMask<Byte> m, boolean offsetInRange) {
+        super.intoBooleanArray0Template(Byte512Mask.class, a, offset, (Byte512Mask) m, offsetInRange);
     }
 
     @ForceInline
@@ -1029,15 +1029,15 @@ final class Byte512Vector extends ByteVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Byte> m) {
-        super.intoByteArray0Template(Byte512Mask.class, a, offset, (Byte512Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Byte> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Byte512Mask.class, a, offset, (Byte512Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Byte> m) {
-        super.intoByteBuffer0Template(Byte512Mask.class, bb, offset, (Byte512Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Byte> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Byte512Mask.class, bb, offset, (Byte512Mask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
@@ -895,16 +895,16 @@ final class Byte64Vector extends ByteVector {
     @ForceInline
     @Override
     final
-    void intoArray0(byte[] a, int offset, VectorMask<Byte> m) {
-        super.intoArray0Template(Byte64Mask.class, a, offset, (Byte64Mask) m);
+    void intoArray0(byte[] a, int offset, VectorMask<Byte> m, boolean offsetInRange) {
+        super.intoArray0Template(Byte64Mask.class, a, offset, (Byte64Mask) m, offsetInRange);
     }
 
 
     @ForceInline
     @Override
     final
-    void intoBooleanArray0(boolean[] a, int offset, VectorMask<Byte> m) {
-        super.intoBooleanArray0Template(Byte64Mask.class, a, offset, (Byte64Mask) m);
+    void intoBooleanArray0(boolean[] a, int offset, VectorMask<Byte> m, boolean offsetInRange) {
+        super.intoBooleanArray0Template(Byte64Mask.class, a, offset, (Byte64Mask) m, offsetInRange);
     }
 
     @ForceInline
@@ -917,15 +917,15 @@ final class Byte64Vector extends ByteVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Byte> m) {
-        super.intoByteArray0Template(Byte64Mask.class, a, offset, (Byte64Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Byte> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Byte64Mask.class, a, offset, (Byte64Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Byte> m) {
-        super.intoByteBuffer0Template(Byte64Mask.class, bb, offset, (Byte64Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Byte> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Byte64Mask.class, bb, offset, (Byte64Mask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
@@ -881,16 +881,16 @@ final class ByteMaxVector extends ByteVector {
     @ForceInline
     @Override
     final
-    void intoArray0(byte[] a, int offset, VectorMask<Byte> m) {
-        super.intoArray0Template(ByteMaxMask.class, a, offset, (ByteMaxMask) m);
+    void intoArray0(byte[] a, int offset, VectorMask<Byte> m, boolean offsetInRange) {
+        super.intoArray0Template(ByteMaxMask.class, a, offset, (ByteMaxMask) m, offsetInRange);
     }
 
 
     @ForceInline
     @Override
     final
-    void intoBooleanArray0(boolean[] a, int offset, VectorMask<Byte> m) {
-        super.intoBooleanArray0Template(ByteMaxMask.class, a, offset, (ByteMaxMask) m);
+    void intoBooleanArray0(boolean[] a, int offset, VectorMask<Byte> m, boolean offsetInRange) {
+        super.intoBooleanArray0Template(ByteMaxMask.class, a, offset, (ByteMaxMask) m, offsetInRange);
     }
 
     @ForceInline
@@ -903,15 +903,15 @@ final class ByteMaxVector extends ByteVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Byte> m) {
-        super.intoByteArray0Template(ByteMaxMask.class, a, offset, (ByteMaxMask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Byte> m, boolean offsetInRange) {
+        super.intoByteArray0Template(ByteMaxMask.class, a, offset, (ByteMaxMask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Byte> m) {
-        super.intoByteBuffer0Template(ByteMaxMask.class, bb, offset, (ByteMaxMask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Byte> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(ByteMaxMask.class, bb, offset, (ByteMaxMask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -3320,8 +3320,12 @@ public abstract class ByteVector extends AbstractVector<Byte> {
             intoArray(a, offset);
         } else {
             ByteSpecies vsp = vspecies();
-            checkMaskFromIndexSize(offset, vsp, m, 1, a.length);
-            intoArray0(a, offset, m);
+            if (offset >= 0 && offset <= (a.length - vsp.length())) {
+                intoArray0(a, offset, m, /* offsetInRange */ true);
+            } else {
+                checkMaskFromIndexSize(offset, vsp, m, 1, a.length);
+                intoArray0(a, offset, m, /* offsetInRange */ false);
+            }
         }
     }
 
@@ -3475,8 +3479,12 @@ public abstract class ByteVector extends AbstractVector<Byte> {
             intoBooleanArray(a, offset);
         } else {
             ByteSpecies vsp = vspecies();
-            checkMaskFromIndexSize(offset, vsp, m, 1, a.length);
-            intoBooleanArray0(a, offset, m);
+            if (offset >= 0 && offset <= (a.length - vsp.length())) {
+                intoBooleanArray0(a, offset, m, /* offsetInRange */ true);
+            } else {
+                checkMaskFromIndexSize(offset, vsp, m, 1, a.length);
+                intoBooleanArray0(a, offset, m, /* offsetInRange */ false);
+            }
         }
     }
 
@@ -3596,8 +3604,12 @@ public abstract class ByteVector extends AbstractVector<Byte> {
             intoByteArray(a, offset, bo);
         } else {
             ByteSpecies vsp = vspecies();
-            checkMaskFromIndexSize(offset, vsp, m, 1, a.length);
-            maybeSwap(bo).intoByteArray0(a, offset, m);
+            if (offset >= 0 && offset <= (a.length - vsp.vectorByteSize())) {
+                maybeSwap(bo).intoByteArray0(a, offset, m, /* offsetInRange */ true);
+            } else {
+                checkMaskFromIndexSize(offset, vsp, m, 1, a.length);
+                maybeSwap(bo).intoByteArray0(a, offset, m, /* offsetInRange */ false);
+            }
         }
     }
 
@@ -3632,8 +3644,12 @@ public abstract class ByteVector extends AbstractVector<Byte> {
                 throw new ReadOnlyBufferException();
             }
             ByteSpecies vsp = vspecies();
-            checkMaskFromIndexSize(offset, vsp, m, 1, bb.limit());
-            maybeSwap(bo).intoByteBuffer0(bb, offset, m);
+            if (offset >= 0 && offset <= (bb.limit() - vsp.vectorByteSize())) {
+                maybeSwap(bo).intoByteBuffer0(bb, offset, m, /* offsetInRange */ true);
+            } else {
+                checkMaskFromIndexSize(offset, vsp, m, 1, bb.limit());
+                maybeSwap(bo).intoByteBuffer0(bb, offset, m, /* offsetInRange */ false);
+            }
         }
     }
 
@@ -3823,39 +3839,51 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     }
 
     abstract
-    void intoArray0(byte[] a, int offset, VectorMask<Byte> m);
+    void intoArray0(byte[] a, int offset, VectorMask<Byte> m, boolean offsetInRange);
     @ForceInline
     final
     <M extends VectorMask<Byte>>
-    void intoArray0Template(Class<M> maskClass, byte[] a, int offset, M m) {
+    void intoArray0Template(Class<M> maskClass, byte[] a, int offset, M m, boolean offsetInRange) {
+        intoArray0Template(maskClass, a, arrayAddress(a, offset), offset,
+            this, m, offsetInRange,
+            (arr, off, v, vm) -> v.stOp(arr, off, vm,
+                                        (arr_, off_, i, e) -> arr_[off_ + i] = e));
+    }
+
+    @ForceInline
+    final
+    <C, M extends VectorMask<Byte>>
+    void intoArray0Template(Class<M> maskClass, C base, long offset, int index, ByteVector v, M m, boolean offsetInRange,
+                            VectorSupport.StoreVectorMaskedOperation<C, ByteVector, M> defaultImpl) {
         m.check(species());
         ByteSpecies vsp = vspecies();
-        VectorSupport.storeMasked(
-            vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            this, m, a, offset,
-            (arr, off, v, vm)
-            -> v.stOp(arr, off, vm,
-                      (arr_, off_, i, e) -> arr_[off_ + i] = e));
+        if (offsetInRange) {
+            VectorSupport.storeMasked(
+                vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
+                base, offset,
+                v, m, /* offsetInRange */ 1,
+                base, index, defaultImpl);
+        } else {
+            VectorSupport.storeMasked(
+                vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
+                base, offset,
+                v, m, /* offsetInRange */ 0,
+                base, index, defaultImpl);
+        }
     }
 
 
     abstract
-    void intoBooleanArray0(boolean[] a, int offset, VectorMask<Byte> m);
+    void intoBooleanArray0(boolean[] a, int offset, VectorMask<Byte> m, boolean offsetInRange);
     @ForceInline
     final
     <M extends VectorMask<Byte>>
-    void intoBooleanArray0Template(Class<M> maskClass, boolean[] a, int offset, M m) {
-        m.check(species());
-        ByteSpecies vsp = vspecies();
+    void intoBooleanArray0Template(Class<M> maskClass, boolean[] a, int offset, M m, boolean offsetInRange) {
         ByteVector normalized = this.and((byte) 1);
-        VectorSupport.storeMasked(
-            vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, booleanArrayAddress(a, offset),
-            normalized, m, a, offset,
-            (arr, off, v, vm)
-            -> v.stOp(arr, off, vm,
-                      (arr_, off_, i, e) -> arr_[off_ + i] = (e & 1) != 0));
+        intoArray0Template(maskClass, a, booleanArrayAddress(a, offset), offset,
+            normalized,  m, offsetInRange,
+            (arr, off, v, vm) -> v.stOp(arr, off, vm,
+                                        (arr_, off_, i, e) -> arr_[off_ + i] = (e & 1) != 0));
     }
 
     abstract
@@ -3876,17 +3904,13 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     }
 
     abstract
-    void intoByteArray0(byte[] a, int offset, VectorMask<Byte> m);
+    void intoByteArray0(byte[] a, int offset, VectorMask<Byte> m, boolean offsetInRange);
     @ForceInline
     final
     <M extends VectorMask<Byte>>
-    void intoByteArray0Template(Class<M> maskClass, byte[] a, int offset, M m) {
-        ByteSpecies vsp = vspecies();
-        m.check(vsp);
-        VectorSupport.storeMasked(
-            vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, byteArrayAddress(a, offset),
-            this, m, a, offset,
+    void intoByteArray0Template(Class<M> maskClass, byte[] a, int offset, M m, boolean offsetInRange) {
+        intoArray0Template(maskClass, a, byteArrayAddress(a, offset), offset,
+            this, m, offsetInRange,
             (arr, off, v, vm) -> {
                 ByteBuffer wb = wrapper(arr, NATIVE_ENDIAN);
                 v.stOp(wb, off, vm,
@@ -3909,16 +3933,16 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     }
 
     abstract
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Byte> m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Byte> m, boolean offsetInRange);
     @ForceInline
     final
     <M extends VectorMask<Byte>>
-    void intoByteBuffer0Template(Class<M> maskClass, ByteBuffer bb, int offset, M m) {
+    void intoByteBuffer0Template(Class<M> maskClass, ByteBuffer bb, int offset, M m, boolean offsetInRange) {
         ByteSpecies vsp = vspecies();
         m.check(vsp);
         ScopedMemoryAccess.storeIntoByteBufferMasked(
                 vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-                this, m, bb, offset,
+                this, m, offsetInRange, bb, offset,
                 (buf, off, v, vm) -> {
                     ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
                     v.stOp(wb, off, vm,

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
@@ -865,8 +865,8 @@ final class Double128Vector extends DoubleVector {
     @ForceInline
     @Override
     final
-    void intoArray0(double[] a, int offset, VectorMask<Double> m) {
-        super.intoArray0Template(Double128Mask.class, a, offset, (Double128Mask) m);
+    void intoArray0(double[] a, int offset, VectorMask<Double> m, boolean offsetInRange) {
+        super.intoArray0Template(Double128Mask.class, a, offset, (Double128Mask) m, offsetInRange);
     }
 
     @ForceInline
@@ -887,15 +887,15 @@ final class Double128Vector extends DoubleVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Double> m) {
-        super.intoByteArray0Template(Double128Mask.class, a, offset, (Double128Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Double> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Double128Mask.class, a, offset, (Double128Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Double> m) {
-        super.intoByteBuffer0Template(Double128Mask.class, bb, offset, (Double128Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Double> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Double128Mask.class, bb, offset, (Double128Mask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
@@ -869,8 +869,8 @@ final class Double256Vector extends DoubleVector {
     @ForceInline
     @Override
     final
-    void intoArray0(double[] a, int offset, VectorMask<Double> m) {
-        super.intoArray0Template(Double256Mask.class, a, offset, (Double256Mask) m);
+    void intoArray0(double[] a, int offset, VectorMask<Double> m, boolean offsetInRange) {
+        super.intoArray0Template(Double256Mask.class, a, offset, (Double256Mask) m, offsetInRange);
     }
 
     @ForceInline
@@ -891,15 +891,15 @@ final class Double256Vector extends DoubleVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Double> m) {
-        super.intoByteArray0Template(Double256Mask.class, a, offset, (Double256Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Double> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Double256Mask.class, a, offset, (Double256Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Double> m) {
-        super.intoByteBuffer0Template(Double256Mask.class, bb, offset, (Double256Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Double> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Double256Mask.class, bb, offset, (Double256Mask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
@@ -877,8 +877,8 @@ final class Double512Vector extends DoubleVector {
     @ForceInline
     @Override
     final
-    void intoArray0(double[] a, int offset, VectorMask<Double> m) {
-        super.intoArray0Template(Double512Mask.class, a, offset, (Double512Mask) m);
+    void intoArray0(double[] a, int offset, VectorMask<Double> m, boolean offsetInRange) {
+        super.intoArray0Template(Double512Mask.class, a, offset, (Double512Mask) m, offsetInRange);
     }
 
     @ForceInline
@@ -899,15 +899,15 @@ final class Double512Vector extends DoubleVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Double> m) {
-        super.intoByteArray0Template(Double512Mask.class, a, offset, (Double512Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Double> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Double512Mask.class, a, offset, (Double512Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Double> m) {
-        super.intoByteBuffer0Template(Double512Mask.class, bb, offset, (Double512Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Double> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Double512Mask.class, bb, offset, (Double512Mask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
@@ -863,8 +863,8 @@ final class Double64Vector extends DoubleVector {
     @ForceInline
     @Override
     final
-    void intoArray0(double[] a, int offset, VectorMask<Double> m) {
-        super.intoArray0Template(Double64Mask.class, a, offset, (Double64Mask) m);
+    void intoArray0(double[] a, int offset, VectorMask<Double> m, boolean offsetInRange) {
+        super.intoArray0Template(Double64Mask.class, a, offset, (Double64Mask) m, offsetInRange);
     }
 
     @ForceInline
@@ -885,15 +885,15 @@ final class Double64Vector extends DoubleVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Double> m) {
-        super.intoByteArray0Template(Double64Mask.class, a, offset, (Double64Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Double> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Double64Mask.class, a, offset, (Double64Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Double> m) {
-        super.intoByteBuffer0Template(Double64Mask.class, bb, offset, (Double64Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Double> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Double64Mask.class, bb, offset, (Double64Mask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
@@ -862,8 +862,8 @@ final class DoubleMaxVector extends DoubleVector {
     @ForceInline
     @Override
     final
-    void intoArray0(double[] a, int offset, VectorMask<Double> m) {
-        super.intoArray0Template(DoubleMaxMask.class, a, offset, (DoubleMaxMask) m);
+    void intoArray0(double[] a, int offset, VectorMask<Double> m, boolean offsetInRange) {
+        super.intoArray0Template(DoubleMaxMask.class, a, offset, (DoubleMaxMask) m, offsetInRange);
     }
 
     @ForceInline
@@ -884,15 +884,15 @@ final class DoubleMaxVector extends DoubleVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Double> m) {
-        super.intoByteArray0Template(DoubleMaxMask.class, a, offset, (DoubleMaxMask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Double> m, boolean offsetInRange) {
+        super.intoByteArray0Template(DoubleMaxMask.class, a, offset, (DoubleMaxMask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Double> m) {
-        super.intoByteBuffer0Template(DoubleMaxMask.class, bb, offset, (DoubleMaxMask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Double> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(DoubleMaxMask.class, bb, offset, (DoubleMaxMask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -3036,8 +3036,12 @@ public abstract class DoubleVector extends AbstractVector<Double> {
             intoArray(a, offset);
         } else {
             DoubleSpecies vsp = vspecies();
-            checkMaskFromIndexSize(offset, vsp, m, 1, a.length);
-            intoArray0(a, offset, m);
+            if (offset >= 0 && offset <= (a.length - vsp.length())) {
+                intoArray0(a, offset, m, /* offsetInRange */ true);
+            } else {
+                checkMaskFromIndexSize(offset, vsp, m, 1, a.length);
+                intoArray0(a, offset, m, /* offsetInRange */ false);
+            }
         }
     }
 
@@ -3183,8 +3187,12 @@ public abstract class DoubleVector extends AbstractVector<Double> {
             intoByteArray(a, offset, bo);
         } else {
             DoubleSpecies vsp = vspecies();
-            checkMaskFromIndexSize(offset, vsp, m, 8, a.length);
-            maybeSwap(bo).intoByteArray0(a, offset, m);
+            if (offset >= 0 && offset <= (a.length - vsp.vectorByteSize())) {
+                maybeSwap(bo).intoByteArray0(a, offset, m, /* offsetInRange */ true);
+            } else {
+                checkMaskFromIndexSize(offset, vsp, m, 8, a.length);
+                maybeSwap(bo).intoByteArray0(a, offset, m, /* offsetInRange */ false);
+            }
         }
     }
 
@@ -3219,8 +3227,12 @@ public abstract class DoubleVector extends AbstractVector<Double> {
                 throw new ReadOnlyBufferException();
             }
             DoubleSpecies vsp = vspecies();
-            checkMaskFromIndexSize(offset, vsp, m, 8, bb.limit());
-            maybeSwap(bo).intoByteBuffer0(bb, offset, m);
+            if (offset >= 0 && offset <= (bb.limit() - vsp.vectorByteSize())) {
+                maybeSwap(bo).intoByteBuffer0(bb, offset, m, /* offsetInRange */ true);
+            } else {
+                checkMaskFromIndexSize(offset, vsp, m, 8, bb.limit());
+                maybeSwap(bo).intoByteBuffer0(bb, offset, m, /* offsetInRange */ false);
+            }
         }
     }
 
@@ -3433,20 +3445,37 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     }
 
     abstract
-    void intoArray0(double[] a, int offset, VectorMask<Double> m);
+    void intoArray0(double[] a, int offset, VectorMask<Double> m, boolean offsetInRange);
     @ForceInline
     final
     <M extends VectorMask<Double>>
-    void intoArray0Template(Class<M> maskClass, double[] a, int offset, M m) {
+    void intoArray0Template(Class<M> maskClass, double[] a, int offset, M m, boolean offsetInRange) {
+        intoArray0Template(maskClass, a, arrayAddress(a, offset), offset,
+            this, m, offsetInRange,
+            (arr, off, v, vm) -> v.stOp(arr, off, vm,
+                                        (arr_, off_, i, e) -> arr_[off_ + i] = e));
+    }
+
+    @ForceInline
+    final
+    <C, M extends VectorMask<Double>>
+    void intoArray0Template(Class<M> maskClass, C base, long offset, int index, DoubleVector v, M m, boolean offsetInRange,
+                            VectorSupport.StoreVectorMaskedOperation<C, DoubleVector, M> defaultImpl) {
         m.check(species());
         DoubleSpecies vsp = vspecies();
-        VectorSupport.storeMasked(
-            vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            this, m, a, offset,
-            (arr, off, v, vm)
-            -> v.stOp(arr, off, vm,
-                      (arr_, off_, i, e) -> arr_[off_ + i] = e));
+        if (offsetInRange) {
+            VectorSupport.storeMasked(
+                vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
+                base, offset,
+                v, m, /* offsetInRange */ 1,
+                base, index, defaultImpl);
+        } else {
+            VectorSupport.storeMasked(
+                vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
+                base, offset,
+                v, m, /* offsetInRange */ 0,
+                base, index, defaultImpl);
+        }
     }
 
     abstract
@@ -3521,17 +3550,13 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     }
 
     abstract
-    void intoByteArray0(byte[] a, int offset, VectorMask<Double> m);
+    void intoByteArray0(byte[] a, int offset, VectorMask<Double> m, boolean offsetInRange);
     @ForceInline
     final
     <M extends VectorMask<Double>>
-    void intoByteArray0Template(Class<M> maskClass, byte[] a, int offset, M m) {
-        DoubleSpecies vsp = vspecies();
-        m.check(vsp);
-        VectorSupport.storeMasked(
-            vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, byteArrayAddress(a, offset),
-            this, m, a, offset,
+    void intoByteArray0Template(Class<M> maskClass, byte[] a, int offset, M m, boolean offsetInRange) {
+        intoArray0Template(maskClass, a, byteArrayAddress(a, offset), offset,
+            this, m, offsetInRange,
             (arr, off, v, vm) -> {
                 ByteBuffer wb = wrapper(arr, NATIVE_ENDIAN);
                 v.stOp(wb, off, vm,
@@ -3554,16 +3579,16 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     }
 
     abstract
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Double> m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Double> m, boolean offsetInRange);
     @ForceInline
     final
     <M extends VectorMask<Double>>
-    void intoByteBuffer0Template(Class<M> maskClass, ByteBuffer bb, int offset, M m) {
+    void intoByteBuffer0Template(Class<M> maskClass, ByteBuffer bb, int offset, M m, boolean offsetInRange) {
         DoubleSpecies vsp = vspecies();
         m.check(vsp);
         ScopedMemoryAccess.storeIntoByteBufferMasked(
                 vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-                this, m, bb, offset,
+                this, m, offsetInRange, bb, offset,
                 (buf, off, v, vm) -> {
                     ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
                     v.stOp(wb, off, vm,

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
@@ -869,8 +869,8 @@ final class Float128Vector extends FloatVector {
     @ForceInline
     @Override
     final
-    void intoArray0(float[] a, int offset, VectorMask<Float> m) {
-        super.intoArray0Template(Float128Mask.class, a, offset, (Float128Mask) m);
+    void intoArray0(float[] a, int offset, VectorMask<Float> m, boolean offsetInRange) {
+        super.intoArray0Template(Float128Mask.class, a, offset, (Float128Mask) m, offsetInRange);
     }
 
     @ForceInline
@@ -891,15 +891,15 @@ final class Float128Vector extends FloatVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Float> m) {
-        super.intoByteArray0Template(Float128Mask.class, a, offset, (Float128Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Float> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Float128Mask.class, a, offset, (Float128Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Float> m) {
-        super.intoByteBuffer0Template(Float128Mask.class, bb, offset, (Float128Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Float> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Float128Mask.class, bb, offset, (Float128Mask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
@@ -877,8 +877,8 @@ final class Float256Vector extends FloatVector {
     @ForceInline
     @Override
     final
-    void intoArray0(float[] a, int offset, VectorMask<Float> m) {
-        super.intoArray0Template(Float256Mask.class, a, offset, (Float256Mask) m);
+    void intoArray0(float[] a, int offset, VectorMask<Float> m, boolean offsetInRange) {
+        super.intoArray0Template(Float256Mask.class, a, offset, (Float256Mask) m, offsetInRange);
     }
 
     @ForceInline
@@ -899,15 +899,15 @@ final class Float256Vector extends FloatVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Float> m) {
-        super.intoByteArray0Template(Float256Mask.class, a, offset, (Float256Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Float> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Float256Mask.class, a, offset, (Float256Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Float> m) {
-        super.intoByteBuffer0Template(Float256Mask.class, bb, offset, (Float256Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Float> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Float256Mask.class, bb, offset, (Float256Mask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
@@ -893,8 +893,8 @@ final class Float512Vector extends FloatVector {
     @ForceInline
     @Override
     final
-    void intoArray0(float[] a, int offset, VectorMask<Float> m) {
-        super.intoArray0Template(Float512Mask.class, a, offset, (Float512Mask) m);
+    void intoArray0(float[] a, int offset, VectorMask<Float> m, boolean offsetInRange) {
+        super.intoArray0Template(Float512Mask.class, a, offset, (Float512Mask) m, offsetInRange);
     }
 
     @ForceInline
@@ -915,15 +915,15 @@ final class Float512Vector extends FloatVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Float> m) {
-        super.intoByteArray0Template(Float512Mask.class, a, offset, (Float512Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Float> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Float512Mask.class, a, offset, (Float512Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Float> m) {
-        super.intoByteBuffer0Template(Float512Mask.class, bb, offset, (Float512Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Float> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Float512Mask.class, bb, offset, (Float512Mask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
@@ -865,8 +865,8 @@ final class Float64Vector extends FloatVector {
     @ForceInline
     @Override
     final
-    void intoArray0(float[] a, int offset, VectorMask<Float> m) {
-        super.intoArray0Template(Float64Mask.class, a, offset, (Float64Mask) m);
+    void intoArray0(float[] a, int offset, VectorMask<Float> m, boolean offsetInRange) {
+        super.intoArray0Template(Float64Mask.class, a, offset, (Float64Mask) m, offsetInRange);
     }
 
     @ForceInline
@@ -887,15 +887,15 @@ final class Float64Vector extends FloatVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Float> m) {
-        super.intoByteArray0Template(Float64Mask.class, a, offset, (Float64Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Float> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Float64Mask.class, a, offset, (Float64Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Float> m) {
-        super.intoByteBuffer0Template(Float64Mask.class, bb, offset, (Float64Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Float> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Float64Mask.class, bb, offset, (Float64Mask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
@@ -862,8 +862,8 @@ final class FloatMaxVector extends FloatVector {
     @ForceInline
     @Override
     final
-    void intoArray0(float[] a, int offset, VectorMask<Float> m) {
-        super.intoArray0Template(FloatMaxMask.class, a, offset, (FloatMaxMask) m);
+    void intoArray0(float[] a, int offset, VectorMask<Float> m, boolean offsetInRange) {
+        super.intoArray0Template(FloatMaxMask.class, a, offset, (FloatMaxMask) m, offsetInRange);
     }
 
     @ForceInline
@@ -884,15 +884,15 @@ final class FloatMaxVector extends FloatVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Float> m) {
-        super.intoByteArray0Template(FloatMaxMask.class, a, offset, (FloatMaxMask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Float> m, boolean offsetInRange) {
+        super.intoByteArray0Template(FloatMaxMask.class, a, offset, (FloatMaxMask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Float> m) {
-        super.intoByteBuffer0Template(FloatMaxMask.class, bb, offset, (FloatMaxMask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Float> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(FloatMaxMask.class, bb, offset, (FloatMaxMask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -3042,8 +3042,12 @@ public abstract class FloatVector extends AbstractVector<Float> {
             intoArray(a, offset);
         } else {
             FloatSpecies vsp = vspecies();
-            checkMaskFromIndexSize(offset, vsp, m, 1, a.length);
-            intoArray0(a, offset, m);
+            if (offset >= 0 && offset <= (a.length - vsp.length())) {
+                intoArray0(a, offset, m, /* offsetInRange */ true);
+            } else {
+                checkMaskFromIndexSize(offset, vsp, m, 1, a.length);
+                intoArray0(a, offset, m, /* offsetInRange */ false);
+            }
         }
     }
 
@@ -3170,8 +3174,12 @@ public abstract class FloatVector extends AbstractVector<Float> {
             intoByteArray(a, offset, bo);
         } else {
             FloatSpecies vsp = vspecies();
-            checkMaskFromIndexSize(offset, vsp, m, 4, a.length);
-            maybeSwap(bo).intoByteArray0(a, offset, m);
+            if (offset >= 0 && offset <= (a.length - vsp.vectorByteSize())) {
+                maybeSwap(bo).intoByteArray0(a, offset, m, /* offsetInRange */ true);
+            } else {
+                checkMaskFromIndexSize(offset, vsp, m, 4, a.length);
+                maybeSwap(bo).intoByteArray0(a, offset, m, /* offsetInRange */ false);
+            }
         }
     }
 
@@ -3206,8 +3214,12 @@ public abstract class FloatVector extends AbstractVector<Float> {
                 throw new ReadOnlyBufferException();
             }
             FloatSpecies vsp = vspecies();
-            checkMaskFromIndexSize(offset, vsp, m, 4, bb.limit());
-            maybeSwap(bo).intoByteBuffer0(bb, offset, m);
+            if (offset >= 0 && offset <= (bb.limit() - vsp.vectorByteSize())) {
+                maybeSwap(bo).intoByteBuffer0(bb, offset, m, /* offsetInRange */ true);
+            } else {
+                checkMaskFromIndexSize(offset, vsp, m, 4, bb.limit());
+                maybeSwap(bo).intoByteBuffer0(bb, offset, m, /* offsetInRange */ false);
+            }
         }
     }
 
@@ -3402,20 +3414,37 @@ public abstract class FloatVector extends AbstractVector<Float> {
     }
 
     abstract
-    void intoArray0(float[] a, int offset, VectorMask<Float> m);
+    void intoArray0(float[] a, int offset, VectorMask<Float> m, boolean offsetInRange);
     @ForceInline
     final
     <M extends VectorMask<Float>>
-    void intoArray0Template(Class<M> maskClass, float[] a, int offset, M m) {
+    void intoArray0Template(Class<M> maskClass, float[] a, int offset, M m, boolean offsetInRange) {
+        intoArray0Template(maskClass, a, arrayAddress(a, offset), offset,
+            this, m, offsetInRange,
+            (arr, off, v, vm) -> v.stOp(arr, off, vm,
+                                        (arr_, off_, i, e) -> arr_[off_ + i] = e));
+    }
+
+    @ForceInline
+    final
+    <C, M extends VectorMask<Float>>
+    void intoArray0Template(Class<M> maskClass, C base, long offset, int index, FloatVector v, M m, boolean offsetInRange,
+                            VectorSupport.StoreVectorMaskedOperation<C, FloatVector, M> defaultImpl) {
         m.check(species());
         FloatSpecies vsp = vspecies();
-        VectorSupport.storeMasked(
-            vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            this, m, a, offset,
-            (arr, off, v, vm)
-            -> v.stOp(arr, off, vm,
-                      (arr_, off_, i, e) -> arr_[off_ + i] = e));
+        if (offsetInRange) {
+            VectorSupport.storeMasked(
+                vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
+                base, offset,
+                v, m, /* offsetInRange */ 1,
+                base, index, defaultImpl);
+        } else {
+            VectorSupport.storeMasked(
+                vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
+                base, offset,
+                v, m, /* offsetInRange */ 0,
+                base, index, defaultImpl);
+        }
     }
 
     abstract
@@ -3471,17 +3500,13 @@ public abstract class FloatVector extends AbstractVector<Float> {
     }
 
     abstract
-    void intoByteArray0(byte[] a, int offset, VectorMask<Float> m);
+    void intoByteArray0(byte[] a, int offset, VectorMask<Float> m, boolean offsetInRange);
     @ForceInline
     final
     <M extends VectorMask<Float>>
-    void intoByteArray0Template(Class<M> maskClass, byte[] a, int offset, M m) {
-        FloatSpecies vsp = vspecies();
-        m.check(vsp);
-        VectorSupport.storeMasked(
-            vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, byteArrayAddress(a, offset),
-            this, m, a, offset,
+    void intoByteArray0Template(Class<M> maskClass, byte[] a, int offset, M m, boolean offsetInRange) {
+        intoArray0Template(maskClass, a, byteArrayAddress(a, offset), offset,
+            this, m, offsetInRange,
             (arr, off, v, vm) -> {
                 ByteBuffer wb = wrapper(arr, NATIVE_ENDIAN);
                 v.stOp(wb, off, vm,
@@ -3504,16 +3529,16 @@ public abstract class FloatVector extends AbstractVector<Float> {
     }
 
     abstract
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Float> m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Float> m, boolean offsetInRange);
     @ForceInline
     final
     <M extends VectorMask<Float>>
-    void intoByteBuffer0Template(Class<M> maskClass, ByteBuffer bb, int offset, M m) {
+    void intoByteBuffer0Template(Class<M> maskClass, ByteBuffer bb, int offset, M m, boolean offsetInRange) {
         FloatSpecies vsp = vspecies();
         m.check(vsp);
         ScopedMemoryAccess.storeIntoByteBufferMasked(
                 vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-                this, m, bb, offset,
+                this, m, offsetInRange, bb, offset,
                 (buf, off, v, vm) -> {
                     ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
                     v.stOp(wb, off, vm,

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
@@ -880,8 +880,8 @@ final class Int128Vector extends IntVector {
     @ForceInline
     @Override
     final
-    void intoArray0(int[] a, int offset, VectorMask<Integer> m) {
-        super.intoArray0Template(Int128Mask.class, a, offset, (Int128Mask) m);
+    void intoArray0(int[] a, int offset, VectorMask<Integer> m, boolean offsetInRange) {
+        super.intoArray0Template(Int128Mask.class, a, offset, (Int128Mask) m, offsetInRange);
     }
 
     @ForceInline
@@ -902,15 +902,15 @@ final class Int128Vector extends IntVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Integer> m) {
-        super.intoByteArray0Template(Int128Mask.class, a, offset, (Int128Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Integer> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Int128Mask.class, a, offset, (Int128Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Integer> m) {
-        super.intoByteBuffer0Template(Int128Mask.class, bb, offset, (Int128Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Integer> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Int128Mask.class, bb, offset, (Int128Mask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
@@ -888,8 +888,8 @@ final class Int256Vector extends IntVector {
     @ForceInline
     @Override
     final
-    void intoArray0(int[] a, int offset, VectorMask<Integer> m) {
-        super.intoArray0Template(Int256Mask.class, a, offset, (Int256Mask) m);
+    void intoArray0(int[] a, int offset, VectorMask<Integer> m, boolean offsetInRange) {
+        super.intoArray0Template(Int256Mask.class, a, offset, (Int256Mask) m, offsetInRange);
     }
 
     @ForceInline
@@ -910,15 +910,15 @@ final class Int256Vector extends IntVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Integer> m) {
-        super.intoByteArray0Template(Int256Mask.class, a, offset, (Int256Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Integer> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Int256Mask.class, a, offset, (Int256Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Integer> m) {
-        super.intoByteBuffer0Template(Int256Mask.class, bb, offset, (Int256Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Integer> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Int256Mask.class, bb, offset, (Int256Mask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
@@ -904,8 +904,8 @@ final class Int512Vector extends IntVector {
     @ForceInline
     @Override
     final
-    void intoArray0(int[] a, int offset, VectorMask<Integer> m) {
-        super.intoArray0Template(Int512Mask.class, a, offset, (Int512Mask) m);
+    void intoArray0(int[] a, int offset, VectorMask<Integer> m, boolean offsetInRange) {
+        super.intoArray0Template(Int512Mask.class, a, offset, (Int512Mask) m, offsetInRange);
     }
 
     @ForceInline
@@ -926,15 +926,15 @@ final class Int512Vector extends IntVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Integer> m) {
-        super.intoByteArray0Template(Int512Mask.class, a, offset, (Int512Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Integer> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Int512Mask.class, a, offset, (Int512Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Integer> m) {
-        super.intoByteBuffer0Template(Int512Mask.class, bb, offset, (Int512Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Integer> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Int512Mask.class, bb, offset, (Int512Mask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
@@ -876,8 +876,8 @@ final class Int64Vector extends IntVector {
     @ForceInline
     @Override
     final
-    void intoArray0(int[] a, int offset, VectorMask<Integer> m) {
-        super.intoArray0Template(Int64Mask.class, a, offset, (Int64Mask) m);
+    void intoArray0(int[] a, int offset, VectorMask<Integer> m, boolean offsetInRange) {
+        super.intoArray0Template(Int64Mask.class, a, offset, (Int64Mask) m, offsetInRange);
     }
 
     @ForceInline
@@ -898,15 +898,15 @@ final class Int64Vector extends IntVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Integer> m) {
-        super.intoByteArray0Template(Int64Mask.class, a, offset, (Int64Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Integer> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Int64Mask.class, a, offset, (Int64Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Integer> m) {
-        super.intoByteBuffer0Template(Int64Mask.class, bb, offset, (Int64Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Integer> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Int64Mask.class, bb, offset, (Int64Mask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
@@ -885,8 +885,8 @@ final class IntMaxVector extends IntVector {
     @ForceInline
     @Override
     final
-    void intoArray0(int[] a, int offset, VectorMask<Integer> m) {
-        super.intoArray0Template(IntMaxMask.class, a, offset, (IntMaxMask) m);
+    void intoArray0(int[] a, int offset, VectorMask<Integer> m, boolean offsetInRange) {
+        super.intoArray0Template(IntMaxMask.class, a, offset, (IntMaxMask) m, offsetInRange);
     }
 
     @ForceInline
@@ -907,15 +907,15 @@ final class IntMaxVector extends IntVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Integer> m) {
-        super.intoByteArray0Template(IntMaxMask.class, a, offset, (IntMaxMask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Integer> m, boolean offsetInRange) {
+        super.intoByteArray0Template(IntMaxMask.class, a, offset, (IntMaxMask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Integer> m) {
-        super.intoByteBuffer0Template(IntMaxMask.class, bb, offset, (IntMaxMask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Integer> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(IntMaxMask.class, bb, offset, (IntMaxMask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -3185,8 +3185,12 @@ public abstract class IntVector extends AbstractVector<Integer> {
             intoArray(a, offset);
         } else {
             IntSpecies vsp = vspecies();
-            checkMaskFromIndexSize(offset, vsp, m, 1, a.length);
-            intoArray0(a, offset, m);
+            if (offset >= 0 && offset <= (a.length - vsp.length())) {
+                intoArray0(a, offset, m, /* offsetInRange */ true);
+            } else {
+                checkMaskFromIndexSize(offset, vsp, m, 1, a.length);
+                intoArray0(a, offset, m, /* offsetInRange */ false);
+            }
         }
     }
 
@@ -3313,8 +3317,12 @@ public abstract class IntVector extends AbstractVector<Integer> {
             intoByteArray(a, offset, bo);
         } else {
             IntSpecies vsp = vspecies();
-            checkMaskFromIndexSize(offset, vsp, m, 4, a.length);
-            maybeSwap(bo).intoByteArray0(a, offset, m);
+            if (offset >= 0 && offset <= (a.length - vsp.vectorByteSize())) {
+                maybeSwap(bo).intoByteArray0(a, offset, m, /* offsetInRange */ true);
+            } else {
+                checkMaskFromIndexSize(offset, vsp, m, 4, a.length);
+                maybeSwap(bo).intoByteArray0(a, offset, m, /* offsetInRange */ false);
+            }
         }
     }
 
@@ -3349,8 +3357,12 @@ public abstract class IntVector extends AbstractVector<Integer> {
                 throw new ReadOnlyBufferException();
             }
             IntSpecies vsp = vspecies();
-            checkMaskFromIndexSize(offset, vsp, m, 4, bb.limit());
-            maybeSwap(bo).intoByteBuffer0(bb, offset, m);
+            if (offset >= 0 && offset <= (bb.limit() - vsp.vectorByteSize())) {
+                maybeSwap(bo).intoByteBuffer0(bb, offset, m, /* offsetInRange */ true);
+            } else {
+                checkMaskFromIndexSize(offset, vsp, m, 4, bb.limit());
+                maybeSwap(bo).intoByteBuffer0(bb, offset, m, /* offsetInRange */ false);
+            }
         }
     }
 
@@ -3545,20 +3557,37 @@ public abstract class IntVector extends AbstractVector<Integer> {
     }
 
     abstract
-    void intoArray0(int[] a, int offset, VectorMask<Integer> m);
+    void intoArray0(int[] a, int offset, VectorMask<Integer> m, boolean offsetInRange);
     @ForceInline
     final
     <M extends VectorMask<Integer>>
-    void intoArray0Template(Class<M> maskClass, int[] a, int offset, M m) {
+    void intoArray0Template(Class<M> maskClass, int[] a, int offset, M m, boolean offsetInRange) {
+        intoArray0Template(maskClass, a, arrayAddress(a, offset), offset,
+            this, m, offsetInRange,
+            (arr, off, v, vm) -> v.stOp(arr, off, vm,
+                                        (arr_, off_, i, e) -> arr_[off_ + i] = e));
+    }
+
+    @ForceInline
+    final
+    <C, M extends VectorMask<Integer>>
+    void intoArray0Template(Class<M> maskClass, C base, long offset, int index, IntVector v, M m, boolean offsetInRange,
+                            VectorSupport.StoreVectorMaskedOperation<C, IntVector, M> defaultImpl) {
         m.check(species());
         IntSpecies vsp = vspecies();
-        VectorSupport.storeMasked(
-            vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            this, m, a, offset,
-            (arr, off, v, vm)
-            -> v.stOp(arr, off, vm,
-                      (arr_, off_, i, e) -> arr_[off_ + i] = e));
+        if (offsetInRange) {
+            VectorSupport.storeMasked(
+                vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
+                base, offset,
+                v, m, /* offsetInRange */ 1,
+                base, index, defaultImpl);
+        } else {
+            VectorSupport.storeMasked(
+                vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
+                base, offset,
+                v, m, /* offsetInRange */ 0,
+                base, index, defaultImpl);
+        }
     }
 
     abstract
@@ -3614,17 +3643,13 @@ public abstract class IntVector extends AbstractVector<Integer> {
     }
 
     abstract
-    void intoByteArray0(byte[] a, int offset, VectorMask<Integer> m);
+    void intoByteArray0(byte[] a, int offset, VectorMask<Integer> m, boolean offsetInRange);
     @ForceInline
     final
     <M extends VectorMask<Integer>>
-    void intoByteArray0Template(Class<M> maskClass, byte[] a, int offset, M m) {
-        IntSpecies vsp = vspecies();
-        m.check(vsp);
-        VectorSupport.storeMasked(
-            vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, byteArrayAddress(a, offset),
-            this, m, a, offset,
+    void intoByteArray0Template(Class<M> maskClass, byte[] a, int offset, M m, boolean offsetInRange) {
+        intoArray0Template(maskClass, a, byteArrayAddress(a, offset), offset,
+            this, m, offsetInRange,
             (arr, off, v, vm) -> {
                 ByteBuffer wb = wrapper(arr, NATIVE_ENDIAN);
                 v.stOp(wb, off, vm,
@@ -3647,16 +3672,16 @@ public abstract class IntVector extends AbstractVector<Integer> {
     }
 
     abstract
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Integer> m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Integer> m, boolean offsetInRange);
     @ForceInline
     final
     <M extends VectorMask<Integer>>
-    void intoByteBuffer0Template(Class<M> maskClass, ByteBuffer bb, int offset, M m) {
+    void intoByteBuffer0Template(Class<M> maskClass, ByteBuffer bb, int offset, M m, boolean offsetInRange) {
         IntSpecies vsp = vspecies();
         m.check(vsp);
         ScopedMemoryAccess.storeIntoByteBufferMasked(
                 vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-                this, m, bb, offset,
+                this, m, offsetInRange, bb, offset,
                 (buf, off, v, vm) -> {
                     ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
                     v.stOp(wb, off, vm,

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
@@ -866,8 +866,8 @@ final class Long128Vector extends LongVector {
     @ForceInline
     @Override
     final
-    void intoArray0(long[] a, int offset, VectorMask<Long> m) {
-        super.intoArray0Template(Long128Mask.class, a, offset, (Long128Mask) m);
+    void intoArray0(long[] a, int offset, VectorMask<Long> m, boolean offsetInRange) {
+        super.intoArray0Template(Long128Mask.class, a, offset, (Long128Mask) m, offsetInRange);
     }
 
     @ForceInline
@@ -888,15 +888,15 @@ final class Long128Vector extends LongVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Long> m) {
-        super.intoByteArray0Template(Long128Mask.class, a, offset, (Long128Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Long> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Long128Mask.class, a, offset, (Long128Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Long> m) {
-        super.intoByteBuffer0Template(Long128Mask.class, bb, offset, (Long128Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Long> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Long128Mask.class, bb, offset, (Long128Mask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
@@ -870,8 +870,8 @@ final class Long256Vector extends LongVector {
     @ForceInline
     @Override
     final
-    void intoArray0(long[] a, int offset, VectorMask<Long> m) {
-        super.intoArray0Template(Long256Mask.class, a, offset, (Long256Mask) m);
+    void intoArray0(long[] a, int offset, VectorMask<Long> m, boolean offsetInRange) {
+        super.intoArray0Template(Long256Mask.class, a, offset, (Long256Mask) m, offsetInRange);
     }
 
     @ForceInline
@@ -892,15 +892,15 @@ final class Long256Vector extends LongVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Long> m) {
-        super.intoByteArray0Template(Long256Mask.class, a, offset, (Long256Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Long> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Long256Mask.class, a, offset, (Long256Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Long> m) {
-        super.intoByteBuffer0Template(Long256Mask.class, bb, offset, (Long256Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Long> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Long256Mask.class, bb, offset, (Long256Mask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
@@ -878,8 +878,8 @@ final class Long512Vector extends LongVector {
     @ForceInline
     @Override
     final
-    void intoArray0(long[] a, int offset, VectorMask<Long> m) {
-        super.intoArray0Template(Long512Mask.class, a, offset, (Long512Mask) m);
+    void intoArray0(long[] a, int offset, VectorMask<Long> m, boolean offsetInRange) {
+        super.intoArray0Template(Long512Mask.class, a, offset, (Long512Mask) m, offsetInRange);
     }
 
     @ForceInline
@@ -900,15 +900,15 @@ final class Long512Vector extends LongVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Long> m) {
-        super.intoByteArray0Template(Long512Mask.class, a, offset, (Long512Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Long> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Long512Mask.class, a, offset, (Long512Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Long> m) {
-        super.intoByteBuffer0Template(Long512Mask.class, bb, offset, (Long512Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Long> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Long512Mask.class, bb, offset, (Long512Mask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
@@ -864,8 +864,8 @@ final class Long64Vector extends LongVector {
     @ForceInline
     @Override
     final
-    void intoArray0(long[] a, int offset, VectorMask<Long> m) {
-        super.intoArray0Template(Long64Mask.class, a, offset, (Long64Mask) m);
+    void intoArray0(long[] a, int offset, VectorMask<Long> m, boolean offsetInRange) {
+        super.intoArray0Template(Long64Mask.class, a, offset, (Long64Mask) m, offsetInRange);
     }
 
     @ForceInline
@@ -886,15 +886,15 @@ final class Long64Vector extends LongVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Long> m) {
-        super.intoByteArray0Template(Long64Mask.class, a, offset, (Long64Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Long> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Long64Mask.class, a, offset, (Long64Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Long> m) {
-        super.intoByteBuffer0Template(Long64Mask.class, bb, offset, (Long64Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Long> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Long64Mask.class, bb, offset, (Long64Mask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
@@ -864,8 +864,8 @@ final class LongMaxVector extends LongVector {
     @ForceInline
     @Override
     final
-    void intoArray0(long[] a, int offset, VectorMask<Long> m) {
-        super.intoArray0Template(LongMaxMask.class, a, offset, (LongMaxMask) m);
+    void intoArray0(long[] a, int offset, VectorMask<Long> m, boolean offsetInRange) {
+        super.intoArray0Template(LongMaxMask.class, a, offset, (LongMaxMask) m, offsetInRange);
     }
 
     @ForceInline
@@ -886,15 +886,15 @@ final class LongMaxVector extends LongVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Long> m) {
-        super.intoByteArray0Template(LongMaxMask.class, a, offset, (LongMaxMask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Long> m, boolean offsetInRange) {
+        super.intoByteArray0Template(LongMaxMask.class, a, offset, (LongMaxMask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Long> m) {
-        super.intoByteBuffer0Template(LongMaxMask.class, bb, offset, (LongMaxMask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Long> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(LongMaxMask.class, bb, offset, (LongMaxMask) m, offsetInRange);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
@@ -895,8 +895,8 @@ final class Short128Vector extends ShortVector {
     @ForceInline
     @Override
     final
-    void intoArray0(short[] a, int offset, VectorMask<Short> m) {
-        super.intoArray0Template(Short128Mask.class, a, offset, (Short128Mask) m);
+    void intoArray0(short[] a, int offset, VectorMask<Short> m, boolean offsetInRange) {
+        super.intoArray0Template(Short128Mask.class, a, offset, (Short128Mask) m, offsetInRange);
     }
 
 
@@ -911,22 +911,22 @@ final class Short128Vector extends ShortVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Short> m) {
-        super.intoByteArray0Template(Short128Mask.class, a, offset, (Short128Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Short> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Short128Mask.class, a, offset, (Short128Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Short> m) {
-        super.intoByteBuffer0Template(Short128Mask.class, bb, offset, (Short128Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Short> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Short128Mask.class, bb, offset, (Short128Mask) m, offsetInRange);
     }
 
     @ForceInline
     @Override
     final
-    void intoCharArray0(char[] a, int offset, VectorMask<Short> m) {
-        super.intoCharArray0Template(Short128Mask.class, a, offset, (Short128Mask) m);
+    void intoCharArray0(char[] a, int offset, VectorMask<Short> m, boolean offsetInRange) {
+        super.intoCharArray0Template(Short128Mask.class, a, offset, (Short128Mask) m, offsetInRange);
     }
 
     // End of specialized low-level memory operations.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
@@ -911,8 +911,8 @@ final class Short256Vector extends ShortVector {
     @ForceInline
     @Override
     final
-    void intoArray0(short[] a, int offset, VectorMask<Short> m) {
-        super.intoArray0Template(Short256Mask.class, a, offset, (Short256Mask) m);
+    void intoArray0(short[] a, int offset, VectorMask<Short> m, boolean offsetInRange) {
+        super.intoArray0Template(Short256Mask.class, a, offset, (Short256Mask) m, offsetInRange);
     }
 
 
@@ -927,22 +927,22 @@ final class Short256Vector extends ShortVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Short> m) {
-        super.intoByteArray0Template(Short256Mask.class, a, offset, (Short256Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Short> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Short256Mask.class, a, offset, (Short256Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Short> m) {
-        super.intoByteBuffer0Template(Short256Mask.class, bb, offset, (Short256Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Short> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Short256Mask.class, bb, offset, (Short256Mask) m, offsetInRange);
     }
 
     @ForceInline
     @Override
     final
-    void intoCharArray0(char[] a, int offset, VectorMask<Short> m) {
-        super.intoCharArray0Template(Short256Mask.class, a, offset, (Short256Mask) m);
+    void intoCharArray0(char[] a, int offset, VectorMask<Short> m, boolean offsetInRange) {
+        super.intoCharArray0Template(Short256Mask.class, a, offset, (Short256Mask) m, offsetInRange);
     }
 
     // End of specialized low-level memory operations.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
@@ -943,8 +943,8 @@ final class Short512Vector extends ShortVector {
     @ForceInline
     @Override
     final
-    void intoArray0(short[] a, int offset, VectorMask<Short> m) {
-        super.intoArray0Template(Short512Mask.class, a, offset, (Short512Mask) m);
+    void intoArray0(short[] a, int offset, VectorMask<Short> m, boolean offsetInRange) {
+        super.intoArray0Template(Short512Mask.class, a, offset, (Short512Mask) m, offsetInRange);
     }
 
 
@@ -959,22 +959,22 @@ final class Short512Vector extends ShortVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Short> m) {
-        super.intoByteArray0Template(Short512Mask.class, a, offset, (Short512Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Short> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Short512Mask.class, a, offset, (Short512Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Short> m) {
-        super.intoByteBuffer0Template(Short512Mask.class, bb, offset, (Short512Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Short> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Short512Mask.class, bb, offset, (Short512Mask) m, offsetInRange);
     }
 
     @ForceInline
     @Override
     final
-    void intoCharArray0(char[] a, int offset, VectorMask<Short> m) {
-        super.intoCharArray0Template(Short512Mask.class, a, offset, (Short512Mask) m);
+    void intoCharArray0(char[] a, int offset, VectorMask<Short> m, boolean offsetInRange) {
+        super.intoCharArray0Template(Short512Mask.class, a, offset, (Short512Mask) m, offsetInRange);
     }
 
     // End of specialized low-level memory operations.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
@@ -887,8 +887,8 @@ final class Short64Vector extends ShortVector {
     @ForceInline
     @Override
     final
-    void intoArray0(short[] a, int offset, VectorMask<Short> m) {
-        super.intoArray0Template(Short64Mask.class, a, offset, (Short64Mask) m);
+    void intoArray0(short[] a, int offset, VectorMask<Short> m, boolean offsetInRange) {
+        super.intoArray0Template(Short64Mask.class, a, offset, (Short64Mask) m, offsetInRange);
     }
 
 
@@ -903,22 +903,22 @@ final class Short64Vector extends ShortVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Short> m) {
-        super.intoByteArray0Template(Short64Mask.class, a, offset, (Short64Mask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Short> m, boolean offsetInRange) {
+        super.intoByteArray0Template(Short64Mask.class, a, offset, (Short64Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Short> m) {
-        super.intoByteBuffer0Template(Short64Mask.class, bb, offset, (Short64Mask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Short> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(Short64Mask.class, bb, offset, (Short64Mask) m, offsetInRange);
     }
 
     @ForceInline
     @Override
     final
-    void intoCharArray0(char[] a, int offset, VectorMask<Short> m) {
-        super.intoCharArray0Template(Short64Mask.class, a, offset, (Short64Mask) m);
+    void intoCharArray0(char[] a, int offset, VectorMask<Short> m, boolean offsetInRange) {
+        super.intoCharArray0Template(Short64Mask.class, a, offset, (Short64Mask) m, offsetInRange);
     }
 
     // End of specialized low-level memory operations.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
@@ -881,8 +881,8 @@ final class ShortMaxVector extends ShortVector {
     @ForceInline
     @Override
     final
-    void intoArray0(short[] a, int offset, VectorMask<Short> m) {
-        super.intoArray0Template(ShortMaxMask.class, a, offset, (ShortMaxMask) m);
+    void intoArray0(short[] a, int offset, VectorMask<Short> m, boolean offsetInRange) {
+        super.intoArray0Template(ShortMaxMask.class, a, offset, (ShortMaxMask) m, offsetInRange);
     }
 
 
@@ -897,22 +897,22 @@ final class ShortMaxVector extends ShortVector {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<Short> m) {
-        super.intoByteArray0Template(ShortMaxMask.class, a, offset, (ShortMaxMask) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<Short> m, boolean offsetInRange) {
+        super.intoByteArray0Template(ShortMaxMask.class, a, offset, (ShortMaxMask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Short> m) {
-        super.intoByteBuffer0Template(ShortMaxMask.class, bb, offset, (ShortMaxMask) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<Short> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template(ShortMaxMask.class, bb, offset, (ShortMaxMask) m, offsetInRange);
     }
 
     @ForceInline
     @Override
     final
-    void intoCharArray0(char[] a, int offset, VectorMask<Short> m) {
-        super.intoCharArray0Template(ShortMaxMask.class, a, offset, (ShortMaxMask) m);
+    void intoCharArray0(char[] a, int offset, VectorMask<Short> m, boolean offsetInRange) {
+        super.intoCharArray0Template(ShortMaxMask.class, a, offset, (ShortMaxMask) m, offsetInRange);
     }
 
     // End of specialized low-level memory operations.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -4074,8 +4074,12 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
             intoArray(a, offset);
         } else {
             $Type$Species vsp = vspecies();
-            checkMaskFromIndexSize(offset, vsp, m, 1, a.length);
-            intoArray0(a, offset, m);
+            if (offset >= 0 && offset <= (a.length - vsp.length())) {
+                intoArray0(a, offset, m, /* offsetInRange */ true);
+            } else {
+                checkMaskFromIndexSize(offset, vsp, m, 1, a.length);
+                intoArray0(a, offset, m, /* offsetInRange */ false);
+            }
         }
     }
 
@@ -4292,8 +4296,12 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
             intoCharArray(a, offset);
         } else {
             $Type$Species vsp = vspecies();
-            checkMaskFromIndexSize(offset, vsp, m, 1, a.length);
-            intoCharArray0(a, offset, m);
+            if (offset >= 0 && offset <= (a.length - vsp.length())) {
+                intoCharArray0(a, offset, m, /* offsetInRange */ true);
+            } else {
+                checkMaskFromIndexSize(offset, vsp, m, 1, a.length);
+                intoCharArray0(a, offset, m, /* offsetInRange */ false);
+            }
         }
     }
 
@@ -4454,8 +4462,12 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
             intoBooleanArray(a, offset);
         } else {
             $Type$Species vsp = vspecies();
-            checkMaskFromIndexSize(offset, vsp, m, 1, a.length);
-            intoBooleanArray0(a, offset, m);
+            if (offset >= 0 && offset <= (a.length - vsp.length())) {
+                intoBooleanArray0(a, offset, m, /* offsetInRange */ true);
+            } else {
+                checkMaskFromIndexSize(offset, vsp, m, 1, a.length);
+                intoBooleanArray0(a, offset, m, /* offsetInRange */ false);
+            }
         }
     }
 
@@ -4576,8 +4588,12 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
             intoByteArray(a, offset, bo);
         } else {
             $Type$Species vsp = vspecies();
-            checkMaskFromIndexSize(offset, vsp, m, $sizeInBytes$, a.length);
-            maybeSwap(bo).intoByteArray0(a, offset, m);
+            if (offset >= 0 && offset <= (a.length - vsp.vectorByteSize())) {
+                maybeSwap(bo).intoByteArray0(a, offset, m, /* offsetInRange */ true);
+            } else {
+                checkMaskFromIndexSize(offset, vsp, m, $sizeInBytes$, a.length);
+                maybeSwap(bo).intoByteArray0(a, offset, m, /* offsetInRange */ false);
+            }
         }
     }
 
@@ -4612,8 +4628,12 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
                 throw new ReadOnlyBufferException();
             }
             $Type$Species vsp = vspecies();
-            checkMaskFromIndexSize(offset, vsp, m, $sizeInBytes$, bb.limit());
-            maybeSwap(bo).intoByteBuffer0(bb, offset, m);
+            if (offset >= 0 && offset <= (bb.limit() - vsp.vectorByteSize())) {
+                maybeSwap(bo).intoByteBuffer0(bb, offset, m, /* offsetInRange */ true);
+            } else {
+                checkMaskFromIndexSize(offset, vsp, m, $sizeInBytes$, bb.limit());
+                maybeSwap(bo).intoByteBuffer0(bb, offset, m, /* offsetInRange */ false);
+            }
         }
     }
 
@@ -4895,20 +4915,37 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     }
 
     abstract
-    void intoArray0($type$[] a, int offset, VectorMask<$Boxtype$> m);
+    void intoArray0($type$[] a, int offset, VectorMask<$Boxtype$> m, boolean offsetInRange);
     @ForceInline
     final
     <M extends VectorMask<$Boxtype$>>
-    void intoArray0Template(Class<M> maskClass, $type$[] a, int offset, M m) {
+    void intoArray0Template(Class<M> maskClass, $type$[] a, int offset, M m, boolean offsetInRange) {
+        intoArray0Template(maskClass, a, arrayAddress(a, offset), offset,
+            this, m, offsetInRange,
+            (arr, off, v, vm) -> v.stOp(arr, off, vm,
+                                        (arr_, off_, i, e) -> arr_[off_ + i] = e));
+    }
+
+    @ForceInline
+    final
+    <C, M extends VectorMask<$Boxtype$>>
+    void intoArray0Template(Class<M> maskClass, C base, long offset, int index, $abstractvectortype$ v, M m, boolean offsetInRange,
+                            VectorSupport.StoreVectorMaskedOperation<C, $abstractvectortype$, M> defaultImpl) {
         m.check(species());
         $Type$Species vsp = vspecies();
-        VectorSupport.storeMasked(
-            vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            this, m, a, offset,
-            (arr, off, v, vm)
-            -> v.stOp(arr, off, vm,
-                      (arr_, off_, i, e) -> arr_[off_ + i] = e));
+        if (offsetInRange) {
+            VectorSupport.storeMasked(
+                vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
+                base, offset,
+                v, m, /* offsetInRange */ 1,
+                base, index, defaultImpl);
+        } else {
+            VectorSupport.storeMasked(
+                vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
+                base, offset,
+                v, m, /* offsetInRange */ 0,
+                base, index, defaultImpl);
+        }
     }
 
 #if[!byteOrShort]
@@ -4975,21 +5012,16 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
 #if[byte]
     abstract
-    void intoBooleanArray0(boolean[] a, int offset, VectorMask<$Boxtype$> m);
+    void intoBooleanArray0(boolean[] a, int offset, VectorMask<$Boxtype$> m, boolean offsetInRange);
     @ForceInline
     final
     <M extends VectorMask<$Boxtype$>>
-    void intoBooleanArray0Template(Class<M> maskClass, boolean[] a, int offset, M m) {
-        m.check(species());
-        $Type$Species vsp = vspecies();
+    void intoBooleanArray0Template(Class<M> maskClass, boolean[] a, int offset, M m, boolean offsetInRange) {
         ByteVector normalized = this.and((byte) 1);
-        VectorSupport.storeMasked(
-            vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, booleanArrayAddress(a, offset),
-            normalized, m, a, offset,
-            (arr, off, v, vm)
-            -> v.stOp(arr, off, vm,
-                      (arr_, off_, i, e) -> arr_[off_ + i] = (e & 1) != 0));
+        intoArray0Template(maskClass, a, booleanArrayAddress(a, offset), offset,
+            normalized,  m, offsetInRange,
+            (arr, off, v, vm) -> v.stOp(arr, off, vm,
+                                        (arr_, off_, i, e) -> arr_[off_ + i] = (e & 1) != 0));
     }
 #end[byte]
 
@@ -5011,17 +5043,13 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     }
 
     abstract
-    void intoByteArray0(byte[] a, int offset, VectorMask<$Boxtype$> m);
+    void intoByteArray0(byte[] a, int offset, VectorMask<$Boxtype$> m, boolean offsetInRange);
     @ForceInline
     final
     <M extends VectorMask<$Boxtype$>>
-    void intoByteArray0Template(Class<M> maskClass, byte[] a, int offset, M m) {
-        $Type$Species vsp = vspecies();
-        m.check(vsp);
-        VectorSupport.storeMasked(
-            vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, byteArrayAddress(a, offset),
-            this, m, a, offset,
+    void intoByteArray0Template(Class<M> maskClass, byte[] a, int offset, M m, boolean offsetInRange) {
+        intoArray0Template(maskClass, a, byteArrayAddress(a, offset), offset,
+            this, m, offsetInRange,
             (arr, off, v, vm) -> {
                 ByteBuffer wb = wrapper(arr, NATIVE_ENDIAN);
                 v.stOp(wb, off, vm,
@@ -5044,16 +5072,16 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     }
 
     abstract
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<$Boxtype$> m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<$Boxtype$> m, boolean offsetInRange);
     @ForceInline
     final
     <M extends VectorMask<$Boxtype$>>
-    void intoByteBuffer0Template(Class<M> maskClass, ByteBuffer bb, int offset, M m) {
+    void intoByteBuffer0Template(Class<M> maskClass, ByteBuffer bb, int offset, M m, boolean offsetInRange) {
         $Type$Species vsp = vspecies();
         m.check(vsp);
         ScopedMemoryAccess.storeIntoByteBufferMasked(
                 vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-                this, m, bb, offset,
+                this, m, offsetInRange, bb, offset,
                 (buf, off, v, vm) -> {
                     ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
                     v.stOp(wb, off, vm,
@@ -5064,20 +5092,15 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 #if[short]
     /*package-private*/
     abstract
-    void intoCharArray0(char[] a, int offset, VectorMask<$Boxtype$> m);
+    void intoCharArray0(char[] a, int offset, VectorMask<$Boxtype$> m, boolean offsetInRange);
     @ForceInline
     final
     <M extends VectorMask<$Boxtype$>>
-    void intoCharArray0Template(Class<M> maskClass, char[] a, int offset, M m) {
-        m.check(species());
-        $Type$Species vsp = vspecies();
-        VectorSupport.storeMasked(
-            vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, charArrayAddress(a, offset),
-            this, m, a, offset,
-            (arr, off, v, vm)
-            -> v.stOp(arr, off, vm,
-                      (arr_, off_, i, e) -> arr_[off_ + i] = (char) e));
+    void intoCharArray0Template(Class<M> maskClass, char[] a, int offset, M m, boolean offsetInRange) {
+        intoArray0Template(maskClass, a, charArrayAddress(a, offset), offset,
+            this, m, offsetInRange,
+            (arr, off, v, vm) -> v.stOp(arr, off, vm,
+                                        (arr_, off_, i, e) -> arr_[off_ + i] = (char) e));
     }
 #end[short]
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
@@ -1194,8 +1194,8 @@ final class $vectortype$ extends $abstractvectortype$ {
     @ForceInline
     @Override
     final
-    void intoArray0($type$[] a, int offset, VectorMask<$Boxtype$> m) {
-        super.intoArray0Template($masktype$.class, a, offset, ($masktype$) m);
+    void intoArray0($type$[] a, int offset, VectorMask<$Boxtype$> m, boolean offsetInRange) {
+        super.intoArray0Template($masktype$.class, a, offset, ($masktype$) m, offsetInRange);
     }
 
 #if[!byteOrShort]
@@ -1211,8 +1211,8 @@ final class $vectortype$ extends $abstractvectortype$ {
     @ForceInline
     @Override
     final
-    void intoBooleanArray0(boolean[] a, int offset, VectorMask<$Boxtype$> m) {
-        super.intoBooleanArray0Template($masktype$.class, a, offset, ($masktype$) m);
+    void intoBooleanArray0(boolean[] a, int offset, VectorMask<$Boxtype$> m, boolean offsetInRange) {
+        super.intoBooleanArray0Template($masktype$.class, a, offset, ($masktype$) m, offsetInRange);
     }
 #end[byte]
 
@@ -1226,23 +1226,23 @@ final class $vectortype$ extends $abstractvectortype$ {
     @ForceInline
     @Override
     final
-    void intoByteArray0(byte[] a, int offset, VectorMask<$Boxtype$> m) {
-        super.intoByteArray0Template($masktype$.class, a, offset, ($masktype$) m);  // specialize
+    void intoByteArray0(byte[] a, int offset, VectorMask<$Boxtype$> m, boolean offsetInRange) {
+        super.intoByteArray0Template($masktype$.class, a, offset, ($masktype$) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<$Boxtype$> m) {
-        super.intoByteBuffer0Template($masktype$.class, bb, offset, ($masktype$) m);
+    void intoByteBuffer0(ByteBuffer bb, int offset, VectorMask<$Boxtype$> m, boolean offsetInRange) {
+        super.intoByteBuffer0Template($masktype$.class, bb, offset, ($masktype$) m, offsetInRange);
     }
 
 #if[short]
     @ForceInline
     @Override
     final
-    void intoCharArray0(char[] a, int offset, VectorMask<$Boxtype$> m) {
-        super.intoCharArray0Template($masktype$.class, a, offset, ($masktype$) m);
+    void intoCharArray0(char[] a, int offset, VectorMask<$Boxtype$> m, boolean offsetInRange) {
+        super.intoCharArray0Template($masktype$.class, a, offset, ($masktype$) m, offsetInRange);
     }
 #end[short]
 

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/StoreMaskedBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/StoreMaskedBenchmark.java
@@ -1,0 +1,138 @@
+//
+// Copyright (c) 2022, Arm Limited. All rights reserved.
+// DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+//
+// This code is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License version 2 only, as
+// published by the Free Software Foundation.
+//
+// This code is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// version 2 for more details (a copy is included in the LICENSE file that
+// accompanied this code).
+//
+// You should have received a copy of the GNU General Public License version
+// 2 along with this work; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+// or visit www.oracle.com if you need additional information or have any
+// questions.
+//
+//
+package org.openjdk.bench.jdk.incubator.vector;
+
+import java.util.concurrent.TimeUnit;
+import jdk.incubator.vector.*;
+import org.openjdk.jmh.annotations.*;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 1, jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+public class StoreMaskedBenchmark {
+    @Param({"1024"})
+    private int size;
+
+    private byte[] byteIn;
+    private byte[] byteOut;
+    private short[] shortIn;
+    private short[] shortOut;
+    private int[] intIn;
+    private int[] intOut;
+    private long[] longIn;
+    private long[] longOut;
+    private float[] floatIn;
+    private float[] floatOut;
+    private double[] doubleIn;
+    private double[] doubleOut;
+
+    private boolean[] m;
+
+    private static final VectorSpecies<Byte> bspecies = VectorSpecies.ofLargestShape(byte.class);
+    private static final VectorSpecies<Short> sspecies = VectorSpecies.ofLargestShape(short.class);
+    private static final VectorSpecies<Integer> ispecies = VectorSpecies.ofLargestShape(int.class);
+    private static final VectorSpecies<Long> lspecies = VectorSpecies.ofLargestShape(long.class);
+    private static final VectorSpecies<Float> fspecies = VectorSpecies.ofLargestShape(float.class);
+    private static final VectorSpecies<Double> dspecies = VectorSpecies.ofLargestShape(double.class);
+
+    @Setup(Level.Trial)
+    public void Setup() {
+        byteIn = new byte[size];
+        byteOut = new byte[size];
+        shortIn = new short[size];
+        shortOut = new short[size];
+        intIn = new int[size];
+        intOut = new int[size];
+        longIn = new long[size];
+        longOut = new long[size];
+        floatIn = new float[size];
+        floatOut = new float[size];
+        doubleIn = new double[size];
+        doubleOut = new double[size];
+        m = new boolean[size];
+
+        for (int i = 0; i < size; i++) {
+            byteIn[i] = (byte) i;
+            shortIn[i] = (short) i;
+            intIn[i] = i;
+            longIn[i] = i;
+            floatIn[i] = (float) i;
+            doubleIn[i] = (double) i;
+        }
+        for (int i = 0; i < size; i++) {
+            m[i] = i % 2 == 0;
+        }
+    }
+
+    @Benchmark
+    public void byteStoreArrayMask() {
+        for (int i = 0; i < size; i += bspecies.length()) {
+            VectorMask<Byte> mask = VectorMask.fromArray(bspecies, m, i);
+            ByteVector.fromArray(bspecies, byteIn, i).intoArray(byteOut, i, mask);
+        }
+    }
+
+    @Benchmark
+    public void shortStoreArrayMask() {
+        for (int i = 0; i < size; i += sspecies.length()) {
+            VectorMask<Short> mask = VectorMask.fromArray(sspecies, m, i);
+            ShortVector.fromArray(sspecies, shortIn, i).intoArray(shortOut, i, mask);
+        }
+    }
+
+    @Benchmark
+    public void intStoreArrayMask() {
+        for (int i = 0; i < size; i += ispecies.length()) {
+            VectorMask<Integer> mask = VectorMask.fromArray(ispecies, m, i);
+            IntVector.fromArray(ispecies, intIn, i).intoArray(intOut, i, mask);
+        }
+    }
+
+    @Benchmark
+    public void longStoreArrayMask() {
+        for (int i = 0; i < size; i += lspecies.length()) {
+            VectorMask<Long> mask = VectorMask.fromArray(lspecies, m, i);
+            LongVector.fromArray(lspecies, longIn, i).intoArray(longOut, i, mask);
+        }
+    }
+
+    @Benchmark
+    public void floatStoreArrayMask() {
+        for (int i = 0; i < size; i += fspecies.length()) {
+            VectorMask<Float> mask = VectorMask.fromArray(fspecies, m, i);
+            FloatVector.fromArray(fspecies, floatIn, i).intoArray(floatOut, i, mask);
+        }
+    }
+
+    @Benchmark
+    public void doubleStoreArrayMask() {
+        for (int i = 0; i < size; i += dspecies.length()) {
+            VectorMask<Double> mask = VectorMask.fromArray(dspecies, m, i);
+            DoubleVector.fromArray(dspecies, doubleIn, i).intoArray(doubleOut, i, mask);
+        }
+    }
+}


### PR DESCRIPTION
Currently the vectorization of masked vector store is implemented by the masked store instruction only on architectures that support the predicate feature. The compiler will fall back to the java scalar code for non-predicate supported architectures like ARM NEON. However, for these systems, the masked store can be vectorized with the non-masked vector `"load + blend + store"`. For example, storing a vector` "v"` controlled by a mask` "m"` into a memory with address` "addr" (i.e. "store(addr, v, m)")` can be implemented with:

```
 1) mem_v = load(addr)     ; non-masked load from the same memory
 2) v = blend(mem_v, v, m) ; blend with the src vector with the mask
 3) store(addr, v)         ; non-masked store into the memory
```

Since the first full loading needs the array offset must be inside of the valid array bounds, we make the compiler do the vectorization only when the offset is in range of the array boundary. And the compiler will still fall back to the java scalar code if not all offsets are valid. Besides, the original offset check for masked lanes are only applied when the offset is not always inside of the array range. This also improves the performance for masked store when the offset is always valid. The whole process is similar to the masked load API.

Here is the performance data for the masked vector store benchmarks on a X86 non avx-512 system, which improves about `20x ~ 50x`:
```
Benchmark                                  before    after   Units
StoreMaskedBenchmark.byteStoreArrayMask   221.733  11094.126 ops/ms
StoreMaskedBenchmark.doubleStoreArrayMask  41.086   1034.408 ops/ms
StoreMaskedBenchmark.floatStoreArrayMask   73.820   1985.015 ops/ms
StoreMaskedBenchmark.intStoreArrayMask     75.028   2027.557 ops/ms
StoreMaskedBenchmark.longStoreArrayMask    40.929   1032.928 ops/ms
StoreMaskedBenchmark.shortStoreArrayMask  135.794   5307.567 ops/ms
```
Similar performance gain can also be observed on ARM NEON system.

And here is the performance data on X86 avx-512 system, which improves about `1.88x - 2.81x`:
```
Benchmark                                  before     after   Units
StoreMaskedBenchmark.byteStoreArrayMask   11185.956 21012.824 ops/ms
StoreMaskedBenchmark.doubleStoreArrayMask  1480.644  3911.720 ops/ms
StoreMaskedBenchmark.floatStoreArrayMask   2738.352  7708.365 ops/ms
StoreMaskedBenchmark.intStoreArrayMask     4191.904  9300.428 ops/ms
StoreMaskedBenchmark.longStoreArrayMask    2025.031  4604.504 ops/ms
StoreMaskedBenchmark.shortStoreArrayMask   8339.389 17817.128 ops/ms
```
Similar performance gain can also be observed on ARM SVE system.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Integration blocker
&nbsp;⚠️ Dependency #8035 must be integrated first

### Issue
 * [JDK-8284050](https://bugs.openjdk.java.net/browse/JDK-8284050): [vectorapi] Optimize masked store for non-predicated architectures


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8544/head:pull/8544` \
`$ git checkout pull/8544`

Update a local copy of the PR: \
`$ git checkout pull/8544` \
`$ git pull https://git.openjdk.java.net/jdk pull/8544/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8544`

View PR using the GUI difftool: \
`$ git pr show -t 8544`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8544.diff">https://git.openjdk.java.net/jdk/pull/8544.diff</a>

</details>
