### PR TITLE
8286285: G1: Rank issues with ParGCRareEvent_lock and Threads_lock

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -525,8 +525,7 @@ public:
       oop obj = CompressedOops::decode_not_null(heap_oop);
       bool failed = false;
       if (!_g1h->is_in(obj) || _g1h->is_obj_dead_cond(obj, _vo)) {
-        MutexLocker x(ParGCRareEvent_lock,
-          Mutex::_no_safepoint_check_flag);
+        MutexLocker x(ParGCRareEvent_lock, Mutex::_no_safepoint_check_flag);
 
         if (!_failures) {
           log.error("----------");
@@ -597,8 +596,7 @@ public:
                 cv_field == dirty :
                 cv_obj == dirty || cv_field == dirty));
         if (is_bad) {
-          MutexLocker x(ParGCRareEvent_lock,
-            Mutex::_no_safepoint_check_flag);
+          MutexLocker x(ParGCRareEvent_lock, Mutex::_no_safepoint_check_flag);
 
           if (!_failures) {
             log.error("----------");

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -242,7 +242,6 @@ void mutex_init() {
   }
   def(StringDedup_lock             , PaddedMonitor, nosafepoint);
   def(StringDedupIntern_lock       , PaddedMutex  , nosafepoint);
-  def(ParGCRareEvent_lock          , PaddedMutex  , safepoint, true);
   def(RawMonitor_lock              , PaddedMutex  , nosafepoint-1);
 
   def(Metaspace_lock               , PaddedMutex  , nosafepoint-3);
@@ -361,6 +360,8 @@ void mutex_init() {
   if (UseG1GC) {
     defl(G1OldGCCount_lock         , PaddedMonitor, Threads_lock, true);
   }
+  defl(ParGCRareEvent_lock         , PaddedMutex  , Threads_lock, true);
+
   defl(CompileTaskAlloc_lock       , PaddedMutex ,  MethodCompileQueue_lock);
 #ifdef INCLUDE_PARALLELGC
   if (UseParallelGC) {


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that fixes up the rank of the `ParGCRareEvent_lock` lock? It might be called in the vm-thread that holds the `Threads_lock` during (single-threaded) verification.

Testing: gha, local testing inducing uses of `ParGCRareEvent_lock` in the VM thread

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286285](https://bugs.openjdk.java.net/browse/JDK-8286285): G1: Rank issues with ParGCRareEvent_lock and Threads_lock


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8573/head:pull/8573` \
`$ git checkout pull/8573`

Update a local copy of the PR: \
`$ git checkout pull/8573` \
`$ git pull https://git.openjdk.java.net/jdk pull/8573/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8573`

View PR using the GUI difftool: \
`$ git pr show -t 8573`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8573.diff">https://git.openjdk.java.net/jdk/pull/8573.diff</a>

</details>
