### PR TITLE
8285739: disable EA when both JVMTI and Preview are enabled

### DIFF
--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -1155,7 +1155,7 @@ void JvmtiTagMap::iterate_through_heap(jint heap_filter,
 {
   // EA based optimizations on tagged objects are already reverted.
   // disabled if vritual threads are enabled with --enable-preview
-  EscapeBarrier eb(!Continuations::enabled() && !(heap_filter & JVMTI_HEAP_FILTER_UNTAGGED), JavaThread::current());
+  EscapeBarrier eb(!(heap_filter & JVMTI_HEAP_FILTER_UNTAGGED), JavaThread::current());
   eb.deoptimize_objects_all_threads();
   MutexLocker ml(Heap_lock);
   IterateThroughHeapObjectClosure blk(this,

--- a/src/hotspot/share/runtime/escapeBarrier.hpp
+++ b/src/hotspot/share/runtime/escapeBarrier.hpp
@@ -28,6 +28,7 @@
 
 #include "compiler/compiler_globals.hpp"
 #include "memory/allocation.hpp"
+#include "runtime/continuation.hpp"
 #include "utilities/macros.hpp"
 
 class JavaThread;
@@ -71,7 +72,7 @@ public:
   // Revert ea based optimizations for given deoptee thread
   EscapeBarrier(bool barrier_active, JavaThread* calling_thread, JavaThread* deoptee_thread)
     : _calling_thread(calling_thread), _deoptee_thread(deoptee_thread),
-      _barrier_active(barrier_active && (JVMCI_ONLY(UseJVMCICompiler) NOT_JVMCI(false)
+      _barrier_active(barrier_active && !Continuations::enabled() && (JVMCI_ONLY(UseJVMCICompiler) NOT_JVMCI(false)
                       COMPILER2_PRESENT(|| DoEscapeAnalysis)))
   {
     if (_barrier_active) sync_and_suspend_one();
@@ -80,7 +81,7 @@ public:
   // Revert ea based optimizations for all java threads
   EscapeBarrier(bool barrier_active, JavaThread* calling_thread)
     : _calling_thread(calling_thread), _deoptee_thread(NULL),
-      _barrier_active(barrier_active && (JVMCI_ONLY(UseJVMCICompiler) NOT_JVMCI(false)
+      _barrier_active(barrier_active && !Continuations::enabled() && (JVMCI_ONLY(UseJVMCICompiler) NOT_JVMCI(false)
                       COMPILER2_PRESENT(|| DoEscapeAnalysis)))
   {
     if (_barrier_active) sync_and_suspend_all();


### PR DESCRIPTION
The fix disables EscapeBarrier and EscapeAnalysis when certain JVMTI capabilities are enabled and --enable-preview.

It restores the same behavior as it was before https://bugs.openjdk.java.net/browse/JDK-8227745 "Enable Escape Analysis for Better Performance in the Presence of JVMTI Agents" is implemented when Continuations are enabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8285739](https://bugs.openjdk.java.net/browse/JDK-8285739): disable EA when both JVMTI and Preview are enabled


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8589/head:pull/8589` \
`$ git checkout pull/8589`

Update a local copy of the PR: \
`$ git checkout pull/8589` \
`$ git pull https://git.openjdk.java.net/jdk pull/8589/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8589`

View PR using the GUI difftool: \
`$ git pr show -t 8589`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8589.diff">https://git.openjdk.java.net/jdk/pull/8589.diff</a>

</details>
