### PR TITLE
8285820: C2: LCM prioritizes locally dependent CreateEx nodes over projections after 8270090

### DIFF
--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -489,9 +489,11 @@ void PhaseCFG::implicit_null_check(Block* block, Node *proj, Node *val, int allo
 
 //------------------------------select-----------------------------------------
 // Select a nice fellow from the worklist to schedule next. If there is only one
-// choice, then use it. CreateEx nodes must start their blocks and are selected
-// eagerly. After them, projections take top priority for correctness. Next
-// after projections are constants and CheckCastPP nodes. There are a number of
+// choice, then use it. CreateEx nodes that are initially ready must start their
+// blocks and are given the highest priority, by being placed at the beginning
+// of the worklist. Next after initially-ready CreateEx nodes are projections,
+// which must follow their parents, and CreateEx nodes with local input
+// dependencies. Next are constants and CheckCastPP nodes. There are a number of
 // other special cases, for instructions that consume condition codes, et al.
 // These are chosen immediately. Some instructions are required to immediately
 // precede the last instruction in the block, and these are taken last. Of the
@@ -529,27 +531,21 @@ Node* PhaseCFG::select(
     Node *n = worklist[i];      // Get Node on worklist
 
     int iop = n->is_Mach() ? n->as_Mach()->ideal_Opcode() : 0;
-    if (iop == Op_CreateEx) {
-      // CreateEx must start the block (after Phi and Parm nodes which are
-      // pre-scheduled): select it right away.
+    if (iop == Op_CreateEx || n->is_Proj()) {
+      // CreateEx nodes that are initially ready must start the block (after Phi
+      // and Parm nodes which are pre-scheduled) and get top priority. This is
+      // currently enforced by placing them at the beginning of the initial
+      // worklist and selecting them eagerly here. After these, projections and
+      // other CreateEx nodes are selected with equal priority.
       worklist.map(i,worklist.pop());
       return n;
     }
 
-    uint n_choice = 2;
-    if (n->is_Proj()) {
-      // Projections should follow their parents.
-      n_choice = 5;
-    } else if (n->Opcode() == Op_Con || iop == Op_CheckCastPP) {
+    if (n->Opcode() == Op_Con || iop == Op_CheckCastPP) {
       // Constants and CheckCastPP nodes have higher priority than the rest of
-      // the nodes tested below.
-      n_choice = 4;
-    }
-
-    if (n_choice >= 4 && choice < n_choice) {
-      // n is a constant, a projection, or a CheckCastPP node: record as current
-      // winner, but keep looking for higher-priority nodes in the worklist.
-      choice  = n_choice;
+      // the nodes tested below. Record as current winner, but keep looking for
+      // higher-priority nodes in the worklist.
+      choice  = 4;
       // Latency and score are only used to break ties among low-priority nodes.
       latency = 0;
       score   = 0;
@@ -574,6 +570,8 @@ Node* PhaseCFG::select(
         continue;
       }
     }
+
+    uint n_choice = 2;
 
     // See if this instruction is consumed by a branch. If so, then (as the
     // branch is the last instruction in the basic block) force it to the
@@ -1078,6 +1076,10 @@ bool PhaseCFG::schedule_local(Block* block, GrowableArray<int>& ready_cnt, Vecto
         // of the phi to be scheduled first. The select() method breaks
         // ties in scheduling by worklist order.
         delay.push(m);
+      } else if (m->is_Mach() && m->as_Mach()->ideal_Opcode() == Op_CreateEx) {
+        // Place CreateEx nodes that are initially ready at the beginning of the
+        // worklist so they are selected first and scheduled at the block start.
+        worklist.insert(0, m);
       } else {
         worklist.push(m);         // Then on to worklist!
       }


### PR DESCRIPTION
This changeset lowers the priority of locally-dependent CreateEx nodes, that is CreateEx nodes that are not initially ready for scheduling in LCM. The proposed scheme assigns them the same priority as projection nodes when selecting the next node to be scheduled, restoring the relative prioritization between projections and CreateEx nodes to the state it was before [JDK-8270090](https://bugs.openjdk.java.net/browse/JDK-8270090). JDK-8270090 wrongly gave all CreateEx nodes the highest priority, which leads to failures whenever projection nodes are expected to get higher priority than locally-dependent CreateEx nodes. See the [JBS issue report](https://bugs.openjdk.java.net/browse/JDK-8285820) for further detail.

More specifically, the current ranking to select the next node to be scheduled in `PhaseCFG::select()` is:

1. CreateEx nodes (initially ready or not)
2. Projections
3. Constants and CheckCastPP nodes (tie)
4. ...

After this changeset, the ranking becomes:

1. Initially ready CreateEx nodes
2. Projections and other CreateEx nodes (tie)
3. Constants and CheckCastPP nodes (tie)
4. ...

which still addresses the issue handled by JDK-8270090 but in a form that is closer to the original ranking before JDK-8270090:

1. Initially ready CreateEx nodes
2. Projections, other CreateEx nodes, constants and CheckCastPP nodes (tie)
3. ...

This changeset implements the minimal changes to restore the relative prioritization between CreateEx nodes and projections to the state it was before JDK-8270090, for risk minimization and ease of backporting. I will file a separate RFE proposing a more robust alternative than altering the order of the LCM worklist for ensuring that initially ready CreateEx nodes are scheduled at the block start.

#### Testing

##### Functionality

- Original failure on x86_32 using `-XX:+UseShenandoahGC` (thanks to Aleksey Shipilev for testing).
- Original failure of JDK-8270090 on arm32 (thanks to Marc Hoffmann for testing).
- hs-tier1-5 (windows-x64, linux-x64, linux-aarch64, and macosx-x64; release and debug mode).
- hs-tier1-3 (windows-x64, linux-x64, linux-aarch64, and macosx-x64; debug mode) with StressLCM and StressGCM (5 different seeds).

##### Performance

Tested performance on a set of standard benchmark suites (DaCapo, SPECjbb2015, SPECjvm2008, ...) and on linux-x64, linux-aarch64, windows-x64, and macosx-x64. No significant regression was observed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8285820](https://bugs.openjdk.java.net/browse/JDK-8285820): C2: LCM prioritizes locally dependent CreateEx nodes over projections after 8270090


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Contributors
 * Aleksey Shipilev `<shade@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8568/head:pull/8568` \
`$ git checkout pull/8568`

Update a local copy of the PR: \
`$ git checkout pull/8568` \
`$ git pull https://git.openjdk.java.net/jdk pull/8568/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8568`

View PR using the GUI difftool: \
`$ git pr show -t 8568`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8568.diff">https://git.openjdk.java.net/jdk/pull/8568.diff</a>

</details>
