### PR TITLE
8286331: jni_GetStringUTFChars() uses wrong heap allocator

### DIFF
--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -2233,7 +2233,7 @@ JNI_ENTRY(const char*, jni_GetStringUTFChars(JNIEnv *env, jstring string, jboole
   if (s_value != NULL) {
     size_t length = java_lang_String::utf8_length(java_string, s_value);
     /* JNI Specification states return NULL on OOM */
-    result = AllocateHeap(length + 1, mtInternal, 0, AllocFailStrategy::RETURN_NULL);
+    result = AllocateHeap(length + 1, mtInternal, AllocFailStrategy::RETURN_NULL);
     if (result != NULL) {
       java_lang_String::as_utf8_string(java_string, s_value, result, (int) length + 1);
       if (isCopy != NULL) {

--- a/src/hotspot/share/utilities/nativeCallStack.hpp
+++ b/src/hotspot/share/utilities/nativeCallStack.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ public:
     memset(_stack, 0, sizeof(_stack));
   }
 
-  NativeCallStack(int toSkip);
+  explicit NativeCallStack(int toSkip);
   NativeCallStack(address* pc, int frameCount);
 
   static inline const NativeCallStack& empty_stack() { return _empty_stack; }


### PR DESCRIPTION
jni_GetStringUTFChars()  calls `AllocateHeap(length + 1, mtInternal, 0, AllocFailStrategy::RETURN_NULL);` to allocate memory, where it passes `0` as `NativeCallStack` reference, that results construction of `NativeCallStack`.

In `NativeCallStack`'s constructor, it performs stack walk to capture native call stack. This is unnecessary, if NMT detail tracking is not enabled.

It should use `char* AllocateHeap(size_t size,
                   MEMFLAGS flags,
                   AllocFailType alloc_failmode /* = AllocFailStrategy::EXIT_OOM*/)` heap allocator instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286331](https://bugs.openjdk.java.net/browse/JDK-8286331): jni_GetStringUTFChars() uses wrong heap allocator


### Reviewers
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [df1b8c33](https://git.openjdk.java.net/jdk/pull/8579/files/df1b8c33e6fe7111dadffa2017887bc8fe67f341)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8579/head:pull/8579` \
`$ git checkout pull/8579`

Update a local copy of the PR: \
`$ git checkout pull/8579` \
`$ git pull https://git.openjdk.java.net/jdk pull/8579/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8579`

View PR using the GUI difftool: \
`$ git pr show -t 8579`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8579.diff">https://git.openjdk.java.net/jdk/pull/8579.diff</a>

</details>
