### PR TITLE
8286189 G1: Change "wasted" memory to "unused" memory in reporting 

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.cpp
@@ -909,8 +909,8 @@ size_t G1CardSet::mem_size() const {
          _mm->mem_size();
 }
 
-size_t G1CardSet::wasted_mem_size() const {
-  return _mm->wasted_mem_size();
+size_t G1CardSet::unused_mem_size() const {
+  return _mm->unused_mem_size();
 }
 
 size_t G1CardSet::static_mem_size() {

--- a/src/hotspot/share/gc/g1/g1CardSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.hpp
@@ -324,7 +324,7 @@ public:
 
   // Returns size of the actual remembered set containers in bytes.
   size_t mem_size() const;
-  size_t wasted_mem_size() const;
+  size_t unused_mem_size() const;
   // Returns the size of static data in bytes.
   static size_t static_mem_size();
 

--- a/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
@@ -60,11 +60,11 @@ size_t G1CardSetAllocator::mem_size() const {
          _segmented_array.num_available_slots() * _segmented_array.slot_size();
 }
 
-size_t G1CardSetAllocator::wasted_mem_size() const {
-  uint num_wasted_slots = _segmented_array.num_available_slots() -
+size_t G1CardSetAllocator::unused_mem_size() const {
+  uint num_unused_slots = _segmented_array.num_available_slots() -
                           _segmented_array.num_allocated_slots() -
                           (uint)_free_slots_list.pending_count();
-  return num_wasted_slots * _segmented_array.slot_size();
+  return num_unused_slots * _segmented_array.slot_size();
 }
 
 uint G1CardSetAllocator::num_segments() const {
@@ -142,10 +142,10 @@ size_t G1CardSetMemoryManager::mem_size() const {
     (sizeof(G1CardSetAllocator) * num_mem_object_types());
 }
 
-size_t G1CardSetMemoryManager::wasted_mem_size() const {
+size_t G1CardSetMemoryManager::unused_mem_size() const {
   size_t result = 0;
   for (uint i = 0; i < num_mem_object_types(); i++) {
-    result += _allocators[i].wasted_mem_size();
+    result += _allocators[i].unused_mem_size();
   }
   return result;
 }

--- a/src/hotspot/share/gc/g1/g1CardSetMemory.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.hpp
@@ -83,9 +83,11 @@ public:
   // be called in a globally synchronized area.
   void drop_all();
 
+  // Total memory allocated.
   size_t mem_size() const;
 
-  size_t wasted_mem_size() const;
+  // Unused (but usable) memory.
+  size_t unused_mem_size() const;
 
   uint num_segments() const;
 
@@ -119,7 +121,7 @@ public:
   void print(outputStream* os);
 
   size_t mem_size() const;
-  size_t wasted_mem_size() const;
+  size_t unused_mem_size() const;
 
   G1SegmentedArrayMemoryStats memory_stats() const;
 };

--- a/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
@@ -114,7 +114,7 @@ class RegionTypeCounter {
 private:
   const char* _name;
 
-  size_t _rs_wasted_mem_size;
+  size_t _rs_unused_mem_size;
   size_t _rs_mem_size;
   size_t _cards_occupied;
   size_t _amount;
@@ -144,12 +144,12 @@ private:
 
 public:
 
-  RegionTypeCounter(const char* name) : _name(name), _rs_wasted_mem_size(0), _rs_mem_size(0), _cards_occupied(0),
+  RegionTypeCounter(const char* name) : _name(name), _rs_unused_mem_size(0), _rs_mem_size(0), _cards_occupied(0),
     _amount(0), _amount_tracked(0), _code_root_mem_size(0), _code_root_elems(0) { }
 
-  void add(size_t rs_wasted_mem_size, size_t rs_mem_size, size_t cards_occupied,
+  void add(size_t rs_unused_mem_size, size_t rs_mem_size, size_t cards_occupied,
            size_t code_root_mem_size, size_t code_root_elems, bool tracked) {
-    _rs_wasted_mem_size += rs_wasted_mem_size;
+    _rs_unused_mem_size += rs_unused_mem_size;
     _rs_mem_size += rs_mem_size;
     _cards_occupied += cards_occupied;
     _code_root_mem_size += code_root_mem_size;
@@ -158,7 +158,7 @@ public:
     _amount_tracked += tracked ? 1 : 0;
   }
 
-  size_t rs_wasted_mem_size() const { return _rs_wasted_mem_size; }
+  size_t rs_unused_mem_size() const { return _rs_unused_mem_size; }
   size_t rs_mem_size() const { return _rs_mem_size; }
   size_t cards_occupied() const { return _cards_occupied; }
 
@@ -167,10 +167,10 @@ public:
 
   void print_rs_mem_info_on(outputStream * out, size_t total) {
     out->print_cr("    " SIZE_FORMAT_W(8) " (%5.1f%%) by " SIZE_FORMAT " "
-                  "(" SIZE_FORMAT ") %s regions wasted " SIZE_FORMAT,
+                  "(" SIZE_FORMAT ") %s regions unused " SIZE_FORMAT,
                   rs_mem_size(), rs_mem_size_percent_of(total),
                   amount_tracked(), amount(),
-                  _name, rs_wasted_mem_size());
+                  _name, rs_unused_mem_size());
   }
 
   void print_cards_occupied_info_on(outputStream * out, size_t total) {
@@ -206,7 +206,7 @@ private:
   size_t _max_rs_mem_sz;
   HeapRegion* _max_rs_mem_sz_region;
 
-  size_t total_rs_wasted_mem_sz() const     { return _all.rs_wasted_mem_size(); }
+  size_t total_rs_unused_mem_sz() const     { return _all.rs_unused_mem_size(); }
   size_t total_rs_mem_sz() const            { return _all.rs_mem_size(); }
   size_t total_cards_occupied() const       { return _all.cards_occupied(); }
 
@@ -234,7 +234,7 @@ public:
 
     // HeapRegionRemSet::mem_size() includes the
     // size of the code roots
-    size_t rs_wasted_mem_sz = hrrs->wasted_mem_size();
+    size_t rs_unused_mem_sz = hrrs->unused_mem_size();
     size_t rs_mem_sz = hrrs->mem_size();
     if (rs_mem_sz > _max_rs_mem_sz) {
       _max_rs_mem_sz = rs_mem_sz;
@@ -262,9 +262,9 @@ public:
     } else {
       ShouldNotReachHere();
     }
-    current->add(rs_wasted_mem_sz, rs_mem_sz, occupied_cards,
+    current->add(rs_unused_mem_sz, rs_mem_sz, occupied_cards,
                  code_root_mem_sz, code_root_elems, r->rem_set()->is_tracked());
-    _all.add(rs_wasted_mem_sz, rs_mem_sz, occupied_cards,
+    _all.add(rs_unused_mem_sz, rs_mem_sz, occupied_cards,
              code_root_mem_sz, code_root_elems, r->rem_set()->is_tracked());
 
     return false;
@@ -275,10 +275,10 @@ public:
 
     out->print_cr(" Current rem set statistics");
     out->print_cr("  Total per region rem sets sizes = " SIZE_FORMAT
-                  " Max = " SIZE_FORMAT " wasted = " SIZE_FORMAT,
+                  " Max = " SIZE_FORMAT " unused = " SIZE_FORMAT,
                   total_rs_mem_sz(),
                   max_rs_mem_sz(),
-                  total_rs_wasted_mem_sz());
+                  total_rs_unused_mem_sz());
     for (RegionTypeCounter** current = &counters[0]; *current != NULL; current++) {
       (*current)->print_rs_mem_info_on(out, total_rs_mem_sz());
     }

--- a/src/hotspot/share/gc/g1/g1SegmentedArray.hpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArray.hpp
@@ -215,8 +215,8 @@ class G1SegmentedArray : public FreeListConfig  {
   G1SegmentedArrayFreeList* _free_segment_list;   // The global free segment list to preferentially
                                                   // get new segments from.
 
-  volatile uint _num_available_slots; // Number of slots available in all segments (allocated + free + pending + not yet used).
-  volatile uint _num_allocated_slots; // Number of total slots allocated and in use.
+  volatile uint _num_available_slots; // Number of slots available in all segments (allocated + not yet used).
+  volatile uint _num_allocated_slots; // Number of total slots allocated ever (including free and pending).
 
 private:
   inline G1SegmentedArraySegment* create_new_segment(G1SegmentedArraySegment* const prev);

--- a/src/hotspot/share/gc/g1/heapRegionRemSet.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.hpp
@@ -136,8 +136,8 @@ public:
            + code_roots_mem_size();
   }
 
-  size_t wasted_mem_size() {
-    return _card_set.wasted_mem_size();
+  size_t unused_mem_size() {
+    return _card_set.unused_mem_size();
   }
 
   // Returns the memory occupancy of all static data structures associated


### PR DESCRIPTION
Hi all,

  please review this change of the term "wasted" to "unused" in memory reporting; "wasted" is a bit ambiguous, meaning memory that can't be used because it's blocked by something external (like the space at the end of humongous regions where gc needs to wait until the humongous objects is freed by the application).

Testing: gha

Thanks,
  Thomas