### PR TITLE
8286297: G1: Simplify parallel and serial verification code paths

### DIFF
--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -491,20 +491,15 @@ void G1HeapVerifier::verify(VerifyOption vo) {
   }
 
   log_debug(gc, verify)("HeapRegions");
-  if (GCParallelVerificationEnabled && ParallelGCThreads > 1) {
 
-    G1ParVerifyTask task(_g1h, vo);
+  G1ParVerifyTask task(_g1h, vo);
+  if (GCParallelVerificationEnabled) {
     _g1h->workers()->run_task(&task);
-    if (task.failures()) {
-      failures = true;
-    }
-
   } else {
-    VerifyRegionClosure blk(false, vo);
-    _g1h->heap_region_iterate(&blk);
-    if (blk.failures()) {
-      failures = true;
-    }
+    task.work(0);
+  }
+  if (task.failures()) {
+    failures = true;
   }
 
   if (failures) {

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -492,12 +492,9 @@ void G1HeapVerifier::verify(VerifyOption vo) {
 
   log_debug(gc, verify)("HeapRegions");
 
+  uint num_workers = GCParallelVerificationEnabled ? _g1h->workers()->active_workers() : 1u;
   G1ParVerifyTask task(_g1h, vo);
-  if (GCParallelVerificationEnabled) {
-    _g1h->workers()->run_task(&task);
-  } else {
-    task.work(0);
-  }
+  _g1h->workers()->run_task(&task, num_workers);
   if (task.failures()) {
     failures = true;
   }

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -437,7 +437,7 @@ public:
   }
 
   void work(uint worker_id) {
-    VerifyRegionClosure blk(true, _vo);
+    VerifyRegionClosure blk(_vo);
     _g1h->heap_region_par_iterate_from_worker_offset(&blk, &_hrclaimer, worker_id);
     if (blk.failures()) {
       _failures = true;

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -352,15 +352,13 @@ void G1HeapVerifier::verify_archive_regions() {
 
 class VerifyRegionClosure: public HeapRegionClosure {
 private:
-  bool             _par;
   VerifyOption     _vo;
   bool             _failures;
 public:
   // _vo == UsePrevMarking -> use "prev" marking information,
   // _vo == UseFullMarking -> use "next" marking bitmap but no TAMS
-  VerifyRegionClosure(bool par, VerifyOption vo)
-    : _par(par),
-      _vo(vo),
+  VerifyRegionClosure(VerifyOption vo)
+    : _vo(vo),
       _failures(false) {}
 
   bool failures() {
@@ -415,9 +413,9 @@ public:
   }
 };
 
-// This is the task used for parallel verification of the heap regions
+// This is the task used for verification of the heap regions
 
-class G1ParVerifyTask: public WorkerTask {
+class G1VerifyTask: public WorkerTask {
 private:
   G1CollectedHeap*  _g1h;
   VerifyOption      _vo;
@@ -427,8 +425,8 @@ private:
 public:
   // _vo == UsePrevMarking -> use "prev" marking information,
   // _vo == UseFullMarking -> use "next" marking bitmap but no TAMS
-  G1ParVerifyTask(G1CollectedHeap* g1h, VerifyOption vo) :
-      WorkerTask("Parallel verify task"),
+  G1VerifyTask(G1CollectedHeap* g1h, VerifyOption vo) :
+      WorkerTask("Verify task"),
       _g1h(g1h),
       _vo(vo),
       _failures(false),
@@ -493,7 +491,7 @@ void G1HeapVerifier::verify(VerifyOption vo) {
   log_debug(gc, verify)("HeapRegions");
 
   uint num_workers = GCParallelVerificationEnabled ? _g1h->workers()->active_workers() : 1u;
-  G1ParVerifyTask task(_g1h, vo);
+  G1VerifyTask task(_g1h, vo);
   _g1h->workers()->run_task(&task, num_workers);
   if (task.failures()) {
     failures = true;


### PR DESCRIPTION
Hi all,

  please review this small change that simplifies the path splitting parallel/serial execution of verification.

Testing: gha, local testing

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286297](https://bugs.openjdk.java.net/browse/JDK-8286297): G1: Simplify parallel and serial verification code paths


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [c328f39a](https://git.openjdk.java.net/jdk/pull/8572/files/c328f39a9572ef2b613cb5ba2a9ac3bb93d0a9e0)
 * [Leo Korinth](https://openjdk.java.net/census#lkorinth) (@lkorinth - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8572/head:pull/8572` \
`$ git checkout pull/8572`

Update a local copy of the PR: \
`$ git checkout pull/8572` \
`$ git pull https://git.openjdk.java.net/jdk pull/8572/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8572`

View PR using the GUI difftool: \
`$ git pr show -t 8572`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8572.diff">https://git.openjdk.java.net/jdk/pull/8572.diff</a>

</details>
