### PR TITLE
8284675: "jpackage.exe" creates application launcher without Windows Application Manfiest

### DIFF
--- a/make/modules/jdk.jpackage/Lib.gmk
+++ b/make/modules/jdk.jpackage/Lib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 #
 
 include LibCommon.gmk
+include LauncherCommon.gmk
 
 ################################################################################
 
@@ -75,6 +76,8 @@ $(eval $(call SetupJdkExecutable, BUILD_JPACKAGE_APPLAUNCHEREXE, \
     LIBS_macosx := $(LIBCXX) -framework Cocoa, \
     LIBS_windows := $(LIBCXX), \
     LIBS_linux := -ldl, \
+    MANIFEST := $(JAVA_MANIFEST), \
+    MANIFEST_VERSION := $(VERSION_NUMBER_FOUR_POSITIONS) \
 ))
 
 JPACKAGE_TARGETS += $(BUILD_JPACKAGE_APPLAUNCHEREXE)
@@ -175,6 +178,8 @@ ifeq ($(call isTargetOs, windows), true)
       LDFLAGS := $(BUILD_JPACKAGE_APPLAUNCHEREXE_LDFLAGS), \
       LIBS := $(BUILD_JPACKAGE_APPLAUNCHEREXE_LIBS), \
       LIBS_windows := $(BUILD_JPACKAGE_APPLAUNCHEREXE_LIBS_windows), \
+      MANIFEST := $(JAVA_MANIFEST), \
+      MANIFEST_VERSION := $(VERSION_NUMBER_FOUR_POSITIONS) \
   ))
 
   JPACKAGE_TARGETS += $(BUILD_JPACKAGE_APPLAUNCHERWEXE)


### PR DESCRIPTION
Copy missing manifest-related parameters to `SetupJdkExecutable` calls building app launchers from `SetupBuildLauncher` function:https://github.com/openjdk/jdk/blob/0c3094c8186b4d53e8bad80e2369fc7b9ae9e201/make/common/modules/LauncherCommon.gmk#L174-L175

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8284675](https://bugs.openjdk.java.net/browse/JDK-8284675): "jpackage.exe" creates application launcher without Windows Application Manfiest


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8561/head:pull/8561` \
`$ git checkout pull/8561`

Update a local copy of the PR: \
`$ git checkout pull/8561` \
`$ git pull https://git.openjdk.java.net/jdk pull/8561/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8561`

View PR using the GUI difftool: \
`$ git pr show -t 8561`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8561.diff">https://git.openjdk.java.net/jdk/pull/8561.diff</a>

</details>
