### PR TITLE
8286291: G1: Remove unused segment allocator printouts

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.cpp
@@ -922,8 +922,3 @@ void G1CardSet::clear() {
   _num_occupied = 0;
   _mm->flush();
 }
-
-void G1CardSet::print(outputStream* os) {
-  _table->print(os);
-  _mm->print(os);
-}

--- a/src/hotspot/share/gc/g1/g1CardSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.cpp
@@ -295,10 +295,6 @@ public:
     }
   }
 
-  void print(outputStream* os) {
-    os->print("TBL " PTR_FORMAT " size %zu mem %zu ", p2i(&_table), _table.get_size_log2(Thread::current()), _table.get_mem_size(Thread::current()));
-  }
-
   void grow() {
     size_t new_limit = _table.get_size_log2(Thread::current()) + 1;
     _table.grow(Thread::current(), new_limit);

--- a/src/hotspot/share/gc/g1/g1CardSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.hpp
@@ -331,8 +331,6 @@ public:
   // Clear the entire contents of this remembered set.
   void clear();
 
-  void print(outputStream* os);
-
   // Iterate over the container, calling a method on every card or card range contained
   // in the card container.
   // For every container, first calls

--- a/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
@@ -56,7 +56,7 @@ void G1CardSetAllocator::drop_all() {
 
 size_t G1CardSetAllocator::mem_size() const {
   return sizeof(*this) +
-         _segmented_array.num_segments() * sizeof(G1CardSetSegment) +
+         num_segments() * sizeof(G1CardSetSegment) +
          _segmented_array.num_total_slots() * _segmented_array.slot_size();
 }
 
@@ -104,13 +104,6 @@ void G1CardSetMemoryManager::free(uint type, void* value) {
 void G1CardSetMemoryManager::flush() {
   for (uint i = 0; i < num_mem_object_types(); i++) {
     _allocators[i].drop_all();
-  }
-}
-
-void G1CardSetMemoryManager::print(outputStream* os) {
-  os->print_cr("MM " PTR_FORMAT " size %zu", p2i(this), sizeof(*this));
-  for (uint i = 0; i < num_mem_object_types(); i++) {
-    _allocators[i].print(os);
   }
 }
 

--- a/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.cpp
@@ -71,25 +71,6 @@ uint G1CardSetAllocator::num_segments() const {
   return _segmented_array.num_segments();
 }
 
-void G1CardSetAllocator::print(outputStream* os) {
-  uint num_allocated_slots = _segmented_array.num_allocated_slots();
-  uint num_total_slots = _segmented_array.num_total_slots();
-  uint highest = _segmented_array.first_array_segment() != nullptr
-               ? _segmented_array.first_array_segment()->num_slots()
-               : 0;
-  uint num_segments = _segmented_array.num_segments();
-  uint num_pending_slots = (uint)_free_slots_list.pending_count();
-  os->print("MA " PTR_FORMAT ": %u slots pending (allocated %u total %u) used %.3f highest %u segments %u size %zu ",
-            p2i(this),
-            num_pending_slots,
-            num_allocated_slots,
-            num_total_slots,
-            percent_of(num_allocated_slots - num_pending_slots, num_total_slots),
-            highest,
-            num_segments,
-            mem_size());
-}
-
 G1CardSetMemoryManager::G1CardSetMemoryManager(G1CardSetConfiguration* config,
                                                G1CardSetFreePool* free_list_pool) : _config(config) {
 

--- a/src/hotspot/share/gc/g1/g1CardSetMemory.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetMemory.hpp
@@ -86,12 +86,9 @@ public:
   // Total memory allocated.
   size_t mem_size() const;
 
-  // Unused (but usable) memory.
   size_t unused_mem_size() const;
 
   uint num_segments() const;
-
-  void print(outputStream* os);
 };
 
 using G1CardSetFreePool = G1SegmentedArrayFreePool;
@@ -117,8 +114,6 @@ public:
   inline void free_node(void* value);
 
   void flush();
-
-  void print(outputStream* os);
 
   size_t mem_size() const;
   size_t unused_mem_size() const;


### PR DESCRIPTION
Hi all,

  please review this (trivial) removal of some unused debug code.

Testing: gha, local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286291](https://bugs.openjdk.java.net/browse/JDK-8286291): G1: Remove unused segment allocator printouts


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8574/head:pull/8574` \
`$ git checkout pull/8574`

Update a local copy of the PR: \
`$ git checkout pull/8574` \
`$ git pull https://git.openjdk.java.net/jdk pull/8574/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8574`

View PR using the GUI difftool: \
`$ git pr show -t 8574`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8574.diff">https://git.openjdk.java.net/jdk/pull/8574.diff</a>

</details>
