### PR TITLE
Add compiler name to warning messages in Compiler Directive

### DIFF
--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,12 +102,20 @@ void CompilerDirectives::finalize(outputStream* st) {
 }
 
 void DirectiveSet::finalize(outputStream* st) {
-  // Check LogOption and warn
+  const char* level;
+  if (is_c1(this->directive())) {
+    level = "c1";
+  } else if (is_c2(this->directive())) {
+    level = "c2";
+  } else {
+    ShouldNotReachHere();
+  }
+
   if (LogOption && !LogCompilation) {
-    st->print_cr("Warning:  +LogCompilation must be set to enable compilation logging from directives");
+    st->print_cr("Warning: %s: +LogCompilation must be set to enable compilation logging from directives", level);
   }
   if (PrintAssemblyOption && FLAG_IS_DEFAULT(DebugNonSafepoints)) {
-    warning("printing of assembly code is enabled; turning on DebugNonSafepoints to gain additional output");
+    warning("%s: printing of assembly code is enabled; turning on DebugNonSafepoints to gain additional output", level);
     DebugNonSafepoints = true;
   }
 
@@ -183,6 +191,14 @@ DirectiveSet* CompilerDirectives::get_for(AbstractCompiler *comp) {
     assert(comp->is_c1() || comp->is_jvmci(), "");
     return _c1_store;
   }
+}
+
+bool DirectiveSet::is_c1(CompilerDirectives* directive) {
+  return this == directive->_c1_store;
+}
+
+bool DirectiveSet::is_c2(CompilerDirectives* directive) {
+  return this == directive->_c2_store;
 }
 
 // In the list of Control/disabled intrinsics, the ID of the control intrinsics can separated:

--- a/src/hotspot/share/compiler/compilerDirectives.hpp
+++ b/src/hotspot/share/compiler/compilerDirectives.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -128,6 +128,8 @@ public:
   bool is_intrinsic_disabled(const methodHandle& method);
   static ccstrlist canonicalize_control_intrinsic(ccstrlist option_value);
   void finalize(outputStream* st);
+  bool is_c1(CompilerDirectives* directive);
+  bool is_c2(CompilerDirectives* directive);
 
   typedef enum {
 #define enum_of_flags(name, type, dvalue, cc_flag) name##Index,


### PR DESCRIPTION
When using Compiler Directive such as `java -XX:+UnlockDiagnosticVMOptions -XX:CompilerDirectivesFile=<CompilerDirectives.json> <Java.class>` ,
it shows totally the same message for c1 and c2 compiler and the user would be confused about 
which compiler is affected by this message.
This should show messages with their compiler name so that the user knows which compiler shows this message.

My change result would be like the below.

```
OpenJDK 64-Bit Server VM warning: printing of assembly code is enabled; turning on DebugNonSafepoints to gain additional output
OpenJDK 64-Bit Server VM warning: printing of assembly code is enabled; turning on DebugNonSafepoints to gain additional output
```
->
```
OpenJDK 64-Bit Server VM warning: c1: printing of assembly code is enabled; turning on DebugNonSafepoints to gain additional output
OpenJDK 64-Bit Server VM warning: c2: printing of assembly code is enabled; turning on DebugNonSafepoints to gain additional output
```