### PR TITLE
8261650: Add a comment with details for MTLVC_MAX_INDEX

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLVertexCache.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLVertexCache.h
@@ -30,7 +30,14 @@
 #include "fontscalerdefs.h"
 
 /**
- * Constants that control the size of the vertex cache.
+ * The max size of the vertex cache.
+ *
+ * Note:
+ * This is the max number of vertices (of struct J2DVertex - 16 bytes)
+ * that can be accommodated in 4KB.
+ *
+ * [MTLRenderCommandEncoder setVertexBytes] expects the data size
+ * to be less than or equal to 4KB.
  */
 #define MTLVC_MAX_INDEX         250
 


### PR DESCRIPTION
This is a trivial fix which adds more details about the constant MTLVC_MAX_INDEX.
This had come up during the review of [JDK-8261632](https://bugs.openjdk.java.net/browse/JDK-8261632).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8261650](https://bugs.openjdk.java.net/browse/JDK-8261650): Add a comment with details for MTLVC_MAX_INDEX


### Reviewers
 * [Jayathirth D V](https://openjdk.java.net/census#jdv) (@jayathirthrao - **Reviewer**)
 * [Alexey Ushakov](https://openjdk.java.net/census#avu) (@avu - Committer)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk pull/8592/head:pull/8592` \
`$ git checkout pull/8592`

Update a local copy of the PR: \
`$ git checkout pull/8592` \
`$ git pull https://git.openjdk.java.net/jdk pull/8592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8592`

View PR using the GUI difftool: \
`$ git pr show -t 8592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk/pull/8592.diff">https://git.openjdk.java.net/jdk/pull/8592.diff</a>

</details>
