### PR TITLE
JDK-8286338: suppress warnings about bad @author tags when author info is not generated.

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletManager.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/TagletManager.java
@@ -381,9 +381,15 @@ public class TagletManager {
             final Taglet taglet = allTaglets.get(name);
             // Check and verify tag usage
             if (taglet != null) {
+                if (taglet instanceof SimpleTaglet st && !st.enabled) {
+                    // taglet has been disabled
+                    return;
+                }
+
                 if (inlineTrees && !taglet.isInlineTag()) {
                     printTagMisuseWarn(ch, taglet, tag, "inline");
                 }
+
                 // nothing more to do
                 if (element == null) {
                     return;

--- a/test/langtools/jdk/javadoc/doclet/testAuthor/TestAuthor.java
+++ b/test/langtools/jdk/javadoc/doclet/testAuthor/TestAuthor.java
@@ -31,6 +31,7 @@
  * @run main TestAuthor
  */
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -79,6 +80,45 @@ public class TestAuthor extends JavadocTester {
         checkExit(Exit.OK);
 
         checkAuthor(false);
+    }
+
+    @Test
+    public void testBadAuthor_NoWarning(Path base) throws IOException {
+        testBadAuthor(base, false);
+    }
+
+    @Test
+    public void testBadAuthor_Warning(Path base) throws IOException {
+        testBadAuthor(base, true);
+    }
+
+    public void testBadAuthor(Path base, boolean useAuthorOption) throws IOException {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                """
+                    package pkg;
+                    /** Comment. */
+                    public class Test {
+                        private Test() { }
+                        /**
+                         * Comment.
+                         * @author anonymous
+                         */
+                        public void m() { }
+                    }""");
+
+        javadoc("-d", base.resolve("out").toString(),
+                "-sourcepath", src.toString(),
+                "-Xdoclint:none",
+                (useAuthorOption ? "-author" : "-XDdummy=dummy"),
+                "pkg");
+        checkExit(Exit.OK);
+
+        // bad tags never cause corresponding output, whether the option is enabled or not
+        checkAuthor(false);
+
+        checkOutput(Output.OUT, useAuthorOption,
+                "warning: Tag @author cannot be used in method documentation.");
     }
 
     void checkAuthor(boolean on) {

--- a/test/langtools/jdk/javadoc/doclet/testSimpleTagInherit/TestSimpleTagInherit.java
+++ b/test/langtools/jdk/javadoc/doclet/testSimpleTagInherit/TestSimpleTagInherit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,16 +34,6 @@
 import javadoc.tester.JavadocTester;
 
 public class TestSimpleTagInherit extends JavadocTester {
-
-    //Javadoc arguments.
-    private static final String[] ARGS = new String[] {
-
-    };
-
-    //Input for string search tests.
-    private static final String[][] TEST = {
-        {  }
-    };
 
     public static void main(String... args) throws Exception {
         TestSimpleTagInherit tester = new TestSimpleTagInherit();

--- a/test/langtools/jdk/javadoc/doclet/testVersionTag/TestVersionTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testVersionTag/TestVersionTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@
  * @run main TestVersionTag
  */
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -53,7 +54,7 @@ public class TestVersionTag extends JavadocTester {
         tb.writeJavaFiles(src,
                   """
                       package pkg;
-                      /** Introduction.\s
+                      /** Introduction.
                        * @version 1.2.3
                        */
                       public class Test { }
@@ -79,6 +80,45 @@ public class TestVersionTag extends JavadocTester {
         checkExit(Exit.OK);
 
         checkVersion(false);
+    }
+
+    @Test
+    public void testBadVersion_NoWarning(Path base) throws IOException {
+        testBadVersion(base, false);
+    }
+
+    @Test
+    public void testBadVersion_Warning(Path base) throws IOException {
+        testBadVersion(base, true);
+    }
+
+    public void testBadVersion(Path base, boolean useVersionOption) throws IOException {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                """
+                    package pkg;
+                    /** Comment. */
+                    public class Test {
+                        private Test() { }
+                        /**
+                         * Comment.
+                         * @version 1.2.3
+                         */
+                        public void m() { }
+                    }""");
+
+        javadoc("-d", base.resolve("out").toString(),
+                "-sourcepath", src.toString(),
+                "-Xdoclint:none",
+                (useVersionOption ? "-version" : "-XDdummy=dummy"),
+                "pkg");
+        checkExit(Exit.OK);
+
+        // bad tags never cause corresponding output, whether the option is enabled or not
+        checkVersion(false);
+
+        checkOutput(Output.OUT, useVersionOption,
+                "warning: Tag @version cannot be used in method documentation.");
     }
 
     void checkVersion(boolean on) {


### PR DESCRIPTION
Please review a simple small change to `TagletManager`, to not report warnings about bad use of tags (such as `@author` and `@version`) when command-line options have not been given to enable the use of the tags in the output (i.e. the `-author` and the dreadfully-named `-version` option.)

The change is more pragmatic than anything else.  There are lots of "bad" uses of `@author` in JDK API documentation, on methods. The alternative would be to permit the tag anywhere, but that would be both a spec change and work to implement the change that we're not really interest in, since the tag is now somewhat deprecated.

Two existing tests are updated, to test the handling of "bad" tags, with and without the enabling option.

Another test has some very (very) old unused lines deleted. If today was Thursday, I'd call it Throwback Thursday. These lines predate the `JavadocTester` conversion.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286338](https://bugs.openjdk.java.net/browse/JDK-8286338): suppress warnings about bad @author tags when author info is not generated.


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8583/head:pull/8583` \
`$ git checkout pull/8583`

Update a local copy of the PR: \
`$ git checkout pull/8583` \
`$ git pull https://git.openjdk.java.net/jdk pull/8583/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8583`

View PR using the GUI difftool: \
`$ git pr show -t 8583`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8583.diff">https://git.openjdk.java.net/jdk/pull/8583.diff</a>

</details>
