### PR TITLE
8284550: test failure_handler is not properly invoking jhsdb jstack, resulting in failure to produce a stack when a test times out

### DIFF
--- a/test/failure_handler/src/share/conf/common.properties
+++ b/test/failure_handler/src/share/conf/common.properties
@@ -35,7 +35,7 @@ onTimeout=\
         jcmd.vm.symboltable jcmd.vm.uptime jcmd.vm.dynlibs \
         jcmd.vm.system_properties \
   jcmd.gc.heap_info jcmd.gc.class_histogram jcmd.gc.finalizer_info jcmd.thread.dump_to_file \
-  jstack jhsdb.jstack
+  jstack jhsdb.jstack.live
 
 jinfo.app=jinfo
 
@@ -64,13 +64,13 @@ jstack.args=-e -l %p
 jstack.params.repeat=6
 
 jhsdb.app=jhsdb
-jhsdb.jstack.args=jstack --mixed --pid %p
-jhsdb.jstack.params.repeat=6
+jhsdb.jstack.live.args=jstack --mixed --pid %p
+jhsdb.jstack.live.params.repeat=6
 
-cores=jhsdb.jstack
-jhsdb.jstack.app=jhsdb
+cores=jhsdb.jstack.core jhsdb.jstack.core.mixed
 # Assume that java standard laucher has been used
-jhsdb.jstack.args=jstack --mixed --core %p --exe %java
+jhsdb.jstack.core.args=jstack --core %p --exe %java
+jhsdb.jstack.core.mixed.args=jstack --mixed --core %p --exe %java
 
 ################################################################################
 # environment info to gather


### PR DESCRIPTION
…resulting in failure to produce a stack when a test times out

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8284550](https://bugs.openjdk.java.net/browse/JDK-8284550): test failure_handler is not properly invoking jhsdb jstack, resulting in failure to produce a stack when a test times out


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8588/head:pull/8588` \
`$ git checkout pull/8588`

Update a local copy of the PR: \
`$ git checkout pull/8588` \
`$ git pull https://git.openjdk.java.net/jdk pull/8588/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8588`

View PR using the GUI difftool: \
`$ git pr show -t 8588`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8588.diff">https://git.openjdk.java.net/jdk/pull/8588.diff</a>

</details>
