### PR TITLE
8286263: compiler/c1/TestPinnedIntrinsics.java failed with "RuntimeException: testCurrentTimeMillis failed with -3"

### DIFF
--- a/test/hotspot/jtreg/compiler/c1/TestPinnedIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/c1/TestPinnedIntrinsics.java
@@ -24,10 +24,9 @@
 /*
  * @test
  * @bug 8184271
- * @summary Test correct scheduling of System.nanoTime and System.currentTimeMillis C1 intrinsics.
+ * @summary Test correct scheduling of System.nanoTime C1 intrinsic.
  * @run main/othervm -XX:TieredStopAtLevel=1 -Xbatch
  *                   -XX:CompileCommand=dontinline,compiler.c1.TestPinnedIntrinsics::checkNanoTime
- *                   -XX:CompileCommand=dontinline,compiler.c1.TestPinnedIntrinsics::checkCurrentTimeMillis
  *                   compiler.c1.TestPinnedIntrinsics
  */
 
@@ -47,22 +46,9 @@ public class TestPinnedIntrinsics {
         }
     }
 
-    private static void testCurrentTimeMillis() {
-        long start = System.currentTimeMillis();
-        long end = System.currentTimeMillis();
-        checkCurrentTimeMillis(end - start);
-    }
-
-    private static void checkCurrentTimeMillis(long diff) {
-        if (diff < 0) {
-            throw new RuntimeException("testCurrentTimeMillis failed with " + diff);
-        }
-    }
-
     public static void main(String[] args) {
         for (int i = 0; i < 100_000; ++i) {
             testNanoTime();
-            testCurrentTimeMillis();
         }
     }
 }


### PR DESCRIPTION
This test incorrectly assumes calls to System.currentTimeMillis() are monotonic.  The only fix I can think of is to remove that test and leave the test for System.nanoTime().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286263](https://bugs.openjdk.java.net/browse/JDK-8286263): compiler/c1/TestPinnedIntrinsics.java failed with "RuntimeException: testCurrentTimeMillis failed with -3"


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8566/head:pull/8566` \
`$ git checkout pull/8566`

Update a local copy of the PR: \
`$ git checkout pull/8566` \
`$ git pull https://git.openjdk.java.net/jdk pull/8566/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8566`

View PR using the GUI difftool: \
`$ git pr show -t 8566`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8566.diff">https://git.openjdk.java.net/jdk/pull/8566.diff</a>

</details>
