### PR TITLE
8286190: Add test to verify constant folding for Enum fields

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestEnumFinalFold.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestEnumFinalFold.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import jdk.test.lib.Asserts;
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8286190
+ * @summary Verify constant folding for Enum fields
+ * @library /test/lib /
+ * @requires vm.compiler2.enabled
+ * @run driver compiler.c2.irTests.TestEnumFinalFold
+ */
+public class TestEnumFinalFold {
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    private enum MyEnum {
+        VALUE1,
+        VALUE2;
+    }
+
+    @Test
+    @IR(failOn = {IRNode.ADD_I, IRNode.LOAD_I})
+    public int testOrdinalSum() {
+        return MyEnum.VALUE1.ordinal() + MyEnum.VALUE2.ordinal();
+    }
+
+    @Run(test = "testOrdinalSum")
+    public void runOrdinalSum() {
+        testOrdinalSum();
+    }
+
+    @Test
+    @IR(failOn = {IRNode.ADD_I})
+    public int testNameLengthSum() {
+        return MyEnum.VALUE1.name().length() + MyEnum.VALUE2.name().length();
+    }
+
+    @Run(test = "testNameLengthSum")
+    public void runNameLengthSum() {
+        testNameLengthSum();
+    }
+
+}


### PR DESCRIPTION
There is the [JDK-8161245](https://bugs.openjdk.java.net/browse/JDK-8161245) to make compilers trust Enum final fields. It was implicitly implemented by [JDK-8234049](https://bugs.openjdk.java.net/browse/JDK-8234049), which added the wildcard trust for everything in java/lang:
  https://github.com/openjdk/jdk/blob/c5a0687f80367a3a284dfd56781c371826264d3b/src/hotspot/share/ci/ciField.cpp#L230

It would be better to have the explicit test that verifies the constant folding of Enum fields indeed happens.

Additional testing:
 - [x] Linux x86_64 fastdebug, new test passes
 - [x] Linux x86_64 release, new test passes
 - [x] Linux x86_32 fastdebug, new test passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286190](https://bugs.openjdk.java.net/browse/JDK-8286190): Add test to verify constant folding for Enum fields


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8551/head:pull/8551` \
`$ git checkout pull/8551`

Update a local copy of the PR: \
`$ git checkout pull/8551` \
`$ git pull https://git.openjdk.java.net/jdk pull/8551/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8551`

View PR using the GUI difftool: \
`$ git pr show -t 8551`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8551.diff">https://git.openjdk.java.net/jdk/pull/8551.diff</a>

</details>
