### PR TITLE
8285616: [macos] Incorrect path for launcher-as-service.txt in .cfg file

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LauncherAsServiceVerifier.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LauncherAsServiceVerifier.java
@@ -227,12 +227,13 @@ public final class LauncherAsServiceVerifier {
         pkg.addInstallVerifier(cmd -> {
             if (canVerifyInstall(cmd)) {
                 delayInstallVerify();
+                Path outputFilePath = appOutputFilePathVerify(cmd);
                 HelloApp.assertApp(cmd.appLauncherPath())
                         .addParam("jpackage.test.appOutput",
-                                appOutputFilePathVerify(cmd).toString())
+                                outputFilePath.toString())
                         .addDefaultArguments(expectedValue)
                         .verifyOutput();
-                TKit.deleteIfExists(appOutputFileName);
+                TKit.deleteIfExists(outputFilePath);
             }
         });
         pkg.addInstallVerifier(cmd -> {
@@ -247,7 +248,7 @@ public final class LauncherAsServiceVerifier {
                 if (canVerifyInstall(cmd)) {
                     delayInstallVerify();
                     super.verify(cmd);
-                    TKit.deleteIfExists(appOutputFileName);
+                    TKit.deleteIfExists(appOutputFilePathVerify(cmd));
                 }
                 LauncherAsServiceVerifier.verify(cmd, launcherName);
             }
@@ -320,7 +321,7 @@ public final class LauncherAsServiceVerifier {
         if (TKit.isWindows()) {
             dir = Path.of("$ROOTDIR");
         } else {
-            dir = Path.of(System.getProperty("java.io.tmpdir"));
+            dir = Path.of("/tmp");
         }
         return dir.resolve(appOutputFileName);
     }


### PR DESCRIPTION
- Replace `System.getProperty("java.io.tmpdir")` call with hardcoded `/tmp` string to get root folder for test files.
- Fix test cleanup - the test didn't delete test files upon completion

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8285616](https://bugs.openjdk.java.net/browse/JDK-8285616): [macos] Incorrect path for launcher-as-service.txt in .cfg file


### Reviewers
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8563/head:pull/8563` \
`$ git checkout pull/8563`

Update a local copy of the PR: \
`$ git checkout pull/8563` \
`$ git pull https://git.openjdk.java.net/jdk pull/8563/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8563`

View PR using the GUI difftool: \
`$ git pr show -t 8563`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8563.diff">https://git.openjdk.java.net/jdk/pull/8563.diff</a>

</details>
