### PR TITLE
8286371: Avoid use of deprecated str[n]icmp

### DIFF
--- a/src/hotspot/os/windows/symbolengine.cpp
+++ b/src/hotspot/os/windows/symbolengine.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -218,14 +218,14 @@ public:
       char* q = strchr(p, ';');
       if (q != NULL) {
         if (len == (q - p)) {
-          if (strnicmp(p, directory, len) == 0) {
+          if (_strnicmp(p, directory, len) == 0) {
             return true;
           }
         }
         p = q + 1;
       } else {
         // tail
-        return stricmp(p, directory) == 0 ? true : false;
+        return _stricmp(p, directory) == 0;
       }
     }
     return false;


### PR DESCRIPTION
Please review this trivial change to use _str[n]icmp instead of (deprecated)
str[n]icmp in the only places the latter are used in HotSpot, in
Windows-specific code.  This change is in preparation for removing the global
disable of deprecation warnings for HotSpot Windows builds.

An alternative would be to use str[n]casecmp, which are defined in
globalDefinitions_visCPP.hpp for compatibilty in shared code. But since the
uses of the functions being changed are in Windows-specific code I think the
non-deprecated Windows-specific functions are more appropriate.

There are some other uses of the deprecated functions in the JDK. I didn't
change them. Those other places have different approaches to dealing with the
source compatibility and deprecation than does HotSpot, suppressing the
warning for this and various other functions using _CRT_NONSTDC_NO_DEPRECATE.

Note that the deprecation message for these functions is the same one used for
deprecating various POSIX functions, and the deprecation is under the control
of the same macro, even though these aren't actually from POSIX.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286371](https://bugs.openjdk.java.net/browse/JDK-8286371): Avoid use of deprecated str[n]icmp


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8590/head:pull/8590` \
`$ git checkout pull/8590`

Update a local copy of the PR: \
`$ git checkout pull/8590` \
`$ git pull https://git.openjdk.java.net/jdk pull/8590/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8590`

View PR using the GUI difftool: \
`$ git pr show -t 8590`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8590.diff">https://git.openjdk.java.net/jdk/pull/8590.diff</a>

</details>
