### PR TITLE
8286312: Stop mixing signed and unsigned types in bit operations

### DIFF
--- a/src/hotspot/share/runtime/atomic.hpp
+++ b/src/hotspot/share/runtime/atomic.hpp
@@ -818,14 +818,14 @@ inline T Atomic::cmpxchg_using_helper(Fn fn,
 inline uint32_t Atomic::CmpxchgByteUsingInt::set_byte_in_int(uint32_t n,
                                                              uint8_t b,
                                                              uint32_t idx) {
-  int bitsIdx = BitsPerByte * idx;
+  uint32_t bitsIdx = BitsPerByte * idx;
   return (n & ~(static_cast<uint32_t>(0xff) << bitsIdx))
           | (static_cast<uint32_t>(b) << bitsIdx);
 }
 
 inline uint8_t Atomic::CmpxchgByteUsingInt::get_byte_in_int(uint32_t n,
                                                             uint32_t idx) {
-  int bitsIdx = BitsPerByte * idx;
+  uint32_t bitsIdx = BitsPerByte * idx;
   return (uint8_t)(n >> bitsIdx);
 }
 


### PR DESCRIPTION
uint32_t is a much more natural type for bitsIdx.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286312](https://bugs.openjdk.java.net/browse/JDK-8286312): Stop mixing signed and unsigned types in bit operations


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8581/head:pull/8581` \
`$ git checkout pull/8581`

Update a local copy of the PR: \
`$ git checkout pull/8581` \
`$ git pull https://git.openjdk.java.net/jdk pull/8581/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8581`

View PR using the GUI difftool: \
`$ git pr show -t 8581`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8581.diff">https://git.openjdk.java.net/jdk/pull/8581.diff</a>

</details>
