### PR TITLE
8283849: AsyncGetCallTrace may crash JVM on guarantee

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -658,10 +658,11 @@ CodeBlob* CodeCache::find_blob(void* start) {
   CodeBlob* result = find_blob_unsafe(start);
   // We could potentially look up non_entrant methods
   bool is_zombie = result != NULL && result->is_zombie();
-  guarantee(!is_zombie || result->is_locked_by_vm() || VMError::is_error_reported() || is_in_asgct(), "unsafe access to zombie method");
+  bool is_result_safe = !is_zombie || result->is_locked_by_vm() || VMError::is_error_reported();
+  guarantee(is_result_safe || is_in_asgct(), "unsafe access to zombie method");
   // When in ASGCT the previous gurantee will pass for a zombie method but we still don't want that code blob returned in order
   // to minimize the chance of accessing dead memory
-  return is_zombie ? NULL : result;
+  return is_result_safe ? result : NULL;
 }
 
 // Lookup that does not fail if you lookup a zombie method (if you call this, be sure to know

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -655,7 +655,7 @@ CodeBlob* CodeCache::find_blob(void* start) {
   if (current_thread != NULL && current_thread->in_asgct()) {
     // when in ASGCT handler things might get rough and not all guarantees are held
     // if the resolved blob is already a zombie return NULL instead of crashing on guarantee
-    return result != NULL || result->is_zombie() ? NULL : result;
+    return (result == NULL || result->is_zombie()) ? NULL : result;
   }
   // We could potentially look up non_entrant methods
   guarantee(result == NULL || !result->is_zombie() || result->is_locked_by_vm() || VMError::is_error_reported(), "unsafe access to zombie method");

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -646,20 +646,22 @@ bool CodeCache::contains(nmethod *nm) {
   return contains((void *)nm);
 }
 
+static bool is_in_asgct() {
+  Thread* current_thread = Thread::current_or_null_safe();
+  return current_thread != NULL && current_thread->is_Java_thread() && JavaThread::cast(current_thread)->in_asgct();
+}
+
 // This method is safe to call without holding the CodeCache_lock, as long as a dead CodeBlob is not
 // looked up (i.e., one that has been marked for deletion). It only depends on the _segmap to contain
 // valid indices, which it will always do, as long as the CodeBlob is not in the process of being recycled.
 CodeBlob* CodeCache::find_blob(void* start) {
   CodeBlob* result = find_blob_unsafe(start);
-  Thread* current_thread = Thread::current_or_null_safe();
-  if (current_thread != NULL && current_thread->is_Java_thread() && JavaThread::cast(current_thread)->in_asgct()) {
-    // If called from ASGCT the usual invariants may not apply so if we find
-    // a zombie method just return NULL
-    return (result == NULL || result->is_zombie()) ? NULL : result;
-  }
   // We could potentially look up non_entrant methods
-  guarantee(result == NULL || !result->is_zombie() || result->is_locked_by_vm() || VMError::is_error_reported(), "unsafe access to zombie method");
-  return result;
+  bool is_zombie = result != NULL && result->is_zombie();
+  guarantee(!is_zombie || result->is_locked_by_vm() || VMError::is_error_reported() || is_in_asgct(), "unsafe access to zombie method");
+  // When in ASGCT the previous gurantee will pass for a zombie method but we still don't want that code blob returned in order
+  // to minimize the chance of accessing dead memory
+  return is_zombie ? NULL : result;
 }
 
 // Lookup that does not fail if you lookup a zombie method (if you call this, be sure to know

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -652,8 +652,8 @@ bool CodeCache::contains(nmethod *nm) {
 CodeBlob* CodeCache::find_blob(void* start) {
   CodeBlob* result = find_blob_unsafe(start);
   Thread* current_thread = Thread::current_or_null_safe();
-  if (current_thread != NULL && current_thread->in_agct()) {
-    // If called from AGCT the usual invariants may not apply so if we find
+  if (current_thread != NULL && current_thread->in_asgct()) {
+    // If called from ASGCT the usual invariants may not apply so if we find
     // a zombie method just return NULL
     return (result == NULL || result->is_zombie()) ? NULL : result;
   }

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -652,9 +652,9 @@ bool CodeCache::contains(nmethod *nm) {
 CodeBlob* CodeCache::find_blob(void* start) {
   CodeBlob* result = find_blob_unsafe(start);
   Thread* current_thread = Thread::current_or_null_safe();
-  if (current_thread != NULL && current_thread->in_asgct()) {
-    // when in ASGCT handler things might get rough and not all guarantees are held
-    // if the resolved blob is already a zombie return NULL instead of crashing on guarantee
+  if (current_thread != NULL && current_thread->in_agct()) {
+    // If called from AGCT the usual invariants may not apply so if we find
+    // a zombie method just return NULL
     return (result == NULL || result->is_zombie()) ? NULL : result;
   }
   // We could potentially look up non_entrant methods

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -651,6 +651,12 @@ bool CodeCache::contains(nmethod *nm) {
 // valid indices, which it will always do, as long as the CodeBlob is not in the process of being recycled.
 CodeBlob* CodeCache::find_blob(void* start) {
   CodeBlob* result = find_blob_unsafe(start);
+  Thread* current_thread = Thread::current_or_null_safe();
+  if (current_thread != NULL && current_thread->in_asgct()) {
+    // when in ASGCT handler things might get rough and not all guarantees are held
+    // if the resolved blob is already a zombie return NULL instead of crashing on guarantee
+    return result != NULL || result->is_zombie() ? NULL : result;
+  }
   // We could potentially look up non_entrant methods
   guarantee(result == NULL || !result->is_zombie() || result->is_locked_by_vm() || VMError::is_error_reported(), "unsafe access to zombie method");
   return result;

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -652,7 +652,7 @@ bool CodeCache::contains(nmethod *nm) {
 CodeBlob* CodeCache::find_blob(void* start) {
   CodeBlob* result = find_blob_unsafe(start);
   Thread* current_thread = Thread::current_or_null_safe();
-  if (current_thread != NULL && current_thread->in_asgct()) {
+  if (current_thread != NULL && current_thread->is_Java_thread() && JavaThread::cast(current_thread)->in_asgct()) {
     // If called from ASGCT the usual invariants may not apply so if we find
     // a zombie method just return NULL
     return (result == NULL || result->is_zombie()) ? NULL : result;

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -591,7 +591,7 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
     return;
   }
 
-  thread->set_in_asgct(true);
+  ASGCTMark mark;
   switch (thread->thread_state()) {
   case _thread_new:
   case _thread_uninitialized:
@@ -649,7 +649,6 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
     trace->num_frames = ticks_unknown_state; // -7
     break;
   }
-  thread->set_in_asgct(false);
 }
 
 

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -591,7 +591,7 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
     return;
   }
 
-  // !important! make sure all return points will reset the IN_ASGCT flag to 'false'
+  // !important! make sure all to call thread->set_in_asgct(false) before every return
   thread->set_in_asgct(true);
 
   switch (thread->thread_state()) {

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -591,7 +591,7 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
     return;
   }
 
-  ASGCTMark mark;
+  ASGCTMark mark(thread);
   switch (thread->thread_state()) {
   case _thread_new:
   case _thread_uninitialized:

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -591,6 +591,7 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
     return;
   }
 
+  thread->set_in_asgct(true);
   switch (thread->thread_state()) {
   case _thread_new:
   case _thread_uninitialized:
@@ -648,6 +649,7 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
     trace->num_frames = ticks_unknown_state; // -7
     break;
   }
+  thread->set_in_asgct(false);
 }
 
 

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -591,7 +591,9 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
     return;
   }
 
-  ASGCTMark mark(thread);
+  // !important! make sure all return points will reset the IN_ASGCT flag to 'false'
+  thread->set_in_asgct(true);
+
   switch (thread->thread_state()) {
   case _thread_new:
   case _thread_uninitialized:
@@ -649,6 +651,7 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
     trace->num_frames = ticks_unknown_state; // -7
     break;
   }
+  thread->set_in_asgct(false);
 }
 
 

--- a/src/hotspot/share/prims/forte.hpp
+++ b/src/hotspot/share/prims/forte.hpp
@@ -39,18 +39,21 @@ class Forte : AllStatic {
 // A small RAII mark class to manage 'in_asgct' thread status
 class ASGCTMark : public StackObj {
  private:
-  // NONCOPYABLE(ASGCTMark);
-  ASGCTMark(JavaThread* thread) {
-    if (thread != nullptr) {
-      assert(thread == JavaThread::current(), "not the current thread");
-      thread->set_in_asgct(true);
-    }
-  }
+  JavaThread* _thread;
+  NONCOPYABLE(ASGCTMark);
 
  public:
-  ASGCTMark() : ASGCTMark(JavaThread::current()) {}
+  ASGCTMark(JavaThread* thread) : _thread(thread) {
+    if (_thread != nullptr) {
+      assert(_thread == Thread::current_or_null_safe(), "not the current thread");
+      _thread->set_in_asgct(true);
+    }
+  }
   ~ASGCTMark() {
-    JavaThread::current()->set_in_asgct(false);
+    if (_thread != nullptr) {
+      assert(_thread == Thread::current_or_null_safe(), "not the current thread");
+      _thread->set_in_asgct(false);
+    }
   }
 };
 

--- a/src/hotspot/share/prims/forte.hpp
+++ b/src/hotspot/share/prims/forte.hpp
@@ -25,6 +25,8 @@
 #ifndef SHARE_PRIMS_FORTE_HPP
 #define SHARE_PRIMS_FORTE_HPP
 
+#include "memory/allocation.hpp"
+
 // Interface to Forte support.
 
 class Forte : AllStatic {
@@ -32,6 +34,24 @@ class Forte : AllStatic {
    static void register_stub(const char* name, address start, address end)
                                                  NOT_JVMTI_RETURN;
                                                  // register internal VM stub
+};
+
+// A small RAII mark class to manage 'in_asgct' thread status
+class ASGCTMark : public StackObj {
+ private:
+  // NONCOPYABLE(ASGCTMark);
+  ASGCTMark(JavaThread* thread) {
+    if (thread != nullptr) {
+      assert(thread == JavaThread::current(), "not the current thread");
+      thread->set_in_asgct(true);
+    }
+  }
+
+ public:
+  ASGCTMark() : ASGCTMark(JavaThread::current()) {}
+  ~ASGCTMark() {
+    JavaThread::current()->set_in_asgct(false);
+  }
 };
 
 #endif // SHARE_PRIMS_FORTE_HPP

--- a/src/hotspot/share/prims/forte.hpp
+++ b/src/hotspot/share/prims/forte.hpp
@@ -36,25 +36,4 @@ class Forte : AllStatic {
                                                  // register internal VM stub
 };
 
-// A small RAII mark class to manage 'in_asgct' thread status
-class ASGCTMark : public StackObj {
- private:
-  JavaThread* _thread;
-  NONCOPYABLE(ASGCTMark);
-
- public:
-  ASGCTMark(JavaThread* thread) : _thread(thread) {
-    if (_thread != nullptr) {
-      assert(_thread == Thread::current_or_null_safe(), "not the current thread");
-      _thread->set_in_asgct(true);
-    }
-  }
-  ~ASGCTMark() {
-    if (_thread != nullptr) {
-      assert(_thread == Thread::current_or_null_safe(), "not the current thread");
-      _thread->set_in_asgct(false);
-    }
-  }
-};
-
 #endif // SHARE_PRIMS_FORTE_HPP

--- a/src/hotspot/share/prims/forte.hpp
+++ b/src/hotspot/share/prims/forte.hpp
@@ -25,8 +25,6 @@
 #ifndef SHARE_PRIMS_FORTE_HPP
 #define SHARE_PRIMS_FORTE_HPP
 
-#include "memory/allocation.hpp"
-
 // Interface to Forte support.
 
 class Forte : AllStatic {

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -255,8 +255,6 @@ Thread::Thread() {
   // and ::Release()
   _ParkEvent   = ParkEvent::Allocate(this);
 
-  _in_asgct = false; // initialize the ASGCT handler flag
-
 #ifdef CHECK_UNHANDLED_OOPS
   if (CheckUnhandledOops) {
     _unhandled_oops = new UnhandledOops(this);
@@ -994,6 +992,7 @@ void JavaThread::check_for_valid_safepoint_state() {
 JavaThread::JavaThread() :
   // Initialize fields
 
+  _in_asgct(false),
   _on_thread_list(false),
   DEBUG_ONLY(_java_call_counter(0) COMMA)
   _entry_point(nullptr),

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -255,7 +255,7 @@ Thread::Thread() {
   // and ::Release()
   _ParkEvent   = ParkEvent::Allocate(this);
 
-  _in_agct = false; // initialize in-asgct state
+  _in_asgct = false; // initialize the ASGCT handler flag
 
 #ifdef CHECK_UNHANDLED_OOPS
   if (CheckUnhandledOops) {

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -255,6 +255,8 @@ Thread::Thread() {
   // and ::Release()
   _ParkEvent   = ParkEvent::Allocate(this);
 
+  _in_asgct = false; // initialize in-asgct state
+
 #ifdef CHECK_UNHANDLED_OOPS
   if (CheckUnhandledOops) {
     _unhandled_oops = new UnhandledOops(this);

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -255,7 +255,7 @@ Thread::Thread() {
   // and ::Release()
   _ParkEvent   = ParkEvent::Allocate(this);
 
-  _in_asgct = false; // initialize in-asgct state
+  _in_agct = false; // initialize in-asgct state
 
 #ifdef CHECK_UNHANDLED_OOPS
   if (CheckUnhandledOops) {

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -590,6 +590,7 @@ protected:
 
  private:
   volatile int _jvmti_env_iteration_count;
+  bool _in_asgct;
 
  public:
   void entering_jvmti_env_iteration()            { ++_jvmti_env_iteration_count; }
@@ -611,6 +612,9 @@ protected:
   static ByteSize allocated_bytes_offset()       { return byte_offset_of(Thread, _allocated_bytes); }
 
   JFR_ONLY(DEFINE_THREAD_LOCAL_OFFSET_JFR;)
+
+  inline bool in_asgct(void)                     {return _in_asgct;}
+  inline void set_in_asgct(bool value)           {_in_asgct = value;}
 
  public:
   ParkEvent * volatile _ParkEvent;            // for Object monitors, JVMTI raw monitors,
@@ -643,14 +647,6 @@ protected:
     assert(_wx_state == expected, "wrong state");
   }
 #endif // __APPLE__ && AARCH64
-
- // support AGCT
- private:
-  bool _in_agct;
-
- public:
-  inline bool in_agct(void) {return _in_agct;}
-  inline void set_in_asgct(bool value) {_in_agct = value;}
 };
 
 // Inline implementation of Thread::current()

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -643,6 +643,14 @@ protected:
     assert(_wx_state == expected, "wrong state");
   }
 #endif // __APPLE__ && AARCH64
+
+ // support ASGCT
+ private:
+  bool _in_asgct;
+
+ public:
+  inline bool in_asgct(void) {return _in_asgct;}
+  inline void set_in_asgct(bool value) {_in_asgct = value;}
 };
 
 // Inline implementation of Thread::current()

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1647,7 +1647,6 @@ public:
   // resource allocation failure.
   static void vm_exit_on_osthread_failure(JavaThread* thread);
 
-
   // AsyncGetCallTrace support
   inline bool in_asgct(void) {return _in_asgct;}
   inline void set_in_asgct(bool value) {_in_asgct = value;}

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -644,13 +644,13 @@ protected:
   }
 #endif // __APPLE__ && AARCH64
 
- // support ASGCT
+ // support AGCT
  private:
-  bool _in_asgct;
+  bool _in_agct;
 
  public:
-  inline bool in_asgct(void) {return _in_asgct;}
-  inline void set_in_asgct(bool value) {_in_asgct = value;}
+  inline bool in_agct(void) {return _in_agct;}
+  inline void set_in_asgct(bool value) {_in_agct = value;}
 };
 
 // Inline implementation of Thread::current()

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -590,7 +590,6 @@ protected:
 
  private:
   volatile int _jvmti_env_iteration_count;
-  bool _in_asgct;
 
  public:
   void entering_jvmti_env_iteration()            { ++_jvmti_env_iteration_count; }
@@ -612,9 +611,6 @@ protected:
   static ByteSize allocated_bytes_offset()       { return byte_offset_of(Thread, _allocated_bytes); }
 
   JFR_ONLY(DEFINE_THREAD_LOCAL_OFFSET_JFR;)
-
-  inline bool in_asgct(void)                     {return _in_asgct;}
-  inline void set_in_asgct(bool value)           {_in_asgct = value;}
 
  public:
   ParkEvent * volatile _ParkEvent;            // for Object monitors, JVMTI raw monitors,
@@ -685,6 +681,7 @@ class JavaThread: public Thread {
   friend class ThreadsSMRSupport; // to access _threadObj for exiting_threads_oops_do
   friend class HandshakeState;
  private:
+  bool           _in_asgct;                      // Is set when this JavaThread is handling ASGCT call
   bool           _on_thread_list;                // Is set when this JavaThread is added to the Threads list
   OopHandle      _threadObj;                     // The Java level thread object
 
@@ -1649,6 +1646,11 @@ public:
   // Helper function to do vm_exit_on_initialization for osthread
   // resource allocation failure.
   static void vm_exit_on_osthread_failure(JavaThread* thread);
+
+
+  // AsyncGetCallTrace support
+  inline bool in_asgct(void) {return _in_asgct;}
+  inline void set_in_asgct(bool value) {_in_asgct = value;}
 };
 
 inline JavaThread* JavaThread::current_or_null() {


### PR DESCRIPTION
A gist of the fix is to allow relaxed special handling of code blob lookup when done for ASGCT. 

Currently, a guarantee will fail when we happen to hit a zombie method which is still on stack. While this would indicate a serious error for the normal execution flow, in case of ASGCT being in progress when the executing thread can be expected at any possible method this is something which may happen and we really should not take the profiled JVM down due to it.

<hr>
Unfortunately, I am not able to create a simple reproducer for the crash other that testing in our production where the crash is happening sporadically.
However, thanks to @parttimenerd and his [ASGCT stress test](https://github.com/parttimenerd/asgct2-tester.git) the problem can be reproduced quite reliably.

<br><br>

_Note: This is a followup PR for #8061_

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8283849](https://bugs.openjdk.java.net/browse/JDK-8283849): AsyncGetCallTrace may crash JVM on guarantee


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [ce5924d7](https://git.openjdk.java.net/jdk/pull/8549/files/ce5924d7733b8c0967f7408777bb881cc4c761d4)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [ce5924d7](https://git.openjdk.java.net/jdk/pull/8549/files/ce5924d7733b8c0967f7408777bb881cc4c761d4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8549/head:pull/8549` \
`$ git checkout pull/8549`

Update a local copy of the PR: \
`$ git checkout pull/8549` \
`$ git pull https://git.openjdk.java.net/jdk pull/8549/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8549`

View PR using the GUI difftool: \
`$ git pr show -t 8549`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8549.diff">https://git.openjdk.java.net/jdk/pull/8549.diff</a>

</details>
