### PR TITLE
JDK-8286198: [linux] Fix process-memory information

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2152,23 +2152,26 @@ void os::Linux::print_process_memory_info(outputStream* st) {
   // - Print glibc tunables
 #ifdef __GLIBC__
   size_t total_allocated = 0;
+  size_t free_retained = 0;
   bool might_have_wrapped = false;
   if (_mallinfo2 != NULL) {
     struct glibc_mallinfo2 mi = _mallinfo2();
-    total_allocated = mi.uordblks;
+    total_allocated = mi.uordblks + mi.hblkhd;
+    free_retained = mi.fordblks;
   } else if (_mallinfo != NULL) {
     // mallinfo is an old API. Member names mean next to nothing and, beyond that, are 32-bit signed.
     // So for larger footprints the values may have wrapped around. We try to detect this here: if the
     // process whole resident set size is smaller than 4G, malloc footprint has to be less than that
     // and the numbers are reliable.
     struct glibc_mallinfo mi = _mallinfo();
-    total_allocated = (size_t)(unsigned)mi.uordblks;
+    total_allocated = (size_t)(unsigned)mi.uordblks + (size_t)(unsigned)mi.hblkhd;
+    free_retained = (size_t)(unsigned)mi.fordblks;
     // Since mallinfo members are int, glibc values may have wrapped. Warn about this.
     might_have_wrapped = (info.vmrss * K) > UINT_MAX && (info.vmrss * K) > (total_allocated + UINT_MAX);
   }
   if (_mallinfo2 != NULL || _mallinfo != NULL) {
-    st->print_cr("C-Heap outstanding allocations: " SIZE_FORMAT "K%s",
-                 total_allocated / K,
+    st->print_cr("C-Heap outstanding allocations: " SIZE_FORMAT "K, retained: " SIZE_FORMAT "K%s",
+                 total_allocated / K, free_retained / K,
                  might_have_wrapped ? " (may have wrapped)" : "");
   }
   // Tunables


### PR DESCRIPTION
We use mallinfo/mallinfo2 to obtain information about the glibc used memory, but there is an error which causes it to be correct only for fine granular malloc allocations. glibc puts larger allocations in mmap-allocated areas, which were missing from the old calculation.

This patch fixes that; it also adds information about memory retained in the glibc after free. Note that the latter unfortunately does not follow glibc trims because trimming is done AFAIK with madvice(MADV_DONTNEED) which does not seem to affect glibc internal bookkeeping. Still its a very valuable thing to know in order to estimate glibc overhead especially in fine granular mass allocation scenarios.