### PR TITLE
8286179: Node::find(int) should not traverse from new to old nodes

### DIFF
--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -1614,8 +1614,7 @@ Node* find_node(const int idx) {
 // Call this from debugger, search in old nodes:
 Node* find_old_node(const int idx) {
   Node* root = old_root();
-  assert(root != nullptr, "must have old_root() to find old nodes");
-  return root->find(idx);
+  return (root == nullptr) ? nullptr : root->find(idx);
 }
 
 // Call this from debugger, search in same graph as n:
@@ -1631,8 +1630,7 @@ Node* find_ctrl(const int idx) {
 // Call this from debugger, search in old nodes:
 Node* find_old_ctrl(const int idx) {
   Node* root = old_root();
-  assert(root != nullptr, "must have old_root() to find old nodes");
-  return root->find_ctrl(idx);
+  return (root == nullptr) ? nullptr : root->find_ctrl(idx);
 }
 
 //------------------------------find_ctrl--------------------------------------

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -1588,23 +1588,47 @@ jfloat Node::getf() const {
 #ifndef PRODUCT
 
 // Call this from debugger:
+Node* old_root() {
+  Matcher* matcher = Compile::current()->matcher();
+  if (matcher != nullptr) {
+    Node* new_root = Compile::current()->root();
+    Node* old_root = matcher->find_old_node(new_root);
+    if (old_root != nullptr) {
+      return old_root;
+    }
+  }
+  tty->print("old_root: not found.\n");
+  return nullptr;
+}
+
+// Call this from debugger, search in same graph as n:
 Node* find_node(Node* n, const int idx) {
   return n->find(idx);
 }
 
-// Call this from debugger with root node as default:
+// Call this from debugger, search in new nodes:
 Node* find_node(const int idx) {
   return Compile::current()->root()->find(idx);
 }
 
-// Call this from debugger:
+// Call this from debugger, search in old nodes:
+Node* find_old_node(const int idx) {
+  return old_root()->find(idx);
+}
+
+// Call this from debugger, search in same graph as n:
 Node* find_ctrl(Node* n, const int idx) {
   return n->find_ctrl(idx);
 }
 
-// Call this from debugger with root node as default:
+// Call this from debugger, search in new nodes:
 Node* find_ctrl(const int idx) {
   return Compile::current()->root()->find_ctrl(idx);
+}
+
+// Call this from debugger, search in old nodes:
+Node* find_old_ctrl(const int idx) {
+  return old_root()->find_ctrl(idx);
 }
 
 //------------------------------find_ctrl--------------------------------------
@@ -1652,13 +1676,6 @@ Node* Node::find(const int idx, bool only_ctrl) {
         add_to_worklist(n->raw_out(i), &worklist, old_arena, &old_space, &new_space);
       }
     }
-#ifdef ASSERT
-    // Search along debug_orig edges last
-    Node* orig = n->debug_orig();
-    while (orig != NULL && add_to_worklist(orig, &worklist, old_arena, &old_space, &new_space)) {
-      orig = orig->debug_orig();
-    }
-#endif // ASSERT
   }
   return result;
 }

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -1613,7 +1613,9 @@ Node* find_node(const int idx) {
 
 // Call this from debugger, search in old nodes:
 Node* find_old_node(const int idx) {
-  return old_root()->find(idx);
+  Node* root = old_root();
+  assert(root != nullptr, "must have old_root() to find old nodes");
+  return root->find(idx);
 }
 
 // Call this from debugger, search in same graph as n:
@@ -1628,7 +1630,9 @@ Node* find_ctrl(const int idx) {
 
 // Call this from debugger, search in old nodes:
 Node* find_old_ctrl(const int idx) {
-  return old_root()->find_ctrl(idx);
+  Node* root = old_root();
+  assert(root != nullptr, "must have old_root() to find old nodes");
+  return root->find_ctrl(idx);
 }
 
 //------------------------------find_ctrl--------------------------------------


### PR DESCRIPTION
**Problem:**
`Node::find` traverses input and output edges of nodes during its BFS, and searches for nodes with a specific `idx`.
However, if `ASSERT` is on, it also traverses `debug_orig`. This not only seems unnecessary. But Mach nodes (after matching) point back to the old IR nodes. This means we traverse from the new graph to the old graph, and potentially find multiple nodes matching the `idx`. Only the last found will be returned, sometimes this happens to be the new node, sometimes the old node. This is inconsistent and can be quite annoying during debugging.

**Implemented Solution:**
1. Remove traversing `debug_orig`.
2. Instead, add debug only functions `old_root`, which finds the old root if it exists. Question: I now put a warning in if the `old_root` cannot be found. I think this is helpful for in the debugger. I could make it an assert if that is preferred.
3. `find_node` and `find_ctrl` only search in new nodes now (start BFS at new root).
4. Added `find_old_node` and `find_old_ctrl`, which search in new nodes (start BFS at old root).

I hope this improves your debugging experience.
Ran larger tests to see that `find_node` did not break anything, reran sanity test after implementing suggestions from reviewers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286179](https://bugs.openjdk.java.net/browse/JDK-8286179): Node::find(int) should not traverse from new to old nodes


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * @limck599 (no known github.com user name / role)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8567/head:pull/8567` \
`$ git checkout pull/8567`

Update a local copy of the PR: \
`$ git checkout pull/8567` \
`$ git pull https://git.openjdk.java.net/jdk pull/8567/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8567`

View PR using the GUI difftool: \
`$ git pr show -t 8567`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8567.diff">https://git.openjdk.java.net/jdk/pull/8567.diff</a>

</details>
